### PR TITLE
[Chore][CI] Add benchmark smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
           python -m pytest -q tests  | tee tileops_test_release.log
         shell: bash
 
+      - name: Smoke-test benchmark imports
+        run: |
+          VENV_DIR="tileops_release_venv"
+          source "${{ runner.tool_cache }}/${VENV_DIR}/bin/activate"
+          export PYTHONPATH="$(pwd):$PYTHONPATH"
+          python -m pytest --collect-only benchmarks/
+        shell: bash
+
       - name: Cleanup venv
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Closes #319

## Summary

- Add `pytest --collect-only benchmarks/` step to CI workflow
- Catches broken benchmark imports (e.g. missing modules, bad references) at zero GPU cost
- Runs after the test step, reusing the same venv

## Test plan

- [x] pre-commit passed
- [x] `pytest --collect-only benchmarks/` collects 91 tests successfully
- [x] Verified broken imports cause non-zero exit (collection error)