### PR TITLE
[CI] Reuse trusted hash venv for fork gpu smoke

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -515,12 +515,7 @@ jobs:
             source "${VENV_PATH}/bin/activate"
             python --version
             python -m pip --version
-            python - <<'PY'
-            import tileops
-            import torch
-
-            print("Copied fork venv import check ok")
-            PY
+            python -c "import tileops, torch; print('Copied fork venv import check ok')"
             exit 0
           fi
 


### PR DESCRIPTION
Closes #676

## Summary

- reuse the trusted hash-keyed venv for fork PR gpu-smoke runs by copying it into the per-run runtime root when available
- fall back to the existing fresh venv creation and dependency install path when no matching trusted venv exists
- add a lightweight copied-venv validation step before continuing to tests

## Test plan

- [x] pre-commit passed
- [ ] pytest passed

## Benchmark

- not run locally; this change targets CI environment setup latency rather than kernel runtime

## Regression

- fork PR jobs still keep isolated runtime state under RUNNER_TEMP
- fork PR jobs still fall back to fresh environment creation when the trusted hash venv is unavailable

## Additional context

- issue: #676
