### PR TITLE
[Bench] Redesign GQA benchmark params to match real LLM workloads

### DIFF
--- a/benchmarks/ops/bench_gqa.py
+++ b/benchmarks/ops/bench_gqa.py
@@ -126,10 +126,47 @@ def _torch_gqa_bwd(test):
     return fn
 
 
+# GQA forward benchmark parameters.
+#
+# Three head profiles cover the mainstream LLM GQA configurations:
+#   small  (32:8:128) — Llama-3.1-8B, Qwen3-8B, Mistral-24B
+#   medium (64:8:128) — Llama-3.1-70B, Qwen3-32B, Qwen2.5-72B
+#   large  (128:8:128) — Llama-3.1-405B
+# head_dim=128 and kv_heads=8 are near-universal across Llama, Qwen3, and Mistral.
+#
+# Inference prefill (fp16): seq_len from 1K to 128K covers short chat to
+# full-context workloads.  B=1 because prefill is single-request in practice.
+#
+# Training (bf16): seq_len 2K-8K covers SFT (2K) and pretraining (4K-8K).
+# B=1-2 reflects typical micro-batch sizes.  No long-context training configs
+# since >90% of pretraining compute is at 4K-8K.
 _GQA_FWD_BENCH_PARAMS = [
-    pytest.param(1, 1024, 8, 4, 64, False, torch.float16, True, id="prefill-fp16"),
-    pytest.param(4, 2048, 64, 4, 128, False, torch.float16, True, id="throughput-fp16"),
-    pytest.param(4, 2048, 64, 4, 128, False, torch.bfloat16, True, id="throughput-bf16"),
+    # ── Inference prefill: B=1, causal, fp16 ──
+    # Short chat prompt
+    pytest.param(1, 1024, 32, 8, 128, True, torch.float16, True, id="llama8b-1k"),
+    # Document QA / code completion
+    pytest.param(1, 4096, 32, 8, 128, True, torch.float16, True, id="llama8b-4k"),
+    # RAG context / Llama-4 chunk_size
+    pytest.param(1, 8192, 32, 8, 128, True, torch.float16, True, id="llama8b-8k"),
+    # Long-document summarization
+    pytest.param(1, 32768, 32, 8, 128, True, torch.float16, True, id="llama8b-32k"),
+    # Full-context (Llama-3.1 max)
+    pytest.param(1, 131072, 32, 8, 128, True, torch.float16, True, id="llama8b-128k"),
+    # 70B-class single-request prefill
+    pytest.param(1, 4096, 64, 8, 128, True, torch.float16, True, id="llama70b-4k"),
+    # 405B-class single-request prefill
+    pytest.param(1, 4096, 128, 8, 128, True, torch.float16, True, id="llama405b-4k"),
+    # ── Training: bf16, fwd benchmarked here, bwd below ──
+    # Pretraining main phase (8B-class, micro-batch=2)
+    pytest.param(2, 4096, 32, 8, 128, True, torch.bfloat16, True, id="train-8b-4k"),
+    # Pretraining longer sequences (8B-class)
+    pytest.param(1, 8192, 32, 8, 128, True, torch.bfloat16, True, id="train-8b-8k"),
+    # Pretraining 70B-class
+    pytest.param(1, 4096, 64, 8, 128, True, torch.bfloat16, True, id="train-70b-4k"),
+    # Pretraining 405B-class
+    pytest.param(1, 4096, 128, 8, 128, True, torch.bfloat16, True, id="train-405b-4k"),
+    # SFT / LoRA fine-tuning (shorter sequences, micro-batch=2)
+    pytest.param(2, 2048, 32, 8, 128, True, torch.bfloat16, True, id="sft-8b"),
 ]
 
 
