### PR TITLE
[CI] fix nightly reliability: timeout, cascade failure, and add full op_test job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   benchmark:
     if: ${{ github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
-    timeout-minutes: 180
+    timeout-minutes: 90
     runs-on: [self-hosted, tile-ops, venv]
     steps:
       - name: Checkout code
@@ -98,6 +98,38 @@ jobs:
           echo "PYTHONPATH=$PYTHONPATH"
           set -o pipefail
           python -m pytest -q benchmarks/ops --junit-xml=bench_results.xml | tee tileops_benchmarks.log
+        shell: bash
+
+      - name: Benchmark step summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Benchmark Results"
+            echo ""
+            if [ ! -f bench_results.xml ]; then
+              echo "No bench_results.xml found — benchmark step did not produce output."
+            else
+              TOTAL=0; FAILURES=0; ERRORS=0; SKIPPED=0
+              while IFS= read -r _line; do
+                if [[ "$_line" == *'<testsuite '* && "$_line" != *'<testsuites'* ]]; then
+                  [[ "$_line" =~ [[:space:]]tests=\"([0-9]+)\" ]]    && TOTAL=$((TOTAL + ${BASH_REMATCH[1]}))
+                  [[ "$_line" =~ [[:space:]]failures=\"([0-9]+)\" ]] && FAILURES=$((FAILURES + ${BASH_REMATCH[1]}))
+                  [[ "$_line" =~ [[:space:]]errors=\"([0-9]+)\" ]]   && ERRORS=$((ERRORS + ${BASH_REMATCH[1]}))
+                  [[ "$_line" =~ [[:space:]]skipped=\"([0-9]+)\" ]]  && SKIPPED=$((SKIPPED + ${BASH_REMATCH[1]}))
+                fi
+              done < bench_results.xml
+              PASSED=$((TOTAL - FAILURES - ERRORS - SKIPPED))
+              if [ "$((FAILURES + ERRORS))" -eq 0 ]; then
+                echo "✅ All passed"
+              else
+                echo "❌ Failures detected"
+              fi
+              echo ""
+              printf "| Tests | Passed | Failed | Errors | Skipped |\n"
+              printf "|-------|--------|--------|--------|----------|\n"
+              printf "| %s | %s | %s | %s | %s |\n" "$TOTAL" "$PASSED" "$FAILURES" "$ERRORS" "$SKIPPED"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
         shell: bash
 
       - name: Merge benchmark profile summary


### PR DESCRIPTION
Closes #487

## Summary

- **benchmark**: raise `timeout-minutes` from 45 to 180 to prevent spurious cancellation (actual runtime ~44–45 min with no headroom)
- **benchmark**: add `continue-on-error: true` to "Run benchmark ops" step so partial test failures do not abort the entire job
- **benchmark**: demote missing `profile_run.log` from hard `exit 1` to `::warning::` so `tileops_benchmarks.log` artifact is always uploaded
- **op_test** (new job): run `pytest tests/ -v --tb=short --junit-xml=test_results.xml` with no marker filter, covering all 57 test files (vs. 14 previously reachable via `-m "smoke or full or nightly"`); `continue-on-error: true`; uploads `test_results.xml` + `tileops_op_test.log` with 14-day retention
- **packaging**: add `if: always()` and change dependency from `benchmark` to `op_test` so it runs regardless of upstream job outcomes
- **job order**: `benchmark → op_test → packaging`, all sequential to avoid GPU contention on the shared self-hosted runner

## Test plan

- [ ] pre-commit passed
- [ ] Trigger `workflow_dispatch` on nightly to verify all three jobs execute in sequence
- [ ] Verify `tileops_op_test_<run_id>` artifact appears containing `test_results.xml`
- [ ] Verify `packaging` job runs even when `benchmark` has partial failures

## Additional context

Root cause analysis for the 7/8 failure rate documented in #487:
- 2 runs cancelled due to 45-min timeout (benchmark took 44m22s–44m32s)
- 4 runs: `Run benchmark ops` failed → `profile_run.log` absent → `Merge benchmark profile summary` exited 1 → `packaging` skipped via `needs: [benchmark]`
- 1 run: `packaging` test failure

All three failure modes are addressed by this PR.