### PR TITLE
[Fix][Elementwise] Clamp scalar literals to dtype range in kernel layer

### DIFF
--- a/tests/test_elementwise_independent_fp8.py
+++ b/tests/test_elementwise_independent_fp8.py
@@ -68,6 +68,24 @@ def test_kernel_accepts_fp8(dtype, kernel_name, extra_kwargs):
     assert kernel.dtype == dtype
 
 
+@pytest.mark.smoke
+def test_masked_fill_kernel_clamps_overflow_fill_value():
+    """MaskedFillKernel clamps fill_value exceeding e4m3fn max (448)."""
+    dtype = torch.float8_e4m3fn
+    kernel = _kern_mod.MaskedFillKernel(N_total=_N, dtype=dtype, fill_value=1e4)
+    assert kernel.fill_value == torch.finfo(dtype).max
+
+
+@pytest.mark.smoke
+def test_nan_to_num_kernel_clamps_overflow_defaults():
+    """NanToNumKernel clamps default posinf_val/neginf_val for e4m3fn."""
+    dtype = torch.float8_e4m3fn
+    kernel = _kern_mod.NanToNumKernel(N_total=_N, dtype=dtype)
+    finfo = torch.finfo(dtype)
+    assert kernel.posinf_val == finfo.max
+    assert kernel.neginf_val == finfo.min
+
+
 # ---------------------------------------------------------------------------
 # AC2: fp8 default_config uses num_per_thread=16 for 128-bit alignment
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -191,6 +191,9 @@ def _clamp_to_dtype_range(value: float, dtype: torch.dtype) -> float:
 
     Prevents TVM FloatImm range-check failures when a scalar literal exceeds
     the target dtype's maximum (e.g. 1e4 into float8_e4m3fn whose max is 448).
+    NaN values are passed through unchanged (NaN is a valid sentinel, not an
+    out-of-range finite value).  Infinities are mapped to the dtype's
+    max/min finite value.
     """
     if math.isnan(value):
         return value
@@ -2561,12 +2564,11 @@ class MaskedFillKernel(Kernel):
             )
         self.N_total = N_total
         self.dtype = dtype
-        self.fill_value = fill_value
         self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
-        fill_value = _clamp_to_dtype_range(fill_value, self.output_dtype)
+        self.fill_value = _clamp_to_dtype_range(fill_value, self.output_dtype)
         cfg = self.default_config
         self.kernel = _make_masked_fill_kernel(
-            N_total, self.dtype_str, fill_value,
+            N_total, self.dtype_str, self.fill_value,
             output_dtype=self.dtype_to_str(self.output_dtype),
             is_fp8=_is_fp8(dtype),
             threads=cfg["threads"], npt=cfg["num_per_thread"],
@@ -2694,16 +2696,13 @@ class NanToNumKernel(Kernel):
             )
         self.N_total = N_total
         self.dtype = dtype
-        self.nan_val = nan_val
-        self.posinf_val = posinf_val
-        self.neginf_val = neginf_val
         self._fp8_output_dtype, self.output_dtype = _get_fp8_output_dtypes(dtype)
-        nan_val = _clamp_to_dtype_range(nan_val, self.output_dtype)
-        posinf_val = _clamp_to_dtype_range(posinf_val, self.output_dtype)
-        neginf_val = _clamp_to_dtype_range(neginf_val, self.output_dtype)
+        self.nan_val = _clamp_to_dtype_range(nan_val, self.output_dtype)
+        self.posinf_val = _clamp_to_dtype_range(posinf_val, self.output_dtype)
+        self.neginf_val = _clamp_to_dtype_range(neginf_val, self.output_dtype)
         cfg = self.default_config
         self.kernel = _make_nan_to_num_kernel(
-            N_total, self.dtype_str, nan_val, posinf_val, neginf_val,
+            N_total, self.dtype_str, self.nan_val, self.posinf_val, self.neginf_val,
             output_dtype=self.dtype_to_str(self.output_dtype),
             is_fp8=_is_fp8(dtype),
             threads=cfg["threads"], npt=cfg["num_per_thread"],


### PR DESCRIPTION
## Summary

- Add `_clamp_to_dtype_range()` helper that clamps scalar values to the target dtype's finite representable range before they reach `T.cast()`, preventing TVM `FloatImm` range-check failures for narrow dtypes
- Apply clamping in `MaskedFillKernel.__init__` (`fill_value`) and `NanToNumKernel.__init__` (`nan_val`, `posinf_val`, `neginf_val`)
- Fixes CI failure: `test_kernel_accepts_fp8[nan_to_num-e4m3fn]` where default `posinf_val=1e4` exceeds `float8_e4m3fn` max of 448

Closes https://github.com/tile-ai/TileOPs/pull/583

## Context

PR #570 added Op-layer validation (`_validate_scalar_param_repr`) that rejects out-of-range values when users go through the Op API. However, the kernel layer itself still crashes when constructed directly with overflow values — which is exactly what `test_kernel_accepts_fp8` does. This PR adds kernel-level defense so both paths are safe.

## Test plan

- [x] `tests/test_elementwise_independent_fp8.py` — 22/22 passed (including previously failing `nan_to_num-e4m3fn`)
- [x] `tests/test_elementwise_fp8.py` — 65/65 passed
- [x] 87 total fp8 tests, 0 regressions
- [x] pre-commit passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)