### PR TITLE
[CI] Add issue-label and pr-validation workflows

### DIFF
--- a/.claude/creating-pull-request/SKILL.md
+++ b/.claude/creating-pull-request/SKILL.md
@@ -18,6 +18,7 @@ ______________________________________________________________________
 **Goal**: avoid opening a PR that immediately fails formatting/tests.
 
 0. If it’s not clear what the PR is fixing/adding, ask the user what issue/task this PR is for (link or short description).
+1. **Read `docs/CONTRIBUTING.md`** to confirm the latest branch naming, commit message, and PR title conventions. Do NOT rely on other files (workflow configs, CI scripts) for naming rules — `CONTRIBUTING.md` is the single source of truth.
 1. Confirm repository root and current git state:
    - `git status`
    - `git diff --stat`
@@ -77,7 +78,9 @@ git push -u origin <branch-name>
 
 Branch naming + commit conventions:
 
-- Follow the project documentation (`Claude.md`, `docs/DEVELOPMENT.md`).
+- Follow `docs/CONTRIBUTING.md` (the single source of truth for naming conventions).
+- Commit/PR titles use bracket format: `[Type] Description` or `[Type][Scope] Description`.
+- See `Claude.md` § "Commit & PR Title Convention" for quick reference.
 
 ______________________________________________________________________
 
@@ -97,7 +100,8 @@ PR body:
 
 2. PR title guidelines:
 
-- Start with bracket tags when appropriate: `[Fix]`, `[Docs]`, `[Bench]`.
+- **Must** use bracket format from `docs/CONTRIBUTING.md`: `[Type] Description` or `[Type][Scope] Description`.
+- Examples: `[Feat][GEMV] Add forward kernel`, `[CI] Add pr-validation workflow`.
 - Keep it under ~80 chars, describe the user-facing change.
 
 3. PR body should include:

