### PR TITLE
[Refactor] Fix enable_rasteration → enable_rasterization typo across kernel configs

### DIFF
--- a/tileops/kernels/conv/conv1d.py
+++ b/tileops/kernels/conv/conv1d.py
@@ -36,7 +36,7 @@ def _conv1d_kernel(
         block_k: int,
         num_stages: int,
         threads: int,
-        enable_rasteration: bool,
+        enable_rasterization: bool,
     ):
         @T.prim_func
         def _conv1d_main(
@@ -58,7 +58,7 @@ def _conv1d_kernel(
                 weight_flat = T.Tensor((k_total, c_out), dtype, weight.data)
                 out_flat = T.Tensor((n * out_l, c_out), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasteration)
+                T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -128,14 +128,14 @@ def _conv1d_wrapped_kernel(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
         n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasteration)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
 @_conv1d_wrapped_kernel.register_fake
@@ -154,7 +154,7 @@ def _(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
     out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
@@ -215,7 +215,7 @@ class Conv1dKernel(Kernel):
                 "block_k": 64,
                 "num_stages": 3,
                 "threads": 128,
-                "enable_rasteration": True,
+                "enable_rasterization": True,
             }
         return {
             "block_m": 128,
@@ -223,7 +223,7 @@ class Conv1dKernel(Kernel):
             "block_k": 64,
             "num_stages": 2,
             "threads": 128,
-            "enable_rasteration": True,
+            "enable_rasterization": True,
         }
 
     @property
@@ -238,7 +238,7 @@ class Conv1dKernel(Kernel):
             [True],
         )
         valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasteration in configs:
+        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
             shared_memory_bytes = conv_shared_memory_bytes(
                 block_m, block_n, block_k, num_stages, self.dtype)
             if shared_memory_bytes > shared_memory_limit_bytes:
@@ -249,7 +249,7 @@ class Conv1dKernel(Kernel):
                 "block_k": block_k,
                 "num_stages": num_stages,
                 "threads": threads,
-                "enable_rasteration": enable_rasteration,
+                "enable_rasterization": enable_rasterization,
             })
         return valid_configs
 
@@ -278,7 +278,7 @@ class Conv1dKernel(Kernel):
             self.config["block_k"],
             self.config["num_stages"],
             self.config["threads"],
-            self.config["enable_rasteration"],
+            self.config["enable_rasterization"],
             x,
             weight_kio,
             bias,

