### PR TITLE
[Docs][Tooling] Add creating-issue skill for Claude Code

### DIFF
--- a/.claude/skills/creating-issue/skill.md
+++ b/.claude/skills/creating-issue/skill.md
@@ -1,6 +1,6 @@
 ---
 name: creating-issue
-description: Create a high-quality issue which conforms the rules of TileOPs development
+description: Create a high-quality issue which conforms to the rules of TileOPs development
 ---
 
 # Creating Issues — Guidelines and Lessons Learned


### PR DESCRIPTION
Closes #233

## Summary
- Add `.claude/skills/creating-issue/skill.md` — a Claude Code skill capturing TileOps issue-filing best practices
- Documents the `[TYPE][COMPONENT]` title format, required body structure, language requirement, and when to file before a PR
- Includes AI tooling notes to prevent Conventional Commits style drift and a case log for reference

## Test plan
- [x] Verify skill is recognized by Claude Code (`/creating-issue` loads correctly)
- [x] Confirm skill content matches the conventions used in recent issues (#232, #233)

🤖 Generated with [Claude Code](https://claude.com/claude-code)