### PR TITLE
[CI] Remove label-pr job from pr-validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -64,4 +64,3 @@ jobs:
             exit 1
           fi
           echo "PR title is valid: $PR_TITLE"
-


### PR DESCRIPTION
## Summary

- Remove the `label-pr` job from `pr-validation.yml` that fails with `Resource not accessible by integration` error
- The `pull_request` event restricts `GITHUB_TOKEN` to read-only for fork PRs, making `gh pr edit --add-label` impossible
- Remove the now-unnecessary `pull-requests: write` permission

Closes #194