### PR TITLE
[Fix] fix benchmark bugs in indexer, quant and topk_selector

### DIFF
--- a/benchmarks/ops/bench_fp8_lighting_indexer.py
+++ b/benchmarks/ops/bench_fp8_lighting_indexer.py
@@ -33,24 +33,32 @@ class Fp8LightingIndexerBenchmark(BenchmarkBase):
 
 
 _FP8_LIGHTING_INDEXER_BENCH_PARAMS = [
-    pytest.param(4096, 32, 64, 8192, True, None, False, id="default-config"),
-    pytest.param(2048, 16, 64, 4096, True, None, False, id="mid-shape"),
+    pytest.param(1, 4096, 32, 64, 8192, 1, True, None, False, id="default-config"),
+    pytest.param(1, 2048, 16, 64, 4096, 1, True, None, False, id="mid-shape"),
 ]
 
 
 @pytest.mark.parametrize(
-    "seq_len, heads, index_dim, seq_len_kv, clean_logits, config, tune",
+    "batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune",
     _FP8_LIGHTING_INDEXER_BENCH_PARAMS,
 )
-def test_fp8_lighting_indexer_bench(seq_len: int, heads: int, index_dim: int, seq_len_kv: int,
-                                    clean_logits: bool, config: Optional[dict],
-                                    tune: bool) -> None:
-    test = Fp8LightingIndexerTest(seq_len, heads, index_dim, seq_len_kv, clean_logits, config)
+def test_fp8_lighting_indexer_bench(batch: int, seq_len: int, heads: int, index_dim: int,
+                                    seq_len_kv: int, kv_group: int, clean_logits: bool,
+                                    config: Optional[dict], tune: bool) -> None:
+    test = Fp8LightingIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+                                  clean_logits, config)
     bm = Fp8LightingIndexerBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = Fp8LightingIndexerOp(seq_len, heads, index_dim, seq_len_kv, clean_logits, config,
-                               tune=tune)
+    op = Fp8LightingIndexerOp(batch=batch,
+                              seq_len=seq_len,
+                              heads=heads,
+                              index_dim=index_dim,
+                              seq_len_kv=seq_len_kv,
+                              kv_group=kv_group,
+                              clean_logits=clean_logits,
+                              config=config,
+                              tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("fp8_lighting_indexer", locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -21,21 +21,27 @@ class Fp8QuantBenchmark(BenchmarkBase):
 
 
 _FP8_QUANT_BENCH_PARAMS = [
-    pytest.param(8192, 64, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(8192, 64, torch.bfloat16, True, id="mainstream-bf16"),
-    pytest.param(4096, 128, torch.float32, True, id="wider-index"),
-    pytest.param(16384, 32, torch.float32, True, id="long-sequence"),
+    pytest.param(1, 8192, 1, 64, torch.float16, True, id="mainstream-fp16"),
+    pytest.param(1, 8192, 1, 64, torch.bfloat16, True, id="mainstream-bf16"),
+    pytest.param(1, 4096, 1, 128, torch.float32, True, id="wider-index"),
+    pytest.param(1, 16384, 1, 32, torch.float32, True, id="long-sequence"),
 ]
 
 
-@pytest.mark.parametrize("seq_len_kv, index_dim, in_dtype, tune", _FP8_QUANT_BENCH_PARAMS)
-def test_fp8_quant_bench(seq_len_kv: int, index_dim: int, in_dtype: torch.dtype,
-                         tune: bool) -> None:
-    test = Fp8QuantTest(seq_len_kv, index_dim, in_dtype)
+@pytest.mark.parametrize("batch, seq_len_kv, kv_group, index_dim, in_dtype, tune",
+                         _FP8_QUANT_BENCH_PARAMS)
+def test_fp8_quant_bench(batch: int, seq_len_kv: int, kv_group: int, index_dim: int,
+                         in_dtype: torch.dtype, tune: bool) -> None:
+    test = Fp8QuantTest(batch, seq_len_kv, kv_group, index_dim, in_dtype)
     bm = Fp8QuantBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = Fp8QuantOp(seq_len_kv=seq_len_kv, index_dim=index_dim, in_dtype=in_dtype, tune=tune)
+    op = Fp8QuantOp(batch=batch,
+                    seq_len_kv=seq_len_kv,
+                    kv_group=kv_group,
+                    index_dim=index_dim,
+                    in_dtype=in_dtype,
+                    tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("fp8_quant", locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -24,26 +24,49 @@ class TopkSelectorBenchmark(BenchmarkBase):
 
 
 _TOPK_SELECTOR_BENCH_PARAMS = [
-    pytest.param(64, 32 * 1024, 1024, "float32", "int32", True, id="base-topk1024"),
-    pytest.param(64, 32 * 1024, 2048, "float32", "int32", True, id="base-topk2048"),
-    pytest.param(128, 64 * 1024, 1024, "float32", "int32", True, id="large-batch-topk1024"),
-    pytest.param(128, 64 * 1024, 2048, "float32", "int32", True, id="large-batch-topk2048"),
+    pytest.param(1, 32 * 1024, 64 * 1024, 1, 1024, "float32", "int32", True, id="base-topk1024"),
+    pytest.param(1, 32 * 1024, 64 * 1024, 1, 2048, "float32", "int32", True, id="base-topk2048"),
+    pytest.param(1, 65535, 128 * 1024, 1, 1024, "float32", "int32", True,
+                 id="large-batch-topk1024"),
+    pytest.param(1, 65535, 128 * 1024, 1, 2048, "float32", "int32", True,
+                 id="large-batch-topk2048"),
 ]
 
 
 @pytest.mark.parametrize(
-    "batch, seq_len, topk, in_dtype_str, out_dtype_str, tune",
+    "batch, seq_len, seq_len_kv, kv_group, topk, in_dtype_str, out_dtype_str, tune",
     _TOPK_SELECTOR_BENCH_PARAMS,
 )
-def test_topk_selector_bench(batch: int, seq_len: int, topk: int, in_dtype_str: str,
-                              out_dtype_str: str, tune: bool) -> None:
+def test_topk_selector_bench(batch: int, seq_len: int, seq_len_kv: int, kv_group: int, topk: int,
+                             in_dtype_str: str, out_dtype_str: str, tune: bool) -> None:
     in_dtype = str2dtype[in_dtype_str]
     out_dtype = str2dtype[out_dtype_str]
-    test = TopkSelectorTest(batch, seq_len, topk, in_dtype, out_dtype)
+    test = TopkSelectorTest(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype)
     bm = TopkSelectorBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = TopkSelectorOp(batch, seq_len, topk, in_dtype, out_dtype, tune=tune)
+    tune_used = tune
+    try:
+        op = TopkSelectorOp(batch=batch,
+                            seq_len=seq_len,
+                            seq_len_kv=seq_len_kv,
+                            kv_group=kv_group,
+                            topk=topk,
+                            in_dtype=in_dtype,
+                            out_dtype=out_dtype,
+                            tune=tune)
+    except RuntimeError as e:
+        if "auto-tuning failed" not in str(e).lower():
+            raise
+        tune_used = False
+        op = TopkSelectorOp(batch=batch,
+                            seq_len=seq_len,
+                            seq_len_kv=seq_len_kv,
+                            kv_group=kv_group,
+                            topk=topk,
+                            in_dtype=in_dtype,
+                            out_dtype=out_dtype,
+                            tune=False)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("topk_selector", locals(), result, tag="tileops")
 


### PR DESCRIPTION
## Description
 fixed runtime issues in DeepSeek MLA benchmark cases.

1. Updated bench_fp8_lighting_indexer.py to pass batch and kv_group consistently to both Fp8LightingIndexerTest and Fp8LightingIndexerOp, fixing the NoneType shape/type mismatch.
2. Updated bench_fp8_quant.py to include batch and kv_group in benchmark params and pass them through to Fp8QuantTest/Fp8QuantOp, resolving constructor argument errors.
3. Updated bench_topk_selector.py to include seq_len_kv and kv_group for TopkSelectorTest/TopkSelectorOp, reduced oversized benchmark shapes to avoid OOM, added fallback to tune=False when autotuning fails, and fixed CUDA invalid launch by capping large seq_len case to 65535 (grid-y limit).


## Type of Change

- [x] Bug fix
- [ ] New operator implementation
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Infrastructure/CI

## Checklist

- [x] I have run `pre-commit run --all-files` and fixed all linting issues.
- [x] I have verified that my changes pass the relevant local unit tests.
