### PR TITLE
[CI] Run packaging wheel smoke tests from tests/ops

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -660,7 +660,7 @@ jobs:
           ls -lh dist/*.whl
         shell: bash
 
-      - name: Run unit tests against built wheel
+      - name: Run ops smoke tests against built wheel
         run: |
           set -euo pipefail
           source "${VENV_PATH}/bin/activate"
@@ -679,7 +679,7 @@ jobs:
           for key in ("TILELANG_CACHE_DIR", "TILELANG_TMP_DIR", "TRITON_CACHE_DIR"):
               print(f"{key}={os.environ.get(key)}")
           PY
-          python -m pytest -q tests -m "smoke"
+          python -m pytest -q tests/ops -m "smoke"
         shell: bash
 
       - name: Upload wheel artifact


### PR DESCRIPTION
Closes #566

## Summary

- narrow the nightly packaging wheel smoke step to run `tests/ops` instead of the full `tests` tree
- keep copying the full `tests/` directory into the temporary validation workspace so shared test helpers and `conftest.py` remain available

## Test plan

- [x] local pre-commit checks passed during `git commit`
- [ ] GitHub Actions nightly packaging job passes with the updated smoke target

## Regression

- fixes packaging failures caused by source-tree-only smoke tests such as `tests/test_elementwise_strategy_bench.py` and `tests/test_reduction_init_files.py`
- keeps the broader `op_test` job responsible for full repository unit coverage

## Additional context

- the repository skill references `scripts/validate.sh`, but that script does not exist in this checkout, so the documented pre/post validation gate could not be run