### PR TITLE
[Refactor][Manifest] Add kernel_map to all implemented entries

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -125,6 +125,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/layer_norm.py
+      kernel_map:
+        layer_norm: LayerNormKernel
       op: tileops/ops/norm/layer_norm.py
       test: tests/ops/test_layer_norm.py
       bench: benchmarks/ops/bench_layer_norm.py
@@ -166,6 +168,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/ada_layer_norm/fwd.py
+      kernel_map:
+        ada_layer_norm: AdaLayerNormKernel
       op: tileops/ops/norm/ada_layer_norm.py
       test: tests/ops/test_ada_layer_norm.py
       bench: benchmarks/ops/bench_ada_layer_norm.py
@@ -209,6 +213,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/ada_layer_norm_zero/__init__.py
+      kernel_map:
+        ada_layer_norm: AdaLayerNormKernel
       op: tileops/ops/norm/ada_layer_norm_zero.py
       test: tests/ops/test_ada_layer_norm_zero.py
       bench: benchmarks/ops/bench_ada_layer_norm.py
@@ -255,6 +261,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/fused_add_norm/fwd.py
+      kernel_map:
+        fused_add_layer_norm: FusedAddLayerNormKernel
       op: tileops/ops/norm/fused_add_layer_norm.py
       test: tests/ops/test_fused_add_layer_norm.py
       bench: benchmarks/ops/bench_fused_add_layer_norm.py
@@ -302,6 +310,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/fused_add_norm/fwd.py
+      kernel_map:
+        fused_add_rms_norm: FusedAddRmsNormKernel
       op: tileops/ops/norm/fused_add_rmsnorm.py
       test: tests/ops/test_fused_add_rmsnorm.py
       bench: benchmarks/ops/bench_fused_add_rmsnorm.py
@@ -359,6 +369,9 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/batch_norm.py
+      kernel_map:
+        fwd_train_kernel: BatchNormFwdTrainKernel
+        fwd_infer_kernel: BatchNormFwdInferKernel
       op: tileops/ops/norm/batch_norm.py
       test: tests/ops/test_batch_norm.py
       bench: benchmarks/ops/bench_batch_norm.py
@@ -409,6 +422,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/batch_norm.py
+      kernel_map:
+        bwd_kernel: BatchNormBwdKernel
       op: tileops/ops/norm/batch_norm.py
       test: tests/ops/test_batch_norm.py
       bench: benchmarks/ops/bench_batch_norm.py
@@ -493,6 +508,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/group_norm.py
+      kernel_map:
+        group_norm: GroupNormKernel
       op: tileops/ops/norm/instance_norm.py
       test: tests/ops/test_instance_norm.py
       bench: benchmarks/ops/bench_instance_norm.py
@@ -534,6 +551,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
+      kernel_map:
+        mha_fwd_kernel: MhaFwdKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
@@ -581,6 +600,10 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_attn/bwd.py
+      kernel_map:
+        mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
+        mha_bwd_kernel: MhaBwdKernel
+        mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
@@ -619,6 +642,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
+      kernel_map:
+        gqa_fwd_kernel: GqaFwdKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
@@ -667,6 +692,10 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_attn/bwd.py
+      kernel_map:
+        gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
+        gqa_bwd_kernel: GqaBwdKernel
+        gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
@@ -709,6 +738,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_decode/mha_decode.py
+      kernel_map:
+        mha_decode_kernel: MhaDecodeKernel
       op: tileops/ops/mha_decode.py
       test: tests/ops/test_mha_decode.py
       bench: benchmarks/ops/bench_mha_decode.py
@@ -761,6 +792,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_decode/mha_decode_paged.py
+      kernel_map:
+        mha_decode_paged_kernel: MhaDecodePagedKernel
       op: tileops/ops/mha_decode_paged.py
       test: tests/ops/test_mha_decode_paged.py
       bench: benchmarks/ops/bench_mha_decode_paged.py
@@ -800,6 +833,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_decode/gqa_decode.py
+      kernel_map:
+        gqa_decode_kernel: GqaDecodeKernel
       op: tileops/ops/gqa_decode.py
       test: tests/ops/test_gqa_decode.py
       bench: benchmarks/ops/bench_gqa_decode.py
@@ -852,6 +887,8 @@ ops:
 
     source:
       kernel: tileops/kernels/flash_decode/gqa_decode_paged.py
+      kernel_map:
+        gqa_decode_paged_kernel: GqaDecodePagedKernel
       op: tileops/ops/gqa_decode_paged.py
       test: tests/ops/test_gqa_decode_paged.py
       bench: benchmarks/ops/bench_gqa_decode_paged.py
@@ -896,6 +933,8 @@ ops:
 
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_fwd.py
+      kernel_map:
+        gqa_sliding_window_fwd: GqaSlidingWindowFwdKernel
       op: tileops/ops/gqa_sliding_window_fwd.py
       test: tests/ops/test_gqa_sliding_window_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_fwd.py
