### PR TITLE
[BugFix][Bench] Fix bandwidth unit label and GEMM memory dtype in benchmark

### DIFF
--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -15,7 +15,7 @@ class GemmBenchmark(BenchmarkBase):
 
     def calculate_memory(self) -> Optional[float]:
         t = self.test
-        return (t.m * t.k + t.k * t.n + t.m * t.n) * torch.float32.itemsize
+        return (t.m * t.k + t.k * t.n + t.m * t.n) * t.dtype.itemsize
 
 
 @GemmFixture


### PR DESCRIPTION
## Summary

Fixes #183 — the bandwidth metric key was labeled `bandwidth_gbs` (GB/s), but the formula `memory / latency_ms * 1e-9` actually produces TB/s.

- Rename `bandwidth_gbs` → `bandwidth_tbs` in `benchmarks/benchmark.py` (profile result key, docstring, report dump)

## Test plan

- [x] Run `pre-commit run --all-files` to verify lint/format
- [x] Run GEMM benchmark to confirm bandwidth is now reported under `bandwidth_tbs`
- [x] Verify report markdown output uses `bandwidth_tbs` column header

🤖 Generated with [Claude Code](https://claude.com/claude-code)