### PR TITLE
[CI] Sync libtilelang.so mtime in fork venvs for cache key compatibility

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -516,10 +516,10 @@ jobs:
             # TileLang cache keys include the library's mtime (kernel_cache.py); a fresh
             # pip install produces a new mtime, causing all rsync'd cache entries to miss.
             # See: https://github.com/tile-ai/TileOPs/issues/594
-            TRUSTED_VENV=$(find "${{ runner.tool_cache }}" -maxdepth 1 -type d -name "tileops_ci_venv_*" 2>/dev/null | head -1)
+            TRUSTED_VENV=$(find "${{ runner.tool_cache }}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -exec test -x '{}/bin/python' \; -print 2>/dev/null | sort -t_ -k5 -r | head -1 || true)
             if [[ -n "$TRUSTED_VENV" ]]; then
-              TRUSTED_LIB=$(find "$TRUSTED_VENV" -name "libtilelang.so" -type f 2>/dev/null | head -1)
-              FORK_LIB=$(find "${VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1)
+              TRUSTED_LIB=$(find "$TRUSTED_VENV" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
+              FORK_LIB=$(find "${VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               if [[ -n "$TRUSTED_LIB" && -n "$FORK_LIB" ]]; then
                 touch -r "$TRUSTED_LIB" "$FORK_LIB"
                 echo "Synced libtilelang.so mtime for cache key compatibility"


### PR DESCRIPTION
Closes #594

## Summary

- Fork PR GPU smoke tests regressed to ~27 min despite rsync'ing the trusted compile cache (#510 security hardening)
- Root cause: TileLang cache keys include `libtilelang.so` mtime in nanoseconds; a fresh `pip install` in fork venvs produces a new mtime, causing all rsync'd cache entries to miss
- Fix: after fork venv `pip install`, sync `libtilelang.so` mtime with the trusted venv's copy so cache keys match
- Expected result: fork PR test time drops from ~27 min to ~3-4 min, matching trusted PR performance

## Test plan

- [x] pre-commit passed
- [x] YAML syntax validated
- [ ] Fork PR GPU smoke completes in ≤ 5 min on cache-hit run (CI verification)

## Regression

- Trusted PR / push-to-main path is unchanged (no code path touched)
- Fork isolation unchanged: isolated venv, isolated cache dir, cleanup on completion