### PR TITLE
[Refactor][Skill] Extract TileLang facts and case studies from skills to wiki KB

### DIFF
--- a/.claude/skills/kernel-debug/skill.md
+++ b/.claude/skills/kernel-debug/skill.md
@@ -1,11 +1,12 @@
 ---
 name: kernel-debug
-description: Debugging patterns and pitfalls for TileLang GPU kernels in TileOPs — correctness triage, JIT cache, pipeline pitfalls
+description: Debugging SOP for TileLang GPU kernels in TileOPs — correctness triage workflow, common failure signals, and when to check the wiki KB
 ---
 
 # TileOps / TileLang Kernel Debugging Guide
 
-> Debugging patterns and pitfalls when writing and tuning custom GPU kernels with TileLang, based on hands-on experience in TileOps.
+> Step-by-step process for diagnosing correctness failures in TileLang kernels.
+> TileLang-specific facts (API pitfalls, error semantics, JIT cache behaviour) live in the wiki Knowledge Base — this skill references them rather than duplicating them.
 
 ______________________________________________________________________
 
@@ -15,14 +16,16 @@ ______________________________________________________________________
 
 **First question**: does the error reproduce across ALL configs (block sizes, pipeline stages) for the same shape?
 
-| Error pattern                                 | Likely cause                                                  |
-| --------------------------------------------- | ------------------------------------------------------------- |
-| Same max_err for all configs, same shape      | Shape-level bug (alignment, index formula, boundary handling) |
-| Error only for specific (block_n, num_stages) | Code path bug in that branch                                  |
-| Error only when `tune=True`                   | Autotune corrupts state or selects a broken config            |
-| Intermittent / changes across runs            | Race condition or uninitialized memory                        |
+| Error pattern                                   | Likely cause                                                  |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| Same `max_err` for all configs, same shape      | Shape-level bug (alignment, index formula, boundary handling) |
+| Error only for specific `(block_n, num_stages)` | Code-path bug in that branch                                  |
+| Error only when `tune=True`                     | Autotune corrupts state or selects a broken config            |
+| Intermittent / changes across runs              | Race condition or uninitialized memory                        |
 