@@ -161,7 +198,13 @@ def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
 
 
-_GQA_BWD_BENCH_PARAMS = _GQA_FWD_BENCH_PARAMS
+# GQA backward benchmark parameters (training only).
+# Backward is only used during training — extract the training subset from
+# _GQA_FWD_BENCH_PARAMS by ID prefix to avoid manual duplication.
+_GQA_BWD_BENCH_PARAMS = [
+    p for p in _GQA_FWD_BENCH_PARAMS
+    if p.id.startswith(("train", "sft"))
+]
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_gqa_decode.py
+++ b/benchmarks/ops/bench_gqa_decode.py
@@ -89,10 +89,21 @@ def _flashinfer_gqa_decode_fwd(test, q, k, v):
     return run_fn
 
 
+# GQA decode (non-paged) benchmark parameters.
+#
+# Non-paged KV cache is used for single-request inference (no serving framework).
+# B=1 exclusively — multi-request scenarios use paged KV cache instead.
+# Configs target the three standard head profiles (see bench_gqa.py) with
+# KV cache lengths representing typical chat (4K) and long-context (32K) use.
 _GQA_DECODE_BENCH_PARAMS = [
-    pytest.param(1, 32, 8, 8192, 128, torch.float16, False, id="single-batch-fp16"),
-    pytest.param(4, 32, 4, 4096, 128, torch.bfloat16, False, id="bf16-mid-cache"),
-    pytest.param(8, 64, 16, 8192, 128, torch.float16, False, id="multi-batch-fp16"),
+    # Single-user chat (8B-class, 4K context)
+    pytest.param(1, 32, 8, 4096, 128, torch.float16, True, id="llama8b-4k"),
+    # Long-context generation (8B-class, 32K context)
+    pytest.param(1, 32, 8, 32768, 128, torch.float16, True, id="llama8b-32k"),
+    # 70B-class single-request decode
+    pytest.param(1, 64, 8, 4096, 128, torch.float16, True, id="llama70b-4k"),
+    # 405B-class single-request decode
+    pytest.param(1, 128, 8, 8192, 128, torch.float16, True, id="llama405b-8k"),
 ]
 
 

--- a/benchmarks/ops/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/bench_gqa_decode_paged.py
@@ -96,11 +96,41 @@ def _flashinfer_gqa_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
     return run_fn
 
 
