### PR TITLE
[CI] Use manual docker run for nightly tests with local image

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -62,6 +62,10 @@ RUN MAX_JOBS=64 NVCC_THREADS=64 pip install --no-cache-dir --no-build-isolation 
         "sgl-kernel==0.3.21" \
     || echo "WARNING: Some bench deps failed to install -- non-fatal for runner image"
 
+RUN MAX_JOBS=32 pip install --no-cache-dir \
+        "git+https://github.com/fla-org/native-sparse-attention.git@bd67af59b90afa34b25f61d2922e612d10dba3bd" \
+    || echo "WARNING: native-sparse-attention failed to install -- non-fatal"
+
 # ── Install TileOPs (editable) ───────────────────────────────────────────────
 WORKDIR /home/ci-runner/tileops
 COPY --chown=ci-runner:ci-runner . .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,9 +55,6 @@ jobs:
               mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
               PIP_NO_BUILD_ISOLATION=1 pip install -e ".[dev]"
-              MAX_JOBS=32 PIP_NO_BUILD_ISOLATION=1 pip install -e ".[bench]"
-              MAX_JOBS=32 pip install git+https://github.com/fla-org/native-sparse-attention.git@bd67af59b90afa34b25f61d2922e612d10dba3bd \
-                || echo "::warning::native-sparse-attention installation failed; skipping"
 
               export PYTHONPATH="/workspace${PYTHONPATH:+:$PYTHONPATH}"
               echo "Starting kernel cache warmup..."
@@ -119,9 +116,6 @@ jobs:
               done
 
               PIP_NO_BUILD_ISOLATION=1 pip install -e ".[dev]"
-              MAX_JOBS=32 PIP_NO_BUILD_ISOLATION=1 pip install -e ".[bench]"
-              MAX_JOBS=32 pip install git+https://github.com/fla-org/native-sparse-attention.git@bd67af59b90afa34b25f61d2922e612d10dba3bd \
-                || echo "::warning::native-sparse-attention installation failed; skipping"
 
               export PYTHONPATH="/workspace${PYTHONPATH:+:$PYTHONPATH}"
               python -c "


### PR DESCRIPTION
## Summary

Closes #679

Switch nightly workflow from the `container:` directive to manual `docker run`, using the locally built `tileops-runner:latest` image on the host. This avoids any dependency on external Docker registries.

## Background

GitHub Actions `container:` directive always attempts `docker pull` before starting a job. This fails in our setup because:
- The image is built and stored locally on the self-hosted runner host
- Pushing to ghcr.io requires organization-level package write permissions

Using manual `docker run` gives us full control: the locally built image is used directly, no registry or authentication needed.

## Architecture

```
Host (self-hosted runner, label: nightly)
├── ~/actions-runner/           — Runner service (systemd, auto-start)
├── tileops-runner:latest       — Local Docker image (pre-built)
└── /data/ci-cache/             — Persistent caches (tilelang, triton, pip, wheels)

Nightly workflow triggers:
  1. Runner picks up job on host
  2. actions/checkout runs on host
  3. docker run tileops-runner:latest executes tests with:
     - GPU 1 (--gpus "device=1", locked at 1830 MHz)
     - Workspace mounted from host
     - Cache volumes mounted from /data/ci-cache/
  4. Container exits, artifacts uploaded from host
```

## Changes to nightly.yml

- Replace `container:` blocks with explicit `docker run` commands
- All 4 phases (cache-warmup, benchmark, op_test, packaging) use the same pattern
- GitHub Actions steps (checkout, upload/download-artifact) run on host; shell commands run inside the container
- Remove venv caching logic — the Docker image has all dependencies pre-installed; only `pip install -e .` is needed per run
- Simplified cache configuration (env vars passed via `docker run -e`)

## Image maintenance

The Dockerfile (`.github/runner/Dockerfile`) is checked into the repo. When the environment needs updating:

1. Edit the Dockerfile, merge to main
2. Rebuild on host: `docker build -f .github/runner/Dockerfile -t tileops-runner:latest .`

The existing image continues to work until explicitly rebuilt. Docker layer caching makes incremental rebuilds fast.

## Other workflows

No changes to `gpu-smoke.yml` or `preflight.yml` — they continue using the existing `venv`-labeled runners.

## Test plan

- [ ] Merge and trigger nightly via `workflow_dispatch`
- [ ] Verify all 4 phases complete successfully
- [ ] Verify tilelang cache hits in warmup logs
- [ ] Confirm gpu-smoke still runs on old runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)