### PR TITLE
[Fix][CI] Guard gpu-smoke always-on steps against unset env vars

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -620,7 +620,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "=== Trusted cache stats ==="
-          for cache_dir in "${TILELANG_CACHE_DIR}" "${TRITON_CACHE_DIR}" "${WHEEL_DIR}"; do
+          for cache_dir in "${TILELANG_CACHE_DIR:-}" "${TRITON_CACHE_DIR:-}" "${WHEEL_DIR:-}"; do
+            if [[ -z "${cache_dir}" ]]; then
+              continue
+            fi
             if [[ -d "${cache_dir}" ]]; then
               file_count=$(find "${cache_dir}" -type f | wc -l)
               cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1)
@@ -643,4 +646,7 @@ jobs:
 
       - name: Cleanup isolated fork state
         if: ${{ always() && needs.security-policy.outputs.is_fork == 'true' }}
-        run: rm -rf "${RUNTIME_ROOT}"
+        run: |
+          if [[ -n "${RUNTIME_ROOT:-}" ]]; then
+            rm -rf "${RUNTIME_ROOT}"
+          fi


### PR DESCRIPTION
## Summary
- The `Cache stats` step in gpu-smoke workflow crashes with `TILELANG_CACHE_DIR: unbound variable` when the checkout step fails (e.g. network timeout), because the `Resolve runtime state` step never runs to export env vars, but `Cache stats` runs unconditionally via `if: always()` with `set -euo pipefail`.
- Use `${VAR:-}` default syntax and skip empty entries so these `always()`-guarded steps degrade gracefully.
- Same guard applied to the `Cleanup isolated fork state` step for `RUNTIME_ROOT`.

## Context
- CI failure: https://github.com/tile-ai/TileOPs/actions/runs/23999697311/job/69993642735
- The primary failure was a transient network timeout on the self-hosted runner (not fixable in code). This PR fixes the secondary cascade failure.

## Test plan
- [x] Verify the workflow YAML is valid (passed `check yaml` pre-commit hook)
- [ ] Re-run the gpu-smoke workflow to confirm it passes when checkout succeeds
- [ ] Simulate checkout failure to verify `Cache stats` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)