### PR TITLE
[CI] Cancel in-progress stale runs for the same PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
   workflow_dispatch:
     # Allow manual triggering of the workflow
 
+concurrency:
+  # Keep only the newest run for the same PR or branch ref.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #228

## Summary
- add workflow-level concurrency to .github/workflows/ci.yml
- group runs by PR number for pull_request events, otherwise by git ref
- enable cancel-in-progress so only the latest commit run continues

## Test plan
- [x] PRE_COMMIT_HOME=/tmp/pre-commit-cache pre-commit run --files .github/workflows/ci.yml
- [ ] verify on GitHub Actions by pushing two quick consecutive commits to one PR