### PR TITLE
[BugFix] Add guard for missing self.kernel in Kernel.autotune()

### DIFF
--- a/tileops/kernels/kernel.py
+++ b/tileops/kernels/kernel.py
@@ -53,6 +53,10 @@ class Kernel(ABC):
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         if self.autotune_configs is None:
             return  # kernel doesn't support autotuning
+        if not hasattr(self, 'kernel') or self.kernel is None:
+            raise AttributeError(
+                f"Cannot autotune {self.__class__.__name__}: 'self.kernel' is not set. "
+                "Set 'self.kernel' in __init__ before calling init_config with tune=True.")
         print(f'Start autotuning {self.__class__.__name__}...')
 
         # Apply autotune decorator to the kernel function


### PR DESCRIPTION
## Summary

- Add a `hasattr` guard in `Kernel.autotune()` to check that `self.kernel` is set before attempting to use it
- Raises a clear `AttributeError` with an actionable message instead of a cryptic attribute error when `tune=True` is passed to a kernel that hasn't set `self.kernel`
- Prevents crashes in all affected NSA kernels (`NSAFwdVarlenKernel`, `NSATopkVarlenKernel`, `NSACmpFwdVarlenKernel`, `MeanPoolingFwdKernel`, `GQAWindowSlidingKernel`) and any future kernels that omit `self.kernel`

Closes #197

## Test plan

- [ ] Verify that instantiating an affected NSA kernel with `tune=True` now raises a clear error message instead of a cryptic `AttributeError`
- [ ] Verify that kernels which do set `self.kernel` (e.g., `MHAFwdKernel`) still autotune correctly when `tune=True`
- [ ] Verify that `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)