### PR TITLE
[CI][Bug] Fix Bug in CI conda 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,14 +103,11 @@ jobs:
 
       - name: Setup & Run tests
         run: |
-          source ~/.bashrc
-          export PATH=/usr/local/cuda-12.9/bin:$PATH
-          export LD_LIBRARY_PATH=/usr/local/cuda-12.9/lib64:$LD_LIBRARY_PATH
-          source /home/lyc/miniconda3/etc/profile.d/conda.sh
-          conda activate tileops-nightly
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda activate tileops-release
           export PYTHONPATH="$(pwd):$PYTHONPATH"
           echo "PYTHONPATH=$PYTHONPATH"
-          bash benchmarks/profile_run.sh --log profile_out/tileops_profile_nightly.log
+          bash benchmarks/profile_run.sh --log profile_out/tileops_profile_release.log
         shell: bash
 
       - name: Upload profile_out artifacts


### PR DESCRIPTION
## Description

Fix the bug of CI runtime not being able to find conda.sh: 
1.  To enable CI to run on runners started by different users, the step that exposed specific user paths was removed, causing the above error #143;  
2.  By using the generic path ~, conda.sh can be started without exposing specific users.
3. Each CI-runner is exclusively bound to a GPU, eliminating the need to specify a GPU in the CI program.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have run `pre-commit run --all-files` and fixed all linting issues.
- [x] I have verified that my changes pass local unit tests.
