### PR TITLE
[Feat][Reduction] Add list[int] dim support for LogSumExpOp

### DIFF
--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -341,6 +341,60 @@ def test_logsumexp_keepdim(shape: tuple, dim: int, dtype: torch.dtype) -> None:
 
 
 # ===================================================================
+# LogSumExp — multi-dim reduction (dim=list[int])
+# ===================================================================
+
+
+class LogSumExpMultiDimFixture(FixtureBase):
+    PARAMS = [
+        (
+            "shape, dim, keepdim, dtype",
+            [
+                # Smoke: 3D, reduce last two dims, fp32
+                pytest.param((4, 16, 256), [1, 2], False, torch.float32, marks=[pytest.mark.smoke]),
+                # 3D, reduce last two dims — all dtypes
+                pytest.param((4, 16, 256), [1, 2], False, torch.float16, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [1, 2], False, torch.bfloat16, marks=pytest.mark.full),
+                # 3D, non-contiguous dims [0, 2] — exercises permutation
+                pytest.param((4, 16, 256), [0, 2], False, torch.float32, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [0, 2], False, torch.float16, marks=pytest.mark.full),
+                # 3D, reduce first two dims
+                pytest.param((4, 16, 256), [0, 1], False, torch.float32, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [0, 1], False, torch.float16, marks=pytest.mark.full),
+                # 4D, reduce middle two dims
+                pytest.param((2, 4, 8, 256), [1, 2], False, torch.float32, marks=pytest.mark.full),
+                pytest.param((2, 4, 8, 256), [1, 2], False, torch.float16, marks=pytest.mark.full),
+                # keepdim=True variants
+                pytest.param((4, 16, 256), [1, 2], True, torch.float32, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [0, 2], True, torch.float32, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [0, 2], True, torch.float16, marks=pytest.mark.full),
+                # 4D, keepdim=True
+                pytest.param((2, 4, 8, 256), [1, 2], True, torch.float32, marks=pytest.mark.full),
+                # Negative dim indices
+                pytest.param((4, 16, 256), [-2, -1], False, torch.float32, marks=pytest.mark.full),
+                pytest.param((4, 16, 256), [-2, -1], False, torch.float16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@LogSumExpMultiDimFixture
+def test_logsumexp_multi_dim(shape: tuple, dim: list, keepdim: bool, dtype: torch.dtype) -> None:
+    """Test logsumexp with multi-dim reduction (dim=list[int])."""
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    op = LogSumExpOp(dtype=dtype, dim=dim, keepdim=keepdim)
+
+    y_ref = torch.logsumexp(x.float(), dim=dim, keepdim=keepdim).to(dtype)
+    y = op(x)
+    assert y.shape == y_ref.shape, f"Shape mismatch: {y.shape} vs {y_ref.shape}"
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"Multi-dim logsumexp failed (dim={dim}, keepdim={keepdim}), "
+        f"max err: {(y - y_ref).abs().max()}"
+    )
+
+
+# ===================================================================
 # Non-contiguous input tests (spec interface)
 # ===================================================================
 

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -395,6 +395,18 @@ def test_logsumexp_multi_dim(shape: tuple, dim: list, keepdim: bool, dtype: torc
 
 
 # ===================================================================
+# LogSumExp — empty dim rejection (regression for issue #795)
+# ===================================================================
+
+
+@pytest.mark.smoke
+def test_logsumexp_empty_dim_rejected() -> None:
+    """Empty dim=[] must raise ValueError, not silently return input."""
+    with pytest.raises(ValueError, match="empty"):
+        LogSumExpOp(dtype=torch.float32, dim=[])
+
+
+# ===================================================================
 # Non-contiguous input tests (spec interface)
 # ===================================================================
 

--- a/tileops/ops/reduction/logsumexp.py
+++ b/tileops/ops/reduction/logsumexp.py
@@ -64,6 +64,11 @@ class LogSumExpOp(_SoftmaxBaseOp):
         # placeholder (the base __init__ only uses dim for storage;
         # we override forward to handle multi-dim).
         if isinstance(dim, (list, tuple)):
+            if len(dim) == 0:
+                raise ValueError(
+                    "dim must be non-empty when provided as a list; "
+                    "pass a single int to reduce over one dimension"
+                )
             super().__init__(
                 dtype=dtype, dim=-1, kernel_map=kernel_map, tune=tune
             )

--- a/tileops/ops/reduction/logsumexp.py
+++ b/tileops/ops/reduction/logsumexp.py
@@ -3,17 +3,27 @@
 Provides:
   - LogSumExpOp: y = logsumexp(x, dim, keepdim)
 
+Supports both single-int and multi-dim (list[int]) reduction, matching
+``torch.logsumexp`` semantics.
+
 Example:
     >>> op = LogSumExpOp(dtype=torch.float16, dim=-1)
     >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
     >>> y = op(x)  # shape: (1024,)
+
+    >>> op = LogSumExpOp(dtype=torch.float16, dim=[1, 2])
+    >>> x = torch.randn(4, 16, 256, dtype=torch.float16, device="cuda")
+    >>> y = op(x)  # shape: (4,)
 """
 
-from typing import Dict, Optional
+from math import prod
+from typing import Dict, List, Optional, Union
 
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel import Kernel
+from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
 from tileops.kernels.reduction.softmax import LogSumExpKernel
 
 from ._softmax_base import _SoftmaxBaseOp
@@ -24,12 +34,13 @@ __all__ = ["LogSumExpOp"]
 class LogSumExpOp(_SoftmaxBaseOp):
     """LogSumExp operator: y = logsumexp(x, dim, keepdim).
 
-    Output shape is input shape without the reduction dimension
+    Output shape is input shape without the reduction dimension(s)
     (or with size-1 if keepdim=True).
 
     Args:
         dtype: Data type (float32, float16, or bfloat16).
-        dim: Reduction dimension (default -1).
+        dim: Reduction dimension(s) (default -1).  Accepts a single int
+            or a list of ints for multi-dim reduction.
         keepdim: Retain reduced dimension (default False).
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
@@ -43,10 +54,87 @@ class LogSumExpOp(_SoftmaxBaseOp):
         self,
         *,
         dtype: torch.dtype,
-        dim: int = -1,
+        dim: Union[int, List[int]] = -1,
         keepdim: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune)
+        # For single-int dim, delegate fully to the base class.
+        # For multi-dim, store the raw dim list and pass dim=-1 as a
+        # placeholder (the base __init__ only uses dim for storage;
+        # we override forward to handle multi-dim).
+        if isinstance(dim, (list, tuple)):
+            super().__init__(
+                dtype=dtype, dim=-1, kernel_map=kernel_map, tune=tune
+            )
+            self.dim = list(dim)
+        else:
+            super().__init__(
+                dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune
+            )
         self.keepdim = keepdim
+
+    # ------------------------------------------------------------------
+    # Multi-dim forward
+    # ------------------------------------------------------------------
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run logsumexp, supporting both single-int and list[int] dim."""
+        if isinstance(self.dim, int):
+            return super().forward(x)
+        return self._forward_multi_dim(x)
+
+    def _forward_multi_dim(self, x: torch.Tensor) -> torch.Tensor:
+        """Multi-dim logsumexp: flatten reduction dims, run kernel, reshape."""
+        self._validate(x)
+        orig_shape = x.shape
+        ndim = x.ndim
+
+        # Normalize and validate each dim.
+        dims = []
+        for d in self.dim:
+            if d < -ndim or d >= ndim:
+                raise IndexError(
+                    f"Dimension out of range (expected to be in range of "
+                    f"[{-ndim}, {ndim - 1}], but got {d})"
+                )
+            dims.append(d % ndim)
+
+        if len(set(dims)) != len(dims):
+            raise ValueError("Repeated dim in reduction dimensions")
+
+        dims_sorted = sorted(dims)
+
+        # Permute so that reduction dims are at the end (in their
+        # original relative order), and non-reduction dims come first.
+        kept_dims = [i for i in range(ndim) if i not in dims_sorted]
+        perm = kept_dims + dims_sorted
+        x = x.permute(perm)
+
+        # Flatten: kept dims -> M, reduction dims -> N.
+        N = prod(orig_shape[d] for d in dims_sorted)
+        M = prod(orig_shape[d] for d in kept_dims) if kept_dims else 1
+
+        x = x.contiguous().reshape(M, N)
+
+        # Get or create cached kernel for this (M, N).
+        kernel = self._get_or_create_kernel(M, N)
+
+        # Pad hidden dim to alignment.
+        N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        if N_padded != N:
+            x = F.pad(x, (0, N_padded - N), value=float("-inf"))
+
+        y = kernel(x)
+
+        # Reshape output.
+        if self.keepdim:
+            out_shape = list(orig_shape)
+            for d in dims_sorted:
+                out_shape[d] = 1
+            y = y.reshape(out_shape)
+        else:
+            out_shape = [orig_shape[d] for d in kept_dims]
+            y = y.squeeze() if len(out_shape) == 0 else y.reshape(out_shape)
+
+        return y


### PR DESCRIPTION
## Summary

Extends `LogSumExpOp` to accept `dim` as `int | list[int]`, matching the `torch.logsumexp` signature. Multi-dim reduction flattens the specified dimensions into a single reduction axis before the (M, N) reshape. Also rejects empty `dim=[]` with a clear `ValueError`.

Closes #795

## Test plan

- [x] AC-1: `LogSumExpOp(dtype=..., dim=[1, 2])` produces correct results matching `torch.logsumexp(x, dim=[1, 2])`
- [x] AC-2: `LogSumExpOp(dtype=..., dim=[0, 2], keepdim=True)` shape and values match PyTorch
- [x] AC-3: 15 new multi-dim test cases added (`LogSumExpMultiDimFixture`) covering 3D/4D, contiguous/non-contiguous dims, keepdim True/False, negative indices, fp32/fp16/bf16
- [x] AC-4: Manifest validator passes with `--check-op logsumexp_fwd`
- [ ] AC-5: Status flip from `spec-only` to `implemented` deferred to follow-up PR per manifest-trust-model rule

## Notes

- `softmax_fwd` and `log_softmax_fwd` only specify `dim: int` (single) and are not affected
- Empty `dim=[]` now raises `ValueError` (regression test: `test_logsumexp_empty_dim_rejected`)
- Manifest is not modified in this PR per trust-model policy; status flip will be a separate PR