### PR TITLE
[Refactor][Manifest] Enforce status as required and validate kernel_map schema

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -248,8 +248,9 @@ def check_l0(
         )
 
     # status: must be "implemented" or "spec-only"
+    # (skip if already caught by missing top-level fields check)
     status = entry.get("status")
-    if not isinstance(status, str):
+    if "status" in entry and not isinstance(status, str):
         errors.append(
             f"[schema] {op_name}: status must be a string, "
             f"got {type(status).__name__}"
@@ -260,8 +261,9 @@ def check_l0(
             f"got '{status}'"
         )
 
-    # kernel_map: validated when present; warned when missing for implemented ops
-    kernel_map = entry.get("kernel_map")
+    # kernel_map: lives under source (source.kernel_map per manifest spec)
+    source = entry.get("source", {})
+    kernel_map = source.get("kernel_map") if isinstance(source, dict) else None
     if kernel_map is not None:
         if not isinstance(kernel_map, dict):
             errors.append(
@@ -864,8 +866,7 @@ def check_l4_benchmark(
 def _is_spec_only(entry: dict) -> bool:
     """Check if the entry is spec-only.
 
-    Raises KeyError if status is missing — callers must ensure schema
-    validation (which requires ``status``) has passed before calling.
+    Returns True for missing or non-string status (safe default).
     """
     status = entry.get("status")
     if not isinstance(status, str):

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -249,7 +249,7 @@ def check_l0(
 
     # status: must be "implemented" or "spec-only"
     status = entry.get("status")
-    if status is not None and not isinstance(status, str):
+    if not isinstance(status, str):
         errors.append(
             f"[schema] {op_name}: status must be a string, "
             f"got {type(status).__name__}"

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -273,12 +273,12 @@ def check_l0(
                 if not isinstance(k, str) or not isinstance(v, str):
                     errors.append(
                         f"[schema] {op_name}: kernel_map entries must be "
-                        f"str → str, got {k!r}: {v!r}"
+                        f"str -> str, got {k!r}: {v!r}"
                     )
     elif status == "implemented" and warnings is not None:
         warnings.append(
             f"[schema] {op_name}: status is 'implemented' but "
-            f"kernel_map is missing (should be a mapping of str → str)"
+            f"kernel_map is missing (should be a mapping of str -> str)"
         )
 
     return errors
@@ -868,11 +868,10 @@ def _is_spec_only(entry: dict) -> bool:
     validation (which requires ``status``) has passed before calling.
     """
     status = entry.get("status")
-    if status is None:
-        raise KeyError(
-            "Entry is missing required 'status' field; "
-            "schema validation should have caught this"
-        )
+    if not isinstance(status, str):
+        # Missing or non-string status — treat as spec-only (safe default).
+        # Schema validation catches this; defensive here for --levels bypass.
+        return True
     return status == "spec-only"
 
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -58,7 +58,9 @@ _VALID_LAYOUTS = {"channels_last"}
 # schema: YAML structure validation
 # ---------------------------------------------------------------------------
 
-def check_l0(op_name: str, entry: dict) -> list[str]:
+def check_l0(
+    op_name: str, entry: dict, *, warnings: list[str] | None = None,
+) -> list[str]:
     """Validate structural schema of a manifest entry. Returns error strings."""
     errors: list[str] = []
 
@@ -247,21 +249,21 @@ def check_l0(op_name: str, entry: dict) -> list[str]:
 
     # status: must be "implemented" or "spec-only"
     status = entry.get("status")
-    if isinstance(status, str) and status not in ("implemented", "spec-only"):
+    if status is not None and not isinstance(status, str):
+        errors.append(
+            f"[schema] {op_name}: status must be a string, "
+            f"got {type(status).__name__}"
+        )
+    elif isinstance(status, str) and status not in ("implemented", "spec-only"):
         errors.append(
             f"[schema] {op_name}: status must be 'implemented' or 'spec-only', "
             f"got '{status}'"
         )
 
-    # kernel_map: required when status is "implemented", must be dict of str → str
-    if status == "implemented":
-        kernel_map = entry.get("kernel_map")
-        if kernel_map is None:
-            errors.append(
-                f"[schema] {op_name}: status is 'implemented' but "
-                f"kernel_map is missing (must be a mapping of str → str)"
-            )
-        elif not isinstance(kernel_map, dict):
+    # kernel_map: validated when present; warned when missing for implemented ops
+    kernel_map = entry.get("kernel_map")
+    if kernel_map is not None:
+        if not isinstance(kernel_map, dict):
             errors.append(
                 f"[schema] {op_name}: kernel_map must be a mapping, "
                 f"got {type(kernel_map).__name__}"
@@ -273,6 +275,11 @@ def check_l0(op_name: str, entry: dict) -> list[str]:
                         f"[schema] {op_name}: kernel_map entries must be "
                         f"str → str, got {k!r}: {v!r}"
                     )
+    elif status == "implemented" and warnings is not None:
+        warnings.append(
+            f"[schema] {op_name}: status is 'implemented' but "
+            f"kernel_map is missing (should be a mapping of str → str)"
+        )
 
     return errors
 
@@ -948,7 +955,7 @@ def validate_manifest(
 
         # schema: YAML structure validation
         if "schema" in levels:
-            schema_errors = check_l0(op_name, entry)
+            schema_errors = check_l0(op_name, entry, warnings=all_warnings)
             all_errors.extend(schema_errors)
             if schema_errors:
                 continue

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -46,7 +46,7 @@ _TORCH_DTYPES = {
 _SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
 
 # Required top-level fields per op entry
-_REQUIRED_TOP = {"family", "signature", "workloads", "roofline", "source"}
+_REQUIRED_TOP = {"family", "status", "signature", "workloads", "roofline", "source"}
 _REQUIRED_SIGNATURE = {"inputs", "outputs"}
 _REQUIRED_SOURCE = {"kernel", "op", "test", "bench"}
 
@@ -244,6 +244,35 @@ def check_l0(op_name: str, entry: dict) -> list[str]:
         errors.append(
             f"[schema] {op_name}: ref_api must be a string"
         )
+
+    # status: must be "implemented" or "spec-only"
+    status = entry.get("status")
+    if isinstance(status, str) and status not in ("implemented", "spec-only"):
+        errors.append(
+            f"[schema] {op_name}: status must be 'implemented' or 'spec-only', "
+            f"got '{status}'"
+        )
+
+    # kernel_map: required when status is "implemented", must be dict of str → str
+    if status == "implemented":
+        kernel_map = entry.get("kernel_map")
+        if kernel_map is None:
+            errors.append(
+                f"[schema] {op_name}: status is 'implemented' but "
+                f"kernel_map is missing (must be a mapping of str → str)"
+            )
+        elif not isinstance(kernel_map, dict):
+            errors.append(
+                f"[schema] {op_name}: kernel_map must be a mapping, "
+                f"got {type(kernel_map).__name__}"
+            )
+        else:
+            for k, v in kernel_map.items():
+                if not isinstance(k, str) or not isinstance(v, str):
+                    errors.append(
+                        f"[schema] {op_name}: kernel_map entries must be "
+                        f"str → str, got {k!r}: {v!r}"
+                    )
 
     return errors
 
@@ -826,8 +855,18 @@ def check_l4_benchmark(
 # ---------------------------------------------------------------------------
 
 def _is_spec_only(entry: dict) -> bool:
-    """Default is spec-only when status is absent."""
-    return entry.get("status", "spec-only") == "spec-only"
+    """Check if the entry is spec-only.
+
+    Raises KeyError if status is missing — callers must ensure schema
+    validation (which requires ``status``) has passed before calling.
+    """
+    status = entry.get("status")
+    if status is None:
+        raise KeyError(
+            "Entry is missing required 'status' field; "
+            "schema validation should have caught this"
+        )
+    return status == "spec-only"
 
 
 def _is_bench_manifest_driven(entry: dict) -> bool:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -38,8 +38,12 @@ def validator():
 # ---------------------------------------------------------------------------
 
 def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
-                 source_kernel="k.py", **extra):
-    """Build a minimal valid manifest entry for testing, with overrides."""
+                 source_kernel="k.py", status="spec-only", **extra):
+    """Build a minimal valid manifest entry for testing, with overrides.
+
+    Use ``status=None`` to explicitly omit the status field (for testing
+    that the validator rejects entries without status).
+    """
     sig = {
         "inputs": inputs or {"x": {"dtype": "float16"}},
         "outputs": outputs or {"y": {"dtype": "same_as(x)"}},
@@ -59,6 +63,8 @@ def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
             "test": "t.py", "bench": "b.py",
         },
     }
+    if status is not None:
+        entry["status"] = status
     entry.update(extra)
     return entry
 
@@ -75,6 +81,8 @@ class TestSchema:
         entry = {
             "family": "normalization",
             "ref_api": "torch.nn.functional.rms_norm",
+            "status": "implemented",
+            "kernel_map": {"fwd": "RMSNormFwdKernel"},
             "signature": {
                 "inputs": {"x": {"dtype": "float16"}},
                 "outputs": {"y": {"dtype": "same_as(x)"}},
@@ -254,6 +262,70 @@ class TestSchema:
         entry = _make_entry(source_kernel=42)
         errors = validator.check_l0("test_op", entry)
         assert any("source.kernel" in e for e in errors)
+
+    def test_missing_status_fails(self, validator):
+        """Entry without status field must produce a schema error."""
+        entry = _make_entry(status=None)
+        assert "status" not in entry
+        errors = validator.check_l0("test_op", entry)
+        assert any("status" in e for e in errors), (
+            f"Expected schema error about missing status, got: {errors}"
+        )
+
+    def test_status_implemented_passes(self, validator):
+        """Entry with status: implemented and kernel_map passes schema check."""
+        entry = _make_entry(status="implemented", kernel_map={"fwd": "FwdKernel"})
+        errors = validator.check_l0("test_op", entry)
+        assert errors == [], f"Unexpected schema errors: {errors}"
+
+    def test_status_spec_only_passes(self, validator):
+        """Entry with status: spec-only passes schema check."""
+        entry = _make_entry(status="spec-only")
+        errors = validator.check_l0("test_op", entry)
+        assert errors == [], f"Unexpected schema errors: {errors}"
+
+    def test_kernel_map_valid_passes(self, validator):
+        """status: implemented with valid kernel_map dict passes."""
+        entry = _make_entry(status="implemented", kernel_map={"fwd": "FwdKernel"})
+        errors = validator.check_l0("test_op", entry)
+        assert errors == [], f"Unexpected schema errors: {errors}"
+
+    def test_kernel_map_required_when_implemented(self, validator):
+        """status: implemented without kernel_map must produce a schema error."""
+        entry = _make_entry(status="implemented")
+        entry.pop("kernel_map", None)
+        assert "kernel_map" not in entry
+        errors = validator.check_l0("test_op", entry)
+        assert any("kernel_map" in e for e in errors), (
+            f"Expected error about missing kernel_map for implemented op, got: {errors}"
+        )
+
+    def test_kernel_map_not_required_when_spec_only(self, validator):
+        """status: spec-only without kernel_map must NOT produce a kernel_map error."""
+        entry = _make_entry(status="spec-only")
+        errors = validator.check_l0("test_op", entry)
+        kernel_map_errors = [e for e in errors if "kernel_map" in e]
+        assert kernel_map_errors == [], (
+            f"spec-only op should not need kernel_map, got: {kernel_map_errors}"
+        )
+
+    def test_kernel_map_non_dict_fails(self, validator):
+        """kernel_map that is not a dict must fail."""
+        entry = _make_entry(status="implemented", kernel_map="not_a_dict")
+        errors = validator.check_l0("test_op", entry)
+        assert any("kernel_map" in e and "mapping" in e for e in errors)
+
+    def test_kernel_map_non_string_key_fails(self, validator):
+        """kernel_map with non-string values must fail."""
+        entry = _make_entry(status="implemented", kernel_map={"fwd": 123})
+        errors = validator.check_l0("test_op", entry)
+        assert any("kernel_map" in e for e in errors)
+
+    def test_kernel_map_empty_dict_passes(self, validator):
+        """status: implemented with empty kernel_map dict passes (valid dict of str:str)."""
+        entry = _make_entry(status="implemented", kernel_map={})
+        errors = validator.check_l0("test_op", entry)
+        assert errors == [], f"Unexpected schema errors: {errors}"
 
 
 # ---------------------------------------------------------------------------
@@ -683,10 +755,9 @@ class TestCheckOp:
             f"Spec-only op should only have schema errors (if any), got: {non_schema}"
         )
 
-    def test_missing_status_defaults_to_spec_only(self, validator, tmp_path):
-        """Entry without status field defaults to spec-only (skips L1-L4)."""
-        entry = _make_entry()
-        entry.pop("status", None)  # remove status entirely
+    def test_missing_status_rejected_at_schema_level(self, validator, tmp_path):
+        """Entry without status field is rejected by schema validation."""
+        entry = _make_entry(status=None)
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         import yaml
@@ -696,9 +767,9 @@ class TestCheckOp:
             manifest_path=manifest_file,
             repo_root=tmp_path,
         )
-        non_schema = [e for e in errors if "[schema]" not in e]
-        assert non_schema == [], (
-            f"Missing-status op should default to spec-only (L0 only), got: {non_schema}"
+        status_errors = [e for e in errors if "status" in e]
+        assert len(status_errors) > 0, (
+            f"Missing-status op should produce a schema error, got: {errors}"
         )
 
     def test_check_op_nonexistent_op_reports_error(self, validator, tmp_path):

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -284,20 +284,33 @@ class TestSchema:
         errors = validator.check_l0("test_op", entry)
         assert errors == [], f"Unexpected schema errors: {errors}"
 
+    def test_status_non_string_rejected(self, validator):
+        """Non-string status (e.g. integer) must produce a schema error."""
+        entry = _make_entry(status="placeholder")
+        entry["status"] = 123
+        errors = validator.check_l0("test_op", entry)
+        assert any("status" in e and "string" in e for e in errors), (
+            f"Expected schema error about non-string status, got: {errors}"
+        )
+
     def test_kernel_map_valid_passes(self, validator):
         """status: implemented with valid kernel_map dict passes."""
         entry = _make_entry(status="implemented", kernel_map={"fwd": "FwdKernel"})
         errors = validator.check_l0("test_op", entry)
         assert errors == [], f"Unexpected schema errors: {errors}"
 
-    def test_kernel_map_required_when_implemented(self, validator):
-        """status: implemented without kernel_map must produce a schema error."""
+    def test_kernel_map_missing_when_implemented_warns(self, validator):
+        """status: implemented without kernel_map produces a warning, not error."""
         entry = _make_entry(status="implemented")
         entry.pop("kernel_map", None)
         assert "kernel_map" not in entry
-        errors = validator.check_l0("test_op", entry)
-        assert any("kernel_map" in e for e in errors), (
-            f"Expected error about missing kernel_map for implemented op, got: {errors}"
+        warnings = []
+        errors = validator.check_l0("test_op", entry, warnings=warnings)
+        assert not any("kernel_map" in e for e in errors), (
+            f"Missing kernel_map should be a warning, not an error: {errors}"
+        )
+        assert any("kernel_map" in w for w in warnings), (
+            f"Expected warning about missing kernel_map, got warnings: {warnings}"
         )
 
     def test_kernel_map_not_required_when_spec_only(self, validator):
@@ -1242,4 +1255,18 @@ class TestIntegration:
             f"Validator failed with return code {result.returncode}.\n"
             f"stdout:\n{result.stdout}\n"
             f"stderr:\n{result.stderr}"
+        )
+
+    def test_schema_validation_no_errors_on_real_manifest(self, validator):
+        """Schema-level validation on the checked-in manifest produces no errors.
+
+        Warnings (e.g. missing kernel_map for implemented ops) are acceptable
+        since populating kernel_map for all ops is tracked separately.
+        """
+        errors, warnings = validator.validate_manifest(
+            levels=frozenset({"schema"}),
+        )
+        assert errors == [], (
+            f"Schema validation produced {len(errors)} error(s) on the "
+            f"checked-in manifest:\n" + "\n".join(errors)
         )

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -38,11 +38,13 @@ def validator():
 # ---------------------------------------------------------------------------
 
 def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
-                 source_kernel="k.py", status="spec-only", **extra):
+                 source_kernel="k.py", status="spec-only", kernel_map=None,
+                 **extra):
     """Build a minimal valid manifest entry for testing, with overrides.
 
     Use ``status=None`` to explicitly omit the status field (for testing
     that the validator rejects entries without status).
+    ``kernel_map`` is placed under ``source`` per the manifest spec.
     """
     sig = {
         "inputs": inputs or {"x": {"dtype": "float16"}},
@@ -52,16 +54,19 @@ def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
         sig["params"] = params
     if dtype_combos is not None:
         sig["dtype_combos"] = dtype_combos
+    source = {
+        "kernel": source_kernel, "op": "o.py",
+        "test": "t.py", "bench": "b.py",
+    }
+    if kernel_map is not None:
+        source["kernel_map"] = kernel_map
     entry = {
         "family": "test",
         "ref_api": "none",
         "signature": sig,
         "workloads": [{"x_shape": [1, 4096], "dtypes": ["float16"]}],
         "roofline": {"flops": "2 * M", "bytes": "M * 2"},
-        "source": {
-            "kernel": source_kernel, "op": "o.py",
-            "test": "t.py", "bench": "b.py",
-        },
+        "source": source,
     }
     if status is not None:
         entry["status"] = status
@@ -82,7 +87,6 @@ class TestSchema:
             "family": "normalization",
             "ref_api": "torch.nn.functional.rms_norm",
             "status": "implemented",
-            "kernel_map": {"fwd": "RMSNormFwdKernel"},
             "signature": {
                 "inputs": {"x": {"dtype": "float16"}},
                 "outputs": {"y": {"dtype": "same_as(x)"}},
@@ -93,6 +97,7 @@ class TestSchema:
             "roofline": {"flops": "2 * M * N", "bytes": "M * N * 2"},
             "source": {
                 "kernel": "tileops/kernels/norm/rms_norm.py",
+                "kernel_map": {"fwd": "RMSNormFwdKernel"},
                 "op": "tileops/ops/norm/rms_norm.py",
                 "test": "tests/ops/test_rms_norm.py",
                 "bench": "benchmarks/ops/bench_rms_norm.py",
@@ -302,8 +307,8 @@ class TestSchema:
     def test_kernel_map_missing_when_implemented_warns(self, validator):
         """status: implemented without kernel_map produces a warning, not error."""
         entry = _make_entry(status="implemented")
-        entry.pop("kernel_map", None)
-        assert "kernel_map" not in entry
+        entry["source"].pop("kernel_map", None)
+        assert "kernel_map" not in entry["source"]
         warnings = []
         errors = validator.check_l0("test_op", entry, warnings=warnings)
         assert not any("kernel_map" in e for e in errors), (


### PR DESCRIPTION
## Summary

Update the manifest validator to enforce `status` as required and validate `kernel_map` schema.

- `status` added to `_REQUIRED_TOP` — entries missing it produce a schema error
- `status` must be a string (`"implemented"` or `"spec-only"`); null and non-string values rejected
- `source.kernel_map` validated when present: must be `dict[str, str]`
- Missing `kernel_map` for `status: implemented` entries produces a **warning** (not error) — full enforcement deferred to #887 which populates kernel_map for all existing ops
- `_is_spec_only()` defaults to `True` on missing/non-string status (safe for `--levels` bypass)
- Integration test validates against the real checked-in manifest

## Changed files

- `scripts/validate_manifest.py` — status required, kernel_map validation, _is_spec_only safe default
- `tests/test_validate_manifest.py` — 9 new tests, updated helper, integration test

## Test plan

- [x] `pytest tests/test_validate_manifest.py` — 84 passed, 1 xfailed
- [x] `python scripts/validate_manifest.py` exits 0 on real manifest (25 kernel_map warnings)
- [x] Pre-commit hooks pass

Closes #886

## Follow-up

- #887 — Populate kernel_map for all implemented ops (converts warnings to clean pass)

No additional follow-up issues or suggestions.