### PR TITLE
[Chore][CI] Schedule packaging daily and remove nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           extra_args: --all-files --show-diff-on-failure
 
   packaging:
-    if: ${{ (github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.repository == 'tile-ai/TileOPs' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch' }}
     runs-on: [self-hosted, tile-ops, venv]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #217

## Summary
- schedule packaging workflow to run daily via GitHub Actions cron
- keep packaging job dedicated to schedule-triggered runs
- remove legacy `tileops_test_nightly` job from CI workflow
- packaging will run in UTC-8 02:00 everyday

## Test plan
- [x] pre-commit run --all-files
- [x] Test packaging pipeline and upload whl to [artifact](https://github.com/tile-ai/TileOPs/actions/runs/22559922603)
