### PR TITLE
[Fix][Bench] Cap no-split mha_decode threads to prevent LayoutInference crash

### DIFF
--- a/tileops/kernels/flash_decode/mha_decode.py
+++ b/tileops/kernels/flash_decode/mha_decode.py
@@ -473,9 +473,15 @@ class mha_decode_kernel(Kernel):
         # Dispatch: use no-split for short sequences where splitting is not beneficial
         threshold = num_split * block_N
         if real_seqlen_kv < threshold:
+            # The no-split kernel does not support all thread counts that the
+            # split kernel accepts.  With threads=256 the LayoutInference pass
+            # hits a fragment conflict between acc_s (float32) and acc_s_cast
+            # (float16/bfloat16) whose MMA layouts differ in replicate count.
+            # Cap to the default thread count which is always safe for the no-split variant.
+            no_split_threads = min(threads, self.default_config["threads"])
             return _mha_decode_no_split_op(self.batch, self.heads, self.seqlen_q, self.seqlen_kv,
                                            real_seqlen_kv, self.dim, self.is_causal, self.dtype_str,
-                                           block_M, block_N, num_stages, threads, Q, K, V)
+                                           block_M, block_N, num_stages, no_split_threads, Q, K, V)
 
         # Split path: compute per-split lengths
         base_len = real_seqlen_kv // (num_split * block_N) * block_N


### PR DESCRIPTION
## Summary

- Cap `threads` to 128 when dispatching to the no-split kernel path in `mha_decode_kernel.forward()`
- Fixes nightly benchmark crash on `test_mha_decode_bench[short-kv-tail]` (s_kv=5)

## Problem

The split kernel autotuner may select `threads=256`, but when `forward()` dispatches to the no-split path for short KV sequences (`real_seqlen_kv < num_split * block_N`), this thread count causes a TileLang `LayoutInference` conflict:

- `acc_s` (float32): replicate=2, 32 elements/thread
- `acc_s_cast` (float16): replicate=1, 16 elements/thread

`ProveFragmentContains` fails because the replicate mismatch makes `forward_thread` mappings incompatible, throwing `LayoutConflictException`.

## Fix

```python
no_split_threads = min(threads, 128)
```

`threads=128` is the `default_config` value and always produces compatible fragment layouts. The split kernel path is unaffected.

## Test plan

- [x] Reproduced crash locally: `_mha_decode_no_split_kernel(...)(64, 64, 2, 256)` → `InternalError`
- [x] Verified fix: same call with `threads=128` compiles and runs correctly
- [x] All 3 benchmarks pass: `fp16-long-cache`, `bf16-long-cache`, `short-kv-tail`
- [x] All 3 correctness tests pass (including `s_kv=5`)

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)