### PR TITLE
[Feat] Add Gemm ops benchmark baseline profile

### DIFF
--- a/benchmarks/gemm/gemm.py
+++ b/benchmarks/gemm/gemm.py
@@ -33,15 +33,10 @@ class GemmBenchmark(Benchmark):
         return (self.m * self.k + self.k * self.n + self.m * self.n) * self.dtype.itemsize
 
     def gen_inputs(self) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.trans_a:
-            a = torch.randn(self.k, self.m, device='cuda', dtype=self.dtype)
-        else:
-            a = torch.randn(self.m, self.k, device='cuda', dtype=self.dtype)
-
-        if self.trans_b:
-            b = torch.randn(self.n, self.k, device='cuda', dtype=self.dtype)
-        else:
-            b = torch.randn(self.k, self.n, device='cuda', dtype=self.dtype)
+        shape_a = (self.k, self.m) if self.trans_a else (self.m, self.k)
+        a = torch.randn(*shape_a, device='cuda', dtype=self.dtype)
+        shape_b = (self.n, self.k) if self.trans_b else (self.k, self.n)
+        b = torch.randn(*shape_b, device='cuda', dtype=self.dtype)
         return a, b
 
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:

--- a/benchmarks/profile/profile_gemm.py
+++ b/benchmarks/profile/profile_gemm.py
@@ -7,13 +7,13 @@ from top.ops import GemmOp
 from top.utils import str2dtype
 
 
-def test_gemm(m: int,
-              n: int,
-              k: int,
-              dtype: torch.dtype,
-              trans_a: bool = False,
-              trans_b: bool = False,
-              tune: bool = False) -> None:
+def run_gemm_benchmark(m: int,
+                       n: int,
+                       k: int,
+                       dtype: torch.dtype,
+                       trans_a: bool = False,
+                       trans_b: bool = False,
+                       tune: bool = False) -> None:
     op = GemmOp(m, n, k, trans_a=trans_a, trans_b=trans_b, dtype=dtype, tune=tune)
     benchmark = GemmBenchmark(m, n, k, dtype, trans_a=trans_a, trans_b=trans_b)
 
@@ -35,4 +35,5 @@ if __name__ == "__main__":
     parser.add_argument('--tune', action='store_true', default=False, help='enable autotune')
     args = parser.parse_args()
 
-    test_gemm(args.m, args.n, args.k, str2dtype[args.dtype], args.trans_a, args.trans_b, args.tune)
+    run_gemm_benchmark(args.m, args.n, args.k, str2dtype[args.dtype], args.trans_a, args.trans_b,
+                       args.tune)


### PR DESCRIPTION
## Description

resolve #153 

1. Added the gemm baseline_profile class method, with the specific implementation based on torch.mm 
2. Modified the input generation method for the gemm operator.
