### PR TITLE
[Doc] Add elementwise kernel performance checklist and evidence

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,24 @@
+# Performance Guides
+
+Empirical performance lessons per op category. Each category has:
+
+- **Checklist** — heuristic rules for audit (lightweight, always load)
+- **Evidence** — measured data and reasoning (load on demand)
+
+## Test Environment
+
+All conclusions are scoped to this configuration. Re-validate when any component changes.
+
+| Component     | Value                                                                        |
+| ------------- | ---------------------------------------------------------------------------- |
+| GPU           | NVIDIA H200 (HBM3e, 4.8 TB/s peak, SM_90a)                                   |
+| Driver / CUDA | 575.57.08 / 12.8                                                             |
+| PyTorch       | 2.9.1+cu128                                                                  |
+| TileLang      | 0.1.8                                                                        |
+| Profiler      | CUPTI (primary); CUDA event+median fallback when CUPTI singleton unavailable |
+
+## Index
+
+| Category    | Checklist                        | Evidence                                           |
+| ----------- | -------------------------------- | -------------------------------------------------- |
+| Elementwise | [elementwise.md](elementwise.md) | [elementwise-evidence.md](elementwise-evidence.md) |

--- a/docs/perf/elementwise-evidence.md
+++ b/docs/perf/elementwise-evidence.md
@@ -1,0 +1,51 @@
+# Elementwise Performance Evidence
+
+Reasoning and data behind [elementwise.md](elementwise.md). Test environment defined in [README.md](README.md).
+
+______________________________________________________________________
+
+## §1. Strategy Selection
+
+| Category          | Strategy            | Key Number                        |
+| ----------------- | ------------------- | --------------------------------- |
+| Unary             | `register_copy`     | 3.53 vs 0.99 TB/s (relu 16M fp16) |
+| Binary broadcast  | `explicit_parallel` | 3.65 TB/s (add 16M fp16)          |
+| Binary same-shape | `register_copy`     | max/min 121–146% PyTorch          |
+| FusedGated        | `explicit_parallel` | 3.38 vs 1.51 TB/s                 |
+
+`register_copy` emits `uint4` 128-bit loads via `T.copy`. TVM auto-vectorizer fails on complex `op_func`, making `T.copy` necessary.
+
+## §2. Vectorization
+
+`T.copy` → 128-bit `uint4` loads (8×fp16 / 4×fp32). 2–3× BW gain.
+
+**Bool**: TileLang cannot vectorize bool. Pack as `uint8` in Op layer → masked_fill: 0.81× → **1.55×** (fp16), 0.88× → **1.86×** (fp32).
+
+## §3. Configuration
+
+**npt**: `explicit_parallel` stride = `npt × elem_size`; larger npt → worse coalescing for small dtypes. `register_copy` uses cooperative `T.copy`; larger npt → bigger tile → better amortization.
+
+| Strategy            | fp16/bf16 | fp32 | fp8 |
+| ------------------- | --------- | ---- | --- |
+| `explicit_parallel` | 4         | 4    | 16  |
+| `register_copy`     | 8         | 4    | 16  |
+
+fp16 npt=4 vs 8 under explicit_parallel: **+42%** (1.05 vs 0.74 TB/s). Thread count 256 vs 128: \<5% delta.
+
+## §4. IR Complexity
+
+max/min: 5-node chain → `T.max` + `isnan`: 1.32 → **3.36 TB/s** (+155%). Prefer TileLang intrinsics.
+
+## §5. Caching
+
+`init_config()` stores `_compiled_fn`. Cold ~1.1s, disk-cached ~25ms, warm \<1ms.
+
+## §6. Register Pressure
+
+In-place write to input fragment, not a new `T.alloc_fragment` for output.
+
+## §7. Profiling
+
+- **Primary backend**: CUPTI — gives pure kernel time without host-launch overhead
+- **Fallback**: CUDA event + median — only when CUPTI returns 0 (global singleton held by `ncu` or another process)
+- **CUPTI filter fix**: tilelang excludes `vectorized_elementwise` kernels to strip `cache.zero_()`, but this also kills PyTorch baselines. Monkey-patch requires both `vectorized_elementwise` AND `FillFunctor` in kernel name to exclude

--- a/docs/perf/elementwise.md
+++ b/docs/perf/elementwise.md
@@ -1,0 +1,26 @@
+# Elementwise Kernel Performance Checklist
+
+> These are empirically-backed heuristics, not hard requirements. A violation is not necessarily wrong — but should be **deliberate and documented**. Flag unchecked items as "needs justification", not "needs fix". See [elementwise-evidence.md](elementwise-evidence.md) for reasoning and data.
+
+## Strategy (§1)
+
+- [ ] Unary-like kernel → `register_copy`
+- [ ] Binary broadcast → `explicit_parallel`
+- [ ] Binary same-shape → auto-selects `register_copy`
+
+## Vectorization (§2)
+
+- [ ] `register_copy` path uses `T.alloc_fragment` + `T.copy`
+- [ ] Bool inputs packed as `uint8` in Op layer
+
+## Config (§3)
+
+- [ ] `explicit_parallel` npt: fp16/bf16=4, fp32=4, fp8=16
+- [ ] `register_copy` npt: fp16/bf16=8, fp32=4, fp8=16
+- [ ] `autotune_configs` defined: threads∈{128,256,512} × npt∈{2,4,8}
+- [ ] Kernel caches `_compiled_fn` in `init_config()`
+
+## Code Quality (§4–§6)
+
+- [ ] `op_func` uses TileLang intrinsics over manual comparison chains
+- [ ] Results written in-place to input register fragment


### PR DESCRIPTION
## Summary

- Add `docs/perf/` directory with structured performance documentation for elementwise kernels
- **Checklist** (`elementwise.md`, ~25 lines): heuristic rules for agent/reviewer audit covering strategy selection, vectorization, config tuning, caching, and code quality
- **Evidence** (`elementwise-evidence.md`): measured data and reasoning from PRs #500, #537, #538, #539 — loaded on demand only when justification is needed
- **Index** (`README.md`): test environment table (H200/CUDA 12.8/TileLang 0.1.8) scoping all conclusions, plus category index for future op families
- Checklist framed as heuristics with explicit guidance: violations need justification, not mandatory fixes

## Test plan

- [x] All markdown files pass mdformat and codespell pre-commit hooks
- [x] Cross-links between checklist, evidence, and README verified
- [x] No runtime code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>