### PR TITLE
[Refactor][Elementwise] Extract shared _wrap_fp8_accumulation helper for fp8 kernels

### DIFF
--- a/tests/test_elementwise_fp8.py
+++ b/tests/test_elementwise_fp8.py
@@ -133,6 +133,33 @@ def test_fused_gated_kernel_forward_e5m2_dtype():
 
 
 @pytest.mark.smoke
+def test_fused_gated_direct_e5m2_preserves_inf():
+    """FusedGated direct strategy must preserve Inf for e5m2, not saturate.
+
+    Regression test: the direct kernel previously declared its output buffer
+    as e5m2, causing TileLang to saturate fp16 Inf to 57344.0 on store.
+    The fix routes e5m2 through an fp16 output buffer (matching
+    explicit_parallel) so PyTorch's .to() preserves Inf/NaN.
+    """
+    from tileops.kernels.elementwise import SiluAndMulKernel
+
+    M, N = 1, 16
+    dtype = torch.float8_e5m2
+    # Large values that silu(gate)*value will overflow to Inf in fp16
+    gate_fp16 = torch.full((M, N), 50000.0, dtype=torch.float16, device="cuda")
+    value_fp16 = torch.full((M, N), 50000.0, dtype=torch.float16, device="cuda")
+    x_fp16 = torch.cat([gate_fp16, value_fp16], dim=1)
+    x = x_fp16.to(dtype)
+    kernel = SiluAndMulKernel(M=M, N=N, dtype=dtype, strategy="direct")
+    out = kernel(x)
+    out_fp32 = out.to(torch.float32)
+    assert torch.any(torch.isinf(out_fp32)), (
+        f"FusedGated direct e5m2 should produce Inf on overflow, "
+        f"got max={out_fp32.max().item()}"
+    )
+
+
+@pytest.mark.smoke
 def test_unary_kernel_forward_e5m2_preserves_inf():
     """UnaryKernel.forward() preserves Inf for e5m2 (direct kernel call)."""
     from tileops.kernels.elementwise import ExpKernel

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -376,19 +376,23 @@ def _make_binary_explicit(
 # ---------------------------------------------------------------------------
 
 
-def _make_fused_gated_direct(M, N, dtype, op_func, threads=256):
+def _make_fused_gated_direct(M, N, dtype, op_func, threads=256, output_dtype=None):
     """FusedGated direct: 1 element per thread. x[:, :N] is gate, x[:, N:] is value.
 
     ``op_func(gate, value)`` is the compound operation that applies the
     activation to *gate* and multiplies by *value*.  For fp8 dtypes the
     caller wraps it via ``_wrap_fp8_accumulation`` so this factory stays
     fp8-agnostic.
+
+    Args:
+        output_dtype: TileLang dtype string for the output tensor. Defaults to dtype.
     """
+    out_dtype = output_dtype or dtype
 
     @tilelang.jit(out_idx=[1])
     def kernel(threads_arg):
         @T.prim_func
-        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), dtype)):
+        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
             with T.Kernel(T.ceildiv(N, threads_arg), M, threads=threads_arg) as (bx, by):
                 for i in T.Parallel(threads_arg):
                     col = bx * threads_arg + i
@@ -739,6 +743,7 @@ class FusedGatedKernel(Kernel):
             return _make_fused_gated_direct(
                 self.M, self.N, self.dtype_str, effective_op,
                 threads=cfg["threads"],
+                output_dtype=self._kernel_output_dtype,
             )
         elif strategy == "explicit_parallel":
             return _make_fused_gated_explicit(


### PR DESCRIPTION
## Summary

- Extract a shared `_wrap_fp8_accumulation(op_func, dtype)` helper that handles both saturating (e4m3fn) and non-saturating (e5m2) fp8 accumulation paths
- Replace duplicated `_get_effective_op_func()` bodies in UnaryKernel, BinaryKernel, and FusedGatedKernel with calls to the shared helper
- Fix FusedGated direct strategy e5m2 output routing through fp16 buffer to preserve Inf/NaN semantics

Closes #502

## Test plan

- [x] Modified files pass unit tests: `python -m pytest -q tests/test_elementwise_fp8.py tests/ops/test_special_elementwise.py` -- 77 passed
- [x] No new public API -- helper is module-private (`_wrap_fp8_accumulation`, not in `__all__`)
- [x] Saturating (e4m3fn) and non-saturating (e5m2) semantics preserved exactly (overflow/Inf regression coverage included)

## Changes

- `tileops/kernels/elementwise.py` -- consolidated fp8 accumulation logic into `_wrap_fp8_accumulation`; fixed FusedGated direct e5m2 output dtype routing
- `tests/test_elementwise_fp8.py` -- added 5 new helper tests + 1 e5m2 Inf regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)