### PR TITLE
[Spec][Conv] Add conv1d manifest entries

### DIFF
--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -20,6 +20,7 @@ ______________________________________________________________________
 - `status: implemented` = all validator levels apply. `status: spec-only` = L0 only. Default is `implemented`.
 - Roofline `vars` maps variable names to Python expressions over tensor shapes and params. Required for arbitrary-rank ops.
 - Op signatures must match PyTorch's public API (parameter names, parameter set, semantics). Do not invent parameters.
+- `dtype` fields align to PyTorch's supported dtypes **minus float64 and complex types** (complex32, complex64, complex128). TileOPs is a GPU kernel library; float64 and complex dtypes are not target dtypes.
 - No `Optional[Tensor]` in manifest. Ops with conditional inputs are split into variant entries linked by `variant_of`.
   - `variant_of` is one level only. Variant → primary. Primary must not have `variant_of`.
   - Variants share `source.kernel` and `source.op`. Each has its own `signature`, `workloads`, `roofline`.

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2122,3 +2122,75 @@ ops:
       op: tileops/ops/reduction/cumprod.py
       test: tests/ops/test_cumulative.py
       bench: benchmarks/ops/bench_cumulative.py
+
+  # ── conv family ──────────────────────────────────────────────────────
+
+  conv1d_fwd:
+    family: conv
+    status: spec-only
+
+    signature:
+      inputs:
+        input: {dtype: "float16 | bfloat16", shape: "[N, C_in, L_in]"}
+        weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, K]"}
+      outputs:
+        output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
+      params:
+        stride: {type: int, default: 1}
+        padding: {type: int, default: 0}
+        dilation: {type: int, default: 1}
+        groups: {type: int, default: 1}
+      shape_rules:
+        - "C_in_g == C_in // groups"
+        - "L_out == (L_in + 2 * padding - dilation * (K - 1) - 1) // stride + 1"
+
+    workloads:
+      # Human decision required — placeholder workloads for validation
+      - {input_shape: [1, 64, 128], weight_shape: [128, 64, 3], dtypes: [float16, bfloat16], label: "small-1d"}
+
+    roofline:
+      flops: "2 * N * C_out * L_out * C_in_g * K"
+      bytes: "(N * C_in * L_in + C_out * C_in_g * K + N * C_out * L_out) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/conv/conv1d.py
+      op: tileops/ops/conv1d.py
+      test: tests/ops/test_conv1d.py
+      bench: benchmarks/ops/bench_conv1d.py
+      bench_manifest_driven: false
+
+  conv1d_fwd_bias:
+    family: conv
+    status: spec-only
+    variant_of: conv1d_fwd
+
+    signature:
+      inputs:
+        input: {dtype: "float16 | bfloat16", shape: "[N, C_in, L_in]"}
+        weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, K]"}
+        bias: {dtype: "same_as(input)", shape: "[C_out]"}
+      outputs:
+        output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
+      params:
+        stride: {type: int, default: 1}
+        padding: {type: int, default: 0}
+        dilation: {type: int, default: 1}
+        groups: {type: int, default: 1}
+      shape_rules:
+        - "C_in_g == C_in // groups"
+        - "L_out == (L_in + 2 * padding - dilation * (K - 1) - 1) // stride + 1"
+
+    workloads:
+      # Human decision required — placeholder workloads for validation
+      - {input_shape: [1, 64, 128], weight_shape: [128, 64, 3], bias_shape: [128], dtypes: [float16, bfloat16], label: "small-1d-bias"}
+
+    roofline:
+      flops: "2 * N * C_out * L_out * C_in_g * K + N * C_out * L_out"
+      bytes: "(N * C_in * L_in + C_out * C_in_g * K + C_out + N * C_out * L_out) * elem_bytes"
+
+    source:
+      kernel: tileops/kernels/conv/conv1d.py
+      op: tileops/ops/conv1d.py
+      test: tests/ops/test_conv1d.py
+      bench: benchmarks/ops/bench_conv1d.py
+      bench_manifest_driven: false


### PR DESCRIPTION
## Summary

- Adds `conv1d_fwd` and `conv1d_fwd_bias` spec-only manifest entries aligned to `torch.nn.functional.conv1d`
- Primary/variant split for `Optional[Tensor] bias` parameter (R16)
- Codifies dtype exclusion rule (no float64/complex) in `.claude/domain-rules/manifest-spec.md`

## Validation

- **L0 (schema)**: PASS
- **L1+ (signature)**: Expected failures — `status: spec-only`, code has known gaps

## Spec-audit gap report (`conv` family)

| Op | Classification | Gaps |
|---|---|---|
| `conv1d_fwd` | `semantic_gap` | `forward()` uses `x` instead of `input`; `__init__` missing `dilation`, `groups` |
| `conv1d_fwd_bias` | `semantic_gap` | Same as above; `bias` currently `Optional[Tensor]` in forward, variant makes it required |

## Follow-up items

- [ ] **Workloads**: placeholder only — needs human decision on representative shapes
- [ ] **Roofline review**: formulas follow standard conv FLOPs/bytes — confirm correctness
- [ ] **Spec migration** (`semantic_gap` → `implemented`):
  - Rename `x` → `input` in `forward()`
  - Add `dilation` and `groups` params to `__init__` and kernel dispatch
  - Split `forward()` into primary (no bias) and variant (with bias) or keep unified with dispatch
  - Resolution path: `spec-test` → `spec-implement` → flip status

## Test plan

- [x] L0 schema validation passes
- [ ] After spec migration: `--check-op conv1d_fwd` passes all levels