### PR TITLE
[CI][Lint] Add yamllint to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
         args: [--ignore-case]
         files: ^docs/spelling_wordlist\.txt$
 
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args: [-c, .yamllint.yml]
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,32 @@
+extends: default
+
+rules:
+  # 2-space indentation, consistent throughout
+  indentation:
+    spaces: 2
+    indent-sequences: whatever
+
+  # Disable line-length: manifest workloads are intentionally long flow-style
+  line-length: disable
+
+  # Allow both document-start styles
+  document-start: disable
+
+  # Allow inline/flow-style mappings (used heavily in ops_manifest.yaml workloads)
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+
+  brackets:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+
+  # Catch real problems
+  key-duplicates: enable
+
+  # Relax truthy to avoid flagging 'on' in GitHub workflow triggers
+  truthy:
+    allowed-values: ["true", "false"]
+    check-keys: false


### PR DESCRIPTION
Closes #748

## Summary

- Add `yamllint` pre-commit hook with project-level `.yamllint.yml` config
- Config allows flow-style mappings (preserving `ops_manifest.yaml` workload format), disables line-length, enforces 2-space indent and duplicate key detection

## Test plan

- [x] pre-commit passed
- [x] `yamllint` passes on all YAML files in repo
- [x] Flow-style workload entries in `ops_manifest.yaml` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)