### PR TITLE
[Chore][Skills] Rename "compliance" to "readiness" across PR skill and docs

### DIFF
--- a/.claude/skills/creating-pull-request/SKILL.md
+++ b/.claude/skills/creating-pull-request/SKILL.md
@@ -34,16 +34,16 @@ gh repo view --json nameWithOwner -q '.nameWithOwner'
 
 Split into `{owner}` and `{repo}`.
 
-### Step 2: Structural compliance check (new ops only)
+### Step 2: Structural readiness check (new ops only)
 
 If this PR does **not** touch kernel/op code, skip to Step 3.
 
 If this PR introduces or modifies a kernel/op:
 
-1. Read [op-compliance-checklist.md](op-compliance-checklist.md) for the full checklist.
+1. Read [op-readiness-checklist.md](op-readiness-checklist.md) for the full checklist.
 1. Verify the code against every item. Record each as `PASS`, `FAIL (reason)`, or `SKIP (reason)`.
 
-**HARD GATE:** Any `[REQUIRED]` item that is `FAIL` must be fixed before proceeding. `[RECOMMENDED]` items may be skipped with a reason. In the PR body `## Structural Compliance`, only list failures and skips. If all pass, write "All checks passed."
+**HARD GATE:** Any `[REQUIRED]` item that is `FAIL` must be fixed before proceeding. `[RECOMMENDED]` items may be skipped with a reason. In the PR body `## Structural Readiness`, only list failures and skips. If all pass, write "All checks passed."
 
 ### Step 3: Create the PR
 

--- a/.claude/skills/creating-pull-request/op-readiness-checklist.md
+++ b/.claude/skills/creating-pull-request/op-readiness-checklist.md
@@ -1,4 +1,4 @@
-# Op Structural Compliance Checklist
+# Op Structural Readiness Checklist
 
 Items marked **[REQUIRED]** must pass — block the PR if they fail.
 Items marked **[RECOMMENDED]** should pass — note in PR body if skipped with reason.

--- a/.claude/skills/creating-pull-request/template.md
+++ b/.claude/skills/creating-pull-request/template.md
@@ -12,7 +12,7 @@ Closes #<issue-number>
 
 <!-- OPTIONAL SECTIONS: Delete entirely if not applicable. Never leave empty headers. -->
 
-## Structural Compliance
+## Structural Readiness
 
 <!-- Required for new ops or kernel/op changes. Agent-generated — do not edit manually. -->
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Only after **2 Peer Approvals + 1 Mentor Approval + CI Passing** can the code be
 
 **Architecture & Design**
 
-- [ ] **2-Layer Compliance**: Does it cleanly separate `Kernel` (L1) -> `Op` (L2)?
+- [ ] **2-Layer Readiness**: Does it cleanly separate `Kernel` (L1) -> `Op` (L2)?
 - [ ] **API Design**: Is the L2 Op interface Pythonic and standard?
 - [ ] **Compatibility**: Is the L2 Op compatible with `torch.compile` and CUDA Graphs?
 


### PR DESCRIPTION
## Summary

- Rename `op-compliance-checklist.md` → `op-readiness-checklist.md`
- Replace all references from "Structural Compliance" to "Structural Readiness" across skill files and docs
- "Readiness" better reflects agent-human co-creation: the checklist asks "is this op ready to ship?" rather than "does this comply?"

**Changed files:**

| File | Change |
|------|--------|
| `.claude/skills/creating-pull-request/op-compliance-checklist.md` | Renamed to `op-readiness-checklist.md`, updated heading |
| `.claude/skills/creating-pull-request/SKILL.md` | Updated step title, file reference, and PR body section name |
| `.claude/skills/creating-pull-request/template.md` | `## Structural Compliance` → `## Structural Readiness` |
| `docs/CONTRIBUTING.md` | `2-Layer Compliance` → `2-Layer Readiness` |

**Not changed:** `docs/DEVELOPMENT.md:195` ("code style compliance") — generic English usage, unrelated to op checklist.

## Test plan

- [x] `grep -ri compliance` across non-worktree files returns only the unrelated `docs/DEVELOPMENT.md` hit
- [x] All internal links (`op-readiness-checklist.md`) resolve correctly
- [x] pre-commit passes

---
Generated with [Claude Code](https://claude.com/claude-code)