@@ -941,6 +980,8 @@ ops:
 
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_varlen_fwd.py
+      kernel_map:
+        gqa_sliding_window_varlen_fwd: GqaSlidingWindowVarlenFwdKernel
       op: tileops/ops/gqa_sliding_window_varlen_fwd.py
       test: tests/ops/test_gqa_sliding_window_varlen_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
@@ -986,6 +1027,8 @@ ops:
 
     source:
       kernel: tileops/kernels/deepseek_mla/deepseek_mla_decode.py
+      kernel_map:
+        mla_decode_kernel: MlaDecodeKernel
       op: tileops/ops/deepseek_mla_decode.py
       test: tests/ops/test_deepseek_mla_decode.py
       bench: benchmarks/ops/bench_deepseek_mla_decode.py
@@ -1028,6 +1071,8 @@ ops:
 
     source:
       kernel: tileops/kernels/deepseek_mla/deepseek_dsa_decode.py
+      kernel_map:
+        sparse_mla_kernel: SparseMlaKernel
       op: tileops/ops/deepseek_dsa_decode.py
       test: tests/ops/test_deepseek_dsa_decode.py
       bench: benchmarks/ops/bench_deepseek_dsa_decode.py
@@ -1389,6 +1434,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/softmax/softmax_fwd.py
+      kernel_map:
+        softmax_fwd: SoftmaxKernel
       op: tileops/ops/reduction/softmax.py
       test: tests/ops/test_softmax.py
       bench: benchmarks/ops/bench_softmax.py
@@ -1427,6 +1474,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/softmax/softmax_fwd.py
+      kernel_map:
+        softmax_fwd: SoftmaxKernel
       op: tileops/ops/reduction/log_softmax.py
       test: tests/ops/test_softmax.py
       bench: benchmarks/ops/bench_softmax.py
@@ -1467,6 +1516,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/softmax/logsumexp_fwd.py
+      kernel_map:
+        logsumexp_fwd: LogSumExpKernel
       op: tileops/ops/reduction/logsumexp.py
       test: tests/ops/test_softmax.py
       bench: benchmarks/ops/bench_softmax.py
@@ -1835,6 +1886,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/argreduce/fwd.py
+      kernel_map:
+        argreduce: ArgreduceKernel
       op: tileops/ops/reduction/argmax.py
       test: tests/ops/test_argreduce.py
       bench: benchmarks/ops/bench_argreduce.py
@@ -1873,6 +1926,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/argreduce/fwd.py
+      kernel_map:
+        argreduce: ArgreduceKernel
       op: tileops/ops/reduction/argmin.py
       test: tests/ops/test_argreduce.py
       bench: benchmarks/ops/bench_argreduce.py

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -552,7 +552,9 @@ ops:
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
       kernel_map:
-        mha_fwd_kernel: MhaFwdKernel
+        mha_fwd_kernel:
+          - MhaFwdKernel
+          - MhaFwdWgmmaPipelinedKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
@@ -602,7 +604,9 @@ ops:
       kernel: tileops/kernels/flash_attn/bwd.py
       kernel_map:
         mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        mha_bwd_kernel: MhaBwdKernel
+        mha_bwd_kernel:
+          - MhaBwdKernel
+          - MhaBwdWgmmaPipelinedKernel
         mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
@@ -643,7 +647,9 @@ ops:
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
       kernel_map:
-        gqa_fwd_kernel: GqaFwdKernel
+        gqa_fwd_kernel:
+          - GqaFwdKernel
+          - GqaFwdWgmmaPipelinedKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
@@ -694,7 +700,9 @@ ops:
       kernel: tileops/kernels/flash_attn/bwd.py
       kernel_map:
         gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        gqa_bwd_kernel: GqaBwdKernel
+        gqa_bwd_kernel:
+          - GqaBwdKernel
+          - GqaBwdWgmmaPipelinedKernel
         gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
@@ -934,7 +942,9 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_fwd.py
       kernel_map:
-        gqa_sliding_window_fwd: GqaSlidingWindowFwdKernel
+        gqa_sliding_window_fwd:
+          - GqaSlidingWindowFwdKernel
+          - GqaSlidingWindowFwdWgmmaPipelinedKernel
       op: tileops/ops/gqa_sliding_window_fwd.py
       test: tests/ops/test_gqa_sliding_window_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_fwd.py
@@ -981,7 +991,9 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_varlen_fwd.py
       kernel_map:
-        gqa_sliding_window_varlen_fwd: GqaSlidingWindowVarlenFwdKernel
+        gqa_sliding_window_varlen_fwd:
+          - GqaSlidingWindowVarlenFwdKernel
+          - GqaSlidingWindowVarlenFwdWgmmaPipelinedKernel
       op: tileops/ops/gqa_sliding_window_varlen_fwd.py
       test: tests/ops/test_gqa_sliding_window_varlen_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
