### PR TITLE
[BugFix][NSA] Fix negative loop_range in causal gqa_window_sliding

### DIFF
--- a/tileops/kernels/deepseek_nsa/gqa_window_sliding.py
+++ b/tileops/kernels/deepseek_nsa/gqa_window_sliding.py
@@ -85,7 +85,7 @@ def _gqa_window_sliding_kernel(
                 offset = kv_current_seqlen - q_current_seqlen
 
                 if is_causal:
-                    max_visible_k_idx = offset + (bx + 1) * block_m
+                    max_visible_k_idx = T.max(offset + (bx + 1) * block_m, 0)
                     loop_range = T.min(
                         T.ceildiv(max_visible_k_idx, block_n),
                         T.ceildiv(kv_current_seqlen, block_n))


### PR DESCRIPTION
## Description

Fixes intermittent CI mismatches in `test_nsa_gqa_window_sliding_op`.

### Root Cause

When `offset` (`kv_seqlen - q_seqlen`) is negative and large enough, `max_visible_k_idx = offset + (bx + 1) * block_m` becomes negative. `T.ceildiv` of a negative value produces an incorrect `loop_range`, causing the kernel to iterate over wrong KV blocks and yielding large numerical errors (max err ~5.56).

### Fix

```diff
- max_visible_k_idx = offset + (bx + 1) * block_m
+ max_visible_k_idx = T.max(offset + (bx + 1) * block_m, 0)
```

Clamp `max_visible_k_idx >= 0` with `T.max()` in a single expression.

**Note:** The original Codex PR attempted to use `T.if_then_else` rebinding, but TileLang silently ignores immutable variable rebinding (CI warned: `WARNING: Immutable value 'max_visible_k_idx' is re-bound`). Using `T.max()` avoids this entirely.

### Validation

- All 3 test cases pass locally (5 consecutive runs, 0 failures)
- 1 file changed, 1 line modified

Fixes #291.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have verified that my changes pass local unit tests.
