### PR TITLE
[CI] Fix workspace ownership with docker chown before checkout

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,11 +26,18 @@ jobs:
     timeout-minutes: 60
     runs-on: [self-hosted, tile-ops, nightly]
     steps:
+      - name: Fix workspace ownership
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            --entrypoint chown \
+            tileops-runner:latest \
+            -R "$(id -u):$(id -g)" /workspace
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          clean: false
 
       - name: Warm kernel compilation cache
         continue-on-error: true
@@ -72,11 +79,18 @@ jobs:
     timeout-minutes: 120
     runs-on: [self-hosted, tile-ops, nightly]
     steps:
+      - name: Fix workspace ownership
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            --entrypoint chown \
+            tileops-runner:latest \
+            -R "$(id -u):$(id -g)" /workspace
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          clean: false
 
       - name: Run benchmark ops
         id: benchmark_tests
@@ -163,11 +177,18 @@ jobs:
     timeout-minutes: 180
     runs-on: [self-hosted, tile-ops, nightly]
     steps:
+      - name: Fix workspace ownership
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            --entrypoint chown \
+            tileops-runner:latest \
+            -R "$(id -u):$(id -g)" /workspace
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          clean: false
 
       - name: Run full op tests
         id: op_tests
@@ -291,10 +312,16 @@ jobs:
       contents: write
     runs-on: [self-hosted, tile-ops, nightly]
     steps:
+      - name: Fix workspace ownership
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            --entrypoint chown \
+            tileops-runner:latest \
+            -R "$(id -u):$(id -g)" /workspace
+
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          clean: false
 
       - name: Build and test wheel package
         run: |


### PR DESCRIPTION
## Summary

- Fix `actions/checkout` EACCES failure caused by root-owned files from docker containers
- PR #686 set `clean: false` but that only prevents `git clean -ffdx`, **not** the workspace directory reinitialization phase ("Deleting the contents") where checkout fails
- Add a lightweight `docker run --entrypoint chown` step before each checkout to reclaim file ownership using the local `tileops-runner:latest` image — no `sudo` required
- Remove the now-unnecessary `clean: false`

## Root cause

Docker containers run as root and create `__pycache__/*.pyc` files owned by `root:root` in the bind-mounted workspace. When the next job's `actions/checkout` needs to reinitialize the workspace directory, it tries to delete all files but fails on root-owned files with `EACCES`.

## Why PR #686 didn't work

`clean: false` controls `git clean -ffdx` (post-fetch cleanup), but the error occurs in a separate earlier phase — workspace directory preparation ("Deleting the contents") — which is **not** governed by the `clean` option.

## Test plan

- [ ] Trigger nightly via `workflow_dispatch` and verify all 4 jobs pass checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)