### PR TITLE
[Fix][Bench] Add torch SDPA fallback baseline when FA3 is missing

### DIFF
--- a/benchmarks/ops/bench_gqa.py
+++ b/benchmarks/ops/bench_gqa.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import pytest
 import torch
+from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gqa import (
@@ -75,6 +76,30 @@ def _baseline_gqa_bwd(test: GqaBwdTest):
     return baseline_fn
 
 
+def _torch_gqa_fwd(test):
+    """Torch SDPA forward baseline."""
+    def fn(q, k, v):
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+            is_causal=test.is_causal, enable_gqa=True)
+        return out.transpose(1, 2)
+    return fn
+
+
+def _torch_gqa_bwd(test):
+    """Torch SDPA backward baseline (includes forward recompute)."""
+    def fn(q, k, v, o, grad_output, lse):
+        q = q.detach().requires_grad_(True)
+        k = k.detach().requires_grad_(True)
+        v = v.detach().requires_grad_(True)
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+            is_causal=test.is_causal, enable_gqa=True)
+        out.transpose(1, 2).contiguous().backward(grad_output)
+        return q.grad, k.grad, v.grad
+    return fn
+
+
 _GQA_FWD_BENCH_PARAMS = [
     pytest.param(1, 1024, 8, 4, 64, False, torch.float16, True, id="prefill-fp16"),
     pytest.param(4, 2048, 64, 4, 128, False, torch.float16, True, id="throughput-fp16"),
@@ -100,6 +125,9 @@ def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     if baseline_fn is not None:
         result_bl = bm.profile(baseline_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="FA3")
+    else:
+        result_bl = bm.profile(_torch_gqa_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 _GQA_BWD_BENCH_PARAMS = _GQA_FWD_BENCH_PARAMS
@@ -123,6 +151,9 @@ def test_gqa_bwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     if baseline_fn is not None:
         result_bl = bm.profile(baseline_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="FA3")
+    else:
+        result_bl = bm.profile(_torch_gqa_bwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_sliding_window_fwd.py
+++ b/benchmarks/ops/bench_gqa_sliding_window_fwd.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 import torch
+from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gqa_sliding_window_fwd import GqaSlidingWindowFwdTest
@@ -28,6 +29,28 @@ class GqaSlidingWindowFwdBenchmark(BenchmarkBase):
         t = self.test
         elem = torch.tensor([], dtype=t.dtype).element_size()
         return 2 * t.batch * t.seq * (t.heads + t.heads_kv) * t.dim * elem
+
+
+def _torch_sliding_window_fwd(test):
+    """Torch SDPA forward baseline with explicit sliding window mask."""
+    def fn(q, k, v):
+        S = test.seq
+        q_idx = torch.arange(S, device=q.device).unsqueeze(1)
+        k_idx = torch.arange(S, device=q.device).unsqueeze(0)
+        mask = torch.zeros(S, S, dtype=torch.bool, device=q.device)
+        if test.is_causal:
+            mask |= (k_idx > q_idx)
+        if test.wl >= 0:
+            mask |= (k_idx < q_idx - test.wl)
+        if test.wr >= 0:
+            mask |= (k_idx > q_idx + test.wr)
+        attn_mask = torch.zeros(S, S, dtype=q.dtype, device=q.device)
+        attn_mask.masked_fill_(mask, float('-inf'))
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+            attn_mask=attn_mask, enable_gqa=True)
+        return out.transpose(1, 2)
+    return fn
 
 
 def _fa3_baseline(q, k, v, is_causal, wl, wr):
@@ -87,6 +110,9 @@ def test_gqa_sliding_window_fwd_bench(
         result_bl = bm.profile(
             lambda q, k, v: _fa3_baseline(q, k, v, is_causal, wl, wr), *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+    else:
+        result_bl = bm.profile(_torch_sliding_window_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
+++ b/benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 import torch
+from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gqa_sliding_window_varlen_fwd import GqaSlidingWindowVarlenFwdTest
@@ -69,6 +70,59 @@ class GqaSlidingWindowVarlenFwdBenchmark(BenchmarkBase):
                 total_q * t.heads * t.dim) * elem
 
 
+def _torch_sliding_window_varlen_fwd(test):
+    """Torch SDPA forward baseline: unpack varlen to padded batch, single SDPA call."""
+    def fn(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q):
+        B = test.batch
+        seqlens_q = test.seqlens_q
+        seqlens_k = test.seqlens_k
+        max_sq = max(seqlens_q)
+        max_sk = max(seqlens_k)
+        H, Hkv, D = test.heads, test.heads_kv, test.dim
+
+        # Unpack packed varlen tensors to padded [B, max_s, H, D]
+        q_pad = q.new_zeros(B, max_sq, H, D)
+        k_pad = k.new_zeros(B, max_sk, Hkv, D)
+        v_pad = v.new_zeros(B, max_sk, Hkv, D)
+        for i in range(B):
+            qs, qe = cu_seqlens_q[i].item(), cu_seqlens_q[i + 1].item()
+            ks, ke = cu_seqlens_k[i].item(), cu_seqlens_k[i + 1].item()
+            q_pad[i, :qe - qs] = q[qs:qe]
+            k_pad[i, :ke - ks] = k[ks:ke]
+            v_pad[i, :ke - ks] = v[ks:ke]
+
+        # Build combined mask [B, max_sq, max_sk]
+        q_idx = torch.arange(max_sq, device=q.device).view(1, -1, 1)
+        k_idx = torch.arange(max_sk, device=q.device).view(1, 1, -1)
+        sq_t = torch.tensor(seqlens_q, device=q.device, dtype=torch.long).view(B, 1, 1)
+        sk_t = torch.tensor(seqlens_k, device=q.device, dtype=torch.long).view(B, 1, 1)
+        offsets = sk_t - sq_t  # per-sample offset [B, 1, 1]
+
+        # Padding positions
+        mask = (q_idx >= sq_t) | (k_idx >= sk_t)
+        # Sliding window + causal constraints
+        if test.is_causal:
+            mask = mask | (k_idx > q_idx + offsets)
+        if test.wl >= 0:
+            mask = mask | (k_idx < q_idx + offsets - test.wl)
+        if test.wr >= 0:
+            mask = mask | (k_idx > q_idx + offsets + test.wr)
+
+        attn_mask = torch.zeros(B, max_sq, max_sk, dtype=q.dtype, device=q.device)
+        attn_mask.masked_fill_(mask, float('-inf'))
+
+        # SDPA call: transpose to [B, H, S, D], mask broadcasts as [B, 1, max_sq, max_sk]
+        out = F.scaled_dot_product_attention(
+            q_pad.transpose(1, 2), k_pad.transpose(1, 2), v_pad.transpose(1, 2),
+            attn_mask=attn_mask.unsqueeze(1), enable_gqa=True)
+        out = out.transpose(1, 2)  # [B, max_sq, H, D]
+
+        # Repack valid positions to [total_q, H, D]
+        parts = [out[i, :seqlens_q[i]] for i in range(B)]
+        return torch.cat(parts, dim=0)
+    return fn
+
+
 def _fa3_varlen_baseline(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q,
                          max_seqlen_k, is_causal, wl, wr):
     """FA3 varlen reference baseline."""
@@ -132,8 +186,10 @@ def test_gqa_sliding_window_varlen_fwd_bench(
             lambda q, k, v, csq, csk, msq: _fa3_varlen_baseline(
                 q, k, v, csq, csk, msq, max_seqlen_k, is_causal, wl, wr),
             *inputs)
-        BenchmarkReport.record(
-            "gqa_sliding_window_varlen_fwd", locals(), result_bl, tag="fa3")
+        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+    else:
+        result_bl = bm.profile(_torch_sliding_window_varlen_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mha.py
+++ b/benchmarks/ops/bench_mha.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import pytest
 import torch
+from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_mha import (
@@ -72,6 +73,30 @@ def _baseline_mha_bwd(test: MhaBwdTest):
     return baseline_fn
 
 
+def _torch_mha_fwd(test):
+    """Torch SDPA forward baseline."""
+    def fn(q, k, v):
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+            is_causal=test.is_causal)
+        return out.transpose(1, 2)
+    return fn
+
+
+def _torch_mha_bwd(test):
+    """Torch SDPA backward baseline (includes forward recompute)."""
+    def fn(q, k, v, o, grad_output, lse):
+        q = q.detach().requires_grad_(True)
+        k = k.detach().requires_grad_(True)
+        v = v.detach().requires_grad_(True)
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+            is_causal=test.is_causal)
+        out.transpose(1, 2).contiguous().backward(grad_output)
+        return q.grad, k.grad, v.grad
+    return fn
+
+
 _MHA_FWD_BENCH_PARAMS = [
     pytest.param(1, 1024, 8, 64, False, torch.float16, True, id="prefill-fp16"),
     pytest.param(16, 2048, 16, 128, False, torch.float16, True, id="throughput-fp16"),
@@ -94,6 +119,9 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     if baseline_fn is not None:
         result_bl = bm.profile(baseline_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="FA3")
+    else:
+        result_bl = bm.profile(_torch_mha_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 _MHA_BWD_BENCH_PARAMS = _MHA_FWD_BENCH_PARAMS
@@ -114,6 +142,9 @@ def test_mha_bwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     if baseline_fn is not None:
         result_bl = bm.profile(baseline_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="FA3")
+    else:
+        result_bl = bm.profile(_torch_mha_bwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #617

- 4 benchmark files (`bench_mha`, `bench_gqa`, `bench_gqa_sliding_window_fwd`, `bench_gqa_sliding_window_varlen_fwd`) silently skip baseline recording when FA3 is not installed, leaving the nightly report without comparison data.
- Added `torch.nn.functional.scaled_dot_product_attention` fallback in the `else` branch of each FA3 check:
  - **MHA / GQA**: direct SDPA call (`enable_gqa=True` for GQA)
  - **Sliding window**: explicit `[S, S]` attn_mask encoding causal + wl + wr constraints
  - **Sliding window varlen**: unpack packed varlen tensors to padded `[B, max_sq, H, D]`, build `[B, max_sq, max_sk]` mask with per-sample offset + padding, single SDPA call, repack output

## Verification

- Correctness: 25/25 cases pass against `test.ref_program` (max diff ≤ 6e-5)
- Performance on H200: MHA/GQA fallback ~1.2–1.8x slower than TileOPs; sliding window fallback ~13–51x slower (SDPA math backend, no flash path for custom masks) — expected and acceptable as baseline

## Test plan

- [ ] Verify nightly bench CI produces baseline rows for all 4 files without FA3 installed
- [ ] Spot-check that FA3 path is still preferred when FA3 **is** available

🤖 Generated with [Claude Code](https://claude.com/claude-code)