### PR TITLE
[Fix][Bench] Fix FlashInfer GQA decode: use decode kernel instead of prefill

### DIFF
--- a/benchmarks/ops/bench_gqa_decode.py
+++ b/benchmarks/ops/bench_gqa_decode.py
@@ -40,30 +40,51 @@ def _fa3_gqa_decode_fwd(test):
 
 
 def _flashinfer_gqa_decode_fwd(test, q, k, v):
-    """Set up FlashInfer batched ragged prefill (seqlen_q=1). Returns callable or None."""
+    """Set up FlashInfer batched paged decode for non-paged KV cache.
+
+    Reshapes the contiguous (B, S_kv, H_kv, D) KV into paged format with
+    page_size=256, then uses the specialized decode kernel.
+    """
     try:
-        from flashinfer.prefill import BatchPrefillWithRaggedKVCacheWrapper  # noqa: PLC0415
+        from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper  # noqa: PLC0415
     except ImportError:
         return None
 
     # Q is (B, H, D) — single token per request
+    # K/V is (B, S_kv, H_kv, D)
     B, H, D = q.shape
     Hkv = k.shape[2]
     Skv = k.shape[1]
-    cu_seqlens_q = torch.arange(0, B + 1, dtype=torch.int32, device=q.device)
-    cu_seqlens_k = torch.arange(0, B + 1, dtype=torch.int32, device=q.device) * Skv
+    page_size = 256
+    pages_per_seq = (Skv + page_size - 1) // page_size
+
+    # Reshape (B, S_kv, H_kv, D) → (B * pages_per_seq, page_size, H_kv, D)
+    # Pad S_kv to a multiple of page_size if needed
+    if Skv % page_size != 0:
+        pad = page_size * pages_per_seq - Skv
+        k = torch.nn.functional.pad(k, (0, 0, 0, 0, 0, pad))
+        v = torch.nn.functional.pad(v, (0, 0, 0, 0, 0, pad))
+    k_paged = k.reshape(B * pages_per_seq, page_size, Hkv, D)
+    v_paged = v.reshape(B * pages_per_seq, page_size, Hkv, D)
+    kv_data = (k_paged, v_paged)
+
+    total_pages = B * pages_per_seq
+    indptr = torch.arange(0, B + 1, dtype=torch.int32, device=q.device) * pages_per_seq
+    indices = torch.arange(0, total_pages, dtype=torch.int32, device=q.device)
+    last_page_len_val = Skv - (pages_per_seq - 1) * page_size
+    last_page_len = torch.full((B,), last_page_len_val, dtype=torch.int32, device=q.device)
 
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=q.device)
-    wrapper = BatchPrefillWithRaggedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper = BatchDecodeWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
     wrapper.plan(
-        qo_indptr=cu_seqlens_q, kv_indptr=cu_seqlens_k,
-        num_qo_heads=H, num_kv_heads=Hkv, head_dim_qk=D,
+        indptr=indptr, indices=indices, last_page_len=last_page_len,
+        num_qo_heads=H, num_kv_heads=Hkv, head_dim=D,
+        page_size=page_size,
         q_data_type=q.dtype,
     )
 
     def run_fn(q, k, v):
-        # Q: (B, H, D) → (B, H, D) — already packed (1 token per request)
-        return wrapper.run(q, k.reshape(-1, Hkv, D), v.reshape(-1, Hkv, D))
+        return wrapper.run(q, kv_data)
 
     return run_fn
 


### PR DESCRIPTION
## Summary

The FlashInfer baseline for GQA decode was using `BatchPrefillWithRaggedKVCacheWrapper` (prefill kernel) for single-token decode, causing an **8x slowdown** vs TileOPs. The prefill kernel is not optimized for seq_len_q=1.

Fix: reshape the contiguous KV cache into paged format (page_size=256) and use `BatchDecodeWithPagedKVCacheWrapper` (specialized decode kernel).

## Results (H200, tileops-runner:latest, GPU1 @ 1830 MHz)

| Config | Before (prefill kernel) | After (decode kernel) |
|--------|:-----------------------:|:---------------------:|
| single-batch-fp16 (B=1) | FI/TileOPs = 8.26x | **0.36x** |
| bf16-mid-cache (B=4) | 3.27x | **0.36x** |
| multi-batch-fp16 (B=8) | 4.82x | **0.86x** |

## Root cause

`BatchPrefillWithRaggedKVCacheWrapper` launches a prefill kernel even when seq_len_q=1 per request. FlashInfer's decode kernel (`BatchDecodeWithPagedKVCacheWrapper`) is purpose-built for this workload and much faster.

The non-paged KV tensor `(B, S_kv, H_kv, D)` is reshaped into paged format `(B * pages_per_seq, 256, H_kv, D)` with identity page indices, requiring no data copy (just a view + optional padding).

## Test plan

- [x] 3/3 GQA decode benchmarks passed in Docker (tileops-runner:latest, H200)
- [x] FlashInfer now shows expected performance (faster than TileOPs for decode)
- [x] bf16 config verified