### PR TITLE
[Refactor][Naming] Rename 12 Op classes to match manifest keys

### DIFF
--- a/benchmarks/ops/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/bench_deepseek_dsa_decode.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import DeepSeekDsaDecodeFwdOp
+from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.deepseek_dsa_decode import DsaDecodeTest
 
 
@@ -104,7 +104,7 @@ def test_dsa_decode_bench(batch: int, heads: int, seq_len_q: int, seq_len_kv: in
     bm = DsaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = DeepSeekDsaDecodeFwdOp(
+    op = DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)

--- a/benchmarks/ops/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/bench_deepseek_mla_decode.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from einops import einsum, rearrange
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import DeepSeekMlaDecodeFwdOp
+from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.deepseek_mla_decode import MlaDecodeTest
 
 
@@ -94,7 +94,7 @@ def test_mla_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int
     bm = MlaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = DeepSeekMlaDecodeFwdOp(
+    op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_gqa.py
+++ b/benchmarks/ops/bench_gqa.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import GqaBwdOp, GqaFwdOp
+from tileops.ops import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from workloads.ops.gqa import (
     GqaBwdTest,
     GqaFwdTest,
@@ -182,7 +182,7 @@ def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     bm = GqaFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GqaFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -220,7 +220,7 @@ def test_gqa_bwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     bm = GqaBwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GqaBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_gqa_decode.py
+++ b/benchmarks/ops/bench_gqa_decode.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import GqaDecodeFwdOp
+from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.gqa_decode import GqaDecodeTest
 
 
@@ -134,7 +134,7 @@ def test_gqa_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int
     bm = GqaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GqaDecodeFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
+    op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/bench_gqa_decode_paged.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import GqaDecodePagedFwdOp
+from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.ops.gqa_decode_paged import GqaDecodePagedTest
 
 
@@ -192,7 +192,7 @@ def test_gqa_decode_paged_bench(batch: int, heads: int, heads_kv: int, seqlen_kv
     inputs = test.gen_inputs()
     q, k, v, real_seqlen_kv, block_table = inputs
 
-    op = GqaDecodePagedFwdOp(
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_mha.py
+++ b/benchmarks/ops/bench_mha.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import MhaBwdOp, MhaFwdOp
+from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.ops.mha import (
     MhaBwdTest,
     MhaFwdTest,
@@ -138,7 +138,7 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     bm = MhaFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = MhaFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -167,7 +167,7 @@ def test_mha_bwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     bm = MhaBwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = MhaBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_mha_decode.py
+++ b/benchmarks/ops/bench_mha_decode.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import MhaDecodeFwdOp
+from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.mha_decode import MhaDecodeTest
 
 
@@ -96,7 +96,7 @@ def test_mha_decode_bench(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: to
     bm = MhaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = MhaDecodeFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
+    op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_mha_decode_paged.py
+++ b/benchmarks/ops/bench_mha_decode_paged.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.ops import MhaDecodePagedFwdOp
+from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.ops.mha_decode_paged import MhaDecodePagedTest
 
 
@@ -152,7 +152,7 @@ def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv
     inputs = test.gen_inputs()
     q, k, v, real_seqlen_kv, block_table = inputs
 
-    op = MhaDecodePagedFwdOp(
+    op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/tests/ops/test_deepseek_dsa_decode.py
+++ b/tests/ops/test_deepseek_dsa_decode.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import DeepSeekDsaDecodeFwdOp
+from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.deepseek_dsa_decode import DsaDecodeTest as _DsaDecodeTestWorkload
 
 
@@ -74,7 +74,7 @@ def test_sparse_mla_decode(batch: int, heads: int, seq_len_q: int, seq_len_kv: i
     test = DsaDecodeTest(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype)
-    op = DeepSeekDsaDecodeFwdOp(
+    op = DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=3e-4, rtol=1e-5)

--- a/tests/ops/test_deepseek_mla_decode.py
+++ b/tests/ops/test_deepseek_mla_decode.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from einops import einsum, rearrange
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import DeepSeekMlaDecodeFwdOp
+from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.deepseek_mla_decode import MlaDecodeTest as _MlaDecodeTestWorkload
 
 
@@ -66,7 +66,7 @@ class MlaDecodeFixture(FixtureBase):
 def test_mla_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dim_pe: int, dtype: torch.dtype, tune: bool):
     test = MlaDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype)
-    op = DeepSeekMlaDecodeFwdOp(
+    op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=3e-4, rtol=1e-5)
 

--- a/tests/ops/test_gqa.py
+++ b/tests/ops/test_gqa.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GqaBwdOp, GqaFwdOp
+from tileops.ops import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from workloads.ops.gqa import GqaBwdTest as _GqaBwdTestWorkload
 from workloads.ops.gqa import GqaFwdTest as _GqaFwdTestWorkload
 
@@ -65,7 +65,7 @@ class GqaBwdFixture(FixtureBase):
 def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
     test = GqaFwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
-    op = GqaFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 
@@ -73,7 +73,7 @@ def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, 
 def test_gqa_bwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
     test = GqaBwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
-    op = GqaBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 

--- a/tests/ops/test_gqa_decode.py
+++ b/tests/ops/test_gqa_decode.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GqaDecodeFwdOp
+from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.gqa_decode import GqaDecodeTest as _GqaDecodeTestWorkload
 
 
@@ -34,7 +34,7 @@ class GqaDecodeFixture(FixtureBase):
 def test_gqa_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dtype: torch.dtype, tune: bool) -> None:
     test = GqaDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dtype)
-    op = GqaDecodeFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
+    op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
 
 

--- a/tests/ops/test_gqa_decode_paged.py
+++ b/tests/ops/test_gqa_decode_paged.py
@@ -1,4 +1,4 @@
-"""Test GqaDecodePagedFwdOp (paged GQA decode with dynamic KV cache)."""
+"""Test GroupedQueryAttentionDecodePagedWithKVCacheFwdOp (paged GQA decode with dynamic KV cache)."""
 
 
 import math
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GqaDecodePagedFwdOp
+from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.ops.gqa_decode_paged import GqaDecodePagedTest as _GqaDecodePagedTestWorkload
 
 
@@ -85,7 +85,7 @@ def test_gqa_decode_paged_op(
     tune: bool,
 ) -> None:
     test = GqaDecodePagedTest(batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype)
-    op = GqaDecodePagedFwdOp(
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
         batch=batch,
         heads=heads,
         heads_kv=heads_kv,

--- a/tests/ops/test_mha.py
+++ b/tests/ops/test_mha.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import MhaBwdOp, MhaFwdOp
+from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.ops.mha import MhaBwdTest as _MhaBwdTestWorkload
 from workloads.ops.mha import MhaFwdTest as _MhaFwdTestWorkload
 
@@ -89,7 +89,7 @@ class MhaBwdFixture(FixtureBase):
 def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
     test = MhaFwdTest(batch, heads, seq_len, dim, causal, dtype)
-    op = MhaFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 
@@ -97,7 +97,7 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
 def test_mha_bwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
-    op = MhaBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 

--- a/tests/ops/test_mha_decode.py
+++ b/tests/ops/test_mha_decode.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import MhaDecodeFwdOp
+from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.ops.mha_decode import MhaDecodeTest as _MhaDecodeTestWorkload
 
 
@@ -34,7 +34,7 @@ class MhaDecodeFixture(FixtureBase):
 def test_mha_decode(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: torch.dtype,
                     tune: bool) -> None:
     test = MhaDecodeTest(b, h, s_q, s_kv, d, dtype)
-    op = MhaDecodeFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
+    op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=2e-3, rtol=1e-5)
 
 

--- a/tests/ops/test_mha_decode_paged.py
+++ b/tests/ops/test_mha_decode_paged.py
@@ -1,4 +1,4 @@
-"""Test MhaDecodePagedFwdOp (paged MHA decode with dynamic KV cache)."""
+"""Test MultiHeadAttentionDecodePagedWithKVCacheFwdOp (paged MHA decode with dynamic KV cache)."""
 
 
 import math
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import MhaDecodePagedFwdOp
+from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.ops.mha_decode_paged import MhaDecodePagedTest as _MhaDecodePagedTestWorkload
 
 
@@ -93,7 +93,7 @@ def test_mha_decode_paged_op(
     tune: bool,
 ) -> None:
     test = MhaDecodePagedTest(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
-    op = MhaDecodePagedFwdOp(
+    op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch=batch,
         heads=heads,
         seqlen_q=seqlen_q,

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from tileops.ops import MhaFwdOp
+from tileops.ops import MultiHeadAttentionFwdOp
 
 
 @pytest.mark.nightly
@@ -13,7 +13,7 @@ from tileops.ops import MhaFwdOp
 )
 def test_mha_kernel_autotune(B: int, S: int, H: int, D: int, causal: bool, dtype: torch.dtype):
     # 1. test autotune at initialization
-    op = MhaFwdOp(B, H, S, D, causal, dtype, tune=True)
+    op = MultiHeadAttentionFwdOp(B, H, S, D, causal, dtype, tune=True)
 
     # 2. test op.autotune()
     op.autotune()

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -6,7 +6,7 @@ import torch
 
 from tests.ops.test_mha import MhaFwdTest
 from tests.test_base import FixtureBase
-from tileops.ops import MhaFwdOp
+from tileops.ops import MultiHeadAttentionFwdOp
 
 
 class MhaCompileFixture(FixtureBase):
@@ -23,7 +23,7 @@ class MhaCompileFixture(FixtureBase):
 @MhaCompileFixture
 def test_mha_kernel_compile(B: int, S: int, H: int, D: int, causal: bool, dtype: torch.dtype):
     test = MhaFwdTest(B, H, S, D, causal, dtype)
-    op = MhaFwdOp(B, H, S, D, causal, dtype)
+    op = MultiHeadAttentionFwdOp(B, H, S, D, causal, dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=5e-3, rtol=1e-5)

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1151,15 +1151,6 @@ class TestResolveOpClass:
 class TestIntegration:
     """Run the actual validator script and verify it passes."""
 
-    # FIXME(staged-rollout): validator xfail — 12 manifest keys don't match cls.__name__
-    #
-    # Broken invariant: cls.__name__ != manifest_key for 12 attention/MoE ops
-    # Why: trust model requires manifest and code renames in separate PRs
-    # Cleanup: remove when all 12 Op classes are renamed to match their manifest keys
-    @pytest.mark.xfail(
-        reason="12 manifest keys renamed; Op classes not yet renamed to match",
-        strict=True,
-    )
     def test_validator_passes_on_current_codebase(self):
         result = subprocess.run(
             [sys.executable, str(VALIDATOR_SCRIPT)],

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -5,8 +5,8 @@ from .conv1d import Conv1dBiasFwdOp, Conv1dFwdOp
 from .conv2d import Conv2dOp
 from .conv3d import Conv3dOp
 from .da_cumsum_fwd import DaCumsumFwdOp
-from .deepseek_dsa_decode import DeepSeekDsaDecodeFwdOp
-from .deepseek_mla_decode import DeepSeekMlaDecodeFwdOp
+from .deepseek_dsa_decode import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
+from .deepseek_mla_decode import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from .deepseek_nsa import (
     MeanPoolingForwardOp,
     NSACmpFwdVarlenOp,
@@ -25,15 +25,15 @@ from .gated_deltanet_recurrence import GatedDeltaNetDecodeOp
 from .gemm import GemmOp
 from .gla_chunkwise import GLABwdOp, GLAFwdOp
 from .gla_recurrence import GLADecodeOp
-from .gqa import GqaBwdOp, GqaFwdOp
-from .gqa_decode import GqaDecodeFwdOp
-from .gqa_decode_paged import GqaDecodePagedFwdOp
+from .gqa import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
+from .gqa_decode import GroupedQueryAttentionDecodeWithKVCacheFwdOp
+from .gqa_decode_paged import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from .gqa_sliding_window_fwd import GqaSlidingWindowFwdOp
 from .gqa_sliding_window_varlen_fwd import GqaSlidingWindowVarlenFwdOp
 from .grouped_gemm import GroupedGemmOp
-from .mha import MhaBwdOp, MhaFwdOp
-from .mha_decode import MhaDecodeFwdOp
-from .mha_decode_paged import MhaDecodePagedFwdOp
+from .mha import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
+from .mha_decode import MultiHeadAttentionDecodeWithKVCacheFwdOp
+from .mha_decode_paged import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from .mhc_post import MHCPostOp
 from .mhc_pre import MHCPreOp
 from .moe import MoePermuteAlignFwdOp
@@ -104,7 +104,7 @@ __all__ = [
     "Conv2dOp",
     "Conv3dOp",
     "DaCumsumFwdOp",
-    "DeepSeekDsaDecodeFwdOp",
+    "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp",
     "DropoutOp",
     "FFTC2COp",
     "FP8LightingIndexerOp",
@@ -126,10 +126,10 @@ __all__ = [
     "GemmOp",
     "GqaSlidingWindowFwdOp",
     "GqaSlidingWindowVarlenFwdOp",
-    "GqaBwdOp",
-    "GqaDecodePagedFwdOp",
-    "GqaDecodeFwdOp",
-    "GqaFwdOp",
+    "GroupedQueryAttentionBwdOp",
+    "GroupedQueryAttentionDecodePagedWithKVCacheFwdOp",
+    "GroupedQueryAttentionDecodeWithKVCacheFwdOp",
+    "GroupedQueryAttentionFwdOp",
     "GroupNormFwdOp",
     "GroupedGemmOp",
     "InstanceNormFwdOp",
@@ -137,11 +137,11 @@ __all__ = [
     "MHCPostOp",
     "MHCPreOp",
     "MeanPoolingForwardOp",
-    "MhaBwdOp",
-    "MhaDecodePagedFwdOp",
-    "MhaDecodeFwdOp",
-    "MhaFwdOp",
-    "DeepSeekMlaDecodeFwdOp",
+    "MultiHeadAttentionBwdOp",
+    "MultiHeadAttentionDecodePagedWithKVCacheFwdOp",
+    "MultiHeadAttentionDecodeWithKVCacheFwdOp",
+    "MultiHeadAttentionFwdOp",
+    "MultiHeadLatentAttentionDecodeWithKVCacheFwdOp",
     "NSACmpFwdVarlenOp",
     "NSAFwdVarlenOp",
     "NSATopkVarlenOp",

--- a/tileops/ops/deepseek_dsa_decode.py
+++ b/tileops/ops/deepseek_dsa_decode.py
@@ -7,10 +7,10 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["DeepSeekDsaDecodeFwdOp"]
+__all__ = ["DeepSeekSparseAttentionDecodeWithKVCacheFwdOp"]
 
 
-class DeepSeekDsaDecodeFwdOp(Op):
+class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
     """
     Sparse Attention Decode Operation with Key-Value Cache for DeepSeek.
 

--- a/tileops/ops/deepseek_mla_decode.py
+++ b/tileops/ops/deepseek_mla_decode.py
@@ -8,10 +8,10 @@ from tileops.utils import is_hopper
 
 from .op import Op
 
-__all__ = ["DeepSeekMlaDecodeFwdOp"]
+__all__ = ["MultiHeadLatentAttentionDecodeWithKVCacheFwdOp"]
 
 
-class DeepSeekMlaDecodeFwdOp(Op):
+class MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,

--- a/tileops/ops/gqa.py
+++ b/tileops/ops/gqa.py
@@ -15,10 +15,10 @@ from tileops.utils import is_hopper
 
 from .op import Op
 
-__all__ = ['GqaFwdOp', 'GqaBwdOp']
+__all__ = ['GroupedQueryAttentionFwdOp', 'GroupedQueryAttentionBwdOp']
 
 
-class GqaFwdOp(Op):
+class GroupedQueryAttentionFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,
@@ -52,7 +52,7 @@ class GqaFwdOp(Op):
         return self.kernel(q, k, v)
 
 
-class GqaBwdOp(Op):
+class GroupedQueryAttentionBwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,

--- a/tileops/ops/gqa.py
+++ b/tileops/ops/gqa.py
@@ -15,7 +15,7 @@ from tileops.utils import is_hopper
 
 from .op import Op
 
-__all__ = ['GroupedQueryAttentionFwdOp', 'GroupedQueryAttentionBwdOp']
+__all__ = ["GroupedQueryAttentionFwdOp", "GroupedQueryAttentionBwdOp"]
 
 
 class GroupedQueryAttentionFwdOp(Op):

--- a/tileops/ops/gqa_decode.py
+++ b/tileops/ops/gqa_decode.py
@@ -8,10 +8,10 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["GqaDecodeFwdOp"]
+__all__ = ["GroupedQueryAttentionDecodeWithKVCacheFwdOp"]
 
 
-class GqaDecodeFwdOp(Op):
+class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,

--- a/tileops/ops/gqa_decode_paged.py
+++ b/tileops/ops/gqa_decode_paged.py
@@ -7,10 +7,10 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["GqaDecodePagedFwdOp"]
+__all__ = ["GroupedQueryAttentionDecodePagedWithKVCacheFwdOp"]
 
 
-class GqaDecodePagedFwdOp(Op):
+class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
     """Paged GQA decode with dynamic KV cache. Layout: Q [batch, heads, dim] (BHD);
     K, V physical cache [seqlen_kv, heads_kv, dim]; real_seqlen_kv [batch]; block_table [batch, num_pages].
     """

--- a/tileops/ops/mha.py
+++ b/tileops/ops/mha.py
@@ -15,10 +15,10 @@ from tileops.utils import is_hopper
 
 from .op import Op
 
-__all__ = ['MhaFwdOp', 'MhaBwdOp']
+__all__ = ['MultiHeadAttentionFwdOp', 'MultiHeadAttentionBwdOp']
 
 
-class MhaFwdOp(Op):
+class MultiHeadAttentionFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,
@@ -50,7 +50,7 @@ class MhaFwdOp(Op):
         return self.kernel(q, k, v)
 
 
-class MhaBwdOp(Op):
+class MultiHeadAttentionBwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,

--- a/tileops/ops/mha.py
+++ b/tileops/ops/mha.py
@@ -15,7 +15,7 @@ from tileops.utils import is_hopper
 
 from .op import Op
 
-__all__ = ['MultiHeadAttentionFwdOp', 'MultiHeadAttentionBwdOp']
+__all__ = ["MultiHeadAttentionFwdOp", "MultiHeadAttentionBwdOp"]
 
 
 class MultiHeadAttentionFwdOp(Op):

--- a/tileops/ops/mha_decode.py
+++ b/tileops/ops/mha_decode.py
@@ -8,10 +8,10 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["MhaDecodeFwdOp"]
+__all__ = ["MultiHeadAttentionDecodeWithKVCacheFwdOp"]
 
 
-class MhaDecodeFwdOp(Op):
+class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,

--- a/tileops/ops/mha_decode_paged.py
+++ b/tileops/ops/mha_decode_paged.py
@@ -7,10 +7,10 @@ from tileops.kernels.kernel import Kernel
 
 from .op import Op
 
-__all__ = ["MhaDecodePagedFwdOp"]
+__all__ = ["MultiHeadAttentionDecodePagedWithKVCacheFwdOp"]
 
 
-class MhaDecodePagedFwdOp(Op):
+class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
     """Paged MHA decode with dynamic KV cache. Layout: Q [batch, seqlen_q, heads, dim] (BSHD);
     K, V physical cache [seqlen_kv, heads, dim]; real_seqlen_kv [batch]; block_table [batch, num_pages].
     """

--- a/tileops/ops/moe/__init__.py
+++ b/tileops/ops/moe/__init__.py
@@ -1,7 +1,7 @@
 """MoE operator package."""
 
 from .fused_moe import FusedMoe
-from .fused_moe_experts import MoeFusedExpertsFwdOp, MoeFusedExpertsPaddedFwdOp
+from .fused_moe_experts import FusedMoeExpertsFwdOp, FusedMoeExpertsPaddedFwdOp
 from .fused_topk import FusedTopKOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
 from .permute_align import MoePermuteAlignFwdOp
@@ -12,8 +12,8 @@ from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
     "FusedMoe",
-    "MoeFusedExpertsFwdOp",
-    "MoeFusedExpertsPaddedFwdOp",
+    "FusedMoeExpertsFwdOp",
+    "FusedMoeExpertsPaddedFwdOp",
     "FusedTopKOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteAlignFwdOp",

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -1,7 +1,7 @@
 """Unified routed MoE FFN operator — FusedMoe.
 
 Corresponds to vLLM's FusedMoE layer: combines FusedTopKOp (routing) and
-MoeFusedExpertsFwdOp (permute + GEMM + SwiGLU + GEMM + unpermute) into a single
+FusedMoeExpertsFwdOp (permute + GEMM + SwiGLU + GEMM + unpermute) into a single
 forward pass.
 
 Does NOT handle shared experts (handled by an upper SharedFusedMoe layer,
@@ -20,7 +20,7 @@ EP note:
     For multi-GPU EP with local filtering, pass expert_map [E_global] int32.
     All-to-All communication is NOT performed here; use an external framework
     (vLLM / SGLang / Megatron) to handle dispatch/combine and call
-    MoeFusedExpertsFwdOp directly with pre-dispatched tokens.
+    FusedMoeExpertsFwdOp directly with pre-dispatched tokens.
 """
 
 from typing import Dict, Optional
@@ -28,7 +28,7 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.ops.moe.fused_moe_experts import MoeFusedExpertsFwdOp, MoeFusedExpertsPaddedFwdOp
+from tileops.ops.moe.fused_moe_experts import FusedMoeExpertsFwdOp, FusedMoeExpertsPaddedFwdOp
 from tileops.ops.moe.fused_topk import FusedTopKOp
 
 from ..op import Op
@@ -105,7 +105,7 @@ class FusedMoe(Op):
         if layout not in ("nopad", "padded"):
             raise ValueError(f"Unknown layout {layout!r}; expected 'nopad' or 'padded'")
 
-        experts_cls = MoeFusedExpertsFwdOp if layout == "nopad" else MoeFusedExpertsPaddedFwdOp
+        experts_cls = FusedMoeExpertsFwdOp if layout == "nopad" else FusedMoeExpertsPaddedFwdOp
         self._experts = experts_cls(
             num_tokens=num_tokens,
             num_experts=num_experts,

--- a/tileops/ops/moe/fused_moe_experts.py
+++ b/tileops/ops/moe/fused_moe_experts.py
@@ -1,7 +1,7 @@
 """Local routed expert GEMM — tight (no-pad) and padded layout variants.
 
-MoeFusedExpertsFwdOp        — tight layout (T*K rows), GPU tile scheduler, fastest.
-MoeFusedExpertsPaddedFwdOp  — block_m-aligned padding, reference / comparison baseline.
+FusedMoeExpertsFwdOp        — tight layout (T*K rows), GPU tile scheduler, fastest.
+FusedMoeExpertsPaddedFwdOp  — block_m-aligned padding, reference / comparison baseline.
 
 Both classes share an identical forward signature:
 
@@ -34,12 +34,12 @@ from tileops.ops.moe.unpermute import MoeUnpermuteFwdOp
 
 from ..op import Op
 
-__all__ = ["MoeFusedExpertsFwdOp", "MoeFusedExpertsPaddedFwdOp"]
+__all__ = ["FusedMoeExpertsFwdOp", "FusedMoeExpertsPaddedFwdOp"]
 
 _BLOCK_M: int = _GEMM_DEFAULT_CONFIGS[(False, True)]["block_m"]
 
 
-class MoeFusedExpertsFwdOp(Op):
+class FusedMoeExpertsFwdOp(Op):
     """Local routed expert GEMM, tight layout (T*K rows, no padding).
 
     Receives pre-computed routing (topk_weights, topk_ids) from the caller and
@@ -159,10 +159,10 @@ class MoeFusedExpertsFwdOp(Op):
         return output
 
 
-class MoeFusedExpertsPaddedFwdOp(Op):
+class FusedMoeExpertsPaddedFwdOp(Op):
     """Local routed expert GEMM, block_m-aligned padded layout.
 
-    Identical semantics to MoeFusedExpertsFwdOp but uses MoePermutePaddedFwdOp and
+    Identical semantics to FusedMoeExpertsFwdOp but uses MoePermutePaddedFwdOp and
     GroupedGemmOp instead of the no-pad variants.  Used as a comparison
     baseline to quantify the benefit of the tight (no-pad) layout.
 
@@ -199,7 +199,7 @@ class MoeFusedExpertsPaddedFwdOp(Op):
         if expert_map is not None:
             raise NotImplementedError(
                 "expert_map is not yet supported for the padded layout. "
-                "Use MoeFusedExpertsFwdOp (nopad) for EP mode."
+                "Use FusedMoeExpertsFwdOp (nopad) for EP mode."
             )
 
         numel = num_tokens * top_k

--- a/tileops/ops/op.py
+++ b/tileops/ops/op.py
@@ -17,8 +17,8 @@ class Op(ABC):
     - Autotuning interface
 
     Examples:
-        >>> from tileops.ops import MhaFwdOp #MhaFwdOp is a subclass of Op
-        >>> op = MhaFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
+        >>> from tileops.ops import MultiHeadAttentionFwdOp
+        >>> op = MultiHeadAttentionFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
         >>> Q, K, V = op.gen_inputs()
         >>> output = op(Q, K, V)
         >>> op.check()  # Verify correctness

--- a/workloads/ops/gqa.py
+++ b/workloads/ops/gqa.py
@@ -49,7 +49,7 @@ class GqaBwdTest(WorkloadBase):
             self.batch, self.seq_len, self.heads, self.dim, dtype=self.dtype, device='cuda')
 
         fwd_op = GroupedQueryAttentionFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
-                                          self.dim, self.is_causal, self.dtype)
+                                            self.dim, self.is_causal, self.dtype)
         with torch.no_grad():
             o, lse = fwd_op(q, k, v)
 

--- a/workloads/ops/gqa.py
+++ b/workloads/ops/gqa.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import torch
 
-from tileops.ops import GqaFwdOp
+from tileops.ops import GroupedQueryAttentionFwdOp
 from workloads.base import WorkloadBase
 
 
@@ -48,7 +48,7 @@ class GqaBwdTest(WorkloadBase):
         grad_output = torch.randn(
             self.batch, self.seq_len, self.heads, self.dim, dtype=self.dtype, device='cuda')
 
-        fwd_op = GqaFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
+        fwd_op = GroupedQueryAttentionFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
                                           self.dim, self.is_causal, self.dtype)
         with torch.no_grad():
             o, lse = fwd_op(q, k, v)

--- a/workloads/ops/mha.py
+++ b/workloads/ops/mha.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import torch
 
-from tileops.ops import MhaFwdOp
+from tileops.ops import MultiHeadAttentionFwdOp
 from workloads.base import WorkloadBase
 
 
@@ -47,7 +47,7 @@ class MhaBwdTest(WorkloadBase):
         grad_output = torch.randn(
             self.batch, self.seq_len, self.heads, self.dim, dtype=self.dtype, device='cuda')
 
-        fwd_op = MhaFwdOp(self.batch, self.heads, self.seq_len, self.dim,
+        fwd_op = MultiHeadAttentionFwdOp(self.batch, self.heads, self.seq_len, self.dim,
                                          self.is_causal, self.dtype)
         with torch.no_grad():
             o, lse = fwd_op(q, k, v)


### PR DESCRIPTION
## Summary

Rename 12 Op classes so that `__class__.__name__` matches the corresponding manifest key, completing the staged rollout from #880 and #873. Remove the `FIXME(staged-rollout)` xfail marker from the validator integration test.

Closes #881

## Changes

- Rename 10 attention Op classes (MHA, GQA, decode, paged variants) and 2 MoE Op classes to match their manifest keys
- Update all imports across tests, benchmarks, and workloads
- Update `__init__.py` re-exports
- Remove `FIXME(staged-rollout)` xfail marker from `test_validate_manifest.py`
- No changes to `tileops/ops_manifest.yaml`

## Test plan

- [x] AC-1: All 12 Op classes have `__class__.__name__` matching their manifest key
  - `python scripts/validate_manifest.py` -> All manifest checks passed (0 errors)
- [x] AC-2: `FIXME(staged-rollout)` marker removed
  - `rg -n 'FIXME(staged-rollout)' tests` -> no matches
- [x] AC-3: Validator integration test passes without xfail
  - `pytest -q tests/test_validate_manifest.py::TestIntegration::test_validator_passes_on_current_codebase` passed
- [x] AC-4: All tests pass
  - 109 passed, 237 warnings in 35.56s (manifest validator, compile, autotune, all attention + MoE op tests)
- [x] AC-5: No changes to `tileops/ops_manifest.yaml`
  - `git diff --stat main...HEAD -- tileops/ops_manifest.yaml` -> no output

## Follow-up

No follow-up issues. Suggestions: clarify in `docs/trust-model.md` that mechanical renames (import-only changes forced by upstream class renames) are exempt from staged rollout boundaries.