### PR TITLE
[Fix][Manifest] Update Conv1d source.op path after #890 rename

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2306,7 +2306,7 @@ ops:
 
     source:
       kernel: tileops/kernels/conv/conv1d.py
-      op: tileops/ops/conv1d.py
+      op: tileops/ops/convolution.py
       test: tests/ops/test_conv1d.py
       bench: benchmarks/ops/bench_conv1d.py
       bench_manifest_driven: false
@@ -2355,7 +2355,7 @@ ops:
 
     source:
       kernel: tileops/kernels/conv/conv1d.py
-      op: tileops/ops/conv1d.py
+      op: tileops/ops/convolution.py
       test: tests/ops/test_conv1d.py
       bench: benchmarks/ops/bench_conv1d.py
       bench_manifest_driven: false


### PR DESCRIPTION
## Summary
- PR #890 renamed `tileops/ops/conv1d.py` → `tileops/ops/convolution.py` but missed updating the manifest `source.op` paths
- Fixes `Conv1dFwdOp` and `Conv1dBiasFwdOp` entries in `ops_manifest.yaml` to point to `tileops/ops/convolution.py`
- Resolves CI failure: `test_all_source_paths_exist` ([run](https://github.com/tile-ai/TileOPs/actions/runs/24241945891/job/70778466219))

## Test plan
- [x] `pytest tests/test_ops_manifest.py::TestSourcePaths::test_all_source_paths_exist` passes locally