### PR TITLE
[Bench] Add benchmark for ManifoldConstrainedHyperConnectionPostOp

### DIFF
--- a/benchmarks/ops/bench_mhc_post.py
+++ b/benchmarks/ops/bench_mhc_post.py
@@ -1,7 +1,11 @@
 from typing import Optional
 
-from tests.ops.test_mhc_post import MhcPostTest
+import pytest
+import torch
+
+from tests.ops.test_mhc_post import MhcPostFixture, MhcPostTest
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tileops.ops import ManifoldConstrainedHyperConnectionPostOp
 
 
 class MhcPostBenchmark(BenchmarkBase):
@@ -15,3 +19,23 @@ class MhcPostBenchmark(BenchmarkBase):
     def calculate_memory(self) -> Optional[float]:
         t = self.test
         return (t.n_expand * 2 + 1) * t.c_x
+
+
+@MhcPostFixture
+def test_mhc_post_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
+                         tune: bool) -> None:
+    test = MhcPostTest(batch, n_expand, c_x, dtype)
+    bm = MhcPostBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = ManifoldConstrainedHyperConnectionPostOp(
+        batch, n_expand, c_x, dtype=str(dtype).split('.')[-1], tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("mhc_post", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("mhc_post", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #253

## Summary
- Add `test_mhc_post_bench()` function to `benchmarks/ops/bench_mhc_post.py`
- Profile TileOPs `ManifoldConstrainedHyperConnectionPostOp` via `bm.profile(op, *inputs)`
- Profile baseline implementation via `bm.profile(test.ref_program, *inputs)`
- Record both results with `BenchmarkReport.record()` for FLOPS and memory metrics

## Test plan
- [x] pre-commit passed
- [x] pytest benchmark runs (3 passed, GPU: NVIDIA H200)

## Benchmark

### `profile_run.log` output

#### tileops

| batch | n_expand | c_x | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 4 | 1280 | torch.bfloat16 | 0.00 | 34.14 | 0.01 |
| 2 | 4 | 1920 | torch.bfloat16 | 0.00 | 144.67 | 0.01 |
| 4 | 4 | 2560 | torch.bfloat16 | 0.00 | 394.24 | 0.01 |

#### baseline

| batch | n_expand | c_x | dtype | latency_ms | tflops | bandwidth_gbs |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | 4 | 1280 | torch.bfloat16 | 0.01 | 5.59 | 0.00 |
| 2 | 4 | 1920 | torch.bfloat16 | 0.01 | 21.99 | 0.00 |
| 4 | 4 | 2560 | torch.bfloat16 | 0.01 | 76.75 | 0.00 |

**TileOPs achieves ~5-6x speedup** in TFLOPS over baseline across all configurations.