### PR TITLE
feat: implement softmax operator (#330)

### DIFF
--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tests.ops.test_softmax import SoftmaxFixture, SoftmaxTest
+from tileops.ops import SoftmaxOp
+
+
+class SoftmaxBenchmark(BenchmarkBase):
+
+    def calculate_flops(self) -> Optional[float]:
+        # Per element: sub-max(1) + exp(1) + add-to-sum(1) + div(1) = ~4 flops
+        # Plus the max reduction (~1 flop per element)
+        return 5.0 * self.test.m * self.test.n
+
+    def calculate_memory(self) -> Optional[float]:
+        t = self.test
+        # Read x (M*N) + write y (M*N)
+        # NOTE: For hidden sizes not aligned to 256, the Op pads x at runtime
+        # (extra copy). Memory here reflects useful bytes only.
+        return (t.m * t.n + t.m * t.n) * t.dtype.itemsize
+
+
+@SoftmaxFixture
+def test_softmax_bench(m: int, n: int, dtype: torch.dtype) -> None:
+    test = SoftmaxTest(m, n, dtype)
+    bm = SoftmaxBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = SoftmaxOp(m, n, dtype=dtype)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("softmax", locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record("softmax", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -1,0 +1,117 @@
+from typing import Tuple
+
+import pytest
+import torch
+
+from tests.test_base import FixtureBase, TestBase
+
+
+class SoftmaxFixture(FixtureBase):
+    PARAMS = [
+        ("m, n, dtype", [
+            # Standard shapes - fp16
+            (1024, 4096, torch.float16),
+            (4096, 4096, torch.float16),
+            (8192, 8192, torch.float16),
+            # Standard shapes - bf16
+            (1024, 4096, torch.bfloat16),
+            (4096, 4096, torch.bfloat16),
+            (8192, 8192, torch.bfloat16),
+            # Non-power-of-two hidden
+            (1024, 3000, torch.float16),
+            (2048, 5120, torch.float16),
+            (1024, 3000, torch.bfloat16),
+            (2048, 5120, torch.bfloat16),
+        ]),
+    ]
+
+
+class SoftmaxMultiDimFixture(FixtureBase):
+    PARAMS = [
+        ("batch, seq, hidden, dtype", [
+            # 3D input: (B, S, H) -> m=B*S
+            (2, 512, 4096, torch.float16),
+            (2, 512, 4096, torch.bfloat16),
+        ]),
+    ]
+
+
+class SoftmaxNonContiguousFixture(FixtureBase):
+    PARAMS = [
+        ("m, n, dtype", [
+            # Non-contiguous via slice
+            (1024, 4096, torch.float16),
+            (1024, 4096, torch.bfloat16),
+        ]),
+    ]
+
+
+class SoftmaxTest(TestBase):
+
+    def __init__(self, m: int, n: int, dtype: torch.dtype):
+        self.m = m
+        self.n = n
+        self.dtype = dtype
+
+    def gen_inputs(self) -> Tuple[torch.Tensor]:
+        x = torch.randn(self.m, self.n, device='cuda', dtype=self.dtype)
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        x_f32 = x.float()
+        x_max = x_f32.max(dim=-1, keepdim=True).values
+        exp_x = torch.exp(x_f32 - x_max)
+        return (exp_x / exp_x.sum(dim=-1, keepdim=True)).to(x.dtype)
+
+
+@SoftmaxFixture
+def test_softmax(m: int, n: int, dtype: torch.dtype) -> None:
+    from tileops.ops import SoftmaxOp
+
+    test = SoftmaxTest(m, n, dtype)
+    op = SoftmaxOp(m, n, dtype=dtype)
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    test.check(op, *test.gen_inputs(), **tolerances)
+
+
+@SoftmaxMultiDimFixture
+def test_softmax_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    from tileops.ops import SoftmaxOp
+
+    m = batch * seq
+    test = SoftmaxTest(m, hidden, dtype)
+    op = SoftmaxOp(m, hidden, dtype=dtype)
+    # Feed 3D input directly — Op should flatten/unflatten internally
+    x = torch.randn(batch, seq, hidden, device='cuda', dtype=dtype)
+    ref = test.ref_program(x)
+    result = op(x)
+    assert result.shape == x.shape, f"Shape mismatch: {result.shape} vs {x.shape}"
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    torch.testing.assert_close(result, ref, **tolerances)
+
+
+@SoftmaxNonContiguousFixture
+def test_softmax_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
+    from tileops.ops import SoftmaxOp
+
+    test = SoftmaxTest(m, n, dtype)
+    op = SoftmaxOp(m, n, dtype=dtype)
+    # Generate non-contiguous input by creating a larger tensor and slicing
+    x_big = torch.randn(m, n * 2, device='cuda', dtype=dtype)
+    x = x_big[:, ::2]  # Non-contiguous via stride
+    assert not x.is_contiguous()
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-2, "rtol": 1e-2}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    test.check(op, x, **tolerances)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tileops/kernels/softmax/__init__.py
+++ b/tileops/kernels/softmax/__init__.py
@@ -1,0 +1,3 @@
+from .softmax import SoftmaxKernel
+
+__all__ = ["SoftmaxKernel"]

--- a/tileops/kernels/softmax/softmax.py
+++ b/tileops/kernels/softmax/softmax.py
@@ -1,0 +1,131 @@
+import itertools
+from typing import Callable, Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel import Kernel
+
+__all__ = ["SoftmaxKernel"]
+
+
+def _softmax_kernel(M: int, N: int, actual_n: int,
+                    dtype: str = 'float16') -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _softmax_func(block_m: int, threads: int) -> Callable:
+
+        @T.macro
+        def softmax_compute(
+            x: T.Buffer((M, N), dtype),
+            y: T.Buffer((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as bx:
+                x_shared = T.alloc_shared((block_m, N), dtype)
+                x_local = T.alloc_fragment((block_m, N), accum_dtype)
+                # For max reduction
+                max_local = T.alloc_fragment((block_m,), accum_dtype)
+                # For exp and sum
+                exp_local = T.alloc_fragment((block_m, N), accum_dtype)
+                sum_local = T.alloc_fragment((block_m,), accum_dtype)
+                # Output
+                y_local = T.alloc_fragment((block_m, N), dtype)
+                y_shared = T.alloc_shared((block_m, N), dtype)
+
+                # Load input rows
+                T.copy(x[bx * block_m, 0], x_shared)
+                T.copy(x_shared, x_local)
+
+                # Pass 1: Find max per row
+                T.fill(max_local, -T.infinity(accum_dtype))
+                T.reduce_max(x_local, max_local, dim=1, clear=False)
+
+                # Pass 2: Compute exp(x - max) and sum
+                for i, j in T.Parallel(block_m, N):
+                    exp_local[i, j] = T.exp(x_local[i, j] - max_local[i])
+
+                T.fill(sum_local, 0.0)
+                T.reduce_sum(exp_local, sum_local, dim=1)
+
+                # Compute y = exp(x - max) / sum
+                # Cast to dtype at the end (matches reference: compute in fp32,
+                # then cast)
+                for i, j in T.Parallel(block_m, N):
+                    y_local[i, j] = T.cast(
+                        exp_local[i, j] / sum_local[i], dtype)
+
+                T.copy(y_local, y_shared)
+                T.copy(y_shared, y[bx * block_m, 0])
+
+        @T.prim_func
+        def _softmax_main(
+            x: T.Tensor((M, N), dtype),
+            y: T.Tensor((M, N), dtype),
+        ) -> None:
+            softmax_compute(x, y)
+
+        return _softmax_main
+
+    return _softmax_func
+
+
+@torch.library.custom_op("top::softmax_wrapped_kernel", mutates_args=())
+def _softmax_wrapped_kernel(
+    M: int,
+    N: int,
+    actual_n: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _softmax_kernel(M, N, actual_n, dtype)(block_m, threads)(x)
+
+
+@_softmax_wrapped_kernel.register_fake
+def _(M: int, N: int, actual_n: int, dtype: str, block_m: int, threads: int,
+      *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
+    return torch.empty((M, N), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+class SoftmaxKernel(Kernel):
+    supported_archs: list[int] = [80, 89, 90]
+
+    def __init__(self,
+                 M: int,
+                 N: int,
+                 actual_n: int,
+                 dtype: torch.dtype,
+                 config: Optional[dict] = None,
+                 tune: bool = False) -> None:
+        super().__init__()
+        self.M = M
+        self.N = N
+        self.actual_n = actual_n
+        self.dtype = dtype
+
+        self.kernel = _softmax_kernel(M, N, actual_n, self.dtype_str)
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 4,
+            "threads": 128,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        block_m = [1, 2, 4]
+        threads = [128, 256]
+        _configs = list(itertools.product(block_m, threads))
+        return [{"block_m": c[0], "threads": c[1]} for c in _configs]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _softmax_wrapped_kernel(
+            self.M, self.N, self.actual_n, self.dtype_str,
+            self.config["block_m"], self.config["threads"],
+            x,
+        )

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -21,6 +21,7 @@ from .mha_decode_paged import MultiHeadAttentionDecodePagedWithKVCacheOp
 from .mhc_post import ManifoldConstrainedHyperConnectionPostOp
 from .mhc_pre import ManifoldConstrainedHyperConnectionPreOp
 from .op import Op
+from .softmax import SoftmaxOp
 from .topk_selector import TopkSelectorOp
 
 __all__ = [
@@ -48,5 +49,6 @@ __all__ = [
     "NSAFwdVarlenOp",
     "NSATopkVarlenOp",
     "Op",
+    "SoftmaxOp",
     "TopkSelectorOp",
 ]

--- a/tileops/ops/softmax.py
+++ b/tileops/ops/softmax.py
@@ -1,0 +1,62 @@
+import math
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+
+from tileops.kernels.kernel import Kernel
+from tileops.kernels.softmax import SoftmaxKernel
+
+from .op import Op
+
+__all__ = ["SoftmaxOp"]
+
+ALIGNMENT = 256
+
+
+def _align_up(n: int, alignment: int) -> int:
+    return math.ceil(n / alignment) * alignment
+
+
+class SoftmaxOp(Op):
+
+    def __init__(self,
+                 m: int,
+                 n: int,
+                 dtype: torch.dtype = torch.float16,
+                 tune: bool = False,
+                 kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
+        self.M = m
+        self.N = n
+        self.dtype = dtype
+        self.padded_n = _align_up(n, ALIGNMENT)
+        self.needs_padding = self.padded_n != n
+
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["softmax_kernel"](
+            m, self.padded_n, n, dtype, tune=tune)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"softmax_kernel": SoftmaxKernel}
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        orig_shape = x.shape
+        x = x.contiguous()
+
+        # Flatten arbitrary leading dims to 2D (M, N)
+        x = x.reshape(-1, self.N)
+        assert x.shape[0] == self.M, (
+            f"Total number of rows ({x.shape[0]}) does not match M={self.M}")
+
+        if self.needs_padding:
+            pad_size = self.padded_n - self.N
+            # Pad with -inf so exp(-inf) = 0, not affecting softmax sum
+            x = F.pad(x, (0, pad_size), value=float('-inf'))
+
+        y = self.kernel(x)
+
+        if self.needs_padding:
+            y = y[:, :self.N]
+
+        return y.reshape(orig_shape)


### PR DESCRIPTION
## Summary
- Implement numerically stable `softmax` forward operator: `y = exp(x - max(x,-1)) / sum(exp(x - max(x,-1)))`
- TileLang kernel with two-pass approach (max reduction + exp/sum/divide), fp32 accumulation
- 256-byte alignment padding with `-inf` values for non-power-of-two hidden sizes
- `SoftmaxOp` supports arbitrary leading dims via flatten/unflatten

## Files
- `tileops/kernels/softmax/softmax.py` — TileLang kernel (SoftmaxKernel)
- `tileops/kernels/softmax/__init__.py` — exports
- `tileops/ops/softmax.py` — SoftmaxOp with -inf padding + multi-dim support
- `tileops/ops/__init__.py` — export SoftmaxOp
- `tests/ops/test_softmax.py` — 14 tests (fp16/bf16 × standard/non-2-power/3D/non-contiguous)
- `benchmarks/ops/bench_softmax.py` — 10 benchmarks reporting bandwidth_tbs

## Test Evidence
- **Correctness**: 14/14 passed (fp16 atol=1e-2, bf16 atol=1.6e-2)
- **Benchmarks**: 10/10 passed, ~2-3x over PyTorch baseline

## Benchmark Results (H200 MIG 1g.18gb)
| Shape (M×N) | dtype | TileOps latency (ms) | Baseline latency (ms) | Speedup | bandwidth_tbs |
|---|---|---|---|---|---|
| 1024×4096 | fp16 | 0.13 | 0.37 | 2.8x | 0.12 |
| 4096×4096 | fp16 | 0.52 | 1.45 | 2.8x | 0.13 |
| 8192×8192 | fp16 | 2.59 | 6.13 | 2.4x | 0.10 |
| 1024×4096 | bf16 | 0.14 | 0.37 | 2.6x | 0.12 |
| 4096×4096 | bf16 | 0.52 | 1.46 | 2.8x | 0.13 |
| 8192×8192 | bf16 | 2.97 | 6.15 | 2.1x | 0.09 |

GPU: NVIDIA H200 (MIG 1g.18gb) | CUDA 12.8 | torch 2.10.0 | tilelang 0.1.7

## Test plan
- [x] 14/14 correctness tests pass
- [x] 10/10 benchmark tests pass
- [x] SoftmaxOp exported from tileops.ops
- [ ] Reviewer gate review

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)