### PR TITLE
[Chore][CI] Skip redundant CI runs on ready_for_review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: write
+  checks: read
 
 on:
   push:


### PR DESCRIPTION
## Summary

- Added a lightweight `ci-gate` job (`ubuntu-latest`, no checkout) that detects `ready_for_review` events and checks whether CI has already passed for the current head SHA via the Checks API.
- Removed the `github.event.pull_request.draft == false` gate from heavy jobs (`pre-commit`, `tileops_test_release`), allowing draft PRs to run CI (enables automation pipelines like Foundry).
- Heavy jobs now depend on `ci-gate` and skip when `ci-gate.outputs.skip == 'true'`, avoiding redundant self-hosted runner usage on `ready_for_review` transitions.
- Added `checks: read` permission for the Checks API call in `ci-gate`.

Closes #379

## Test plan

Verification (T004) confirmed all 5 acceptance criteria:
- **AC-1**: Heavy jobs `if:` condition no longer contains `draft == false`
- **AC-2**: `ci-gate` job exists with `runs-on: ubuntu-latest` and outputs a `skip` variable
- **AC-3**: `ci-gate` only queries existing check results when `github.event.action == 'ready_for_review'`; all other events output `skip=false`
- **AC-4**: Heavy jobs declare `needs: ci-gate` and their `if:` condition includes `needs.ci-gate.outputs.skip != 'true'`
- **AC-5**: Check names queried in `ci-gate` match actual job names (`pre-commit`, `tileops_test_release`)

Workflow YAML validation passed (2/2 checks: valid YAML structure, correct job dependencies).