### PR TITLE
[SparseMLA] Add sparse MLA kernel and tests

### DIFF
--- a/tests/test_sparse_mla.py
+++ b/tests/test_sparse_mla.py
@@ -1,0 +1,57 @@
+import argparse
+import torch
+from top import SparseMLAKernel
+
+
+def test_sparsemla_kernel(batch, seq_len, seq_len_kv, q_start_index_s, heads, dim, tail_dim, topk,
+                          kv_stride, kv_group, sm_scale, dtype):
+    sparse_mla = SparseMLAKernel(
+        batch=batch,
+        seq_len=seq_len,
+        seq_len_kv=seq_len_kv,
+        q_start_index_s=q_start_index_s,
+        heads=heads,
+        dim=dim,
+        tail_dim=tail_dim,
+        topk=topk,
+        kv_stride=kv_stride,
+        kv_group=kv_group,
+        sm_scale=sm_scale,
+        is_casual=True,
+        dtype=dtype,
+        device='cuda',
+    )
+    sparse_mla.check()
+    latency = sparse_mla.profile()
+    print(f"Latency: {latency:.4f} ms")
+    print(f'fwd tflops = ',
+          (batch * seq_len * (dim + tail_dim + dim) * topk * 2 * heads) / (latency * 1e-3) / 1e12)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--batch', type=int, default=1, help='batch size')
+    parser.add_argument('--seq_len', type=int, default=1024, help='sequence length')
+    parser.add_argument('--seq_len_kv', type=int, default=2048, help='key/value sequence length')
+    parser.add_argument('--heads', type=int, default=128, help='num heads')
+    parser.add_argument('--dim', type=int, default=512, help='head dim')
+    parser.add_argument('--tail_dim', type=int, default=64, help='tail dim')
+    parser.add_argument('--topk', type=int, default=2048, help='topk')
+    parser.add_argument('--kv_stride', type=int, default=1, help='kv_stride')
+    parser.add_argument('--kv_group', type=int, default=1, help='kv_group')
+    parser.add_argument('--sm_scale', type=float, default=None, help='softmax scaling factor')
+    args = parser.parse_args()
+    batch = args.batch
+    seq_len = args.seq_len
+    seq_len_kv = args.seq_len_kv
+    heads = args.heads
+    dim = args.dim
+    tail_dim = args.tail_dim
+    topk = args.topk
+    kv_stride = args.kv_stride
+    kv_group = args.kv_group
+    sm_scale = args.sm_scale
+    dtype = torch.bfloat16
+
+    test_sparsemla_kernel(batch, seq_len, seq_len_kv, 1024, heads, dim, tail_dim, topk, kv_stride,
+                          kv_group, sm_scale, dtype)

--- a/top/__init__.py
+++ b/top/__init__.py
@@ -6,10 +6,11 @@ from .kernel.mamba_chunk_state import MambaChunkStateKernel
 from .kernel.blocksparse_attention import BlockSparseAttentionKernel
 from .kernel.linear_attention.linear_attn import LinearAttentionFusedChunkKernel, LinearAttentionFusedRecurrentKernel
 from .kernel.bitnet import Bitnet_158_int8xint2_kernel
+from .kernel.sparse_mla import SparseMLAKernel
 
 __all__ = [
     "MHAKernel", "MHADecodeKernel", "MLAKernel", "GQAKernel", "GQADecodeKernel",
     "MambaChunkScanKernel", "MambaChunkStateKernel", "BlockSparseAttentionKernel",
     "LinearAttentionFusedChunkKernel", "LinearAttentionFusedRecurrentKernel",
-    "Bitnet_158_int8xint2_kernel"
+    "Bitnet_158_int8xint2_kernel", "SparseMLAKernel"
 ]

