### PR TITLE
[Fix][Bench] Fix 11 nightly benchmark failures and report omission

### DIFF
--- a/benchmarks/ops/bench_engram_bwd.py
+++ b/benchmarks/ops/bench_engram_bwd.py
@@ -45,7 +45,11 @@ def test_engram_gate_conv_bwd_bench(M, seq_len, d, dtype, tune):
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    @torch.enable_grad()
+    def ref_with_grad(*args):
+        return test.ref_program(*args)
+
+    result_bl = bm.profile(ref_with_grad, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_gqa.py
+++ b/benchmarks/ops/bench_gqa.py
@@ -88,6 +88,7 @@ def _torch_gqa_fwd(test):
 
 def _torch_gqa_bwd(test):
     """Torch SDPA backward baseline (includes forward recompute)."""
+    @torch.enable_grad()
     def fn(q, k, v, o, grad_output, lse):
         q = q.detach().requires_grad_(True)
         k = k.detach().requires_grad_(True)

--- a/benchmarks/ops/bench_mha.py
+++ b/benchmarks/ops/bench_mha.py
@@ -85,6 +85,7 @@ def _torch_mha_fwd(test):
 
 def _torch_mha_bwd(test):
     """Torch SDPA backward baseline (includes forward recompute)."""
+    @torch.enable_grad()
     def fn(q, k, v, o, grad_output, lse):
         q = q.detach().requires_grad_(True)
         k = k.detach().requires_grad_(True)

--- a/benchmarks/ops/bench_mha_decode.py
+++ b/benchmarks/ops/bench_mha_decode.py
@@ -44,7 +44,7 @@ def test_mha_decode_bench(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: to
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="baseline")
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -103,6 +103,8 @@ def parse_bench_xml(path: str) -> list[dict]:
             "outcome": outcome,
             "op": props.get("op"),
             "op_module": props.get("op_module"),
+            "failure_message": (failure.attrib.get("message", "") if failure is not None
+                                else None),
         }
         # Perf data
         for key in ("tileops_latency_ms", "tileops_tflops", "tileops_bandwidth_tbs",
@@ -165,6 +167,20 @@ def aggregate_bench_results(results: list[dict]) -> dict:
                 config_entry[key] = r[key]
         d["configs"].append(config_entry)
     return dict(ops)
+
+
+def collect_bench_failures(results: list[dict]) -> list[dict]:
+    """Collect failed benchmark results for reporting."""
+    return [
+        {
+            "nodeid": r["nodeid"],
+            "name": r["name"],
+            "op": r.get("op"),
+            "failure_message": r.get("failure_message"),
+        }
+        for r in results
+        if r["outcome"] == "failed"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +364,7 @@ def _ratio_emoji(ratio: float) -> str:
 def generate_report(
     test_ops: dict | None,
     bench_ops: dict | None,
+    bench_failures: list[dict],
     regressions: list[dict],
     improvements: list[dict],
     baseline_alerts: list[dict],
@@ -366,7 +383,8 @@ def generate_report(
                       for d in (test_ops or {}).values())
     total_passed = sum(d["passed"] for d in (test_ops or {}).values())
 
-    health = _PASS if (n_failures == 0 and not regressions) else _FAIL
+    health = _PASS if (n_failures == 0 and not regressions
+                       and not bench_failures) else _FAIL
     lines.append(f"# {health} TileOPs Nightly Report")
     lines.append("")
     lines.append(f"> **{now}** &ensp;|&ensp; `{commit}` &ensp;|&ensp; {gpu}")
@@ -374,6 +392,8 @@ def generate_report(
 
     # ── Summary ───────────────────────────────────────────────────────────
     corr_icon = _PASS if n_failures == 0 else f"{_FAIL} {n_failures} failed"
+    bench_fail_icon = (f"{_FAIL} {len(bench_failures)}"
+                       if bench_failures else f"{_PASS} None")
     reg_icon = f"{_PASS} None" if not regressions else f"{_WARN} {len(regressions)}"
     alert_icon = (f"{_WARN} {len(baseline_alerts)}"
                   if baseline_alerts else f"{_PASS} None")
@@ -384,6 +404,7 @@ def generate_report(
                  f" &ensp; ({total_passed}/{total_tests} tests across"
                  f" {n_test_ops} ops) |")
     lines.append(f"| **Benchmarked Ops** | {n_bench_ops} |")
+    lines.append(f"| **Benchmark Failures** | {bench_fail_icon} |")
     lines.append(f"| **Regressions** (vs 14-day best) | {reg_icon} |")
     lines.append(f"| **Baseline Alerts** (< {BASELINE_RATIO_ALERT:.0%}) |"
                  f" {alert_icon} |")
@@ -408,6 +429,21 @@ def generate_report(
                 lines.append(f"| **{op}** | `{d['module'] or 'N/A'}` "
                              f"| {d['failed']}/{total} | {tests_str} |")
             lines.append("")
+
+    # ── Benchmark Failures (only if any) ─────────────────────────────────
+    if bench_failures:
+        lines.append(f"## {_FAIL} Benchmark Failures")
+        lines.append("")
+        lines.append("| Test | Error |")
+        lines.append("|:-----|:------|")
+        for f in bench_failures:
+            name = f["name"]
+            msg = f.get("failure_message") or ""
+            if len(msg) > 120:
+                msg = msg[:120] + "..."
+            msg = msg.replace("|", "\\|")
+            lines.append(f"| {name} | {msg} |")
+        lines.append("")
 
     # ── Regressions ───────────────────────────────────────────────────────
     if regressions:
@@ -535,9 +571,11 @@ def main():
         test_ops = aggregate_test_results(test_results)
 
     bench_ops = None
+    bench_failures = []
     if args.bench_xml and Path(args.bench_xml).exists():
         bench_results = parse_bench_xml(args.bench_xml)
         bench_ops = aggregate_bench_results(bench_results)
+        bench_failures = collect_bench_failures(bench_results)
 
     # Load history and detect regressions
     history_runs = load_history(args.history)
@@ -546,7 +584,8 @@ def main():
     baseline_alerts = detect_baseline_alerts(bench_ops) if bench_ops else []
 
     # Generate report
-    report = generate_report(test_ops, bench_ops, regressions, improvements, baseline_alerts)
+    report = generate_report(test_ops, bench_ops, bench_failures,
+                             regressions, improvements, baseline_alerts)
     Path(args.output).write_text(report)
     print(f"Report written to {args.output}")
 

--- a/tileops/kernels/flash_decode/mha_decode.py
+++ b/tileops/kernels/flash_decode/mha_decode.py
@@ -204,9 +204,13 @@ def _mha_decode_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, dtype)
                     MMA1(V, V_shared, real_seqlen_kv, acc_s_cast, acc_o, k, hid, bid, sid)
 
                 for i, j in T.Parallel(block_M, dim):
-                    acc_o[i, j] /= logsum[i]
+                    acc_o[i, j] = T.if_then_else(
+                        logsum[i] > 0, acc_o[i, j] / logsum[i], 0)
                 for i in T.Parallel(block_M):
-                    logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
+                    logsum[i] = T.if_then_else(
+                        logsum[i] > 0,
+                        T.log2(logsum[i]) + scores_max[i] * scale,
+                        -T.infinity(accum_dtype))
                 T.copy(logsum, glse[bid, hid, sid, mid * block_M:(mid + 1) * block_M])
                 T.copy(acc_o, O_shared)
                 T.copy(
@@ -324,8 +328,6 @@ def _mha_decode_wrapped_kernel(batch: int, heads: int, seqlen_q: int, seqlen_kv:
     split_length[-1] = real_seqlen_kv - (num_split - 1) * (
         real_seqlen_kv // (num_split * block_N) * block_N)
 
-    if (split_length[0] == 0):
-        num_split = 1
     if num_split == 1:
         return _mha_decode_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal,
                                   dtype)(block_M, block_N, num_split, num_stages,


### PR DESCRIPTION
## Summary

- **Backward baselines fail under `no_grad()`**: `BenchmarkBase.profile()` wraps calls in `torch.no_grad()`, breaking autograd-based torch SDPA backward baselines when FA3 is unavailable. Fixed by adding `@torch.enable_grad()` to baseline functions in `bench_engram_bwd`, `bench_gqa`, and `bench_mha`.
- **mha_decode `result_idx` OOB**: When autotune selects `num_split>1` but `seqlen_kv` is too small, the runtime fallback to `num_split=1` recompiles `mha_decode_no_split` (5 params) with `out_idx=[7]` (resolved from the 8-param split function). Fixed by guarding the split kernel's `logsum` division against zero (empty splits) and removing the runtime `num_split` fallback.
- **Nightly report silently drops benchmark failures**: `aggregate_bench_results()` filters `outcome != "passed"`, so failed benchmarks never appear. Added `collect_bench_failures()`, a "Benchmark Failures" section, summary row, and health indicator integration.

Closes #634

## Test plan

- [x] `bench_engram_bwd` — all 4 cases pass locally (no FA3)
- [x] `bench_gqa::test_gqa_bwd_bench` — all 3 cases pass locally (no FA3)
- [x] `bench_mha::test_mha_bwd_bench` — all 3 cases pass locally (no FA3)
- [x] `bench_mha_decode::test_mha_decode_bench[short-kv-tail]` — passes locally
- [x] `test_mha_decode` unit tests — all 3 cases pass (including `seqlen_kv=5`)
- [x] Nightly report shows benchmark failures in synthetic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)