### PR TITLE
[Fix][NSA] Fixed a bug in pytest parameter passing in `test_deepseek_nsa_cmp_fwd`.

### DIFF
--- a/tests/ops/test_deepseek_nsa_cmp_fwd.py
+++ b/tests/ops/test_deepseek_nsa_cmp_fwd.py
@@ -37,7 +37,7 @@ def test_nsa_cmp_fwd_varlen_op(
     # to avoid including pytest-injected local variables.
     # Note: Need to capture locals() before list comprehension due to scope issues
     local_vars = locals()
-    sig = inspect.signature(test_nsa_cmp_fwd_varlen_op)
+    sig = inspect.signature(globals()[inspect.stack()[0].function])
     params = {name: local_vars[name] for name in sig.parameters}
     benchmark = NSACmpFwdVarlenBenchmark(**params)
     inputs = benchmark.gen_inputs()


### PR DESCRIPTION
## Description

The error TypeError: NSACmpFwdVarlenBenchmark.__init__() got an unexpected keyword argument '@py_assert1' occurs because:

- locals().copy() captures all local variables in the current scope
- pytest may inject internal variables (such as @py_assert1) during assertion rewriting
- These internal variables are inadvertently passed to NSACmpFwdVarlenBenchmark.__init__(), causing the TypeError

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have run `pre-commit run --all-files` and fixed all linting issues.
- [x] I have verified that my changes pass local unit tests.
