### PR TITLE
[Feat][Reduce] Add softmax-family ops (softmax, log_softmax, logsumexp)

### DIFF
--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -1,0 +1,135 @@
+"""Benchmarks for softmax-family ops (softmax, log_softmax, logsumexp).
+
+Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
+from tests.ops.test_softmax import (
+    LogSoftmaxFixture,
+    LogSoftmaxTest,
+    LogSumExpFixture,
+    LogSumExpTest,
+    SoftmaxFixture,
+    SoftmaxTest,
+)
+from tileops.ops.reduction.log_softmax import LogSoftmaxOp
+from tileops.ops.reduction.logsumexp import LogSumExpOp
+from tileops.ops.reduction.softmax import SoftmaxOp
+
+
+class SoftmaxBenchmark(BenchmarkBase):
+    """Benchmark for softmax op (4N FLOPs: max, exp, sum, div)."""
+
+    def calculate_flops(self) -> Optional[float]:
+        t = self.test
+        return 4 * t.m * t.n
+
+    def calculate_memory(self) -> Optional[float]:
+        """Read x (M*N) + write y (M*N)."""
+        t = self.test
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        return (2 * t.m * t.n) * elem_bytes
+
+
+class LogSoftmaxBenchmark(BenchmarkBase):
+    """Benchmark for log_softmax op (5N FLOPs: max, exp, sum, div, log)."""
+
+    def calculate_flops(self) -> Optional[float]:
+        t = self.test
+        return 5 * t.m * t.n
+
+    def calculate_memory(self) -> Optional[float]:
+        """Read x (M*N) + write y (M*N)."""
+        t = self.test
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        return (2 * t.m * t.n) * elem_bytes
+
+
+class LogSumExpBenchmark(BenchmarkBase):
+    """Benchmark for logsumexp op (3N FLOPs: max, exp, sum + 1 log+add)."""
+
+    def calculate_flops(self) -> Optional[float]:
+        t = self.test
+        return 3 * t.m * t.n
+
+    def calculate_memory(self) -> Optional[float]:
+        """Read x (M*N) + write y (M)."""
+        t = self.test
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        return (t.m * t.n + t.m) * elem_bytes
+
+
+# ===================================================================
+# Softmax benchmarks
+# ===================================================================
+
+
+@SoftmaxFixture
+def test_softmax_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = SoftmaxTest(m, n, dtype)
+    bm = SoftmaxBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = SoftmaxOp(M=m, N=n, dtype=dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("softmax", locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return F.softmax(x, dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record("softmax", locals(), result_bl, tag="baseline")
+
+
+# ===================================================================
+# LogSoftmax benchmarks
+# ===================================================================
+
+
+@LogSoftmaxFixture
+def test_log_softmax_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = LogSoftmaxTest(m, n, dtype)
+    bm = LogSoftmaxBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = LogSoftmaxOp(M=m, N=n, dtype=dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("log_softmax", locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return F.log_softmax(x, dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record("log_softmax", locals(), result_bl, tag="baseline")
+
+
+# ===================================================================
+# LogSumExp benchmarks
+# ===================================================================
+
+
+@LogSumExpFixture
+def test_logsumexp_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = LogSumExpTest(m, n, dtype)
+    bm = LogSumExpBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = LogSumExpOp(M=m, N=n, dtype=dtype, tune=tune)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record("logsumexp", locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch.logsumexp(x, dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record("logsumexp", locals(), result_bl, tag="baseline")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -1,0 +1,492 @@
+"""Correctness tests for softmax-family ops (softmax, log_softmax, logsumexp).
+
+Tests cover fp32/fp16/bf16 dtypes, 1D-4D inputs, non-contiguous tensors,
+power-of-2 and non-power-of-2 hidden dims, tail-M cases, and validate
+against PyTorch reference implementations.
+
+Smoke tests (1 per function, first param) use small data for quick CI.
+Full tests use small data for config breadth + large data for stress.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tests.test_base import FixtureBase, TestBase
+from tileops.ops.reduction.log_softmax import LogSoftmaxOp
+from tileops.ops.reduction.logsumexp import LogSumExpOp
+from tileops.ops.reduction.softmax import SoftmaxOp
+
+# ---------------------------------------------------------------------------
+# Tolerances (from DEVELOPMENT.md)
+# ---------------------------------------------------------------------------
+
+
+def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype == torch.float32:
+        return 1e-5, 1e-5
+    elif dtype == torch.float16:
+        return 1e-3, 1e-3
+    else:  # bfloat16
+        return 1.6e-2, 1.6e-2
+
+
+# ===================================================================
+# Softmax — 2D
+# ===================================================================
+
+
+class SoftmaxFixture(FixtureBase):
+    PARAMS = [
+        (
+            "m, n, dtype, tune",
+            [
+                # Smoke: first param — small data, fp32, pow2 dim
+                pytest.param(32, 256, torch.float32, False, marks=pytest.mark.smoke),
+                # Full: all dtypes x pow2/non-pow2 x normal-M/tail-M (small data)
+                pytest.param(32, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                # Full: larger configs
+                pytest.param(1024, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+class SoftmaxTest(TestBase):
+    def __init__(self, m: int, n: int, dtype: torch.dtype):
+        self.m = m
+        self.n = n
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return F.softmax(x.float(), dim=-1).to(x.dtype)
+
+
+@SoftmaxFixture
+def test_softmax_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = SoftmaxTest(m, n, dtype)
+    op = SoftmaxOp(M=m, N=n, dtype=dtype, tune=tune)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+# ===================================================================
+# LogSoftmax — 2D
+# ===================================================================
+
+
+class LogSoftmaxFixture(FixtureBase):
+    PARAMS = [
+        (
+            "m, n, dtype, tune",
+            [
+                pytest.param(32, 256, torch.float32, False, marks=pytest.mark.smoke),
+                pytest.param(32, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.float16, False, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+class LogSoftmaxTest(TestBase):
+    def __init__(self, m: int, n: int, dtype: torch.dtype):
+        self.m = m
+        self.n = n
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return F.log_softmax(x.float(), dim=-1).to(x.dtype)
+
+
+@LogSoftmaxFixture
+def test_log_softmax_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = LogSoftmaxTest(m, n, dtype)
+    op = LogSoftmaxOp(M=m, N=n, dtype=dtype, tune=tune)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+# ===================================================================
+# LogSumExp — 2D
+# ===================================================================
+
+
+class LogSumExpFixture(FixtureBase):
+    PARAMS = [
+        (
+            "m, n, dtype, tune",
+            [
+                pytest.param(32, 256, torch.float32, False, marks=pytest.mark.smoke),
+                pytest.param(32, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 256, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(33, 300, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float32, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float16, False, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.bfloat16, False, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.float16, False, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+class LogSumExpTest(TestBase):
+    def __init__(self, m: int, n: int, dtype: torch.dtype):
+        self.m = m
+        self.n = n
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.logsumexp(x.float(), dim=-1).to(x.dtype)
+
+
+@LogSumExpFixture
+def test_logsumexp_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = LogSumExpTest(m, n, dtype)
+    op = LogSumExpOp(M=m, N=n, dtype=dtype, tune=tune)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+# ===================================================================
+# Non-contiguous input tests — all 3 ops x all 3 dtypes
+# ===================================================================
+
+
+class NonContigFixture(FixtureBase):
+    PARAMS = [
+        (
+            "m, n, dtype",
+            [
+                pytest.param(32, 256, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(32, 256, torch.float16, marks=pytest.mark.full),
+                pytest.param(32, 256, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float32, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.float16, marks=pytest.mark.full),
+                pytest.param(32, 300, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float32, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(1024, 4096, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@NonContigFixture
+def test_softmax_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
+    """Test softmax with non-contiguous input (sliced tensor)."""
+    x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
+    x = x_full[:, :n]  # non-contiguous slice
+
+    op = SoftmaxOp(M=m, N=n, dtype=dtype)
+
+    y_ref = F.softmax(x.float().contiguous(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"Non-contiguous softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@NonContigFixture
+def test_log_softmax_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
+    """Test log_softmax with non-contiguous input."""
+    x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
+    x = x_full[:, :n]
+
+    op = LogSoftmaxOp(M=m, N=n, dtype=dtype)
+
+    y_ref = F.log_softmax(x.float().contiguous(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"Non-contiguous log_softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@NonContigFixture
+def test_logsumexp_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
+    """Test logsumexp with non-contiguous input."""
+    x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
+    x = x_full[:, :n]
+
+    op = LogSumExpOp(M=m, N=n, dtype=dtype)
+
+    y_ref = torch.logsumexp(x.float().contiguous(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"Non-contiguous logsumexp failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+# ===================================================================
+# 1D input tests — all 3 ops x all 3 dtypes x pow2/non-pow2
+# ===================================================================
+
+
+class Input1DFixture(FixtureBase):
+    PARAMS = [
+        (
+            "n, dtype",
+            [
+                pytest.param(256, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(256, torch.float16, marks=pytest.mark.full),
+                pytest.param(256, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(300, torch.float32, marks=pytest.mark.full),
+                pytest.param(300, torch.float16, marks=pytest.mark.full),
+                pytest.param(300, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@Input1DFixture
+def test_softmax_1d(n: int, dtype: torch.dtype) -> None:
+    """Test softmax with 1D input (single row)."""
+    x = torch.randn(n, dtype=dtype, device="cuda")
+    op = SoftmaxOp(M=1, N=n, dtype=dtype)
+
+    y_ref = F.softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"1D softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input1DFixture
+def test_log_softmax_1d(n: int, dtype: torch.dtype) -> None:
+    """Test log_softmax with 1D input."""
+    x = torch.randn(n, dtype=dtype, device="cuda")
+    op = LogSoftmaxOp(M=1, N=n, dtype=dtype)
+
+    y_ref = F.log_softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"1D log_softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input1DFixture
+def test_logsumexp_1d(n: int, dtype: torch.dtype) -> None:
+    """Test logsumexp with 1D input -- output should be a scalar."""
+    x = torch.randn(n, dtype=dtype, device="cuda")
+    op = LogSumExpOp(M=1, N=n, dtype=dtype)
+
+    y_ref = torch.logsumexp(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert y.shape == y_ref.shape, f"Shape mismatch: {y.shape} vs {y_ref.shape}"
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"1D logsumexp failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+# ===================================================================
+# 3D input tests — all 3 ops x all 3 dtypes x pow2/non-pow2
+# ===================================================================
+
+
+class Input3DFixture(FixtureBase):
+    PARAMS = [
+        (
+            "batch, seq, hidden, dtype",
+            [
+                pytest.param(2, 16, 256, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(2, 16, 256, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 16, 256, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(2, 16, 300, torch.float32, marks=pytest.mark.full),
+                pytest.param(2, 16, 300, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 16, 300, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(2, 512, 4096, torch.float32, marks=pytest.mark.full),
+                pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 512, 4096, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@Input3DFixture
+def test_softmax_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Test softmax with 3D input (batch, seq, hidden)."""
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    M = batch * seq
+    op = SoftmaxOp(M=M, N=hidden, dtype=dtype)
+
+    y_ref = F.softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"3D softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input3DFixture
+def test_log_softmax_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Test log_softmax with 3D input."""
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    M = batch * seq
+    op = LogSoftmaxOp(M=M, N=hidden, dtype=dtype)
+
+    y_ref = F.log_softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"3D log_softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input3DFixture
+def test_logsumexp_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Test logsumexp with 3D input -- output shape should be (batch, seq)."""
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    M = batch * seq
+    op = LogSumExpOp(M=M, N=hidden, dtype=dtype)
+
+    y_ref = torch.logsumexp(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert y.shape == y_ref.shape, f"Shape mismatch: {y.shape} vs {y_ref.shape}"
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"3D logsumexp failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+# ===================================================================
+# 4D input tests — all 3 ops x all 3 dtypes x pow2/non-pow2
+# ===================================================================
+
+
+class Input4DFixture(FixtureBase):
+    PARAMS = [
+        (
+            "b, h, s, d, dtype",
+            [
+                pytest.param(2, 4, 8, 256, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(2, 4, 8, 256, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 4, 8, 256, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(2, 4, 8, 300, torch.float32, marks=pytest.mark.full),
+                pytest.param(2, 4, 8, 300, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 4, 8, 300, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(2, 4, 128, 256, torch.float32, marks=pytest.mark.full),
+                pytest.param(2, 4, 128, 256, torch.float16, marks=pytest.mark.full),
+                pytest.param(2, 4, 128, 256, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@Input4DFixture
+def test_softmax_4d(b: int, h: int, s: int, d: int, dtype: torch.dtype) -> None:
+    """Test softmax with 4D input (batch, heads, seq, dim)."""
+    x = torch.randn(b, h, s, d, dtype=dtype, device="cuda")
+    M = b * h * s
+    op = SoftmaxOp(M=M, N=d, dtype=dtype)
+
+    y_ref = F.softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"4D softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input4DFixture
+def test_log_softmax_4d(b: int, h: int, s: int, d: int, dtype: torch.dtype) -> None:
+    """Test log_softmax with 4D input (batch, heads, seq, dim)."""
+    x = torch.randn(b, h, s, d, dtype=dtype, device="cuda")
+    M = b * h * s
+    op = LogSoftmaxOp(M=M, N=d, dtype=dtype)
+
+    y_ref = F.log_softmax(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"4D log_softmax failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@Input4DFixture
+def test_logsumexp_4d(b: int, h: int, s: int, d: int, dtype: torch.dtype) -> None:
+    """Test logsumexp with 4D input -- output shape should be (b, h, s)."""
+    x = torch.randn(b, h, s, d, dtype=dtype, device="cuda")
+    M = b * h * s
+    op = LogSumExpOp(M=M, N=d, dtype=dtype)
+
+    y_ref = torch.logsumexp(x.float(), dim=-1).to(dtype)
+    y = op(x)
+    atol, rtol = _get_tolerances(dtype)
+    assert y.shape == y_ref.shape, f"Shape mismatch: {y.shape} vs {y_ref.shape}"
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"4D logsumexp failed, max err: {(y - y_ref).abs().max()}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/test_reduction_init_files.py
+++ b/tests/test_reduction_init_files.py
@@ -1,9 +1,12 @@
-"""Tests for reduction placeholder __init__.py files (issue #432).
+"""Tests for reduction __init__.py files (issue #432).
 
 Validates that:
-- tileops/kernels/reduction/__init__.py has commented-out imports for 6 Kernel classes
-- tileops/ops/reduction/__init__.py has commented-out imports for 20 Op classes
-- tileops/ops/__init__.py has commented-out reduction imports and __all__ entries
+- tileops/kernels/reduction/__init__.py has active imports for implemented kernels
+  and commented-out imports for placeholder kernel classes
+- tileops/ops/reduction/__init__.py has active imports for implemented op classes
+  and commented-out imports for placeholder op classes
+- tileops/ops/__init__.py has active imports/exports for implemented reduction ops
+  and commented-out entries for placeholder reduction ops
 - All files pass ruff check and ruff format --check
 """
 
@@ -21,20 +24,36 @@ KERNEL_INIT = ROOT / "tileops" / "kernels" / "reduction" / "__init__.py"
 OPS_REDUCTION_INIT = ROOT / "tileops" / "ops" / "reduction" / "__init__.py"
 OPS_INIT = ROOT / "tileops" / "ops" / "__init__.py"
 
-# --- Expected kernel classes (6) ---
+# --- Implemented kernel classes (active imports) ---
 
-KERNEL_CLASSES = [
+IMPLEMENTED_KERNEL_CLASSES = [
+    "LogSumExpKernel",
+    "SoftmaxKernel",
+]
+
+# --- Placeholder kernel classes (still commented out) ---
+
+PLACEHOLDER_KERNEL_CLASSES = [
     "ArgreduceKernel",
     "CumulativeKernel",
     "LogicalReduceKernel",
     "ReduceKernel",
-    "SoftmaxKernel",
     "VectorNormKernel",
 ]
 
-# --- Expected op classes (20) ---
+ALL_KERNEL_CLASSES = IMPLEMENTED_KERNEL_CLASSES + PLACEHOLDER_KERNEL_CLASSES
 
-OP_CLASSES = [
+# --- Implemented op classes (active imports) ---
+
+IMPLEMENTED_OP_CLASSES = [
+    "LogSoftmaxOp",
+    "LogSumExpOp",
+    "SoftmaxOp",
+]
+
+# --- Placeholder op classes (still commented out) ---
+
+PLACEHOLDER_OP_CLASSES = [
     "AllOp",
     "AnyOp",
     "ArgmaxOp",
@@ -47,15 +66,14 @@ OP_CLASSES = [
     "InfNormOp",
     "L1NormOp",
     "L2NormOp",
-    "LogSoftmaxOp",
-    "LogSumExpOp",
     "ReduceMaxOp",
     "ReduceMeanOp",
     "ReduceMinOp",
     "ReduceProdOp",
     "ReduceSumOp",
-    "SoftmaxOp",
 ]
+
+ALL_OP_CLASSES = IMPLEMENTED_OP_CLASSES + PLACEHOLDER_OP_CLASSES
 
 
 class TestKernelReductionInit:
@@ -64,51 +82,76 @@ class TestKernelReductionInit:
     def test_file_exists(self):
         assert KERNEL_INIT.exists(), f"{KERNEL_INIT} does not exist"
 
-    def test_has_all_kernel_classes_commented(self):
+    def test_has_all_kernel_classes(self):
         content = KERNEL_INIT.read_text()
-        for cls in KERNEL_CLASSES:
+        for cls in ALL_KERNEL_CLASSES:
             assert cls in content, f"Kernel class {cls!r} not found in {KERNEL_INIT}"
 
-    def test_imports_are_commented_out(self):
+    def test_implemented_imports_are_active(self):
         content = KERNEL_INIT.read_text()
-        for cls in KERNEL_CLASSES:
-            # The class should appear in a commented-out import line
+        for cls in IMPLEMENTED_KERNEL_CLASSES:
+            # The class should appear in an uncommented import line
+            found_active = False
+            for line in content.splitlines():
+                if cls in line and not line.lstrip().startswith("#"):
+                    found_active = True
+                    break
+            assert found_active, (
+                f"Implemented kernel class {cls!r} should have an active (uncommented) import"
+            )
+
+    def test_placeholder_imports_are_commented_out(self):
+        content = KERNEL_INIT.read_text()
+        for cls in PLACEHOLDER_KERNEL_CLASSES:
             found_commented = False
             for line in content.splitlines():
                 if cls in line and line.lstrip().startswith("#"):
                     found_commented = True
                     break
-            assert found_commented, f"Kernel class {cls!r} should be in a commented-out import"
+            assert found_commented, (
+                f"Placeholder kernel class {cls!r} should be in a commented-out import"
+            )
 
     def test_has_all_dunder_all(self):
         content = KERNEL_INIT.read_text()
         assert "__all__" in content, "__all__ not found"
 
-    def test_all_entries_are_commented_out(self):
+    def test_implemented_all_entries_are_active(self):
         content = KERNEL_INIT.read_text()
-        for cls in KERNEL_CLASSES:
-            # Each class should appear in __all__ as a commented-out string entry
+        for cls in IMPLEMENTED_KERNEL_CLASSES:
+            found_active = False
+            for line in content.splitlines():
+                if f'"{cls}"' in line and not line.lstrip().startswith("#"):
+                    found_active = True
+                    break
+            assert found_active, (
+                f"Implemented kernel class {cls!r} should have an active __all__ entry"
+            )
+
+    def test_placeholder_all_entries_are_commented_out(self):
+        content = KERNEL_INIT.read_text()
+        for cls in PLACEHOLDER_KERNEL_CLASSES:
             found_commented_all = False
             for line in content.splitlines():
                 if f'"{cls}"' in line and line.lstrip().startswith("#"):
                     found_commented_all = True
                     break
             assert found_commented_all, (
-                f"Kernel class {cls!r} should have a commented-out __all__ entry"
+                f"Placeholder kernel class {cls!r} should have a commented-out __all__ entry"
             )
 
     def test_exact_kernel_count(self):
         content = KERNEL_INIT.read_text()
-        # Count commented-out __all__ entries
-        commented_all = [
+        # Count all __all__ entries (both active and commented) with "Kernel" in them
+        all_entries = [
             line
             for line in content.splitlines()
-            if line.lstrip().startswith("#") and '"' in line and "Kernel" in line
+            if '"' in line
+            and "Kernel" in line
+            and ("__all__" not in line)  # skip the __all__ = [...] declaration line
         ]
-        # Should be at least 6 kernel classes in __all__
-        assert len(commented_all) >= len(KERNEL_CLASSES), (
-            f"Expected at least {len(KERNEL_CLASSES)} commented kernel entries, "
-            f"found {len(commented_all)}"
+        assert len(all_entries) >= len(ALL_KERNEL_CLASSES), (
+            f"Expected at least {len(ALL_KERNEL_CLASSES)} kernel entries, found {len(all_entries)}"
         )
 
 
@@ -118,77 +161,114 @@ class TestOpsReductionInit:
     def test_file_exists(self):
         assert OPS_REDUCTION_INIT.exists(), f"{OPS_REDUCTION_INIT} does not exist"
 
-    def test_has_all_op_classes_commented(self):
+    def test_has_all_op_classes(self):
         content = OPS_REDUCTION_INIT.read_text()
-        for cls in OP_CLASSES:
+        for cls in ALL_OP_CLASSES:
             assert cls in content, f"Op class {cls!r} not found in {OPS_REDUCTION_INIT}"
 
-    def test_imports_are_commented_out(self):
+    def test_implemented_imports_are_active(self):
         content = OPS_REDUCTION_INIT.read_text()
-        for cls in OP_CLASSES:
+        for cls in IMPLEMENTED_OP_CLASSES:
+            found_active = False
+            for line in content.splitlines():
+                if cls in line and not line.lstrip().startswith("#"):
+                    found_active = True
+                    break
+            assert found_active, (
+                f"Implemented op class {cls!r} should have an active (uncommented) import"
+            )
+
+    def test_placeholder_imports_are_commented_out(self):
+        content = OPS_REDUCTION_INIT.read_text()
+        for cls in PLACEHOLDER_OP_CLASSES:
             found_commented = False
             for line in content.splitlines():
                 if cls in line and line.lstrip().startswith("#"):
                     found_commented = True
                     break
-            assert found_commented, f"Op class {cls!r} should be in a commented-out import"
+            assert found_commented, (
+                f"Placeholder op class {cls!r} should be in a commented-out import"
+            )
 
     def test_has_all_dunder_all(self):
         content = OPS_REDUCTION_INIT.read_text()
         assert "__all__" in content, "__all__ not found"
 
-    def test_all_entries_are_commented_out(self):
+    def test_implemented_all_entries_are_active(self):
         content = OPS_REDUCTION_INIT.read_text()
-        for cls in OP_CLASSES:
+        for cls in IMPLEMENTED_OP_CLASSES:
+            found_active = False
+            for line in content.splitlines():
+                if f'"{cls}"' in line and not line.lstrip().startswith("#"):
+                    found_active = True
+                    break
+            assert found_active, f"Implemented op class {cls!r} should have an active __all__ entry"
+
+    def test_placeholder_all_entries_are_commented_out(self):
+        content = OPS_REDUCTION_INIT.read_text()
+        for cls in PLACEHOLDER_OP_CLASSES:
             found_commented_all = False
             for line in content.splitlines():
                 if f'"{cls}"' in line and line.lstrip().startswith("#"):
                     found_commented_all = True
                     break
             assert found_commented_all, (
-                f"Op class {cls!r} should have a commented-out __all__ entry"
+                f"Placeholder op class {cls!r} should have a commented-out __all__ entry"
             )
 
     def test_exact_op_count(self):
         content = OPS_REDUCTION_INIT.read_text()
-        commented_all = [
+        # Count all __all__ entries (both active and commented) with "Op" in them
+        all_entries = [
             line
             for line in content.splitlines()
-            if line.lstrip().startswith("#") and '"' in line and "Op" in line
+            if '"' in line and "Op" in line and ("__all__" not in line)
         ]
-        assert len(commented_all) >= len(OP_CLASSES), (
-            f"Expected at least {len(OP_CLASSES)} commented op entries, found {len(commented_all)}"
+        assert len(all_entries) >= len(ALL_OP_CLASSES), (
+            f"Expected at least {len(ALL_OP_CLASSES)} op entries, found {len(all_entries)}"
         )
 
 
 class TestOpsMainInit:
     """Tests for tileops/ops/__init__.py reduction entries."""
 
-    def test_has_reduction_imports_commented(self):
+    def test_has_reduction_import(self):
         content = OPS_INIT.read_text()
-        # Should have a commented-out import from .reduction
+        # Should have an active import from .reduction (not fully commented)
         found = False
         for line in content.splitlines():
-            if ".reduction" in line and line.lstrip().startswith("#"):
+            if ".reduction" in line and "import" in line and not line.lstrip().startswith("#"):
                 found = True
                 break
-        assert found, "Commented-out .reduction import not found in ops/__init__.py"
+        assert found, "Active .reduction import not found in ops/__init__.py"
 
     def test_has_all_op_classes_in_all(self):
         content = OPS_INIT.read_text()
-        for cls in OP_CLASSES:
+        for cls in ALL_OP_CLASSES:
             assert cls in content, f"Op class {cls!r} not found in ops/__init__.py __all__"
 
-    def test_all_op_entries_are_commented(self):
+    def test_implemented_op_entries_are_active(self):
         content = OPS_INIT.read_text()
-        for cls in OP_CLASSES:
+        for cls in IMPLEMENTED_OP_CLASSES:
+            found_active = False
+            for line in content.splitlines():
+                if f'"{cls}"' in line and not line.lstrip().startswith("#"):
+                    found_active = True
+                    break
+            assert found_active, (
+                f"Implemented op class {cls!r} should have an active __all__ entry in ops/__init__.py"
+            )
+
+    def test_placeholder_op_entries_are_commented(self):
+        content = OPS_INIT.read_text()
+        for cls in PLACEHOLDER_OP_CLASSES:
             found_commented_all = False
             for line in content.splitlines():
                 if f'"{cls}"' in line and line.lstrip().startswith("#"):
                     found_commented_all = True
                     break
             assert found_commented_all, (
-                f"Op class {cls!r} should have a commented-out __all__ entry"
+                f"Placeholder op class {cls!r} should have a commented-out __all__ entry"
             )
 
 

--- a/tileops/kernels/online_softmax.py
+++ b/tileops/kernels/online_softmax.py
@@ -19,7 +19,7 @@ def make_log2e_scale(dim):
 
     Returns (1/sqrt(dim)) * log2(e) for use with exp2-based softmax.
     """
-    return (1.0 / dim)**0.5 * LOG2E
+    return (1.0 / dim) ** 0.5 * LOG2E
 
 
 def make_online_softmax(scale, accum_dtype, block_rows, block_cols):

--- a/tileops/kernels/reduction/__init__.py
+++ b/tileops/kernels/reduction/__init__.py
@@ -16,12 +16,12 @@ from ._primitives import (
 
 # Placeholder imports for reduction kernels.
 # Each sub-category PR uncomments its own lines.
-
 # from .argreduce import ArgreduceKernel
 # from .cumulative import CumulativeKernel
 # from .logical_reduce import LogicalReduceKernel
 # from .reduce import ReduceKernel
-# from .softmax import SoftmaxKernel
+from .softmax import LogSumExpKernel, SoftmaxKernel
+
 # from .vector_norm import VectorNormKernel
 
 __all__: list[str] = [
@@ -35,6 +35,7 @@ __all__: list[str] = [
     # "CumulativeKernel",
     # "LogicalReduceKernel",
     # "ReduceKernel",
-    # "SoftmaxKernel",
+    "LogSumExpKernel",
+    "SoftmaxKernel",
     # "VectorNormKernel",
 ]

--- a/tileops/kernels/reduction/softmax/__init__.py
+++ b/tileops/kernels/reduction/softmax/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) Tile-AI. All rights reserved.
+"""Softmax-family kernels (softmax, log_softmax, logsumexp)."""
+
+from .logsumexp_fwd import LogSumExpKernel
+from .softmax_fwd import SoftmaxKernel
+
+__all__: list[str] = [
+    "LogSumExpKernel",
+    "SoftmaxKernel",
+]

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -1,0 +1,191 @@
+"""LogSumExp forward kernel using TileLang.
+
+Implements a 2-pass online algorithm for:
+  - logsumexp: y[i] = max_i + log(sum_i(exp(x[i,j] - max_i)))
+
+256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
+memory instructions. Padding zeros are handled by using -infinity fill so
+they contribute 0 to the softmax denominator.
+"""
+
+import itertools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel import Kernel
+from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
+
+__all__ = ["LogSumExpKernel"]
+
+
+def _logsumexp_kernel(M: int, N: int, dtype: str):
+    """Build a TileLang logsumexp kernel.
+
+    Uses a 2-pass approach:
+      Pass 1: Compute row-wise max for numerical stability.
+      Pass 2: Compute exp(x - max) and row-wise sum, then max + log(sum).
+
+    Args:
+        M: Number of rows (product of all leading dimensions).
+        N: Hidden dimension (last dim).
+        dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
+
+    Returns:
+        A TileLang JIT-compiled kernel factory accepting (block_m, threads).
+    """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+
+    # Output is (M,) -- one scalar per row
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m, threads):
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N_padded), dtype],
+            y: T.Tensor[(M,), dtype],
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                x_local = T.alloc_fragment((block_m, N_padded), dtype)
+                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                row_max = T.alloc_fragment((block_m,), "float32")
+                row_sum = T.alloc_fragment((block_m,), "float32")
+
+                # Load input via shared memory
+                T.copy(x[pid_m * block_m, 0], shared_buf)
+                T.copy(shared_buf, x_local)
+
+                # Cast to fp32
+                for i, j in T.Parallel(block_m, N_padded):
+                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+                # Pass 1: row-wise max
+                T.fill(row_max, -T.infinity("float32"))
+                T.reduce_max(x_f32, row_max, dim=1, clear=False)
+
+                # Pass 2: exp(x - max) and row-wise sum
+                for i, j in T.Parallel(block_m, N_padded):
+                    x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                T.reduce_sum(x_f32, row_sum, dim=1)
+
+                # logsumexp = max + log(sum)
+                # Correct for padding: padded positions had -inf, exp(-inf - max) = 0
+                # so they don't affect the sum.
+                out_local = T.alloc_fragment((block_m,), dtype)
+                for i in T.Parallel(block_m):
+                    out_local[i] = row_max[i] + T.log(row_sum[i])
+
+                T.copy(out_local, y[pid_m * block_m])
+
+        return main
+
+    return _func
+
+
+# ---------------------------------------------------------------------------
+# custom_op wrappers for torch.compile compatibility
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("top::logsumexp_fwd", mutates_args=())
+def _logsumexp_fwd_wrapped(
+    M: int,
+    N: int,
+    dtype_str: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _logsumexp_kernel(M, N, dtype_str)(block_m, threads)(x)
+
+
+@_logsumexp_fwd_wrapped.register_fake
+def _(M, N, dtype_str, block_m, threads, x):
+    return torch.empty((M,), dtype=x.dtype, device=x.device)
+
+
+# ---------------------------------------------------------------------------
+# Kernel class
+# ---------------------------------------------------------------------------
+
+
+class LogSumExpKernel(Kernel):
+    """LogSumExp forward kernel.
+
+    Supports SM80+ architectures. Uses 256-element alignment for shared
+    memory copies. Implements a 2-pass online algorithm.
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        op_kind: Must be "logsumexp" (kept for API consistency with SoftmaxKernel).
+        dtype: Data type (float32, float16, or bfloat16).
+        config: Optional kernel configuration dict.
+        tune: Whether to autotune (default False).
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        M: int,
+        N: int,
+        op_kind: str,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        if op_kind != "logsumexp":
+            raise ValueError(f"Unsupported op_kind '{op_kind}'. Expected 'logsumexp'.")
+        self.M = M
+        self.N = N
+        self.op_kind = op_kind
+        self.dtype = dtype
+        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        self.kernel = _logsumexp_kernel(
+            self.M,
+            self.N,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        """Select default block_m based on shared memory budget."""
+        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_m = 1
+        for bm in [1, 2, 4, 8, 16]:
+            if bm <= max_block_m:
+                block_m = bm
+        return {"block_m": block_m, "threads": 256}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
+        threads_list = [128, 256]
+        configs = list(itertools.product(block_ms, threads_list))
+        return [{"block_m": bm, "threads": t} for bm, t in configs]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the logsumexp kernel.
+
+        Args:
+            x: Input tensor of shape (M, N_padded).
+
+        Returns:
+            Output tensor of shape (M,).
+        """
+        return _logsumexp_fwd_wrapped(
+            self.M,
+            self.N,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -1,0 +1,248 @@
+"""Softmax / log-softmax forward kernel using TileLang.
+
+Implements a 2-pass online softmax algorithm for two operations:
+  - softmax:     y[i,j] = exp(x[i,j] - max_i) / sum_i(exp(x[i,j] - max_i))
+  - log_softmax: y[i,j] = x[i,j] - max_i - log(sum_i(exp(x[i,j] - max_i)))
+
+256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
+memory instructions. Padding zeros are handled by using -infinity fill so
+they contribute 0 to the softmax denominator.
+"""
+
+import itertools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel import Kernel
+from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
+
+__all__ = ["SoftmaxKernel"]
+
+
+def _softmax_kernel(M: int, N: int, op_kind: str, dtype: str):
+    """Build a TileLang softmax/log_softmax kernel.
+
+    Uses a 2-pass approach:
+      Pass 1: Compute row-wise max for numerical stability.
+      Pass 2: Compute exp(x - max) and row-wise sum, then normalize.
+
+    Args:
+        M: Number of rows (product of all leading dimensions).
+        N: Hidden dimension (last dim).
+        op_kind: One of "softmax", "log_softmax".
+        dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
+
+    Returns:
+        A TileLang JIT-compiled kernel factory accepting (block_m, threads).
+    """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+
+    if op_kind == "softmax":
+
+        @tilelang.jit(out_idx=[1])
+        def _func(block_m, threads):
+            @T.prim_func
+            def main(
+                x: T.Tensor[(M, N_padded), dtype],
+                y: T.Tensor[(M, N_padded), dtype],
+            ):
+                with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                    x_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                    row_max = T.alloc_fragment((block_m,), "float32")
+                    row_sum = T.alloc_fragment((block_m,), "float32")
+
+                    # Load input via shared memory
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+
+                    # Cast to fp32
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+                    # Pass 1: row-wise max
+                    T.fill(row_max, -T.infinity("float32"))
+                    T.reduce_max(x_f32, row_max, dim=1, clear=False)
+
+                    # Pass 2: exp(x - max) and row-wise sum
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                    T.reduce_sum(x_f32, row_sum, dim=1)
+
+                    # Epilogue: normalize (softmax)
+                    out_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                    for i, j in T.Parallel(block_m, N_padded):
+                        out_f32[i, j] = x_f32[i, j] / row_sum[i]
+
+                    # Cast back to original dtype and write via shared memory
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = out_f32[i, j]
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
+
+            return main
+
+    else:  # log_softmax
+
+        @tilelang.jit(out_idx=[1])
+        def _func(block_m, threads):
+            @T.prim_func
+            def main(
+                x: T.Tensor[(M, N_padded), dtype],
+                y: T.Tensor[(M, N_padded), dtype],
+            ):
+                with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                    x_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                    row_max = T.alloc_fragment((block_m,), "float32")
+                    row_sum = T.alloc_fragment((block_m,), "float32")
+
+                    # Load input via shared memory
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+
+                    # Cast to fp32
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+                    # Pass 1: row-wise max
+                    T.fill(row_max, -T.infinity("float32"))
+                    T.reduce_max(x_f32, row_max, dim=1, clear=False)
+
+                    # Pass 2: exp(x - max) and row-wise sum
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                    T.reduce_sum(x_f32, row_sum, dim=1)
+
+                    # Epilogue: log-normalize (log_softmax)
+                    out_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                    for i, j in T.Parallel(block_m, N_padded):
+                        out_f32[i, j] = T.log(x_f32[i, j] / row_sum[i])
+
+                    # Cast back to original dtype and write via shared memory
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = out_f32[i, j]
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
+
+            return main
+
+    return _func
+
+
+# ---------------------------------------------------------------------------
+# custom_op wrappers for torch.compile compatibility
+# ---------------------------------------------------------------------------
+
+
+@torch.library.custom_op("top::softmax_fwd", mutates_args=())
+def _softmax_fwd_wrapped(
+    M: int,
+    N: int,
+    op_kind: str,
+    dtype_str: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _softmax_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
+
+
+@_softmax_fwd_wrapped.register_fake
+def _(M, N, op_kind, dtype_str, block_m, threads, x):
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
+
+
+# ---------------------------------------------------------------------------
+# Kernel class
+# ---------------------------------------------------------------------------
+
+
+class SoftmaxKernel(Kernel):
+    """Softmax / log-softmax forward kernel.
+
+    Supports SM80+ architectures. Uses 256-element alignment for shared
+    memory copies. Implements a 2-pass online softmax algorithm.
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        op_kind: One of "softmax", "log_softmax".
+        dtype: Data type (float32, float16, or bfloat16).
+        config: Optional kernel configuration dict.
+        tune: Whether to autotune (default False).
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        M: int,
+        N: int,
+        op_kind: str,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        if op_kind not in ("softmax", "log_softmax"):
+            raise ValueError(
+                f"Unsupported op_kind '{op_kind}'. Expected one of 'softmax', 'log_softmax'."
+            )
+        self.M = M
+        self.N = N
+        self.op_kind = op_kind
+        self.dtype = dtype
+        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        self.kernel = _softmax_kernel(
+            self.M,
+            self.N,
+            self.op_kind,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        """Select default block_m based on shared memory budget."""
+        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_m = 1
+        for bm in [1, 2, 4, 8, 16]:
+            if bm <= max_block_m:
+                block_m = bm
+        return {"block_m": block_m, "threads": 256}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
+        threads_list = [128, 256]
+        configs = list(itertools.product(block_ms, threads_list))
+        return [{"block_m": bm, "threads": t} for bm, t in configs]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the softmax/log_softmax kernel.
+
+        Args:
+            x: Input tensor of shape (M, N_padded).
+
+        Returns:
+            Output tensor of shape (M, N_padded).
+        """
+        return _softmax_fwd_wrapped(
+            self.M,
+            self.N,
+            self.op_kind,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -37,28 +37,28 @@ from .norm import (
 from .op import Op
 
 # --- Reduction ops (uncomment as sub-category PRs land) ---
-# from .reduction import (
-#     AllOp,
-#     AnyOp,
-#     ArgmaxOp,
-#     ArgminOp,
-#     CountNonzeroOp,
-#     CummaxOp,
-#     CumminOp,
-#     CumprodOp,
-#     CumsumOp,
-#     InfNormOp,
-#     L1NormOp,
-#     L2NormOp,
-#     LogSoftmaxOp,
-#     LogSumExpOp,
-#     ReduceMaxOp,
-#     ReduceMeanOp,
-#     ReduceMinOp,
-#     ReduceProdOp,
-#     ReduceSumOp,
-#     SoftmaxOp,
-# )
+from .reduction import (
+    # AllOp,
+    # AnyOp,
+    # ArgmaxOp,
+    # ArgminOp,
+    # CountNonzeroOp,
+    # CummaxOp,
+    # CumminOp,
+    # CumprodOp,
+    # CumsumOp,
+    # InfNormOp,
+    # L1NormOp,
+    # L2NormOp,
+    LogSoftmaxOp,
+    LogSumExpOp,
+    # ReduceMaxOp,
+    # ReduceMeanOp,
+    # ReduceMinOp,
+    # ReduceProdOp,
+    # ReduceSumOp,
+    SoftmaxOp,
+)
 from .topk_selector import TopkSelectorOp
 
 __all__ = [
@@ -113,12 +113,12 @@ __all__ = [
     # "InfNormOp",
     # "L1NormOp",
     # "L2NormOp",
-    # "LogSoftmaxOp",
-    # "LogSumExpOp",
+    "LogSoftmaxOp",
+    "LogSumExpOp",
     # "ReduceMaxOp",
     # "ReduceMeanOp",
     # "ReduceMinOp",
     # "ReduceProdOp",
     # "ReduceSumOp",
-    # "SoftmaxOp",
+    "SoftmaxOp",
 ]

--- a/tileops/ops/reduction/__init__.py
+++ b/tileops/ops/reduction/__init__.py
@@ -17,9 +17,9 @@ kernels are implemented.
 # from .reduce_prod import ReduceProdOp
 
 # --- SoftmaxKernel ops ---
-# from .softmax import SoftmaxOp
-# from .log_softmax import LogSoftmaxOp
-# from .log_sum_exp import LogSumExpOp
+from .log_softmax import LogSoftmaxOp
+from .logsumexp import LogSumExpOp
+from .softmax import SoftmaxOp
 
 # --- ArgreduceKernel ops ---
 # from .argmax import ArgmaxOp
@@ -49,9 +49,9 @@ __all__: list[str] = [
     # "ReduceMinOp",
     # "ReduceProdOp",
     # --- SoftmaxKernel ops ---
-    # "SoftmaxOp",
-    # "LogSoftmaxOp",
-    # "LogSumExpOp",
+    "SoftmaxOp",
+    "LogSoftmaxOp",
+    "LogSumExpOp",
     # --- ArgreduceKernel ops ---
     # "ArgmaxOp",
     # "ArgminOp",

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -1,0 +1,110 @@
+"""Base class for softmax-family operators (L2 Op layer).
+
+Provides the shared validate -> reshape -> pad -> kernel -> trim -> reshape
+pattern for softmax, log_softmax, and logsumexp ops.
+"""
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+
+from tileops.kernels.kernel import Kernel
+from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
+
+from ..op import Op
+
+__all__ = ["_SoftmaxBaseOp"]
+
+
+class _SoftmaxBaseOp(Op):
+    """Base class for softmax-family ops.
+
+    Handles shared validation, reshape, pad/trim logic. Subclasses only
+    need to set ``_op_kind``, ``_kernel_key``, ``_kernel_class`` and
+    override output reshaping if needed.
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        dtype: Data type (float32, float16, or bfloat16).
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+    """
+
+    _op_kind: str  # set by subclass
+    _kernel_key: str  # set by subclass
+    _kernel_class: type  # set by subclass
+
+    def __init__(
+        self,
+        M: int,
+        N: int,
+        dtype: torch.dtype,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        self.M = M
+        self.N = N
+        self.dtype = dtype
+        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map[self._kernel_key](
+            M,
+            N,
+            self._op_kind,
+            dtype,
+            tune=tune,
+        )
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {self._kernel_key: self._kernel_class}
+
+    def _validate(self, x: torch.Tensor) -> None:
+        """Validate input tensor."""
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.dtype != self.dtype:
+            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        if x.shape[-1] != self.N:
+            raise ValueError(f"Expected hidden dim {self.N}, got {x.shape[-1]}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the softmax-family op.
+
+        Accepts 1D-4D input. Operates along dim=-1.
+
+        Args:
+            x: Input tensor with last dim == N.
+
+        Returns:
+            Output tensor. Same shape as input for softmax/log_softmax,
+            or input shape without last dim for logsumexp.
+        """
+        self._validate(x)
+        orig_shape = x.shape
+
+        # Flatten leading dims: (..., N) -> (M, N)
+        x = x.contiguous().reshape(-1, self.N)
+        M_actual = x.shape[0]
+        if M_actual != self.M:
+            raise ValueError(f"Expected M={self.M} (product of leading dims), got {M_actual}")
+
+        # Pad hidden dim to alignment
+        if self.N_padded != self.N:
+            x = F.pad(x, (0, self.N_padded - self.N), value=float("-inf"))
+
+        y = self.kernel(x)
+
+        return self._reshape_output(y, orig_shape)
+
+    def _reshape_output(
+        self,
+        y: torch.Tensor,
+        orig_shape: torch.Size,
+    ) -> torch.Tensor:
+        """Trim padding and restore original leading dims."""
+        if self.N_padded != self.N:
+            y = y[:, : self.N]
+        return y.reshape(orig_shape)

--- a/tileops/ops/reduction/log_softmax.py
+++ b/tileops/ops/reduction/log_softmax.py
@@ -1,0 +1,37 @@
+"""Log-softmax operator (L2 Op layer).
+
+Provides:
+  - LogSoftmaxOp: y = log_softmax(x, dim=-1)
+
+Follows the validate -> reshape -> pad -> kernel -> trim -> reshape pattern
+and supports 1D-4D input with dim=-1.
+"""
+
+from tileops.kernels.reduction.softmax import SoftmaxKernel
+
+from ._softmax_base import _SoftmaxBaseOp
+
+__all__ = ["LogSoftmaxOp"]
+
+
+class LogSoftmaxOp(_SoftmaxBaseOp):
+    """Log-softmax operator: y = log_softmax(x, dim=-1).
+
+    Output has the same shape and dtype as input.
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        dtype: Data type (float32, float16, or bfloat16).
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = LogSoftmaxOp(M=1024, N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        >>> y = op(x)  # shape: (1024, 4096)
+    """
+
+    _op_kind = "log_softmax"
+    _kernel_key = "softmax_fwd"
+    _kernel_class = SoftmaxKernel

--- a/tileops/ops/reduction/logsumexp.py
+++ b/tileops/ops/reduction/logsumexp.py
@@ -1,0 +1,52 @@
+"""LogSumExp operator (L2 Op layer).
+
+Provides:
+  - LogSumExpOp: y = logsumexp(x, dim=-1)
+
+Follows the validate -> reshape -> pad -> kernel -> trim -> reshape pattern
+and supports 1D-4D input with dim=-1.
+"""
+
+import torch
+
+from tileops.kernels.reduction.softmax import LogSumExpKernel
+
+from ._softmax_base import _SoftmaxBaseOp
+
+__all__ = ["LogSumExpOp"]
+
+
+class LogSumExpOp(_SoftmaxBaseOp):
+    """LogSumExp operator: y = logsumexp(x, dim=-1).
+
+    Output shape is input shape without the last dimension (*leading,).
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        dtype: Data type (float32, float16, or bfloat16).
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = LogSumExpOp(M=1024, N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        >>> y = op(x)  # shape: (1024,)
+    """
+
+    _op_kind = "logsumexp"
+    _kernel_key = "logsumexp_fwd"
+    _kernel_class = LogSumExpKernel
+
+    def _reshape_output(
+        self,
+        y: torch.Tensor,
+        orig_shape: torch.Size,
+    ) -> torch.Tensor:
+        """Restore leading dims without the last dimension."""
+        # y is (M,) -- reshape to (*leading_dims,)
+        leading_shape = orig_shape[:-1]
+        if len(leading_shape) == 0:
+            # 1D input -> scalar output
+            return y.squeeze()
+        return y.reshape(leading_shape)

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -1,0 +1,37 @@
+"""Softmax operator (L2 Op layer).
+
+Provides:
+  - SoftmaxOp: y = softmax(x, dim=-1)
+
+Follows the validate -> reshape -> pad -> kernel -> trim -> reshape pattern
+and supports 1D-4D input with dim=-1.
+"""
+
+from tileops.kernels.reduction.softmax import SoftmaxKernel
+
+from ._softmax_base import _SoftmaxBaseOp
+
+__all__ = ["SoftmaxOp"]
+
+
+class SoftmaxOp(_SoftmaxBaseOp):
+    """Softmax operator: y = softmax(x, dim=-1).
+
+    Output has the same shape and dtype as input.
+
+    Args:
+        M: Number of rows (product of all dims except last).
+        N: Hidden dimension (last dim).
+        dtype: Data type (float32, float16, or bfloat16).
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = SoftmaxOp(M=1024, N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        >>> y = op(x)  # shape: (1024, 4096)
+    """
+
+    _op_kind = "softmax"
+    _kernel_key = "softmax_fwd"
+    _kernel_class = SoftmaxKernel


### PR DESCRIPTION
## Summary

- Add three softmax-family reduction operators: `SoftmaxOp`, `LogSoftmaxOp`, `LogSumExpOp` with a clean split architecture
- Ops split into 3 files plus a shared base class (`_softmax_base.py`); kernels split into 2 files with no if-branching on `op_kind`
- 166 correctness test cases covering all 3 ops, 3 dtypes (fp32/fp16/bf16), contiguous + non-contiguous layouts, 1D-4D tensors, pow2 + non-pow2 dims; 29 init/import tests

Closes #420

## Architecture

### Ops (3 files + shared base)
| File | Class |
|------|-------|
| `tileops/ops/reduction/softmax.py` | `SoftmaxOp` |
| `tileops/ops/reduction/log_softmax.py` | `LogSoftmaxOp` |
| `tileops/ops/reduction/logsumexp.py` | `LogSumExpOp` |
| `tileops/ops/reduction/_softmax_base.py` | `_SoftmaxBaseOp` (shared) |

### Kernels (2 files, no op_kind branching)
| File | Class | Covers |
|------|-------|--------|
| `tileops/kernels/reduction/softmax/softmax_fwd.py` | `SoftmaxKernel` | softmax + log_softmax (compile-time dispatch) |
| `tileops/kernels/reduction/softmax/logsumexp_fwd.py` | `LogSumExpKernel` | logsumexp only |

## Test plan

- [x] AC-1: Ops split into 3 separate files (softmax.py, log_softmax.py, logsumexp.py)
- [x] AC-2: Kernel split into 2 files (softmax_fwd.py, logsumexp_fwd.py) with no if-branching on op_kind
- [x] AC-3: Smoke tests cover ALL configurations (all dtypes, contiguous/non-contiguous, 1D-4D, pow2/non-pow2)
- [x] AC-4: Benchmark data included in PR body (see below)
- [x] AC-5: All correctness tests pass against PyTorch refs (166 cases)
- [x] AC-6: `__init__.py` files updated with correct re-exports
- [x] AC-7: Lint passes (ruff check, ruff format --check)
- [x] AC-8: `test_reduction_init_files.py` passes (29/29)

## Benchmark

**67/67 benchmarks passed** on NVIDIA H200 (Torch 2.9.1+cu128, CUDA 12.8, Driver 575.57.08)

### Summary (fp16, 4096x4096)

| Op | TileOPs (TFLOPS) | PyTorch (TFLOPS) | Speedup |
|---|---|---|---|
| softmax | 1.00 | 0.39 | **2.6x** |
| log_softmax | 0.93 | 0.72 | **1.3x** |
| logsumexp | 1.36 | 0.27 | **5.0x** |

### softmax

<details>
<summary>TileOPs</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.00 | 0.01 | 0.02 |
| 32 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 32 | 300 | fp32 | 0.02 | 0.00 | 0.01 |
| 32 | 300 | fp16 | 0.01 | 0.00 | 0.00 |
| 32 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.00 | 0.01 | 0.02 |
| 33 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 33 | 300 | fp32 | 0.01 | 0.00 | 0.01 |
| 33 | 300 | fp16 | 0.01 | 0.00 | 0.00 |
| 33 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 1024 | 4096 | fp32 | 0.02 | 0.68 | 1.37 |
| 4096 | 4096 | fp32 | 0.09 | 0.76 | 1.53 |
| 1024 | 4096 | fp16 | 0.02 | 0.93 | 0.93 |
| 4096 | 4096 | fp16 | 0.07 | 1.00 | 1.00 |
| 1024 | 4096 | bf16 | 0.02 | 0.90 | 0.90 |
| 4096 | 4096 | bf16 | 0.07 | 0.99 | 0.99 |
| 1024 | 3000 | fp32 | 0.03 | 0.37 | 0.74 |
| 1024 | 3000 | fp16 | 0.03 | 0.42 | 0.42 |
| 1024 | 3000 | bf16 | 0.03 | 0.41 | 0.41 |
| 1025 | 4096 | fp16 | 0.02 | 0.91 | 0.91 |
| 1025 | 4096 | bf16 | 0.02 | 0.92 | 0.92 |

</details>

<details>
<summary>PyTorch Baseline</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.00 | 0.01 | 0.02 |
| 32 | 256 | fp16 | 0.01 | 0.00 | 0.00 |
| 32 | 256 | bf16 | 0.01 | 0.00 | 0.00 |
| 32 | 300 | fp32 | 0.01 | 0.00 | 0.01 |
| 32 | 300 | fp16 | 0.01 | 0.00 | 0.00 |
| 32 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | fp16 | 0.01 | 0.00 | 0.00 |
| 33 | 256 | bf16 | 0.01 | 0.01 | 0.01 |
| 33 | 300 | fp32 | 0.01 | 0.00 | 0.01 |
| 33 | 300 | fp16 | 0.02 | 0.00 | 0.00 |
| 33 | 300 | bf16 | 0.01 | 0.01 | 0.01 |
| 1024 | 4096 | fp32 | 0.05 | 0.31 | 0.63 |
| 4096 | 4096 | fp32 | 0.16 | 0.43 | 0.86 |
| 1024 | 4096 | fp16 | 0.06 | 0.29 | 0.29 |
| 4096 | 4096 | fp16 | 0.17 | 0.39 | 0.39 |
| 1024 | 4096 | bf16 | 0.05 | 0.33 | 0.33 |
| 4096 | 4096 | bf16 | 0.16 | 0.43 | 0.43 |
| 1024 | 3000 | fp32 | 0.04 | 0.28 | 0.56 |
| 1024 | 3000 | fp16 | 0.04 | 0.30 | 0.30 |
| 1024 | 3000 | bf16 | 0.05 | 0.27 | 0.27 |
| 1025 | 4096 | fp16 | 0.06 | 0.26 | 0.26 |
| 1025 | 4096 | bf16 | 0.05 | 0.31 | 0.31 |

</details>

### log_softmax

<details>
<summary>TileOPs</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 32 | 300 | fp32 | 0.02 | 0.00 | 0.00 |
| 32 | 300 | fp16 | 0.02 | 0.00 | 0.00 |
| 32 | 300 | bf16 | 0.02 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 33 | 300 | fp32 | 0.02 | 0.00 | 0.00 |
| 33 | 300 | fp16 | 0.02 | 0.00 | 0.00 |
| 33 | 300 | bf16 | 0.02 | 0.00 | 0.00 |
| 1024 | 4096 | fp32 | 0.03 | 0.67 | 1.07 |
| 4096 | 4096 | fp32 | 0.12 | 0.73 | 1.16 |
| 1024 | 4096 | fp16 | 0.02 | 0.85 | 0.68 |
| 4096 | 4096 | fp16 | 0.09 | 0.93 | 0.74 |
| 1024 | 4096 | bf16 | 0.03 | 0.83 | 0.66 |
| 4096 | 4096 | bf16 | 0.09 | 0.91 | 0.73 |
| 1024 | 3000 | fp32 | 0.04 | 0.41 | 0.65 |
| 1024 | 3000 | fp16 | 0.04 | 0.40 | 0.32 |
| 1024 | 3000 | bf16 | 0.04 | 0.40 | 0.32 |
| 1025 | 4096 | fp16 | 0.02 | 0.86 | 0.69 |

</details>

<details>
<summary>PyTorch Baseline</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.00 | 0.01 | 0.02 |
| 32 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 32 | 300 | fp32 | 0.01 | 0.01 | 0.01 |
| 32 | 300 | fp16 | 0.00 | 0.01 | 0.01 |
| 32 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.01 | 0.01 | 0.01 |
| 33 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 33 | 300 | fp32 | 0.00 | 0.02 | 0.03 |
| 33 | 300 | fp16 | 0.01 | 0.01 | 0.00 |
| 33 | 300 | bf16 | 0.01 | 0.01 | 0.01 |
| 1024 | 4096 | fp32 | 0.04 | 0.59 | 0.95 |
| 4096 | 4096 | fp32 | 0.15 | 0.56 | 0.89 |
| 1024 | 4096 | fp16 | 0.03 | 0.76 | 0.61 |
| 4096 | 4096 | fp16 | 0.12 | 0.72 | 0.58 |
| 1024 | 4096 | bf16 | 0.04 | 0.53 | 0.43 |
| 4096 | 4096 | bf16 | 0.14 | 0.60 | 0.48 |
| 1024 | 3000 | fp32 | 0.04 | 0.43 | 0.69 |
| 1024 | 3000 | fp16 | 0.05 | 0.32 | 0.26 |
| 1024 | 3000 | bf16 | 0.03 | 0.47 | 0.38 |
| 1025 | 4096 | fp16 | 0.04 | 0.51 | 0.41 |

</details>

### logsumexp

<details>
<summary>TileOPs</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 32 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 32 | 300 | fp32 | 0.01 | 0.00 | 0.00 |
| 32 | 300 | fp16 | 0.01 | 0.00 | 0.00 |
| 32 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | fp16 | 0.00 | 0.01 | 0.01 |
| 33 | 256 | bf16 | 0.00 | 0.01 | 0.01 |
| 33 | 300 | fp32 | 0.01 | 0.00 | 0.00 |
| 33 | 300 | fp16 | 0.01 | 0.00 | 0.00 |
| 33 | 300 | bf16 | 0.01 | 0.00 | 0.00 |
| 1024 | 4096 | fp32 | 0.02 | 0.81 | 1.07 |
| 4096 | 4096 | fp32 | 0.05 | 0.94 | 1.25 |
| 1024 | 4096 | fp16 | 0.01 | 1.15 | 0.76 |
| 4096 | 4096 | fp16 | 0.04 | 1.36 | 0.91 |
| 1024 | 4096 | bf16 | 0.01 | 1.12 | 0.75 |
| 4096 | 4096 | bf16 | 0.04 | 1.33 | 0.89 |
| 1024 | 3000 | fp32 | 0.02 | 0.43 | 0.57 |
| 1024 | 3000 | fp16 | 0.02 | 0.49 | 0.33 |
| 1024 | 3000 | bf16 | 0.02 | 0.49 | 0.33 |
| 1025 | 4096 | fp16 | 0.01 | 1.12 | 0.75 |

</details>

<details>
<summary>PyTorch Baseline</summary>

| M | N | dtype | Latency (ms) | TFLOPS | BW (TB/s) |
|---|---|---|---|---|---|
| 32 | 256 | fp32 | 0.02 | 0.00 | 0.00 |
| 32 | 256 | fp16 | 0.03 | 0.00 | 0.00 |
| 32 | 256 | bf16 | 0.03 | 0.00 | 0.00 |
| 32 | 300 | fp32 | 0.03 | 0.00 | 0.00 |
| 32 | 300 | fp16 | 0.03 | 0.00 | 0.00 |
| 32 | 300 | bf16 | 0.04 | 0.00 | 0.00 |
| 33 | 256 | fp32 | 0.02 | 0.00 | 0.00 |
| 33 | 256 | fp16 | 0.03 | 0.00 | 0.00 |
| 33 | 256 | bf16 | 0.05 | 0.00 | 0.00 |
| 33 | 300 | fp32 | 0.03 | 0.00 | 0.00 |
| 33 | 300 | fp16 | 0.02 | 0.00 | 0.00 |
| 33 | 300 | bf16 | 0.02 | 0.00 | 0.00 |
| 1024 | 4096 | fp32 | 0.11 | 0.12 | 0.16 |
| 4096 | 4096 | fp32 | 0.12 | 0.42 | 0.56 |
| 1024 | 4096 | fp16 | 0.11 | 0.12 | 0.08 |
| 4096 | 4096 | fp16 | 0.18 | 0.27 | 0.18 |
| 1024 | 4096 | bf16 | 0.10 | 0.12 | 0.08 |
| 4096 | 4096 | bf16 | 0.22 | 0.23 | 0.15 |
| 1024 | 3000 | fp32 | 0.10 | 0.09 | 0.12 |
| 1024 | 3000 | fp16 | 0.08 | 0.11 | 0.07 |
| 1024 | 3000 | bf16 | 0.10 | 0.10 | 0.06 |
| 1025 | 4096 | fp16 | 0.04 | 0.29 | 0.19 |

</details>