### PR TITLE
[BugFix][CI] Fix packaging wheel assets and failure logs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -667,39 +667,67 @@ jobs:
         run: |
           set -euo pipefail
           source "${VENV_PATH}/bin/activate"
-          python -m build --wheel
-          echo "Build artifacts:"
-          ls -lh dist/*.whl
+
+          PACKAGING_LOG="${GITHUB_WORKSPACE}/packaging.log"
+          : > "${PACKAGING_LOG}"
+
+          {
+            echo "=== Build wheel package ==="
+            python -m build --wheel
+            echo
+            echo "=== Build artifacts ==="
+            ls -lh dist/*.whl
+          } 2>&1 | tee -a "${PACKAGING_LOG}"
         shell: bash
 
       - name: Run ops smoke tests against built wheel
         run: |
           set -euo pipefail
           source "${VENV_PATH}/bin/activate"
-          pip install --force-reinstall dist/*.whl
 
-          TMP_TEST_DIR="$(mktemp -d)"
-          trap 'rm -rf "${TMP_TEST_DIR}"' EXIT
-          cp -r tests "${TMP_TEST_DIR}/tests"
-          unset PYTHONPATH || true
+          PACKAGING_LOG="${GITHUB_WORKSPACE}/packaging.log"
 
-          cd "${TMP_TEST_DIR}"
-          python - <<'PY'
-          import os
+          {
+            echo
+            echo "=== Install built wheel ==="
+            pip install --force-reinstall dist/*.whl
 
-          print("Runtime cache env:")
-          for key in ("TILELANG_CACHE_DIR", "TILELANG_TMP_DIR", "TRITON_CACHE_DIR"):
-              print(f"{key}={os.environ.get(key)}")
-          PY
-          python -m pytest -q tests/ops -m "smoke"
+            TMP_TEST_DIR="$(mktemp -d)"
+            trap 'rm -rf "${TMP_TEST_DIR}"' EXIT
+            cp -r tests "${TMP_TEST_DIR}/tests"
+            unset PYTHONPATH || true
+
+            cd "${TMP_TEST_DIR}"
+
+            echo
+            echo "=== Runtime cache env ==="
+            python -c 'import os; [print(f"{key}={os.environ.get(key)}") for key in ("TILELANG_CACHE_DIR", "TILELANG_TMP_DIR", "TRITON_CACHE_DIR")]'
+
+            echo
+            echo "=== Run pytest smoke ==="
+            python -m pytest -q tests/ops -m "smoke" \
+              --junit-xml="${GITHUB_WORKSPACE}/packaging_smoke.xml"
+          } 2>&1 | tee -a "${PACKAGING_LOG}"
         shell: bash
 
       - name: Upload wheel artifact
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: tileops-wheel-${{ github.sha }}
           path: dist/*.whl
           if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload packaging logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: packaging-logs-${{ github.sha }}
+          path: |
+            packaging.log
+            packaging_smoke.xml
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Publish wheel to GitHub Release (tag only)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 exclude = ["tests", "tests.*", "benchmarks", "benchmarks.*"]
 
+[tool.setuptools.package-data]
+tileops = ["kernels/moe/_atomic_helper.h"]
+
 [tool.codespell]
 ignore-words-list = "nd, te, ist, LOD, offen, NotIn, HSA"
 skip = [


### PR DESCRIPTION
Closes #612

## Summary

- include `tileops/kernels/moe/_atomic_helper.h` in the built wheel so the installed package can compile the MoE kernel helper path in packaging smoke tests
- capture a single packaging log from wheel build through wheel install and pytest, upload logs on failure, and only upload the wheel artifact when the packaging smoke test succeeds

## Test plan

- [x] `python -m pip wheel . --no-deps --no-build-isolation -w /tmp/tileops-wheel-check`
- [x] verified `/tmp/tileops-wheel-check/tileops-0.0.1.dev2-py3-none-any.whl` contains `tileops/kernels/moe/_atomic_helper.h`
- [x] created an isolated Python 3.11 venv, installed the built wheel, copied `tests/` to `/tmp/tileops-packaging-testdir`, unset `PYTHONPATH`, and confirmed `tileops` imports from the venv `site-packages`
- [x] `python -m pytest -q tests/ops/test_moe_permute_align.py -m smoke` from `/tmp/tileops-packaging-testdir`

## Regression

- previous packaging failure reproduced as missing `site-packages/tileops/kernels/moe/_atomic_helper.h` during nvcc compilation
- local packaging-style validation now passes the MoE smoke tests from the installed wheel without that missing-header error

## Additional context

- the repository does not currently contain `scripts/validate.sh`, so the documented pre/post validation gate could not be run locally
- the isolated runtime check reused `torch`, `tilelang`, and `pytest` from `tileops-dev` via a fresh venv with `--system-site-packages`; `tileops` itself was imported from the installed wheel path in the new environment