--- a/top/kernel/sparse_mla.py
+++ b/top/kernel/sparse_mla.py
@@ -1,0 +1,501 @@
+import torch
+import torch.nn.functional as F
+import tilelang
+import tilelang.language as T
+import torch.nn as nn
+from einops import rearrange, einsum
+from tilelang.utils.tensor import torch_assert_close
+
+
+@tilelang.jit(
+    out_idx=[-1],
+    compile_flags=[
+        "-O3", "-Wno-deprecated-declarations", "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__", "-U__CUDA_NO_HALF2_OPERATORS__",
+        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__", "--expt-relaxed-constexpr", "--expt-extended-lambda",
+        "--ptxas-options=-v,--register-usage-level=10", "-DNDEBUG"
+    ],
+)
+def sparse_attention_fwd(
+    batch,
+    seq_len,
+    seq_len_kv,
+    heads,
+    dim,
+    tail_dim,
+    topk,
+    kv_stride,
+    kv_group=1,
+    sm_scale=None,
+    is_causal=True,
+    CP0=True,
+    block_I=64,
+    num_stages=0,
+    threads=384,
+):
+    '''
+    This code implements sparse attn
+    Note that the first kv_stride - 1 token's out would be nan. since this isn't used, we assume it doesn't matter. (**still, one might have to handle carefully in backward to avoid dout * nan propagated!**)
+    It might be OK to set these nan to zero, but we assume it might serve as a reminder of taking care of these out in 'delta = out * dout'.
+    The above feature might be replaced with out being undefined if we fix CP0 logic (this logic is currently wrong due to some bug in compiler)
+    '''
+    assert dim == tilelang.math.next_power_of_2(
+        dim), f"haven't check padding correctness yet, dim={dim}"
+    assert tail_dim == tilelang.math.next_power_of_2(
+        tail_dim), f"haven't check padding correctness yet, dim={tail_dim}"
+    assert is_causal == True, 'non-casual is not supported'
+    assert topk % block_I == 0, 'otherwise will load some index=0 thus causing wrong kv to be loaded'
+    if sm_scale is None:
+        sm_scale = (1.0 / (dim + tail_dim))**0.5 * 1.44269504  # log2(e)
+    else:
+        sm_scale = sm_scale * 1.44269504  # log2(e)
+
+    head_kv = heads // kv_group
+    q_shape = [batch, seq_len, heads, dim + tail_dim]
+    kv_shape = [batch, seq_len_kv, kv_group, dim + tail_dim]
+    o_shape = [batch, seq_len, heads, dim]
+    indices_shape = [batch, seq_len, kv_group, topk]
+    lse_shape = [batch, seq_len, heads]
+    indices_dtype = "int32"
+    dtype = "bfloat16"
+    accum_dtype = "float"
+
+    G = kv_group
+    heads = head_kv
+    # print(f'heads = {heads}')
+    padded_H = max(tilelang.math.next_power_of_2(head_kv), 16)
+    if padded_H != heads:
+        assert kv_group == 1, 'here we solve the heads padding automically, other wise you should handle Q copy and Output copy with your mask (when kv_group == 1, use g_i * padded_H:(g_i+1) * padded_H would be handled automically)'
+    # print(f'padded_H = {padded_H}, heads = {heads}')
+    BI = block_I
+    NI = tilelang.cdiv(topk, block_I)
+    assert NI % 2 == 0, 'NI should be a multiple of 2'
+    D = dim
+    D_tail = tail_dim
+    # Q0 = q_start_index_s
+    KV_stride = kv_stride
+    # CP0 = q_start_index_s == 0
+    # if CP0:
+    #     seq_len -= kv_stride - 1
+    if head_kv > 64:
+        assert head_kv % 64 == 0, 'head_kv should be a multiple of 64'
+        REPLICATE_H = head_kv // 64
+    else:
+        REPLICATE_H = 1
+
+    H_per_block = padded_H if REPLICATE_H == 1 else 64
+
+    @T.prim_func
+    def main(
+            Q: T.Tensor(q_shape, dtype),  # type: ignore
+            KV: T.Tensor(kv_shape, dtype),  # type: ignore
+            Indices: T.Tensor(indices_shape, indices_dtype),  # type: ignore
+            q_start_index_s: T.Tensor(1, indices_dtype),
+            Output: T.Tensor(o_shape, dtype),  # type: ignore
+    ):
+        with T.Kernel(
+            (seq_len - kv_stride + 1 if CP0 else seq_len) * REPLICATE_H,
+                batch,
+                kv_group,
+                threads=threads) as (bx, by, bz):
+            Q_shared_l = T.alloc_shared([H_per_block, D // 2], dtype)
+            Q_shared_r = T.alloc_shared([H_per_block, D // 2], dtype)
+            Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
+            KV_shared_0_l = T.alloc_shared([BI, D // 2], dtype)
+            KV_shared_0_r = T.alloc_shared([BI, D // 2], dtype)
+            KV_shared_1_l = T.alloc_shared([BI, D // 2], dtype)
+            KV_shared_1_r = T.alloc_shared([BI, D // 2], dtype)
+            K_tail_shared_0 = T.alloc_shared([BI, D_tail], dtype)
+            K_tail_shared_1 = T.alloc_shared([BI, D_tail], dtype)
+            O_shared_l = Q_shared_l
+            O_shared_r = Q_shared_r
+            is_kv_valid = T.alloc_shared([BI], "bool", scope="shared")
+
+            acc_o_l = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
+            acc_o_r = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
+            acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
+            S_shared = T.alloc_shared([H_per_block, BI], dtype)
+            sumexp = T.alloc_fragment([H_per_block], accum_dtype)
+            sum_exp_shared = T.alloc_shared([H_per_block], accum_dtype)
+            sumexp_i = T.alloc_fragment([H_per_block], accum_dtype)
+            alpha_shared = T.alloc_shared([H_per_block], accum_dtype, scope="shared")
+            alpha_local = T.alloc_fragment([H_per_block], accum_dtype)
+            m_i = T.alloc_fragment([H_per_block], accum_dtype)
+            m_i_prev = T.alloc_fragment([H_per_block], accum_dtype)
+            indices_local = T.alloc_local([1], indices_dtype)
+
+            # TODO: Multi buffer
+            bar_q = T.alloc_barrier(arrive_count=384)
+            bar_k_0_ready = T.alloc_barrier(arrive_count=128)
+            bar_k_1_ready = T.alloc_barrier(arrive_count=128)
+            bar_k_0_free = T.alloc_barrier(arrive_count=256)
+            bar_k_1_free = T.alloc_barrier(arrive_count=256)
+            bar_sScale_and_sS_ready = T.alloc_barrier(arrive_count=256)
+            bar_sScale_and_sS_free = T.alloc_barrier(arrive_count=256)
+
+            b_i, g_i = by, bz
+            s_i = (bx + (KV_stride - 1 if CP0 else 0)) if REPLICATE_H == 1 else (
+                bx // REPLICATE_H + (KV_stride - 1 if CP0 else 0))
+            q_i = q_start_index_s[0] + s_i
+            max_kv_i = (q_i + 1 - KV_stride) // KV_stride
+
+            H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
+            H1 = H0 + H_per_block
+
+            tx = T.get_thread_binding()
+
+            T.copy(Q[b_i, s_i, H0:H1, 0:D // 2], Q_shared_l)
+            T.copy(Q[b_i, s_i, H0:H1, D // 2:D], Q_shared_r)
+            T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
+            T.barrier_arrive(bar_q)
+
+            if tx < 128:
+                T.set_max_nreg(240, 1)
+                T.fill(sumexp, 0)
+                T.fill(m_i, -2**30)  # avoid -inf - inf to cause nan
+                T.fill(acc_o_l, 0)
+                T.barrier_wait(bar_q, 0)
+
+                for i_i in T.serial(T.ceildiv(NI, 2)):
+
+                    # Buffer 0
+                    T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
+
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0,
+                                                          -T.infinity(acc_s.dtype))
+                    T.gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True, wg_wait=-1)
+                    T.gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True, wg_wait=-1)
+                    T.gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True, wg_wait=-1)
+
+                    T.wait_wgmma(0)
+
+                    if i_i != 0:
+                        T.barrier_arrive(bar_sScale_and_sS_free)
+                        T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2) & 1) ^ 1)
+
+                    T.copy(m_i, m_i_prev)
+                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                    for h_i in T.Parallel(H_per_block):
+                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                    for h_i in T.Parallel(H_per_block):
+                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
+                    T.copy(alpha_local, alpha_shared)
+
+                    T.copy(acc_s, S_shared)
+                    T.gemm(S_shared, KV_shared_0_l, acc_o_l)
+
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_arrive(bar_k_0_free[0])
+
+                    # Buffer 1
+                    T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
+
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0,
+                                                          -T.infinity(acc_s.dtype))
+                    T.gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True, wg_wait=-1)
+                    T.gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True, wg_wait=-1)
+                    T.gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True, wg_wait=-1)
+
+                    T.wait_wgmma(0)
+
+                    T.barrier_arrive(bar_sScale_and_sS_free)
+                    T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2 + 1) & 1) ^ 1)
+
+                    T.copy(m_i, m_i_prev)
+                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                    for h_i in T.Parallel(H_per_block):
+                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                    for h_i in T.Parallel(H_per_block):
+                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
+                    T.copy(alpha_local, alpha_shared)
+
+                    T.copy(acc_s, S_shared)
+                    T.gemm(S_shared, KV_shared_1_l, acc_o_l)
+
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_arrive(bar_k_1_free[0])
+
+                # Rescale
+                for h_i in T.Parallel(H_per_block):
+                    sum_exp_shared[h_i] = sumexp[h_i]
+                for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                    acc_o_l[h_i, d_i] /= sumexp[h_i]
+                for h_i in T.Parallel(H_per_block):
+                    sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
+                T.copy(acc_o_l, O_shared_l)
+                T.copy(O_shared_l, Output[b_i, s_i, H0:H1, 0:D // 2])
+
+            elif tx >= 128 and tx < 256:
+                T.set_max_nreg(168, 1)
+                T.fill(acc_o_r, 0)
+                for i_i in T.serial(T.ceildiv(NI, 2)):
+                    # Buffer 0
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
+                    T.gemm(S_shared, KV_shared_0_r, acc_o_r)
+                    T.barrier_arrive(bar_k_0_free[0])
+                    T.barrier_arrive(bar_sScale_and_sS_free)
+
+                    # Buffer 1
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
+                    T.gemm(S_shared, KV_shared_1_r, acc_o_r)
+                    T.barrier_arrive(bar_k_1_free[0])
+                    if i_i != T.ceildiv(NI, 2) - 1:
+                        T.barrier_arrive(bar_sScale_and_sS_free)
+
+                # Rescale
+                for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                    acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
+
+                T.copy(acc_o_r, O_shared_r)
+                T.copy(O_shared_r, Output[b_i, s_i, H0:H1, D // 2:D])
+            elif tx >= 256:
+                # producer
+                T.set_max_nreg(80, 0)
+                for i_i in T.serial(T.ceildiv(NI, 2)):
+                    # Buffer 0
+                    T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
+                    for r in T.serial(4):
+                        indices_local[0] = Indices[b_i, s_i, g_i,
+                                                   (i_i * 2) * BI + r * 16 + (tx - 256) // 8]
+                        is_kv_valid[r * 16 + (tx - 256) // 8] = indices_local[0] <= max_kv_i
+                        if is_kv_valid[r * 16 + (tx - 256) // 8]:
+                            with T.attr("default", "async_scope", 1):
+                                for u in T.serial(4):
+                                    for v in T.vectorized(8):
+                                        KV_shared_0_l[r * 16 + (tx - 256) // 8,
+                                                      64 * u + (tx - 256) % 8 * 8 +
+                                                      v] = KV[b_i, indices_local[0], g_i,
+                                                              64 * u + (tx - 256) % 8 * 8 + v]
+                                        KV_shared_0_r[r * 16 + (tx - 256) // 8,
+                                                      64 * u + (tx - 256) % 8 * 8 +
+                                                      v] = KV[b_i, indices_local[0], g_i, D // 2 +
+                                                              64 * u + (tx - 256) % 8 * 8 + v]
+                            with T.attr("default", "async_scope", 1):
+                                for v in T.vectorized(8):
+                                    K_tail_shared_0[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8 +
+                                                    v] = KV[b_i, indices_local[0], g_i,
+                                                            D + (tx - 256) % 8 * 8 + v]
+                    T.cp_async_barrier_noinc(bar_k_0_ready[0])
+
+                    # Buffer 1
+                    T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
+                    for r in T.serial(4):
+                        indices_local[0] = Indices[b_i, s_i, g_i,
+                                                   (i_i * 2 + 1) * BI + r * 16 + (tx - 256) // 8]
+                        is_kv_valid[r * 16 + (tx - 256) // 8] = indices_local[0] <= max_kv_i
+                        if is_kv_valid[r * 16 + (tx - 256) // 8]:
+                            with T.attr("default", "async_scope", 1):
+                                for u in T.serial(4):
+                                    for v in T.vectorized(8):
+                                        KV_shared_1_l[r * 16 + (tx - 256) // 8,
+                                                      64 * u + (tx - 256) % 8 * 8 +
+                                                      v] = KV[b_i, indices_local[0], g_i,
+                                                              64 * u + (tx - 256) % 8 * 8 + v]
+                                        KV_shared_1_r[r * 16 + (tx - 256) // 8,
+                                                      64 * u + (tx - 256) % 8 * 8 +
+                                                      v] = KV[b_i, indices_local[0], g_i, D // 2 +
+                                                              64 * u + (tx - 256) % 8 * 8 + v]
+                            with T.attr("default", "async_scope", 1):
+                                for v in T.vectorized(8):
+                                    K_tail_shared_1[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8 +
+                                                    v] = KV[b_i, indices_local[0], g_i,
+                                                            D + (tx - 256) % 8 * 8 + v]
+                    T.cp_async_barrier_noinc(bar_k_1_ready[0])
+
+    return main
+
+
+class SparseMLAKernel(nn.Module):
+
+    def __init__(self,
+                 batch,
+                 seq_len,
+                 seq_len_kv,
+                 q_start_index_s,
+                 heads,
+                 dim,
+                 tail_dim,
+                 topk,
+                 kv_stride,
+                 kv_group=1,
+                 sm_scale=None,
+                 is_casual=True,
+                 dtype=torch.float16,
+                 device="cuda"):
+        super().__init__()
+
+        self.batch = batch
+        self.seq_len = seq_len
+        self.seq_len_kv = seq_len_kv
+        self.heads = heads
+        self.dim = dim
+        self.tail_dim = tail_dim
+        self.topk = topk
+        self.kv_stride = kv_stride
+        self.kv_group = kv_group
+        self.sm_scale = sm_scale
+        self.is_casual = is_casual
+        self.dtype = dtype
+        self.device = device
+
+        if q_start_index_s != 0:
+            assert q_start_index_s > kv_stride, "If it is because each cp has too short length, you should fix the logic involving CP0 (cp_rank == 0), to make sure q with pos < KV_Stride - 1 is masked (or you may just ignore how this is handled if nan in these q's Out would not effect others, which is reported to be likely to happen by wangding)"
+
+        CP0 = q_start_index_s == 0
+        self.q_start_index_s = torch.tensor([q_start_index_s], dtype=torch.int32, device=device)
+        self.kernel = sparse_attention_fwd(batch, seq_len, seq_len_kv, heads, dim, tail_dim, topk,
+                                           kv_stride, kv_group, sm_scale, is_casual, CP0)
+
+    def forward(self, q, kv, indices):
+        o = self.kernel(q, kv, indices, self.q_start_index_s)
+        return o
+
+    def prepare_inputs(self):
+        torch.random.manual_seed(0)
+        q = torch.randn((self.batch, self.seq_len, self.heads, self.dim + self.tail_dim),
+                        dtype=self.dtype,
+                        device=self.device).requires_grad_(True) / 10
+        kv = torch.randn((self.batch, self.seq_len_kv, self.kv_group, self.dim + self.tail_dim),
+                         dtype=self.dtype,
+                         device=self.device).requires_grad_(True) / 10
+
+        q.clamp_(-10, 10)
+        kv.clamp_(-10, 10)
+
+        indices = torch.full((self.batch, self.seq_len, self.kv_group, self.topk),
+                             self.seq_len_kv,
+                             dtype=torch.int32,
+                             device=self.device)
+        for b in range(self.batch):
+            for t in range(self.seq_len):
+                for h in range(self.kv_group):
+                    i_i = torch.randperm(
+                        min(
+                            max(1, ((t + int(self.q_start_index_s[0])) // self.kv_stride)),
+                            self.seq_len_kv))[:self.topk]
+                    indices[b, t, h, :len(i_i)] = i_i
+
+        return q, kv, indices
+
+    def profile(self):
+
+        def do_bench(fn, *args, warmup=10, rep=10, **kwargs):
+            """
+            Do benchmark for a function.
+            """
+            start_event = [torch.cuda.Event(enable_timing=True) for i in range(rep)]
+            end_event = [torch.cuda.Event(enable_timing=True) for i in range(rep)]
+            for _ in range(warmup):
+                fn(*args, **kwargs)
+
+            torch.cuda.synchronize()
+            for i in range(rep):
+                start_event[i].record()
+                fn(*args, **kwargs)
+                end_event[i].record()
+            torch.cuda.synchronize()
+
+            # Record clocks
+            times = torch.tensor(
+                [s.elapsed_time(e) for s, e in zip(start_event, end_event)],
+                dtype=torch.float,
+            )
+
+            return times.mean().item()
+
+        q, kv, indices = self.prepare_inputs()
+        latency = do_bench(self.kernel, q, kv, indices, self.q_start_index_s)
+        return latency
+
+    def ref_program(self,
+                    q,
+                    kv,
+                    indices,
+                    q_start_index_s,
+                    kv_stride=4,
+                    sm_scale=None,
+                    is_casual=True):
+        q = q.float()
+        kv = kv.float()
+        indices = indices.transpose(1, 2)
+        b, sq, h, dim_q = q.shape
+        b, sk, g, _ = kv.shape
+        if q_start_index_s is None:
+            q_start_index_s = sk * kv_stride - sq
+
+        assert kv.shape[-1] == 576, 'you should assign dim otherwise'
+        dim = 512
+        k = kv
+        v = kv[..., :dim]
+
+        b, _, _, dim_v = v.shape
+        num_kv_per_index = 1
+        g_index = g
+        h_index = h // g
+        compressed_casual_mask = torch.arange(
+            q_start_index_s, sq + q_start_index_s, dtype=torch.int32,
+            device="cuda").view(-1, 1) >= torch.arange(
+                kv_stride - 1, sk * kv_stride, kv_stride, dtype=torch.int32,
+                device="cuda").view(1, -1)
+
+        mask = q.new_zeros(b, g_index, sq, sk + 1, dtype=torch.bool).scatter(3, indices.long(), 1)
+        mask = mask[..., :-1]
+        mask = mask & compressed_casual_mask.view(1, 1, sq, sk)
+        mask[:, :, :kv_stride - 1, 0] = True
+        mask = mask.view(b, g_index, 1, sq, sk)
+
+        q = q.view(b, sq, g, -1, dim_q)
+        score = torch.einsum("bmghd,bngd->bghmn", q, k)
+        sm_scale = dim_q**-0.5 if sm_scale is None else sm_scale
+        score = score.masked_fill(~mask, float("-inf")).mul(sm_scale)
+        p = score.softmax(dim=-1)
+        p = p.view(b, g_index, h_index, -1, sq, sk)
+        p = p.view(b, g, -1, sq, sk)
+        o = torch.einsum("bghmn,bngd->bmghd", p.type(v.dtype), v)
+        o = o.reshape(b, sq, h, dim_v)
+        return o.to(torch.float16)
+
+    def check(self):
+        q, kv, indices = self.prepare_inputs()
+
+        def print_red_warning(message):
+            print(f"\033[31mWARNING: {message}\033[0m")
+
+        def calc_sim(x, y, name="tensor"):
+            x, y = x.data.double(), y.data.double()
+            denominator = (x * x + y * y).sum()
+            if denominator == 0:
+                print_red_warning(f'{name} all zero')
+                return 1
+            sim = 2 * (x * y).sum() / denominator
+            return sim
+
+        def assert_similar(x, y, eps=1e-5, name="tensor"):
+            sim = calc_sim(x, y, name)
+            diff = 1. - sim
+            if not (0 <= diff <= eps):
+                print_red_warning(f'{name} Error: {diff}')
+                assert False
+
+        ref_out = self.ref_program(q, kv, indices, int(self.q_start_index_s[0]), self.kv_stride)
+        o = self.kernel(q, kv, indices, self.q_start_index_s)
+        assert_similar(o, ref_out)
+        print("SparseMLA kernel check passed!")


### PR DESCRIPTION
This pull request introduces a new kernel for sparse multi-head local attention (MLA) and adds a corresponding test script to facilitate profiling and validation. The main changes are the addition of the `SparseMLAKernel` to the codebase and the creation of a new test file to benchmark its performance.

**New Kernel Integration:**

* Added `SparseMLAKernel` to the import list and `__all__` in `top/__init__.py`, making it available as a public API for use in the package.

**Testing and Profiling:**

* Created a new test script `tests/test_sparse_mla.py` that allows users to profile and validate the `SparseMLAKernel` using configurable command-line arguments for kernel parameters, and prints latency and throughput metrics.