### PR TITLE
[Refactor][Manifest] Rename 12 abbreviated attention/MoE manifest keys to descriptive names

### DIFF
--- a/.claude/domain-rules/testing-budget.md
+++ b/.claude/domain-rules/testing-budget.md
@@ -9,8 +9,25 @@
 ______________________________________________________________________
 
 - Every test case must trace back to a specific code path, dtype dispatch, or regression. Do not add cases for combinatorial confidence.
+
 - All supported dtypes must be tested. Dtype and shape coverage serve different purposes — do not cross them unless the combination triggers a distinct code path.
+
 - Do not generate test fixtures from ops_manifest.yaml workloads. Test parameters are a curated correctness subset.
+
 - Before committing, review test cases added during development. Remove scaffolding tests that verified intermediate implementation steps but do not guard a final code path. Keep only tests that remain valuable after the implementation is stable.
+
 - Run `scripts/test_node_delta.py` before submitting PRs that modify test files. No growth on existing files: nothing to report. Growth on existing files: include script output and one-line justification in PR description. New test files only: no delta report needed.
+
 - Binary operator tests must cover broadcast semantics: bias-add `(B,S,D)+(1,1,D)`, row `(B,S,D)+(B,S,1)`, scalar `(M,N)+(1,1)`. Applies to arithmetic, comparison, logical, and bitwise binary ops.
+
+- When a PR intentionally degrades a test (xfail, skip, weakened assertion) due to a process constraint (e.g. trust model requiring separate manifest and code PRs), mark it with `FIXME(staged-rollout)` using this template:
+
+  ```python
+  # FIXME(staged-rollout): <one-line summary of what's degraded>
+  #
+  # Broken invariant: <what contract is currently violated>
+  # Why: <which process constraint requires this temporary state>
+  # Cleanup: <concrete condition that triggers removal of this marker>
+  ```
+
+  Do not use ad-hoc references like "PR-B" or "next PR" — state the cleanup condition in terms of the technical invariant being restored. These markers are machine-greppable: `grep -rn 'FIXME(staged-rollout)'`.

