### PR TITLE
[Refactor][FP8] Rename Fp8* class names to FP8* per naming convention

### DIFF
--- a/benchmarks/ops/bench_fp8_lighting_indexer.py
+++ b/benchmarks/ops/bench_fp8_lighting_indexer.py
@@ -4,11 +4,11 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import Fp8LightingIndexerOp
-from workloads.ops.fp8_lighting_indexer import Fp8LightingIndexerTest
+from tileops.ops import FP8LightingIndexerOp
+from workloads.ops.fp8_lighting_indexer import FP8LightingIndexerTest
 
 
-class _Fp8LightingIndexerTestBaseline(Fp8LightingIndexerTest):
+class _FP8LightingIndexerTestBaseline(FP8LightingIndexerTest):
     """Adds baseline ref_program for benchmark profiling."""
 
     def ref_program(self, q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
@@ -39,7 +39,7 @@ class _Fp8LightingIndexerTestBaseline(Fp8LightingIndexerTest):
         return (logits,)
 
 
-class Fp8LightingIndexerBenchmark(BenchmarkBase):
+class FP8LightingIndexerBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         # Flops depend on the actual mask cost which varies per input
@@ -76,12 +76,12 @@ _FP8_LIGHTING_INDEXER_BENCH_PARAMS = [
 def test_fp8_lighting_indexer_bench(batch: int, seq_len: int, heads: int, index_dim: int,
                                     seq_len_kv: int, kv_group: int, clean_logits: bool,
                                     config: Optional[dict], tune: bool) -> None:
-    test = _Fp8LightingIndexerTestBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+    test = _FP8LightingIndexerTestBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
-    bm = Fp8LightingIndexerBenchmark(test)
+    bm = FP8LightingIndexerBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = Fp8LightingIndexerOp(batch=batch,
+    op = FP8LightingIndexerOp(batch=batch,
                               seq_len=seq_len,
                               heads=heads,
                               index_dim=index_dim,

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -4,11 +4,11 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import Fp8QuantOp
-from workloads.ops.fp8_quant import Fp8QuantTest
+from tileops.ops import FP8QuantOp
+from workloads.ops.fp8_quant import FP8QuantTest
 
 
-class _Fp8QuantTestBaseline(Fp8QuantTest):
+class _FP8QuantTestBaseline(FP8QuantTest):
     """Adds baseline ref_program for benchmark profiling."""
 
     def ref_program(self, input_tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -20,7 +20,7 @@ class _Fp8QuantTestBaseline(Fp8QuantTest):
         return scale_tensor.squeeze(dim=-1), output_tensor
 
 
-class Fp8QuantBenchmark(BenchmarkBase):
+class FP8QuantBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -44,11 +44,11 @@ _FP8_QUANT_BENCH_PARAMS = [
                          _FP8_QUANT_BENCH_PARAMS)
 def test_fp8_quant_bench(batch: int, seq_len_kv: int, kv_group: int, index_dim: int,
                          in_dtype: torch.dtype, tune: bool) -> None:
-    test = _Fp8QuantTestBaseline(batch, seq_len_kv, kv_group, index_dim, in_dtype)
-    bm = Fp8QuantBenchmark(test)
+    test = _FP8QuantTestBaseline(batch, seq_len_kv, kv_group, index_dim, in_dtype)
+    bm = FP8QuantBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = Fp8QuantOp(batch=batch,
+    op = FP8QuantOp(batch=batch,
                     seq_len_kv=seq_len_kv,
                     kv_group=kv_group,
                     index_dim=index_dim,

--- a/tests/ops/test_fp8_lighting_indexer.py
+++ b/tests/ops/test_fp8_lighting_indexer.py
@@ -4,13 +4,13 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import Fp8LightingIndexerOp
+from tileops.ops import FP8LightingIndexerOp
 from workloads.ops.fp8_lighting_indexer import (
-    Fp8LightingIndexerTest as _Fp8LightingIndexerTestWorkload,
+    FP8LightingIndexerTest as _FP8LightingIndexerTestWorkload,
 )
 
 
-class Fp8LightingIndexerTest(_Fp8LightingIndexerTestWorkload, TestBase):
+class FP8LightingIndexerTest(_FP8LightingIndexerTestWorkload, TestBase):
 
     @staticmethod
     def _compute_correlation(a: torch.Tensor, b: torch.Tensor) -> float:
@@ -39,7 +39,7 @@ class Fp8LightingIndexerTest(_Fp8LightingIndexerTestWorkload, TestBase):
         ).all(), "Error: nonfinite value mismatch"
         output = output.masked_fill(~a_finite, 0)
         output_ref = output_ref.masked_fill(~b_finite, 0)
-        correlation = Fp8LightingIndexerTest._compute_correlation(output, output_ref)
+        correlation = FP8LightingIndexerTest._compute_correlation(output, output_ref)
         difference = 1.0 - correlation
         assert 0 <= difference <= tolerance, \
             f"outputs is not close to outputs_ref, difference: {difference}"
@@ -72,7 +72,7 @@ class Fp8LightingIndexerTest(_Fp8LightingIndexerTestWorkload, TestBase):
         return (logits,)
 
 
-class Fp8LightingIndexerFixture(FixtureBase):
+class FP8LightingIndexerFixture(FixtureBase):
     PARAMS = [
         ("batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune", [
              pytest.param(1, 4096, 32, 64, 8192, 1, True, None, False, marks=pytest.mark.smoke),
@@ -80,12 +80,12 @@ class Fp8LightingIndexerFixture(FixtureBase):
     ]
 
 
-@Fp8LightingIndexerFixture
+@FP8LightingIndexerFixture
 def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_kv: int,
                  kv_group: int, clean_logits: bool, config: Optional[dict], tune: bool) -> None:
-    test = Fp8LightingIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+    test = FP8LightingIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
-    op = Fp8LightingIndexerOp(
+    op = FP8LightingIndexerOp(
         batch=batch,
         seq_len=seq_len,
         heads=heads,
@@ -95,7 +95,7 @@ def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_k
         clean_logits=clean_logits,
         config=config,
         tune=tune)
-    test.check(op, *test.gen_inputs(), compare=Fp8LightingIndexerTest._validate_tensor_match)
+    test.check(op, *test.gen_inputs(), compare=FP8LightingIndexerTest._validate_tensor_match)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_fp8_quant.py
+++ b/tests/ops/test_fp8_quant.py
@@ -6,11 +6,11 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import Fp8QuantOp
-from workloads.ops.fp8_quant import Fp8QuantTest as _Fp8QuantTestWorkload
+from tileops.ops import FP8QuantOp
+from workloads.ops.fp8_quant import FP8QuantTest as _FP8QuantTestWorkload
 
 
-class Fp8QuantTest(_Fp8QuantTestWorkload, TestBase):
+class FP8QuantTest(_FP8QuantTestWorkload, TestBase):
     def ref_program(self, input_tensor: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         # input_tensor: (batch, seq_len_kv, kv_group, index_dim)
         amax_value = torch.abs(input_tensor).amax(dim=-1, keepdim=True).clamp(min=1e-4)
@@ -20,7 +20,7 @@ class Fp8QuantTest(_Fp8QuantTestWorkload, TestBase):
         return scale_tensor.squeeze(dim=-1), output_tensor
 
 
-class Fp8QuantFixture(FixtureBase):
+class FP8QuantFixture(FixtureBase):
     PARAMS = [
         ("batch, seq_len_kv, kv_group, index_dim, in_dtype, tune", [
             pytest.param(1, 8192, 1, 64, torch.float16, False, marks=pytest.mark.smoke),
@@ -41,11 +41,11 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
         f"Cosine similarity too low: {cos_sim.item()}"
 
 
-@Fp8QuantFixture
+@FP8QuantFixture
 def test_fp8_quant_op(batch: int, seq_len_kv: int, kv_group: int, index_dim: int,
                       in_dtype: torch.dtype, tune: bool) -> None:
-    test = Fp8QuantTest(batch, seq_len_kv, kv_group, index_dim, in_dtype)
-    op = Fp8QuantOp(
+    test = FP8QuantTest(batch, seq_len_kv, kv_group, index_dim, in_dtype)
+    op = FP8QuantOp(
         batch=batch,
         seq_len_kv=seq_len_kv,
         kv_group=kv_group,

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -1,7 +1,7 @@
 from .conv import Conv1dKernel, Conv2d1x1Kernel, Conv2dKernel, Conv3dKernel
 from .deepseek_mla import (
-    Fp8LightingIndexerKernel,
-    Fp8QuantKernel,
+    FP8LightingIndexerKernel,
+    FP8QuantKernel,
     SparseMlaKernel,
     TopkSelectorKernel,
     mla_decode_kernel,
@@ -87,8 +87,8 @@ __all__ = [
     "FusedGatedKernel",
     "FlashAttnBwdPostprocessKernel",
     "FlashAttnBwdPreprocessKernel",
-    "Fp8LightingIndexerKernel",
-    "Fp8QuantKernel",
+    "FP8LightingIndexerKernel",
+    "FP8QuantKernel",
     "GqaSlidingWindowFwdKernel",
     "GqaSlidingWindowFwdWgmmaPipelinedKernel",
     "GqaSlidingWindowVarlenFwdKernel",

--- a/tileops/kernels/deepseek_mla/__init__.py
+++ b/tileops/kernels/deepseek_mla/__init__.py
@@ -1,12 +1,12 @@
 from .deepseek_dsa_decode import SparseMlaKernel
 from .deepseek_mla_decode import mla_decode_kernel, mla_decode_ws_kernel
-from .fp8_lighting_indexer import Fp8LightingIndexerKernel
-from .fp8_quant import Fp8QuantKernel
+from .fp8_lighting_indexer import FP8LightingIndexerKernel
+from .fp8_quant import FP8QuantKernel
 from .topk_selector import TopkSelectorKernel
 
 __all__ = [
-    "Fp8LightingIndexerKernel",
-    "Fp8QuantKernel",
+    "FP8LightingIndexerKernel",
+    "FP8QuantKernel",
     "SparseMlaKernel",
     "TopkSelectorKernel",
     "mla_decode_kernel",

--- a/tileops/kernels/deepseek_mla/fp8_lighting_indexer.py
+++ b/tileops/kernels/deepseek_mla/fp8_lighting_indexer.py
@@ -9,7 +9,7 @@ from tilelang.autotuner import autotune
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["Fp8LightingIndexerKernel"]
+__all__ = ["FP8LightingIndexerKernel"]
 
 
 @functools.lru_cache(maxsize=32)
@@ -201,7 +201,7 @@ def _(
     return fake_o
 
 
-class Fp8LightingIndexerKernel(Kernel):
+class FP8LightingIndexerKernel(Kernel):
     supported_archs: list[int] = [90]
 
     def __init__(self,

--- a/tileops/kernels/deepseek_mla/fp8_quant.py
+++ b/tileops/kernels/deepseek_mla/fp8_quant.py
@@ -8,7 +8,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["Fp8QuantKernel"]
+__all__ = ["FP8QuantKernel"]
 
 
 @functools.lru_cache(maxsize=32)
@@ -78,7 +78,7 @@ def _(batch, seq_len_kv, kv_group, index_dim, in_dtype, num_stages, block_m, *in
                            device=inputs[0].device)
 
 
-class Fp8QuantKernel(Kernel):
+class FP8QuantKernel(Kernel):
 
     supported_archs: list[int] = [90]
 

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -18,8 +18,8 @@ from .deltanet_recurrence import DeltaNetDecodeOp
 from .dropout import DropoutOp
 from .elementwise import BinaryOp, FusedGatedOp, UnaryOp
 from .fft import FFTC2COp
-from .fp8_lighting_indexer import Fp8LightingIndexerOp
-from .fp8_quant import Fp8QuantOp
+from .fp8_lighting_indexer import FP8LightingIndexerOp
+from .fp8_quant import FP8QuantOp
 from .gated_deltanet_chunkwise import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
 from .gated_deltanet_recurrence import GatedDeltaNetDecodeOp
 from .gemm import GemmOp
@@ -106,8 +106,8 @@ __all__ = [
     "DeepSeekSparseAttentionDecodeWithKVCacheOp",
     "DropoutOp",
     "FFTC2COp",
-    "Fp8LightingIndexerOp",
-    "Fp8QuantOp",
+    "FP8LightingIndexerOp",
+    "FP8QuantOp",
     "FusedAddLayerNormOp",
     "FusedAddRmsNormOp",
     "FusedGatedOp",

--- a/tileops/ops/fp8_lighting_indexer.py
+++ b/tileops/ops/fp8_lighting_indexer.py
@@ -2,15 +2,15 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from tileops.kernels.deepseek_mla import Fp8LightingIndexerKernel
+from tileops.kernels.deepseek_mla import FP8LightingIndexerKernel
 from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["Fp8LightingIndexerOp"]
+__all__ = ["FP8LightingIndexerOp"]
 
 
-class Fp8LightingIndexerOp(Op):
+class FP8LightingIndexerOp(Op):
 
     def __init__(self,
                  batch,
@@ -37,7 +37,7 @@ class Fp8LightingIndexerOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"fp8_lighting_indexer_kernel": Fp8LightingIndexerKernel}
+        return {"fp8_lighting_indexer_kernel": FP8LightingIndexerKernel}
 
     def torch_quant_forward(self, index_q: torch.Tensor, index_k: torch.Tensor,
                             weights: torch.Tensor, cu_seqlen_ks: torch.Tensor,

--- a/tileops/ops/fp8_quant.py
+++ b/tileops/ops/fp8_quant.py
@@ -2,15 +2,15 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from tileops.kernels.deepseek_mla import Fp8QuantKernel
+from tileops.kernels.deepseek_mla import FP8QuantKernel
 from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["Fp8QuantOp"]
+__all__ = ["FP8QuantOp"]
 
 
-class Fp8QuantOp(Op):
+class FP8QuantOp(Op):
 
     def __init__(self,
                  batch,
@@ -31,7 +31,7 @@ class Fp8QuantOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"fp8_quant_kernel": Fp8QuantKernel}
+        return {"fp8_quant_kernel": FP8QuantKernel}
 
     def forward(self, input_tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.kernel(input_tensor)

--- a/workloads/ops/fp8_lighting_indexer.py
+++ b/workloads/ops/fp8_lighting_indexer.py
@@ -5,7 +5,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class Fp8LightingIndexerTest(WorkloadBase):
+class FP8LightingIndexerTest(WorkloadBase):
 
     def __init__(self,
                  batch: int,

--- a/workloads/ops/fp8_quant.py
+++ b/workloads/ops/fp8_quant.py
@@ -5,7 +5,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class Fp8QuantTest(WorkloadBase):
+class FP8QuantTest(WorkloadBase):
 
     def __init__(self, batch: int, seq_len_kv: int, kv_group: int, index_dim: int,
                  in_dtype: torch.dtype):


### PR DESCRIPTION
Closes #852. Phase 1 of #850. Depends on #854 (Phase 0 doc) — please review and merge that first; this PR is the first mechanical application of the convention it establishes.

## Summary

Renames the four FP8 classes from PascalCase abbreviation (`Fp8`) to ALL CAPS (`FP8`) per the convention in `docs/naming-convention.md` (added by #854). This is the smallest of the family-rename phases (4 source classes, no file moves) and serves as a warm-up that exercises every step of the per-PR checklist before the larger phases (gqa, mamba) begin.

## Mapping

**Op layer**

| Old | New | File |
|---|---|---|
| `Fp8QuantOp` | `FP8QuantOp` | `tileops/ops/fp8_quant.py` |
| `Fp8LightingIndexerOp` | `FP8LightingIndexerOp` | `tileops/ops/fp8_lighting_indexer.py` |

**Kernel layer**

| Old | New | File |
|---|---|---|
| `Fp8QuantKernel` | `FP8QuantKernel` | `tileops/kernels/deepseek_mla/fp8_quant.py` |
| `Fp8LightingIndexerKernel` | `FP8LightingIndexerKernel` | `tileops/kernels/deepseek_mla/fp8_lighting_indexer.py` |

**Workload / test / bench layer (cascading from the rename above)**

| Old | New |
|---|---|
| `Fp8QuantTest` | `FP8QuantTest` |
| `Fp8QuantFixture` | `FP8QuantFixture` |
| `Fp8QuantBenchmark` | `FP8QuantBenchmark` |
| `_Fp8QuantTestBaseline` | `_FP8QuantTestBaseline` |
| `Fp8LightingIndexerTest` | `FP8LightingIndexerTest` |
| `Fp8LightingIndexerFixture` | `FP8LightingIndexerFixture` |
| `Fp8LightingIndexerBenchmark` | `FP8LightingIndexerBenchmark` |
| `_Fp8LightingIndexerTestBaseline` | `_FP8LightingIndexerTestBaseline` |

## Files touched (13)

- `tileops/ops/{fp8_quant.py, fp8_lighting_indexer.py, __init__.py}`
- `tileops/kernels/__init__.py`
- `tileops/kernels/deepseek_mla/{fp8_quant.py, fp8_lighting_indexer.py, __init__.py}`
- `workloads/ops/{fp8_quant.py, fp8_lighting_indexer.py}`
- `tests/ops/{test_fp8_quant.py, test_fp8_lighting_indexer.py}`
- `benchmarks/ops/{bench_fp8_quant.py, bench_fp8_lighting_indexer.py}`

File names stay snake_case (`fp8_quant.py`, `fp8_lighting_indexer.py`) per the convention in `docs/naming-convention.md`. `tileops/ops_manifest.yaml` does not currently register FP8 ops; no manifest update needed. `tileops/perf/formulas.py` has no FP8 roofline references.

## Acceptance checklist

- [x] **AC-1**: All four classes renamed; `grep -rn 'Fp8Quant\|Fp8LightingIndexer' tileops/ tests/ benchmarks/ workloads/` returns zero matches
- [x] **AC-2**: `pytest --collect-only tests/ops/test_fp8_quant.py tests/ops/test_fp8_lighting_indexer.py` collects 6 items, no import errors
- [x] **AC-3**: `pytest --collect-only benchmarks/ops/bench_fp8_quant.py benchmarks/ops/bench_fp8_lighting_indexer.py` collects 6 items, no import errors
- [x] **AC-4**: `python -c "from tileops.ops import FP8QuantOp, FP8LightingIndexerOp; from tileops.kernels.deepseek_mla import FP8QuantKernel, FP8LightingIndexerKernel"` succeeds
- [x] **AC-5**: `pre-commit run --files <13 files>`: passes
- [x] **AC-6**: PR description reproduces the mapping table from #852

## Acknowledgement

This PR resets the nightly perf-history baseline for `Fp8QuantOp` and `Fp8LightingIndexerOp` for ~14 days. Other families are unaffected. This cost is documented in #850 and accepted as the trade-off for landing the convention.

## Out of scope

- The unrelated `Fp8DtypeFixture`, `Fp8UnaryFixture`, `Fp8BinaryFixture`, `TestFp8BuilderLogicCentralized`, etc. classes in `tests/test_elementwise_fp8.py`, `tests/test_elementwise_independent_fp8.py`, `tests/test_parametric_unary_base.py`, `benchmarks/ops/bench_elementwise_fp8.py`, and `benchmarks/ops/bench_independent_elementwise.py` belong to the elementwise FP8 dtype family — they are not Op/Kernel classes covered by #852 and will be picked up by either a future cleanup PR or by the lint script in Phase 9 of #850.
- File renames — `fp8_*.py` files keep their snake_case names per Rule 5 of the convention.

## Test plan

- [x] `pre-commit run --files <13 files>` passes locally
- [x] `pytest --collect-only` on the four affected test/bench files collects all 12 expected items with no import errors
- [x] Smoke import test of all four renamed classes succeeds
- [ ] CI: pre-commit, ruff, gitleaks, validate-manifest pass
- [ ] CI (after merge): nightly bench picks up new `op.__class__.__name__` and starts a fresh perf-history series for `FP8QuantOp` / `FP8LightingIndexerOp`
