### PR TITLE
[Chore] Add benchmark for TopkSelectorOp

### DIFF
--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -1,7 +1,12 @@
 from typing import Optional
 
-from tests.ops.test_topk_selector import TopkSelectorTest
+import pytest
+import torch
+
+from tests.ops.test_topk_selector import TopkSelectorFixture, TopkSelectorTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import TopkSelectorOp
+from tileops.utils import str2dtype
 
 
 class TopkSelectorBenchmark(BenchmarkBase):
@@ -16,3 +21,24 @@ class TopkSelectorBenchmark(BenchmarkBase):
         starts_memory = t.batch * t.out_dtype.itemsize
         ends_memory = t.batch * t.out_dtype.itemsize
         return index_score_memory + index_memory + starts_memory + ends_memory
+
+
+@TopkSelectorFixture
+def test_topk_selector_bench(batch: int, seq_len: int, topk: int, in_dtype_str: str,
+                              out_dtype_str: str, tune: bool) -> None:
+    in_dtype = str2dtype[in_dtype_str]
+    out_dtype = str2dtype[out_dtype_str]
+    test = TopkSelectorTest(batch, seq_len, topk, in_dtype, out_dtype)
+    bm = TopkSelectorBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = TopkSelectorOp(batch, seq_len, topk, in_dtype, out_dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("topk_selector", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("topk_selector", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #256

## Summary

- Add `test_topk_selector_bench()` function to `benchmarks/ops/bench_topk_selector.py`
- Profile TileOPs `TopkSelectorOp` and baseline `torch.topk` via `bm.profile()`
- Record results with `BenchmarkReport.record()` for both tileops and baseline tags
- FLOPS returns `None` (memory-bound operation); memory bandwidth metrics are computed

## Test plan

- [x] pre-commit passed (all checks green)
- [x] pytest benchmark runs (4 passed, GPU: NVIDIA H200)

## Benchmark

### `profile_run.log` output

#### tileops

| batch | seq_len | topk | in_dtype_str | out_dtype_str | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 64 | 32768 | 1024 | float32 | int32 | 0.09 | N/A | 0.10 |
| 64 | 32768 | 2048 | float32 | int32 | 0.09 | N/A | 0.10 |
| 128 | 65536 | 1024 | float32 | int32 | 0.34 | N/A | 0.10 |
| 128 | 65536 | 2048 | float32 | int32 | 0.35 | N/A | 0.10 |

#### baseline (torch.topk)

| batch | seq_len | topk | in_dtype_str | out_dtype_str | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 64 | 32768 | 1024 | float32 | int32 | 0.27 | N/A | 0.03 |
| 64 | 32768 | 2048 | float32 | int32 | 0.27 | N/A | 0.03 |
| 128 | 65536 | 1024 | float32 | int32 | 0.83 | N/A | 0.04 |
| 128 | 65536 | 2048 | float32 | int32 | 0.87 | N/A | 0.04 |

**TileOPs achieves ~2.5-3x speedup** over `torch.topk` baseline across all configurations.