### PR TITLE
[CI] Add gpu smoke workflow summary report

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -608,7 +608,8 @@ jobs:
           python scripts/gpu_smoke_report.py \
             --test-xml gpu_smoke_results.xml \
             --target "${REPORT_TARGET}" \
-            --output gpu_smoke_report.md
+            --output gpu_smoke_report.md \
+            || echo "::warning::gpu_smoke_report.py failed"
 
       - name: Post gpu-smoke report to step summary
         if: ${{ always() && hashFiles('gpu_smoke_report.md') != '' }}

--- a/scripts/gpu_smoke_report.py
+++ b/scripts/gpu_smoke_report.py
@@ -104,7 +104,9 @@ def generate_report(results: list[dict[str, str]], target: str) -> str:
     )
 
     correctness = f"{_PASS} Pass" if not failed_cases else f"{_FAIL} {len(failed_cases)} failed"
-    failures_ops_str = ", ".join(failed_ops) if failed_ops else "-"
+    failures_ops_str = (
+        ", ".join(_escape_markdown_cell(op) for op in failed_ops) if failed_ops else "-"
+    )
     health = _PASS if not failed_cases else _FAIL
 
     lines = [


### PR DESCRIPTION
Closes #763

## Summary

- add a JUnit-XML-based GPU smoke report generator for workflow summaries
- publish GPU smoke summary and artifacts from the gpu-smoke workflow

## Test plan

- [x] `python -m py_compile scripts/gpu_smoke_report.py`
- [x] generated a sample report from a minimal JUnit XML fixture

## Additional context

- `Gpu-smoke ops number` reports testcase count, per issue clarification.
- The workflow still uses existing pytest metadata from `tests/conftest.py`; no test selection policy changed.