--- a/tileops/kernels/conv/conv2d.py
+++ b/tileops/kernels/conv/conv2d.py
@@ -39,7 +39,7 @@ def _conv2d_1x1_kernel(
         block_k: int,
         num_stages: int,
         threads: int,
-        enable_rasteration: bool,
+        enable_rasterization: bool,
     ):
         @T.prim_func
         def _conv2d_1x1_main(
@@ -61,7 +61,7 @@ def _conv2d_1x1_kernel(
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
 
-                T.use_swizzle(10, enable=enable_rasteration)
+                T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(c_in, block_k), num_stages=num_stages):
@@ -120,7 +120,7 @@ def _conv2d_kernel(
         block_k: int,
         num_stages: int,
         threads: int,
-        enable_rasteration: bool,
+        enable_rasterization: bool,
     ):
         @T.prim_func
         def _conv2d_main(
@@ -149,7 +149,7 @@ def _conv2d_kernel(
                 weight_flat = T.Tensor((k_total, c_out), dtype, weight.data)
                 out_flat = T.Tensor((n * out_h * out_w, c_out), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasteration)
+                T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -229,14 +229,14 @@ def _conv2d_1x1_wrapped_kernel(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv2d_1x1_kernel(
         n, c_in, h, w, c_out, 1, 1, 0, 0, True, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasteration)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
 @_conv2d_1x1_wrapped_kernel.register_fake
@@ -252,7 +252,7 @@ def _(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
     return torch.empty((n, h, w, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
@@ -278,14 +278,14 @@ def _conv2d_wrapped_kernel(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv2d_kernel(
         n, c_in, h, w, c_out, kernel_h, kernel_w, stride_h, stride_w, pad_h, pad_w, has_bias, dtype
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasteration)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
 @_conv2d_wrapped_kernel.register_fake
@@ -308,7 +308,7 @@ def _(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
     out_h = (h + 2 * pad_h - kernel_h) // stride_h + 1
@@ -382,7 +382,7 @@ class Conv2dKernel(Kernel):
                 "block_k": 64,
                 "num_stages": 3,
                 "threads": 128,
-                "enable_rasteration": False,
+                "enable_rasterization": False,
             }
         if sm_version in {80}:
             return {
@@ -391,7 +391,7 @@ class Conv2dKernel(Kernel):
                 "block_k": 64,
                 "threads": 128,
                 "num_stages": 2,
-                "enable_rasteration": True,
+                "enable_rasterization": True,
             }
         return {
             "block_m": 64,
@@ -399,7 +399,7 @@ class Conv2dKernel(Kernel):
             "block_k": 64,
             "threads": 128,
             "num_stages": 2,
-            "enable_rasteration": True,
+            "enable_rasterization": True,
         }
 
     @property
@@ -414,7 +414,7 @@ class Conv2dKernel(Kernel):
             [True],
         )
         valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasteration in configs:
+        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
             shared_memory_bytes = conv_shared_memory_bytes(
                 block_m, block_n, block_k, num_stages, self.dtype)
             if shared_memory_bytes > shared_memory_limit_bytes:
@@ -425,7 +425,7 @@ class Conv2dKernel(Kernel):
                 "block_k": block_k,
                 "num_stages": num_stages,
                 "threads": threads,
-                "enable_rasteration": enable_rasteration,
+                "enable_rasterization": enable_rasterization,
             })
         return valid_configs
 
@@ -458,7 +458,7 @@ class Conv2dKernel(Kernel):
             self.config["block_k"],
             self.config["num_stages"],
             self.config["threads"],
-            self.config["enable_rasteration"],
+            self.config["enable_rasterization"],
             x,
             weight_hwcf,
             bias,
@@ -522,7 +522,7 @@ class Conv2d1x1Kernel(Kernel):
                 "block_k": 64,
                 "num_stages": 1,
                 "threads": 128,
-                "enable_rasteration": True,
+                "enable_rasterization": True,
             }
         if sm_version in {90}:
             return {
@@ -531,7 +531,7 @@ class Conv2d1x1Kernel(Kernel):
                 "block_k": 128,
                 "num_stages": 2,
                 "threads": 128,
-                "enable_rasteration": True,
+                "enable_rasterization": True,
             }
         return {
             "block_m": 64,
@@ -539,7 +539,7 @@ class Conv2d1x1Kernel(Kernel):
             "block_k": 64,
             "num_stages": 1,
             "threads": 128,
-            "enable_rasteration": True,
+            "enable_rasterization": True,
         }
 
     @property
@@ -554,7 +554,7 @@ class Conv2d1x1Kernel(Kernel):
             [True],
         )
         valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasteration in configs:
+        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
             shared_memory_bytes = conv_shared_memory_bytes(
                 block_m, block_n, block_k, num_stages, self.dtype)
             if shared_memory_bytes > shared_memory_limit_bytes:
@@ -565,7 +565,7 @@ class Conv2d1x1Kernel(Kernel):
                 "block_k": block_k,
                 "num_stages": num_stages,
                 "threads": threads,
-                "enable_rasteration": enable_rasteration,
+                "enable_rasterization": enable_rasterization,
             })
         return valid_configs
 
@@ -591,7 +591,7 @@ class Conv2d1x1Kernel(Kernel):
             self.config["block_k"],
             self.config["num_stages"],
             self.config["threads"],
-            self.config["enable_rasteration"],
+            self.config["enable_rasterization"],
             x,
             weight_oc_ci,
             bias,

--- a/tileops/kernels/conv/conv3d.py
+++ b/tileops/kernels/conv/conv3d.py
@@ -46,7 +46,7 @@ def _conv3d_kernel(
         block_k: int,
         num_stages: int,
         threads: int,
-        enable_rasteration: bool,
+        enable_rasterization: bool,
     ):
         @T.prim_func
         def _conv3d_main(
@@ -68,7 +68,7 @@ def _conv3d_kernel(
                 weight_flat = T.Tensor((k_total, c_out), dtype, weight.data)
                 out_flat = T.Tensor((n * out_d * out_h * out_w, c_out), dtype, out.data)
 
-                T.use_swizzle(10, enable=enable_rasteration)
+                T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
@@ -157,7 +157,7 @@ def _conv3d_wrapped_kernel(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     x: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
@@ -180,7 +180,7 @@ def _conv3d_wrapped_kernel(
         pad_w,
         has_bias,
         dtype,
-    )(block_m, block_n, block_k, num_stages, threads, enable_rasteration)(x, weight, bias)
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
 @_conv3d_wrapped_kernel.register_fake
@@ -207,7 +207,7 @@ def _(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
     out_d = (d_in + 2 * pad_d - kernel_d) // stride_d + 1
@@ -296,7 +296,7 @@ class Conv3dKernel(Kernel):
                 "block_k": 64,
                 "num_stages": 3,
                 "threads": 128,
-                "enable_rasteration": True,
+                "enable_rasterization": True,
             }
         return {
             "block_m": 64,
@@ -304,7 +304,7 @@ class Conv3dKernel(Kernel):
             "block_k": 64,
             "num_stages": 2,
             "threads": 128,
-            "enable_rasteration": True,
+            "enable_rasterization": True,
         }
 
     @property
@@ -319,7 +319,7 @@ class Conv3dKernel(Kernel):
             [True],
         )
         valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasteration in configs:
+        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
             shared_memory_bytes = conv_shared_memory_bytes(
                 block_m, block_n, block_k, num_stages, self.dtype)
             if shared_memory_bytes > shared_memory_limit_bytes:
@@ -330,7 +330,7 @@ class Conv3dKernel(Kernel):
                 "block_k": block_k,
                 "num_stages": num_stages,
                 "threads": threads,
-                "enable_rasteration": enable_rasteration,
+                "enable_rasterization": enable_rasterization,
             })
         return valid_configs
 
@@ -367,7 +367,7 @@ class Conv3dKernel(Kernel):
             self.config["block_k"],
             self.config["num_stages"],
             self.config["threads"],
-            self.config["enable_rasteration"],
+            self.config["enable_rasterization"],
             x,
             weight_kdhwio,
             bias,

--- a/tileops/kernels/gemm/gemm.py
+++ b/tileops/kernels/gemm/gemm.py
@@ -25,7 +25,7 @@ def _gemm_kernel(m: int,
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _gemm_func(block_m: int, block_n: int, block_k: int, threads: int, num_stages: int,
-                   enable_rasteration: bool) -> Callable:
+                   enable_rasterization: bool) -> Callable:
 
         a_shape = (k, m) if trans_a else (m, k)
         b_shape = (n, k) if trans_b else (k, n)
@@ -48,7 +48,7 @@ def _gemm_kernel(m: int,
                 T.annotate_layout({
                     c_shared: tilelang.layout.make_swizzled_layout(c_shared),
                 })
-                T.use_swizzle(10, enable=enable_rasteration)
+                T.use_swizzle(10, enable=enable_rasterization)
 
                 T.clear(c_local)
 
@@ -89,19 +89,19 @@ def _gemm_wrapped_kernel(
     block_k: int,
     num_stages: int,
     threads: int,
-    enable_rasteration: bool,
+    enable_rasterization: bool,
     a: torch.Tensor,
     b: torch.Tensor,
 ) -> torch.Tensor:
     return _gemm_kernel(m, n, k, trans_a, trans_b, dtype)(block_m, block_n, block_k, threads,
-                                                          num_stages, enable_rasteration)(a, b)
+                                                          num_stages, enable_rasterization)(a, b)
 
 
 @_gemm_wrapped_kernel.register_fake
 def _(m: int, n: int, k: int,
       trans_a: bool, trans_b: bool,
       dtype: str, block_m: int, block_n: int, block_k: int,
-      num_stages: int, threads: int, enable_rasteration: bool,
+      num_stages: int, threads: int, enable_rasterization: bool,
       *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
     return torch.empty((m, n), dtype=inputs[0].dtype, device=inputs[0].device)
 
@@ -142,7 +142,7 @@ class GemmKernel(Kernel):
                 "block_k": 32,
                 "num_stages": 2,
                 "threads": 128,
-                "enable_rasteration": True
+                "enable_rasterization": True
             }
         if sm_version in {90}:
             return {
@@ -151,7 +151,7 @@ class GemmKernel(Kernel):
                 "block_k": 64,
                 "num_stages": 3,
                 "threads": 256,
-                "enable_rasteration": True
+                "enable_rasterization": True
             }
 
         return {
@@ -160,7 +160,7 @@ class GemmKernel(Kernel):
             "block_k": 32,
             "num_stages": 0,
             "threads": 128,
-            "enable_rasteration": True
+            "enable_rasterization": True
         }
 
     @property
@@ -171,9 +171,9 @@ class GemmKernel(Kernel):
         block_k = [32, 64]
         num_stages = [0, 1, 2, 3]
         threads = [128, 256]
-        enable_rasteration = [True, False]
+        enable_rasterization = [True, False]
         _configs = list(
-            itertools.product(block_m, block_n, block_k, num_stages, threads, enable_rasteration))
+            itertools.product(block_m, block_n, block_k, num_stages, threads, enable_rasterization))
 
         return [{
             'block_m': c[0],
@@ -181,14 +181,14 @@ class GemmKernel(Kernel):
             'block_k': c[2],
             'num_stages': c[3],
             'threads': c[4],
-            'enable_rasteration': c[5]
+            'enable_rasterization': c[5]
         } for c in _configs]
 
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return _gemm_wrapped_kernel(self.m, self.n, self.k, self.trans_a, self.trans_b,
                                     self.dtype_str, self.config["block_m"], self.config["block_n"],
                                     self.config["block_k"], self.config["num_stages"],
-                                    self.config["threads"], self.config["enable_rasteration"], a, b)
+                                    self.config["threads"], self.config["enable_rasterization"], a, b)
 
 
 # TODO: add persistent, split-k, steam-k...