@@ -1028,7 +1040,9 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_mla/deepseek_mla_decode.py
       kernel_map:
-        mla_decode_kernel: MlaDecodeKernel
+        mla_decode_kernel:
+          - MlaDecodeKernel
+          - MlaDecodeWsKernel
       op: tileops/ops/deepseek_mla_decode.py
       test: tests/ops/test_deepseek_mla_decode.py
       bench: benchmarks/ops/bench_deepseek_mla_decode.py

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -552,9 +552,7 @@ ops:
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
       kernel_map:
-        mha_fwd_kernel:
-          - MhaFwdKernel
-          - MhaFwdWgmmaPipelinedKernel
+        mha_fwd_kernel: MhaFwdKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
       bench: benchmarks/ops/bench_mha.py
@@ -604,9 +602,7 @@ ops:
       kernel: tileops/kernels/flash_attn/bwd.py
       kernel_map:
         mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        mha_bwd_kernel:
-          - MhaBwdKernel
-          - MhaBwdWgmmaPipelinedKernel
+        mha_bwd_kernel: MhaBwdKernel
         mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/mha.py
       test: tests/ops/test_mha.py
@@ -647,9 +643,7 @@ ops:
     source:
       kernel: tileops/kernels/flash_attn/fwd.py
       kernel_map:
-        gqa_fwd_kernel:
-          - GqaFwdKernel
-          - GqaFwdWgmmaPipelinedKernel
+        gqa_fwd_kernel: GqaFwdKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
       bench: benchmarks/ops/bench_gqa.py
@@ -700,9 +694,7 @@ ops:
       kernel: tileops/kernels/flash_attn/bwd.py
       kernel_map:
         gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        gqa_bwd_kernel:
-          - GqaBwdKernel
-          - GqaBwdWgmmaPipelinedKernel
+        gqa_bwd_kernel: GqaBwdKernel
         gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
       op: tileops/ops/gqa.py
       test: tests/ops/test_gqa.py
@@ -942,9 +934,7 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_fwd.py
       kernel_map:
-        gqa_sliding_window_fwd:
-          - GqaSlidingWindowFwdKernel
-          - GqaSlidingWindowFwdWgmmaPipelinedKernel
+        gqa_sliding_window_fwd: GqaSlidingWindowFwdKernel
       op: tileops/ops/gqa_sliding_window_fwd.py
       test: tests/ops/test_gqa_sliding_window_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_fwd.py
@@ -991,9 +981,7 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_nsa/gqa_sliding_window_varlen_fwd.py
       kernel_map:
-        gqa_sliding_window_varlen_fwd:
-          - GqaSlidingWindowVarlenFwdKernel
-          - GqaSlidingWindowVarlenFwdWgmmaPipelinedKernel
+        gqa_sliding_window_varlen_fwd: GqaSlidingWindowVarlenFwdKernel
       op: tileops/ops/gqa_sliding_window_varlen_fwd.py
       test: tests/ops/test_gqa_sliding_window_varlen_fwd.py
       bench: benchmarks/ops/bench_gqa_sliding_window_varlen_fwd.py
@@ -1040,9 +1028,7 @@ ops:
     source:
       kernel: tileops/kernels/deepseek_mla/deepseek_mla_decode.py
       kernel_map:
-        mla_decode_kernel:
-          - MlaDecodeKernel
-          - MlaDecodeWsKernel
+        mla_decode_kernel: MlaDecodeKernel
       op: tileops/ops/deepseek_mla_decode.py
       test: tests/ops/test_deepseek_mla_decode.py
       bench: benchmarks/ops/bench_deepseek_mla_decode.py


### PR DESCRIPTION
## Summary

Add `kernel_map` to every `status: implemented` manifest entry, matching the Op's actual `default_kernel_map`. Hardware-conditional ops (MHA fwd/bwd, GQA fwd/bwd, sliding window fwd/varlen, MLA decode) use the base (non-Hopper) kernel class name as the canonical representative, since the manifest spec states kernel_map "does not describe dispatch strategy."

Closes #887

## Test plan

- [x] **AC-1**: Every `status: implemented` entry has a `kernel_map` in `source` -- verified: all 25 implemented entries have kernel_map (0 without)
- [x] **AC-2**: Each `kernel_map` matches the Op's actual `default_kernel_map` -- verified: all kernel class names confirmed via importlib; hardware-conditional ops use base kernel name per spec ("does not describe dispatch strategy")
- [x] **AC-3**: Validator passes -- `scripts/validate_manifest.py` exits 0 after rebase onto main (signature errors from #880 resolved by #883)

## Constraints

- Must not regress PR #878
- Manifest-only change per trust model -- no code modifications
- Depends on #886 (validator kernel_map checking)

## Follow-up

- #891 — Extend kernel_map schema to support hardware-conditional kernel variants (7 attention ops declare only the base kernel; Hopper WGMMA variants not representable in current schema)