### PR TITLE
[BugFix][NSA] Fix missing loop_start in gqa_window_sliding KV loop

### DIFF
--- a/tileops/kernels/deepseek_nsa/gqa_window_sliding.py
+++ b/tileops/kernels/deepseek_nsa/gqa_window_sliding.py
@@ -84,15 +84,28 @@ def _gqa_window_sliding_kernel(
 
                 offset = kv_current_seqlen - q_current_seqlen
 
+                # Compute loop end (causal upper bound)
                 if is_causal:
                     max_visible_k_idx = T.max(offset + (bx + 1) * block_m, 0)
-                    loop_range = T.min(
+                    loop_end = T.min(
                         T.ceildiv(max_visible_k_idx, block_n),
                         T.ceildiv(kv_current_seqlen, block_n))
                 else:
-                    loop_range = T.ceildiv(kv_current_seqlen, block_n)
+                    loop_end = T.ceildiv(kv_current_seqlen, block_n)
 
-                for k in T.Pipelined(loop_range, num_stages=num_stages):
+                # Compute loop start (window lower bound) to skip
+                # KV blocks entirely outside the sliding window.
+                if has_window and window_size_left >= 0:
+                    min_visible_kv = T.max(
+                        offset + bx * block_m - window_size_left, 0)
+                    loop_start = min_visible_kv // block_n
+                else:
+                    loop_start = 0
+
+                loop_count = T.max(loop_end - loop_start, 0)
+
+                for k_offset in T.Pipelined(loop_count, num_stages=num_stages):
+                    k = k_offset + loop_start
                     T.copy(
                         k_unpad[kv_start_idx + k * block_n:kv_start_idx + (k + 1) * block_n,
                                 kv_head_idx, :], k_shared)


### PR DESCRIPTION
Closes #295

## Summary

- Compute `loop_start` from the sliding window's lower bound so that KV blocks entirely outside the window are skipped before entering the pipelined loop.
- Without this bound, the kernel iterated over fully-masked KV blocks where `-1e9` score masking combined with CUDA fast-math float32 accumulation could produce incorrect attention outputs (catastrophic cancellation), causing intermittent CI failures in `test_nsa_gqa_window_sliding_op`.
- Rename the inner loop variable from `k` to `k_offset` and compute `k = k_offset + loop_start` to reflect the offset-based iteration correctly.

## Test plan

- [x] pre-commit passed
- [x] pytest passed (`tests/kernels/deepseek_nsa/test_gqa_window_sliding.py`)

## Regression

Reproduces the intermittent failure from issue #295 and confirms it is resolved:
- Previously, `loop_start = 0` caused the loop to visit fully-masked blocks; `softmax(all -1e9)` under fast-math could accumulate to a non-zero finite output.
- After the fix, masked-only blocks are skipped entirely, so the attention output matches the reference on every run.