--- a/tileops/kernels/moe/shared_expert_mlp.py
+++ b/tileops/kernels/moe/shared_expert_mlp.py
@@ -12,7 +12,7 @@ from tileops.kernels.kernel import Kernel
 
 __all__ = ["SharedExpertMLPKernel"]
 
-_DEFAULT_CONFIG = {"block_m": 128, "block_n": 256, "block_k": 64, "num_stages": 3, "threads": 256, "enable_rasteration": True}
+_DEFAULT_CONFIG = {"block_m": 128, "block_n": 256, "block_k": 64, "num_stages": 3, "threads": 256, "enable_rasterization": True}
 
 
 @functools.lru_cache(maxsize=16)


### PR DESCRIPTION
## Background

During PR #778 review, `enable_rasteration` was flagged as a likely typo in `SharedExpertMLPKernel`. Investigation confirmed the misspelling was introduced early and copy-pasted across all kernel `_DEFAULT_CONFIG` dictionaries — affecting GEMM, Conv1D/2D/3D, and MoE kernels.

> Note: the flag was **not** silently ignored. It is consumed correctly as a local variable passed to `T.use_swizzle(enable=...)`. This is a spelling-only fix with no behavioral change.

## Changes

Renamed `enable_rasteration` → `enable_rasterization` across 5 files, 55 occurrences:

| File | Occurrences |
|------|-------------|
| `tileops/kernels/gemm/gemm.py` | 12 |
| `tileops/kernels/conv/conv2d.py` | 22 |
| `tileops/kernels/conv/conv1d.py` | 10 |
| `tileops/kernels/conv/conv3d.py` | 10 |
| `tileops/kernels/moe/shared_expert_mlp.py` | 1 |

Single atomic commit — no partial renames, no behavioral change.

## Acceptance Criteria

- [x] AC-1: Zero occurrences of `enable_rasteration` remain in the codebase
- [x] AC-2: All existing kernel tests pass (`test_gemm`: 21/21, `test_conv1d/2d/3d`: 29/29)

Closes #829