### PR TITLE
[Refactor][Bench] Make torch-ref baseline a fallback when no external libraries available

### DIFF
--- a/benchmarks/ops/bench_gqa.py
+++ b/benchmarks/ops/bench_gqa.py
@@ -188,14 +188,15 @@ def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     if fa3_fn is not None:
         result_bl = bm.profile(fa3_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(_torch_gqa_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
     fi_fn = _flashinfer_gqa_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(_torch_gqa_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
 
 # GQA backward benchmark parameters (training only).
@@ -228,6 +229,7 @@ def test_gqa_bwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     else:
         result_bl = bm.profile(_torch_gqa_bwd(test), *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+    # No FlashInfer baseline for bwd (FlashInfer has no backward API)
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_decode.py
+++ b/benchmarks/ops/bench_gqa_decode.py
@@ -122,14 +122,15 @@ def test_gqa_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int
     if fa3_fn is not None:
         result_bl = bm.profile(fa3_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
     fi_fn = _flashinfer_gqa_decode_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(test.ref_program, *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/bench_gqa_decode_paged.py
@@ -150,9 +150,6 @@ def test_gqa_decode_paged_bench(batch: int, heads: int, heads_kv: int, seqlen_kv
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
-
     fa3_fn = _fa3_gqa_decode_paged(test, k, v)
     if fa3_fn is not None:
         result_fa3 = bm.profile(fa3_fn, *inputs)
@@ -162,6 +159,10 @@ def test_gqa_decode_paged_bench(batch: int, heads: int, heads_kv: int, seqlen_kv
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(test.ref_program, *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_sliding_window_fwd.py
+++ b/benchmarks/ops/bench_gqa_sliding_window_fwd.py
@@ -144,15 +144,16 @@ def test_gqa_sliding_window_fwd_bench(
         result_bl = bm.profile(
             lambda q, k, v: _fa3_baseline(q, k, v, is_causal, wl, wr), *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(_torch_sliding_window_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
     # FlashInfer baseline
     fi_fn = _flashinfer_sliding_window_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_out is None and fi_fn is None:
+        result_bl = bm.profile(_torch_sliding_window_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
+++ b/benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
@@ -194,15 +194,16 @@ def test_gqa_sliding_window_varlen_fwd_bench(
                 q, k, v, csq, csk, msq, max_seqlen_k, is_causal, wl, wr),
             *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(_torch_sliding_window_varlen_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
     # FlashInfer baseline
     fi_fn = _flashinfer_varlen_sliding_window_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_out is None and fi_fn is None:
+        result_bl = bm.profile(_torch_sliding_window_varlen_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mha.py
+++ b/benchmarks/ops/bench_mha.py
@@ -144,14 +144,15 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     if fa3_fn is not None:
         result_bl = bm.profile(fa3_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(_torch_mha_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
     fi_fn = _flashinfer_mha_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(_torch_mha_fwd(test), *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
 
 _MHA_BWD_BENCH_PARAMS = _MHA_FWD_BENCH_PARAMS

--- a/benchmarks/ops/bench_mha_decode.py
+++ b/benchmarks/ops/bench_mha_decode.py
@@ -88,14 +88,15 @@ def test_mha_decode_bench(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: to
     if fa3_fn is not None:
         result_bl = bm.profile(fa3_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
-    else:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
     fi_fn = _flashinfer_mha_decode_fwd(test, *inputs)
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(test.ref_program, *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mha_decode_paged.py
+++ b/benchmarks/ops/bench_mha_decode_paged.py
@@ -119,9 +119,6 @@ def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
-
     fa3_fn = _fa3_mha_decode_paged(test, k, v)
     if fa3_fn is not None:
         result_fa3 = bm.profile(fa3_fn, *inputs)
@@ -131,6 +128,10 @@ def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv
     if fi_fn is not None:
         result_fi = bm.profile(fi_fn, *inputs)
         BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+
+    if fa3_fn is None and fi_fn is None:
+        result_bl = bm.profile(test.ref_program, *inputs)
+        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -106,21 +106,10 @@ def test_fused_topk_bench(
     result = bm.profile(op, gating_output)
     BenchmarkReport.record("fused_topk", locals(), result, tag="tileops")
 
-    # PyTorch reference baseline
-    # NOTE: Uses torch.softmax/sigmoid + torch.topk, which is a reasonable
-    # vectorized implementation. Performance gap vs TileOPs reflects the benefit
-    # of fused kernels that avoid intermediate materialization.
-    def _ref_fn(gating_output):
-        return _ref_fused_topk(gating_output, top_k, scoring_func, renormalize)
-
-    _ref_fn(gating_output)  # warmup
-    torch.cuda.synchronize()
-
-    result_ref = bm.profile(_ref_fn, gating_output)
-    BenchmarkReport.record("fused_topk", locals(), result_ref, tag="pytorch-ref")
-
     # vLLM baseline (optional)
+    has_external = False
     if _VLLM_AVAILABLE and scoring_func in ("softmax", "sigmoid"):
+        has_external = True
         hidden_dummy = torch.empty(num_tokens, 1, device=gating_output.device)
         # Cast bf16→f32 inside the timed call to match TileOPs' input conditions.
         def _vllm_fn(gating_output):
@@ -137,3 +126,14 @@ def test_fused_topk_bench(
 
         result_vllm = bm.profile(_vllm_fn, gating_output)
         BenchmarkReport.record("fused_topk", locals(), result_vllm, tag="vllm")
+
+    # Fallback: torch reference baseline (only when no external baselines)
+    if not has_external:
+        def _ref_fn(gating_output):
+            return _ref_fused_topk(gating_output, top_k, scoring_func, renormalize)
+
+        _ref_fn(gating_output)  # warmup
+        torch.cuda.synchronize()
+
+        result_ref = bm.profile(_ref_fn, gating_output)
+        BenchmarkReport.record("fused_topk", locals(), result_ref, tag="torch-ref")

--- a/benchmarks/ops/bench_moe_permute.py
+++ b/benchmarks/ops/bench_moe_permute.py
@@ -114,45 +114,6 @@ def test_moe_permute_bench(
     result = bm.profile(op, hidden_states, topk_ids)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    # PyTorch optimized baseline: vectorized gather with index computation
-    numel = total_tokens * top_k
-    padded_batch_sum_max = numel + num_experts * 64
-    perm_h_pad_buf = torch.zeros(padded_batch_sum_max, hidden_size,
-                                  dtype=dtype, device=hidden_states.device)
-    token_indices = torch.arange(total_tokens, device=hidden_states.device).unsqueeze(1).expand(-1, top_k).flatten()
-    scatter_indices = torch.empty(numel, dtype=torch.int64, device=hidden_states.device)
-
-    def _torch_fn(hidden_states, topk_ids):
-        gathered = hidden_states[token_indices]  # [T*K, H]
-        flat_ids = topk_ids.flatten().to(torch.int64)
-
-        # Vectorized padded layout
-        counts = torch.bincount(flat_ids, minlength=num_experts)
-        padded_sizes = torch.where(counts > 0, ((counts + 63) // 64) * 64, torch.zeros_like(counts))
-        padded_offsets = torch.cat([torch.zeros(1, dtype=torch.int64, device=flat_ids.device),
-                                     padded_sizes.cumsum(0)[:-1]])
-        padded_batch_sum = padded_sizes.sum().item()
-
-        # Vectorized scatter index: sort by expert, compute within-expert rank, then invert
-        sorted_idx = torch.argsort(flat_ids, stable=True)          # [T*K]
-        sorted_experts = flat_ids[sorted_idx]                      # expert IDs in sorted order
-        expert_first = torch.cat([torch.zeros(1, dtype=torch.int64, device=flat_ids.device),
-                                   counts.cumsum(0)[:-1]])
-        within_rank = torch.arange(numel, device=flat_ids.device) - expert_first[sorted_experts]
-        scatter_for_sorted = padded_offsets[sorted_experts] + within_rank
-        # Map back: scatter_indices[j] = destination for gathered[j]
-        scatter_indices[sorted_idx] = scatter_for_sorted
-
-        perm_h_pad_buf[:padded_batch_sum].zero_()
-        perm_h_pad_buf[scatter_indices] = gathered
-        return perm_h_pad_buf[:padded_batch_sum], padded_offsets.to(torch.int32), padded_sizes.to(torch.int32)
-
-    _torch_fn(hidden_states, topk_ids)  # warmup
-    torch.cuda.synchronize()
-
-    result_ref = bm.profile(_torch_fn, hidden_states, topk_ids)
-    BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
-
     # vLLM baseline (optional) - outputs tight layout [T*K, H] without padding
     if _VLLM_AVAILABLE:
         def _vllm_fn(hidden_states, topk_ids):
@@ -163,6 +124,39 @@ def test_moe_permute_bench(
 
         result_vllm = bm.profile(_vllm_fn, hidden_states, topk_ids)
         BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+    else:
+        # Fallback: PyTorch optimized baseline (vectorized gather + scatter)
+        numel = total_tokens * top_k
+        padded_batch_sum_max = numel + num_experts * 64
+        perm_h_pad_buf = torch.zeros(padded_batch_sum_max, hidden_size,
+                                      dtype=dtype, device=hidden_states.device)
+        token_indices = torch.arange(total_tokens, device=hidden_states.device).unsqueeze(1).expand(-1, top_k).flatten()
+        scatter_indices = torch.empty(numel, dtype=torch.int64, device=hidden_states.device)
+
+        def _torch_fn(hidden_states, topk_ids):
+            gathered = hidden_states[token_indices]  # [T*K, H]
+            flat_ids = topk_ids.flatten().to(torch.int64)
+            counts = torch.bincount(flat_ids, minlength=num_experts)
+            padded_sizes = torch.where(counts > 0, ((counts + 63) // 64) * 64, torch.zeros_like(counts))
+            padded_offsets = torch.cat([torch.zeros(1, dtype=torch.int64, device=flat_ids.device),
+                                         padded_sizes.cumsum(0)[:-1]])
+            padded_batch_sum = padded_sizes.sum().item()
+            sorted_idx = torch.argsort(flat_ids, stable=True)
+            sorted_experts = flat_ids[sorted_idx]
+            expert_first = torch.cat([torch.zeros(1, dtype=torch.int64, device=flat_ids.device),
+                                       counts.cumsum(0)[:-1]])
+            within_rank = torch.arange(numel, device=flat_ids.device) - expert_first[sorted_experts]
+            scatter_for_sorted = padded_offsets[sorted_experts] + within_rank
+            scatter_indices[sorted_idx] = scatter_for_sorted
+            perm_h_pad_buf[:padded_batch_sum].zero_()
+            perm_h_pad_buf[scatter_indices] = gathered
+            return perm_h_pad_buf[:padded_batch_sum], padded_offsets.to(torch.int32), padded_sizes.to(torch.int32)
+
+        _torch_fn(hidden_states, topk_ids)  # warmup
+        torch.cuda.synchronize()
+
+        result_ref = bm.profile(_torch_fn, hidden_states, topk_ids)
+        BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -103,25 +103,6 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
     result = bm.profile(op, mm2_pad, fwd_idx, topk_weights)
     BenchmarkReport.record("moe_unpermute", locals(), result, tag="tileops")
 
-    # PyTorch vectorized baseline: gather + weighted sum
-    # fwd_idx[t*K+k] = padded_slot for (token t, expert choice k), so after gather
-    # rows are in token-major order → can reshape to [T, K, H] and reduce directly.
-    # This avoids index_add_ (atomic ops) and uses a fused mul+sum path instead.
-    fwd_idx_long = fwd_idx.long()
-    topk_weights_f32 = topk_weights.float()
-
-    def _torch_fn(mm2_pad, fwd_idx, topk_weights):
-        gathered = mm2_pad[fwd_idx_long].float()                  # [T*K, H]
-        weighted_sum = (gathered.view(total_tokens, top_k, hidden_size)
-                        * topk_weights_f32.unsqueeze(-1)).sum(dim=1)  # [T, H]
-        return weighted_sum.to(mm2_pad.dtype)
-
-    _torch_fn(mm2_pad, fwd_idx, topk_weights)  # warmup
-    torch.cuda.synchronize()
-
-    result_torch = bm.profile(_torch_fn, mm2_pad, fwd_idx, topk_weights)
-    BenchmarkReport.record("moe_unpermute", locals(), result_torch, tag="torch-ref")
-
     # vLLM baseline (optional)
     if _VLLM_AVAILABLE:
         # vLLM uses inv_permuted_idx (reverse mapping: padded_slot → flat_idx)
@@ -140,6 +121,22 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
 
         result_vllm = bm.profile(_vllm_fn, mm2_pad, fwd_idx, topk_weights)
         BenchmarkReport.record("moe_unpermute", locals(), result_vllm, tag="vllm")
+    else:
+        # Fallback: PyTorch vectorized baseline (gather + weighted sum)
+        fwd_idx_long = fwd_idx.long()
+        topk_weights_f32 = topk_weights.float()
+
+        def _torch_fn(mm2_pad, fwd_idx, topk_weights):
+            gathered = mm2_pad[fwd_idx_long].float()                  # [T*K, H]
+            weighted_sum = (gathered.view(total_tokens, top_k, hidden_size)
+                            * topk_weights_f32.unsqueeze(-1)).sum(dim=1)  # [T, H]
+            return weighted_sum.to(mm2_pad.dtype)
+
+        _torch_fn(mm2_pad, fwd_idx, topk_weights)  # warmup
+        torch.cuda.synchronize()
+
+        result_torch = bm.profile(_torch_fn, mm2_pad, fwd_idx, topk_weights)
+        BenchmarkReport.record("moe_unpermute", locals(), result_torch, tag="torch-ref")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Unified baseline logic: torch-ref / torch-sdpa only runs when ALL external baselines (FA3, FlashInfer, vLLM, FLA) are unavailable for a config. Previously some benchmarks always ran the slow torch reference alongside external baselines, wasting CI time.

## Before / After

```python
# Before (paged decode, MoE permute/unpermute/fused_topk):
record(torch-ref)          # always runs (~10-100x slower)
if fa3: record(fa3)
if flashinfer: record(flashinfer)

# After:
if fa3: record(fa3)
if flashinfer: record(flashinfer)
if not fa3 and not flashinfer:
    record(torch-ref)      # only when no external baselines
```

## Files changed (11)

| File | External baselines | Change |
|------|-------------------|--------|
| bench_gqa.py (fwd) | fa3, flashinfer | torch-sdpa now checks both |
| bench_gqa_decode.py | fa3, flashinfer | same |
| bench_gqa_decode_paged.py | fa3, flashinfer | torch-ref moved to fallback |
| bench_mha.py (fwd) | fa3, flashinfer | torch-sdpa now checks both |
| bench_mha_decode.py | fa3, flashinfer | same |
| bench_mha_decode_paged.py | fa3, flashinfer | torch-ref moved to fallback |
| bench_gqa_sliding_window_fwd.py | fa3, flashinfer | torch now checks both |
| bench_gqa_sliding_window_varlen_fwd.py | fa3, flashinfer | same |
| bench_moe_fused_topk.py | vllm | torch-ref moved to fallback; pytorch-ref renamed to torch-ref |
| bench_moe_permute.py | vllm | torch-ref moved to fallback |
| bench_moe_unpermute.py | vllm | torch-ref moved to fallback |

No change needed: bench_moe_fused_moe (already fallback), bench_moe_permute_nopad (already fallback), bench_gated_deltanet_recurrence (already fallback)

## Test plan

- [ ] All benchmarks still pass in nightly CI
- [ ] torch-ref/torch-sdpa does NOT appear in report when FA3/FlashInfer/vLLM are installed