--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -1,0 +1,60 @@
+name: issue-label
+
+permissions:
+  issues: write
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract type from title and apply label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Extract type from issue title (e.g., "[CI] ..." -> "CI", "[BugFix][mHC] ..." -> "BugFix")
+          TYPE=$(echo "$ISSUE_TITLE" | grep -oP '^\[\K(Feat|Feature|Fix|BugFix|Bug|Refactor|CI|Docs|Test|Build|Chore|Perf|Style|Enhancement)(?=\])' || true)
+
+          if [ -z "$TYPE" ]; then
+            echo "No type tag found in title, skipping label"
+            exit 0
+          fi
+
+          # Normalize to lowercase label
+          LABEL=$(echo "$TYPE" | tr '[:upper:]' '[:lower:]')
+          # Merge aliases
+          case "$LABEL" in
+            feature) LABEL="feat" ;;
+            bugfix|bug) LABEL="fix" ;;
+          esac
+
+          echo "Detected type: $TYPE -> label: $LABEL"
+
+          # Check if correct label already applied
+          CURRENT_LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          if echo "$CURRENT_LABELS" | grep -qx "$LABEL"; then
+            echo "Label '$LABEL' already applied, skipping"
+            exit 0
+          fi
+
+          # Remove any stale type labels
+          for l in feat fix refactor ci docs test build chore perf style enhancement; do
+            if echo "$CURRENT_LABELS" | grep -qx "$l"; then
+              gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" --remove-label "$l"
+            fi
+          done
+
+          # Ensure label exists (create if missing)
+          if ! gh label list --repo "${{ github.repository }}" --search "$LABEL" --json name --jq '.[].name' | grep -qx "$LABEL"; then
+            gh label create "$LABEL" --repo "${{ github.repository }}" --description "Auto-created by issue labeler" --force
+            echo "Created label: $LABEL"
+          fi
+
+          # Apply the matching label
+          gh issue edit "$ISSUE_NUMBER" --repo "${{ github.repository }}" --add-label "$LABEL"
+          echo "Applied label: $LABEL"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,123 @@
+name: pr-validation
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate commit messages
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "Checking commits from $BASE_SHA to $HEAD_SHA"
+
+          # TileOPs convention: [Type] description  or  [Type][Scope] description
+          PATTERN='^\[(Feat|Feature|Fix|BugFix|Refactor|CI|Docs|Test|Build|Chore|Perf|Style|Enhancement|Bench)\](\[[a-zA-Z0-9_-]+\])? .+'
+
+          STATUS=0
+          while IFS= read -r COMMIT_SHA; do
+            SUBJECT="$(git log -1 --format=%s "$COMMIT_SHA")"
+            if [[ ! "$SUBJECT" =~ $PATTERN ]]; then
+              echo "::error::Commit $COMMIT_SHA does not follow TileOPs format."
+              echo "  Expected: [Type] description  or  [Type][Scope] description"
+              echo "  Got: $SUBJECT"
+              STATUS=1
+            else
+              echo "OK: $SUBJECT"
+            fi
+          done < <(git log --format=%H "${BASE_SHA}..${HEAD_SHA}")
+
+          exit $STATUS
+
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    if: github.event.action != 'synchronize'
+    steps:
+      - name: Validate PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Expected: [Type] description  or  [Type][Scope] description
+          # Type: Feat, Feature, Fix, BugFix, Refactor, CI, Docs, Test, Build, Chore, Perf, Style, Enhancement
+          PATTERN='^\[(Feat|Feature|Fix|BugFix|Refactor|CI|Docs|Test|Build|Chore|Perf|Style|Enhancement)\](\[[a-zA-Z0-9_-]+\])? .+'
+          if [[ ! "$PR_TITLE" =~ $PATTERN ]]; then
+            echo "::error::PR title does not follow TileOPs format."
+            echo "Expected: [Type] description  or  [Type][Scope] description"
+            echo "Types: Feat, Feature, Fix, BugFix, Refactor, CI, Docs, Test, Build, Chore, Perf, Style, Enhancement"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi
+          echo "PR title is valid: $PR_TITLE"
+
+  label-pr:
+    runs-on: ubuntu-latest
+    needs: [validate-commits, validate-pr-title]
+    if: >-
+      github.event.action != 'synchronize' &&
+      needs.validate-pr-title.result == 'success' &&
+      needs.validate-commits.result == 'success'
+    steps:
+      - name: Extract type and apply label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Extract type from PR title (e.g., "[Feat][GEMV] ..." -> "Feat")
+          TYPE=$(echo "$PR_TITLE" | grep -oP '^\[\K(Feat|Feature|Fix|BugFix|Refactor|CI|Docs|Test|Build|Chore|Perf|Style|Enhancement)(?=\])' || true)
+
+          if [ -z "$TYPE" ]; then
+            echo "No type tag found in title, skipping label"
+            exit 0
+          fi
+
+          # Normalize to lowercase label
+          LABEL=$(echo "$TYPE" | tr '[:upper:]' '[:lower:]')
+          # Merge aliases
+          case "$LABEL" in
+            feature) LABEL="feat" ;;
+            bugfix)  LABEL="fix" ;;
+          esac
+
+          echo "Detected type: $TYPE -> label: $LABEL"
+
+          # Check if correct label already applied — skip if no change needed
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '.labels[].name')
+          if echo "$CURRENT_LABELS" | grep -qx "$LABEL"; then
+            echo "Label '$LABEL' already applied, skipping"
+            exit 0
+          fi
+
+          # Remove any stale type labels
+          for l in feat fix refactor ci docs test build chore perf style enhancement; do
+            if echo "$CURRENT_LABELS" | grep -qx "$l"; then
+              gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label "$l"
+            fi
+          done
+
+          # Ensure label exists (create if missing)
+          if ! gh label list --repo "${{ github.repository }}" --search "$LABEL" --json name --jq '.[].name' | grep -qx "$LABEL"; then
+            gh label create "$LABEL" --repo "${{ github.repository }}" --description "Auto-created by PR validation" --force
+            echo "Created label: $LABEL"
+          fi
+
+          # Apply the matching label
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label "$LABEL"
+          echo "Applied label: $LABEL"


### PR DESCRIPTION
## Summary
- Add `issue-label.yml`: Automatically labels issues based on conventional commit type prefixes in the title (feat, fix, ci, docs, etc.)
- Add `pr-validation.yml`: Validates PR titles and commit messages follow conventional commit format, and auto-labels PRs accordingly

Closes #185

## Test plan
- [ ] Verify `issue-label.yml` triggers on issue open/edit and applies correct labels
- [x] Verify `pr-validation.yml` validates PR title format on PR open
- [x] Verify `pr-validation.yml` validates commit messages on PR open/synchronize
- [ ] Verify label-pr job applies correct label based on PR title type prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)