### PR TITLE
[Chore] Add benchmark test for NSATopkVarlenOp

### DIFF
--- a/benchmarks/ops/bench_deepseek_nsa_topk.py
+++ b/benchmarks/ops/bench_deepseek_nsa_topk.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
-from tests.ops.test_deepseek_nsa_topk import NsaTopkTest
+import pytest
+import torch
+
+from tests.ops.test_deepseek_nsa_topk import NsaTopkFixture, NsaTopkTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import NSATopkVarlenOp
 
 
 class NsaTopkBenchmark(BenchmarkBase):
@@ -19,3 +23,27 @@ class NsaTopkBenchmark(BenchmarkBase):
         k_read = (t.head_kv * t.dim * t.c_seq_len**2 * t.dtype.itemsize) // t.bs
         indices_write = t.c_seq_len * t.head_kv * t.selected_block_num * 4
         return q_read + k_read + indices_write
+
+
+@NsaTopkFixture
+def test_nsa_topk_bench(seq_num: int, c_seq_len: int, heads: int, dim: int, group: int,
+                         scale: float, selected_block_num: int, bc: int, bs: int, bk: int,
+                         dtype: torch.dtype, accum_dtype: torch.dtype, tune: bool) -> None:
+    test = NsaTopkTest(seq_num, c_seq_len, heads, dim, group, scale, selected_block_num, bc, bs,
+                       bk, dtype, accum_dtype)
+    bm = NsaTopkBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = NSATopkVarlenOp(
+        seq_num=seq_num, c_seq_len=c_seq_len, heads=heads, dim=dim, group=group, scale=scale,
+        selected_block_num=selected_block_num, bc=bc, bs=bs, bk=bk, dtype=dtype,
+        accum_dtype=accum_dtype, tune=tune, chunk_num=test.chunk_num)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("nsa_topk", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("nsa_topk", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
## Summary

Closes #260

Adds a `test_nsa_topk_bench()` function to `benchmarks/ops/bench_deepseek_nsa_topk.py` that profiles both the TileOPs `NSATopkVarlenOp` and a baseline implementation, recording FLOPS and memory bandwidth metrics.

## Changes

- Add `test_nsa_topk_bench()` benchmark function decorated with `@NsaTopkFixture`
- Profile `NSATopkVarlenOp` (tileops) and `test.ref_program` (baseline)
- Record results via `BenchmarkReport.record()` with `tileops` and `baseline` tags
- Add `if __name__ == "__main__"` block for standalone execution

## Benchmark Results

```
# TileOPs Benchmark Report
Generated: 2026-02-28 14:08:23

## nsa_topk

### tileops

| seq_num | c_seq_len | heads | dim | group | scale | selected_block_num | bc | bs | bk | dtype | accum_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 5 | 1024 | 32 | 128 | 16 | 1 | 16 | 32 | 32 | 128 | torch.float16 | torch.float32 | 0.23 | 1.14 | 0.11 |
| 3 | 512 | 32 | 128 | 16 | 1 | 16 | 32 | 32 | 128 | torch.float16 | torch.float32 | 111.62 | 0.00 | 0.00 |

### baseline

| seq_num | c_seq_len | heads | dim | group | scale | selected_block_num | bc | bs | bk | dtype | accum_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 5 | 1024 | 32 | 128 | 16 | 1 | 16 | 32 | 32 | 128 | torch.float16 | torch.float32 | 132.73 | 0.00 | 0.00 |
| 3 | 512 | 32 | 128 | 16 | 1 | 16 | 32 | 32 | 128 | torch.float16 | torch.float32 | 66.02 | 0.00 | 0.00 |
```

## Checklist

- [x] Pre-commit checks pass
- [x] Benchmark test runs successfully
- [x] Results included in PR description