+# GQA paged decode benchmark parameters.
+#
+# Paged KV cache is the standard in production serving (vLLM, SGLang).
+# Batch sizes reflect real multi-request serving: B=4-64.
+#
+# Three page_size tiers:
+#   64  — TileOPs current minimum supported page_size (block_N constraint)
+#   256 — FlashInfer's optimized page_size, also FA3-compatible (multiple of 256)
+#   16  — vLLM/SGLang default; skip-marked until kernel supports page_size<64
+#
+# Head profiles and KV cache lengths match non-paged decode configs.
 _GQA_DECODE_PAGED_BENCH_PARAMS = [
-    pytest.param(1, 16, 8, 512, 128, 128, torch.float16, True, id="baseline-page128"),
-    pytest.param(2, 8, 4, 1024, 64, 256, torch.float16, True, id="batch2-page256"),
-    pytest.param(1, 16, 4, 2048, 128, 512, torch.float16, True, id="long-cache-page512"),
-    pytest.param(1, 32, 16, 512, 64, 128, torch.float16, True, id="high-head-ratio"),
+    # ── page_size=64 (TileOPs minimum) ──
+    # 8B-class online serving (B=32, 4K context)
+    pytest.param(32, 32, 8, 4096, 128, 64, torch.float16, True, id="serving-8b-p64"),
+    # 8B-class long-context serving (B=8, 32K context)
+    pytest.param(8, 32, 8, 32768, 128, 64, torch.float16, True, id="serving-8b-long-p64"),
+    # 8B-class high-throughput batch (B=64, short output)
+    pytest.param(64, 32, 8, 2048, 128, 64, torch.float16, True, id="throughput-8b-p64"),
+    # 70B-class online serving
+    pytest.param(8, 64, 8, 4096, 128, 64, torch.float16, True, id="serving-70b-p64"),
+    # ── page_size=256 (FlashInfer optimized, FA3 compatible) ──
+    # 8B-class online serving
+    pytest.param(32, 32, 8, 4096, 128, 256, torch.float16, True, id="serving-8b-p256"),
+    # 70B-class online serving
+    pytest.param(8, 64, 8, 4096, 128, 256, torch.float16, True, id="serving-70b-p256"),
+    # 405B-class online serving (B=4, limited by model size)
+    pytest.param(4, 128, 8, 4096, 128, 256, torch.float16, True, id="serving-405b-p256"),
+    # ── page_size=16 (vLLM/SGLang default) — skip until kernel support ──
+    pytest.param(32, 32, 8, 4096, 128, 16, torch.float16, True, id="serving-8b-p16",
+                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
+    pytest.param(64, 32, 8, 2048, 128, 16, torch.float16, True, id="throughput-8b-p16",
+                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
+    pytest.param(8, 64, 8, 4096, 128, 16, torch.float16, True, id="serving-70b-p16",
+                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
 ]
 
 


### PR DESCRIPTION
## Summary

Replace ad-hoc GQA benchmark params with configs derived from mainstream LLM architectures.

## Motivation

Existing benchmark params do not correspond to any real model:
- `causal=False` on all prefill configs — decoder LLMs always use causal attention
- `dim=64` in several configs — every modern model uses `dim=128`
- GQA ratios like 8:4, 64:16 with head counts that match no production model
- Paged decode with B=1 and KV cache 512-2048 — real serving uses B=8-64, KV cache 4K-32K+
- Prefill stops at seq_len=2048 — misses the long-context workloads (8K-128K) that are now standard

## Head profile selection

Surveyed the attention configs of Llama 3.1/4, Qwen 2.5/3, Mistral, Gemma 3, Command A, Phi-4, and DeepSeek-V3. Key findings:

1. **head_dim=128 is universal** (only Gemma uses 256)
2. **kv_heads=8 is dominant** — Llama, Qwen3, Mistral, Cohere all use 8 KV heads regardless of model size
3. **GQA ratio scales with model size**: 4:1 (8B-class), 8:1 (70B-class), 16:1 (400B-class)

This yields three profiles that cover the field:

| Profile | Q:KV:dim | GQA ratio | Representative models |
|---------|----------|-----------|----------------------|
| small | 32:8:128 | 4:1 | Llama-3.1-8B, Qwen3-8B, Mistral-Small-24B, Phi-4 (40:10, close) |
| medium | 64:8:128 | 8:1 | Llama-3.1-70B, Qwen3-32B, Qwen2.5-72B |
| large | 128:8:128 | 16:1 | Llama-3.1-405B, Mistral-Large (96:8, bracketed by medium/large) |

Llama 4 Scout (40:8:128) is close to the small profile. These three profiles cover the GQA kernel's performance across different head counts without needing per-model entries.

## Sequence length and batch size rationale

### Inference prefill (7 configs, fwd only, fp16)
- B=1: prefill processes one request at a time (chunked prefill batches decode+prefill via varlen, not same-shape batching)
- seq_len progression 1K/4K/8K/32K/128K: short chat -> document QA -> RAG -> long-doc summarization -> full-context. The 8K point also matches Llama 4's chunked attention chunk_size
- fp16: standard inference dtype (bf16 offers no advantage over fp16 at inference, both have identical Tensor Core throughput on H100/H200)

### Inference decode, non-paged (4 configs, fp16)
- B=1 only: non-paged KV cache is for single-request scenarios (local inference, llama.cpp). Multi-request serving always uses paged KV cache for memory management
- KV cache 4K (typical chat context) and 32K (long-context generation)

### Inference decode, paged (7 active + 3 skipped, fp16)
- B=4-64: paged KV cache exists specifically for multi-request serving. B=1 paged has no practical use (adds indirection overhead with no benefit)
- Three page_size tiers:
  - **64**: TileOPs current minimum (kernel requires `page_size >= block_N`, block_N candidates are 64/128)
  - **256**: FlashInfer's most optimized page_size; also FA3-compatible (requires multiple of 256)
  - **16**: vLLM and SGLang default; skip-marked with `pytest.mark.skip` pending kernel support (tracked separately)
- KV cache 2K-32K: covers short-output high-throughput (2K) to long-context serving (32K)

### Training (5 configs, fwd+bwd, bf16)
- bf16: training standard (large dynamic range for gradients)
- B=1-2: typical micro-batch size per GPU (global batch is achieved via data parallelism)
- seq_len 2K/4K/8K: SFT fine-tuning (2K), pretraining main phase (4K-8K). No long-context (32K+) training configs since >90% of pretraining compute uses 4K-8K sequences
- bwd runs only with training configs (inference never runs backward)

## Configs

### Inference prefill (bench_gqa.py fwd)
| id | B | heads:kv | seq | dtype |
|----|---|----------|-----|-------|
| llama8b-1k | 1 | 32:8 | 1024 | fp16 |
| llama8b-4k | 1 | 32:8 | 4096 | fp16 |
| llama8b-8k | 1 | 32:8 | 8192 | fp16 |
| llama8b-32k | 1 | 32:8 | 32768 | fp16 |
| llama8b-128k | 1 | 32:8 | 131072 | fp16 |
| llama70b-4k | 1 | 64:8 | 4096 | fp16 |
| llama405b-4k | 1 | 128:8 | 4096 | fp16 |

### Training (bench_gqa.py fwd+bwd)
| id | B | heads:kv | seq | dtype |
|----|---|----------|-----|-------|
| train-8b-4k | 2 | 32:8 | 4096 | bf16 |
| train-8b-8k | 1 | 32:8 | 8192 | bf16 |
| train-70b-4k | 1 | 64:8 | 4096 | bf16 |
| train-405b-4k | 1 | 128:8 | 4096 | bf16 |
| sft-8b | 2 | 32:8 | 2048 | bf16 |

### Decode non-paged (bench_gqa_decode.py)
| id | B | heads:kv | KV cache | dtype |
|----|---|----------|----------|-------|
| llama8b-chat | 1 | 32:8 | 4096 | fp16 |
| llama8b-long | 1 | 32:8 | 32768 | fp16 |
| llama70b | 1 | 64:8 | 4096 | fp16 |
| llama405b | 1 | 128:8 | 8192 | fp16 |

### Decode paged (bench_gqa_decode_paged.py)
| id | B | heads:kv | KV cache | page | dtype | status |
|----|---|----------|----------|------|-------|--------|
| serving-8b-p64 | 32 | 32:8 | 4096 | 64 | fp16 | active |
| serving-8b-p256 | 32 | 32:8 | 4096 | 256 | fp16 | active |
| serving-8b-long | 8 | 32:8 | 32768 | 64 | fp16 | active |
| throughput-8b | 64 | 32:8 | 2048 | 64 | fp16 | active |
| serving-70b-p64 | 8 | 64:8 | 4096 | 64 | fp16 | active |
| serving-70b-p256 | 8 | 64:8 | 4096 | 256 | fp16 | active |
| serving-405b | 4 | 128:8 | 4096 | 256 | fp16 | active |
| serving-8b-p16 | 32 | 32:8 | 4096 | 16 | fp16 | skip |
| throughput-8b-p16 | 64 | 32:8 | 2048 | 16 | fp16 | skip |
| serving-70b-p16 | 8 | 64:8 | 4096 | 16 | fp16 | skip |

## Test plan

- [ ] All active configs (23) pass in tileops-runner Docker
- [ ] Skip-marked page_size=16 configs correctly skipped
- [ ] Nightly report shows realistic model-derived config IDs