### PR TITLE
[CI] Speed up nightly packaging job from 31min to ~1min

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -359,10 +359,11 @@ jobs:
               ls -lh dist/*.whl
 
               echo "=== Install built wheel ==="
-              pip install --force-reinstall dist/*.whl
+              pip install dist/*.whl
 
               TMP_TEST_DIR="$(mktemp -d)"
               cp -r tests "${TMP_TEST_DIR}/tests"
+              cp pyproject.toml "${TMP_TEST_DIR}/"
               cd "${TMP_TEST_DIR}"
 
               echo "=== Runtime cache env ==="
@@ -370,8 +371,8 @@ jobs:
               echo "TILELANG_TMP_DIR=${TILELANG_TMP_DIR:-}"
               echo "TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-}"
 
-              echo "=== Run pytest smoke ==="
-              python -m pytest -q tests/ops -m "smoke" \
+              echo "=== Run pytest packaging ==="
+              python -m pytest -q tests/ops -m "packaging" \
                 --junit-xml=/workspace/packaging_smoke.xml
             ' 2>&1 | tee packaging.log
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,4 +123,5 @@ markers = [
     "smoke: fast PR critical-path tests",
     "full: standard correctness coverage",
     "nightly: exhaustive or long-running coverage",
+    "packaging: minimal wheel-install sanity check (one case per op family)",
 ]

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -15,7 +15,7 @@ class ReluFixture(FixtureBase):
     PARAMS = [
         ("n_total, dtype", [
             # Smoke: fp16, 1M elements
-            pytest.param(1_000_000, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(1_000_000, torch.float16, marks=[pytest.mark.smoke, pytest.mark.packaging]),
             # Full: other dtypes and sizes
             pytest.param(1_000_000, torch.bfloat16, marks=pytest.mark.full),
             pytest.param(1_000_000, torch.float32, marks=pytest.mark.full),

--- a/tests/ops/test_conv1d.py
+++ b/tests/ops/test_conv1d.py
@@ -14,7 +14,7 @@ class Conv1dFixture(FixtureBase):
         ("n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune", [
             pytest.param(
                 2, 64, 512, 128, 3, 1, 1, torch.float16, False,
-                marks=pytest.mark.smoke,
+                marks=[pytest.mark.smoke, pytest.mark.packaging],
                 id="smoke-tcn-k3-s1-fp16",
             ),
             pytest.param(

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -12,7 +12,7 @@ class GemmFixture(FixtureBase):
         ("m, n, k, dtype, trans_a, trans_b, tune", [
             pytest.param(
                 1024, 1024, 1024, torch.float16, False, False, False,
-                marks=pytest.mark.smoke,
+                marks=[pytest.mark.smoke, pytest.mark.packaging],
                 id="smoke-fp16-square",
             ),
             pytest.param(

--- a/tests/ops/test_mha.py
+++ b/tests/ops/test_mha.py
@@ -14,7 +14,7 @@ class MhaFwdFixture(FixtureBase):
         ("batch, seq_len, heads, dim, causal, dtype, tune", [
             pytest.param(
                 1, 1024, 8, 64, False, torch.float16, False,
-                marks=pytest.mark.smoke,
+                marks=[pytest.mark.smoke, pytest.mark.packaging],
                 id="smoke-fwd-fp16",
             ),
             pytest.param(

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -19,7 +19,7 @@ class ReduceBasicFixture(FixtureBase):
         (
             "m, n, dtype",
             [
-                pytest.param(128, 512, torch.float16, marks=pytest.mark.smoke),
+                pytest.param(128, 512, torch.float16, marks=[pytest.mark.smoke, pytest.mark.packaging]),
                 pytest.param(128, 512, torch.float32, marks=pytest.mark.full),
                 pytest.param(128, 512, torch.bfloat16, marks=pytest.mark.full),
                 pytest.param(256, 4096, torch.float16, marks=pytest.mark.full),

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -9,7 +9,7 @@ class RmsNormFixture(FixtureBase):
     PARAMS = [
         ("m, n, dtype, tune", [
             # Standard aligned shapes (AC required)
-            pytest.param(1024, 4096, torch.float16, False, marks=pytest.mark.smoke),
+            pytest.param(1024, 4096, torch.float16, False, marks=[pytest.mark.smoke, pytest.mark.packaging]),
             pytest.param(1024, 4096, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(4096, 4096, torch.float16, False, marks=pytest.mark.full),
             pytest.param(4096, 4096, torch.bfloat16, False, marks=pytest.mark.full),

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -305,7 +305,7 @@ class RopeBasicFixture(FixtureBase):
     """Basic RoPE fixture: shapes x dtypes."""
     PARAMS = [
         ("batch, seq_len, num_heads, head_dim, dtype", [
-            pytest.param(2, 128, 8, 64, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(2, 128, 8, 64, torch.float16, marks=[pytest.mark.smoke, pytest.mark.packaging]),
             pytest.param(2, 128, 8, 64, torch.bfloat16, marks=pytest.mark.full),
             pytest.param(2, 128, 8, 64, torch.float32, marks=pytest.mark.full),
             pytest.param(1, 256, 4, 128, torch.float16, marks=pytest.mark.full),

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -42,7 +42,7 @@ class SoftmaxFixture(FixtureBase):
             "m, n, dtype, tune",
             [
                 # Smoke: first param — small data, fp32, pow2 dim
-                pytest.param(32, 256, torch.float32, False, marks=pytest.mark.smoke),
+                pytest.param(32, 256, torch.float32, False, marks=[pytest.mark.smoke, pytest.mark.packaging]),
                 # Full: all dtypes x pow2/non-pow2 x normal-M/tail-M (small data)
                 pytest.param(32, 256, torch.float16, False, marks=pytest.mark.full),
                 pytest.param(32, 256, torch.bfloat16, False, marks=pytest.mark.full),


### PR DESCRIPTION
## Summary

Fixes #699

- Remove `--force-reinstall` from `pip install` in the packaging step — dependencies are managed by the Docker image, no need to re-download torch (915MB) on every run
- Introduce `packaging` pytest marker for minimal wheel-install sanity checks (one representative case per op family)
- Switch packaging smoke from `-m "smoke"` (445 tests, 27min) to `-m "packaging"` (24 tests, ~10s)
- Copy `pyproject.toml` to temp test directory so pytest properly recognizes registered markers

### Op families covered by `packaging` marker

| Test file | Op family |
|---|---|
| `test_activation.py` | Elementwise (ReLU) |
| `test_rms_norm.py` | Normalization |
| `test_softmax.py` | Softmax reduction |
| `test_gemm.py` | GEMM |
| `test_mha.py` | Multi-head attention |
| `test_rope.py` | RoPE |
| `test_conv1d.py` | Convolution |
| `test_reduce.py` | Reduction primitives |

## Test plan

- [x] Local run: 24 tests pass in 9.4s (vs 445 tests / 27min before)
- [ ] Verify nightly packaging job completes in ~1 min after merge
- [ ] Confirm wheel artifact is still uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)