### PR TITLE
feat: implement layer_norm operator (#327)

### DIFF
--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tests.ops.test_layer_norm import LayerNormFixture, LayerNormTest
+from tileops.ops import LayerNormOp
+
+
+class LayerNormBenchmark(BenchmarkBase):
+
+    def calculate_flops(self) -> Optional[float]:
+        # Per element: sub-mean(1) + square(1) + add-to-sum(1) + mul-inv-N(1) + add-eps(1)
+        # + rsqrt(1) + sub-mean(1) + mul-rstd(1) + mul-weight(1) + add-bias(1)
+        return 10.0 * self.test.m * self.test.n
+
+    def calculate_memory(self) -> Optional[float]:
+        t = self.test
+        # Read x (M*N) + read weight (N) + read bias (N) + write y (M*N)
+        # NOTE: For hidden sizes not aligned to 256, the Op pads x/weight/bias
+        # at runtime (extra copy). Memory here reflects useful bytes only;
+        # real bandwidth for non-aligned shapes will be slightly higher.
+        return (t.m * t.n + t.n + t.n + t.m * t.n) * t.dtype.itemsize
+
+
+@LayerNormFixture
+def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, eps: float) -> None:
+    test = LayerNormTest(m, n, dtype, eps)
+    bm = LayerNormBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = LayerNormOp(m, n, eps=eps, dtype=dtype)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("layer_norm", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("layer_norm", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -1,0 +1,128 @@
+from typing import Tuple
+
+import pytest
+import torch
+
+from tests.test_base import FixtureBase, TestBase
+
+
+class LayerNormFixture(FixtureBase):
+    PARAMS = [
+        ("m, n, dtype, eps", [
+            # Standard shapes - fp16
+            (1024, 4096, torch.float16, 1e-5),
+            (4096, 4096, torch.float16, 1e-5),
+            (8192, 8192, torch.float16, 1e-5),
+            # Standard shapes - bf16
+            (1024, 4096, torch.bfloat16, 1e-5),
+            (4096, 4096, torch.bfloat16, 1e-5),
+            (8192, 8192, torch.bfloat16, 1e-5),
+            # Non-power-of-two hidden
+            (1024, 3000, torch.float16, 1e-5),
+            (2048, 5120, torch.float16, 1e-5),
+            (1024, 3000, torch.bfloat16, 1e-5),
+            (2048, 5120, torch.bfloat16, 1e-5),
+        ]),
+    ]
+
+
+class LayerNormMultiDimFixture(FixtureBase):
+    PARAMS = [
+        ("batch, seq, hidden, dtype, eps", [
+            # 3D input: (B, S, H) -> m=B*S
+            (2, 512, 4096, torch.float16, 1e-5),
+            (2, 512, 4096, torch.bfloat16, 1e-5),
+        ]),
+    ]
+
+
+class LayerNormNonContiguousFixture(FixtureBase):
+    PARAMS = [
+        ("m, n, dtype, eps", [
+            # Non-contiguous via slice
+            (1024, 4096, torch.float16, 1e-5),
+            (1024, 4096, torch.bfloat16, 1e-5),
+        ]),
+    ]
+
+
+class LayerNormTest(TestBase):
+
+    def __init__(self, m: int, n: int, dtype: torch.dtype, eps: float = 1e-5):
+        self.m = m
+        self.n = n
+        self.dtype = dtype
+        self.eps = eps
+
+    def gen_inputs(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        x = torch.randn(self.m, self.n, device='cuda', dtype=self.dtype)
+        weight = torch.randn(self.n, device='cuda', dtype=self.dtype)
+        bias = torch.randn(self.n, device='cuda', dtype=self.dtype)
+        return x, weight, bias
+
+    def ref_program(self, x: torch.Tensor, weight: torch.Tensor,
+                    bias: torch.Tensor) -> torch.Tensor:
+        x_f32 = x.float()
+        mean = x_f32.mean(-1, keepdim=True)
+        variance = ((x_f32 - mean) ** 2).mean(-1, keepdim=True)
+        rstd = torch.rsqrt(variance + self.eps)
+        return ((x_f32 - mean) * rstd).to(x.dtype) * weight + bias
+
+
+@LayerNormFixture
+def test_layer_norm(m: int, n: int, dtype: torch.dtype, eps: float) -> None:
+    from tileops.ops import LayerNormOp
+
+    test = LayerNormTest(m, n, dtype, eps)
+    op = LayerNormOp(m, n, eps=eps, dtype=dtype)
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    test.check(op, *test.gen_inputs(), **tolerances)
+
+
+@LayerNormMultiDimFixture
+def test_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype,
+                       eps: float) -> None:
+    from tileops.ops import LayerNormOp
+
+    m = batch * seq
+    test = LayerNormTest(m, hidden, dtype, eps)
+    op = LayerNormOp(m, hidden, eps=eps, dtype=dtype)
+    # Feed 3D input directly — Op should flatten/unflatten internally
+    x = torch.randn(batch, seq, hidden, device='cuda', dtype=dtype)
+    weight = torch.randn(hidden, device='cuda', dtype=dtype)
+    bias = torch.randn(hidden, device='cuda', dtype=dtype)
+    ref = test.ref_program(x, weight, bias)
+    result = op(x, weight, bias)
+    assert result.shape == x.shape, f"Shape mismatch: {result.shape} vs {x.shape}"
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    torch.testing.assert_close(result, ref, **tolerances)
+
+
+@LayerNormNonContiguousFixture
+def test_layer_norm_non_contiguous(m: int, n: int, dtype: torch.dtype,
+                                   eps: float) -> None:
+    from tileops.ops import LayerNormOp
+
+    test = LayerNormTest(m, n, dtype, eps)
+    op = LayerNormOp(m, n, eps=eps, dtype=dtype)
+    # Generate non-contiguous input by creating a larger tensor and slicing
+    x_big = torch.randn(m, n * 2, device='cuda', dtype=dtype)
+    x = x_big[:, ::2]  # Non-contiguous via stride
+    assert not x.is_contiguous()
+    weight = torch.randn(n, device='cuda', dtype=dtype)
+    bias = torch.randn(n, device='cuda', dtype=dtype)
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    test.check(op, x, weight, bias, **tolerances)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tileops/kernels/norm/__init__.py
+++ b/tileops/kernels/norm/__init__.py
@@ -1,0 +1,3 @@
+from .layer_norm import LayerNormKernel
+
+__all__ = ["LayerNormKernel"]

--- a/tileops/kernels/norm/layer_norm.py
+++ b/tileops/kernels/norm/layer_norm.py
@@ -1,0 +1,175 @@
+import itertools
+from typing import Callable, Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel import Kernel
+
+__all__ = ["LayerNormKernel"]
+
+
+def _layer_norm_kernel(M: int, N: int, actual_n: int, eps: float,
+                       dtype: str = 'float16') -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _layer_norm_func(block_m: int, threads: int) -> Callable:
+
+        @T.macro
+        def layer_norm_compute(
+            x: T.Buffer((M, N), dtype),
+            weight: T.Buffer((N,), dtype),
+            bias: T.Buffer((N,), dtype),
+            y: T.Buffer((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as bx:
+                x_shared = T.alloc_shared((block_m, N), dtype)
+                x_local = T.alloc_fragment((block_m, N), accum_dtype)
+                # For mean reduction
+                sum_local = T.alloc_fragment((block_m, N), accum_dtype)
+                mean_local = T.alloc_fragment((block_m,), accum_dtype)
+                # For variance reduction
+                diff_local = T.alloc_fragment((block_m, N), accum_dtype)
+                diff_sq_local = T.alloc_fragment((block_m, N), accum_dtype)
+                var_sum_local = T.alloc_fragment((block_m,), accum_dtype)
+                rstd_local = T.alloc_fragment((block_m,), accum_dtype)
+                # Weight and bias (keep in original dtype to match reference cast order)
+                w_shared = T.alloc_shared((N,), dtype)
+                w_local = T.alloc_fragment((N,), dtype)
+                b_shared = T.alloc_shared((N,), dtype)
+                b_local = T.alloc_fragment((N,), dtype)
+                # Normalized intermediate (cast to dtype before weight/bias)
+                norm_local = T.alloc_fragment((block_m, N), dtype)
+                # Output
+                y_local = T.alloc_fragment((block_m, N), dtype)
+                y_shared = T.alloc_shared((block_m, N), dtype)
+
+                # Load input rows
+                T.copy(x[bx * block_m, 0], x_shared)
+                T.copy(x_shared, x_local)
+
+                # Load weight and bias
+                T.copy(weight[0], w_shared)
+                T.copy(w_shared, w_local)
+                T.copy(bias[0], b_shared)
+                T.copy(b_shared, b_local)
+
+                # Pass 1: Compute mean per row
+                T.copy(x_shared, sum_local)
+                T.fill(mean_local, 0.0)
+                T.reduce_sum(sum_local, mean_local, dim=1)
+                for i in T.Parallel(block_m):
+                    mean_local[i] = mean_local[i] / T.cast(actual_n, accum_dtype)
+
+                # Compute (x - mean)
+                for i, j in T.Parallel(block_m, N):
+                    diff_local[i, j] = x_local[i, j] - mean_local[i]
+
+                # Pass 2: Compute variance per row = mean((x - mean)^2)
+                for i, j in T.Parallel(block_m, N):
+                    diff_sq_local[i, j] = diff_local[i, j] * diff_local[i, j]
+
+                T.fill(var_sum_local, 0.0)
+                T.reduce_sum(diff_sq_local, var_sum_local, dim=1)
+
+                # rstd = rsqrt(var + eps)
+                for i in T.Parallel(block_m):
+                    rstd_local[i] = T.rsqrt(
+                        var_sum_local[i] / T.cast(actual_n, accum_dtype)
+                        + T.cast(eps, accum_dtype))
+
+                # y = ((x - mean) * rstd).to(dtype) * weight + bias
+                # Cast normalized value to dtype first, then apply weight/bias
+                # in dtype precision (matches PyTorch reference computation order)
+                for i, j in T.Parallel(block_m, N):
+                    norm_local[i, j] = T.cast(
+                        diff_local[i, j] * rstd_local[i], dtype)
+
+                for i, j in T.Parallel(block_m, N):
+                    y_local[i, j] = norm_local[i, j] * w_local[j] + b_local[j]
+
+                T.copy(y_local, y_shared)
+                T.copy(y_shared, y[bx * block_m, 0])
+
+        @T.prim_func
+        def _layer_norm_main(
+            x: T.Tensor((M, N), dtype),
+            weight: T.Tensor((N,), dtype),
+            bias: T.Tensor((N,), dtype),
+            y: T.Tensor((M, N), dtype),
+        ) -> None:
+            layer_norm_compute(x, weight, bias, y)
+
+        return _layer_norm_main
+
+    return _layer_norm_func
+
+
+@torch.library.custom_op("top::layer_norm_wrapped_kernel", mutates_args=())
+def _layer_norm_wrapped_kernel(
+    M: int,
+    N: int,
+    actual_n: int,
+    eps: float,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    return _layer_norm_kernel(M, N, actual_n, eps, dtype)(block_m, threads)(
+        x, weight, bias)
+
+
+@_layer_norm_wrapped_kernel.register_fake
+def _(M: int, N: int, actual_n: int, eps: float, dtype: str, block_m: int,
+      threads: int,
+      *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
+    return torch.empty((M, N), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+class LayerNormKernel(Kernel):
+    supported_archs: list[int] = [80, 89, 90]
+
+    def __init__(self,
+                 M: int,
+                 N: int,
+                 actual_n: int,
+                 eps: float,
+                 dtype: torch.dtype,
+                 config: Optional[dict] = None,
+                 tune: bool = False) -> None:
+        super().__init__()
+        self.M = M
+        self.N = N
+        self.actual_n = actual_n
+        self.eps = eps
+        self.dtype = dtype
+
+        self.kernel = _layer_norm_kernel(M, N, actual_n, eps, self.dtype_str)
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 4,
+            "threads": 128,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        block_m = [1, 2, 4]
+        threads = [128, 256]
+        _configs = list(itertools.product(block_m, threads))
+        return [{"block_m": c[0], "threads": c[1]} for c in _configs]
+
+    def forward(self, x: torch.Tensor, weight: torch.Tensor,
+                bias: torch.Tensor) -> torch.Tensor:
+        return _layer_norm_wrapped_kernel(
+            self.M, self.N, self.actual_n, self.eps, self.dtype_str,
+            self.config["block_m"], self.config["threads"],
+            x, weight, bias,
+        )

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -11,6 +11,7 @@ from .fft import FFTC2CLUTOp, FFTC2COp
 from .fp8_lighting_indexer import Fp8LightingIndexerOp
 from .fp8_quant import Fp8QuantOp
 from .gemm import GemmOp
+from .layer_norm import LayerNormOp
 from .gqa import GroupQueryAttentionBwdOp, GroupQueryAttentionFwdOp
 from .gqa_decode import GroupQueryAttentionDecodeWithKVCacheOp
 from .gqa_decode_paged import GroupQueryAttentionDecodePagedWithKVCacheOp
@@ -36,6 +37,7 @@ __all__ = [
     "GroupQueryAttentionDecodeWithKVCacheOp",
     "GroupQueryAttentionFwdOp",
     "GroupedGemmOp",
+    "LayerNormOp",
     "ManifoldConstrainedHyperConnectionPostOp",
     "ManifoldConstrainedHyperConnectionPreOp",
     "MeanPoolingForwardOp",

--- a/tileops/ops/layer_norm.py
+++ b/tileops/ops/layer_norm.py
@@ -1,0 +1,68 @@
+import math
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+
+from tileops.kernels.kernel import Kernel
+from tileops.kernels.norm import LayerNormKernel
+
+from .op import Op
+
+__all__ = ["LayerNormOp"]
+
+ALIGNMENT = 256
+
+
+def _align_up(n: int, alignment: int) -> int:
+    return math.ceil(n / alignment) * alignment
+
+
+class LayerNormOp(Op):
+
+    def __init__(self,
+                 m: int,
+                 n: int,
+                 eps: float = 1e-5,
+                 dtype: torch.dtype = torch.float16,
+                 tune: bool = False,
+                 kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
+        self.M = m
+        self.N = n
+        self.eps = eps
+        self.dtype = dtype
+        self.padded_n = _align_up(n, ALIGNMENT)
+        self.needs_padding = self.padded_n != n
+
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["layer_norm_kernel"](
+            m, self.padded_n, n, eps, dtype, tune=tune)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"layer_norm_kernel": LayerNormKernel}
+
+    def forward(self, x: torch.Tensor, weight: torch.Tensor,
+                bias: torch.Tensor) -> torch.Tensor:
+        orig_shape = x.shape
+        x = x.contiguous()
+        weight = weight.contiguous()
+        bias = bias.contiguous()
+
+        # Flatten arbitrary leading dims to 2D (M, N)
+        x = x.reshape(-1, self.N)
+        assert x.shape[0] == self.M, (
+            f"Total number of rows ({x.shape[0]}) does not match M={self.M}")
+
+        if self.needs_padding:
+            pad_size = self.padded_n - self.N
+            x = F.pad(x, (0, pad_size))
+            weight = F.pad(weight, (0, pad_size))
+            bias = F.pad(bias, (0, pad_size))
+
+        y = self.kernel(x, weight, bias)
+
+        if self.needs_padding:
+            y = y[:, :self.N]
+
+        return y.reshape(orig_shape)


### PR DESCRIPTION
## Summary
- Implement standalone `layer_norm` forward operator: `y = (x - mean(x)) / sqrt(var(x) + eps) * weight + bias`
- TileLang kernel with two-pass mean+variance reduction, fp32 accumulation, 256-byte alignment padding for non-power-of-two hidden sizes
- `LayerNormOp` supports arbitrary leading dims via flatten/unflatten, matching `x: (..., hidden)` contract
- Cast order matches PyTorch reference for bf16 numerical alignment

## Files
- `tileops/kernels/norm/layer_norm.py` — TileLang kernel (LayerNormKernel)
- `tileops/kernels/norm/__init__.py` — exports
- `tileops/ops/layer_norm.py` — LayerNormOp with padding + multi-dim support
- `tileops/ops/__init__.py` — export LayerNormOp
- `tests/ops/test_layer_norm.py` — 14 tests (fp16/bf16 × standard/non-2-power/3D/non-contiguous)
- `benchmarks/ops/bench_layer_norm.py` — 10 benchmarks reporting bandwidth_tbs

## Test Evidence
- **Correctness**: 14/14 passed (fp16 atol=1e-2, bf16 atol=1.6e-2)
- **Benchmarks**: 10/10 passed, ~8-9x over PyTorch baseline
- **bandwidth_tbs**: ~0.24-0.27 TB/s on H200 MIG 1g.18gb slice

## Benchmark Results (H200 MIG 1g.18gb)
| Shape (M×N) | dtype | TileOps latency (ms) | Baseline latency (ms) | Speedup | bandwidth_tbs |
|---|---|---|---|---|---|
| 1024×4096 | fp16 | 0.07 | 0.62 | 8.9x | 0.25 |
| 4096×4096 | fp16 | 0.25 | 2.44 | 9.8x | 0.27 |
| 8192×8192 | fp16 | 1.11 | 9.73 | 8.8x | 0.24 |
| 1024×4096 | bf16 | 0.07 | 0.63 | 9.0x | 0.25 |
| 4096×4096 | bf16 | 0.26 | 2.45 | 9.4x | 0.26 |
| 8192×8192 | bf16 | 1.13 | 9.77 | 8.6x | 0.24 |

GPU: NVIDIA H200 (MIG 1g.18gb) | CUDA 12.8 | torch 2.10.0 | tilelang 0.1.7

## Test plan
- [x] 14/14 correctness tests pass
- [x] 10/10 benchmark tests pass
- [x] LayerNormOp exported from tileops.ops
- [ ] Reviewer gate review

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)