### PR TITLE
[Refactor][Bench] Migrate 4 legacy do_bench benchmarks to bench_kernel

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -405,7 +405,19 @@ class BenchmarkBase(ABC):
         """
         with torch.no_grad():
             latency = bench_kernel(functor, args=inputs)
+        return self._build_result(latency)
 
+    def profile_autograd(self, functor: Any) -> dict:
+        """Profile a callable that requires autograd (e.g. fwd+bwd).
+
+        Same as profile() but without torch.no_grad(), so the callable
+        can build autograd graphs and call .backward() internally.
+        The functor must be a zero-arg closure that captures its inputs.
+        """
+        latency = bench_kernel(functor)
+        return self._build_result(latency)
+
+    def _build_result(self, latency: float) -> dict:
         result = {"latency_ms": latency}
         flops = self.calculate_flops()
         if flops is not None:

--- a/benchmarks/ops/bench_deltanet_chunkwise.py
+++ b/benchmarks/ops/bench_deltanet_chunkwise.py
@@ -17,7 +17,6 @@ from typing import Optional
 
 import pytest
 import torch
-from tilelang.profiler import do_bench as _do_bench
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_deltanet_chunkwise_bwd import _autograd_bwd_ref
@@ -39,21 +38,6 @@ def _to_fla_layout(q, k, v, beta):
         v.permute(0, 2, 1, 3).contiguous(),
         beta.permute(0, 2, 1).contiguous(),
     )
-
-
-def _profile_manual(fn, bm, warmup=100, rep=100):
-    """Profile a function using do_bench with cupti/event fallback, returning a result dict."""
-    latency = _do_bench(fn, warmup=warmup, rep=rep, backend='cupti')
-    if latency <= 0:
-        latency = _do_bench(fn, warmup=warmup, rep=rep, backend='event')
-    result = {"latency_ms": latency}
-    flops = bm.calculate_flops()
-    if flops is not None:
-        result["tflops"] = flops / latency * 1e-9
-    memory = bm.calculate_memory()
-    if memory is not None:
-        result["bandwidth_tbs"] = memory / latency * 1e-9
-    return result
 
 
 # =============================================================================
@@ -213,13 +197,13 @@ def test_deltanet_vs_fla_bwd(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_bwd, bm)
+        result_fla = bm.profile(fla_bwd)
         BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return _autograd_bwd_ref(do, q, k, v, beta, BC)
-        result_bl = _profile_manual(torch_bwd, bm)
+        result_bl = bm.profile(torch_bwd)
         BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
 
 
@@ -289,7 +273,7 @@ def test_deltanet_vs_fla_fwdbwd(
         o.backward(do)
         return q.grad, k.grad, v.grad
 
-    result = _profile_manual(tileops_fwdbwd, bm, warmup=50)
+    result = bm.profile_autograd(tileops_fwdbwd)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     if chunk_delta_rule is not None:
@@ -307,13 +291,13 @@ def test_deltanet_vs_fla_fwdbwd(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_fwdbwd, bm, warmup=50)
+        result_fla = bm.profile_autograd(fla_fwdbwd)
         BenchmarkReport.record(op, locals(), result_fla, tag="fla")
     else:
         # --- Torch autograd reference baseline ---
         def torch_fwdbwd():
             return _autograd_bwd_ref(do, q.data, k.data, v.data, beta.data, BC)
-        result_bl = _profile_manual(torch_fwdbwd, bm, warmup=50)
+        result_bl = bm.profile_autograd(torch_fwdbwd)
         BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_gated_deltanet_chunkwise.py
+++ b/benchmarks/ops/bench_gated_deltanet_chunkwise.py
@@ -17,7 +17,6 @@ from typing import Optional
 
 import pytest
 import torch
-from tilelang.profiler import do_bench as _do_bench
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gated_deltanet_chunkwise_bwd import _autograd_bwd_ref
@@ -41,20 +40,6 @@ def _to_fla_layout(q, k, v, g, beta):
         beta.permute(0, 2, 1).contiguous(),
     )
 
-
-def _profile_manual(fn, bm, warmup=100, rep=100):
-    """Profile a function using do_bench with cupti/event fallback, returning a result dict."""
-    latency = _do_bench(fn, warmup=warmup, rep=rep, backend='cupti')
-    if latency <= 0:
-        latency = _do_bench(fn, warmup=warmup, rep=rep, backend='event')
-    result = {"latency_ms": latency}
-    flops = bm.calculate_flops()
-    if flops is not None:
-        result["tflops"] = flops / latency * 1e-9
-    memory = bm.calculate_memory()
-    if memory is not None:
-        result["bandwidth_tbs"] = memory / latency * 1e-9
-    return result
 
 # =============================================================================
 # Forward benchmark
@@ -138,7 +123,7 @@ def test_gated_deltanet_vs_fla_fwd(
     else:
         # --- Torch reference baseline ---
         result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 # =============================================================================
@@ -237,14 +222,14 @@ def test_gated_deltanet_vs_fla_bwd(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_bwd, bm)
+        result_fla = bm.profile(fla_bwd)
         BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return _autograd_bwd_ref(do, q, k, v, g, beta, BC)
-        result_bl = _profile_manual(torch_bwd, bm)
-        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch-ref")
+        result_bl = bm.profile(torch_bwd)
+        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
 
 
 # =============================================================================
@@ -325,7 +310,7 @@ def test_gated_deltanet_vs_fla_fwdbwd(
         o.backward(do, retain_graph=True)
         return q.grad, k.grad, v.grad
 
-    result = _profile_manual(tileops_fwdbwd, bm, warmup=50)
+    result = bm.profile_autograd(tileops_fwdbwd)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     if chunk_gated_delta_rule is not None:
@@ -344,14 +329,14 @@ def test_gated_deltanet_vs_fla_fwdbwd(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_fwdbwd, bm, warmup=50)
+        result_fla = bm.profile_autograd(fla_fwdbwd)
         BenchmarkReport.record(op, locals(), result_fla, tag="fla")
     else:
         # --- Torch autograd reference baseline ---
         def torch_fwdbwd():
             return _autograd_bwd_ref(do, q.data, k.data, v.data, g.data, beta.data, BC)
-        result_bl = _profile_manual(torch_fwdbwd, bm, warmup=50)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        result_bl = bm.profile_autograd(torch_fwdbwd)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -14,7 +14,6 @@ from typing import Optional
 
 import pytest
 import torch
-from tilelang.profiler import do_bench as _do_bench
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gla_chunkwise_bwd import _gla_autograd_bwd_ref, _gla_fwd_torch_ref
@@ -25,21 +24,6 @@ try:
     from fla.ops.gla import chunk_gla
 except ImportError:
     chunk_gla = None
-
-
-def _profile_manual(fn, bm, warmup=100, rep=100):
-    """Profile a function using do_bench with cupti/event fallback."""
-    latency = _do_bench(fn, warmup=warmup, rep=rep, backend='cupti')
-    if latency <= 0:
-        latency = _do_bench(fn, warmup=warmup, rep=rep, backend='event')
-    result = {"latency_ms": latency}
-    flops = bm.calculate_flops()
-    if flops is not None:
-        result["tflops"] = flops / latency * 1e-9
-    memory = bm.calculate_memory()
-    if memory is not None:
-        result["bandwidth_tbs"] = memory / latency * 1e-9
-    return result
 
 
 # =============================================================================
@@ -136,7 +120,7 @@ def test_gla_fwd_bench(
     else:
         # --- Torch reference baseline ---
         result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 # =============================================================================
@@ -222,14 +206,14 @@ def test_gla_bwd_bench(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_bwd, bm)
+        result_fla = bm.profile(fla_bwd)
         BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return _gla_autograd_bwd_ref(do, q, k, v, g, BC, scale=scale)
-        result_bl = _profile_manual(torch_bwd, bm)
-        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch-ref")
+        result_bl = bm.profile(torch_bwd)
+        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
 
 
 # =============================================================================
@@ -298,7 +282,7 @@ def test_gla_fwdbwd_bench(
         dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
         return bwd_op.forward(q, k, v, g, h, do, dht)
 
-    result = _profile_manual(tileops_fwdbwd, bm, warmup=50)
+    result = bm.profile_autograd(tileops_fwdbwd)
     BenchmarkReport.record(fwd_op, locals(), result, tag="tileops")
 
     if chunk_gla is not None:
@@ -315,13 +299,13 @@ def test_gla_fwdbwd_bench(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = _profile_manual(fla_fwdbwd, bm, warmup=50)
+        result_fla = bm.profile_autograd(fla_fwdbwd)
         BenchmarkReport.record(fwd_op, locals(), result_fla, tag="fla")
     else:
         def ref_autograd_fwdbwd():
             return _gla_autograd_bwd_ref(do, q, k, v, g, BC, scale=scale)
-        result_bl = _profile_manual(ref_autograd_fwdbwd, bm, warmup=50)
-        BenchmarkReport.record(fwd_op, locals(), result_bl, tag="torch-ref")
+        result_bl = bm.profile_autograd(ref_autograd_fwdbwd)
+        BenchmarkReport.record(fwd_op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -9,7 +9,6 @@ from typing import Optional
 
 import pytest
 import torch
-from tilelang.profiler import do_bench as _do_bench
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_gla_recurrence import GLADecodeTest
@@ -20,21 +19,6 @@ try:
     from fla.ops.gla import fused_recurrent_gla
 except ImportError:
     fused_recurrent_gla = None
-
-
-def _profile_manual(fn, bm, warmup=100, rep=100):
-    """Profile a function using do_bench with cupti/event fallback."""
-    latency = _do_bench(fn, warmup=warmup, rep=rep, backend='cupti')
-    if latency <= 0:
-        latency = _do_bench(fn, warmup=warmup, rep=rep, backend='event')
-    result = {"latency_ms": latency}
-    flops = bm.calculate_flops()
-    if flops is not None:
-        result["tflops"] = flops / latency * 1e-9
-    memory = bm.calculate_memory()
-    if memory is not None:
-        result["bandwidth_tbs"] = memory / latency * 1e-9
-    return result
 
 
 class GLADecodeBenchmark(BenchmarkBase):
@@ -112,12 +96,12 @@ def test_gla_decode_bench(
                 output_final_state=True,
             )
 
-        result_fla = _profile_manual(fla_decode, bm)
+        result_fla = bm.profile(fla_decode)
         BenchmarkReport.record(op, locals(), result_fla, tag="fla")
     else:
         # --- Torch reference baseline ---
         result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #694 (parent: #689)

- Add `BenchmarkBase.profile_autograd()` for fwd+bwd closures that require autograd graphs (skips `torch.no_grad()`)
- Remove `_profile_manual()` and `tilelang.profiler.do_bench` imports from 4 benchmark files
- Replace all `_profile_manual()` calls: bwd-only → `bm.profile()`, fwd+bwd → `bm.profile_autograd()`
- Standardize baseline tags: `"torch-ref"` → `"torch"` per benchmark rules

### Affected files

| File | Change |
|------|--------|
| `benchmarks/benchmark.py` | Add `profile_autograd()` method |
| `bench_deltanet_chunkwise.py` | Remove `_profile_manual`, migrate 5 call sites |
| `bench_gated_deltanet_chunkwise.py` | Remove `_profile_manual`, migrate 5 call sites |
| `bench_gla_chunkwise.py` | Remove `_profile_manual`, migrate 5 call sites |
| `bench_gla_recurrence.py` | Remove `_profile_manual`, migrate 1 call site |

### Why `profile_autograd()`?

`BenchmarkBase.profile()` wraps with `torch.no_grad()`, which breaks fwd+bwd closures that call `.backward()` internally (the forward pass inside the closure needs autograd to build the computation graph). `profile_autograd()` is identical but omits the `no_grad` wrapper.

## Test plan

- [x] All 104 benchmark tests pass in Docker (tileops-runner:latest, H200, GPU device=1)
- [x] Verified before/after latency comparison — absolute numbers change (expected: bench_kernel uses CUPTI kernel-only timing + L2 flush vs old time-based do_bench), relative TileOPs-vs-baseline rankings preserved for primary workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)