### PR TITLE
[Bench][Op] Add FLA baseline for GatedDeltaNetDecode

### DIFF
--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -78,10 +78,12 @@ def test_gated_deltanet_decode_bench(
         g_fla = g.unsqueeze(1)       # [B, H] -> [B, 1, H]
         beta_fla = beta.unsqueeze(1)
 
+        state_fla = state.contiguous()
+
         def fla_decode():
             return fused_recurrent_gated_delta_rule(
                 q_fla, k_fla, v_fla, g=g_fla, beta=beta_fla,
-                initial_state=state.contiguous(),
+                initial_state=state_fla,
                 output_final_state=True,
             )
 


### PR DESCRIPTION
## Summary

- Add `fused_recurrent_gated_delta_rule` (T=1) from FLA as primary baseline for `GatedDeltaNetDecodeOp` benchmark
- Fall back to `torch-ref` when FLA is not installed
- Follows the same pattern as `bench_gla_recurrence.py`

Previously the benchmark unconditionally used `torch-ref`, which is a pure-PyTorch reference — not a meaningful performance comparison.

Closes #716

## Test plan

- [x] `pytest benchmarks/ops/bench_gated_deltanet_recurrence.py` — passes with FLA installed (uses `"fla"` tag)
- [ ] Verify fallback to `"torch-ref"` when FLA is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)