### PR TITLE
[CI] Restrict CI triggers to upstream main push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,14 @@ name: hello-self-hosted
 
 on:
   push:
-    branches: ['**']  # All branches
-    tags:     ['**']  # All tags push will also trigger, can be removed as needed
+    branches: [main]
   pull_request:
-    branches: ['**']  # All branch PRs trigger CI
-  schedule:
-    # Run daily at 00:00 Beijing Time (which is 16:00 UTC)
-    - cron: '0 16 * * *'
-  workflow_dispatch:
-    # Allow manual triggering of the workflow
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   pre-commit:
+    if: ${{ github.repository == 'tile-ai/TileOPs' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -38,6 +34,7 @@ jobs:
           extra_args: --all-files --show-diff-on-failure
 
   packaging:
+    if: ${{ github.repository == 'tile-ai/TileOPs' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -57,6 +54,7 @@ jobs:
 
   tileops_test_release:
     # needs: pre-commit
+    if: ${{ github.repository == 'tile-ai/TileOPs' }}
     runs-on: [self-hosted, tile-ops, venv]
     steps:
       - name: Checkout code
@@ -113,9 +111,8 @@ jobs:
 
   tileops_test_nightly:
     # needs: pre-commit
+    if: ${{ github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: [self-hosted, tile-ops, venv]
-    # Only run this job when the event is schedule or workflow_dispatch
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Closes #230

## Summary
- limit workflow triggers to  on  and  targeting 
- add job-level guard  so fork repositories do not run this CI
- keep nightly job gated so it does not run for normal push/PR events

## Test plan
- [x] PRE_COMMIT_HOME=/tmp/pre-commit-cache pre-commit run --files .github/workflows/ci.yml
- [x] verify in GitHub Actions: fork push should not queue/runs jobs; upstream main push/PR should run