-**How to test**: Run the kernel directly with several explicit configs for the failing shape:
+For a full interpretation table and sweep recipe → [Validation Rules — Error Pattern Interpretation](https://github.com/tile-ai/TileOPs/wiki/TileLang-Validation-Rules#error-pattern-interpretation)
+
+**How to test**: run the kernel directly with several explicit configs for the failing shape:
 
 ```python
 configs = [(1, 32, 1), (4, 32, 2), (8, 32, 3), ...]
@@ -34,92 +37,26 @@ for block_n, rt, ns in configs:
 
 ### 1.2 Distinguish numerical precision from implementation bugs
 
-- **fp16 matmul**: expected max_err ≈ `1e-2` for large K (PyTorch uses Tensor Cores, our kernel uses fp32 accum — different rounding paths)
-- **Suspicious values**: exact powers of 2 (0.125, 0.25, 0.5) usually indicate a **systematic offset** from a wrong index or missing reduction term, not rounding
-- **max_err > 0.1 with `atol=1e-3`**: almost certainly an implementation bug, not numerical
+- **fp16 matmul**: expected `max_err ≈ 1e-2` for large K (different rounding paths)
+- **Exact powers of 2** (0.125, 0.25, 0.5): systematic index offset — not rounding
+- **`max_err > 0.1` with `atol=1e-3`**: almost certainly an implementation bug
 
 ### 1.3 Random seed dependence in pytest vs inline scripts
 
-**Pitfall**: `torch.manual_seed(1235)` at session start does NOT mean inline scripts reproduce the same tensor values as pytest. pytest advances the RNG through all preceding test cases before reaching the failing one.
-
-**Consequence**: an inline diagnostic script may show different max_err from what pytest actually observes. Do not use inline diagnostics to confirm "the tests now pass" — always run pytest.
-
-**Rule**: use inline scripts only to scan across configs; use pytest for the authoritative pass/fail verdict.
+`torch.manual_seed(1235)` at session start does NOT guarantee the same tensor values as pytest (pytest advances the RNG through all preceding tests). Use inline scripts to scan configs; use pytest for the authoritative pass/fail verdict.
 
 ______________________________________________________________________
 
-## 2. TileLang-Specific Pitfalls
+## 2. TileLang-Specific Pitfalls (Quick Reference)
 
-### 2.1 Sentinel values for pipeline depth
+These are the most common TileLang API mistakes encountered in TileOps. Full details in the wiki.
 
-**Bad pattern**: using `num_stages=0` as "disable pipeline" sentinel.
-
-```python
-# WRONG: ambiguous, semantically invalid for T.Pipelined
-if num_stages > 0:
-    for bk in T.Pipelined(..., num_stages=num_stages):
-        ...
-else:
-    for bk in T.serial(...):
-        ...
-```
-
-**Problem**: `T.Pipelined` requires `num_stages >= 1`. Using 0 as a sentinel mixes concerns (pipeline depth vs. code path selection), and if `@tilelang.jit` traces `@T.prim_func` in a way that doesn't treat the `if` as purely compile-time, both branches may interfere.
-
-**Correct pattern**: always `num_stages >= 1`, let the pipeline handle the "no overlap" case with `num_stages=1`:
-
-```python
-# CORRECT: num_stages=1 = sequential (no overlap), >=2 = actual pipeline
-b_shared = T.alloc_shared((block_n, block_k), dtype)
-for bk in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
-    T.copy(b[bn * block_n, bk * block_k], b_shared, disable_tma=True)
-    ...
-```
-
-**Autotune configs**:
-
-```python
-# num_stages=1 is the baseline (shmem, no pipeline overlap)
-# num_stages=2,3 are the actual candidates for latency hiding
-for ns in [1, 2, 3]:
-    ...
-```
-
-### 2.2 TMA vs cp.async for T.copy
-
-`T.copy` on SM90 defaults to TMA, which requires `mbarrier` PTX and layout inference that TileLang cannot always infer for manually-indexed shared memory in non-WGMMA kernels.
-
-**Symptom**: compilation error mentioning `mbarrier` or undefined symbol.
-
-**Fix**: add `disable_tma=True` to use `cp.async` instead:
-
-```python
-T.copy(b[bn * block_n, bk * block_k], b_shared, disable_tma=True)
-```
-
-Note: `cp.async` still hides HBM latency when used inside `T.Pipelined`, just without TMA's extra features.
-
-### 2.3 Thread sync API
-
-TileLang uses `T.sync_threads()` (with underscore), **not** `T.syncthreads()`.
-
-```python
-# WRONG
-T.syncthreads()  # AttributeError: module has no attribute 'syncthreads'
-
-# CORRECT
-T.sync_threads()
-```
-
-### 2.4 JIT cache staleness
-
-`@tilelang.jit` caches compiled kernels on disk. When the kernel signature or structure changes (e.g., adding a new parameter), the old cached binary may be reused if the cache key doesn't capture the change.
-
-**Symptom**: correctness failure that disappears after clearing the cache or in a fresh environment.
-
-**When to clear**: after any structural change to `_gemv_func` or `_gemv_main` (new parameters, changed branching logic).
-
-**Cache location**: typically `~/.tilelang/cache/` or `$TILELANG_CACHE_DIR`.
+| Pitfall                                                         | Fix                                                     | Wiki reference                                                                                                                 |
+| --------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `num_stages=0` as sentinel for `T.Pipelined`                    | Always use `num_stages >= 1`; use `1` for sequential    | [Anti-Patterns #25](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns#25-num_stages0-as-sentinel-for-t-pipelined) |
+| `T.copy` on SM90 uses TMA by default; fails for non-WGMMA shmem | Add `disable_tma=True`                                  | [Language Spec — Data Movement](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec#data-movement)                  |
+| `T.syncthreads()` — wrong name                                  | Use `T.sync_threads()` (underscore)                     | [Anti-Patterns #26](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns#26-tsyncthreads--wrong-sync-api-name)       |
+| JIT cache serves stale binary after structural change           | `tilelang.clear_cache()` or `rm -rf ~/.tilelang/cache/` | [Language Spec — JIT Cache](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec#jit-compilation-cache)              |
 
 ______________________________________________________________________
 
@@ -132,7 +69,7 @@ ______________________________________________________________________
 4. Check for semantically invalid parameter values (num_stages=0, etc.)
 5. Clear JIT cache; re-run → stale cache eliminated?
 6. If numerical: compare accumulation dtypes (fp16 vs fp32 vs tf32)
-7. If systematic offset: inspect reduction scope — missing thread, double-counted element?
+7. If systematic offset (power-of-2 error): inspect reduction scope — missing thread, double-counted element?
 8. Add targeted prints (out[0:10], ref[0:10]) to find the pattern
 ```
 
@@ -140,30 +77,15 @@ ______________________________________________________________________
 
 ## 4. Case Studies
 
-### Case A: `num_stages=0` caused persistent correctness failures (2026-02-27)
-
-**Shape**: `(n=18432, k=7168, fp16, tune=True)`
-**Error**: `max_err=0.125`–`0.25` across ALL configs, reproducible
-**Initial wrong hypothesis**: config-specific bug in the autotune winner (block_n=4)
-**Actual root cause**: `num_stages=0` is semantically invalid for a pipeline parameter; the Python `if num_stages > 0: ... else:` inside `@T.prim_func` created ambiguity in TileLang's tracing, potentially including both branches or causing JIT cache conflicts when the signature changed from O1 (no `num_stages` param) to O3 (with `num_stages` param)
-
-**Fix**: Removed `else` branch entirely. Always use `T.Pipelined` with `num_stages >= 1`. Register-only fallback eliminated from autotune.
-
-**Diagnostic that cracked it**:
-
-```
-block_n= 1 rt=32 ns=0  max_err=0.1250  [FAIL]
-block_n= 4 rt=32 ns=0  max_err=0.1250  [FAIL]
-block_n= 4 rt=32 ns=2  max_err=0.1250  [FAIL]
-→ all configs fail with identical error → not config-specific → design flaw
-```
-
-**Lesson**: identical max_err across all configs → the design concept is wrong, not the implementation detail. Fix the concept first.
+| Case | Summary                                                                                                         | Detail                                                                                                      |
+| ---- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| A    | `num_stages=0` sentinel → `max_err=0.125` across **all** configs; identical error = design flaw, not config bug | [Case Studies A](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-a-num_stages0-sentinel) |
 
 ______________________________________________________________________
 
 ## 5. References
 
-- [TileLang Source — pipelined loops](https://github.com/tile-ai/tilelang)
-- [CUDA cp.async Programming Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#asynchronous-data-copies)
-- [TVM TIR IfThenElse vs Python conditionals](https://tvm.apache.org/docs/reference/langref/relay_expr.html)
+- [TileLang Anti-Patterns](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns)
+- [TileLang Language Spec](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec)
+- [TileLang Validation Rules](https://github.com/tile-ai/TileOPs/wiki/TileLang-Validation-Rules)
+- [TileLang Case Studies](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies)

--- a/.claude/skills/tune-multiplication/skill.md
+++ b/.claude/skills/tune-multiplication/skill.md
@@ -1,38 +1,32 @@
 ---
 name: tune-multiplication
-description: Optimization patterns and lessons learned for matrix-related operators (GEMV, GEMM, Grouped GEMM) in TileOPs
+description: Optimization SOP for matrix-related operators (GEMV, GEMM, Grouped GEMM) in TileOPs
 ---
 
 # Matrix Multiplication Kernel Tuning Guide
 
-> Optimization patterns and lessons learned for matrix-related operators (GEMV, GEMM, Grouped GEMM) in TileOps, written to guide future kernel work.
+> Optimization process and lessons learned for GEMV, GEMM, and Grouped GEMM kernels in TileOps.
+> Hardware numbers (roofline, peak BW, alignment constraints) live in the wiki KB — this skill references them rather than embedding them.
 
 ______________________________________________________________________
 
 ## 1. Core Principle: Profile the Bottleneck First
 
-Before tuning any kernel, compute the **arithmetic intensity**:
+Before tuning any kernel, compute the **arithmetic intensity** to classify the bottleneck:
 
 ```
 Arithmetic Intensity = FLOPs / Bytes
                      = 2MNK / ((MK + KN + MN) × dtype.itemsize)
 ```
 
-Compare against the GPU roofline:
+Then compare against the GPU roofline crossover point to determine if the kernel is **memory-bound** or **compute-bound**.
 
-| GPU      | Peak FP16    | Memory BW | Roofline crossover |
-| -------- | ------------ | --------- | ------------------ |
-| H100 SXM | ~1979 TFLOPS | 3.35 TB/s | ~591 FLOPs/Byte    |
-| H200 SXM | ~1979 TFLOPS | 4.8 TB/s  | ~412 FLOPs/Byte    |
-| A100 SXM | ~312 TFLOPS  | 2.0 TB/s  | ~156 FLOPs/Byte    |
+→ GPU peak numbers, crossover points, and roofline table: [Hardware Constraints — GPU Roofline Model](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#gpu-roofline-model)
 
-- **Intensity < crossover** → Memory-bound: prioritize memory access patterns
-- **Intensity > crossover** → Compute-bound: prioritize Tensor Core utilization
-
-**Typical cases**:
+**Typical cases:**
 
 - GEMV (M=1): intensity ≈ 1 FLOPs/Byte → **heavily memory-bound**
-- GEMM (large M): high intensity → **compute-bound**, Tensor Core is critical
+- GEMM (large M): high intensity → **compute-bound**, Tensor Core utilization is critical
 
 ______________________________________________________________________
 
@@ -40,38 +34,17 @@ ______________________________________________________________________
 
 ### 2.1 Coalescing Is the Top Priority
 
-**Rule**: Threads within a warp (32 consecutive linear thread IDs) must access consecutive memory addresses.
+Threads within a warp (32 consecutive `threadIdx.x` values) must access consecutive memory addresses.
 
-In TileLang, thread layout determines the access pattern:
+In TileLang, `threads=(dim_x, dim_y)` maps `threadIdx.x` to the first (fast-varying) dimension. For row-major matrices the fast-varying thread dimension must correspond to the **column index**.
 
-```python
-# threads=(dim_x, dim_y): threadIdx.x is the fast-varying dimension (varies within a warp)
-with T.Kernel(..., threads=(dim_x, dim_y)) as block_idx:
-    tx = T.get_thread_binding(0)  # threadIdx.x — varies within a warp
-    ty = T.get_thread_binding(1)  # threadIdx.y — varies across warps
-```
+→ Thread layout semantics: [Language Spec — Kernel Launch](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec#kernel-launch)
 
-**Lesson from GEMV (issue #232)**:
+**Checklist:**
 
-Original `threads=(block_n, reduce_threads)` made `tn = threadIdx.x`, so threads within a warp accessed different rows of B at the same column:
-
-```
-warp: B[row+0, col], B[row+1, col], ..., B[row+31, col]
-stride = K × sizeof(dtype) ≈ 32 KB (for k=16384) → 32-way strided access
-```
-
-Fix: swap to `threads=(reduce_threads, block_n)` so `tk = threadIdx.x`; the warp now accesses consecutive columns of the same row:
-
-```
-warp: B[row, col+0:8], B[row, col+8:16], ..., B[row, col+248:256]
-→ 512 bytes fully coalesced, approaching peak bandwidth
-```
-
-**Checklist**:
-
-- [ ] Row-major matrix: fast-varying thread dim must correspond to the column index
-- [ ] Stride between consecutive threads must be `sizeof(dtype)` (1–2 bytes)
-- [ ] Use 128-bit vectorized loads: 8 fp16/bf16 elements per transaction
+- [ ] Fast-varying thread dim maps to column index of the row-major matrix
+- [ ] Stride between consecutive threads is `sizeof(dtype)` (1–2 bytes)
+- [ ] 128-bit vectorized loads: 8 fp16/bf16 elements per transaction
 
 ### 2.2 Shared Memory Reuse to Cut Global Traffic
 
@@ -79,37 +52,34 @@ When multiple outputs reuse the same input tile, cache it in shared memory:
 
 ```python
 a_shared = T.alloc_shared((block_k,), dtype)
-# Load once; all block_n rows share this tile
 for _k in T.vectorized(tile_k):
     a_shared[tk * tile_k + _k] = a[bk * block_k + tk * tile_k + _k]
-T.syncthreads()
-# Use a_shared in FMA instead of global memory
+T.sync_threads()
+# use a_shared in FMA instead of global memory
 ```
 
 **Savings** = `(block_n - 1) / block_n`; larger `block_n` gives more benefit.
 
-**Bank conflict note**:
+→ Bank conflict padding pattern: [Anti-Patterns #27](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns#27-missing-shared-memory-padding-for-bank-conflicts)
 
-- Shared memory has 32 banks of 4 bytes each
-- fp16: 2 elements/bank; `tile_k=8` spans 4 banks — no conflict
-- If conflicts occur, add padding: `T.alloc_shared((block_k + 1,), dtype)`
+> **Note:** On H200, vectors that fit in L1 cache (< 128 KB) are already deduplicated by hardware — explicit shmem for small repeated inputs yields negligible benefit. See [Case Studies B.2](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b2-o2-shared-memory-for-a).
 
 ### 2.3 Optimal Reduce Configuration
 
-For memory-bound reductions:
-
-- Use a **full warp (32 threads)** for reduction to leverage `__shfl_down_sync` hardware
+- Use a **full warp (32 threads)** for reduction to leverage `__shfl_down_sync`
 - `reduce_threads < 32` causes cross-row access within a warp, breaking coalescing
-- TileLang's `tvm_thread_allreduce` maps to the most efficient warp shuffle when `reduce_threads = 32`
+- TileLang's `tvm_thread_allreduce` maps to efficient warp shuffle when `reduce_threads=32`
 
 ### 2.4 Hopper / H200 Specific Features
 
-| Feature                         | Use Case                        | TileLang API (reference)        |
-| ------------------------------- | ------------------------------- | ------------------------------- |
-| TMA (Tensor Memory Accelerator) | Async large-tile loads          | `T.use_tma` / pipeline          |
-| WarpGroup GEMM (WGMMA)          | Compute-bound GEMM              | `T.gemm` with wgmma backend     |
-| 50 MB L2 Cache                  | Small repeated vectors/matrices | Automatic — no special handling |
-| cp.async pipeline               | Hide memory latency             | `T.pipeline()`                  |
+| Feature                         | Use Case               | TileLang API                         |
+| ------------------------------- | ---------------------- | ------------------------------------ |
+| TMA (Tensor Memory Accelerator) | Async large-tile loads | `T.use_tma` / pipeline               |
+| WarpGroup GEMM (WGMMA)          | Compute-bound GEMM     | `T.gemm` with wgmma backend          |
+| 50 MB L2 Cache                  | Small repeated vectors | Automatic — no special handling      |
+| cp.async pipeline               | Hide memory latency    | `T.Pipelined()` + `disable_tma=True` |
+
+→ WGMMA alignment requirements, SM90 shared memory limits: [Hardware Constraints](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#wgmma-tile-size-constraints)
 
 ______________________________________________________________________
 
@@ -117,33 +87,21 @@ ______________________________________________________________________
 
 ### 3.1 Tensor Core Alignment
 
-WGMMA on SM90 requires:
+WGMMA on SM90 requires specific tile size multiples. Misaligned tile sizes cause Tensor Core utilization to collapse.
 
-- M: multiple of 64 (warp group = 4 warps = 128 threads)
-- N: multiple of 8
-- K: multiple of 16 for fp16/bf16; multiple of 32 for fp8
-
-Misaligned tile sizes cause Tensor Core utilization to collapse.
+→ Exact alignment requirements (M, N, K per dtype): [Hardware Constraints — WGMMA Tile Size Constraints](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#wgmma-tile-size-constraints)
 
 ### 3.2 Tile Size Selection
 
-For SM90 (H200):
+For SM90 (H200), the total shared memory usage must stay within the device limit per SM.
 
-```
-block_M × block_N × block_K × 2 × dtype_bytes ≤ 192 KB shared memory
-block_M = 64 or 128   (WGMMA alignment)
-block_N = 128–256
-block_K = 32–64       (minimum unit for latency hiding)
-```
+→ SM90 shared memory capacity and tile sizing guidance: [Hardware Constraints](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#shared-memory-smem)
 
 ### 3.3 Double-Buffering Pipeline
 
-```python
-# Prefetch tile k+1 while computing tile k
-# TileLang controls pipeline depth via pipeline stages parameter
-```
+For H200 (high BW + high compute), pipeline depth 2–4 is usually optimal. Always use `num_stages >= 1` — `num_stages=0` is semantically invalid.
 
-For H200 (high BW + high compute), pipeline depth 2–4 is usually optimal.
+→ Pipeline pitfall: [Anti-Patterns #25](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns#25-num_stages0-as-sentinel-for-t-pipelined)
 
 ______________________________________________________________________
 
@@ -151,7 +109,7 @@ ______________________________________________________________________
 
 ### 4.1 Search Space Design
 
-**Principle**: Cover hardware-aligned configurations; avoid redundant candidates.
+**Principle:** Cover hardware-aligned configurations; avoid redundant candidates.
 
 Recommended search space for GEMV (SM90):
 
@@ -171,7 +129,7 @@ Recommended search space for GEMM (SM90):
 block_M = [64, 128]
 block_N = [64, 128, 256]
 block_K = [32, 64]
-# Constraint: block_M × block_N × block_K × 2 × dtype_bytes ≤ 192 KB
+# Constraint: total shmem usage ≤ device limit per SM
 ```
 
 ### 4.2 Autotune Best Practices
@@ -201,197 +159,21 @@ ______________________________________________________________________
 
 ## 6. Case Studies
 
-### Case 1: GEMV Coalescing Fix (2026-02-27)
-
-- **Issue**: [[PERF][GEMV] tile-ai/TileOPs#232](https://github.com/tile-ai/TileOPs/issues/232)
-
-- **Root cause**: `threads=(block_n, reduce_threads)` → stride-K access to B; effective BW ~3%
-
-- **Affected shapes**: `(7168, 16384)`, `(18432, 7168)` in fp16/bf16
-
-- **Changes made**:
-
-  - O1: Swapped thread dims → `threads=(reduce_threads, block_n)`, `tk = threadIdx.x`
-  - O3: Default `reduce_threads=32` (full warp), `block_n=16` for SM90
-  - O4/O5: Autotune search space expanded to `block_n=[1,2,4,8,16,32]` + `reduce_threads=32`
-
-- **Autotune best configs** (from test run):
-
-  - `(n=7168, k=16384)`: `block_n=8, reduce_threads=32`
-  - `(n=18432, k=7168)`: `block_n=1, reduce_threads=32`
-
-- **Benchmark results** vs `torch` baseline (H200, fp16, tuned):
-
-  | Shape (n, k)  | tileops BW (GB/s) | baseline BW (GB/s) | speedup |
-  | ------------- | ----------------- | ------------------ | ------- |
-  | (7168, 16384) | **3.65**          | 3.34               | 1.09×   |
-  | (18432, 7168) | **3.85**          | 3.34               | 1.15×   |
-  | (1024, 1024)  | **0.76**          | 0.26               | 2.9×    |
-
-- **H200 peak BW**: 4.8 TB/s → achieved ~80% utilization on large shapes
-
-- **Lesson**: For small shapes (n=k=1024), the gap vs baseline is larger (2.9×) because
-  torch's `b @ a` has higher dispatch overhead at small sizes; for large shapes both
-  approach the roofline together (~3.3–3.9 TB/s effective BW)
-
-- **Next step (O3)**: Pipeline B loads via `T.Pipelined + T.copy(disable_tma=True)` with
-  `num_stages >= 1` to hide HBM3e latency using cp.async
-
-### Case 1 addendum: O3 pipelined B loads (2026-02-27)
-
-**Implementation**:
-
-- Replaced `T.serial` loop + direct register loads with `T.Pipelined + T.copy + b_shared`
-- `T.copy(b[bn * block_n, bk * block_k], b_shared, disable_tma=True)` — `disable_tma=True` is required on SM90 to use `cp.async` instead of TMA (TMA needs `mbarrier` that TileLang can't infer for manually-indexed shared memory in non-WGMMA kernels)
-- `num_stages=1`: sequential through shared memory (no overlap)
-- `num_stages=2`: double-buffer (one tile prefetching while current tile is consumed)
-- `num_stages=3`: triple-buffer
-
-**Design decision**: eliminated `num_stages=0` (register-only fallback) entirely. Using 0 as a sentinel for "disable pipeline" is semantically invalid — `T.Pipelined` requires `num_stages >= 1`. The Python `if num_stages > 0:` branch inside `@T.prim_func` caused JIT cache ambiguity and persistent correctness failures. See `.claude/skills/kernel-debug/skill.md` Case A for details.
-
-**Autotune space after O3**:
-
-```python
-[
-    {"block_n": bn, "reduce_threads": 32, "num_stages": ns}
-    for bn in [1, 2, 4, 8, 16]
-    for ns in [1, 2, 3]
-]  # 15 configs total
-```
-
-**Autotune winners** (SM90 / H200):
-
-- `(n=7168,  k=16384)`: `block_n=1, num_stages=3`
-- `(n=18432, k=7168)`: `block_n=1, num_stages=3`
-- `(n=18432, k=7168, bf16)`: `block_n=2, num_stages=3`
-
-**Benchmark results vs torch baseline** (H200, tuned):
-
-| Shape (n, k)  | dtype | tileops BW | baseline BW | speedup |
-| ------------- | ----- | ---------- | ----------- | ------- |
-| (7168, 16384) | fp16  | 3.47 TB/s  | 3.34 TB/s   | 1.04×   |
-| (18432, 7168) | fp16  | 3.83 TB/s  | 3.34 TB/s   | 1.15×   |
-| (7168, 16384) | bf16  | 3.62 TB/s  | 3.35 TB/s   | 1.08×   |
-| (18432, 7168) | bf16  | 3.78 TB/s  | 3.35 TB/s   | 1.13×   |
-| (1024, 1024)  | fp16  | 0.57 TB/s  | 0.26 TB/s   | 2.2×    |
-
-**Important finding**: O3 pipelined shared-memory path is slightly slower than O1 register-only path for `(7168, 16384)` (3.47 vs 3.65 TB/s). Shared memory adds:
-
-- Allocation and TLB overhead for `b_shared`
-- Potential bank conflict (32 threads × 8 elements across 32 banks)
-- `cp.async` setup cost, especially for small `block_n=1`
-
-For shapes with large K (16384), the register path's latency is already partially hidden by the GPU's out-of-order execution; cp.async adds minimal incremental benefit. For shapes with smaller K (7168), O3 helps more (+14.7%) because HBM latency is less naturally hidden.
-
-### Case 1 addendum: Large shape validation (2026-02-27)
-
-Added LLM production-scale shapes to benchmark and test suite:
-
-- `(n=28672, k=8192)` — Llama-3 70B MLP gate/up projection
-- `(n=57344, k=7168)` — DeepSeek-V3 MoE aggregated output (8 experts × 7168)
-
-**Benchmark results** (H200, tuned, `benchmarks/ops/bench_gemv.py`):
-
-| Shape (n, k)  | dtype | tileops BW | baseline BW | speedup | H200 utilization |
-| ------------- | ----- | ---------- | ----------- | ------- | ---------------- |
-| (7168, 16384) | fp16  | 3.47 TB/s  | 3.34 TB/s   | 1.04×   | 72%              |
-| (18432, 7168) | fp16  | 3.80 TB/s  | 3.34 TB/s   | 1.14×   | 79%              |
-| (28672, 8192) | fp16  | 4.02 TB/s  | 3.80 TB/s   | 1.06×   | 84%              |
-| (57344, 7168) | fp16  | 4.26 TB/s  | 3.92 TB/s   | 1.09×   | 89%              |
-| (7168, 16384) | bf16  | 3.61 TB/s  | 3.35 TB/s   | 1.08×   | 75%              |
-| (18432, 7168) | bf16  | 3.75 TB/s  | 3.34 TB/s   | 1.12×   | 78%              |
-| (28672, 8192) | bf16  | 4.08 TB/s  | 3.81 TB/s   | 1.07×   | 85%              |
-| (57344, 7168) | bf16  | 4.30 TB/s  | 3.93 TB/s   | 1.09×   | 90%              |
-
-**Key trend**: larger shapes → higher utilization. `n=57344` gives ~4× more blocks than `n=7168`, placing ~13.5 blocks/SM vs ~3.4 blocks/SM. More warps per SM → better HBM3e latency hiding → 89–90% of peak 4.8 TB/s.
-
-**Lesson**: for GEMV on Hopper, the practical utilization ceiling rises with problem size due to increased warp-level parallelism covering HBM latency. Small shapes (n=1024) remain far below peak due to low occupancy.
-
-### Case 1 addendum: O2 shared memory for `a` (2026-02-27)
-
-**Hypothesis**: caching `a` in shared memory (only `tn==0` warp writes, all rows read)
-would reduce `a` global traffic by `(block_n-1)/block_n`, yielding measurable speedup.
-
-**Implementation notes**:
-
-- TileLang sync API is `T.sync_threads()` (NOT `T.syncthreads()` — easy mistake)
-- Used Python compile-time flag `use_shmem_a = block_n > 1` to skip shmem + sync
-  overhead for `block_n==1` (single warp; registers are faster than shared memory)
-- Runtime guard `if tn == 0:` emits a CUDA `if (threadIdx.y == 0)` conditional
-- Two `T.sync_threads()` per outer-loop iteration: one after write (consistency),
-  one after FMA (prevent next-iteration write-after-read race)
-
-**Actual results** (O1+O2 vs O1 only, H200, fp16):
-
-| Shape (n, k)  | O1 BW     | O1+O2 BW      | delta | Autotune best config |
-| ------------- | --------- | ------------- | ----- | -------------------- |
-| (7168, 16384) | 3.65 GB/s | **3.67 GB/s** | +0.5% | `block_n=8, rt=32`   |
-| (18432, 7168) | 3.85 GB/s | **3.85 GB/s** | 0%    | `block_n=1, rt=32`   |
-| (1024, 1024)  | 0.76 GB/s | 0.71 GB/s     | -7%   | (default, no tune)   |
-
-**Lesson (important)**:
-
-- Explicit shared memory for `a` gave **negligible benefit** on H200 large shapes
-- Root cause: `a` is tiny (14–32 KB) and fits entirely in L1 cache (256 KB per SM);
-  the hardware L1 already deduplicates repeated loads across warps automatically
-- For small shapes, shmem + syncthreads overhead caused a slight regression (-7%)
-- **Rule**: explicit shared memory for a small repeated input only helps when the
-  total working set exceeds L1 capacity; otherwise L1 handles it transparently
-- The remaining ~20% gap to H200 peak (4.8 TB/s) is dominated by HBM3e latency,
-  not by `a` traffic — prefetching/pipelining would be the right next step
-
-### Case 1 addendum: `forward()` Python overhead fix (2026-02-27)
-
-**Problem**: `GemvKernel.forward` was calling `_gemv_wrapped_kernel` (a `torch.library.custom_op`), which recreates a Python closure + JIT lookup on every forward pass. Wall-clock timing showed ~11ms per call even though the GPU kernel itself runs in ~70μs. The overhead scales with call frequency, not problem size.
-
-**Root cause**: `_gemv_wrapped_kernel` calls `_gemv_kernel(n, k, dtype)(block_n, ...)` — creating a new closure object and triggering a JIT cache lookup each time.
-
-**Fix**: Call `self.kernel(...)` directly in `forward()`. `self.kernel` is populated in `__init__` (after `init_config`/autotune) and hits the in-memory JIT cache:
-
-```python
-def forward(self, a, b):
-    a = a.flatten().contiguous()
-    return self.kernel(
-        self.config["block_n"],
-        self.config["reduce_threads"],
-        self.config["num_stages"],
-    )(a, b)
-```
-
-`_gemv_wrapped_kernel` is kept for `torch.compile` compatibility.
+| Case | Summary                                                                                  | Detail                                                                                                                    |
+| ---- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| B    | GEMV: `threads=(block_n, reduce_threads)` → 3% peak BW; swap dims → 80%                  | [Case Studies B](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b-gemv-uncoalesced-b-access)          |
+| B.1  | GEMV O3: pipelined shmem loads via cp.async — helps for small K, marginal for large K    | [Case Studies B.1](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b1-o3-pipelined-b-loads)            |
+| B.2  | GEMV O2: explicit shmem for `a` — negligible benefit (L1 handles it)                     | [Case Studies B.2](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b2-o2-shared-memory-for-a)          |
+| B.3  | GEMV large shapes (Llama-3 70B, DeepSeek-V3): 89–90% H200 utilization at n=57344         | [Case Studies B.3](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b3-large-shape-validation)          |
+| B.4  | GEMV `forward()`: Python closure overhead 11 ms vs 70 µs GPU; cache kernel in `__init__` | [Case Studies B.4](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-b4-forward-python-closure-overhead) |
 
 ______________________________________________________________________
 
-## 7. Problems & Solutions Summary (GEMV Optimization)
+## 7. References
 
-A consolidated reference table for all issues encountered during the GEMV tuning process:
-
-| #   | Problem                               | Symptom                                       | Root Cause                                                                                                    | Fix                                                                                                                                    |
-| --- | ------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| P1  | Uncoalesced B access                  | ~3% of peak BW                                | `threads=(block_n, reduce_threads)` → `tn=threadIdx.x` → stride-K access                                      | Swap to `threads=(reduce_threads, block_n)` so `tk=threadIdx.x`; consecutive threads access consecutive columns                        |
-| P2  | `num_stages=0` sentinel               | max_err=0.125 on ALL configs                  | `T.Pipelined` requires `num_stages>=1`; `if ns>0` inside `@T.prim_func` created JIT trace ambiguity           | Remove `else` branch entirely; autotune space: `ns in [1,2,3]` only                                                                    |
-| P3  | `a` shared memory overhead            | -7% on small shapes                           | `a` (14–32 KB) fits in L1 (256 KB/SM); hardware already deduplicates; shmem+syncthreads overhead not worth it | Remove O2; rely on L1 cache for `a`                                                                                                    |
-| P4  | TMA not usable for manual shmem       | Compilation error (mbarrier)                  | `T.copy` defaults to TMA on SM90; TMA needs mbarrier layout inference not available for non-WGMMA kernels     | `T.copy(..., disable_tma=True)` → `cp.async`                                                                                           |
-| P5  | Python closure overhead in forward    | ~11ms wall-clock vs 70μs GPU                  | `_gemv_wrapped_kernel` recreates closure+JIT lookup each call                                                 | Call `self.kernel(...)` directly in `forward()`; keep wrapper for `torch.compile`                                                      |
-| P6  | nsys with autotune contaminates trace | Avg=91μs, StdDev=24μs (uninterpretable)       | 15 autotune configs × 20 trial runs aggregated with 200 steady-state launches                                 | Fix config via `GemvOp(config=...)` before nsys; only steady-state launches appear                                                     |
-| P7  | ncu requires exclusive lock           | InterprocessLockFailed                        | `/tmp/nsight-compute-lock` held by another user; sticky-bit prevents deletion                                 | Set `TMPDIR` to a user-owned path: `mkdir -p ~/ncu_tmp && export TMPDIR=~/ncu_tmp`; if that also fails, use `nsys profile` as fallback |
-| P8  | `T.syncthreads()` not found           | AttributeError                                | Wrong API name                                                                                                | Use `T.sync_threads()` (with underscore)                                                                                               |
-| P9  | JIT cache staleness                   | Correctness failures after structural changes | `@tilelang.jit` caches compiled binary; old binary reused if cache key misses new params                      | Clear `~/.tilelang/cache/` after structural kernel changes                                                                             |
-
-**Key lessons**:
-
-- For memory-bound kernels: coalescing (P1) is the single highest-impact fix; everything else is secondary
-- Design-level flaws (P2) produce identical errors across all configs; config-level bugs show selective failures
-- L1 cache handles small repeated vectors automatically (P3); explicit shmem only helps above L1 capacity
-- Always profile with fixed config (P6); autotune contamination makes traces uninterpretable
-- GPU time (CUDA events) is the only valid metric for kernel evaluation; wall-clock (P5) includes Python overhead
-
-______________________________________________________________________
-
-## 8. References
-
+- [Hardware Constraints](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints)
+- [TileLang Anti-Patterns](https://github.com/tile-ai/TileOPs/wiki/TileLang-Anti-Patterns)
+- [TileLang Language Spec](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec)
+- [TileLang Case Studies](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies)
 - [CUDA C Programming Guide — Device Memory Accesses](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#device-memory-accesses)
 - [Hopper Architecture Whitepaper](https://resources.nvidia.com/en-us-tensor-core/gtc22-whitepaper-hopper)
-- [TileLang Documentation](https://github.com/tile-ai/tilelang)
-- [CUTLASS GEMM API Design](https://github.com/NVIDIA/cutlass/blob/main/media/docs/gemm_api.md)
-- [Roofline Model for GPU Performance Analysis](https://crd.lbl.gov/assets/pubs_presos/parlab08-roofline-talk.pdf)

--- a/.claude/skills/tune/skill.md
+++ b/.claude/skills/tune/skill.md
@@ -1,11 +1,13 @@
 ---
 name: tune
-description: GPU kernel profiling and performance tuning methodology for TileOPs — benchmark, nsys, bandwidth analysis
+description: GPU kernel profiling and performance tuning methodology for TileOPs — benchmark, nsys, ncu workflow
 ---
 
 # GPU Kernel Profiling Methodology
 
-> Principles for measuring and analysing kernel performance in TileOps. GPU time is the only metric that matters; Python-side overhead is irrelevant to kernel evaluation.
+> Process for measuring and analysing kernel performance in TileOps.
+> GPU time is the only metric that matters; Python-side overhead is irrelevant to kernel evaluation.
+> Hardware peak numbers and profiler API details live in the wiki KB — this skill references them.
 
 ______________________________________________________________________
 
@@ -18,23 +20,20 @@ python -m pytest benchmarks/ops/bench_gemv.py -vvs
 cat profile_run.log
 ```
 
-`BenchmarkBase.profile` uses `tilelang.profiler.do_bench`:
+`BenchmarkBase.profile` uses `tilelang.profiler.do_bench` which measures GPU execution time only (CUDA events), excludes Python overhead, and reports median latency.
 
-- Measures **GPU execution time only** via CUDA events (or CUPTI hardware counters)
-- Python-side call overhead (dispatch, closure creation) is not included — correctly so
-- Runs `warmup` iterations to stabilise caches and GPU clocks before measuring
-- Reports median latency → stable, reproducible number
+→ Full `do_bench` semantics: [Language Spec — Debug & Profiling](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec#debug--profiling)
 
-**When to trust the benchmark**: always, for comparing kernel variants, configs, or implementations.
+**When to trust the benchmark:** always, for comparing kernel variants, configs, or implementations.
 
 ______________________________________________________________________
 
 ## 2. Deep Analysis: nsys + Fixed Config (No Autotune)
 
-When the benchmark reveals a performance gap and you need to understand _why_, use `nsys profile`. However, you must first **disable autotune and fix the best config** to avoid polluting the trace with all the trial runs:
+When the benchmark reveals a performance gap and you need to understand *why*, use `nsys profile`. First **disable autotune and fix the best config** — otherwise all autotune trial runs contaminate the trace.
 
 ```python
-# In test or benchmark script: pass config= to disable autotune
+# Pass config= to disable autotune
 op = GemvOp(
     n, k, dtype=dtype, config={"block_n": 1, "reduce_threads": 32, "num_stages": 3}
 )
@@ -47,9 +46,7 @@ nsys profile --trace=cuda --output=/tmp/gemv_fixed python -m pytest benchmarks/o
 nsys stats /tmp/gemv_fixed.nsys-rep --report cuda_gpu_kern_sum
 ```
 
-**Why disable autotune**: `nsys stats` aggregates ALL launches of a kernel name. With autotuning, 15 configs × 20 calls each = 300 slow trial runs are mixed with the 200 steady-state benchmark calls, inflating avg/stddev and masking the true kernel performance.
-
-With a fixed config, nsys shows only the benchmark's steady-state launches — clean, comparable numbers.
+**Why disable autotune:** `nsys stats` aggregates all launches of a kernel name. With autotuning, many configs × trial runs are mixed with steady-state benchmark calls, inflating avg/stddev and masking true kernel performance.
 
 ______________________________________________________________________
 
@@ -64,63 +61,33 @@ ______________________________________________________________________
 | ---------- | ------------------------------------------------------------------------ |
 | **Min**    | Best-case execution (optimal cache state, full pipeline, no stalls)      |
 | **Med**    | Typical steady-state (more reliable than avg if outliers exist)          |
-| **Avg**    | Inflated if slow warm-up or multi-config autotune runs are included      |
+| **Avg**    | Inflated if autotune trial runs are included                             |
 | **StdDev** | High → heterogeneous launches (autotune contamination or cache variance) |
 
-**Rule**: compare **median** (not avg) when autotune is disabled. Use **min** to understand the kernel's theoretical best.
+**Rule:** compare **median** when autotune is disabled. Use **min** to understand the kernel's theoretical best.
 
 ______________________________________________________________________
 
-## 4. Effective Bandwidth Calculation
+## 4. Effective Bandwidth
 
-For GEMV `c = B @ a` with `n` rows, `k` columns, `dtype_bytes = 2` (fp16/bf16):
+For GEMV `c = B @ a`:
 
 ```
 mem_bytes = (k + n*k + n) * dtype_bytes    # a + B + c
 BW_GB_s   = mem_bytes / latency_s / 1e9
 ```
 
-H200 peak: 4800 GB/s. Realistic achievable: 3000–4000 GB/s (60–80% of peak) for large GEMV.
+→ H200 peak bandwidth, realistic achievable range, and formula derivation: [Hardware Constraints — Effective Bandwidth](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#h200-effective-memory-bandwidth)
 
-When cuBLAS shows two kernels (`*_splitK_*` + `*_splitKreduce_*`), sum their latencies to get the true cuBLAS latency; their memory traffic is also higher (B is read multiple times in split-K mode).
+→ cuBLAS split-K issues two kernels; sum their latencies for comparison: [Hardware Constraints — cuBLAS split-K](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#cublas-split-k-for-gemv)
 
 ______________________________________________________________________
 
-## 5. Case Study: GEMV (n=7168, k=16384, fp16, H200)
-
-### Without fixed config (autotune contaminated trace)
-
-```
-_gemv_main_kernel  Avg=91 701 ns  Med=85 472 ns  StdDev=24 658 ns
-```
-
-Uninterpretable — aggregates 15 configs × 20 trial runs + 200 steady-state calls.
-
-### With fixed best config (bn=1, ns=2, 200 steady-state calls)
-
-```
-_gemv_main_kernel  Avg=64 261 ns  Med=66 208 ns  StdDev=3 733 ns
-cuBLAS splitK      Avg=62 107 ns + 2 354 ns (reduce) ≈ 64 461 ns
-```
-
-- Our kernel: **3.55 TB/s** → 74% of H200 peak (4.8 TB/s)
-- cuBLAS: **3.64 TB/s** (split-K, 2 passes)
-- Both within 5% of each other; benchmark (CUPTI) shows tileops slightly ahead
-
-### Why 74% and not higher
-
-| Factor                      | Impact                                                                                   |
-| --------------------------- | ---------------------------------------------------------------------------------------- |
-| Warp occupancy: 54/64 = 84% | Fixed by problem size (n=7168 / 132 SMs)                                                 |
-| HBM latency hiding          | Covered by warp switching (54 warps/SM); cp.async adds marginal benefit                  |
-| 4-way shmem bank conflicts  | Shmem reads ~4× longer, but shmem is NOT the bottleneck (HBM loading dominates)          |
-| Realistic HBM utilisation   | H200 achieves 60–80% of rated 4.8 TB/s in practice due to latency and row buffer effects |
-
-**Conclusion**: 74% efficiency is near the practical ceiling for this problem size. Fixing bank conflicts or adding pipeline stages gives diminishing returns when warp switching already hides HBM latency.
+## 5. Tuning Workflow (SOP)
 
 ```
 1. Run benchmark → get GB/s and latency_ms for each shape
-2. If result is good vs baseline → done; document in tune-multiplication/skill.md
+2. If result is good vs baseline → done; document in tune-multiplication/skill.md case studies
 3. If there's a gap → disable autotune, fix best config
 4. nsys profile with fixed config → get clean per-kernel stats
 5. Use ncu (Nsight Compute) for detailed per-metric analysis:
@@ -131,9 +98,9 @@ cuBLAS splitK      Avg=62 107 ns + 2 354 ns (reduce) ≈ 64 461 ns
      On shared systems this lock may be held by another user (sticky-bit /tmp
      prevents deletion). Fix: set TMPDIR to a user-owned directory before running:
        mkdir -p /home/$USER/ncu_tmp && export TMPDIR=/home/$USER/ncu_tmp
-     Use --launch-skip N --launch-count M to skip warmup and capture only steady-state kernels:
+     Use --launch-skip N --launch-count M to skip warmup and capture steady-state kernels:
        ncu --set full --launch-skip 51 --launch-count 3 -o /tmp/report python script.py
-     If TMPDIR fix also fails, use nsys profile as the fallback — it covers timeline and kernel-level stats.
+     If TMPDIR fix also fails, use nsys profile as the fallback.
 6. Identify bottleneck → implement fix → re-benchmark to confirm
 7. Open PR — body must contain ONLY:
    - Performance tables (before/after/baseline BW, H200 utilization %)
@@ -141,3 +108,19 @@ cuBLAS splitK      Avg=62 107 ns + 2 354 ns (reduce) ≈ 64 461 ns
    - `Closes #NNN` for the relevant issue
    Omit implementation narrative, code diffs, and analysis prose — those belong in skill.md.
 ```
+
+______________________________________________________________________
+
+## 6. Case Studies
+
+| Case | Summary                                                                         | Detail                                                                                                                            |
+| ---- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| C    | nsys: autotune contamination makes Avg/StdDev uninterpretable; fix config first | [Case Studies C](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-c-nsys-profiling-with-autotune-contamination) |
+
+______________________________________________________________________
+
+## 7. References
+
+- [Hardware Constraints — H200 Bandwidth](https://github.com/tile-ai/TileOPs/wiki/TileLang-Hardware-Constraints#h200-effective-memory-bandwidth)
+- [Language Spec — Debug & Profiling](https://github.com/tile-ai/TileOPs/wiki/TileLang-Language-Spec#debug--profiling)
+- [TileLang Case Studies](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies)


### PR DESCRIPTION
## Summary

Resolves #320, #321, #322.

Skills should encode **process/SOP only** (how to do). Factual knowledge (API semantics, hardware numbers, error patterns) and case studies (full narrative with benchmark data) belong in the wiki Knowledge Base, not embedded in skill files.

This PR refactors all three affected skills accordingly and pushes the extracted content to the wiki.

## Wiki changes (already pushed to `tile-ai/TileOPs.wiki`)

**New page — `TileLang-Case-Studies`:**
- Full case studies with symptoms → root cause → fix → results → lessons narrative
- Cases A (num_stages=0 sentinel), B / B.1–B.4 (GEMV optimization series), C (nsys profiling)
- Sidebar updated to include the new page

**`TileLang-Anti-Patterns` — added #25–27:**
- #25: `num_stages=0` as sentinel for `T.Pipelined`
- #26: `T.syncthreads()` wrong API name
- #27: Missing shared memory bank-conflict padding

**`TileLang-Language-Spec` — added:**
- 2D thread layout semantics (`threads=(dim_x, dim_y)`, `threadIdx.x` fast-varying)
- `T.sync_threads()` correct API with anti-pattern cross-reference
- SM90 TMA default and `disable_tma=True` guidance for non-WGMMA kernels
- `profiler.do_bench()` detailed semantics (CUDA events, median latency)
- JIT cache location (`~/.tilelang/cache/` / `$TILELANG_CACHE_DIR`) and when to clear it

**`TileLang-Hardware-Constraints` — added:**
- GPU Roofline Model section: H100/H200/A100 peak FP16, memory BW, crossover points, arithmetic intensity formula
- H200 effective bandwidth: 4800 GB/s peak, 3000–4000 GB/s realistic (60–80%)
- GEMV effective bandwidth formula with worked example
- cuBLAS split-K two-kernel pattern and latency summation rule

**`TileLang-Validation-Rules` — added:**
- Error Pattern Interpretation: triage table, config-sweep recipe, powers-of-2 heuristic
- JIT cache staleness: symptom, fix, shell commands
- Random seed / pytest vs inline scripts caveat

## Skill file changes (this PR)

| Skill | Removed | Kept |
|-------|---------|------|
| `kernel-debug/skill.md` | Embedded TileLang pitfall details, full Case A | Triage SOP (steps 1–8), quick-reference table with wiki links |
| `tune-multiplication/skill.md` | Roofline table, WGMMA alignment, SM90 shmem limit, thread layout, bank-conflict note, full Cases B/B.1–B.4 | Tuning SOP (steps 1–9), autotune search space, case index table |
| `tune/skill.md` | H200 peak BW, do_bench API detail, bandwidth formula, cuBLAS split-K note, full Case C | Profiling SOP (steps 1–7), nsys/ncu commands, ncu lock workaround |

## Test plan

- [ ] Verify all wiki links in skill files resolve correctly on GitHub
- [ ] Confirm skill files load cleanly in Claude context (no broken references)
- [ ] Spot-check: `kernel-debug/skill.md` still provides actionable SOP without embedded facts
- [ ] Spot-check: `tune/skill.md` bandwidth formula section correctly points to wiki

Closes #320
Closes #321
Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)