### PR TITLE
[Feat][Manifest] Add programmatic API and manifest-driven norm benchmarks

### DIFF
--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -7,51 +7,57 @@ import torch.nn.functional as F
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_ada_layer_norm import AdaLayerNormTest
 from tests.ops.test_ada_layer_norm_zero import AdaLayerNormZeroTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormOp
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroOp
+
+_ADA_OP_NAME = "ada_layernorm_fwd"
+_ADA_ZERO_OP_NAME = "ada_layernorm_zero_fwd"
 
 
 class AdaLayerNormBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N for mean, N for variance, N for normalize, N for scale, N for shift
-        # Simplified: ~5N flops per row
-        return 5 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_ADA_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only. Read x + read scale + read shift + write y."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read scale (M*N) + read shift (M*N) + write y (M*N) = 4*M*N
-        return 4 * t.m * t.n * elem_bytes
+        _, mem_bytes = eval_roofline(_ADA_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
 class AdaLayerNormZeroBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N for mean, N for variance, N for normalize, N for scale, N for shift, N for gate
-        # Simplified: ~6N flops per row
-        return 6 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_ADA_ZERO_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only. Read x + read scale + read shift + read gate + write y."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read scale (M*N) + read shift (M*N) + read gate (M*N) + write y (M*N) = 5*M*N
-        return 5 * t.m * t.n * elem_bytes
+        _, mem_bytes = eval_roofline(_ADA_ZERO_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_ADA_LAYER_NORM_BENCH_PARAMS = [
-    pytest.param(1024, 4096, torch.float16, id="mainstream-fp16"),
-    pytest.param(4096, 4096, torch.bfloat16, id="throughput-bf16"),
-    pytest.param(1024, 3000, torch.float16, id="non-power-of-two"),
-    pytest.param(1025, 4096, torch.float16, id="tail-m"),
-]
+def _manifest_params(op_name):
+    params = []
+    for w in load_workloads(op_name):
+        m, n = w["x_shape"]
+        label = w.get("label", f"{m}x{n}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(m, n, dtype,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("m, n, dtype", _ADA_LAYER_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype", _manifest_params(_ADA_OP_NAME))
 def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormTest(m, n, dtype)
     bm = AdaLayerNormBenchmark(test)
@@ -70,10 +76,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-_ADA_LAYER_NORM_ZERO_BENCH_PARAMS = _ADA_LAYER_NORM_BENCH_PARAMS
-
-
-@pytest.mark.parametrize("m, n, dtype", _ADA_LAYER_NORM_ZERO_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype", _manifest_params(_ADA_ZERO_OP_NAME))
 def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroTest(m, n, dtype)
     bm = AdaLayerNormZeroBenchmark(test)

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -14,7 +14,11 @@ import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_batch_norm import BatchNormBwdTest, BatchNormFwdTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
+
+_FWD_OP_NAME = "batchnorm_fwd"
+_BWD_OP_NAME = "batchnorm_bwd"
 
 # ---------------------------------------------------------------------------
 # Benchmark classes
@@ -28,16 +32,17 @@ class BatchNormFwdBenchmark(BenchmarkBase):
         self.C = C
         self.spatial = spatial
 
-    def calculate_flops(self) -> Optional[float]:
-        # 2 passes × L elements × C channels × ~5 ops (mean/var/norm/scale/shift)
+    def _roofline_vars(self):
         L = self.N * math.prod(self.spatial) if self.spatial else self.N
-        return 5.0 * self.C * L * 2
+        return dict(C=self.C, L=L, elem_bytes=2)
+
+    def calculate_flops(self) -> Optional[float]:
+        flops, _ = eval_roofline(_FWD_OP_NAME, **self._roofline_vars())
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        # Read x + write y + params (weight, bias, running stats)
-        L = self.N * math.prod(self.spatial) if self.spatial else self.N
-        elem_bytes = 2  # float16 / bfloat16
-        return (2 * self.C * L + 4 * self.C) * elem_bytes
+        _, mem_bytes = eval_roofline(_FWD_OP_NAME, **self._roofline_vars())
+        return mem_bytes
 
 
 class BatchNormBwdBenchmark(BenchmarkBase):
@@ -48,14 +53,17 @@ class BatchNormBwdBenchmark(BenchmarkBase):
         self.C = C
         self.spatial = spatial
 
-    def calculate_flops(self) -> Optional[float]:
+    def _roofline_vars(self):
         L = self.N * math.prod(self.spatial) if self.spatial else self.N
-        return 8.0 * self.C * L
+        return dict(C=self.C, L=L, elem_bytes=2)
+
+    def calculate_flops(self) -> Optional[float]:
+        flops, _ = eval_roofline(_BWD_OP_NAME, **self._roofline_vars())
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        L = self.N * math.prod(self.spatial) if self.spatial else self.N
-        elem_bytes = 2
-        return (3 * self.C * L + 3 * self.C) * elem_bytes
+        _, mem_bytes = eval_roofline(_BWD_OP_NAME, **self._roofline_vars())
+        return mem_bytes
 
 
 # ---------------------------------------------------------------------------
@@ -104,30 +112,40 @@ def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
 
 
 # ---------------------------------------------------------------------------
+# Manifest-driven params
+# ---------------------------------------------------------------------------
+
+def _manifest_fwd_params():
+    params = []
+    for w in load_workloads(_FWD_OP_NAME):
+        shape = w["x_shape"]
+        N, C, spatial = shape[0], shape[1], tuple(shape[2:])
+        label = w.get("label", f"{N}x{C}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(N, C, spatial, dtype, True, False,
+                                       id=f"{label}-{dtype_str}"))
+    return params
+
+
+def _manifest_bwd_params():
+    params = []
+    for w in load_workloads(_BWD_OP_NAME):
+        shape = w["x_shape"]
+        N, C, spatial = shape[0], shape[1], tuple(shape[2:])
+        label = w.get("label", f"{N}x{C}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(N, C, spatial, dtype,
+                                       id=f"{label}-{dtype_str}"))
+    return params
+
+
+# ---------------------------------------------------------------------------
 # Benchmark tests
 # ---------------------------------------------------------------------------
 
-# Use a reduced fixture for benchmarks (avoid OOM on large spatial dims).
-_FWD_BENCH_PARAMS = [
-    (32, 64,  (),        torch.float16, True, False),
-    (8,  64,  (32, 32),  torch.float16, True, False),
-    (4,  128, (32, 32),  torch.float16, True, False),
-    (4,  256, (28, 28),  torch.float16, True, False),
-    (4,  128, (1024, 1024),  torch.float16, True, False),
-    (4,  256, (1024, 1024),  torch.float16, True, False),
-]
-
-_BWD_BENCH_PARAMS = [
-    (32, 64,  (),        torch.float16),
-    (8,  64,  (32, 32),  torch.float16),
-    (4,  128, (32, 32),  torch.float16),
-    (4,  256, (28, 28),  torch.float16),
-    (4,  128, (1024, 1024),  torch.float16),
-    (4,  256, (1024, 1024),  torch.float16),
-]
-
-
-@pytest.mark.parametrize("N, C, spatial, dtype, training, tune", _FWD_BENCH_PARAMS)
+@pytest.mark.parametrize("N, C, spatial, dtype, training, tune", _manifest_fwd_params())
 def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     inputs = _make_inputs(N, C, spatial, dtype)
 
@@ -144,7 +162,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cudnn")
 
 
-@pytest.mark.parametrize("N, C, spatial, dtype", _BWD_BENCH_PARAMS)
+@pytest.mark.parametrize("N, C, spatial, dtype", _manifest_bwd_params())
 def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     inputs = _make_bwd_inputs(N, C, spatial, dtype)
 

--- a/benchmarks/ops/bench_fused_add_layer_norm.py
+++ b/benchmarks/ops/bench_fused_add_layer_norm.py
@@ -6,35 +6,40 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_fused_add_layer_norm import FusedAddLayerNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormOp
+
+_OP_NAME = "fused_add_layernorm_fwd"
 
 
 class FusedAddLayerNormBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N adds (residual), N for mean, N for variance, N for normalize,
-        # N for scale, N for bias = ~6N flops per row
-        return 6 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only.  Read x + residual + weight + bias + write y + residual_out."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read residual (M*N) + read weight (N) + read bias (N)
-        # + write y (M*N) + write residual_out (M*N)
-        return (4 * t.m * t.n + 2 * t.n) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_FUSED_ADD_LAYER_NORM_BENCH_PARAMS = [
-    pytest.param(1024, 4096, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(4096, 4096, torch.bfloat16, True, id="throughput-bf16"),
-    pytest.param(1024, 3000, torch.float16, True, id="non-power-of-two"),
-    pytest.param(1025, 4096, torch.float16, True, id="tail-m"),
-]
+def _manifest_params():
+    params = []
+    for w in load_workloads(_OP_NAME):
+        m, n = w["x_shape"]
+        label = w.get("label", f"{m}x{n}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(m, n, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _FUSED_ADD_LAYER_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
 def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddLayerNormTest(m, n, dtype)
     bm = FusedAddLayerNormBenchmark(test)

--- a/benchmarks/ops/bench_fused_add_rmsnorm.py
+++ b/benchmarks/ops/bench_fused_add_rmsnorm.py
@@ -5,35 +5,40 @@ import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_fused_add_rmsnorm import FusedAddRmsNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_rmsnorm import FusedAddRmsNormOp
+
+_OP_NAME = "fused_add_rmsnorm_fwd"
 
 
 class FusedAddRmsNormBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N adds (residual) + N squares + (N-1) adds + 1 div + 1 add
-        # + 1 rsqrt + N muls (x*rrms) + N muls (weight) = ~5N flops per row
-        return 5 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only.  Read x + residual + weight + write y + residual_out."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read residual (M*N) + read weight (N)
-        # + write y (M*N) + write residual_out (M*N)
-        return (4 * t.m * t.n + t.n) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_FUSED_ADD_RMSNORM_BENCH_PARAMS = [
-    pytest.param(1024, 4096, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(4096, 4096, torch.bfloat16, True, id="throughput-bf16"),
-    pytest.param(2048, 5120, torch.float16, True, id="non-power-of-two"),
-    pytest.param(1025, 4096, torch.float16, True, id="tail-m"),
-]
+def _manifest_params():
+    params = []
+    for w in load_workloads(_OP_NAME):
+        m, n = w["x_shape"]
+        label = w.get("label", f"{m}x{n}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(m, n, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _FUSED_ADD_RMSNORM_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
 def test_fused_add_rmsnorm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddRmsNormTest(m, n, dtype)
     bm = FusedAddRmsNormBenchmark(test)

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -7,7 +7,10 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_group_norm import GroupNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.group_norm import GroupNormOp
+
+_OP_NAME = "groupnorm_fwd"
 
 
 class GroupNormBenchmark(BenchmarkBase):
@@ -15,29 +18,35 @@ class GroupNormBenchmark(BenchmarkBase):
     def calculate_flops(self) -> Optional[float]:
         t = self.test
         spatial_size = math.prod(t.spatial)
-        total_elems = t.n * t.c * spatial_size
-        # Per element: subtract mean, square for var, normalize, scale, bias => ~5 flops
-        return 5 * total_elems
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, N=t.n, C=t.c,
+                                 spatial_size=spatial_size, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only. Read x + read weight + read bias + write y."""
         t = self.test
         spatial_size = math.prod(t.spatial)
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = t.n * t.c * spatial_size
-        # Read x + write y + read weight (C, broadcast) + read bias (C, broadcast)
-        return (2 * total_elems + 2 * t.c) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, N=t.n, C=t.c,
+                                     spatial_size=spatial_size, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_GROUP_NORM_BENCH_PARAMS = [
-    pytest.param(8, 128, (32, 32), 32, torch.float16, True, id="image-fp16"),
-    pytest.param(8, 128, (32, 32), 32, torch.bfloat16, True, id="image-bf16"),
-    pytest.param(4, 256, (28, 28), 32, torch.float16, True, id="wider-channel"),
-    pytest.param(4, 128, (30, 30), 16, torch.float16, True, id="tail-spatial"),
-]
+def _manifest_params():
+    params = []
+    for w in load_workloads(_OP_NAME):
+        shape = w["x_shape"]
+        n, c, spatial = shape[0], shape[1], tuple(shape[2:])
+        g = w["groups"]
+        label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(n, c, spatial, g, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("n, c, spatial, g, dtype, tune", _GROUP_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("n, c, spatial, g, dtype, tune", _manifest_params())
 def test_group_norm_bench(n: int, c: int, spatial: tuple, g: int,
                           dtype: torch.dtype, tune: bool) -> None:
     test = GroupNormTest(n, c, spatial, g, dtype)

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -7,7 +7,10 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_instance_norm import InstanceNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.instance_norm import InstanceNormOp
+
+_OP_NAME = "instancenorm_fwd"
 
 
 class InstanceNormBenchmark(BenchmarkBase):
@@ -15,29 +18,34 @@ class InstanceNormBenchmark(BenchmarkBase):
     def calculate_flops(self) -> Optional[float]:
         t = self.test
         spatial_size = math.prod(t.spatial)
-        total_elems = t.n * t.c * spatial_size
-        # Per element: subtract mean, square for var, normalize, scale, bias => ~5 flops
-        return 5 * total_elems
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, N=t.n, C=t.c,
+                                 spatial_size=spatial_size, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only. Read x + read weight + read bias + write y."""
         t = self.test
         spatial_size = math.prod(t.spatial)
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = t.n * t.c * spatial_size
-        # Read x + write y + read weight (C, broadcast) + read bias (C, broadcast)
-        return (2 * total_elems + 2 * t.c) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, N=t.n, C=t.c,
+                                     spatial_size=spatial_size, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_INSTANCE_NORM_BENCH_PARAMS = [
-    pytest.param(8, 128, (32, 32), torch.float16, True, id="image-fp16"),
-    pytest.param(8, 128, (32, 32), torch.bfloat16, True, id="image-bf16"),
-    pytest.param(4, 256, (28, 28), torch.float16, True, id="wider-channel"),
-    pytest.param(4, 64, (30, 30), torch.float16, True, id="tail-spatial"),
-]
+def _manifest_params():
+    params = []
+    for w in load_workloads(_OP_NAME):
+        shape = w["x_shape"]
+        n, c, spatial = shape[0], shape[1], tuple(shape[2:])
+        label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(n, c, spatial, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("n, c, spatial, dtype, tune", _INSTANCE_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("n, c, spatial, dtype, tune", _manifest_params())
 def test_instance_norm_bench(n: int, c: int, spatial: tuple,
                              dtype: torch.dtype, tune: bool) -> None:
     test = InstanceNormTest(n, c, spatial, dtype)

--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -6,34 +6,40 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_layer_norm import LayerNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.layer_norm import LayerNormOp
+
+_OP_NAME = "layernorm_fwd"
 
 
 class LayerNormBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N for mean, N for variance, N for normalize, N for scale, N for bias
-        # Simplified: ~5N flops per row
-        return 5 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only (not padded). Read x + read weight + read bias + write y."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read weight (N, broadcast) + read bias (N, broadcast) + write y (M*N)
-        return (2 * t.m * t.n + 2 * t.n) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_LAYER_NORM_BENCH_PARAMS = [
-    pytest.param(1024, 4096, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(4096, 4096, torch.bfloat16, True, id="throughput-bf16"),
-    pytest.param(2048, 5120, torch.float16, True, id="non-power-of-two"),
-    pytest.param(1025, 4096, torch.float16, True, id="tail-m"),
-]
+def _manifest_params():
+    params = []
+    for w in load_workloads(_OP_NAME):
+        m, n = w["x_shape"]
+        label = w.get("label", f"{m}x{n}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(m, n, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _LAYER_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
 def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = LayerNormTest(m, n, dtype)
     bm = LayerNormBenchmark(test)

--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -5,34 +5,41 @@ import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tests.ops.test_rms_norm import RmsNormTest
+from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.rms_norm import RmsNormOp
+
+_OP_NAME = "rmsnorm_fwd"
 
 
 class RmsNormBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.test
-        # Per row: N squares + (N-1) adds for sum + 1 div + 1 add + 1 rsqrt + N muls (x*rrms) + N muls (weight)
-        # Simplified: ~4N flops per row
-        return 4 * t.m * t.n
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        flops, _ = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return flops
 
     def calculate_memory(self) -> Optional[float]:
-        """Useful bytes only (not padded). Read x + read weight + write y."""
         t = self.test
         elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + read weight (N, broadcast) + write y (M*N)
-        return (2 * t.m * t.n + t.n) * elem_bytes
+        _, mem_bytes = eval_roofline(_OP_NAME, M=t.m, N=t.n, elem_bytes=elem_bytes)
+        return mem_bytes
 
 
-_RMS_NORM_BENCH_PARAMS = [
-    pytest.param(1024, 4096, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(4096, 4096, torch.bfloat16, True, id="throughput-bf16"),
-    pytest.param(2048, 5120, torch.float16, True, id="non-power-of-two"),
-    pytest.param(1025, 4096, torch.float16, True, id="tail-m"),
-]
+def _manifest_params():
+    """Convert manifest workloads to pytest params: (m, n, dtype, tune)."""
+    params = []
+    for w in load_workloads(_OP_NAME):
+        m, n = w["x_shape"]
+        label = w.get("label", f"{m}x{n}")
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(m, n, dtype, True,
+                                       id=f"{label}-{dtype_str}"))
+    return params
 
 
-@pytest.mark.parametrize("m, n, dtype, tune", _RMS_NORM_BENCH_PARAMS)
+@pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
 def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = RmsNormTest(m, n, dtype)
     bm = RmsNormBenchmark(test)

--- a/ops_manifest.yaml
+++ b/ops_manifest.yaml
@@ -4,51 +4,51 @@
 # ------
 # ops:
 #   <op_name>:                       # Unique op identifier (e.g. rmsnorm_fwd)
+#     family: <str>                  # Op family for grouping (e.g. norm, attention)
 #     signature:
-#       inputs:   [{name, dtype, shape}]   # Input tensors
-#       outputs:  [{name, dtype, shape}]   # Output tensors
-#       params:   [{name, type, default}]  # Scalar / config parameters
-#       shape_rules: [str]                 # Optional Python expressions relating dimensions
-#     workloads:  [{x_shape, dtypes, label?}]  # Representative shapes for benchmarking
-#     roofline:                            # Analytical cost model
-#       flops: <expr>                      # Inline Python expression  -OR-
-#       bytes: <expr>                      #   both flops and bytes expressions
-#       func: <module:function>            # Alternative: reference to Python function
+#       inputs:
+#         <name>: {dtype: "<type_expr>"}     # Input tensors
+#       outputs:
+#         <name>: {dtype: "<type_expr>"}     # Output tensors
+#       params:
+#         <name>: {type: <scalar_type>, default: <value>}  # Scalar / config parameters
+#       shape_rules: [str]                   # Optional Python expressions relating dimensions
+#     workloads:  [{<dim>: <val>, dtypes: [...], label?: <str>}]  # Representative shapes
+#     roofline:                              # Analytical cost model
+#       flops: <expr>                        # Inline Python expression  -OR-
+#       bytes: <expr>                        #   both flops and bytes expressions
+#       func: <module.function>              # Alternative: reference to Python function
 #     source:
-#       kernel: <path>                     # Path to kernel implementation
-#       op:     <path>                     # Path to op wrapper
-#       test:   <path>                     # Path to test file
-#       bench:  <path>                     # Path to benchmark file
-#     family: <str>                     # Op family for grouping (e.g. norm, attention)
+#       kernel: <path>                       # Path to kernel implementation
+#       op:     <path>                       # Path to op wrapper
+#       test:   <path>                       # Path to test file
+#       bench:  <path>                       # Path to benchmark file
 #
 # Notes:
-# - Backward ops are registered as independent entries (e.g. rmsnorm_bwd).
+# - Signature uses dict (name as key), not list. See docs/manifest.md.
+# - Backward ops are registered as independent entries (e.g. batchnorm_bwd).
 # - shape_rules use Python expression syntax and are optional.
 # - roofline supports two modes: inline expressions (flops/bytes) or func.
+# - Tensor shape is intentionally unconstrained; shape relationships go in shape_rules.
 
 ops:
+
+  # ---------------------------------------------------------------------------
+  # norm — row-norm ops (operate along last dim, shape: [*leading, N])
+  # ---------------------------------------------------------------------------
+
   rmsnorm_fwd:
     family: norm
 
     signature:
       inputs:
-        - name: x
-          dtype: "{float16, bfloat16}"
-          shape: "[M, N]"
-        - name: weight
-          dtype: "{float16, bfloat16}"
-          shape: "[N]"
+        x: {dtype: "float16 | bfloat16"}
+        weight: {dtype: "same_as(x)"}
       outputs:
-        - name: y
-          dtype: "{float16, bfloat16}"
-          shape: "[M, N]"
+        y: {dtype: "same_as(x)"}
       params:
-        - name: dim
-          type: int
-          default: -1
-        - name: eps
-          type: float
-          default: 1.0e-6
+        dim: {type: int, default: -1}
+        eps: {type: float, default: 1.0e-6}
       shape_rules:
         - "weight.shape == (x.shape[-1],)"
         - "y.shape == x.shape"
@@ -67,11 +67,377 @@ ops:
     roofline:
       # Per row: N squares + (N-1) adds + div + add + rsqrt + N muls (normalize) + N muls (weight) ≈ 4N
       flops: "4 * M * N"
-      # Bytes: read x (M*N) + read weight (N) + write y (M*N), x2 for fp16/bf16 elem_size
-      bytes: "2 * (M * N + N + M * N)"
+      # Read x (M*N) + read weight (N) + write y (M*N), x elem_size
+      bytes: "(2 * M * N + N) * elem_bytes"
 
     source:
       kernel: tileops/kernels/norm/rms_norm.py
       op: tileops/ops/norm/rms_norm.py
       test: tests/ops/test_rms_norm.py
       bench: benchmarks/ops/bench_rms_norm.py
+
+  layernorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        weight: {dtype: "same_as(x)"}
+        bias: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "weight.shape == (x.shape[-1],)"
+        - "bias.shape == (x.shape[-1],)"
+        - "y.shape == x.shape"
+
+    workloads:
+      # Llama-3.1-8B (hidden_dim=4096)
+      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+      # Llama-3.1-70B (hidden_dim=8192)
+      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+      # Llama-3.1-405B (hidden_dim=16384)
+      - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+      - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+
+    roofline:
+      # Per row: N mean + N variance + N normalize + N scale + N bias ≈ 5N
+      flops: "5 * M * N"
+      # Read x (M*N) + read weight (N) + read bias (N) + write y (M*N)
+      bytes: "(2 * M * N + 2 * N) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/layer_norm.py
+      op: tileops/ops/norm/layer_norm.py
+      test: tests/ops/test_layer_norm.py
+      bench: benchmarks/ops/bench_layer_norm.py
+
+  ada_layernorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        scale: {dtype: "same_as(x)"}
+        shift: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "scale.shape == x.shape"
+        - "shift.shape == x.shape"
+        - "y.shape == x.shape"
+
+    workloads:
+      # DiT-XL/2 (hidden_dim=1152)
+      - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+      # Llama-3.1-8B (hidden_dim=4096)
+      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+
+    roofline:
+      # Per row: N mean + N variance + N normalize + N scale + N shift ≈ 5N
+      flops: "5 * M * N"
+      # Read x + read scale + read shift + write y = 4*M*N
+      bytes: "4 * M * N * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/ada_layer_norm
+      op: tileops/ops/norm/ada_layer_norm.py
+      test: tests/ops/test_ada_layer_norm.py
+      bench: benchmarks/ops/bench_ada_layer_norm.py
+
+  ada_layernorm_zero_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        scale: {dtype: "same_as(x)"}
+        shift: {dtype: "same_as(x)"}
+        gate: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "scale.shape == x.shape"
+        - "shift.shape == x.shape"
+        - "gate.shape == x.shape"
+        - "y.shape == x.shape"
+
+    workloads:
+      # DiT-XL/2 (hidden_dim=1152)
+      - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+      # Llama-3.1-8B (hidden_dim=4096)
+      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+
+    roofline:
+      # Per row: N mean + N variance + N normalize + N scale + N shift + N gate ≈ 6N
+      flops: "6 * M * N"
+      # Read x + read scale + read shift + read gate + write y = 5*M*N
+      bytes: "5 * M * N * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/ada_layer_norm_zero
+      op: tileops/ops/norm/ada_layer_norm_zero.py
+      test: tests/ops/test_ada_layer_norm_zero.py
+      bench: benchmarks/ops/bench_ada_layer_norm.py
+
+  fused_add_layernorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        residual: {dtype: "same_as(x)"}
+        weight: {dtype: "same_as(x)"}
+        bias: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+        residual_out: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "residual.shape == x.shape"
+        - "weight.shape == (x.shape[-1],)"
+        - "bias.shape == (x.shape[-1],)"
+        - "y.shape == x.shape"
+        - "residual_out.shape == x.shape"
+
+    workloads:
+      # Llama-3.1-8B (hidden_dim=4096)
+      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+      # Llama-3.1-70B (hidden_dim=8192)
+      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+
+    roofline:
+      # Per row: N add (residual) + N mean + N variance + N normalize + N scale + N bias ≈ 6N
+      flops: "6 * M * N"
+      # Read x + read residual + read weight + read bias + write y + write residual_out
+      bytes: "(4 * M * N + 2 * N) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/fused_add_norm
+      op: tileops/ops/norm/fused_add_layer_norm.py
+      test: tests/ops/test_fused_add_layer_norm.py
+      bench: benchmarks/ops/bench_fused_add_layer_norm.py
+
+  fused_add_rmsnorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float16 | bfloat16"}
+        residual: {dtype: "same_as(x)"}
+        weight: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+        residual_out: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-6}
+      shape_rules:
+        - "residual.shape == x.shape"
+        - "weight.shape == (x.shape[-1],)"
+        - "y.shape == x.shape"
+        - "residual_out.shape == x.shape"
+
+    workloads:
+      # Llama-3.1-8B (hidden_dim=4096)
+      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+      # Llama-3.1-70B (hidden_dim=8192)
+      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+      # Llama-3.1-405B (hidden_dim=16384)
+      - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+      - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+
+    roofline:
+      # Per row: N add (residual) + N squares + (N-1) adds + rsqrt + N normalize + N weight ≈ 5N
+      flops: "5 * M * N"
+      # Read x + read residual + read weight + write y + write residual_out
+      bytes: "(4 * M * N + N) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/fused_add_norm
+      op: tileops/ops/norm/fused_add_rmsnorm.py
+      test: tests/ops/test_fused_add_rmsnorm.py
+      bench: benchmarks/ops/bench_fused_add_rmsnorm.py
+
+  # ---------------------------------------------------------------------------
+  # norm — spatial-norm ops (operate over spatial/channel dims, shape: [N, C, *spatial])
+  # ---------------------------------------------------------------------------
+
+  batchnorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        weight: {dtype: "same_as(x)"}
+        bias: {dtype: "same_as(x)"}
+        running_mean: {dtype: "float32"}
+        running_var: {dtype: "float32"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+        mean: {dtype: "float32"}
+        rstd: {dtype: "float32"}
+      params:
+        training: {type: bool, default: true}
+        eps: {type: float, default: 1.0e-5}
+        momentum: {type: float, default: 0.1}
+      shape_rules:
+        - "weight.shape == (x.shape[1],)"
+        - "bias.shape == (x.shape[1],)"
+        - "running_mean.shape == (x.shape[1],)"
+        - "running_var.shape == (x.shape[1],)"
+        - "y.shape == x.shape"
+        - "mean.shape == (x.shape[1],)"
+        - "rstd.shape == (x.shape[1],)"
+
+    workloads:
+      # ResNet-50 stages
+      - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+      - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+      - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+      # Large spatial
+      - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+
+    roofline:
+      # 2-pass: compute mean/var over L elements per channel, then normalize. ≈ 10*C*L
+      flops: "10 * C * L"
+      # Read x + write y + params (weight, bias, running stats)
+      bytes: "(2 * C * L + 4 * C) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/batch_norm.py
+      op: tileops/ops/norm/batch_norm.py
+      test: tests/ops/test_batch_norm.py
+      bench: benchmarks/ops/bench_batch_norm.py
+
+  batchnorm_bwd:
+    family: norm
+
+    signature:
+      inputs:
+        grad_out: {dtype: "float32 | float16 | bfloat16"}
+        x: {dtype: "same_as(grad_out)"}
+        weight: {dtype: "same_as(grad_out)"}
+        mean: {dtype: "float32"}
+        rstd: {dtype: "float32"}
+      outputs:
+        grad_x: {dtype: "same_as(grad_out)"}
+        grad_weight: {dtype: "same_as(grad_out)"}
+        grad_bias: {dtype: "same_as(grad_out)"}
+      params: {}
+      shape_rules:
+        - "x.shape == grad_out.shape"
+        - "weight.shape == (grad_out.shape[1],)"
+        - "mean.shape == (grad_out.shape[1],)"
+        - "rstd.shape == (grad_out.shape[1],)"
+        - "grad_x.shape == grad_out.shape"
+        - "grad_weight.shape == (grad_out.shape[1],)"
+        - "grad_bias.shape == (grad_out.shape[1],)"
+
+    workloads:
+      # ResNet-50 stages (same as fwd)
+      - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+      - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+      - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+      # Large spatial
+      - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+
+    roofline:
+      # Backward: 3 reductions + elementwise ≈ 8*C*L
+      flops: "8 * C * L"
+      # Read grad_out + read x + read weight + write grad_x + write grad_weight + write grad_bias
+      bytes: "(3 * C * L + 3 * C) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/batch_norm.py
+      op: tileops/ops/norm/batch_norm.py
+      test: tests/ops/test_batch_norm.py
+      bench: benchmarks/ops/bench_batch_norm.py
+
+  groupnorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        weight: {dtype: "same_as(x)"}
+        bias: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+      params:
+        groups: {type: int}
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "weight.shape == (x.shape[1],)"
+        - "bias.shape == (x.shape[1],)"
+        - "x.shape[1] % groups == 0"
+        - "y.shape == x.shape"
+
+    workloads:
+      # Typical CV shapes
+      - {x_shape: [8, 128, 32, 32], groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
+      - {x_shape: [4, 256, 28, 28], groups: 32, dtypes: [float16], label: "wider-channel-g32"}
+      - {x_shape: [4, 128, 30, 30], groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
+
+    roofline:
+      # Per element: subtract mean + square for var + normalize + scale + bias ≈ 5
+      flops: "5 * N * C * spatial_size"
+      # Read x + write y + read weight (C) + read bias (C)
+      bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/group_norm.py
+      op: tileops/ops/norm/group_norm.py
+      test: tests/ops/test_group_norm.py
+      bench: benchmarks/ops/bench_group_norm.py
+
+  instancenorm_fwd:
+    family: norm
+
+    signature:
+      inputs:
+        x: {dtype: "float32 | float16 | bfloat16"}
+        weight: {dtype: "same_as(x)"}
+        bias: {dtype: "same_as(x)"}
+      outputs:
+        y: {dtype: "same_as(x)"}
+      params:
+        eps: {type: float, default: 1.0e-5}
+      shape_rules:
+        - "weight.shape == (x.shape[1],)"
+        - "bias.shape == (x.shape[1],)"
+        - "y.shape == x.shape"
+
+    workloads:
+      # Typical CV shapes (style transfer, image generation)
+      - {x_shape: [8, 128, 32, 32], dtypes: [float16, bfloat16], label: "image"}
+      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "wider-channel"}
+      - {x_shape: [4, 64, 30, 30], dtypes: [float16], label: "tail-spatial"}
+
+    roofline:
+      # Same as GroupNorm (InstanceNorm = GroupNorm with G=C)
+      flops: "5 * N * C * spatial_size"
+      # Read x + write y + read weight (C) + read bias (C)
+      bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/norm/group_norm.py
+      op: tileops/ops/norm/instance_norm.py
+      test: tests/ops/test_instance_norm.py
+      bench: benchmarks/ops/bench_instance_norm.py

--- a/tests/test_ops_manifest.py
+++ b/tests/test_ops_manifest.py
@@ -61,10 +61,10 @@ class TestOpSchema:
         for op_name, entry in all_ops.items():
             sig = entry["signature"]
             assert "inputs" in sig, f"{op_name}: signature missing 'inputs'"
-            assert isinstance(sig["inputs"], list), f"{op_name}: inputs must be a list"
+            assert isinstance(sig["inputs"], dict), f"{op_name}: inputs must be a dict"
             assert len(sig["inputs"]) >= 1, f"{op_name}: must have at least 1 input"
             assert "outputs" in sig, f"{op_name}: signature missing 'outputs'"
-            assert isinstance(sig["outputs"], list), f"{op_name}: outputs must be a list"
+            assert isinstance(sig["outputs"], dict), f"{op_name}: outputs must be a dict"
 
     def test_every_roofline_has_valid_mode(self, all_ops):
         for op_name, entry in all_ops.items():

--- a/tileops/manifest.py
+++ b/tileops/manifest.py
@@ -1,0 +1,81 @@
+"""Programmatic access to ops_manifest.yaml.
+
+Provides two core functions:
+- load_workloads(op_name) — returns workload dicts for an op
+- eval_roofline(op_name, **variables) — evaluates flops/bytes expressions
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MANIFEST_PATH = Path(__file__).resolve().parent.parent / "ops_manifest.yaml"
+
+
+@functools.lru_cache(maxsize=1)
+def _load_manifest() -> dict[str, Any]:
+    """Load and cache the manifest. Called once per process."""
+    with open(_MANIFEST_PATH) as f:
+        data = yaml.safe_load(f)
+    return data["ops"]
+
+
+def load_workloads(op_name: str) -> list[dict[str, Any]]:
+    """Return the workloads list for *op_name*.
+
+    >>> workloads = load_workloads("rmsnorm_fwd")
+    >>> workloads[0]
+    {'x_shape': [2048, 4096], 'dtypes': ['float16', 'bfloat16'], 'label': 'llama-3.1-8b-prefill'}
+    """
+    ops = _load_manifest()
+    if op_name not in ops:
+        raise KeyError(f"op '{op_name}' not found in ops_manifest.yaml")
+    return ops[op_name]["workloads"]
+
+
+def eval_roofline(op_name: str, **variables: float) -> tuple[float, float]:
+    """Evaluate roofline expressions for *op_name* with given variable bindings.
+
+    Returns (flops, bytes).
+
+    >>> flops, mem_bytes = eval_roofline("rmsnorm_fwd", M=2048, N=4096, elem_bytes=2)
+    """
+    ops = _load_manifest()
+    if op_name not in ops:
+        raise KeyError(f"op '{op_name}' not found in ops_manifest.yaml")
+
+    roofline = ops[op_name]["roofline"]
+
+    if "func" in roofline:
+        raise NotImplementedError(
+            f"func-mode roofline not yet supported (op={op_name})"
+        )
+
+    # Evaluate inline expressions in a restricted namespace.
+    ns: dict[str, Any] = {"__builtins__": {}}
+    ns.update(variables)
+
+    flops_expr = roofline["flops"]
+    bytes_expr = roofline["bytes"]
+
+    try:
+        flops = float(eval(flops_expr, ns))  # noqa: S307
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to evaluate roofline flops for '{op_name}': "
+            f"{flops_expr!r} with {variables}"
+        ) from exc
+
+    try:
+        mem_bytes = float(eval(bytes_expr, ns))  # noqa: S307
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to evaluate roofline bytes for '{op_name}': "
+            f"{bytes_expr!r} with {variables}"
+        ) from exc
+
+    return flops, mem_bytes


### PR DESCRIPTION
Closes #704

## Summary

- Add `tileops/manifest.py` with `load_workloads()` and `eval_roofline()` — programmatic API to consume `ops_manifest.yaml`
- Populate `ops_manifest.yaml` with all 10 norm ops using dict-format signatures per spec (`docs/manifest.md`)
- Switch all 8 norm bench files from hardcoded shapes/formulas to manifest-driven workloads and roofline evaluation
- Update `tests/test_ops_manifest.py` to validate dict-format signatures (inputs/outputs as dict, not list)

## Test plan

- [x] pre-commit passed
- [x] `pytest tests/test_ops_manifest.py` — 8/8 passed (schema validation, source paths, shape rules)
- [x] `pytest --collect-only benchmarks/ops/bench_*norm*.py benchmarks/ops/bench_ada*.py benchmarks/ops/bench_fused*.py` — 61 tests collected with manifest-derived IDs (e.g. `llama-3.1-8b-prefill-float16`, `resnet50-stage1-float16`)
- [x] All source paths in manifest verified to exist

## Additional context

This is the first step toward making `ops_manifest.yaml` a live data source rather than a dead documentation file. The two consumption paths now connected are:

1. **Benchmark workloads** — `_manifest_params()` replaces hardcoded `pytest.param` lists
2. **Roofline formulas** — `eval_roofline()` replaces hardcoded `calculate_flops()`/`calculate_memory()` implementations

Next steps: automation tooling to generate manifest entries from code, and CI validation to enforce manifest completeness.