### PR TITLE
[Fix] Fix broken tilelang link in readme; pre-release in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Note: TileOPs is still under rapid development.
 
 ---
 
-![Sparse MLA performance on H800 SXM](docs/figures/sparse_mla_perf.png)
+![DeepSeek-V3.2-Exp DeepSeek Sparse Attention (DSA) performance on H800 SXM](https://raw.githubusercontent.com/tile-ai/TileOPs/main/docs/figures/sparse_mla_perf.png)
+*DeepSeek-V3.2-Exp DeepSeek Sparse Attention (DSA) performance on H800 SXM*
 
 ## 📦 Installation
 
@@ -15,12 +16,12 @@ Note: TileOPs is still under rapid development.
 - Python 3.8+
 - PyTorch >= 2.1
 - GLIBCXX_3.4.32
-- [TileLang](https://github.com/tilelang/tilelang)
+- [TileLang](https://github.com/tile-ai/tilelang)
 
 ### Method 1: Install with Pip
 
 ```bash
-pip install tileops # coming soon...
+pip install tileops
 ```
 
 ### Method 2: Install from source (editable mode for development)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "tileops"
-version = "0.0.1.dev1"
+version = "0.0.1.dev2"
 description = "TileOPs kernels for efficient inference"
+readme = "README.md"
 authors = [{ name="Tile-AI"}]
 dependencies = [    
     "torch>=2.1.0",


### PR DESCRIPTION
* DeepSeek-v3.2-Exp DeepSeek Sparse Attention (DSA) is ready in TileOPs
* Create pypi pre-release v0.0.1.dev2
* Fix broken link in readme