### PR TITLE
[Fix][Ops] Remove missing SSD chunk scan export

### DIFF
--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -81,7 +81,6 @@ from .rope import (
     RopeNonNeoxOp,
     RopeYarnOp,
 )
-from .ssd_chunk_scan_bwd_dstates import SsdChunkScanBwdDstatesOp
 from .ssd_chunk_scan_fwd import SsdChunkScanFwdOp
 from .ssd_chunk_state_fwd import SsdChunkStateFwdOp
 from .ssd_decode import SsdDecodeOp
@@ -142,7 +141,6 @@ __all__ = [
     "Op",
     "MoePermuteAlignOp",
     "RmsNormOp",
-    "SsdChunkScanBwdDstatesOp",
     "SsdChunkScanFwdOp",
     "SsdChunkStateFwdOp",
     "SsdDecodeOp",


### PR DESCRIPTION
## Summary
- remove the stale `SsdChunkScanBwdDstatesOp` import from `tileops.ops`
- remove the matching stale `__all__` entry
- restore `tileops.ops` importability on `main`

## Root cause
The GPU Smoke failure in run https://github.com/tile-ai/TileOPs/actions/runs/23846315011 was caused by `tileops/ops/__init__.py` importing `tileops.ops.ssd_chunk_scan_bwd_dstates`, but that module does not exist in the repository. This caused `ModuleNotFoundError` during test collection and cascaded into many collection errors.

## Validation
- `python -c "import sys; sys.path.insert(0, '/tmp/tileops-ci-fix'); import tileops; import tileops.ops"`
- `pytest -q /tmp/tileops-ci-fix/tests/ops/test_ssd_decode.py -k 'not packaging' --collect-only`

Both passed locally after this change.
