### PR TITLE
[Chore] Add benchmark for Fp8QuantOp

### DIFF
--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
-from tests.ops.test_fp8_quant import Fp8QuantTest
+import torch
+import pytest
+
+from tests.ops.test_fp8_quant import Fp8QuantFixture, Fp8QuantTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import Fp8QuantOp
 
 
 class Fp8QuantBenchmark(BenchmarkBase):
@@ -13,3 +17,22 @@ class Fp8QuantBenchmark(BenchmarkBase):
     def calculate_memory(self) -> Optional[float]:
         t = self.test
         return t.seq_len_kv * t.index_dim * t.in_dtype.itemsize
+
+
+@Fp8QuantFixture
+def test_fp8_quant_bench(seq_len_kv: int, index_dim: int, in_dtype: torch.dtype,
+                         tune: bool) -> None:
+    test = Fp8QuantTest(seq_len_kv, index_dim, in_dtype)
+    bm = Fp8QuantBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = Fp8QuantOp(seq_len_kv=seq_len_kv, index_dim=index_dim, in_dtype=in_dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("fp8_quant", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("fp8_quant", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #254

## Summary

- Add `test_fp8_quant_bench()` function to `benchmarks/ops/bench_fp8_quant.py`
- Profile TileOPs `Fp8QuantOp` via `bm.profile(op, *inputs)` and record with `BenchmarkReport`
- Profile baseline implementation via `test.ref_program` for comparison
- Add missing imports (`torch`, `pytest`, `Fp8QuantFixture`, `Fp8QuantOp`) and `__main__` block

## Test plan

- [x] pre-commit passed (all files)
- [x] pytest benchmark run on GPU — 4/4 passed

## Benchmark

### tileops

| seq_len_kv | index_dim | in_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- |
| 8192 | 64 | torch.float16 | 0.03 | 0.11 | 0.04 |
| 8192 | 64 | torch.bfloat16 | 0.03 | 0.11 | 0.04 |
| 4096 | 128 | torch.float32 | 0.02 | 0.13 | 0.09 |
| 16384 | 32 | torch.float32 | 0.04 | 0.07 | 0.05 |

### baseline

| seq_len_kv | index_dim | in_dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- |
| 8192 | 64 | torch.float16 | 0.03 | 0.09 | 0.03 |
| 8192 | 64 | torch.bfloat16 | 0.03 | 0.09 | 0.03 |
| 4096 | 128 | torch.float32 | 0.02 | 0.14 | 0.09 |
| 16384 | 32 | torch.float32 | 0.05 | 0.07 | 0.05 |

## Additional context

Follows the same pattern as other recently added benchmarks (`bench_gemv.py`, `bench_gqa_window_sliding.py`, `bench_nsa_cmp_fwd_varlen.py`).