### PR TITLE
[Chore] Codify lru_cache builder rule into DEVELOPMENT.md and .claude/rules

### DIFF
--- a/.foundry/mold/op-readiness-checklist.md
+++ b/.foundry/mold/op-readiness-checklist.md
@@ -16,6 +16,7 @@
 
 - [ ] [REQ] `with T.Kernel()` inside `@T.prim_func`; reusable sub-routines as `@T.macro`
 - [ ] [REQ] `Kernel.forward` accepts only GPU tensors, calls only `self.kernel(config...)(tensors)`
+- [ ] [REQ] Builder function (`_<op>_kernel`) decorated with `@functools.lru_cache(maxsize=32)`; all params hashable
 - [ ] [REC] `_<op>_kernel(static_params) -> Callable` closure exists
 - [ ] [REC] `@tilelang.jit(out_idx=[...])` wraps config-parameterised inner function
 - [ ] [REC] No Python builtins (`float()`, `int()`, `math.cos()`) on IR nodes


### PR DESCRIPTION
## Summary

- Add "Kernel Builder Performance" section to `docs/DEVELOPMENT.md` Coding Standards, requiring `@functools.lru_cache(maxsize=32)` on all L1 builder functions
- Add corresponding rule to `.claude/rules/code-style.md` for AI-assisted development
- Add [Case E](https://github.com/tile-ai/TileOPs/wiki/TileLang-Case-Studies#case-e-builder-function-lru_cache--eliminating-28200ms-per-call-overhead) to the wiki TileLang Case Studies page, documenting the full diagnosis, fix, safety analysis, and lessons

### Why

#597 and #600 fixed 51 files / 100+ builder functions that were missing `lru_cache`, causing 28–200ms overhead per `forward()` call. This accumulated over months because no coding standard required the decorator. Codifying the rule prevents recurrence in new kernels.

Closes #601
Ref: #571, #597, #599, #600

## Test plan

- [ ] Documentation review — verify the new section is clear and correctly placed
- [ ] Wiki case study is published and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)