### PR TITLE
[Chore][Manifest] Promote 17 reduction ops from spec-only to implemented

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1398,7 +1398,7 @@ ops:
 
   logsumexp_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1440,7 +1440,7 @@ ops:
 
   sum_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1477,7 +1477,7 @@ ops:
 
   mean_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1514,7 +1514,7 @@ ops:
 
   amax_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1551,7 +1551,7 @@ ops:
 
   amin_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1588,7 +1588,7 @@ ops:
 
   prod_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1629,7 +1629,7 @@ ops:
 
   var_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1667,7 +1667,7 @@ ops:
 
   std_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1705,7 +1705,7 @@ ops:
 
   var_mean_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1750,7 +1750,7 @@ ops:
 
   argmax_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1787,7 +1787,7 @@ ops:
 
   argmin_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1828,7 +1828,7 @@ ops:
 
   all_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1864,7 +1864,7 @@ ops:
 
   any_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1900,7 +1900,7 @@ ops:
 
   count_nonzero_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1940,7 +1940,7 @@ ops:
 
   l1_norm_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -1977,7 +1977,7 @@ ops:
 
   l2_norm_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -2014,7 +2014,7 @@ ops:
 
   inf_norm_fwd:
     family: reduction
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:


### PR DESCRIPTION
## Summary

Flip `status: spec-only` to `status: implemented` for 17 reduction ops after verifying each implementation matches its manifest-declared interface. 14 ops support `dim: int | list[int]` (verified in PR #812); 3 ops (argmax, argmin, prod) support `dim: int` only, matching PyTorch's public API.

Closes #813

### Ops promoted

| Op | `dim` type |
|---|---|
| sum_fwd, mean_fwd, amax_fwd, amin_fwd, var_fwd, std_fwd, var_mean_fwd, logsumexp_fwd, all_fwd, any_fwd, count_nonzero_fwd, l1_norm_fwd, l2_norm_fwd, inf_norm_fwd | `int \| list[int]` |
| argmax_fwd, argmin_fwd, prod_fwd | `int` |

## Test plan

- [x] **AC-1**: All promoted ops pass manifest validator at L1 — `python scripts/validate_manifest.py` output: "All manifest checks passed." (58 bench-level warnings, 0 errors)
- [x] **AC-2**: No code files modified in this PR — `git diff --stat main...HEAD` shows only `tileops/ops_manifest.yaml` (1 file, 17 insertions, 17 deletions)
- [x] **AC-3**: PR description lists each op whose status was changed — all 17 ops listed above

## Follow-up

### Issues
| # | Issue | Category | Parallel |
|---|---|---|---|
| 1 | #823 [TEST][Reduction] Add edge-case tests for Welford padding with non-aligned N | coverage gap | yes |