### PR TITLE
[Refactor][Conv1D] align conv1d kernels and ops with spec

### DIFF
--- a/benchmarks/ops/bench_conv1d.py
+++ b/benchmarks/ops/bench_conv1d.py
@@ -5,7 +5,14 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import Conv1dFwdOp
+from tileops.ops import Conv1dFwdBiasOp
+
+
+def _conv1d_out_length(l_in: int, kernel_size: int, stride: int, padding: int | str, dilation: int) -> int:
+    pad_total = 0 if isinstance(padding, str) else 2 * padding
+    if padding == "same":
+        pad_total = dilation * (kernel_size - 1)
+    return (l_in + pad_total - dilation * (kernel_size - 1) - 1) // stride + 1
 
 
 class Conv1dBenchCase:
@@ -18,7 +25,9 @@ class Conv1dBenchCase:
         c_out: int,
         kernel_size: int,
         stride: int,
-        padding: int,
+        padding: int | str,
+        dilation: int,
+        groups: int,
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -28,31 +37,36 @@ class Conv1dBenchCase:
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        x = torch.randn(self.n, self.l_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        input = torch.randn(self.n, self.l_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
         weight = torch.randn(
-            self.c_out, self.c_in, self.kernel_size,
-            device="cuda", dtype=self.dtype,
+            self.c_out,
+            self.c_in // self.groups,
+            self.kernel_size,
+            device="cuda",
+            dtype=self.dtype,
         ).contiguous()
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
-        return x, weight, bias
+        return input, weight, bias
 
     def ref_program(
         self,
-        x: torch.Tensor,
+        input: torch.Tensor,
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
     ) -> torch.Tensor:
         return F.conv1d(
-            x,
+            input,
             weight,
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
-            groups=1,
+            dilation=self.dilation,
+            groups=self.groups,
         )
 
 
@@ -60,31 +74,31 @@ class Conv1dBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
-        out_l = (t.l_in + 2 * t.padding - t.kernel_size) // t.stride + 1
-        return 2.0 * t.n * t.c_out * out_l * t.c_in * t.kernel_size
+        out_l = _conv1d_out_length(t.l_in, t.kernel_size, t.stride, t.padding, t.dilation)
+        return 2.0 * t.n * t.c_out * out_l * (t.c_in // t.groups) * t.kernel_size
 
     def calculate_memory(self) -> Optional[float]:
         t = self.workload
-        out_l = (t.l_in + 2 * t.padding - t.kernel_size) // t.stride + 1
+        out_l = _conv1d_out_length(t.l_in, t.kernel_size, t.stride, t.padding, t.dilation)
         bytes_ = (
             t.n * t.c_in * t.l_in
-            + t.c_out * t.c_in * t.kernel_size
+            + t.c_out * (t.c_in // t.groups) * t.kernel_size
             + t.n * t.c_out * out_l
         ) * t.dtype.itemsize
         return bytes_
 
 
 _CONV1D_BENCH_PARAMS = [
-    pytest.param(4, 256, 32000, 512, 1, 1, 0, torch.float16, True, id="convtasnet-pointwise-k1-s1-fp16"),
-    pytest.param(4, 128, 4096, 256, 3, 1, 1, torch.float16, True, id="seanet-k3-s1-fp16"),
-    pytest.param(4, 64, 16000, 128, 5, 2, 2, torch.float16, True, id="audio-downsample-k5-s2-fp16"),
-    pytest.param(4, 128, 8192, 256, 7, 1, 3, torch.float16, True, id="seanet-stem-k7-s1-fp16"),
-    pytest.param(2, 128, 4096, 256, 3, 2, 1, torch.bfloat16, True, id="sequence-downsample-k3-s2-bf16"),
+    pytest.param(4, 256, 32000, 512, 1, 1, 0, 1, 1, torch.float16, True, id="convtasnet-pointwise-k1-s1-fp16"),
+    pytest.param(4, 128, 4096, 256, 3, 1, "same", 1, 1, torch.float16, True, id="seanet-k3-same-fp16"),
+    pytest.param(4, 64, 16000, 128, 5, 2, 2, 1, 1, torch.float16, True, id="audio-downsample-k5-s2-fp16"),
+    pytest.param(4, 128, 8192, 256, 7, 1, 6, 2, 2, torch.float16, True, id="grouped-dilated-k7-fp16"),
+    pytest.param(2, 128, 4096, 256, 3, 2, 1, 1, 1, torch.bfloat16, True, id="sequence-downsample-k3-s2-bf16"),
 ]
 
 
 @pytest.mark.parametrize(
-    "n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune",
+    "n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype, tune",
     _CONV1D_BENCH_PARAMS,
 )
 def test_conv1d_bench(
@@ -94,17 +108,19 @@ def test_conv1d_bench(
     c_out: int,
     kernel_size: int,
     stride: int,
-    padding: int,
+    padding: int | str,
+    dilation: int,
+    groups: int,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv1dBenchCase(n, c_in, l_in, c_out, kernel_size, stride, padding, dtype)
+    test = Conv1dBenchCase(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype)
     bm = Conv1dBenchmark(test)
     inputs = test.gen_inputs()
-    x, weight, bias = inputs
-    x_ncl = x.permute(0, 2, 1).contiguous()
+    input, weight, bias = inputs
+    input_ncl = input.permute(0, 2, 1).contiguous()
 
-    op = Conv1dFwdOp(
+    op = Conv1dFwdBiasOp(
         n=n,
         c_in=c_in,
         l_in=l_in,
@@ -112,14 +128,15 @@ def test_conv1d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
+        dilation=dilation,
+        groups=groups,
         dtype=dtype,
         tune=tune,
     )
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("conv1d", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x_ncl, weight, bias)
+    result_bl = bm.profile(test.ref_program, input_ncl, weight, bias)
     BenchmarkReport.record("conv1d", locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_conv1d.py
+++ b/benchmarks/ops/bench_conv1d.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import Conv1dFwdBiasOp
+from tileops.ops import Conv1dBiasFwdOp
 
 
 def _conv1d_out_length(l_in: int, kernel_size: int, stride: int, padding: int | str, dilation: int) -> int:
@@ -120,7 +120,7 @@ def test_conv1d_bench(
     input, weight, bias = inputs
     input_ncl = input.permute(0, 2, 1).contiguous()
 
-    op = Conv1dFwdBiasOp(
+    op = Conv1dBiasFwdOp(
         n=n,
         c_in=c_in,
         l_in=l_in,

--- a/tests/ops/test_conv1d.py
+++ b/tests/ops/test_conv1d.py
@@ -6,39 +6,44 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.conv import Conv1dKernel
-from tileops.ops import Conv1dFwdOp
+from tileops.ops import Conv1dFwdBiasOp, Conv1dFwdOp
 
 
 class Conv1dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune", [
+        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype, tune", [
             pytest.param(
-                2, 64, 512, 128, 3, 1, 1, torch.float16, False,
+                2, 64, 512, 128, 3, 1, 1, 1, 1, torch.float16, False,
                 marks=[pytest.mark.smoke, pytest.mark.packaging],
-                id="smoke-tcn-k3-s1-fp16",
+                id="smoke-tcn-k3-s1-p1-d1-g1-fp16",
             ),
             pytest.param(
-                4, 256, 32000, 512, 1, 1, 0, torch.float16, False,
+                2, 64, 512, 128, 3, 1, "same", 2, 1, torch.float16, False,
                 marks=pytest.mark.full,
-                id="full-convtasnet-pointwise-k1-s1-fp16",
+                id="smoke-same-padding-k3-d2-fp16",
             ),
             pytest.param(
-                4, 128, 4096, 256, 3, 1, 1, torch.float16, False,
+                2, 64, 256, 128, 5, 1, 4, 2, 2, torch.float16, False,
                 marks=pytest.mark.full,
-                id="full-seanet-residual-k3-s1-fp16",
+                id="smoke-grouped-k5-p4-d2-g2-fp16",
             ),
             pytest.param(
-                4, 64, 16000, 128, 5, 2, 2, torch.float16, False,
+                4, 128, 4096, 256, 3, 1, "valid", 1, 1, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-valid-padding-k3-s1-fp16",
+            ),
+            pytest.param(
+                4, 64, 16000, 128, 5, 2, 2, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-audio-downsample-k5-s2-fp16",
             ),
             pytest.param(
-                1, 32, 256, 64, 7, 1, 3, torch.float16, False,
+                1, 32, 256, 64, 7, 1, 3, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-small-seanet-stem-k7-s1-fp16",
             ),
             pytest.param(
-                2, 128, 4096, 256, 3, 2, 1, torch.bfloat16, False,
+                2, 128, 4096, 256, 3, 2, 1, 1, 1, torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-sequence-downsample-k3-s2-bf16",
             ),
@@ -56,7 +61,9 @@ class Conv1dTest(TestBase):
         c_out: int,
         kernel_size: int,
         stride: int,
-        padding: int,
+        padding: int | str,
+        dilation: int,
+        groups: int,
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -66,31 +73,36 @@ class Conv1dTest(TestBase):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        x = torch.randn(self.n, self.l_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        input = torch.randn(self.n, self.l_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
         weight = torch.randn(
-            self.c_out, self.c_in, self.kernel_size,
-            device="cuda", dtype=self.dtype,
+            self.c_out,
+            self.c_in // self.groups,
+            self.kernel_size,
+            device="cuda",
+            dtype=self.dtype,
         ).contiguous()
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
-        return x, weight, bias
+        return input, weight, bias
 
     def ref_program(
         self,
-        x: torch.Tensor,
+        input: torch.Tensor,
         weight: torch.Tensor,
         bias: Optional[torch.Tensor],
     ) -> torch.Tensor:
         out = F.conv1d(
-            x.permute(0, 2, 1).contiguous(),
+            input.permute(0, 2, 1).contiguous(),
             weight,
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
-            groups=1,
+            dilation=self.dilation,
+            groups=self.groups,
         )
         return out.permute(0, 2, 1).contiguous()
 
@@ -103,12 +115,14 @@ def test_conv1d(
     c_out: int,
     kernel_size: int,
     stride: int,
-    padding: int,
+    padding: int | str,
+    dilation: int,
+    groups: int,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dtype)
-    op = Conv1dFwdOp(
+    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype)
+    op = Conv1dFwdBiasOp(
         n=n,
         c_in=c_in,
         l_in=l_in,
@@ -116,7 +130,8 @@ def test_conv1d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
+        dilation=dilation,
+        groups=groups,
         dtype=dtype,
         tune=tune,
     )
@@ -126,7 +141,7 @@ def test_conv1d(
 
 @pytest.mark.smoke
 def test_conv1d_accepts_zero_bias() -> None:
-    op = Conv1dFwdOp(
+    op = Conv1dFwdBiasOp(
         n=1,
         c_in=32,
         l_in=256,
@@ -134,20 +149,45 @@ def test_conv1d_accepts_zero_bias() -> None:
         kernel_size=5,
         stride=2,
         padding=2,
-        bias=True,
     )
-    x = torch.randn(1, 256, 32, device="cuda", dtype=torch.float16).contiguous()
+    input = torch.randn(1, 256, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 5, device="cuda", dtype=torch.float16).contiguous()
     bias = torch.zeros(64, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight, bias)
-    ref = F.conv1d(x.permute(0, 2, 1).contiguous(), weight, bias=bias, stride=2, padding=2)
+    out = op(input, weight, bias)
+    ref = F.conv1d(input.permute(0, 2, 1).contiguous(), weight, bias=bias, stride=2, padding=2)
+    ref = ref.permute(0, 2, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv1d_fwd_variant_without_bias() -> None:
+    op = Conv1dFwdOp(
+        n=1,
+        c_in=32,
+        l_in=64,
+        c_out=64,
+        kernel_size=3,
+        stride=1,
+        padding="same",
+        dilation=2,
+    )
+    input = torch.randn(1, 64, 32, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 3, device="cuda", dtype=torch.float16).contiguous()
+    out = op(input, weight)
+    ref = F.conv1d(
+        input.permute(0, 2, 1).contiguous(),
+        weight,
+        stride=1,
+        padding="same",
+        dilation=2,
+    )
     ref = ref.permute(0, 2, 1).contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
 def test_conv1d_dispatches_kernel() -> None:
-    op = Conv1dFwdOp(
+    op = Conv1dFwdBiasOp(
         n=1,
         c_in=32,
         l_in=256,
@@ -155,7 +195,6 @@ def test_conv1d_dispatches_kernel() -> None:
         kernel_size=3,
         stride=1,
         padding=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv1dKernel)
 

--- a/tests/ops/test_conv1d.py
+++ b/tests/ops/test_conv1d.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.conv import Conv1dKernel
-from tileops.ops import Conv1dFwdBiasOp, Conv1dFwdOp
+from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp
 
 
 class Conv1dFixture(FixtureBase):
@@ -122,7 +122,7 @@ def test_conv1d(
     tune: bool,
 ) -> None:
     test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype)
-    op = Conv1dFwdBiasOp(
+    op = Conv1dBiasFwdOp(
         n=n,
         c_in=c_in,
         l_in=l_in,
@@ -141,7 +141,7 @@ def test_conv1d(
 
 @pytest.mark.smoke
 def test_conv1d_accepts_zero_bias() -> None:
-    op = Conv1dFwdBiasOp(
+    op = Conv1dBiasFwdOp(
         n=1,
         c_in=32,
         l_in=256,
@@ -187,7 +187,7 @@ def test_conv1d_fwd_variant_without_bias() -> None:
 
 @pytest.mark.smoke
 def test_conv1d_dispatches_kernel() -> None:
-    op = Conv1dFwdBiasOp(
+    op = Conv1dBiasFwdOp(
         n=1,
         c_in=32,
         l_in=256,

--- a/tileops/kernels/conv/common.py
+++ b/tileops/kernels/conv/common.py
@@ -1,6 +1,15 @@
 import torch
 
-__all__ = ["conv_shared_memory_bytes", "get_shared_memory_limit_bytes"]
+from tileops.kernels.pool.common import validate_channels_last_input
+
+__all__ = [
+    "conv_shared_memory_bytes",
+    "get_shared_memory_limit_bytes",
+    "resolve_conv1d_padding",
+    "validate_conv1d_input",
+    "validate_conv1d_params",
+    "validate_conv1d_tensors",
+]
 
 
 def get_shared_memory_limit_bytes() -> int:
@@ -19,3 +28,85 @@ def conv_shared_memory_bytes(
     dtype_bytes = torch.tensor([], dtype=dtype).element_size()
     per_stage_bytes = (block_m * block_k + block_k * block_n) * dtype_bytes
     return per_stage_bytes * max(1, num_stages)
+
+
+def validate_conv1d_params(
+    *,
+    stride: int,
+    dilation: int,
+    groups: int,
+    c_in: int,
+    c_out: int,
+) -> None:
+    if stride <= 0:
+        raise ValueError("stride must be positive")
+    if dilation <= 0:
+        raise ValueError("dilation must be positive")
+    if groups <= 0:
+        raise ValueError("groups must be positive")
+    if c_in % groups != 0:
+        raise ValueError("c_in must be divisible by groups")
+    if c_out % groups != 0:
+        raise ValueError("c_out must be divisible by groups")
+
+
+def resolve_conv1d_padding(
+    padding: int | str,
+    kernel_size: int,
+    stride: int,
+    dilation: int,
+) -> tuple[int, int]:
+    if isinstance(padding, str):
+        if padding == "valid":
+            return 0, 0
+        if padding != "same":
+            raise ValueError(f"Unsupported padding mode: {padding}")
+        if stride != 1:
+            raise ValueError("padding='same' is only supported for stride=1")
+        total_padding = dilation * (kernel_size - 1)
+        pad_left = total_padding // 2
+        pad_right = total_padding - pad_left
+        return pad_left, pad_right
+    if padding < 0:
+        raise ValueError("padding must be non-negative")
+    return padding, padding
+
+
+def validate_conv1d_input(
+    *,
+    op_name: str,
+    input_shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+) -> None:
+    validate_channels_last_input(
+        op_name=op_name,
+        x_shape=input_shape,
+        expected_shape=expected_shape,
+        layout="NLC",
+        ambiguous_layout_shape=(expected_shape[0], expected_shape[2], expected_shape[1]),
+    )
+
+
+def validate_conv1d_tensors(
+    *,
+    op_name: str,
+    input_shape: tuple[int, ...],
+    expected_input_shape: tuple[int, ...],
+    weight_shape: tuple[int, ...],
+    expected_weight_shape: tuple[int, ...],
+    bias_shape: tuple[int, ...] | None,
+    expected_bias_shape: tuple[int, ...],
+) -> None:
+    validate_conv1d_input(
+        op_name=op_name,
+        input_shape=input_shape,
+        expected_shape=expected_input_shape,
+    )
+    if weight_shape != expected_weight_shape:
+        raise ValueError(
+            f"{op_name} expects weight shape {expected_weight_shape}, but got {weight_shape}"
+        )
+    if bias_shape is not None and bias_shape != expected_bias_shape:
+        raise ValueError(
+            f"{op_name} expects bias shape {expected_bias_shape}, but got {bias_shape}"
+        )

--- a/tileops/kernels/conv/conv1d.py
+++ b/tileops/kernels/conv/conv1d.py
@@ -13,6 +13,17 @@ from tileops.utils import get_sm_version
 __all__ = ["Conv1dKernel"]
 
 
+def _conv1d_out_length(
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
+) -> int:
+    return (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+
+
 @functools.lru_cache(maxsize=64)
 def _conv1d_kernel(
     n: int,
@@ -21,12 +32,14 @@ def _conv1d_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
+    out_l = _conv1d_out_length(l_in, kernel_l, stride_l, pad_left, pad_right, dilation_l)
     k_total = kernel_l * c_in
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
@@ -69,7 +82,7 @@ def _conv1d_kernel(
                         ci = k_idx % c_in
                         batch = m_idx // out_l
                         ol = m_idx % out_l
-                        il = ol * stride_l + kw - pad_l
+                        il = ol * stride_l + kw * dilation_l - pad_left
                         in_bound = (
                             (m_idx < n * out_l)
                             & (k_idx < k_total)
@@ -112,6 +125,116 @@ def _conv1d_kernel(
     return _conv1d_func
 
 
+@functools.lru_cache(maxsize=64)
+def _grouped_conv1d_kernel(
+    n: int,
+    groups: int,
+    c_in_per_group: int,
+    l_in: int,
+    c_out_per_group: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    out_l = _conv1d_out_length(l_in, kernel_l, stride_l, pad_left, pad_right, dilation_l)
+    k_total = kernel_l * c_in_per_group
+
+    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _grouped_conv1d_func(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_stages: int,
+        threads: int,
+        enable_rasterization: bool,
+    ):
+        @T.prim_func
+        def _grouped_conv1d_main(
+            x: T.Tensor((n, l_in, groups * c_in_per_group), dtype),  # type: ignore
+            weight: T.Tensor((groups, kernel_l, c_in_per_group, c_out_per_group), dtype),  # type: ignore
+            out: T.Tensor((n, out_l, groups * c_out_per_group), dtype),  # type: ignore
+            bias: T.Tensor((groups, c_out_per_group), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(c_out_per_group, block_n),
+                T.ceildiv(n * out_l, block_m),
+                groups,
+                threads=threads,
+            ) as (bx, by, bz):
+                data_shared = T.alloc_shared((block_m, block_k), dtype)
+                weight_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, j in T.Parallel(block_m, block_k):
+                        m_idx = by * block_m + i
+                        k_idx = k_iter * block_k + j
+                        kw = k_idx // c_in_per_group
+                        ci = k_idx % c_in_per_group
+                        batch = m_idx // out_l
+                        ol = m_idx % out_l
+                        il = ol * stride_l + kw * dilation_l - pad_left
+                        in_bound = (
+                            (m_idx < n * out_l)
+                            & (k_idx < k_total)
+                            & (il >= 0)
+                            & (il < l_in)
+                        )
+                        data_shared[i, j] = T.if_then_else(
+                            in_bound,
+                            x[batch, il, bz * c_in_per_group + ci],
+                            T.cast(0.0, dtype),
+                        )
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        oc = bx * block_n + j
+                        kw = k_idx // c_in_per_group
+                        ci = k_idx % c_in_per_group
+                        weight_shared[i, j] = T.if_then_else(
+                            (k_idx < k_total) & (oc < c_out_per_group),
+                            weight[bz, kw, ci, oc],
+                            T.cast(0.0, dtype),
+                        )
+                    T.gemm(data_shared, weight_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    m_idx = by * block_m + i
+                    oc = bx * block_n + j
+                    if has_bias:
+                        out_shared[i, j] = T.if_then_else(
+                            (m_idx < n * out_l) & (oc < c_out_per_group),
+                            T.cast(out_local[i, j] + T.cast(bias[bz, oc], accum_dtype), dtype),
+                            T.cast(0.0, dtype),
+                        )
+                    else:
+                        out_shared[i, j] = T.if_then_else(
+                            (m_idx < n * out_l) & (oc < c_out_per_group),
+                            T.cast(out_local[i, j], dtype),
+                            T.cast(0.0, dtype),
+                        )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    m_idx = by * block_m + i
+                    oc = bx * block_n + j
+                    if m_idx < n * out_l and oc < c_out_per_group:
+                        batch = m_idx // out_l
+                        ol = m_idx % out_l
+                        out[batch, ol, bz * c_out_per_group + oc] = out_shared[i, j]
+
+        return _grouped_conv1d_main
+
+    return _grouped_conv1d_func
+
+
 @torch.library.custom_op("top::conv1d_wrapped_kernel", mutates_args=())
 def _conv1d_wrapped_kernel(
     n: int,
@@ -120,7 +243,9 @@ def _conv1d_wrapped_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -134,7 +259,7 @@ def _conv1d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, has_bias, dtype
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -146,7 +271,9 @@ def _(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -157,8 +284,75 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
+    out_l = _conv1d_out_length(l_in, kernel_l, stride_l, pad_left, pad_right, dilation_l)
     return torch.empty((n, out_l, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+@torch.library.custom_op("top::grouped_conv1d_wrapped_kernel", mutates_args=())
+def _grouped_conv1d_wrapped_kernel(
+    n: int,
+    groups: int,
+    c_in_per_group: int,
+    l_in: int,
+    c_out_per_group: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    return _grouped_conv1d_kernel(
+        n,
+        groups,
+        c_in_per_group,
+        l_in,
+        c_out_per_group,
+        kernel_l,
+        stride_l,
+        pad_left,
+        pad_right,
+        dilation_l,
+        has_bias,
+        dtype,
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+
+
+@_grouped_conv1d_wrapped_kernel.register_fake
+def _(
+    n: int,
+    groups: int,
+    c_in_per_group: int,
+    l_in: int,
+    c_out_per_group: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_left: int,
+    pad_right: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    *inputs: tuple[torch.Tensor, ...],
+) -> torch.Tensor:
+    _ = (groups, c_in_per_group, has_bias, dtype, block_m, block_n, block_k, num_stages, threads, enable_rasterization)
+    out_l = _conv1d_out_length(l_in, kernel_l, stride_l, pad_left, pad_right, dilation_l)
+    return torch.empty((n, out_l, groups * c_out_per_group), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
 class Conv1dKernel(Kernel):
@@ -172,36 +366,58 @@ class Conv1dKernel(Kernel):
         c_out: int,
         kernel_l: int,
         stride_l: int,
-        pad_l: int,
+        pad_left: int,
+        pad_right: int,
+        dilation_l: int,
         dtype: torch.dtype,
+        groups: int = 1,
         has_bias: bool = False,
         config: Optional[dict] = None,
         tune: bool = False,
     ) -> None:
         super().__init__()
         self.n = n
-        self.c_in = c_in
         self.l_in = l_in
-        self.c_out = c_out
         self.kernel_l = kernel_l
         self.stride_l = stride_l
-        self.pad_l = pad_l
+        self.pad_left = pad_left
+        self.pad_right = pad_right
+        self.dilation_l = dilation_l
         self.dtype = dtype
+        self.groups = groups
         self.has_bias = has_bias
-        self.out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
-        self.m = n * self.out_l
-        self.k_total = c_in * kernel_l
+        self.group_c_in = c_in // groups
+        self.group_c_out = c_out // groups
 
-        self.kernel = _conv1d_kernel(
-            n,
-            c_in,
-            l_in,
-            c_out,
-            kernel_l,
-            stride_l,
-            pad_l,
-            has_bias,
-            self.dtype_str,
+        self.kernel = (
+            _conv1d_kernel(
+                n,
+                self.group_c_in,
+                l_in,
+                self.group_c_out,
+                kernel_l,
+                stride_l,
+                pad_left,
+                pad_right,
+                dilation_l,
+                has_bias,
+                self.dtype_str,
+            )
+            if groups == 1
+            else _grouped_conv1d_kernel(
+                n,
+                groups,
+                self.group_c_in,
+                l_in,
+                self.group_c_out,
+                kernel_l,
+                stride_l,
+                pad_left,
+                pad_right,
+                dilation_l,
+                has_bias,
+                self.dtype_str,
+            )
         )
         self.init_config(config, tune)
 
@@ -259,18 +475,55 @@ class Conv1dKernel(Kernel):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        # OIK -> KIO so the kernel can flatten weights into [K_total, C_out].
-        weight_kio = weight.permute(2, 1, 0).contiguous()
-        return _conv1d_wrapped_kernel(
+        if self.groups == 1:
+            bias_tensor = bias
+            if bias_tensor is None:
+                bias_tensor = torch.zeros(self.group_c_out, device=x.device, dtype=x.dtype)
+            weight_tensor = weight.permute(2, 1, 0).contiguous()
+            return _conv1d_wrapped_kernel(
+                self.n,
+                self.group_c_in,
+                self.l_in,
+                self.group_c_out,
+                self.kernel_l,
+                self.stride_l,
+                self.pad_left,
+                self.pad_right,
+                self.dilation_l,
+                self.has_bias,
+                self.dtype_str,
+                self.config["block_m"],
+                self.config["block_n"],
+                self.config["block_k"],
+                self.config["num_stages"],
+                self.config["threads"],
+                self.config["enable_rasterization"],
+                x,
+                weight_tensor,
+                bias_tensor,
+            )
+
+        bias_tensor = (
+            torch.zeros((self.groups, self.group_c_out), device=x.device, dtype=x.dtype)
+            if bias is None
+            else bias.view(self.groups, self.group_c_out).contiguous()
+        )
+        weight_tensor = (
+            weight.view(self.groups, self.group_c_out, self.group_c_in, self.kernel_l)
+            .permute(0, 3, 2, 1)
+            .contiguous()
+        )
+        return _grouped_conv1d_wrapped_kernel(
             self.n,
-            self.c_in,
+            self.groups,
+            self.group_c_in,
             self.l_in,
-            self.c_out,
+            self.group_c_out,
             self.kernel_l,
             self.stride_l,
-            self.pad_l,
+            self.pad_left,
+            self.pad_right,
+            self.dilation_l,
             self.has_bias,
             self.dtype_str,
             self.config["block_m"],
@@ -280,6 +533,6 @@ class Conv1dKernel(Kernel):
             self.config["threads"],
             self.config["enable_rasterization"],
             x,
-            weight_kio,
-            bias,
+            weight_tensor,
+            bias_tensor,
         )

--- a/tileops/kernels/conv/conv1d.py
+++ b/tileops/kernels/conv/conv1d.py
@@ -160,6 +160,7 @@ def _grouped_conv1d_kernel(
             out: T.Tensor((n, out_l, groups * c_out_per_group), dtype),  # type: ignore
             bias: T.Tensor((groups, c_out_per_group), dtype),  # type: ignore
         ):
+            weight_flat = T.Tensor((groups, k_total, c_out_per_group), dtype, weight.data)
             with T.Kernel(
                 T.ceildiv(c_out_per_group, block_n),
                 T.ceildiv(n * out_l, block_m),
@@ -194,16 +195,7 @@ def _grouped_conv1d_kernel(
                             x[batch, il, bz * c_in_per_group + ci],
                             T.cast(0.0, dtype),
                         )
-                    for i, j in T.Parallel(block_k, block_n):
-                        k_idx = k_iter * block_k + i
-                        oc = bx * block_n + j
-                        kw = k_idx // c_in_per_group
-                        ci = k_idx % c_in_per_group
-                        weight_shared[i, j] = T.if_then_else(
-                            (k_idx < k_total) & (oc < c_out_per_group),
-                            weight[bz, kw, ci, oc],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[bz, k_iter * block_k, bx * block_n], weight_shared)
                     T.gemm(data_shared, weight_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):
@@ -350,7 +342,6 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    _ = (groups, c_in_per_group, has_bias, dtype, block_m, block_n, block_k, num_stages, threads, enable_rasterization)
     out_l = _conv1d_out_length(l_in, kernel_l, stride_l, pad_left, pad_right, dilation_l)
     return torch.empty((n, out_l, groups * c_out_per_group), dtype=inputs[0].dtype, device=inputs[0].device)
 

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -1,7 +1,7 @@
 from .avg_pool1d import AvgPool1dOp
 from .avg_pool2d import AvgPool2dOp
 from .avg_pool3d import AvgPool3dOp
-from .conv1d import Conv1dBiasFwdOp, Conv1dFwdOp
+from .conv1d import Conv1dFwdBiasOp, Conv1dFwdOp
 from .conv2d import Conv2dOp
 from .conv3d import Conv3dOp
 from .da_cumsum_fwd import DaCumsumFwdOp
@@ -99,7 +99,7 @@ __all__ = [
     "AdaLayerNormZeroFwdOp",
     "BatchNormBwdOp",
     "BatchNormFwdOp",
-    "Conv1dBiasFwdOp",
+    "Conv1dFwdBiasOp",
     "Conv1dFwdOp",
     "Conv2dOp",
     "Conv3dOp",

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -1,7 +1,7 @@
 from .avg_pool1d import AvgPool1dOp
 from .avg_pool2d import AvgPool2dOp
 from .avg_pool3d import AvgPool3dOp
-from .conv1d import Conv1dFwdBiasOp, Conv1dFwdOp
+from .conv1d import Conv1dBiasFwdOp, Conv1dFwdOp
 from .conv2d import Conv2dOp
 from .conv3d import Conv3dOp
 from .da_cumsum_fwd import DaCumsumFwdOp
@@ -99,7 +99,7 @@ __all__ = [
     "AdaLayerNormZeroFwdOp",
     "BatchNormBwdOp",
     "BatchNormFwdOp",
-    "Conv1dFwdBiasOp",
+    "Conv1dBiasFwdOp",
     "Conv1dFwdOp",
     "Conv2dOp",
     "Conv3dOp",

--- a/tileops/ops/conv1d.py
+++ b/tileops/ops/conv1d.py
@@ -12,7 +12,7 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["Conv1dFwdOp", "Conv1dFwdBiasOp"]
+__all__ = ["Conv1dFwdOp", "Conv1dBiasFwdOp"]
 
 
 class _Conv1dBaseOp(Op):
@@ -110,7 +110,7 @@ class Conv1dFwdOp(_Conv1dBaseOp):
         return self._run(input, weight)
 
 
-class Conv1dFwdBiasOp(_Conv1dBaseOp):
+class Conv1dBiasFwdOp(_Conv1dBaseOp):
     has_bias = True
 
     def forward(

--- a/tileops/ops/conv1d.py
+++ b/tileops/ops/conv1d.py
@@ -3,14 +3,20 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.conv import Conv1dKernel
+from tileops.kernels.conv.common import (
+    resolve_conv1d_padding,
+    validate_conv1d_params,
+    validate_conv1d_tensors,
+)
 from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["Conv1dFwdOp", "Conv1dBiasFwdOp"]
+__all__ = ["Conv1dFwdOp", "Conv1dFwdBiasOp"]
 
 
-class Conv1dFwdOp(Op):
+class _Conv1dBaseOp(Op):
+    has_bias: bool = False
 
     def __init__(
         self,
@@ -20,12 +26,21 @@ class Conv1dFwdOp(Op):
         c_out: int,
         kernel_size: int,
         stride: int = 1,
-        padding: int = 0,
-        bias: bool = False,
+        padding: int | str = 0,
+        dilation: int = 1,
+        groups: int = 1,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        validate_conv1d_params(
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+            c_in=c_in,
+            c_out=c_out,
+        )
+
         self.n = n
         self.c_in = c_in
         self.l_in = l_in
@@ -33,12 +48,19 @@ class Conv1dFwdOp(Op):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
-        self.has_bias = bias
+        self.dilation = dilation
+        self.groups = groups
         self.dtype = dtype
+        self.pad_left, self.pad_right = resolve_conv1d_padding(
+            padding=padding,
+            kernel_size=kernel_size,
+            stride=stride,
+            dilation=dilation,
+        )
 
         self.dispatch_kernel(kernel_map)
         if "conv1d_kernel" not in self.kernel_map:
-            raise NotImplementedError("Conv1dFwdOp requires 'conv1d_kernel' in kernel_map")
+            raise NotImplementedError(f"{self.__class__.__name__} requires 'conv1d_kernel' in kernel_map")
         self.kernel = self.kernel_map["conv1d_kernel"](
             n=n,
             c_in=c_in,
@@ -46,9 +68,12 @@ class Conv1dFwdOp(Op):
             c_out=c_out,
             kernel_l=kernel_size,
             stride_l=stride,
-            pad_l=padding,
+            pad_left=self.pad_left,
+            pad_right=self.pad_right,
+            dilation_l=dilation,
+            groups=groups,
             dtype=dtype,
-            has_bias=bias,
+            has_bias=self.has_bias,
             tune=tune,
         )
 
@@ -56,43 +81,42 @@ class Conv1dFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"conv1d_kernel": Conv1dKernel}
 
-    def forward(
+    def _run(
         self,
-        x: torch.Tensor,
+        input: torch.Tensor,
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        return self.kernel(x, weight, bias)
-
-
-class Conv1dBiasFwdOp(Conv1dFwdOp):
-    """Conv1d forward with bias=True default.
-
-    Identical to :class:`Conv1dFwdOp` but defaults ``bias=True`` so the
-    manifest key ``Conv1dBiasFwdOp`` resolves to a distinct class name.
-    """
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        l_in: int,
-        c_out: int,
-        kernel_size: int,
-        stride: int = 1,
-        padding: int = 0,
-        bias: bool = True,
-        dtype: torch.dtype = torch.float16,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-    ) -> None:
-        if not bias:
-            raise ValueError(
-                "Conv1dBiasFwdOp requires bias=True. "
-                "Use Conv1dFwdOp for the no-bias variant."
-            )
-        super().__init__(
-            n=n, c_in=c_in, l_in=l_in, c_out=c_out,
-            kernel_size=kernel_size, stride=stride, padding=padding,
-            bias=bias, dtype=dtype, kernel_map=kernel_map, tune=tune,
+        validate_conv1d_tensors(
+            op_name=type(self).__name__,
+            input_shape=tuple(input.shape),
+            expected_input_shape=(self.n, self.l_in, self.c_in),
+            weight_shape=tuple(weight.shape),
+            expected_weight_shape=(self.c_out, self.c_in // self.groups, self.kernel_size),
+            bias_shape=None if bias is None else tuple(bias.shape),
+            expected_bias_shape=(self.c_out,),
         )
+        return self.kernel(input, weight, bias)
+
+
+class Conv1dFwdOp(_Conv1dBaseOp):
+    has_bias = False
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        return self._run(input, weight)
+
+
+class Conv1dFwdBiasOp(_Conv1dBaseOp):
+    has_bias = True
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        return self._run(input, weight, bias)


### PR DESCRIPTION
## Summary

Align Conv1d ops and kernels with the manifest/PyTorch-facing spec tracked in #853.

## What changed

- add `Conv1dFwdOp` and `Conv1dFwdBiasOp` variants and remove the legacy `Conv1dOp` bridge
- align the op interface with PyTorch-style `input`, `padding`, `dilation`, and `groups`
- support `padding="valid"` and `padding="same"` without extra `F.pad` preprocessing
- add a grouped conv1d kernel path alongside the single-group kernel path under `Conv1dKernel`
- move Conv1d parameter/layout/tensor validation into shared conv common helpers
- update Conv1d tests and benchmarks to cover dilation, grouped convolution, string padding, and no-bias variants

## Validation

- `python -m pytest tests/ops/test_conv1d.py -v`
- `python -m pytest benchmarks/ops/bench_conv1d.py -v -k 'seanet-k3-same-fp16'`

## Notes

- `python scripts/validate_manifest.py --check-op conv1d_fwd` is still blocked on this branch because `conv1d_fwd` is not present in the current `ops_manifest.yaml`.

## Refactor Summary

FAMILY: conv

PROMOTED: 0
- none

BLOCKED: 2
- `conv1d_fwd`: code, tests, and benchmark updates are in place, but `python scripts/validate_manifest.py --check-op conv1d_fwd` is currently blocked because `conv1d_fwd` is not present in the current `tileops/ops_manifest.yaml`
- `conv1d_fwd_bias`: blocked for the same reason; the bias variant path is implemented, but there is no manifest entry on this branch to validate or promote

CLEANUP_GROUPS: conv1d
- completed cleanup for the conv1d group by removing the legacy `Conv1dOp` bridge and keeping only explicit `Conv1dFwdOp` / `Conv1dFwdBiasOp` variants
- `Conv1dKernel` now distinguishes single-group and grouped kernel builder paths under one wrapper class
- Conv1d parameter, layout, and tensor validation has been moved into shared conv common helpers

FOLLOW_UPS:
- add or restore `conv1d_fwd` and `conv1d_fwd_bias` entries in `tileops/ops_manifest.yaml`
- rerun:
  - `python scripts/validate_manifest.py --check-op conv1d_fwd`
  - `python scripts/validate_manifest.py --check-op conv1d_fwd_bias`
  - `python -m pytest tests/ops/test_conv1d.py -v`
- once manifest validation passes, perform manifest status promotion only in the orchestrator stage

Validation completed on this branch:
- `python -m pytest tests/ops/test_conv1d.py -v` passed
- `python -m pytest benchmarks/ops/bench_conv1d.py -v -k 'seanet-k3-same-fp16'` passed

Closes #853