### PR TITLE
[Fix]: Disable tma locally

### DIFF
--- a/ci-test.sh
+++ b/ci-test.sh
@@ -45,11 +45,12 @@
         printf "| %-50s | ❌ Fail  |\n" "$file_name" >> ../test_summary.txt
         failed_count=$((failed_count + 1))
       fi
-      # Return to parent directory
-      cd ..
       
       echo "----------------------------------------" >> "$LOG_FILE"
     done
+
+    # Return to parent directory
+    cd ..
 
     # Add statistics summary
     echo "" >> test_summary.txt


### PR DESCRIPTION
# Issue
Auto TMA has an issue with padding seq_q=1 to block_M.

# Solution
Three solutions to address this issue:

- Globally disable TMA during kernel compilation and launch: pass_configs={"tl.disable_tma_lower": True}
    - Pros: Simple modification
    - Cons: May impact performance for copies that could benefit from TMA

- Add a new parameter to the T.copy interface, allowing users to disable TMA per call
    - Pros: Enables localized TMA disable for specific T.copy operations; 
    - Cons: Requires modifications to tilelang

- Replace affected copies between global and shared memory with T.parallel assignments
    - Pros: Allows localized TMA disable without modifying tilelang; 
    - Cons: Requires the most code changes (suitable for cases where TMA cannot be used)

# Performance 
- seqlen_kv: 32768, batch 1
    - Reference(Pytorch):
      - Latency: 0.33 ms
      - FLOPs: 1.64 TFLOPs
     - solution 1:
      - Latency: 0.32 ms
      - FLOPs: 1.67 TFLOPs
    - solution 2:
      - Latency: 0.31 ms
      - FLOPs: 1.72 TFLOPs
    - solution 3: 
        - Latency: 0.31 ms,
        - FLOPs: 1.75 TFLOPs
- seqlen_kv: 32768, batch 8
    - Reference(Pytorch):
      - Latency: 14.87 ms
      - FLOPs: 0.29 TFLOPs
     - solution 1:
      - Latency: 2.20 ms
      - FLOPs: 1.95 TFLOPs
    - solution 2:
      - Latency: 2.21 ms
      - FLOPs: 1.94 TFLOPs
    - solution 3: 
        - Latency: 2.21 ms
        - FLOPs: 1.94 TFLOPs
- seqlen_kv: 8192, batch 1
    - Reference(Pytorch):
        - Latency: 0.11 ms
        - FLOPs: 1.27 TFLOPs
    - solution 1:      
      - Latency: 0.10 ms
      - FLOPs: 1.32 TFLOPs  
    - solution 2:      
      - Latency: 0.10 ms
      - FLOPs: 1.34 TFLOPs  
    - solution 3:      
      - Latency: 0.10 ms
      - FLOPs: 1.34 TFLOPs                                