### PR TITLE
[BugFix][mHC] Fix register_fake signature mismatch in mHC kernels

### DIFF
--- a/tileops/kernels/mhc/mhc_post.py
+++ b/tileops/kernels/mhc/mhc_post.py
@@ -79,6 +79,8 @@ def _(
     n_expand: int,
     c_x: int,
     dtype: str,
+    block_x_b: int,
+    block_C: int,
     num_stages: int,
     threads: int,
     *input,

--- a/tileops/kernels/mhc/mhc_pre.py
+++ b/tileops/kernels/mhc/mhc_pre.py
@@ -276,6 +276,8 @@ def _(
     n_expand: int,
     c_x: int,
     dtype: str,
+    block_x_b: int,
+    block_C: int,
     num_stages: int,
     threads: int,
     *input,


### PR DESCRIPTION
## Summary

- Add missing `block_x_b` and `block_C` parameters to `register_fake` functions in both `mhc_pre.py` and `mhc_post.py` to match their corresponding `custom_op` wrapper signatures

## Details

The `register_fake` functions for `mhc_pre_wrapped_kernel` and `mhc_post_wrapped_kernel` were missing two positional parameters (`block_x_b: int` and `block_C: int`) that are present in the `custom_op` wrapper signatures. This caused positional argument misalignment during fake tensor tracing (e.g., `torch.compile`), where `num_stages` would receive the value meant for `block_x_b`, `threads` would receive `block_C`, and the variadic `*input` would be shifted.

Closes #196

## Test plan

- [ ] Verify `torch.compile` with mHC kernels no longer errors during fake tensor tracing
- [ ] Run existing mHC kernel tests to confirm no regressions