### PR TITLE
[Doc][CI] Add commit message style guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ TileOPs is a high-performance LLM operator library built on TileLang. The goal i
 - Response should include: change summary, affected paths, validation steps, and next suggestions.
 - No GitHub issue numbers or ad-hoc issue annotations in source/test files. Issue refs belong in commit messages and PR descriptions only.
 - When orchestrating sub-agents: verify clean worktree (`git diff --quiet && git diff --cached --quiet`) after each sub-agent returns. If dirty, commit on behalf using a descriptive message (e.g., `Sub-agent [name]: [task summary]`).
-- Write commit messages in `[Type][Scope] description` format per `COMMIT_MSG_PATTERN` in `.claude/conventions/types.sh`. Not CI-enforced, but expected for readability.
+- Write commit messages in `[Type] description` or `[Type][Scope] description` format per `COMMIT_MSG_PATTERN` in `.claude/conventions/types.sh` (scope is optional). Not CI-enforced, but expected for readability.
 
 ## Domain Rules (load on demand)
 


### PR DESCRIPTION
## Summary

- Add a one-line commit message style guideline to CLAUDE.md "Collaboration Rules for Claude" section, referencing the existing `COMMIT_MSG_PATTERN` from `.claude/conventions/types.sh`
- No CI enforcement added — guideline is for readability only

Closes #802

## Test plan

- [x] **AC-1**: CLAUDE.md "Collaboration Rules for Claude" section contains a commit message style guideline referencing `COMMIT_MSG_PATTERN`
- [x] **AC-2**: No changes to CI workflows, pre-commit hooks, or `types.sh`