### PR TITLE
[Chore] Add benchmark for Fp8LightingIndexerOp

### DIFF
--- a/benchmarks/ops/bench_fp8_lighting_indexer.py
+++ b/benchmarks/ops/bench_fp8_lighting_indexer.py
@@ -45,8 +45,14 @@ def test_fp8_lighting_indexer_bench(seq_len: int, heads: int, index_dim: int, se
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("fp8_lighting_indexer", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record("fp8_lighting_indexer", locals(), result_bl, tag="baseline")
+    try:
+        result_bl = bm.profile(test.ref_program, *inputs)
+    except RuntimeError as e:
+        if "out of memory" not in str(e).lower():
+            raise
+        result_bl = None
+    if result_bl is not None:
+        BenchmarkReport.record("fp8_lighting_indexer", locals(), result_bl, tag="baseline")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #255

## Summary
- Add `test_fp8_lighting_indexer_bench()` function to `benchmarks/ops/bench_fp8_lighting_indexer.py`
- Profile TileOPs `Fp8LightingIndexerOp` via `bm.profile(op, *inputs)`
- Profile baseline implementation via `test.ref_program` (with OOM guard)
- FLOPS returns `None` (memory-bound indexing operation); memory bandwidth metrics are computed

## Benchmark Results

### fp8_lighting_indexer — tileops

| seq_len | heads | index_dim | seq_len_kv | clean_logits | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 4096 | 32 | 64 | 8192 | True | 1.06 | N/A | 0.14 |

### fp8_lighting_indexer — baseline

| seq_len | heads | index_dim | seq_len_kv | clean_logits | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 4096 | 32 | 64 | 8192 | True | 72.96 | N/A | 0.00 |

**Speedup: ~69x** over baseline.

## Test plan
- [x] pre-commit passed
- [x] Python AST syntax check passed
- [x] Benchmark run passed (1 passed, profile_run.log generated)