### PR TITLE
[Bug] Fix the bug where the nvcc version is not equal to 12.9 during CI runtime.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           conda activate tileops-release
           export PYTHONPATH="$(pwd):$PYTHONPATH"
           echo "PYTHONPATH=$PYTHONPATH"
+          echo "CUDA_HOME"=$CUDA_HOME
           nvcc --version
           CUDA_VISIBLE_DEVICES=6 bash tests/ci_test.sh tileops_test_release.log
         shell: bash
@@ -80,6 +81,7 @@ jobs:
           conda activate tileops-nightly
           export PYTHONPATH="$(pwd):$PYTHONPATH"
           echo "PYTHONPATH=$PYTHONPATH"
+          echo "CUDA_HOME"=$CUDA_HOME
           nvcc --version
           CUDA_VISIBLE_DEVICES=6 bash tests/ci_test.sh tileops_test_nightly.log
         shell: bash


### PR DESCRIPTION
## Description
During CI runtime, the nvcc version is required to be 12.9, but it is actually running version 12.4.

<!-- Briefly describe the changes introduced by this PR -->

## Type of Change

- [x] Bug fix
- [ ] New operator implementation
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Infrastructure/CI

## Checklist

- [ ] I have run `pre-commit run --all-files` and fixed all linting issues.
- [ ] I have verified that my changes pass local unit tests.
- [ ] **(For new ops)** I have added the corresponding `Benchmark` class in `benchmarks/`.
- [ ] **(For new ops)** I have reported benchmark results in the tracking issue.
