### PR TITLE
[Perf][MoE] Add pre_sharded fast path for SharedFusedMoE TP weight slicing

### DIFF
--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -218,10 +218,20 @@ def test_shared_fused_moe_bench(
     )
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    # ── TileOPs pre_sharded (tp_size=1, weights pre-sliced by caller) ─────────
-    # tp_size=1 is the single-GPU case; with pre_sharded=True the caller owns
-    # weight layout — no internal cat/contiguous on every forward() call.
-    # Demonstrates zero transient shared-weight alloc path.
+    # ── TileOPs pre_sharded (tp_size=2, rank=0, weights pre-sliced by caller) ──
+    # Simulates the TP use-case: caller pre-slices weights at model-load time so
+    # forward() skips the internal cat/narrow/contiguous on every call.
+    # This is the path the optimization is designed to accelerate.
+    _tp_size = 2
+    _tp_rank = 0
+    _shard = shared_ffn_size // _tp_size
+    # Pre-slice: gate[r*s:(r+1)*s] + up[r*s:(r+1)*s] → [2*s, H], down → [H, s]
+    _gate_up_local = torch.cat([
+        shared_w_gate_up[_tp_rank * _shard : (_tp_rank + 1) * _shard],
+        shared_w_gate_up[shared_ffn_size + _tp_rank * _shard : shared_ffn_size + (_tp_rank + 1) * _shard],
+    ], dim=0).contiguous()
+    _down_local = shared_w_down[:, _tp_rank * _shard : (_tp_rank + 1) * _shard].contiguous()
+
     op_pre = SharedFusedMoE(
         num_tokens=num_tokens,
         num_experts=num_experts,
@@ -235,23 +245,22 @@ def test_shared_fused_moe_bench(
         layout="nopad",
         dtype=dtype,
         shared_ffn_size=shared_ffn_size,
-        tp_size=1,
-        tp_rank=0,
+        tp_size=_tp_size,
+        tp_rank=_tp_rank,
         pre_sharded=True,
     )
-    # With tp_size=1 the shard == full weights; no slicing occurs either way.
     op_pre(hidden, gating, w_gate_up, w_down, correction_bias,
-           shared_w_gate_up=shared_w_gate_up, shared_w_down=shared_w_down)  # warmup
+           shared_w_gate_up=_gate_up_local, shared_w_down=_down_local)  # warmup
     torch.cuda.synchronize()
 
     def _tileops_pre_fn(hidden, gating, w_gate_up, w_down, correction_bias,
-                        shared_w_gate_up, shared_w_down):
+                        gate_up_local, down_local):
         return op_pre(hidden, gating, w_gate_up, w_down, correction_bias,
-                      shared_w_gate_up=shared_w_gate_up, shared_w_down=shared_w_down)
+                      shared_w_gate_up=gate_up_local, shared_w_down=down_local)
 
     result_pre = bm.profile(
         _tileops_pre_fn, hidden, gating, w_gate_up, w_down, correction_bias,
-        shared_w_gate_up, shared_w_down,
+        _gate_up_local, _down_local,
     )
     BenchmarkReport.record(op_pre, locals(), result_pre, tag="tileops-pre-sharded")
 

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -188,7 +188,7 @@ def test_shared_fused_moe_bench(
     bm = SharedFusedMoEBenchmark(test)
     hidden, gating, correction_bias, w_gate_up, w_down, shared_w_gate_up, shared_w_down = test.gen_inputs()
 
-    # ── TileOPs ───────────────────────────────────────────────────────────────
+    # ── TileOPs (stateless: full weights, op slices internally) ──────────────
     op = SharedFusedMoE(
         num_tokens=num_tokens,
         num_experts=num_experts,
@@ -217,6 +217,43 @@ def test_shared_fused_moe_bench(
         shared_w_gate_up, shared_w_down,
     )
     BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    # ── TileOPs pre_sharded (tp_size=1, weights pre-sliced by caller) ─────────
+    # tp_size=1 is the single-GPU case; with pre_sharded=True the caller owns
+    # weight layout — no internal cat/contiguous on every forward() call.
+    # Demonstrates zero transient shared-weight alloc path.
+    op_pre = SharedFusedMoE(
+        num_tokens=num_tokens,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        scoring_func=scoring_func,
+        renormalize=renormalize,
+        with_correction_bias=with_correction_bias,
+        routed_scaling_factor=routed_scaling_factor,
+        layout="nopad",
+        dtype=dtype,
+        shared_ffn_size=shared_ffn_size,
+        tp_size=1,
+        tp_rank=0,
+        pre_sharded=True,
+    )
+    # With tp_size=1 the shard == full weights; no slicing occurs either way.
+    op_pre(hidden, gating, w_gate_up, w_down, correction_bias,
+           shared_w_gate_up=shared_w_gate_up, shared_w_down=shared_w_down)  # warmup
+    torch.cuda.synchronize()
+
+    def _tileops_pre_fn(hidden, gating, w_gate_up, w_down, correction_bias,
+                        shared_w_gate_up, shared_w_down):
+        return op_pre(hidden, gating, w_gate_up, w_down, correction_bias,
+                      shared_w_gate_up=shared_w_gate_up, shared_w_down=shared_w_down)
+
+    result_pre = bm.profile(
+        _tileops_pre_fn, hidden, gating, w_gate_up, w_down, correction_bias,
+        shared_w_gate_up, shared_w_down,
+    )
+    BenchmarkReport.record(op_pre, locals(), result_pre, tag="tileops-pre-sharded")
 
     # ── vLLM baseline (optional) ──────────────────────────────────────────────
     if _VLLM_AVAILABLE:

--- a/tests/ops/test_moe_shared_fused_moe.py
+++ b/tests/ops/test_moe_shared_fused_moe.py
@@ -209,3 +209,207 @@ def test_shared_fused_moe_tp_rejects_local_shards():
            shared_w_gate_up=good_gate_up, shared_w_down=bad_w_down)
 
     print("PASS SharedFusedMoE TP rejects TP-local shards")
+
+
+@pytest.mark.smoke
+def test_shared_fused_moe_pre_sharded_matches_stateless():
+    """pre_sharded=True must produce identical output to pre_sharded=False (stateless).
+
+    Uses bfloat16 to match the kernel's default dtype.
+    Slices weights with exactly the same logic forward() uses internally, then
+    passes them via pre_sharded=True and asserts exact bit-for-bit match
+    (rtol=0, atol=0 is valid here: both paths feed identical tensors to the
+    same deterministic kernel — no rounding differences are introduced).
+
+    routed_out is not compared because pre_sharded only affects the shared
+    expert path; the routed expert call (super().forward()) is unchanged.
+    """
+    torch.manual_seed(42)
+    T, E, K, H, F, F_s = 32, 8, 2, 64, 32, 16
+    tp_size = 2
+    dtype = torch.bfloat16
+    dev = "cuda"
+
+    hidden = torch.randn(T, H, dtype=dtype, device=dev)
+    gating = torch.randn(T, E, dtype=dtype, device=dev)
+    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    shared_w_gate_up = torch.randn(F_s * 2, H, dtype=dtype, device=dev) * 0.02
+    shared_w_down = torch.randn(H, F_s, dtype=dtype, device=dev) * 0.02
+
+    for tp_rank in range(tp_size):
+        shard_size = F_s // tp_size
+        r, s = tp_rank, shard_size
+
+        # Stateless path (full weights, op shards internally)
+        op_stateless = SharedFusedMoE(
+            num_tokens=T, num_experts=E, top_k=K,
+            hidden_size=H, ffn_size=F,
+            scoring_func="softmax", renormalize=False,
+            layout="nopad", dtype=dtype,
+            shared_ffn_size=F_s,
+            tp_size=tp_size, tp_rank=tp_rank,
+        )
+        shared_stateless, _ = op_stateless(
+            hidden, gating, w_gate_up, w_down,
+            shared_w_gate_up=shared_w_gate_up,
+            shared_w_down=shared_w_down,
+        )
+
+        # Pre-shard weights manually (same logic as forward() does internally)
+        gate_up_local = torch.cat([
+            shared_w_gate_up[r * s : (r + 1) * s],
+            shared_w_gate_up[F_s + r * s : F_s + (r + 1) * s],
+        ], dim=0).contiguous()  # [2*s, H]
+        down_local = shared_w_down[:, r * s : (r + 1) * s].contiguous()  # [H, s]
+
+        # pre_sharded path (TP-local weights, no internal slicing)
+        op_pre = SharedFusedMoE(
+            num_tokens=T, num_experts=E, top_k=K,
+            hidden_size=H, ffn_size=F,
+            scoring_func="softmax", renormalize=False,
+            layout="nopad", dtype=dtype,
+            shared_ffn_size=F_s,
+            tp_size=tp_size, tp_rank=tp_rank,
+            pre_sharded=True,
+        )
+        shared_pre, _ = op_pre(
+            hidden, gating, w_gate_up, w_down,
+            shared_w_gate_up=gate_up_local,
+            shared_w_down=down_local,
+        )
+
+        # rtol=0, atol=0: both paths feed identical tensors to the kernel,
+        # so outputs must be bit-for-bit equal (SharedExpertMLPKernel is deterministic).
+        torch.testing.assert_close(shared_pre, shared_stateless, rtol=0, atol=0)
+
+    print(f"PASS pre_sharded matches stateless [tp_size={tp_size}]")
+
+
+@pytest.mark.smoke
+def test_shared_fused_moe_pre_sharded_rejects_full_weights():
+    """pre_sharded=True must raise ValueError when full weights are passed.
+
+    The error message must mention 'pre_sharded=True' so callers can diagnose
+    the mismatch. This is distinct from the stateless-path error ('full weights').
+    """
+    T, E, K, H, F, F_s, tp_size = 32, 8, 2, 64, 32, 16, 2
+    dtype = torch.bfloat16
+    dev = "cuda"
+
+    op = SharedFusedMoE(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F,
+        scoring_func="softmax", renormalize=False,
+        layout="nopad", dtype=dtype,
+        shared_ffn_size=F_s,
+        tp_size=tp_size, tp_rank=0,
+        pre_sharded=True,
+    )
+    hidden = torch.randn(T, H, dtype=dtype, device=dev)
+    gating = torch.randn(T, E, dtype=dtype, device=dev)
+    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    shard_size = F_s // tp_size
+
+    # Pass full gate_up (wrong shape) → must raise with pre_sharded=True mention
+    full_gate_up = torch.randn(2 * F_s, H, dtype=dtype, device=dev)
+    good_down_shard = torch.randn(H, shard_size, dtype=dtype, device=dev)
+    with pytest.raises(ValueError, match="pre_sharded=True"):
+        op(hidden, gating, w_gate_up, w_down,
+           shared_w_gate_up=full_gate_up, shared_w_down=good_down_shard)
+
+    # Pass full down (wrong shape) → must raise with pre_sharded=True mention
+    good_gate_up_shard = torch.randn(2 * shard_size, H, dtype=dtype, device=dev)
+    full_down = torch.randn(H, F_s, dtype=dtype, device=dev)
+    with pytest.raises(ValueError, match="pre_sharded=True"):
+        op(hidden, gating, w_gate_up, w_down,
+           shared_w_gate_up=good_gate_up_shard, shared_w_down=full_down)
+
+    print("PASS pre_sharded=True rejects full weights with clear error message")
+
+
+@pytest.mark.smoke
+def test_shared_fused_moe_pre_sharded_zero_transient_alloc():
+    """AC-2: pre_sharded=True must not allocate shard copy buffers in forward().
+
+    The stateless path allocates gate_up_shard [2*s, H] and down_shard [H, s]
+    via cat+contiguous on every forward() call (~95 MB at Kimi K2 tp8 scale).
+    pre_sharded=True must not allocate these copies.
+
+    Measurement strategy:
+      - Use large enough H/F_s so shard_alloc_bytes >> other forward() allocations.
+      - Warmup first to eliminate JIT/kernel-cache allocations.
+      - Compare (pre_sharded=True delta) vs (pre_sharded=False delta):
+        the difference should be approximately shard_alloc_bytes.
+      - pre_sharded=True delta must be < shard_alloc_bytes (no weight copies).
+      - pre_sharded=False delta must be >= shard_alloc_bytes (copies present).
+    """
+    # Use larger dims so shard copies (MB-scale) dominate over output tensors (KB-scale)
+    T, E, K, H, F, F_s, tp_size = 16, 8, 2, 512, 32, 512, 2
+    dtype = torch.bfloat16
+    dev = "cuda"
+    shard_size = F_s // tp_size
+
+    # Shard copy budget: gate_up_shard [2*s, H] + down_shard [H, s], bfloat16 = 2 bytes
+    # With H=512, s=256: 2*256*512*2 + 512*256*2 = 524288 + 262144 = 786432 bytes (~768KB)
+    shard_alloc_bytes = (2 * shard_size * H + H * shard_size) * 2
+
+    shared_w_gate_up = torch.randn(F_s * 2, H, dtype=dtype, device=dev) * 0.02
+    shared_w_down = torch.randn(H, F_s, dtype=dtype, device=dev) * 0.02
+    gate_up_local = torch.cat([
+        shared_w_gate_up[:shard_size],
+        shared_w_gate_up[F_s : F_s + shard_size],
+    ], dim=0).contiguous()
+    down_local = shared_w_down[:, :shard_size].contiguous()
+
+    hidden = torch.randn(T, H, dtype=dtype, device=dev)
+    gating = torch.randn(T, E, dtype=dtype, device=dev)
+    w_gate_up_r = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down_r = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+
+    def make_op(pre_sharded):
+        return SharedFusedMoE(
+            num_tokens=T, num_experts=E, top_k=K,
+            hidden_size=H, ffn_size=F,
+            scoring_func="softmax", renormalize=False,
+            layout="nopad", dtype=dtype,
+            shared_ffn_size=F_s,
+            tp_size=tp_size, tp_rank=0,
+            pre_sharded=pre_sharded,
+        )
+
+    def measure_transient(op, w_gate_up_arg, w_down_arg):
+        """Returns (peak - before) bytes during a single post-warmup forward()."""
+        # Warmup: eliminates JIT, kernel cache, and first-call allocations
+        op(hidden, gating, w_gate_up_r, w_down_r,
+           shared_w_gate_up=w_gate_up_arg, shared_w_down=w_down_arg)
+        torch.cuda.synchronize()
+        # Measure
+        torch.cuda.reset_peak_memory_stats(dev)
+        before = torch.cuda.memory_allocated(dev)
+        op(hidden, gating, w_gate_up_r, w_down_r,
+           shared_w_gate_up=w_gate_up_arg, shared_w_down=w_down_arg)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated(dev)
+        return peak - before
+
+    pre_delta = measure_transient(make_op(True), gate_up_local, down_local)
+    stateless_delta = measure_transient(make_op(False), shared_w_gate_up, shared_w_down)
+
+    # pre_sharded=True: delta must be below shard copy budget (no weight copies)
+    assert pre_delta < shard_alloc_bytes, (
+        f"pre_sharded=True allocated {pre_delta} bytes, expected < {shard_alloc_bytes} "
+        f"(shard copy budget = {shard_alloc_bytes // 1024}KB). "
+        f"Weight copies are being made unexpectedly."
+    )
+    # pre_sharded=False: delta must be at least shard copy budget (copies present)
+    assert stateless_delta >= shard_alloc_bytes, (
+        f"pre_sharded=False allocated {stateless_delta} bytes, expected >= {shard_alloc_bytes}. "
+        f"Shard copies may have been optimised away unexpectedly."
+    )
+    print(
+        f"PASS transient alloc: pre_sharded=True={pre_delta // 1024}KB "
+        f"(< {shard_alloc_bytes // 1024}KB threshold), "
+        f"pre_sharded=False={stateless_delta // 1024}KB"
+    )

--- a/tests/ops/test_moe_shared_fused_moe.py
+++ b/tests/ops/test_moe_shared_fused_moe.py
@@ -6,10 +6,14 @@ Verifies:
   - routed_output matches FusedMoe output
   - When shared_ffn_size=None, shared_output is None
   - TP sharding: partial outputs sum to float32 math reference
+  - pre_sharded=True: output is bit-for-bit identical to stateless path
+  - pre_sharded=True: rejects full weights with a clear ValueError
+  - pre_sharded=True: does not allocate shard copy buffers in forward()
 """
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 from tileops.ops.moe import FusedMoe, SharedFusedMoE
 
@@ -102,15 +106,15 @@ def test_shared_fused_moe_tp():
     TP-sharded and single-GPU computation paths.
     """
     torch.manual_seed(42)
-    T, E, K, H, F, F_s = 32, 8, 2, 64, 32, 16
+    T, E, K, H, ffn, F_s = 32, 8, 2, 64, 32, 16
     tp_size = 2
     dtype = torch.bfloat16
     dev = "cuda"
 
     hidden = torch.randn(T, H, dtype=dtype, device=dev)
     gating = torch.randn(T, E, dtype=dtype, device=dev)
-    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
-    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    w_gate_up = torch.randn(E, ffn * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, ffn, dtype=dtype, device=dev) * 0.02
     shared_w_gate_up = torch.randn(F_s * 2, H, dtype=dtype, device=dev) * 0.02
     shared_w_down = torch.randn(H, F_s, dtype=dtype, device=dev) * 0.02
 
@@ -126,13 +130,13 @@ def test_shared_fused_moe_tp():
         down_shard = shared_w_down[:, tp_rank * shard_size: (tp_rank + 1) * shard_size]              # [H, shard]
         gate_up_out = hidden.float() @ gate_up_shard.float().T     # [T, 2*shard]
         gate, up = gate_up_out.chunk(2, dim=1)
-        act = gate * torch.sigmoid(gate) * up                       # [T, shard]
+        act = F.silu(gate) * up                              # [T, shard]
         partial_sum_ref += act @ down_shard.float().T               # [T, H]
 
     # routed reference (not affected by TP)
     op_routed = FusedMoe(
         num_tokens=T, num_experts=E, top_k=K,
-        hidden_size=H, ffn_size=F,
+        hidden_size=H, ffn_size=ffn,
         scoring_func="softmax", renormalize=False,
         layout="nopad", dtype=dtype,
     )
@@ -143,7 +147,7 @@ def test_shared_fused_moe_tp():
     for tp_rank in range(tp_size):
         op_tp = SharedFusedMoE(
             num_tokens=T, num_experts=E, top_k=K,
-            hidden_size=H, ffn_size=F,
+            hidden_size=H, ffn_size=ffn,
             scoring_func="softmax", renormalize=False,
             layout="nopad", dtype=dtype,
             shared_ffn_size=F_s,
@@ -174,13 +178,13 @@ def test_shared_fused_moe_tp_rejects_local_shards():
     full weights. Passing TP-local shards would silently produce wrong results
     without this guard.
     """
-    T, E, K, H, F, F_s, tp_size = 32, 8, 2, 64, 32, 16, 2
+    T, E, K, H, ffn, F_s, tp_size = 32, 8, 2, 64, 32, 16, 2
     dtype = torch.bfloat16
     dev = "cuda"
 
     op = SharedFusedMoE(
         num_tokens=T, num_experts=E, top_k=K,
-        hidden_size=H, ffn_size=F,
+        hidden_size=H, ffn_size=ffn,
         scoring_func="softmax", renormalize=False,
         layout="nopad", dtype=dtype,
         shared_ffn_size=F_s,
@@ -189,8 +193,8 @@ def test_shared_fused_moe_tp_rejects_local_shards():
 
     hidden = torch.randn(T, H, dtype=dtype, device=dev)
     gating = torch.randn(T, E, dtype=dtype, device=dev)
-    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
-    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    w_gate_up = torch.randn(E, ffn * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, ffn, dtype=dtype, device=dev) * 0.02
 
     shard_size = F_s // tp_size
 
@@ -212,7 +216,8 @@ def test_shared_fused_moe_tp_rejects_local_shards():
 
 
 @pytest.mark.smoke
-def test_shared_fused_moe_pre_sharded_matches_stateless():
+@pytest.mark.parametrize("tp_size", [2, 4])
+def test_shared_fused_moe_pre_sharded_matches_stateless(tp_size):
     """pre_sharded=True must produce identical output to pre_sharded=False (stateless).
 
     Uses bfloat16 to match the kernel's default dtype.
@@ -225,15 +230,15 @@ def test_shared_fused_moe_pre_sharded_matches_stateless():
     expert path; the routed expert call (super().forward()) is unchanged.
     """
     torch.manual_seed(42)
-    T, E, K, H, F, F_s = 32, 8, 2, 64, 32, 16
-    tp_size = 2
+    # F_s=32 is divisible by both tp_size=2 and tp_size=4 (parametrized above)
+    T, E, K, H, ffn, F_s = 32, 8, 2, 64, 32, 32
     dtype = torch.bfloat16
     dev = "cuda"
 
     hidden = torch.randn(T, H, dtype=dtype, device=dev)
     gating = torch.randn(T, E, dtype=dtype, device=dev)
-    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
-    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    w_gate_up = torch.randn(E, ffn * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, ffn, dtype=dtype, device=dev) * 0.02
     shared_w_gate_up = torch.randn(F_s * 2, H, dtype=dtype, device=dev) * 0.02
     shared_w_down = torch.randn(H, F_s, dtype=dtype, device=dev) * 0.02
 
@@ -244,7 +249,7 @@ def test_shared_fused_moe_pre_sharded_matches_stateless():
         # Stateless path (full weights, op shards internally)
         op_stateless = SharedFusedMoE(
             num_tokens=T, num_experts=E, top_k=K,
-            hidden_size=H, ffn_size=F,
+            hidden_size=H, ffn_size=ffn,
             scoring_func="softmax", renormalize=False,
             layout="nopad", dtype=dtype,
             shared_ffn_size=F_s,
@@ -266,7 +271,7 @@ def test_shared_fused_moe_pre_sharded_matches_stateless():
         # pre_sharded path (TP-local weights, no internal slicing)
         op_pre = SharedFusedMoE(
             num_tokens=T, num_experts=E, top_k=K,
-            hidden_size=H, ffn_size=F,
+            hidden_size=H, ffn_size=ffn,
             scoring_func="softmax", renormalize=False,
             layout="nopad", dtype=dtype,
             shared_ffn_size=F_s,
@@ -283,7 +288,7 @@ def test_shared_fused_moe_pre_sharded_matches_stateless():
         # so outputs must be bit-for-bit equal (SharedExpertMLPKernel is deterministic).
         torch.testing.assert_close(shared_pre, shared_stateless, rtol=0, atol=0)
 
-    print(f"PASS pre_sharded matches stateless [tp_size={tp_size}]")
+    print(f"PASS pre_sharded matches stateless [tp_size={tp_size}, F_s={F_s}]")
 
 
 @pytest.mark.smoke
@@ -293,13 +298,13 @@ def test_shared_fused_moe_pre_sharded_rejects_full_weights():
     The error message must mention 'pre_sharded=True' so callers can diagnose
     the mismatch. This is distinct from the stateless-path error ('full weights').
     """
-    T, E, K, H, F, F_s, tp_size = 32, 8, 2, 64, 32, 16, 2
+    T, E, K, H, ffn, F_s, tp_size = 32, 8, 2, 64, 32, 16, 2
     dtype = torch.bfloat16
     dev = "cuda"
 
     op = SharedFusedMoE(
         num_tokens=T, num_experts=E, top_k=K,
-        hidden_size=H, ffn_size=F,
+        hidden_size=H, ffn_size=ffn,
         scoring_func="softmax", renormalize=False,
         layout="nopad", dtype=dtype,
         shared_ffn_size=F_s,
@@ -308,8 +313,8 @@ def test_shared_fused_moe_pre_sharded_rejects_full_weights():
     )
     hidden = torch.randn(T, H, dtype=dtype, device=dev)
     gating = torch.randn(T, E, dtype=dtype, device=dev)
-    w_gate_up = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
-    w_down = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    w_gate_up = torch.randn(E, ffn * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, ffn, dtype=dtype, device=dev) * 0.02
     shard_size = F_s // tp_size
 
     # Pass full gate_up (wrong shape) → must raise with pre_sharded=True mention
@@ -346,7 +351,7 @@ def test_shared_fused_moe_pre_sharded_zero_transient_alloc():
       - pre_sharded=False delta must be >= shard_alloc_bytes (copies present).
     """
     # Use larger dims so shard copies (MB-scale) dominate over output tensors (KB-scale)
-    T, E, K, H, F, F_s, tp_size = 16, 8, 2, 512, 32, 512, 2
+    T, E, K, H, ffn, F_s, tp_size = 16, 8, 2, 512, 32, 512, 2
     dtype = torch.bfloat16
     dev = "cuda"
     shard_size = F_s // tp_size
@@ -365,13 +370,13 @@ def test_shared_fused_moe_pre_sharded_zero_transient_alloc():
 
     hidden = torch.randn(T, H, dtype=dtype, device=dev)
     gating = torch.randn(T, E, dtype=dtype, device=dev)
-    w_gate_up_r = torch.randn(E, F * 2, H, dtype=dtype, device=dev) * 0.02
-    w_down_r = torch.randn(E, H, F, dtype=dtype, device=dev) * 0.02
+    w_gate_up_r = torch.randn(E, ffn * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down_r = torch.randn(E, H, ffn, dtype=dtype, device=dev) * 0.02
 
     def make_op(pre_sharded):
         return SharedFusedMoE(
             num_tokens=T, num_experts=E, top_k=K,
-            hidden_size=H, ffn_size=F,
+            hidden_size=H, ffn_size=ffn,
             scoring_func="softmax", renormalize=False,
             layout="nopad", dtype=dtype,
             shared_ffn_size=F_s,

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -237,7 +237,6 @@ class SharedFusedMoE(FusedMoe):
                     down_shard = shared_w_down
                 else:
                     # Stateless path: slice full weights internally each forward() call.
-                    # Note: F_s already assigned above; no need to reassign.
                     shard_size = F_s // self.tp_size
                     r, s = self.tp_rank, shard_size
                     # shared_w_gate_up is [2*F_s, H]: first F_s rows = gate, last F_s rows = up.

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -230,23 +230,19 @@ class SharedFusedMoE(FusedMoe):
                         "Pass complete weights; the op shards them internally per tp_rank."
                     )
             # TP sharding: ColumnParallel on gate_up (dim=0), RowParallel on down (dim=1)
-            if self.tp_size > 1:
-                if self.pre_sharded:
-                    # Weights already sliced by caller — use directly, zero transient alloc.
-                    gate_up_shard = shared_w_gate_up
-                    down_shard = shared_w_down
-                else:
-                    # Stateless path: slice full weights internally each forward() call.
-                    shard_size = F_s // self.tp_size
-                    r, s = self.tp_rank, shard_size
-                    # shared_w_gate_up is [2*F_s, H]: first F_s rows = gate, last F_s rows = up.
-                    # ColumnParallel: rank r computes neurons [r*s, (r+1)*s), so it needs
-                    # gate[r*s:(r+1)*s] and up[r*s:(r+1)*s] concatenated into [2*s, H].
-                    gate_shard = shared_w_gate_up[r * s : (r + 1) * s]          # [s, H]
-                    up_shard   = shared_w_gate_up[F_s + r * s : F_s + (r + 1) * s]  # [s, H]
-                    gate_up_shard = torch.cat([gate_shard, up_shard], dim=0).contiguous()  # [2*s, H]
-                    down_shard = shared_w_down.narrow(1, r * s, s).contiguous()
+            if self.tp_size > 1 and not self.pre_sharded:
+                # Stateless path: slice full weights internally each forward() call.
+                shard_size = F_s // self.tp_size
+                r, s = self.tp_rank, shard_size
+                # shared_w_gate_up is [2*F_s, H]: first F_s rows = gate, last F_s rows = up.
+                # ColumnParallel: rank r computes neurons [r*s, (r+1)*s), so it needs
+                # gate[r*s:(r+1)*s] and up[r*s:(r+1)*s] concatenated into [2*s, H].
+                gate_shard = shared_w_gate_up[r * s : (r + 1) * s]          # [s, H]
+                up_shard   = shared_w_gate_up[F_s + r * s : F_s + (r + 1) * s]  # [s, H]
+                gate_up_shard = torch.cat([gate_shard, up_shard], dim=0)  # [2*s, H], cat is contiguous
+                down_shard = shared_w_down.narrow(1, r * s, s).contiguous()
             else:
+                # Weights already sliced (pre_sharded=True) or no slicing needed (tp_size=1).
                 gate_up_shard = shared_w_gate_up
                 down_shard = shared_w_down
 

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -243,8 +243,9 @@ class SharedFusedMoE(FusedMoe):
                 down_shard = shared_w_down.narrow(1, r * s, s).contiguous()
             else:
                 # Weights already sliced (pre_sharded=True) or no slicing needed (tp_size=1).
-                gate_up_shard = shared_w_gate_up
-                down_shard = shared_w_down
+                # Normalize contiguity: caller may pass non-contiguous views (e.g. slices).
+                gate_up_shard = shared_w_gate_up.contiguous()
+                down_shard = shared_w_down.contiguous()
 
             shared_out = self._shared_mlp_kernel(hidden_states, gate_up_shard, down_shard)
         else:

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -30,6 +30,24 @@ Usage (TP, tp_size>1):
     )
     # dist.all_reduce(shared_out_partial, group=tp_group)  ← caller's responsibility
     # Must use the TP process group, not the default group (important in EP/DP setups).
+
+Usage (TP, pre_sharded=True — weights already sliced at model-load time):
+    shard_size = F_s // tp_size
+    gate_up_local = torch.cat([
+        shared_w_gate_up[tp_rank*shard_size : (tp_rank+1)*shard_size],
+        shared_w_gate_up[F_s + tp_rank*shard_size : F_s + (tp_rank+1)*shard_size],
+    ], dim=0).contiguous()  # [2*shard_size, H]
+    down_local = shared_w_down[:, tp_rank*shard_size : (tp_rank+1)*shard_size].contiguous()
+
+    op = SharedFusedMoE(
+        ..., tp_size=tp_size, tp_rank=tp_rank, pre_sharded=True,
+    )
+    shared_out_partial, routed_out = op(
+        hidden, gating, w_gate_up, w_down,
+        shared_w_gate_up=gate_up_local,   # [2*shard_size, H]
+        shared_w_down=down_local,          # [H, shard_size]
+    )
+    # dist.all_reduce(shared_out_partial, group=tp_group)  ← caller's responsibility
 """
 
 from typing import Dict, Optional
@@ -61,6 +79,10 @@ class SharedFusedMoE(FusedMoe):
             before TP sharding). If None, no shared expert is computed.
         tp_size: Tensor parallel world size. Default 1 (no TP).
         tp_rank: This rank's index in the TP group. Default 0.
+        pre_sharded: If True, caller must pass TP-local weight shards directly
+            to forward() instead of full weights. The op will skip internal
+            slicing entirely. Only has effect when tp_size > 1 (tp_size=1 never
+            slices regardless). Default False.
         Other args: same as FusedMoe.
 
     Returns:
@@ -86,6 +108,7 @@ class SharedFusedMoE(FusedMoe):
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,
+        pre_sharded: bool = False,
     ):
         super().__init__(
             num_tokens=num_tokens,
@@ -116,6 +139,7 @@ class SharedFusedMoE(FusedMoe):
         self.shared_ffn_size = shared_ffn_size
         self.tp_size = tp_size
         self.tp_rank = tp_rank
+        self.pre_sharded = pre_sharded
 
         # Kernel operates on the local shard size
         self._shared_mlp_kernel = (
@@ -151,12 +175,14 @@ class SharedFusedMoE(FusedMoe):
             w_gate_up: [E, 2F, H] routed expert gate+up weights.
             w_down: [E, H, F] routed expert down weights.
             correction_bias: Optional [E] bias for Kimi-style routing.
-            shared_w_gate_up: [2*F_s, H] shared expert gate+up weights (full).
+            shared_w_gate_up: Shared expert gate+up weights.
+                When pre_sharded=False (default): full weights [2*F_s, H].
+                When pre_sharded=True: TP-local shard [2*(F_s//tp_size), H].
                 Required when shared_ffn_size is not None.
-                When tp_size > 1, sharded along dim=0 internally.
-            shared_w_down: [H, F_s] shared expert down weight (full).
+            shared_w_down: Shared expert down weight.
+                When pre_sharded=False (default): full weights [H, F_s].
+                When pre_sharded=True: TP-local shard [H, F_s//tp_size].
                 Required when shared_ffn_size is not None.
-                When tp_size > 1, sharded along dim=1 internally.
 
         Returns:
             (shared_output, routed_output): tuple of [T, H] tensors.
@@ -172,33 +198,55 @@ class SharedFusedMoE(FusedMoe):
                 )
             F_s = self.shared_ffn_size
             H = shared_w_gate_up.shape[1]
-            # Validate that caller passes full weights, not TP-local shards.
-            # In TP mode the op shards internally; passing pre-sharded weights
-            # would produce silently wrong results.
-            if shared_w_gate_up.shape != (2 * F_s, H):
-                raise ValueError(
-                    f"shared_w_gate_up must be full weights with shape ({2 * F_s}, {H}), "
-                    f"got {tuple(shared_w_gate_up.shape)}. "
-                    "Pass complete weights; the op shards them internally per tp_rank."
-                )
-            if shared_w_down.shape != (H, F_s):
-                raise ValueError(
-                    f"shared_w_down must be full weights with shape ({H}, {F_s}), "
-                    f"got {tuple(shared_w_down.shape)}. "
-                    "Pass complete weights; the op shards them internally per tp_rank."
-                )
+            # Validate shape — behaviour depends on pre_sharded flag.
+            if self.pre_sharded and self.tp_size > 1:
+                # Caller passes TP-local shards; validate shard shapes.
+                shard_size = self.shared_ffn_size // self.tp_size
+                if shared_w_gate_up.shape != (2 * shard_size, H):
+                    raise ValueError(
+                        f"pre_sharded=True: shared_w_gate_up must be TP-local shard "
+                        f"with shape ({2 * shard_size}, {H}), "
+                        f"got {tuple(shared_w_gate_up.shape)}."
+                    )
+                if shared_w_down.shape != (H, shard_size):
+                    raise ValueError(
+                        f"pre_sharded=True: shared_w_down must be TP-local shard "
+                        f"with shape ({H}, {shard_size}), "
+                        f"got {tuple(shared_w_down.shape)}."
+                    )
+            else:
+                # Stateless path (pre_sharded=False, or tp_size=1 where shard == full):
+                # Always validate full-weight shapes.
+                if shared_w_gate_up.shape != (2 * F_s, H):
+                    raise ValueError(
+                        f"shared_w_gate_up must be full weights with shape ({2 * F_s}, {H}), "
+                        f"got {tuple(shared_w_gate_up.shape)}. "
+                        "Pass complete weights; the op shards them internally per tp_rank."
+                    )
+                if shared_w_down.shape != (H, F_s):
+                    raise ValueError(
+                        f"shared_w_down must be full weights with shape ({H}, {F_s}), "
+                        f"got {tuple(shared_w_down.shape)}. "
+                        "Pass complete weights; the op shards them internally per tp_rank."
+                    )
             # TP sharding: ColumnParallel on gate_up (dim=0), RowParallel on down (dim=1)
             if self.tp_size > 1:
-                F_s = self.shared_ffn_size
-                shard_size = F_s // self.tp_size
-                r, s = self.tp_rank, shard_size
-                # shared_w_gate_up is [2*F_s, H]: first F_s rows = gate, last F_s rows = up.
-                # ColumnParallel: rank r computes neurons [r*s, (r+1)*s), so it needs
-                # gate[r*s:(r+1)*s] and up[r*s:(r+1)*s] concatenated into [2*s, H].
-                gate_shard = shared_w_gate_up[r * s : (r + 1) * s]          # [s, H]
-                up_shard   = shared_w_gate_up[F_s + r * s : F_s + (r + 1) * s]  # [s, H]
-                gate_up_shard = torch.cat([gate_shard, up_shard], dim=0).contiguous()  # [2*s, H]
-                down_shard = shared_w_down.narrow(1, r * s, s).contiguous()
+                if self.pre_sharded:
+                    # Weights already sliced by caller — use directly, zero transient alloc.
+                    gate_up_shard = shared_w_gate_up
+                    down_shard = shared_w_down
+                else:
+                    # Stateless path: slice full weights internally each forward() call.
+                    # Note: F_s already assigned above; no need to reassign.
+                    shard_size = F_s // self.tp_size
+                    r, s = self.tp_rank, shard_size
+                    # shared_w_gate_up is [2*F_s, H]: first F_s rows = gate, last F_s rows = up.
+                    # ColumnParallel: rank r computes neurons [r*s, (r+1)*s), so it needs
+                    # gate[r*s:(r+1)*s] and up[r*s:(r+1)*s] concatenated into [2*s, H].
+                    gate_shard = shared_w_gate_up[r * s : (r + 1) * s]          # [s, H]
+                    up_shard   = shared_w_gate_up[F_s + r * s : F_s + (r + 1) * s]  # [s, H]
+                    gate_up_shard = torch.cat([gate_shard, up_shard], dim=0).contiguous()  # [2*s, H]
+                    down_shard = shared_w_down.narrow(1, r * s, s).contiguous()
             else:
                 gate_up_shard = shared_w_gate_up
                 down_shard = shared_w_down


### PR DESCRIPTION
## Summary

- Adds `pre_sharded: bool = False` parameter to `SharedFusedMoE.__init__()` and `forward()`
- When `pre_sharded=True` with `tp_size > 1`, the caller passes TP-local weight shards directly; `forward()` skips the internal `cat + contiguous` copy on every call
- Eliminates ~95 MB transient allocation per forward pass at Kimi K2 TP8 scale (gate_up shard `[2*s, H]` + down shard `[H, s]` are no longer materialized)

## Motivation

At Kimi K2 TP8 (`H=7168, F_s=18432, s=2304, bf16`):
- Stateless path allocates `2×2304×7168×2 + 7168×2304×2 ≈ 95 MB` per forward call via `torch.cat + .contiguous()`
- Serving frameworks pre-shard weights at load time — passing full weights and slicing each forward is pure overhead
- `pre_sharded=True` lets the caller hold TP-local shards and pass them directly → zero transient weight alloc

## Changes

| File | Change |
|------|--------|
| `tileops/ops/moe/shared_fused_moe.py` | Add `pre_sharded` param; fast path in Region A (validation) and Region B (slicing) |
| `tests/ops/test_moe_shared_fused_moe.py` | 3 new tests: output equality, error rejection, alloc budget |
| `benchmarks/ops/bench_moe_shared_fused_moe.py` | Add `tileops-pre-sharded` variant alongside existing `tileops` baseline |

## Test Plan

- [x] `test_shared_fused_moe_pre_sharded_matches_stateless` — bit-for-bit identical output to stateless path (tp_size=2, tp_size=4)
- [x] `test_shared_fused_moe_pre_sharded_rejects_full_weights` — clear `ValueError: pre_sharded=True` when full weights passed
- [x] `test_shared_fused_moe_pre_sharded_zero_transient_alloc` — `pre_sharded=True` delta < 768 KB threshold; stateless delta ≥ 768 KB
- [x] All 8 existing + new smoke tests pass
- [x] pre-commit (ruff, codespell, etc.) clean

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)