### PR TITLE
[Fix][Bench] Fix grouped gemm complete benchmark test class

### DIFF
--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -179,7 +179,7 @@ class GroupedGemmCompleteFixture(FixtureBase):
     ]
 
 
-class GroupedGemmCompleteTest(TestBase):
+class GroupedGemmCompleteTest:
     """Parameter holder for GroupedGemmCompleteBenchmark (forward NT + backward NN + backward TN).
 
     The benchmark test function profiles each variant (NT/NN/TN) individually


### PR DESCRIPTION
Closes #341

## Summary
- Fix `GroupedGemmCompleteTest` instantiation failure in grouped GEMM complete benchmark.
- Change `GroupedGemmCompleteTest` from `TestBase` subclass to a plain parameter-holder class, since it does not implement `gen_inputs`/`ref_program`.

## Test plan
- [x] `python -m pytest -q benchmarks/ops/bench_grouped_gemm.py`
- [x] `.claude/skills/committing-changes/scripts/validate.sh --pre`
- [x] `.claude/skills/committing-changes/scripts/validate.sh --post`

## Regression
- Before fix: `TypeError: Can't instantiate abstract class GroupedGemmCompleteTest with abstract methods gen_inputs, ref_program`
- After fix: benchmark test suite passes (`5 passed`).