### PR TITLE
[CI] Refine nightly benchmark and packaging boundaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,19 +34,25 @@ jobs:
           TILELANG_CACHE_DIR="/home/ci-runner/.tilelang/cache"
           TILELANG_TMP_DIR="${TILELANG_CACHE_DIR}/tmp"
           TRITON_CACHE_DIR="/home/ci-runner/.triton/cache"
+          PIP_CACHE_DIR="/home/ci-runner/.cache/pip"
+          WHEEL_DIR="/home/ci-runner/.wheel-cache"
 
-          mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}"
+          mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
           {
             echo "TILELANG_CACHE_DIR=${TILELANG_CACHE_DIR}"
             echo "TILELANG_TMP_DIR=${TILELANG_TMP_DIR}"
             echo "TRITON_CACHE_DIR=${TRITON_CACHE_DIR}"
+            echo "PIP_CACHE_DIR=${PIP_CACHE_DIR}"
+            echo "WHEEL_DIR=${WHEEL_DIR}"
           } >> "$GITHUB_ENV"
 
           echo "Configured compile caches:"
           echo "  TILELANG_CACHE_DIR=${TILELANG_CACHE_DIR}"
           echo "  TILELANG_TMP_DIR=${TILELANG_TMP_DIR}"
           echo "  TRITON_CACHE_DIR=${TRITON_CACHE_DIR}"
+          echo "  PIP_CACHE_DIR=${PIP_CACHE_DIR}"
+          echo "  WHEEL_DIR=${WHEEL_DIR}"
         shell: bash
 
       - name: Validate GPU frequency
@@ -145,7 +151,13 @@ jobs:
           # shellcheck source=/dev/null
           source "${VENV_PATH}/bin/activate"
           python -m pip install --upgrade pip setuptools wheel --no-user
-          PIP_NO_BUILD_ISOLATION=1 pip install -e '.[dev]'
+          FIND_LINKS_FLAG=""
+          if [[ -d "${WHEEL_DIR}" ]] && ls "${WHEEL_DIR}"/*.whl >/dev/null 2>&1; then
+            FIND_LINKS_FLAG="--find-links ${WHEEL_DIR}"
+          fi
+          # shellcheck disable=SC2086
+          PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' ${FIND_LINKS_FLAG}
+          pip wheel -e '.[dev]' -w "${WHEEL_DIR}" 2>/dev/null || true
         shell: bash
 
       - name: Run benchmark ops
@@ -249,19 +261,25 @@ jobs:
           TILELANG_CACHE_DIR="/home/ci-runner/.tilelang/cache"
           TILELANG_TMP_DIR="${TILELANG_CACHE_DIR}/tmp"
           TRITON_CACHE_DIR="/home/ci-runner/.triton/cache"
+          PIP_CACHE_DIR="/home/ci-runner/.cache/pip"
+          WHEEL_DIR="/home/ci-runner/.wheel-cache"
 
-          mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}"
+          mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
           {
             echo "TILELANG_CACHE_DIR=${TILELANG_CACHE_DIR}"
             echo "TILELANG_TMP_DIR=${TILELANG_TMP_DIR}"
             echo "TRITON_CACHE_DIR=${TRITON_CACHE_DIR}"
+            echo "PIP_CACHE_DIR=${PIP_CACHE_DIR}"
+            echo "WHEEL_DIR=${WHEEL_DIR}"
           } >> "$GITHUB_ENV"
 
           echo "Configured compile caches:"
           echo "  TILELANG_CACHE_DIR=${TILELANG_CACHE_DIR}"
           echo "  TILELANG_TMP_DIR=${TILELANG_TMP_DIR}"
           echo "  TRITON_CACHE_DIR=${TRITON_CACHE_DIR}"
+          echo "  PIP_CACHE_DIR=${PIP_CACHE_DIR}"
+          echo "  WHEEL_DIR=${WHEEL_DIR}"
         shell: bash
 
       - name: Resolve persistent venv
@@ -316,7 +334,13 @@ jobs:
           # shellcheck source=/dev/null
           source "${VENV_PATH}/bin/activate"
           python -m pip install --upgrade pip setuptools wheel --no-user
-          PIP_NO_BUILD_ISOLATION=1 pip install -e '.[dev]'
+          FIND_LINKS_FLAG=""
+          if [[ -d "${WHEEL_DIR}" ]] && ls "${WHEEL_DIR}"/*.whl >/dev/null 2>&1; then
+            FIND_LINKS_FLAG="--find-links ${WHEEL_DIR}"
+          fi
+          # shellcheck disable=SC2086
+          PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' ${FIND_LINKS_FLAG}
+          pip wheel -e '.[dev]' -w "${WHEEL_DIR}" 2>/dev/null || true
         shell: bash
 
       - name: Run full op tests


### PR DESCRIPTION
Closes #529

## Summary

- rename the benchmark persistent venv prefix to `tileops_benchmarks_venv` to separate benchmark dependency management from test environments
- switch `op_test` from a one-off venv to a cache-friendly persistent hashed venv strategy and configure compile cache env vars for that job
- add shared pip and wheel caches for nightly `benchmark` and `op_test` venv provisioning so rebuilt environments can reuse downloaded packages and locally built wheels
- reduce installed-wheel validation in `packaging` to `smoke` so it verifies basic API usability without repeating full nightly correctness coverage

## Test plan

- [x] pre-commit passed
- [x] YAML parse check passed for `.github/workflows/nightly.yml`

## Regression

- confirmed the nightly job ordering remains serial (`benchmark` -> `op_test` -> `packaging`)
- confirmed `benchmark` now uses the `tileops_benchmarks_venv` prefix
- confirmed `op_test` now resolves and reuses a persistent hashed venv instead of recreating a one-off environment each run
- confirmed nightly venv creation now uses `PIP_CACHE_DIR` plus `WHEEL_DIR` / `--find-links` to reuse cached artifacts
- confirmed `packaging` now runs only `smoke`-tagged installed-wheel tests

## Additional context

- PR #255 already addressed packaging dependency installation, so this PR does not modify that part of the workflow
- this PR intentionally does not implement the separate "hash install script contents" follow-up yet
- `scripts/validate.sh` is not present in this checkout, so the available local validation was pre-commit plus direct YAML parsing