### PR TITLE
[Fix][Validator] Resolve op classes in multi-class files by PascalCase convention

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -423,7 +423,7 @@ def _resolve_op_class(op_file: str, op_name: str) -> _ResolveResult:
         if cls.__name__ == pascal:
             return _ResolveResult(cls=cls)
 
-    # Fallback: full op_name as PascalCase (e.g., "batchnorm_fwd" -> "BatchnormFwdOp")
+    # Fallback: full op_name as PascalCase (e.g., "sum_fwd" -> "SumFwdOp")
     full_pascal = "".join(part.capitalize() for part in op_name.split("_")) + "Op"
     for cls in candidates:
         if cls.__name__ == full_pascal:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -807,14 +807,6 @@ class TestResolveOpClass:
         assert result.cls is not None
         assert result.cls.__name__ == "SoftmaxOp"
 
-    def test_fwd_suffix_resolves_single_class_file(self, validator):
-        """A _fwd op name resolves correctly for a single-class file."""
-        result = validator._resolve_op_class(
-            "tileops/ops/reduction/softmax.py", "softmax_fwd",
-        )
-        assert result.cls is not None
-        assert result.cls.__name__ == "SoftmaxOp"
-
     @pytest.mark.parametrize(
         "op_name,expected_class",
         [


### PR DESCRIPTION
## Summary

Fix `_resolve_op_class` to correctly resolve op names to classes when source files contain multiple Op classes (e.g., `reduce.py` with 8 ops). The previous substring heuristic (`all parts in cls_lower`) was too permissive — `var_fwd` matched `AmaxOp` instead of `VarOp` because no class contained `"fwd"`, and the alphabetical fallback picked the wrong candidate.

Closes #803

## Changes

### Resolver heuristic rewrite (`scripts/validate_manifest.py`)
- **Removed** the loose substring-based multi-candidate heuristic (`all(p in cls_lower for p in parts)`)
- **Added** exact PascalCase match as the primary multi-candidate strategy: strip `_fwd`/`_bwd` suffix, convert remainder to PascalCase + `"Op"` (e.g., `var_fwd` → `VarOp`, `var_mean_fwd` → `VarMeanOp`)
- **Added** full-name PascalCase fallback for Fwd/Bwd-suffixed class naming conventions (e.g., `batchnorm_fwd` → `BatchNormFwdOp`)
- Retained suffix matching (`fwd`/`bwd` in class name) as final fallback

### Test coverage (`tests/test_validate_manifest.py`)
- Added `TestResolveOpClass` class with 21 test cases:
  - 8 parametrized tests for `reduce.py` multi-class resolution (SumOp, MeanOp, AmaxOp, AminOp, ProdOp, VarOp, StdOp, VarMeanOp)
  - 11 parametrized tests for all single-file reduction ops (argmax, argmin, all, any, count_nonzero, l1_norm, l2_norm, inf_norm, softmax, log_softmax, logsumexp)
  - Single-class file resolution, import error handling, no-op-class handling

### Review fixes
- Removed duplicate test method flagged by Copilot review
- Fixed misleading comment example (`"batchnorm_fwd" → "BatchnormFwdOp"` → `"sum_fwd" → "SumFwdOp"`)

## Test plan

- [x] **AC-1**: `_resolve_op_class` returns correct class for all 19 reduction ops (8 multi-class in `reduce.py` + 11 single-file) — verified by parametrized tests
- [x] **AC-2**: Existing resolver behavior unchanged for single-class files and Fwd/Bwd-suffixed classes — verified by `test_single_class_file_resolves`
- [x] **AC-3**: Unit tests cover multi-class resolution scenarios — 21 test cases in `TestResolveOpClass`

**Test results:** 72 passed, 0 failed

## Follow-up

- #810 — Emit warning on silent `candidates[0]` fallback
- #811 — Deduplicate PascalCase resolution loops