### PR TITLE
[Fix][Benchmark] Add serial validation to correct noisy autotune configs

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -282,9 +282,11 @@ class BenchmarkReport:
         if isinstance(op_or_name, str):
             name = op_or_name
             op_module = None
+            op_config = None
         else:
             name = op_or_name.__class__.__name__
             op_module = op_or_name.__class__.__module__
+            op_config = getattr(op_or_name, "config", None)
 
         # Filter params to only include serializable benchmark parameters
         filtered_params = {
@@ -294,11 +296,14 @@ class BenchmarkReport:
             and not k.startswith("_")
             and isinstance(v, (int, float, bool, str, torch.dtype))
         }
-        BenchmarkReport._records.setdefault(name, []).append({
+        record_entry = {
             "params": filtered_params,
             "result": result,
             "tag": tag,
-        })
+        }
+        if op_config:
+            record_entry["config"] = op_config
+        BenchmarkReport._records.setdefault(name, []).append(record_entry)
 
         # Accumulate in thread-local for conftest hook.
         if not hasattr(_bench_results, "entries"):
@@ -348,7 +353,10 @@ class BenchmarkReport:
                 lines.append("")
 
                 param_keys = list(tag_group[0]["params"].keys())
+                has_config = any("config" in e for e in tag_group)
                 header_parts = param_keys + result_keys
+                if has_config:
+                    header_parts.append("config")
                 lines.append("| " + " | ".join(header_parts) + " |")
                 lines.append("| " + " | ".join(["---"] * len(header_parts)) + " |")
 
@@ -357,6 +365,9 @@ class BenchmarkReport:
                     for rk in result_keys:
                         val = entry["result"].get(rk)
                         row.append(f"{val:.2f}" if val is not None else "N/A")
+                    if has_config:
+                        cfg = entry.get("config")
+                        row.append(str(cfg) if cfg else "")
                     lines.append("| " + " | ".join(row) + " |")
 
                 lines.append("")

--- a/scripts/conftest_warmup.py
+++ b/scripts/conftest_warmup.py
@@ -1,15 +1,24 @@
-"""Pytest conftest plugin for kernel cache warmup mode.
+"""Pytest conftest plugin for kernel cache warmup and validation.
 
-Activated by environment variable TILEOPS_WARMUP_MODE=1 (set by
-warmup_kernel_cache.py).  Applies patches in every process, including
-pytest-xdist worker subprocesses.
+Two modes, activated by environment variables:
 
-Patches applied:
-  1. ThreadPoolExecutor max_workers → capped to TILEOPS_WARMUP_MAX_WORKERS
-  2. GPU memory released after each test to prevent OOM across workers
+TILEOPS_WARMUP_MODE=1  (parallel warmup)
+  - Skip baseline profiling (only compile/tune tileops kernels)
+  - Cap ThreadPoolExecutor to TILEOPS_WARMUP_MAX_WORKERS
+  - Release GPU memory after each test
 
