### PR TITLE
[BugFix][PACKAGING] Cap torch below 2.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "TileOPs kernels for efficient LLM inference."
 readme = "README.md"
 authors = [{ name="Tile-AI"}]
 dependencies = [
-    "torch>=2.1.0",
+    "torch>=2.1.0,<2.10.0",
     "tilelang==0.1.8",
     "einops",
 ]


### PR DESCRIPTION
Closes #381

## Summary

- cap the package dependency from `torch>=2.1.0` to `torch>=2.1.0,<2.10.0`
- prevent fresh installs from resolving to the known-bad `torch==2.10.0` FP16 GEMM combination

## Test plan

- [x] pre-commit passed on the changed file during `git commit`
- [x] verified `pyproject.toml` parses and now reports `torch>=2.1.0,<2.10.0`
- [x] full `pytest tests -q` was not completed because the suite is long-running and not targeted to this metadata-only change

## Regression

- this is a dependency metadata change only; runtime behavior is unchanged for already-pinned supported torch versions
- fresh installs will avoid the upstream `torch==2.10.0` + `nvidia-cublas-cu12==12.8.4.1` FP16 GEMM failure path tracked in pytorch/pytorch#174949
