### PR TITLE
[CI] Disable checkout clean to avoid root-owned file conflicts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          clean: false
 
       - name: Warm kernel compilation cache
         continue-on-error: true
@@ -75,6 +76,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          clean: false
 
       - name: Run benchmark ops
         id: benchmark_tests
@@ -165,6 +167,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          clean: false
 
       - name: Run full op tests
         id: op_tests
@@ -290,6 +293,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          clean: false
 
       - name: Build and test wheel package
         run: |


### PR DESCRIPTION
## Summary

Fix `actions/checkout` failure in nightly jobs after the `docker run` migration (#682, #685).

Docker containers run as root, creating `__pycache__/*.pyc` files owned by root in the mounted workspace. When the next job's `actions/checkout` tries to clean the workspace, it fails with:

```
EACCES: permission denied, unlink '.../__pycache__/__init__.cpython-311.pyc'
```

Setting `clean: false` on all checkout steps skips the cleanup phase. The checkout still fetches the correct ref — it just doesn't try to delete files it cannot remove.

## Test plan

- [ ] Trigger nightly via `workflow_dispatch` and verify all jobs pass checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)