### PR TITLE
[Perf][CI] Add path-aware smoke selection for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,110 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  detect-test-scope:
+    needs: ci-gate
+    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && needs.ci-gate.outputs.skip != 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      skip_gpu_smoke: ${{ steps.scope.outputs.skip_gpu_smoke }}
+      scope: ${{ steps.scope.outputs.scope }}
+      pytest_targets: ${{ steps.scope.outputs.pytest_targets }}
+    steps:
+      - name: Checkout test files
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            tests/ops
+
+      - name: Determine pytest scope
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          add_target() {
+            local target="$1"
+            if [[ -z "${seen_targets[$target]:-}" ]]; then
+              selected_targets+=("$target")
+              seen_targets["$target"]=1
+            fi
+          }
+
+          scope="full-smoke"
+          skip_gpu_smoke="false"
+          pytest_targets="tests"
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            mapfile -t changed_files < <(
+              gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate \
+                --jq '.[].filename'
+            )
+
+            echo "Changed files (${#changed_files[@]}):"
+            printf ' - %s\n' "${changed_files[@]}"
+
+            scope="skip"
+            declare -A seen_targets=()
+            selected_targets=()
+
+            for path in "${changed_files[@]}"; do
+              case "$path" in
+                *.md|.github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|.github/workflows/auto-label.yml|.github/workflows/stale-issues.yml)
+                  ;;
+                tileops/ops/*.py)
+                  test_path="tests/ops/test_$(basename "${path%.py}").py"
+                  if [[ -f "$test_path" ]]; then
+                    add_target "$test_path"
+                    if [[ "$scope" == "skip" ]]; then
+                      scope="targeted"
+                    fi
+                  else
+                    echo "No direct smoke test mapping for $path; falling back to full smoke."
+                    scope="full-smoke"
+                    break
+                  fi
+                  ;;
+                tests/ops/test_*.py)
+                  add_target "$path"
+                  if [[ "$scope" == "skip" ]]; then
+                    scope="targeted"
+                  fi
+                  ;;
+                *)
+                  echo "Shared or unsupported path $path; falling back to full smoke."
+                  scope="full-smoke"
+                  break
+                  ;;
+              esac
+            done
+
+            if [[ "$scope" == "skip" ]]; then
+              skip_gpu_smoke="true"
+              pytest_targets=""
+            elif [[ "$scope" == "targeted" ]]; then
+              if [[ "${#selected_targets[@]}" -eq 0 ]]; then
+                echo "No mapped tests were collected; falling back to full smoke."
+                scope="full-smoke"
+                pytest_targets="tests"
+              else
+                pytest_targets="${selected_targets[*]}"
+              fi
+            fi
+          fi
+
+          echo "Resolved CI scope: $scope"
+          if [[ "$skip_gpu_smoke" == "true" ]]; then
+            echo "GPU smoke job will be skipped."
+          else
+            echo "Resolved pytest targets: ${pytest_targets:-<none>}"
+          fi
+
+          echo "skip_gpu_smoke=$skip_gpu_smoke" >> "$GITHUB_OUTPUT"
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          echo "pytest_targets=$pytest_targets" >> "$GITHUB_OUTPUT"
+
   pre-commit:
     needs: ci-gate
     if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && needs.ci-gate.outputs.skip != 'true' }}
@@ -73,9 +177,9 @@ jobs:
           extra_args: --all-files --show-diff-on-failure
 
   tileops_test_release:
-    needs: ci-gate
+    needs: [ci-gate, detect-test-scope]
     # needs: pre-commit
-    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && needs.ci-gate.outputs.skip != 'true' }}
+    if: ${{ github.repository == 'tile-ai/TileOPs' && github.event_name != 'schedule' && needs.ci-gate.outputs.skip != 'true' && needs.detect-test-scope.outputs.skip_gpu_smoke != 'true' }}
     runs-on: [self-hosted, tile-ops, venv]
     steps:
       - name: Checkout code
@@ -157,11 +261,18 @@ jobs:
           echo "PYTHONPATH=$PYTHONPATH"
           set -o pipefail
           TEST_MARK_EXPR="smoke or full"
+          TEST_SCOPE="full-smoke"
+          PYTEST_TARGETS="tests"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             TEST_MARK_EXPR="smoke"
+            TEST_SCOPE="${{ needs.detect-test-scope.outputs.scope }}"
+            PYTEST_TARGETS="${{ needs.detect-test-scope.outputs.pytest_targets }}"
           fi
-          echo "Running pytest -m \"${TEST_MARK_EXPR}\""
-          python -m pytest -q tests -m "${TEST_MARK_EXPR}" | tee tileops_test_release.log
+          echo "Resolved test scope: ${TEST_SCOPE}"
+          echo "Resolved pytest targets: ${PYTEST_TARGETS}"
+          read -r -a TARGETS <<< "${PYTEST_TARGETS}"
+          echo "Running pytest -m \"${TEST_MARK_EXPR}\" on ${#TARGETS[@]} target(s)"
+          python -m pytest -q "${TARGETS[@]}" -m "${TEST_MARK_EXPR}" | tee tileops_test_release.log
         shell: bash
 
       - name: Cleanup venv


### PR DESCRIPTION
Closes #430

## Summary

- add a `detect-test-scope` job to classify PR changes as `skip`, `targeted`, or `full-smoke`
- run targeted smoke tests for directly mapped operator and test-file changes, and skip the GPU smoke job for docs-only and other non-runtime changes
- preserve safety by falling back to full smoke whenever a change touches shared CI/runtime paths or cannot be mapped confidently

## Test plan

- [x] `pre-commit run --files .github/workflows/ci.yml`
- [x] parse `.github/workflows/ci.yml` with `yaml.safe_load(...)`
- [x] exercise the scope-selection shell logic locally for `skip`, `targeted`, and `full-smoke` cases

## Benchmark

CI-scope reduction only; no runtime kernel benchmark applies.

Expected PR CI behavior after this change:
- docs-only and metadata-only PRs skip the GPU smoke job entirely
- PRs touching a small set of operators run only the mapped smoke tests instead of `pytest -q tests -m smoke`
- shared or ambiguous changes still fall back to full smoke for safety

## Regression

- non-PR workflows keep the existing `smoke or full` behavior
- PRs still fall back to full smoke when a changed file cannot be mapped safely to specific operator tests
