### PR TITLE
[Doc][TrustModel] Update design docs and domain rules for workloads/ layer and trust boundaries

### DIFF
--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -1,5 +1,14 @@
-- These are condensed rules. If unclear, read [docs/testing.md](../../docs/testing.md) (Benchmark Requirements section) for full spec.
-- `BenchmarkReport.record()` first argument must be the Op object, never a string literal. This enables automatic Op metadata extraction for the nightly report.
-- Every benchmark function must record at least one baseline with a tag other than `"tileops"`. If an external baseline (FA3, fla) is conditional on library availability, add `test.ref_program` as a torch fallback in the `else` branch.
-- Use specific baseline tag names, not generic `"baseline"`. Lowercase, hyphen-separated. `"torch"` for built-in PyTorch API; `"torch-cublas"` / `"torch-cufft"` / `"torch-sdpa"` / `"torch-cudnn"` / `"torch-autograd"` for specific backends; `"torch-ref"` for hand-written references; `"fa3"` / `"fla"` / `"triton"` / `"sgl-kernel"` / `"vllm"` for external libraries. Tags starting with `"tileops"` are treated as TileOPs entries; all others are baselines.
-- `calculate_flops()` and `calculate_memory()` must return non-None values. The nightly report uses these to compute TFLOPS and bandwidth columns.
+## Boundary
+
+- **OWNS**: `benchmarks/`
+- **MUST NOT modify**: `tileops/ops/`, `tileops/kernels/`, `tests/`, `workloads/`, `tileops/ops_manifest.yaml`
+- **MAY READ**: `workloads/`, `tileops/ops/`
+
+→ [trust-model.md §Benchmark](../../docs/trust-model.md#benchmark) | [testing.md §Writing a Benchmark](../../docs/testing.md#writing-a-benchmark)
+
+______________________________________________________________________
+
+- `BenchmarkReport.record()` first arg: Op object (preferred) or string name. Stay consistent per file.
+- Every benchmark must record ≥1 non-`"tileops"` baseline. If external baseline is conditional, add a local torch fallback.
+- Tag names: lowercase, hyphen-separated. `"torch"`, `"torch-cublas"`, `"torch-sdpa"`, `"fa3"`, `"fla"`, `"triton"`, etc. Tags starting with `"tileops"` = TileOPs entries; all others = baselines.
+- `calculate_flops()` / `calculate_memory()`: return numeric or `None` (omits metric from report).

--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -1,4 +1,14 @@
-- These are condensed rules. If unclear, read [docs/manifest.md](../../docs/manifest.md) for full spec, examples, and design rationale.
+## Boundary
+
+- **OWNS**: `tileops/ops_manifest.yaml`
+- **MUST NOT modify**: `tileops/ops/`, `tileops/kernels/`, `tests/`, `benchmarks/`
+- **MAY READ**: PyTorch public API (to match signatures)
+- Manifest changes require human review in a separate PR.
+
+→ [trust-model.md §Manifest](../../docs/trust-model.md#manifest)
+
+______________________________________________________________________
+
 - `inputs`, `outputs`, `params` are ordered dicts. Key order = function signature position. Do not reorder.
 - Params include all PyTorch-supported parameters, even if the current kernel only supports the default.
 - `dtype` syntax: `|` for alternatives, `same_as(ref)` for dependent types.

--- a/.claude/domain-rules/ops-design.md
+++ b/.claude/domain-rules/ops-design.md
@@ -1,3 +1,12 @@
-- These are condensed rules. If unclear, read [docs/ops-design.md](../../docs/ops-design.md) for class hierarchy, principles, and protocol.
+## Boundary
+
+- **OWNS**: `tileops/ops/`, `tileops/kernels/`
+- **MUST NOT modify**: `tests/`, `benchmarks/`, `workloads/`, `tileops/ops_manifest.yaml`
+- **MAY READ**: `tests/` (behavior understanding), `workloads/`, `tileops/ops_manifest.yaml`
+
+→ [trust-model.md §Implementation](../../docs/trust-model.md#implementation) | [ops-design.md](../../docs/ops-design.md)
+
+______________________________________________________________________
+
 - When adding or modifying an intermediate base class, changing kernel dispatch patterns, or introducing new class variable protocols, update `docs/ops-design.md` to reflect the change.
 - When adding a new op family that inherits `Op` directly, evaluate whether it shares `forward()` flow with an existing family before creating a new base class. Document the decision in the PR.

--- a/.claude/domain-rules/testing-budget.md
+++ b/.claude/domain-rules/testing-budget.md
@@ -1,4 +1,13 @@
-- These are condensed rules. If unclear, read [docs/testing.md](../../docs/testing.md) for full policy and rationale.
+## Boundary
+
+- **OWNS**: `tests/`, `workloads/` (test stage creates workload definitions first)
+- **MUST NOT modify**: `tileops/ops/`, `tileops/kernels/`, `benchmarks/`, `tileops/ops_manifest.yaml`
+- **MAY READ**: `workloads/`, `tileops/ops_manifest.yaml`
+
+→ [trust-model.md §Test](../../docs/trust-model.md#test) | [testing.md §Writing a Test](../../docs/testing.md#writing-a-test)
+
+______________________________________________________________________
+
 - Every test case must trace back to a specific code path, dtype dispatch, or regression. Do not add cases for combinatorial confidence.
 - All supported dtypes must be tested. Dtype and shape coverage serve different purposes — do not cross them unless the combination triggers a distinct code path.
 - Do not generate test fixtures from ops_manifest.yaml workloads. Test parameters are a curated correctness subset.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,4 @@ Read the relevant context file **before** modifying files in that domain. Do not
 | `scripts/validate_manifest.py`, `tests/test_validate_manifest.py` | [.claude/domain-rules/manifest-validator.md](.claude/domain-rules/manifest-validator.md) |
 | `tileops/ops/`, `tileops/kernels/`                                | [.claude/domain-rules/ops-design.md](.claude/domain-rules/ops-design.md)                 |
 | `benchmarks/`                                                     | [.claude/domain-rules/benchmark.md](.claude/domain-rules/benchmark.md)                   |
+| `workloads/`                                                      | [docs/trust-model.md](docs/trust-model.md)                                               |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,16 +66,17 @@ graph TD
 
 ### Module reference
 
-| Module              | Responsibility                                                                                       | Key Artifact                       |
-| ------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| **M1: Spec**        | Declare op interface, workloads, roofline formulas                                                   | `ops_manifest.yaml`                |
-| **M2: Kernel + Op** | GPU kernel implementations and user-facing Python API                                                | `tileops/kernels/`, `tileops/ops/` |
-| **M3: Correctness** | Numerical correctness against PyTorch reference                                                      | `tests/`                           |
-| **M4: Perf Tuning** | Benchmark execution time and drive kernel optimization loop                                          | `benchmarks/`                      |
-| **M5: Roofline**    | Hardware efficiency from raw time + formulas + HW profile                                            | `tileops/perf/`                    |
-| **M6: HW Profile**  | GPU hardware parameters (bandwidth, FLOPS) from offline calibration                                  | `tileops/perf/profiles/`           |
-| **M7: CI Gate**     | Correctness and performance regression guard per PR                                                  | CI pipeline                        |
-| **M8: Docs**        | Design docs, API reference, perf tables — agent artifacts published alongside auto-generated content | TileOPs.github.io                  |
+| Module                                       | Responsibility                                                                                                                         | Key Artifact                       |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **M1: Spec**                                 | Declare op interface, workloads, roofline formulas                                                                                     | `ops_manifest.yaml`                |
+| **M2: Kernel + Op**                          | GPU kernel implementations and user-facing Python API                                                                                  | `tileops/kernels/`, `tileops/ops/` |
+| **M3: Correctness**                          | Numerical correctness against PyTorch reference                                                                                        | `tests/`                           |
+| **M4: Perf Tuning**                          | Benchmark execution time and drive kernel optimization loop                                                                            | `benchmarks/`                      |
+| **M5: Roofline**                             | Hardware efficiency from raw time + formulas + HW profile                                                                              | `tileops/perf/`                    |
+| **M6: HW Profile**                           | GPU hardware parameters (bandwidth, FLOPS) from offline calibration                                                                    | `tileops/perf/profiles/`           |
+| **M7: CI Gate**                              | Correctness and performance regression guard per PR                                                                                    | CI pipeline                        |
+| **M8: Docs**                                 | Design docs, API reference, perf tables — agent artifacts published alongside auto-generated content                                   | TileOPs.github.io                  |
+| **Workloads** _(shared layer, not a module)_ | Shared input generation + parametrize decorators consumed by M3 and M4. See [trust-model.md](trust-model.md#workloads-layer-contract). | `workloads/`                       |
 
 ## Data Contracts
 
@@ -144,6 +145,9 @@ TileOPs/
 │       └── profiles/                 # GPU hardware parameters
 │           ├── h100.yaml
 │           └── h200.yaml
+├── workloads/                        # Shared workload definitions (WorkloadBase, FixtureBase)
+│   ├── base.py                       # WorkloadBase, FixtureMeta, FixtureBase
+│   └── ops/                          # Per-op workload subclasses
 ├── benchmarks/
 │   ├── hardware/                     # Microbench (GPU characterization)
 │   │   ├── memory/

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -1,6 +1,6 @@
 # Op Interface Design
 
-## Class Hierarchy (target architecture)
+## Class Hierarchy
 
 ```
 Op (base)
@@ -9,8 +9,10 @@ Op (base)
 ```
 
 - **Op** — abstract base. Defines the `forward()` contract.
-- **FamilyBase** — per-family intermediate base. Owns shared `forward()` flow: validation, reshape, padding, kernel dispatch, trim. One per op family. Current: `RowNormOp` serves norm ops; migration to `NormBase` tracked in #741.
+- **FamilyBase** — per-family intermediate base. Owns shared `forward()` flow: validation, reshape, padding, kernel dispatch, trim. One per op family. Current: `RowNormOp` serves norm ops.
 - **ConcreteOp** — leaf class. Pure declaration: kernel class, supported dtypes, input wiring. No logic override.
+
+For trust boundaries (what implementation OWNS, MUST NOT do, and MAY READ), see [trust-model.md -- Implementation](trust-model.md#implementation).
 
 ## Principle 1: Two-Layer Boundary
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,24 +4,33 @@ Tests and benchmarks are separated by concern: `pytest tests/` validates correct
 
 ## Core Abstractions
 
-| Class             | Location                                                | Role                                                                                                                        |
-| ----------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `FixtureBase`     | [`tests/test_base.py`](../tests/test_base.py)           | Metaclass-based decorator that applies `pytest.mark.parametrize` from a `PARAMS` class attribute.                           |
-| `TestBase`        | [`tests/test_base.py`](../tests/test_base.py)           | ABC with `gen_inputs()`, `ref_program()`, `check()`, `check_fn()`. Each op subclasses this.                                 |
-| `BenchmarkBase`   | [`benchmarks/benchmark.py`](../benchmarks/benchmark.py) | ABC wrapping a `TestBase` instance. Subclass implements `calculate_flops()` and `calculate_memory()`. Provides `profile()`. |
-| `BenchmarkReport` | [`benchmarks/benchmark.py`](../benchmarks/benchmark.py) | Static collector — `record()` stores results, `dump()` writes markdown, `clear()` resets.                                   |
+| Class             | Location                                                | Role                                                                                                                             |
+| ----------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `WorkloadBase`    | [`workloads/base.py`](../workloads/base.py)             | ABC defining `gen_inputs()`. Shared base for input generation used by both tests and benchmarks.                                 |
+| `FixtureBase`     | [`workloads/base.py`](../workloads/base.py)             | Metaclass-based decorator that applies `pytest.mark.parametrize` from a `PARAMS` class attribute or `get_params()` classmethod.  |
+| `TestBase`        | [`tests/test_base.py`](../tests/test_base.py)           | Inherits `WorkloadBase`. Adds `ref_program()` and `check()`. Each op subclasses this for correctness testing.                    |
+| `BenchmarkBase`   | [`benchmarks/benchmark.py`](../benchmarks/benchmark.py) | ABC composing a `WorkloadBase` instance. Subclass implements `calculate_flops()` and `calculate_memory()`. Provides `profile()`. |
+| `BenchmarkReport` | [`benchmarks/benchmark.py`](../benchmarks/benchmark.py) | Static collector -- `record()` stores results, `dump()` writes markdown, `clear()` resets.                                       |
 
 ## Test/Benchmark Pattern
 
 ```python
+# workloads/ops/mha.py
+class MhaFwdWorkload(WorkloadBase):
+    def __init__(self, batch, heads, seq_len, dim, causal, dtype): ...
+    def gen_inputs(self): ...
+
+
 # tests/ops/test_mha.py
+from workloads.ops.mha import MhaFwdWorkload
+
+
+class MhaFwdTest(MhaFwdWorkload, TestBase):
+    def ref_program(self, q, k, v): ...  # correctness oracle, local to test
+
+
 class MhaFwdFixture(FixtureBase):
     PARAMS = [("batch, seq_len, heads, dim, causal, dtype, tune", [...])]
-
-
-class MhaFwdTest(TestBase):
-    def gen_inputs(self): ...
-    def ref_program(self, q, k, v): ...
 
 
 @MhaFwdFixture
@@ -32,6 +41,9 @@ def test_mha_fwd(batch, seq_len, heads, dim, causal, dtype, tune):
 
 
 # benchmarks/ops/bench_mha.py
+from workloads.ops.mha import MhaFwdWorkload  # import workload, NOT test
+
+
 class MhaFwdBenchmark(BenchmarkBase):
     def calculate_flops(self): ...
     def calculate_memory(self): ...
@@ -39,12 +51,12 @@ class MhaFwdBenchmark(BenchmarkBase):
 
 @MhaFwdFixture  # reuses the same parametrize decorator
 def test_mha_fwd_bench(batch, seq_len, heads, dim, causal, dtype, tune):
-    test = MhaFwdTest(batch, heads, seq_len, dim, causal, dtype)
-    bm = MhaFwdBenchmark(test)
-    inputs = test.gen_inputs()
+    workload = MhaFwdWorkload(batch, heads, seq_len, dim, causal, dtype)
+    bm = MhaFwdBenchmark(workload)
+    inputs = workload.gen_inputs()
     op = MultiHeadAttentionFwdOp(...)
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record("mha_fwd", locals(), result, tag="tileops")
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
 ```
 
 ## Unit Test Requirements
@@ -131,13 +143,63 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 - **Growth on existing files**: include script output and a one-line justification in PR description.
 - **New test files only**: no delta to report — follow the policy above.
 
+## Writing a Test
+
+→ Trust boundary: [trust-model.md §Test](trust-model.md#test) | Rules: [testing-budget.md](../.claude/domain-rules/testing-budget.md)
+
+### File checklist
+
+1. **Workload class** in `workloads/ops/` — subclass `WorkloadBase`, implement `gen_inputs()`.
+1. **Fixture class** — subclass `FixtureBase`, define `PARAMS` with `smoke`/`full` marks.
+1. **Test class** in `tests/ops/test_<op>.py` — inherit `(MyWorkload, TestBase)`, implement `ref_program()` locally.
+1. **Test function** — `@YourFixture` decorated, call `test.check(op, *test.gen_inputs())`.
+
+### Class hierarchy
+
+```
+WorkloadBase (workloads/base.py)
+  gen_inputs() -> Any                                    # abstract
+
+TestBase (tests/test_base.py, inherits WorkloadBase)
+  ref_program() -> Any                                   # abstract
+  check(op, *inputs, compare=None, atol, rtol) -> None
+```
+
+## Writing an Op Implementation
+
+→ Trust boundary: [trust-model.md §Implementation](trust-model.md#implementation) | Guide: [ops-design.md](ops-design.md)
+
+## Writing a Benchmark
+
+→ Trust boundary: [trust-model.md §Benchmark](trust-model.md#benchmark) | Rules: [benchmark.md](../.claude/domain-rules/benchmark.md)
+
+### File checklist
+
+1. **Workload class** in `workloads/ops/` — reuse the `WorkloadBase` subclass from the test.
+1. **Fixture class** — reuse the `FixtureBase` subclass from the test.
+1. **Benchmark class** in `benchmarks/ops/bench_<op>.py` — subclass `BenchmarkBase`, implement `calculate_flops()` and `calculate_memory()` (return `None` if not applicable).
+1. **Benchmark function** — `@YourFixture` decorated, construct workload + benchmark, call `inputs = workload.gen_inputs()`, then `bm.profile(op, *inputs)` and `BenchmarkReport.record(op, locals(), result, tag="tileops")`.
+1. **Independent baseline** — record at least one non-`"tileops"` baseline (e.g., `"torch"`, `"fa3"`). If benchmark needs a ref function, define it locally — never import from `tests/` or `workloads/`.
+
+### Class hierarchy
+
+```
+BenchmarkBase (benchmarks/benchmark.py, composes WorkloadBase)
+  __init__(workload: WorkloadBase)
+  calculate_flops() -> Optional[float]
+  calculate_memory() -> Optional[float]
+  profile(op, *inputs) -> dict
+```
+
+See [Reporting Rules](#reporting-rules) below for `record()` and tag conventions.
+
 ## Benchmark Requirements
 
 **Framework:** `benchmarks.benchmark.BenchmarkBase`. **Location:** [`benchmarks/ops/`](../benchmarks/ops/).
 
 **Execution:** `pytest benchmarks/` auto-generates `profile_run.log` (markdown format).
 
-### Metrics (all required)
+### Metrics
 
 - Latency (ms)
 - TFLOPS (Tera Floating-point Operations Per Second)
@@ -151,4 +213,4 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 - Run the targeted correctness suite on the same GPU before reporting benchmark numbers.
 - `BenchmarkReport.record()` first argument may be the Op instance or a string name; stay consistent within a given benchmark file.
 - `calculate_flops()` and `calculate_memory()` should return numeric values when the metric is available; return `None` only if the metric is not applicable, in which case it will be omitted from the report.
-- Every benchmark must record at least one non-`"tileops"` baseline. Use existing tags (`"baseline"`, `"torch"`, `"FA3"`, `"fla"`, `"triton"`) and avoid introducing ad-hoc tags without updating downstream consumers.
+- Every benchmark must record at least one non-`"tileops"` baseline. Use existing tags (`"baseline"`, `"torch"`, `"fa3"`, `"fla"`, `"triton"`) and avoid introducing ad-hoc tags without updating downstream consumers.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -1,0 +1,67 @@
+# Trust Model
+
+Each development stage owns a specific concern. Boundaries prevent one stage from silently weakening another's guarantees. See #789 for case study.
+
+## Pipeline
+
+```
+Manifest → Implementation → Test → Benchmark
+```
+
+Each stage declares **OWNS** / **MUST NOT** / **MAY READ** in its [domain rule file](../.claude/domain-rules/).
+
+## Manifest
+
+Source of truth for op interfaces. Human-reviewed, separate PR.
+
+- **OWNS**: op signatures, dtypes, workload shapes, roofline formulas, status
+- **MUST NOT**: contain implementation details or test logic
+- **MAY READ**: PyTorch public API (to match signatures)
+
+→ Rules: [manifest-spec.md](../.claude/domain-rules/manifest-spec.md) | Guide: [testing.md §Writing a Test](testing.md#writing-a-test)
+
+## Implementation
+
+Kernel (L1) + Op (L2). Developer reads manifest + ref_program for behavior; high-perf optimization is independent.
+
+- **OWNS**: TileLang kernels, op dispatch, class variable protocol
+- **MUST NOT**: define workload shapes, own correctness assertions, modify manifest
+- **MAY READ**: manifest (interface), `tests/` (behavior understanding — not to reverse-engineer passing)
+
+→ Rules: [ops-design.md](../.claude/domain-rules/ops-design.md) | Guide: [ops-design.md](ops-design.md), [testing.md §Writing an Op](testing.md#writing-an-op-implementation)
+
+## Test
+
+PR-level correctness verification. QA writes tests against manifest spec.
+
+- **OWNS**: ref_program, tolerances, assertions, `tests/`, `workloads/`
+- **MUST NOT**: contain kernel code, benchmark logic, or performance measurements
+- **MAY READ**: manifest (to verify interface), `workloads/` (via WorkloadBase inheritance)
+
+→ Rules: [testing-budget.md](../.claude/domain-rules/testing-budget.md) | Guide: [testing.md §Writing a Test](testing.md#writing-a-test)
+
+## Benchmark
+
+Nightly performance guard. Independent baselines — cannot modify op/tests/workloads.
+
+- **OWNS**: profiling, baseline comparisons, `benchmarks/`
+- **MUST NOT**: contain correctness assertions, kernel code, or import oracle/ref functions from `tests/` or `workloads/` (benchmark-local baseline functions are allowed)
+- **MAY READ**: `workloads/` (composition), `tileops/ops/` (to profile)
+
+→ Rules: [benchmark.md](../.claude/domain-rules/benchmark.md) | Guide: [testing.md §Writing a Benchmark](testing.md#writing-a-benchmark)
+
+## Workloads Layer
+
+Shared input-definition layer — not a development stage. Test stage OWNS it (QA creates workload classes first).
+
+**Provides**: `WorkloadBase` (gen_inputs), `FixtureMeta`/`FixtureBase` (parametrize), per-op workload subclasses.
+
+**Must not contain**: ref_program, check/tolerance logic, calculate_flops/memory, benchmark baselines. Reason: prevents shared oracle surface between test correctness and benchmark baselines.
+
+```
+WorkloadBase (workloads/base.py)        # gen_inputs() only
+  ├── TestBase (tests/test_base.py)     # adds ref_program(), check()
+  └── BenchmarkBase (benchmarks/)       # composes WorkloadBase, adds profiling
+```
+
+→ Cross-refs: [architecture.md](architecture.md), [testing.md](testing.md), [workflow.md](workflow.md)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -21,11 +21,10 @@ Bottom-up development flow: Kernel → Op → Test → Benchmark → PR.
 - **Location**: under `tileops/ops/`, e.g. `{family}/{op}.py` or `{op}.py` depending on whether the op belongs to an existing family subpackage.
 - Wrap the kernel in a Python function.
 - Google-style docstrings (Args, Returns, Example).
-- Unit test comparing output against a pure PyTorch reference.
 - Dtype contract: explicitly define supported input dtypes, output dtype, rejected dtypes.
 - Parameter contract: validate scalar parameters at the Op boundary. Invalid values fail with `ValueError` before any TIR/codegen step.
 - Do not fix interface-contract bugs with kernel-local workarounds. Fix the validation boundary first.
-- **Done when**: op passes unit tests.
+- **Done when**: op passes existing unit tests (tests are written by the test stage — see [trust-model.md §Test](trust-model.md#test)).
 
 ## Step 3: Benchmark
 
@@ -36,6 +35,10 @@ Bottom-up development flow: Kernel → Op → Test → Benchmark → PR.
 - **Done when**: benchmark results are posted in the tracking issue.
 
 See [testing.md](testing.md) for framework details, tolerances, and reporting rules.
+
+### Workload sharing (double-inheritance note)
+
+Tests and benchmarks share workload definitions through `workloads/`. `TestBase` inherits from `WorkloadBase` (getting `gen_inputs()`), while `BenchmarkBase` composes a `WorkloadBase` instance. Both reuse the same `FixtureBase` parametrize decorators. This means each op's workload definition is written once in `workloads/` and consumed by both `tests/` and `benchmarks/` without duplication. See [trust-model.md -- Workloads Layer Contract](trust-model.md#workloads-layer-contract) for boundary details.
 
 ## Step 4: PR Submission
 
@@ -123,4 +126,4 @@ Keep commit messages concise. Long verification sections, benchmark tables, and 
 - **Formatter/Linter**: `ruff`.
 - **Docstrings**: Google-style on all public functions and classes. Type info goes in Python type hints, not repeated in docstrings.
 - **Type Hints**: all function signatures (inputs and outputs) must be type-hinted.
-- **Strict Typing** *(planned)*: L2 (Op) APIs will be checked with `mypy` in strict mode.
+- **Strict Typing**: L2 (Op) APIs should use type hints that pass `mypy` strict mode where practical.


### PR DESCRIPTION
## Summary

- New `docs/trust-model.md` — four-stage pipeline trust boundaries (manifest → implementation → test → benchmark) and workloads layer contract
- Added `## Boundary` sections (OWNS / MUST NOT modify / MAY READ) to all 4 domain rule files
- Added "Writing a Test" and "Writing a Benchmark" operation guides to `docs/testing.md`
- Rewrote top-level Test/Benchmark Pattern example to match post-PR#787 three-file architecture
- Fixed outdated class descriptions, directory structure, aspirational claims, and internal contradictions

Resolves #790. Related: #787, #789.

## Key design decisions

1. **workloads/ is not a development stage** — shared input-definition layer. Test stage OWNS it (QA creates workload classes first from manifest).
2. **Implementation MAY READ tests/, MUST NOT MODIFY** — developer reads ref_program for behavior understanding; modifying the correctness oracle is the unacceptable cheat.
3. **Benchmark-local baselines allowed** — benchmarks must not import oracle/ref from tests/ or workloads/, but may define local baseline functions.
4. **Operation guides in testing.md, principles in trust-model.md** — explicit bidirectional cross-references between all documents.

## Changes (10 files, +216 / -40)

| File | Change |
|------|--------|
| `docs/trust-model.md` (new) | Pipeline boundaries, per-stage OWNS/MUST NOT/MAY READ, workloads contract |
| `docs/testing.md` | Rewrote example to three-file pattern, added Writing a Test/Benchmark guides, fixed class table |
| `docs/architecture.md` | Added `workloads/` to directory tree + module table (labeled "shared layer, not a module") |
| `docs/ops-design.md` | Trust boundary cross-ref, removed aspirational "target architecture" label |
| `docs/workflow.md` | Fixed Step 2 to not claim implementer writes tests, added trust-model back-link |
| `.claude/domain-rules/benchmark.md` | Boundary header with file-path MUST NOT, fixed record()/calculate rules |
| `.claude/domain-rules/testing-budget.md` | Boundary header, OWNS tests/ + workloads/ |
| `.claude/domain-rules/ops-design.md` | Boundary header, MAY READ tests/ with rationale |
| `.claude/domain-rules/manifest-spec.md` | Boundary header |
| `CLAUDE.md` | Added `workloads/` row to domain rules table |

## Test plan

- [x] All cross-references bidirectional (every forward ref has matching back ref)
- [x] Top-level example matches "Writing a Benchmark" checklist (one consistent pattern)
- [x] No internal contradictions between trust-model.md, testing.md, domain rules, and workflow.md
- [x] All API descriptions verified against actual code
- [x] No aspirational claims in modified documents
- [x] `pre-commit run --all-files` passes
- [x] Documentation-only PR — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)