-Note: profiling is NOT patched — real GPU measurements run so that
-autotuner results can be cached for the benchmark job.
+TILEOPS_WARMUP_VALIDATE=1  (serial validation)
+  - Skip baseline profiling
+  - Force autotuner cache miss so it re-tunes on a quiet GPU
+  - Correct results overwrite the noisy parallel cache
+
+The validation pass fixes a subtle issue: parallel warmup runs multiple
+workers on one GPU, so autotuner latency measurements are inflated by
+contention.  The cached "best config" may not be optimal under serial
+execution.  Validation re-profiles all configs with exclusive GPU access
+and overwrites any misselected entries.  Compilation is instant (`.so`
+cache hit from warmup), so only profiling runs — typically a few seconds
+per kernel.
 """
 
 import concurrent.futures
@@ -17,12 +26,20 @@ import gc
 import os
 
 
+def _is_warmup():
+    return os.environ.get("TILEOPS_WARMUP_MODE") == "1"
+
+
+def _is_validate():
+    return os.environ.get("TILEOPS_WARMUP_VALIDATE") == "1"
+
+
 def pytest_configure(config):
     """Called in every process (main + xdist workers) before collection."""
-    if os.environ.get("TILEOPS_WARMUP_MODE") != "1":
+    if not _is_warmup() and not _is_validate():
         return
 
-    # --- Patch 1: skip baseline profiling (only compile/tune tileops kernels) ---
+    # --- Shared: skip baseline profiling ---
     from benchmarks.benchmark import BenchmarkBase
     from tileops.ops.op import Op
 
@@ -37,30 +54,35 @@ def pytest_configure(config):
     BenchmarkBase.profile = _warmup_profile
     config._warmup_orig_profile = _orig_profile
 
-    # --- Patch 2: cap compilation parallelism ---
-    max_workers = int(os.environ.get("TILEOPS_WARMUP_MAX_WORKERS", "64"))
-    orig_pool = concurrent.futures.ThreadPoolExecutor
-    config._warmup_orig_pool = orig_pool
+    # --- Warmup-only: cap compilation parallelism ---
+    if _is_warmup():
+        max_workers = int(os.environ.get("TILEOPS_WARMUP_MAX_WORKERS", "64"))
+        orig_pool = concurrent.futures.ThreadPoolExecutor
+        config._warmup_orig_pool = orig_pool
 
-    class _CappedPool(orig_pool):
-        def __init__(self, max_workers=None, **kwargs):  # noqa: N803
-            if max_workers is None or max_workers > _cap:
-                max_workers = _cap
-            super().__init__(max_workers=max_workers, **kwargs)
+        class _CappedPool(orig_pool):
+            def __init__(self, max_workers=None, **kwargs):  # noqa: N803
+                if max_workers is None or max_workers > _cap:
+                    max_workers = _cap
+                super().__init__(max_workers=max_workers, **kwargs)
 
-    _cap = max_workers
-    concurrent.futures.ThreadPoolExecutor = _CappedPool
+        _cap = max_workers
+        concurrent.futures.ThreadPoolExecutor = _CappedPool
+
+    # --- Validate-only: force autotuner cache miss ---
+    if _is_validate():
+        from tilelang.autotuner.tuner import AutoTuner
+
+        config._validate_orig_load = AutoTuner._load_result_from_disk
+        # Return None on disk lookup → forces re-tune with .so cache hit
+        AutoTuner._load_result_from_disk = lambda self, key: None
+        # Clear in-memory cache in case of prior hits in this process
+        AutoTuner._memory_cache.clear()
 
 
 def pytest_runtest_teardown(item, nextitem):
-    """Release GPU memory after each test to prevent OOM across xdist workers.
-
-    Without this, each pytest-xdist worker accumulates GPU memory from compiled
-    kernels and tensors over its lifetime.  Since workers are long-lived
-    processes, idle workers hold onto GPU memory that active workers need,
-    eventually exhausting the device and causing the last worker to hang.
-    """
-    if os.environ.get("TILEOPS_WARMUP_MODE") != "1":
+    """Release GPU memory after each test to prevent OOM across workers."""
+    if not _is_warmup() and not _is_validate():
         return
     try:
         import torch
@@ -81,3 +103,8 @@ def pytest_unconfigure(config):
     orig_pool = getattr(config, "_warmup_orig_pool", None)
     if orig_pool is not None:
         concurrent.futures.ThreadPoolExecutor = orig_pool
+
+    orig_load = getattr(config, "_validate_orig_load", None)
+    if orig_load is not None:
+        from tilelang.autotuner.tuner import AutoTuner
+        AutoTuner._load_result_from_disk = orig_load

--- a/scripts/warmup_kernel_cache.py
+++ b/scripts/warmup_kernel_cache.py
@@ -102,11 +102,41 @@ def main():
     # Infrastructure errors (bad args, internal error, no tests collected)
     # indicate the warmup didn't run at all and should be surfaced.
     print(f"\nWarmup complete (pytest exit code: {exit_code})")
-    if exit_code in (0, 1):
-        sys.exit(0)
-    else:
+    if exit_code not in (0, 1):
         print(f"ERROR: warmup failed with infrastructure error (exit code {exit_code})", file=sys.stderr)
         sys.exit(exit_code)
+
+    # ── Phase 2: Serial validation ──────────────────────────────────────
+    # Parallel warmup selects autotuner configs under GPU contention, which
+    # can be suboptimal.  Re-tune serially on a quiet GPU to correct any
+    # misselected configs.  Compilation is instant (.so cache hit from
+    # phase 1), so only profiling runs.
+    print("\n" + "=" * 60)
+    print("Phase 2: Serial autotune validation")
+    print("=" * 60)
+
+    os.environ.pop("TILEOPS_WARMUP_MODE", None)
+    os.environ["TILEOPS_WARMUP_VALIDATE"] = "1"
+
+    validate_args = [
+        *shard_files,
+        "-v",
+        "--tb=line",
+        "-p", "no:cacheprovider",
+        "-p", "conftest_warmup",
+        "--override-ini=continue_on_collection_errors=true",
+    ]
+    # No -n flag: serial execution for accurate GPU profiling
+
+    validate_code = pytest.main(validate_args)
+    print(f"\nValidation complete (pytest exit code: {validate_code})")
+
+    if validate_code in (0, 1):
+        sys.exit(0)
+    else:
+        print(f"ERROR: validation failed with infrastructure error (exit code {validate_code})",
+              file=sys.stderr)
+        sys.exit(validate_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Parallel warmup (`-n 8`) causes autotuner to select suboptimal configs due to GPU contention noise, which get cached and reused by serial benchmarks
- Add a Phase 2 serial validation pass in `warmup_kernel_cache.py` that re-tunes on a quiet GPU with `.so` cache hits (compilation instant, only profiling re-runs)
- Add autotune config column to `BenchmarkReport` so nightly reports show which config was selected

## How it works

| Phase | Compilation cache (`.so`) | Autotune cache (`best_config`) |
|---|---|---|
| Phase 1: parallel warmup (`-n 8`) | Write (parallel, fast) | Write (noisy — GPU contention) |
| Phase 2: serial validation | Read (cache hit, instant) | Overwrite (accurate — exclusive GPU) |

`conftest_warmup.py` supports a new `TILEOPS_WARMUP_VALIDATE=1` mode that patches `AutoTuner._load_result_from_disk` to return `None`, forcing re-tune while preserving `.so` cache.

## Evidence

Same kernel (`avg_pool2d vision-3x3-s2`) selects different configs under contention vs serial:
- **Parallel (8 workers)**: `{'block_m': 128, 'block_c': 64, 'threads': 256}`
- **Serial (3/3 runs consistent)**: `{'block_m': 64, 'block_c': 32, 'threads': 256}`

Fixes #772

## Test plan
- [x] Full warmup + validation pass completes on all benchmark files
- [x] Serial validation correctly overwrites noisy autotune cache
- [x] `BenchmarkReport` includes config column for tileops entries
- [x] Verified on H200 with `tileops-runner:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)