### PR TITLE
[Fix][MHC] Fix MHC pre auto-tuning: sigmoid serialization and scalar params

### DIFF
--- a/tileops/kernels/kernel.py
+++ b/tileops/kernels/kernel.py
@@ -63,6 +63,17 @@ class Kernel(ABC):
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         return self.forward(*args, **kwargs)
 
+    @property
+    def autotune_supply_prog(self) -> Optional[Callable]:
+        """Return a supply_prog callback for autotuning input generation.
+
+        Override in subclasses whose kernels have scalar (T.int32, etc.) parameters
+        that the default tensor-only auto-generation cannot handle.
+
+        The callback signature is: (params: list[KernelParam]) -> list[Tensor | int | ...]
+        """
+        return None
+
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         if self.autotune_configs is None:
             return  # kernel doesn't support autotuning
@@ -73,9 +84,11 @@ class Kernel(ABC):
         print(f'Start autotuning {self.__class__.__name__}...')
 
         # Apply autotune decorator to the kernel function
-        autotuned_kernel_fn = autotune(
-            configs=self.autotune_configs, warmup=warmup, rep=rep)(
-                self.kernel)
+        autotune_kwargs: Dict[str, Any] = dict(
+            configs=self.autotune_configs, warmup=warmup, rep=rep)
+        if self.autotune_supply_prog is not None:
+            autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+        autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)
 
         # Call without config parameters to trigger autotuning, returns the tuned kernel
         tuned_kernel = autotuned_kernel_fn()

--- a/tileops/kernels/mhc/mhc_pre.py
+++ b/tileops/kernels/mhc/mhc_pre.py
@@ -13,9 +13,6 @@ __all__ = ["mhc_pre_kernel"]
 
 def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = 'bfloat16'):
 
-    def sigmoid(x):
-        return 1 / (1 + T.exp2(-x * LOG2E))
-
     dtype = "float32"
     accum_dtype = "float32"
 
@@ -121,16 +118,16 @@ def _mhc_pre_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = 'bfloat1
                 for i, j in T.Parallel(block_x_b, n_expand * n_expand + 2 * n_expand):
                     if j < n_expand:
                         alpha = alpha_pre
-                        h_pre_shared[i, j] = sigmoid(1 / r[bx * block_x_b + i] * alpha *
-                                                     h_pre_shared[i, j] + b_shared[j])
+                        _x = 1 / r[bx * block_x_b + i] * alpha * h_pre_shared[i, j] + b_shared[j]
+                        h_pre_shared[i, j] = 1 / (1 + T.exp2(-_x * LOG2E))
                         H_pre[bx * block_x_b + i, j] = h_pre_shared[i, j]
 
                     elif j < 2 * n_expand:
                         alpha = alpha_post
+                        _x = (1 / r[bx * block_x_b + i] * alpha *
+                              h_post_shared[i, j - n_expand] + b_shared[j])
                         h_post_shared[i, j -
-                                      n_expand] = 2 * sigmoid(1 / r[bx * block_x_b + i] * alpha *
-                                                              h_post_shared[i, j - n_expand] +
-                                                              b_shared[j])
+                                      n_expand] = 2 / (1 + T.exp2(-_x * LOG2E))
                         H_post[bx * block_x_b + i, j - n_expand] = h_post_shared[i, j - n_expand]
 
                     else:
@@ -304,7 +301,36 @@ class mhc_pre_kernel(Kernel):
         self.weights_dtype = torch.float32
         self.kernel = _mhc_pre_kernel(self.batch, self.n_expand, self.c_x, self.dtype_str)
 
+        self._supply_prog = self._make_supply_prog()
         self.init_config(config, tune)
+
+    def _make_supply_prog(self):
+        """Create a supply_prog that handles scalar parameters (alpha_*, sinkhorn_*)."""
+        from tilelang.utils.tensor import get_tensor_supply as _get_tensor_supply
+
+        default_supply = _get_tensor_supply(tilelang.TensorSupplyType.Auto)
+
+        # Scalar defaults: alpha_pre, alpha_post, alpha_res are T.float;
+        # sinkhorn_repeat is T.int; sinkhorn_eps is T.float
+        scalar_defaults = {
+            "int32": 20,       # sinkhorn_repeat
+            "float32": 0.5,    # alpha or sinkhorn_eps
+        }
+
+        def supply_prog(params):
+            inputs = []
+            for param in params:
+                if param.is_scalar():
+                    inputs.append(scalar_defaults.get(str(param.dtype), 1))
+                else:
+                    inputs.append(default_supply(param))
+            return inputs
+
+        return supply_prog
+
+    @property
+    def autotune_supply_prog(self):
+        return self._supply_prog
 
     @property
     def default_config(self) -> dict:


### PR DESCRIPTION
## Summary

- Inline `sigmoid` local function to avoid closure serialization failure in `@tilelang.jit`
- Add `autotune_supply_prog` to `Kernel` base class (same mechanism as #518) and implement it in `mhc_pre_kernel` for scalar parameters (`alpha_pre/post/res: T.float`, `sinkhorn_repeat: T.int`, `sinkhorn_eps: T.float`)

Closes #519

Note: `kernel.py` changes overlap with #518 — whichever merges second will need a trivial rebase.

## Test plan

- [x] `pytest tests/ops/test_mhc_pre.py` — 3 passed
- [x] `pytest benchmarks/ops/bench_mhc_pre.py` — 3 passed (previously all 3 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)