### PR TITLE
[Benchmark][CI] Resolve nightly perf history artifact lookup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -231,13 +231,68 @@ jobs:
           name: tileops_benchmark_${{ github.run_id }}
         continue-on-error: true
 
+      - name: Resolve previous perf history artifact
+        id: perf_history_source
+        if: ${{ always() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const workflowId = "nightly.yml";
+            const currentRunId = context.runId;
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch: "main",
+                status: "completed",
+                per_page: 100,
+              },
+            );
+
+            for (const run of runs) {
+              if (run.id === currentRunId || run.conclusion !== "success") {
+                continue;
+              }
+
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                },
+              );
+
+              const artifact = artifacts.find(
+                (candidate) =>
+                  !candidate.expired && candidate.name === "tileops_perf_history",
+              );
+              if (!artifact) {
+                continue;
+              }
+
+              core.info(
+                `Using perf history artifact from run ${run.id} (${run.html_url})`,
+              );
+              core.setOutput("run_id", String(run.id));
+              return;
+            }
+
+            core.info("No previous perf history artifact found; nightly report will start a new history baseline.");
+
       - name: Download previous perf history
         uses: actions/download-artifact@v4
-        if: ${{ always() }}
+        if: ${{ always() && steps.perf_history_source.outputs.run_id != '' }}
         with:
           name: tileops_perf_history
           path: .perf_history
-        continue-on-error: true
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.perf_history_source.outputs.run_id }}
 
       - name: Generate nightly report
         if: ${{ always() }}


### PR DESCRIPTION
Closes #837

## Summary

- resolve the nightly perf-history lookup from a previous successful `nightly.yml` run instead of the current run
- skip the download cleanly when no historical artifact exists yet so nightly can bootstrap a new baseline

## Test plan

- [x] pre-commit hooks passed during `git commit`
- [x] YAML parse check passed for `.github/workflows/nightly.yml`

## Regression

- previous behavior tried to download `tileops_perf_history` from the current run before that artifact existed
- new behavior only downloads when a prior successful nightly run with a non-expired artifact is found
