### PR TITLE
[Fix][CI] Benchmark fixes, FA3 paged decode, add mamba-ssm to runner

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -71,6 +71,10 @@ RUN MAX_JOBS=32 pip install --no-cache-dir \
         "git+https://github.com/fla-org/native-sparse-attention.git@bd67af59b90afa34b25f61d2922e612d10dba3bd" \
     || echo "WARNING: native-sparse-attention failed to install -- non-fatal"
 
+RUN MAMBA_FORCE_BUILD=TRUE MAX_JOBS=64 pip install --no-cache-dir --no-deps --no-build-isolation \
+        "mamba-ssm==2.3.1" \
+    || echo "WARNING: mamba-ssm failed to install -- non-fatal"
+
 # ── Install TileOPs (editable) ───────────────────────────────────────────────
 WORKDIR /home/ci-runner/tileops
 COPY --chown=ci-runner:ci-runner . .

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -286,7 +286,8 @@ class BenchmarkReport:
         else:
             name = op_or_name.__class__.__name__
             op_module = op_or_name.__class__.__module__
-            op_config = getattr(op_or_name, "config", None)
+            op_config = getattr(op_or_name, "config", None) or \
+                getattr(getattr(op_or_name, "kernel", None), "config", None)
 
         # Filter params to only include serializable benchmark parameters
         filtered_params = {

--- a/benchmarks/ops/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/bench_gqa_decode_paged.py
@@ -46,7 +46,7 @@ def _fa3_gqa_decode_paged(test, k, v):
         out = flash_attn_with_kvcache(
             q.unsqueeze(1), k_paged, v_paged,
             cache_seqlens=real_seqlen_kv.int(),
-            block_table=block_table.int())
+            page_table=block_table.int())
         out = out[0] if isinstance(out, tuple) else out
         return out.squeeze(1)
 

--- a/benchmarks/ops/bench_mha_decode_paged.py
+++ b/benchmarks/ops/bench_mha_decode_paged.py
@@ -45,7 +45,7 @@ def _fa3_mha_decode_paged(test, k, v):
         out = flash_attn_with_kvcache(
             q, k_paged, v_paged,
             cache_seqlens=real_seqlen_kv.int(),
-            block_table=block_table.int())
+            page_table=block_table.int())
         return out[0] if isinstance(out, tuple) else out
 
     return baseline_fn


### PR DESCRIPTION
## Summary

- Fix autotune config extraction fallback: `op.config` → `op.kernel.config` (subsequently refactored out)
- Fix FA3 paged decode: `block_table` → `page_table` (renamed in flash-attn-interface)
- Add `mamba-ssm==2.3.1` to runner Dockerfile for Mamba-2 benchmarks

## Test plan
- [x] Paged decode benchmarks pass locally (11 passed, 3 skipped, 0 failed)
- [ ] Nightly benchmark run with updated runner image

🤖 Generated with [Claude Code](https://claude.com/claude-code)