### PR TITLE
[Chore][Bench] Add benchmark for MeanPoolingForwardOp

### DIFF
--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -43,7 +43,7 @@ def test_mean_pooling_bench(batch_size: int, seq_len: int, heads: int, dim: int,
             device='cuda',
             requires_grad=False)
         chunks_per_bacth = (seq_len + chunk_size - 1) // chunk_size
-        indices = torch.randint(0, seq_len, (chunks_per_bacth, 2), dtype=torch.int32, device='cuda')
+        indices = torch.empty((chunks_per_bacth, 2), dtype=torch.int32, device='cuda')
         seq_num = batch_size
         use_offsets = 0
 


### PR DESCRIPTION
## Summary

- Adds `benchmarks/ops/bench_mean_pooling.py` with `MeanPoolingBenchmark` class implementing `calculate_flops()` and `calculate_memory()`
- Profiles both TileOPs `MeanPoolingForwardOp` and PyTorch baseline across 6 test cases covering uniform and variable-length (offset-based) chunking scenarios
- All 6 test cases pass

Closes #261

## Profile Run Output

## mean_pooling

### tileops

| batch_size | seq_len | heads | dim | chunk_size | dtype | accum_dtype | chunks_per_bacth | seq_num | use_offsets | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 1 | 0 | 1.20 | 0.06 | 0.11 |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 1 | 0 | 0.87 | 0.08 | 0.16 |
| 2 | 2048 | 64 | 128 | 64 | torch.float16 | torch.float32 | 32 | 2 | 0 | 0.61 | 0.05 | 0.11 |
| 1 | 1024 | 64 | 128 | 64 | torch.float16 | torch.float32 | 16 | 3 | 1 | 0.17 | 0.05 | 0.10 |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 4 | 1 | 1.07 | 0.06 | 0.13 |
| 1 | 1000 | 64 | 128 | 32 | torch.float16 | torch.float32 | 34 | 4 | 1 | 0.10 | 0.09 | 0.16 |

### baseline

| batch_size | seq_len | heads | dim | chunk_size | dtype | accum_dtype | chunks_per_bacth | seq_num | use_offsets | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 1 | 0 | 0.78 | 0.09 | 0.17 |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 1 | 0 | 0.78 | 0.09 | 0.17 |
| 2 | 2048 | 64 | 128 | 64 | torch.float16 | torch.float32 | 32 | 2 | 0 | 0.33 | 0.10 | 0.21 |
| 1 | 1024 | 64 | 128 | 64 | torch.float16 | torch.float32 | 16 | 3 | 1 | 0.12 | 0.07 | 0.15 |
| 1 | 8192 | 64 | 128 | 64 | torch.float16 | torch.float32 | 128 | 4 | 1 | 0.78 | 0.09 | 0.18 |
| 1 | 1000 | 64 | 128 | 32 | torch.float16 | torch.float32 | 34 | 4 | 1 | 0.24 | 0.04 | 0.07 |

## Checklist

- [x] Pre-commit passes
- [x] All 6 benchmark test cases pass
- [x] Only `benchmarks/ops/bench_mean_pooling.py` is added (no generated files committed)
- [x] Profile run output included above