### PR TITLE
[Chore][Skills] Enforce issue claim before work in lifecycle-issue-fixer

### DIFF
--- a/.claude/skills/lifecycle-issue-fixer/SKILL.md
+++ b/.claude/skills/lifecycle-issue-fixer/SKILL.md
@@ -117,27 +117,24 @@ Write `docs/plans/issue-{number}-context.json`:
 }
 ```
 
-### 1g. Guard rails
+### 1g. HARD GATE — Validate and claim
 
-- If the issue is **not found** (404): report error and **stop**.
-- If the issue is **closed**: warn the user and ask "This issue is already closed. Do you still want to proceed?"
-- If the issue has **linked PRs** (use `gh issue view {number} --json linkedPullRequests`): warn the user "This issue may already have linked PR(s) addressing it (e.g., #\{pr}). Proceed anyway?"
+Before any work begins, run these checks in order. Do not proceed to Phase 2 until all pass.
 
-### 1h. HARD GATE — Claim the issue
-
-**Before any work begins, you MUST claim the issue.** Do not proceed to Phase 2 without completing this step.
-
-Check the issue's assignees:
+1. **Not found** (404 from step 1c): report error and **stop**.
+1. **Closed**: warn the user and ask "This issue is already closed. Do you still want to proceed?"
+1. **Linked PRs** (use `gh issue view {number} --json linkedPullRequests`): warn the user "This issue may already have linked PR(s) addressing it (e.g., #\{pr}). Proceed anyway?"
+1. **Assignee check**:
 
 ```bash
 gh issue view {number} --repo {owner}/{repo} --json assignees --jq '.assignees[].login'
 ```
 
-- **No assignees:** Assign yourself by running `gh issue edit {number} --repo {owner}/{repo} --add-assignee @me`, then proceed.
+- **No assignees:** Assign yourself — `gh issue edit {number} --repo {owner}/{repo} --add-assignee @me` — then proceed.
 - **Assigned to current user:** Already claimed, proceed.
-- **Assigned to someone else:** **STOP.** Report to the user: "Issue #\{number} is assigned to @\{assignee}. Will not claim — another contributor is working on it." Do NOT proceed unless the user explicitly overrides.
+- **Assigned to someone else:** **STOP.** Report: "Issue #\{number} is assigned to @\{assignee}. Will not claim — another contributor is working on it." Do NOT proceed unless the user explicitly overrides.
 
-### 1i. Summarize and confirm
+### 1h. Summarize and confirm
 
 Print a summary to the user:
 


### PR DESCRIPTION
## Summary

- Reorder Phase 1 steps in `lifecycle-issue-fixer` skill: guard rails (1g) → claim issue (1h) → summarize (1i)
- Promote "Claim the issue" to a **HARD GATE** — the skill now refuses to proceed to Phase 2 without claiming
- Previously, the summarize step (which says "Proceeding to Phase 2") ran before the claim step, creating a gap where work could begin on an unclaimed issue

## Test plan

- [x] pre-commit passed
- [x] Post-commit validation passed
- [x] Manual review: step ordering in SKILL.md is guard rails → claim → summarize