### PR TITLE
[Chore] Add benchmark for GemvOp

### DIFF
--- a/benchmarks/ops/bench_gemv.py
+++ b/benchmarks/ops/bench_gemv.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
-from tests.ops.test_gemv import GemvTest
+import torch
+import pytest
+
+from tests.ops.test_gemv import GemvFixture, GemvTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import GemvOp
 
 
 class GemvBenchmark(BenchmarkBase):
@@ -12,3 +16,21 @@ class GemvBenchmark(BenchmarkBase):
     def calculate_memory(self) -> Optional[float]:
         t = self.test
         return (t.k + t.k * t.n + t.n) * t.dtype.itemsize
+
+
+@GemvFixture
+def test_gemv_bench(n: int, k: int, dtype: torch.dtype, tune: bool) -> None:
+    test = GemvTest(n, k, dtype)
+    bm = GemvBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = GemvOp(n, k, dtype=dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("gemv", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("gemv", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #248

## Summary

- Add `test_gemv_bench()` function to `benchmarks/ops/bench_gemv.py` that profiles both TileOPs `GemvOp` and a PyTorch baseline (`b @ a`)
- Benchmark covers float16 and bfloat16 across three matrix sizes: (1024, 1024), (7168, 16384), (18432, 7168)
- Reports latency, TFLOPS, and bandwidth metrics via `BenchmarkReport`

## Test plan

- [x] `pre-commit run --all-files` passed
- [x] `pytest benchmarks/ops/bench_gemv.py -v` passed (6/6 tests)
- [x] `profile_run.log` generated with both tileops and baseline results

## Benchmark

### tileops

| n | k | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- |
| 1024 | 1024 | torch.float16 | 0.01 | 0.24 | 0.24 |
| 7168 | 16384 | torch.float16 | 0.77 | 0.31 | 0.31 |
| 18432 | 7168 | torch.float16 | 0.83 | 0.32 | 0.32 |
| 1024 | 1024 | torch.bfloat16 | 0.01 | 0.21 | 0.21 |
| 7168 | 16384 | torch.bfloat16 | 0.77 | 0.30 | 0.30 |
| 18432 | 7168 | torch.bfloat16 | 0.77 | 0.34 | 0.34 |

### baseline

| n | k | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- |
| 1024 | 1024 | torch.float16 | 0.01 | 0.21 | 0.21 |
| 7168 | 16384 | torch.float16 | 0.45 | 0.52 | 0.52 |
| 18432 | 7168 | torch.float16 | 0.55 | 0.48 | 0.48 |
| 1024 | 1024 | torch.bfloat16 | 0.01 | 0.27 | 0.27 |
| 7168 | 16384 | torch.bfloat16 | 0.46 | 0.51 | 0.51 |
| 18432 | 7168 | torch.bfloat16 | 0.56 | 0.47 | 0.47 |