--- a/.claude/domain-rules/testing-budget.md
+++ b/.claude/domain-rules/testing-budget.md
@@ -30,4 +30,4 @@ ______________________________________________________________________
   # Cleanup: <concrete condition that triggers removal of this marker>
   ```
 
-  Do not use ad-hoc references like "PR-B" or "next PR" — state the cleanup condition in terms of the technical invariant being restored. These markers are machine-greppable: `grep -rn 'FIXME(staged-rollout)'`.
+  Cleanup must describe the invariant to restore, not reference a specific PR. Scan with `grep -rn 'FIXME(staged-rollout)'`.

--- a/tests/test_ops_manifest.py
+++ b/tests/test_ops_manifest.py
@@ -267,7 +267,7 @@ class TestManifestAPI:
 
         # Stubs raise NotImplementedError — dispatch succeeds if it reaches them
         with pytest.raises(NotImplementedError):
-            eval_roofline("MhaFwdOp")
+            eval_roofline("MultiHeadAttentionFwdOp")
 
     def test_eval_roofline_func_mode_bad_module_raises(self):
         """Verify func-mode raises ValueError for non-importable module."""
@@ -275,13 +275,13 @@ class TestManifestAPI:
         from tileops.manifest import _load_manifest, eval_roofline
 
         ops = _load_manifest()
-        original = ops["MhaFwdOp"]["roofline"]["func"]
+        original = ops["MultiHeadAttentionFwdOp"]["roofline"]["func"]
         try:
-            ops["MhaFwdOp"]["roofline"]["func"] = "nonexistent.module.fn"
+            ops["MultiHeadAttentionFwdOp"]["roofline"]["func"] = "nonexistent.module.fn"
             with pytest.raises(ValueError, match="Failed to import"):
-                eval_roofline("MhaFwdOp")
+                eval_roofline("MultiHeadAttentionFwdOp")
         finally:
-            ops["MhaFwdOp"]["roofline"]["func"] = original
+            ops["MultiHeadAttentionFwdOp"]["roofline"]["func"] = original
 
 
 class TestCanonicalKeyResolution:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1151,20 +1151,21 @@ class TestResolveOpClass:
 class TestIntegration:
     """Run the actual validator script and verify it passes."""
 
-    # FIXME: Temporary xfail — remove after PR-B lands.
+    # FIXME: Temporary xfail — remove when Op classes are renamed.
     #
     # Broken invariant: 12 manifest keys (e.g. MultiHeadAttentionFwdOp,
     #   GroupQueryAttentionFwdOp) no longer match their Op cls.__name__
     #   (still MhaFwdOp, GqaFwdOp etc.), so _resolve_op_class() fails
     #   the exact-identity check for these entries.
-    # Why expected: manifest rename (#875) lands before code rename (PR-B)
-    #   per trust model — manifest and code changes in separate PRs.
+    # Why expected: trust model requires manifest and code changes in
+    #   separate PRs. Manifest keys are renamed first; Op class rename
+    #   follows in a separate code-only PR.
     # This is a temporary migration state, not the final contract.
-    # Cleanup: the follow-up PR-B renames the 12 Op classes to match,
-    #   at which point this xfail must be removed (strict=True ensures
-    #   CI fails if the test starts passing).
+    # Cleanup condition: once all 12 Op classes are renamed to match
+    #   their manifest keys, this xfail must be removed (strict=True
+    #   ensures CI fails if the test starts passing).
     @pytest.mark.xfail(
-        reason="12 manifest keys renamed; Op classes not yet renamed (PR-B follows)",
+        reason="12 manifest keys renamed; Op classes not yet renamed to match",
         strict=True,
     )
     def test_validator_passes_on_current_codebase(self):

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1153,7 +1153,7 @@ class TestIntegration:
 
     @pytest.mark.xfail(
         reason="Manifest keys renamed but Op classes not yet renamed (PR-B follows)",
-        strict=False,
+        strict=True,
     )
     def test_validator_passes_on_current_codebase(self):
         result = subprocess.run(

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1151,6 +1151,10 @@ class TestResolveOpClass:
 class TestIntegration:
     """Run the actual validator script and verify it passes."""
 
+    @pytest.mark.xfail(
+        reason="Manifest keys renamed but Op classes not yet renamed (PR-B follows)",
+        strict=False,
+    )
     def test_validator_passes_on_current_codebase(self):
         result = subprocess.run(
             [sys.executable, str(VALIDATOR_SCRIPT)],

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1151,8 +1151,20 @@ class TestResolveOpClass:
 class TestIntegration:
     """Run the actual validator script and verify it passes."""
 
+    # FIXME: Temporary xfail — remove after PR-B lands.
+    #
+    # Broken invariant: 12 manifest keys (e.g. MultiHeadAttentionFwdOp,
+    #   GroupQueryAttentionFwdOp) no longer match their Op cls.__name__
+    #   (still MhaFwdOp, GqaFwdOp etc.), so _resolve_op_class() fails
+    #   the exact-identity check for these entries.
+    # Why expected: manifest rename (#875) lands before code rename (PR-B)
+    #   per trust model — manifest and code changes in separate PRs.
+    # This is a temporary migration state, not the final contract.
+    # Cleanup: the follow-up PR-B renames the 12 Op classes to match,
+    #   at which point this xfail must be removed (strict=True ensures
+    #   CI fails if the test starts passing).
     @pytest.mark.xfail(
-        reason="Manifest keys renamed but Op classes not yet renamed (PR-B follows)",
+        reason="12 manifest keys renamed; Op classes not yet renamed (PR-B follows)",
         strict=True,
     )
     def test_validator_passes_on_current_codebase(self):

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1151,19 +1151,11 @@ class TestResolveOpClass:
 class TestIntegration:
     """Run the actual validator script and verify it passes."""
 
-    # FIXME: Temporary xfail — remove when Op classes are renamed.
+    # FIXME(staged-rollout): validator xfail — 12 manifest keys don't match cls.__name__
     #
-    # Broken invariant: 12 manifest keys (e.g. MultiHeadAttentionFwdOp,
-    #   GroupQueryAttentionFwdOp) no longer match their Op cls.__name__
-    #   (still MhaFwdOp, GqaFwdOp etc.), so _resolve_op_class() fails
-    #   the exact-identity check for these entries.
-    # Why expected: trust model requires manifest and code changes in
-    #   separate PRs. Manifest keys are renamed first; Op class rename
-    #   follows in a separate code-only PR.
-    # This is a temporary migration state, not the final contract.
-    # Cleanup condition: once all 12 Op classes are renamed to match
-    #   their manifest keys, this xfail must be removed (strict=True
-    #   ensures CI fails if the test starts passing).
+    # Broken invariant: cls.__name__ != manifest_key for 12 attention/MoE ops
+    # Why: trust model requires manifest and code renames in separate PRs
+    # Cleanup: remove when all 12 Op classes are renamed to match their manifest keys
     @pytest.mark.xfail(
         reason="12 manifest keys renamed; Op classes not yet renamed to match",
         strict=True,

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -501,10 +501,10 @@ ops:
   # attention — multi-head / grouped-query attention (prefill, decode, paged)
   # ---------------------------------------------------------------------------
 
-  MhaFwdOp:
+  MultiHeadAttentionFwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -538,10 +538,10 @@ ops:
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
 
-  MhaBwdOp:
+  MultiHeadAttentionBwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -585,10 +585,10 @@ ops:
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
 
-  GqaFwdOp:
+  GroupQueryAttentionFwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -623,10 +623,10 @@ ops:
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
 
-  GqaBwdOp:
+  GroupQueryAttentionBwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -675,10 +675,10 @@ ops:
   # attention — decode (single-query against KV cache)
   # ---------------------------------------------------------------------------
 
-  MhaDecodeFwdOp:
+  MultiHeadAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -713,10 +713,10 @@ ops:
       test: tests/ops/test_mha_decode.py
       bench: benchmarks/ops/bench_mha_decode.py
 
-  MhaDecodePagedFwdOp:
+  MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -765,10 +765,10 @@ ops:
       test: tests/ops/test_mha_decode_paged.py
       bench: benchmarks/ops/bench_mha_decode_paged.py
 
-  GqaDecodeFwdOp:
+  GroupQueryAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -804,10 +804,10 @@ ops:
       test: tests/ops/test_gqa_decode.py
       bench: benchmarks/ops/bench_gqa_decode.py
 
-  GqaDecodePagedFwdOp:
+  GroupQueryAttentionDecodePagedWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -949,10 +949,10 @@ ops:
   # attention — DeepSeek MLA / DSA decode
   # ---------------------------------------------------------------------------
 
-  DeepSeekMlaDecodeFwdOp:
+  MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -990,10 +990,10 @@ ops:
       test: tests/ops/test_deepseek_mla_decode.py
       bench: benchmarks/ops/bench_deepseek_mla_decode.py
 
-  DeepSeekDsaDecodeFwdOp:
+  DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: implemented
+    status: spec-only  # class rename pending (PR-B)
 
     signature:
       inputs:
@@ -1244,7 +1244,7 @@ ops:
       bench: benchmarks/ops/bench_moe_unpermute.py
       bench_manifest_driven: true
 
-  MoeFusedExpertsFwdOp:
+  FusedMoeExpertsFwdOp:
     ref_api: "none"
     family: moe
     status: spec-only
@@ -1281,7 +1281,7 @@ ops:
       test: tests/ops/test_moe_fused_moe.py
       bench: benchmarks/ops/bench_moe_fused_moe.py
 
-  MoeFusedExpertsPaddedFwdOp:
+  FusedMoeExpertsPaddedFwdOp:
     ref_api: "none"
     family: moe
     status: spec-only

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -946,7 +946,7 @@ ops:
       bench: benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
 
   # ---------------------------------------------------------------------------
-  # attention — DeepSeek MLA / DSA decode
+  # attention — Multi-Head Latent Attention / DeepSeek Sparse Attention decode
   # ---------------------------------------------------------------------------
 
   MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -585,7 +585,7 @@ ops:
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
 
-  GroupQueryAttentionFwdOp:
+  GroupedQueryAttentionFwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
     status: implemented
@@ -623,7 +623,7 @@ ops:
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
 
-  GroupQueryAttentionBwdOp:
+  GroupedQueryAttentionBwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
     status: implemented
@@ -765,7 +765,7 @@ ops:
       test: tests/ops/test_mha_decode_paged.py
       bench: benchmarks/ops/bench_mha_decode_paged.py
 
-  GroupQueryAttentionDecodeWithKVCacheFwdOp:
+  GroupedQueryAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
     status: implemented
@@ -804,7 +804,7 @@ ops:
       test: tests/ops/test_gqa_decode.py
       bench: benchmarks/ops/bench_gqa_decode.py
 
-  GroupQueryAttentionDecodePagedWithKVCacheFwdOp:
+  GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
     status: implemented

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -504,7 +504,7 @@ ops:
   MultiHeadAttentionFwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -541,7 +541,7 @@ ops:
   MultiHeadAttentionBwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -588,7 +588,7 @@ ops:
   GroupQueryAttentionFwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -626,7 +626,7 @@ ops:
   GroupQueryAttentionBwdOp:
     ref_api: "torch.nn.functional.scaled_dot_product_attention"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -678,7 +678,7 @@ ops:
   MultiHeadAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -716,7 +716,7 @@ ops:
   MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -768,7 +768,7 @@ ops:
   GroupQueryAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -807,7 +807,7 @@ ops:
   GroupQueryAttentionDecodePagedWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -952,7 +952,7 @@ ops:
   MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:
@@ -993,7 +993,7 @@ ops:
   DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
     ref_api: "none"
     family: attention
-    status: spec-only  # class rename pending (PR-B)
+    status: implemented
 
     signature:
       inputs:


### PR DESCRIPTION
## Summary

Rename 12 abbreviated manifest keys for attention and MoE operations to restore original descriptive names with Fwd/Bwd/Op suffixes, per the rename map in issue #875. This is a manifest-only change per the trust model — code renames follow in a separate PR.

Closes #875

## Changes

- **tileops/ops_manifest.yaml**: Renamed 12 manifest keys (e.g., `MhaFwdOp` -> `MultiHeadAttentionFwdOp`, `GqaFwdOp` -> `GroupedQueryAttentionFwdOp`, etc.)
- **tests/test_ops_manifest.py**: Updated test fixtures referencing old key names
- **tests/test_validate_manifest.py**: Added xfail marker for validator integration test (manifest keys renamed but Op classes not yet renamed — follows in PR-B per Decision 7 of #860)

## Test plan

- [x] AC-1: All 12 manifest keys renamed per the table in issue #875
- [x] AC-2: No changes to tileops/ops/, tileops/kernels/, or benchmarks/
- [x] AC-3: All tests pass (73 passed, 1 xfailed — xfail is intentional per Decision 7 of #860)

**Test results**: 74 total, 73 passed, 1 xfailed, 0 failed

## Changed files

- `tileops/ops_manifest.yaml` — renamed 12 manifest keys per #875 rename map
- `tests/test_ops_manifest.py` — updated test fixtures referencing renamed keys
- `tests/test_validate_manifest.py` — added `FIXME(staged-rollout)` xfail for validator integration test
- `.claude/domain-rules/testing-budget.md` — added `FIXME(staged-rollout)` template as domain rule

## Follow-up

- #881 — Rename 12 Op classes to match restored manifest keys (removes FIXME(staged-rollout) xfail)