### PR TITLE
[Bench] Add benchmark for NSAFwdVarlenOp

### DIFF
--- a/benchmarks/ops/bench_deepseek_nsa_fwd.py
+++ b/benchmarks/ops/bench_deepseek_nsa_fwd.py
@@ -37,14 +37,15 @@ def test_nsa_fwd_bench(batch: int, heads: int, c_seq_len: int, dim: int, is_caus
     inputs = test.gen_inputs()
 
     op = NSAFwdVarlenOp(
-        batch=test.batch, heads=test.heads, c_seq_len=test.c_seq_len, dim=test.dim,
-        is_causal=test.is_causal, scale=test.scale, block_size=test.block_size,
-        groups=test.groups, selected_blocks=test.selected_blocks, dtype=test.dtype,
-        accum_dtype=test.accum_dtype, tune=tune)
+        batch=batch, heads=heads, c_seq_len=c_seq_len, dim=dim,
+        is_causal=is_causal, scale=scale, block_size=block_size,
+        groups=groups, selected_blocks=selected_blocks, dtype=dtype,
+        accum_dtype=accum_dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("nsa_fwd", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    # Use reduced warmup/rep for the slow Python-loop baseline to avoid timeouts.
+    result_bl = bm.profile(test.ref_program, *inputs, warmup=5, rep=10)
     BenchmarkReport.record("nsa_fwd", locals(), result_bl, tag="baseline")
 
 


### PR DESCRIPTION
Closes #257

## Summary

- Add `test_nsa_fwd_bench()` function to `benchmarks/ops/bench_deepseek_nsa_fwd.py`
- Profiles TileOPs `NSAFwdVarlenOp` and baseline (`NsaFwdTest.ref_program`) via `bm.profile()`
- Records FLOPS and memory bandwidth metrics via `BenchmarkReport.record()`

## Test plan

- [x] pre-commit passed
- [x] pytest benchmark passes on GPU (3/3 passed)

## Benchmark

## nsa_fwd

### tileops

| batch | heads | c_seq_len | dim | is_causal | scale | block_size | groups | selected_blocks | dtype | accum_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 16 | 1024 | 64 | True | 0.1 | 32 | 16 | 1 | torch.float16 | torch.float32 | 0.04 | 3.61 | 0.12 |
| 4 | 16 | 8192 | 64 | True | 0.1 | 32 | 16 | 1 | torch.float16 | torch.float32 | 0.27 | 4.03 | 0.13 |
| 2 | 16 | 8192 | 64 | True | 0.1 | 32 | 16 | 4 | torch.float16 | torch.float32 | 67.36 | 0.06 | 0.00 |

### baseline

| batch | heads | c_seq_len | dim | is_causal | scale | block_size | groups | selected_blocks | dtype | accum_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | 16 | 1024 | 64 | True | 0.1 | 32 | 16 | 1 | torch.float16 | torch.float32 | 46.21 | 0.00 | 0.00 |
| 4 | 16 | 8192 | 64 | True | 0.1 | 32 | 16 | 1 | torch.float16 | torch.float32 | 379.18 | 0.00 | 0.00 |
| 2 | 16 | 8192 | 64 | True | 0.1 | 32 | 16 | 4 | torch.float16 | torch.float32 | 368.96 | 0.01 | 0.00 |
