### PR TITLE
[Chore][CI] Skip CI on draft PRs to save GPU resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' }}
+    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +45,7 @@ jobs:
 
   tileops_test_release:
     # needs: pre-commit
-    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' }}
+    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && github.event.pull_request.draft == false }}
     runs-on: [self-hosted, tile-ops, venv]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Closes #359 Closes https://github.com/tile-ai/TileOPs/issues/297

## Summary

- Add `github.event.pull_request.draft == false` condition to `pre-commit` and `tileops_test_release` jobs in `.github/workflows/ci.yml`
- Draft PRs now skip CI entirely; CI triggers when the PR is marked ready for review via the existing `ready_for_review` event type
- Push-to-main and `workflow_dispatch` behavior unchanged (`null == false` evaluates to `true` in GitHub Actions expressions)

**Expected behavior after the fix:**

| Phase | Event | draft? | Runs CI? |
|---|---|---|---|
| Create draft PR | `opened` | true | skip |
| Push commits during draft | `synchronize` | true | skip |
| Mark ready for review | `ready_for_review` | false | **run** |
| Push after ready | `synchronize` | false | run |

## Test plan

- [x] pre-commit passed
- [x] YAML syntax validated
- [x] Logic verified: `draft == true` → condition `false` → jobs skipped
- [x] Logic verified: `ready_for_review` trigger preserved → CI fires on draft-to-ready transition
- [x] Logic verified: push/workflow_dispatch events unaffected (`null == false` → `true`)