### PR TITLE
[Chore] Add benchmark for GQAWindowSlidingOp

### DIFF
--- a/benchmarks/ops/bench_deepseek_nsa_gqa_window_sliding.py
+++ b/benchmarks/ops/bench_deepseek_nsa_gqa_window_sliding.py
@@ -1,7 +1,14 @@
 from typing import Optional
 
-from tests.ops.test_deepseek_nsa_gqa_window_sliding import GqaWindowSlidingTest
+import pytest
+import torch
+
+from tests.ops.test_deepseek_nsa_gqa_window_sliding import (
+    GqaWindowSlidingFixture,
+    GqaWindowSlidingTest,
+)
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import GQAWindowSlidingOp
 
 
 class GqaWindowSlidingBenchmark(BenchmarkBase):
@@ -21,3 +28,60 @@ class GqaWindowSlidingBenchmark(BenchmarkBase):
         v_memory = t.ukv * head_kv * t.dim * t.dtype.itemsize
         output_memory = t.uq * t.heads * t.dim * t.dtype.itemsize
         return q_memory + k_memory + v_memory + output_memory
+
+
+def _baseline_gqa_window_sliding(test: GqaWindowSlidingTest):
+    """Return FA3 varlen forward baseline callable, or None if not installed."""
+    try:
+        from flash_attn_interface import flash_attn_varlen_func
+    except ImportError:
+        return None
+
+    def baseline_fn(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q):
+        max_seqlen_k = int((cu_seqlens_k[1:] - cu_seqlens_k[:-1]).max().item())
+        return flash_attn_varlen_func(
+            q, k, v, cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q, max_seqlen_k,
+            window_size=(test.window_size_left, test.window_size_right),
+            causal=test.is_causal,
+        )
+
+    return baseline_fn
+
+
+@GqaWindowSlidingFixture
+def test_gqa_window_sliding_bench(
+    batch_size: int,
+    groups: int,
+    uq: int,
+    ukv: int,
+    heads: int,
+    dim: int,
+    is_causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    dtype: torch.dtype,
+    accum_dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    test = GqaWindowSlidingTest(batch_size, groups, uq, ukv, heads, dim, is_causal,
+                                window_size_left, window_size_right, dtype, accum_dtype)
+    bm = GqaWindowSlidingBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = GQAWindowSlidingOp(
+        batch_size=batch_size, groups=groups, uq=uq, ukv=ukv, heads=heads, dim=dim,
+        is_causal=is_causal, window_size_left=window_size_left,
+        window_size_right=window_size_right, dtype=dtype, accum_dtype=accum_dtype, tune=tune,
+    )
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("gqa_window_sliding", locals(), result, tag="tileops")
+
+    baseline_fn = _baseline_gqa_window_sliding(test)
+    if baseline_fn is not None:
+        result_bl = bm.profile(baseline_fn, *inputs)
+        BenchmarkReport.record("gqa_window_sliding", locals(), result_bl, tag="FA3")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #259

## Summary

- Added `test_gqa_window_sliding_bench()` function decorated with `GqaWindowSlidingFixture` to actually run the benchmark (previously the file only defined the class with no runnable test)
- Added `_baseline_gqa_window_sliding()` for FA3 varlen baseline comparison
- Added proper imports: `torch`, `pytest`, `GqaWindowSlidingFixture`, `GQAWindowSlidingOp`
- Added `if __name__ == "__main__"` block for standalone execution

## Benchmark Results

Profile results from `profile_run.log`:

| Config | latency_ms | tflops | bandwidth_gbs |
|--------|-----------|--------|---------------|
| batch=1, uq=1024, causal, window_left=32 | 0.53 | 32.40 | 0.07 |
| batch=3, uq=8192, causal, window_left=2048 | 16.85 | 65.24 | 0.02 |
| batch=3, uq=8192, non-causal, no window | 17.93 | 122.62 | 0.02 |

## Test Plan

- [x] pre-commit: all checks passed
- [x] Benchmark tests: 3 passed
- [x] Existing unit tests: 3 passed (no regressions)
- [x] Profile run generated with reasonable TFLOPS metrics