### PR TITLE
[Refactor] Consolidate duplicated check/check_fn in test classes

### DIFF
--- a/tests/ops/test_fp8_lighting_indexer.py
+++ b/tests/ops/test_fp8_lighting_indexer.py
@@ -181,7 +181,7 @@ class Fp8LightingIndexerTest(TestBase):
         return 2 * (a * b).sum() / norm_sum
 
     @staticmethod
-    def _validate_tensor_match(output, output_ref, tolerance=1e-3):
+    def _validate_tensor_match(output: torch.Tensor, output_ref: torch.Tensor, tolerance: float = 1e-3) -> None:
         if isinstance(output, tuple):
             output = output[0]
         if isinstance(output_ref, tuple):

--- a/tests/ops/test_fp8_quant.py
+++ b/tests/ops/test_fp8_quant.py
@@ -19,7 +19,7 @@ class Fp8QuantFixture(FixtureBase):
     ]
 
 
-def _cosine_compare(output, output_ref):
+def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Compare using cosine similarity (fp8 quantization needs looser checks)."""
     output = output.to(torch.float32)
     output_ref = output_ref.to(torch.float32)

--- a/tests/ops/test_gqa_decode_paged.py
+++ b/tests/ops/test_gqa_decode_paged.py
@@ -92,7 +92,7 @@ class GqaDecodePagedTest(TestBase):
             out_list.append(out_b)
         return torch.cat(out_list, dim=0)
 
-    def _maxdiff_cosine_compare(self, output, output_ref, atol=0.001):
+    def _maxdiff_cosine_compare(self, output: torch.Tensor, output_ref: torch.Tensor, atol: float = 0.001) -> None:
         """Compare using max-diff and cosine similarity."""
         if isinstance(output, (tuple, list)):
             output = output[0]

--- a/tests/ops/test_mha_decode_paged.py
+++ b/tests/ops/test_mha_decode_paged.py
@@ -87,7 +87,7 @@ class MhaDecodePagedTest(TestBase):
             out_list.append(out_b)
         return torch.cat(out_list, dim=0)
 
-    def _maxdiff_cosine_compare(self, output, output_ref, atol=0.001):
+    def _maxdiff_cosine_compare(self, output: torch.Tensor, output_ref: torch.Tensor, atol: float = 0.001) -> None:
         """Compare using max-diff and cosine similarity."""
         if isinstance(output, (tuple, list)):
             output = output[0]

--- a/tests/ops/test_mhc_post.py
+++ b/tests/ops/test_mhc_post.py
@@ -20,7 +20,7 @@ class MhcPostFixture(FixtureBase):
     ]
 
 
-def _cosine_compare(output, output_ref):
+def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Compare using cosine similarity (mhc post uses bf16 and needs looser checks)."""
     cos_sim = F.cosine_similarity(output_ref, output, dim=-1, eps=1e-8)
     assert cos_sim.min() > 0.99, \

--- a/tests/ops/test_mhc_pre.py
+++ b/tests/ops/test_mhc_pre.py
@@ -21,7 +21,7 @@ class MhcPreFixture(FixtureBase):
     ]
 
 
-def _cosine_compare(output, output_ref):
+def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Compare using cosine similarity (mhc pre uses bf16 and needs looser checks)."""
     cos_sim = F.cosine_similarity(output_ref, output, dim=-1, eps=1e-8)
     assert cos_sim.min() > 0.99, \

--- a/tests/ops/test_topk_selector.py
+++ b/tests/ops/test_topk_selector.py
@@ -19,7 +19,7 @@ class TopkSelectorFixture(FixtureBase):
     ]
 
 
-def _set_compare(output, output_ref):
+def _set_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
     """Compare using set intersection (topk indices may be in different order)."""
     ref_np = output_ref.cpu().to(torch.int32).numpy()
     trt_np = output.cpu().to(torch.int32).numpy()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ def _to_tuple(outputs):
     raise ValueError(f"Unsupported output type: {type(outputs)}")
 
 
-def allclose_compare(output, output_ref, atol=1e-8, rtol=1e-5):
+def allclose_compare(output: torch.Tensor, output_ref: torch.Tensor, atol: float = 1e-8, rtol: float = 1e-5) -> None:
     """Default comparison using torch.allclose."""
     max_err = (output - output_ref).abs().max()
     assert torch.allclose(output, output_ref, atol=atol, rtol=rtol), \
@@ -106,8 +106,7 @@ class TestBase(ABC):
 
         comparators = [compare] * len(outputs) if callable(compare) else list(compare)
 
-        for _i, (output, output_ref, cmp) in enumerate(
-                zip(outputs, outputs_ref, comparators, strict=True)):
+        for output, output_ref, cmp in zip(outputs, outputs_ref, comparators, strict=True):
             if output_ref is not None:
                 cmp(output, output_ref)
 


### PR DESCRIPTION
## Summary

Closes #236.

Seven test files each overrode `TestBase.check()` and/or `check_fn()` with ~30 lines of identical boilerplate (OOM handling, output normalization, iteration logic), differing only in their comparison step. `check_fn()` was defined in 4 places but never called anywhere. This PR eliminates all of that duplication.

Changes:
- `tests/test_base.py`: Refactored `check()` to accept a `compare` callable (or sequence of callables) parameter; added `_to_tuple()` helper and `allclose_compare()` default; removed `check_fn()` entirely.
- 7 test files (`test_fp8_quant`, `test_fp8_lighting_indexer`, `test_mhc_post`, `test_mhc_pre`, `test_gqa_decode_paged`, `test_mha_decode_paged`, `test_topk_selector`): Removed duplicated `check()`/`check_fn()` overrides; replaced with small custom compare functions passed to the base `check()`.

Net result: **-335 lines** (109 insertions, 444 deletions — ruff-fixed stat: 211 insertions, 549 deletions from rewrite tracking).

## Test plan

- [x] `pre-commit run --all-files` passes (ruff, codespell, mdformat, etc.)
- [x] `python -m pytest tests/ --co -q` collects all 85 tests without errors
- [ ] Full GPU test suite (requires hardware; not available in CI pre-merge)
