### PR TITLE
[Chore] Add benchmark for MHA Decode Paged

### DIFF
--- a/benchmarks/ops/bench_mha_decode_paged.py
+++ b/benchmarks/ops/bench_mha_decode_paged.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
-from tests.ops.test_mha_decode_paged import MhaDecodePagedTest
+import pytest
+import torch
+
+from tests.ops.test_mha_decode_paged import MhaDecodePagedFixture, MhaDecodePagedTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheOp
 
 
 class MhaDecodePagedBenchmark(BenchmarkBase):
@@ -19,3 +23,24 @@ class MhaDecodePagedBenchmark(BenchmarkBase):
         return (t.batch * t.seqlen_q * t.heads * t.dim * 2 +
                 2 * t.seqlen_kv * t.heads * t.dim) * t.dtype.itemsize + \
             t.batch * num_pages * 4 + t.batch * 4
+
+
+@MhaDecodePagedFixture
+def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv: int, dim: int,
+                                page_size: int, is_causal: bool, dtype: torch.dtype,
+                                tune: bool) -> None:
+    test = MhaDecodePagedTest(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
+    bm = MhaDecodePagedBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = MultiHeadAttentionDecodePagedWithKVCacheOp(
+        batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("mha_decode_paged", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("mha_decode_paged", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #251

## Summary

- Add `test_mha_decode_paged_bench()` function to `benchmarks/ops/bench_mha_decode_paged.py`
- Profile TileOPs `MultiHeadAttentionDecodePagedWithKVCacheOp` via `bm.profile(op, *inputs)`
- Profile baseline implementation via `bm.profile(test.ref_program, *inputs)`
- FLOPS and memory bandwidth metrics computed correctly by the existing `MhaDecodePagedBenchmark` class

## Test plan

- [x] pre-commit passed
- [x] pytest passed (4 parametrized benchmark cases collected and executed)

## Benchmark

### tileops

| batch | heads | seqlen_q | seqlen_kv | dim | page_size | is_causal | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 16 | 1 | 512 | 128 | 128 | False | torch.float16 | 0.04 | 0.09 | 0.09 |
| 1 | 8 | 1 | 1024 | 64 | 256 | False | torch.float16 | 0.03 | 0.07 | 0.07 |
| 2 | 8 | 1 | 1024 | 64 | 256 | False | torch.float16 | 0.04 | 0.10 | 0.05 |
| 1 | 8 | 1 | 512 | 64 | 256 | False | torch.float16 | 0.02 | 0.04 | 0.04 |

### baseline

| batch | heads | seqlen_q | seqlen_kv | dim | page_size | is_causal | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 16 | 1 | 512 | 128 | 128 | False | torch.float16 | 0.06 | 0.07 | 0.07 |
| 1 | 8 | 1 | 1024 | 64 | 256 | False | torch.float16 | 0.04 | 0.05 | 0.05 |
| 2 | 8 | 1 | 1024 | 64 | 256 | False | torch.float16 | 0.09 | 0.05 | 0.02 |
| 1 | 8 | 1 | 512 | 64 | 256 | False | torch.float16 | 0.03 | 0.03 | 0.03 |