### PR TITLE
[Refactor] Extract workload classes for reduction ops

### DIFF
--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from workloads.ops.argreduce import ArgmaxWorkload as _ArgmaxWorkload
+from workloads.ops.argreduce import ArgmaxTest as _ArgmaxWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from workloads.ops.argreduce import ArgmaxTest as _ArgmaxWorkload
+from workloads.ops.argreduce import ArgmaxWorkload as _ArgmaxWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from workloads.ops.argreduce import ArgmaxTest as _ArgmaxWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -101,22 +102,16 @@ class SpecArgreduceFixture(FixtureBase):
 
 
 # ---------------------------------------------------------------------------
-# TestBase helpers
+# TestBase helpers — inherit gen_inputs() from workload classes
 # ---------------------------------------------------------------------------
 
 
-class ArgreduceTest(TestBase):
+class ArgreduceTest(_ArgmaxWorkload, TestBase):
     """Parameterized test helper for argreduce ops."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
+        super().__init__((m, n), dtype)
         self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
         if self.op_kind == "argmax":

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from workloads.ops.logical_reduce import AnyWorkload as _AnyWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -131,56 +132,16 @@ class LogicalReduceKeepdimFixture(FixtureBase):
 
 
 # ---------------------------------------------------------------------------
-# TestBase helpers
+# TestBase helpers — inherit gen_inputs() from workload classes
 # ---------------------------------------------------------------------------
 
 
-class LogicalReduceTest(TestBase):
+class LogicalReduceTest(_AnyWorkload, TestBase):
     """Parameterized test helper for logical reduce ops."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
+        super().__init__((m, n), dtype)
         self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        # Mix of zeros and non-zeros for meaningful logical testing
-        if self.dtype == torch.bool:
-            x = torch.randint(0, 2, (self.m, self.n), dtype=torch.bool, device="cuda")
-            # Force some rows to be all-False for meaningful "any" tests
-            if self.m > 4:
-                x[0] = False
-            # Force some rows to be all-True for "all" tests
-            if self.m > 4:
-                x[1] = True
-        elif self.dtype in (torch.complex64, torch.complex128):
-            real = torch.randn(self.m, self.n, dtype=torch.float32, device="cuda")
-            imag = torch.randn(self.m, self.n, dtype=torch.float32, device="cuda")
-            x = torch.complex(real, imag).to(self.dtype)
-            # Force some rows to be all-zero (complex zero)
-            if self.m > 4:
-                x[0] = 0 + 0j
-            # Force some rows to have all non-zero
-            if self.m > 4:
-                x[1] = 1 + 1j
-        elif self.dtype in (torch.int32, torch.int64):
-            x = torch.randint(-5, 6, (self.m, self.n), dtype=self.dtype, device="cuda")
-            # Force some rows to be all-zero for meaningful "any" tests
-            if self.m > 4:
-                x[0] = 0
-            # Force some rows to have all non-zero for "all" tests
-            if self.m > 4:
-                x[1] = 1
-        else:
-            x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-            # Force some rows to be all-zero for meaningful "any" tests
-            if self.m > 4:
-                x[0] = 0.0
-            # Force some rows to have all non-zero for "all" tests
-            if self.m > 4:
-                x[1] = 1.0
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
         if self.op_kind == "any":

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from workloads.ops.logical_reduce import AnyWorkload as _AnyWorkload
+from workloads.ops.logical_reduce import AnyTest as _AnyWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -9,9 +9,13 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from workloads.ops.reduce import (
-    ProdTest,
-    StdTest,
-    SumTest,
+    ProdTest as _ProdTest,
+)
+from workloads.ops.reduce import (
+    StdTest as _StdTest,
+)
+from workloads.ops.reduce import (
+    SumTest as _SumTest,
 )
 
 # ---------------------------------------------------------------------------
@@ -106,7 +110,7 @@ class BesselFixture(FixtureBase):
 # ---------------------------------------------------------------------------
 
 
-class ReduceTest(SumTest, TestBase):
+class ReduceTest(_SumTest, TestBase):
     """Parameterized test helper for simple reduce ops (sum/mean/amax/amin)."""
 
     def __init__(
@@ -128,7 +132,7 @@ class ReduceTest(SumTest, TestBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class ProdTest(ProdTest, TestBase):
+class ProdTest(_ProdTest, TestBase):
     """Parameterized test helper for prod op (uses small-range inputs)."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype):
@@ -138,7 +142,7 @@ class ProdTest(ProdTest, TestBase):
         return x.float().prod(dim=-1).to(x.dtype)
 
 
-class WelfordTest(StdTest, TestBase):
+class WelfordTest(_StdTest, TestBase):
     """Test helper for Welford-based ops (std, var, var_mean)."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str, correction: int = 1):

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -8,6 +8,11 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from workloads.ops.reduce import (
+    ProdWorkload,
+    StdWorkload,
+    SumWorkload,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -97,29 +102,18 @@ class BesselFixture(FixtureBase):
 
 
 # ---------------------------------------------------------------------------
-# TestBase helpers
+# TestBase helpers — inherit gen_inputs() from workload classes
 # ---------------------------------------------------------------------------
 
 
-class ReduceTest(TestBase):
-    """Parameterized test helper for simple reduce ops."""
+class ReduceTest(SumWorkload, TestBase):
+    """Parameterized test helper for simple reduce ops (sum/mean/amax/amin)."""
 
     def __init__(
-        self, m: int, n: int, dtype: torch.dtype, op_kind: str, use_small_range: bool = False
+        self, m: int, n: int, dtype: torch.dtype, op_kind: str,
     ):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
+        super().__init__((m, n), dtype)
         self.op_kind = op_kind
-        self.use_small_range = use_small_range
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        if self.use_small_range:
-            # For prod, use small values to avoid overflow
-            x = torch.rand(self.m, self.n, dtype=self.dtype, device="cuda") * 0.01 + 0.99
-        else:
-            x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
         x_f32 = x.float()
@@ -131,24 +125,26 @@ class ReduceTest(TestBase):
             return x_f32.amax(dim=-1).to(x.dtype)
         elif self.op_kind == "amin":
             return x_f32.amin(dim=-1).to(x.dtype)
-        elif self.op_kind == "prod":
-            return x_f32.prod(dim=-1).to(x.dtype)
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class WelfordTest(TestBase):
+class ProdTest(ProdWorkload, TestBase):
+    """Parameterized test helper for prod op (uses small-range inputs)."""
+
+    def __init__(self, m: int, n: int, dtype: torch.dtype):
+        super().__init__((m, n), dtype)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return x.float().prod(dim=-1).to(x.dtype)
+
+
+class WelfordTest(StdWorkload, TestBase):
     """Test helper for Welford-based ops (std, var, var_mean)."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str, correction: int = 1):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
+        super().__init__((m, n), dtype)
         self.op_kind = op_kind
         self.correction = correction
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> object:
         x_f32 = x.float()
@@ -276,7 +272,7 @@ def test_amax_op(m: int, n: int, dtype: torch.dtype) -> None:
 def test_prod_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.reduce import ProdFwdOp
 
-    test = ReduceTest(m, n, dtype, "prod", use_small_range=True)
+    test = ProdTest(m, n, dtype)
     op = ProdFwdOp(dtype=dtype)
     # Prod is more numerically sensitive
     tol = {"atol": 5e-2, "rtol": 5e-2} if dtype != torch.float32 else {"atol": 1e-3, "rtol": 1e-3}

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -9,9 +9,9 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from workloads.ops.reduce import (
-    ProdWorkload,
-    StdWorkload,
-    SumWorkload,
+    ProdTest,
+    StdTest,
+    SumTest,
 )
 
 # ---------------------------------------------------------------------------
@@ -106,7 +106,7 @@ class BesselFixture(FixtureBase):
 # ---------------------------------------------------------------------------
 
 
-class ReduceTest(SumWorkload, TestBase):
+class ReduceTest(SumTest, TestBase):
     """Parameterized test helper for simple reduce ops (sum/mean/amax/amin)."""
 
     def __init__(
@@ -128,7 +128,7 @@ class ReduceTest(SumWorkload, TestBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class ProdTest(ProdWorkload, TestBase):
+class ProdTest(ProdTest, TestBase):
     """Parameterized test helper for prod op (uses small-range inputs)."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype):
@@ -138,7 +138,7 @@ class ProdTest(ProdWorkload, TestBase):
         return x.float().prod(dim=-1).to(x.dtype)
 
 
-class WelfordTest(StdWorkload, TestBase):
+class WelfordTest(StdTest, TestBase):
     """Test helper for Welford-based ops (std, var, var_mean)."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str, correction: int = 1):

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, allclose_compare
-from workloads.ops.vector_norm import L1NormWorkload as _L1NormWorkload
+from workloads.ops.vector_norm import L1NormTest as _L1NormWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -94,6 +94,7 @@ class VectorNorm1DFixture(FixtureBase):
 # Map op_kind to the ord parameter for torch.linalg.vector_norm
 _ORD_MAP = {"l1": 1, "l2": 2, "inf": float("inf")}
 
+
 class VectorNormTest(_L1NormWorkload, TestBase):
     """Parameterized test helper for vector norm ops."""
 

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, allclose_compare
+from workloads.ops.vector_norm import L1NormWorkload as _L1NormWorkload
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -86,26 +87,19 @@ class VectorNorm1DFixture(FixtureBase):
 
 
 # ---------------------------------------------------------------------------
-# TestBase helpers
+# TestBase helpers — inherit gen_inputs() from workload classes
 # ---------------------------------------------------------------------------
 
 
 # Map op_kind to the ord parameter for torch.linalg.vector_norm
 _ORD_MAP = {"l1": 1, "l2": 2, "inf": float("inf")}
 
-
-class VectorNormTest(TestBase):
+class VectorNormTest(_L1NormWorkload, TestBase):
     """Parameterized test helper for vector norm ops."""
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
+        super().__init__((m, n), dtype)
         self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
         # Compute in fp32 for reference, then cast back to input dtype

--- a/workloads/base.py
+++ b/workloads/base.py
@@ -9,6 +9,8 @@ Correctness-only logic (ref_program, check, tolerances) stays in tests/.
 from abc import ABC, abstractmethod
 from typing import Any
 
+import torch
+
 
 class WorkloadBase(ABC):
     """Abstract base for workload definitions (input generation + parameters).
@@ -23,6 +25,18 @@ class WorkloadBase(ABC):
     @abstractmethod
     def gen_inputs(self) -> Any:
         raise NotImplementedError
+
+
+class RandnTest(WorkloadBase):
+    """Workload base for ops whose inputs are generated via ``torch.randn``."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
 
 
 class FixtureMeta(type):

--- a/workloads/ops/argreduce.py
+++ b/workloads/ops/argreduce.py
@@ -1,23 +1,9 @@
-import torch
-
-from workloads.base import WorkloadBase
+from workloads.base import RandnTest
 
 
-class _RandnTest(WorkloadBase):
-    """Base for workloads that generate inputs via torch.randn."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class ArgmaxTest(_RandnTest):
+class ArgmaxTest(RandnTest):
     """Workload definition for ArgmaxFwdOp."""
 
 
-class ArgminTest(_RandnTest):
+class ArgminTest(RandnTest):
     """Workload definition for ArgminFwdOp."""

--- a/workloads/ops/argreduce.py
+++ b/workloads/ops/argreduce.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class _RandnWorkload(WorkloadBase):
+class _RandnTest(WorkloadBase):
     """Base for workloads that generate inputs via torch.randn."""
 
     def __init__(self, shape: tuple, dtype: torch.dtype):
@@ -15,14 +15,9 @@ class _RandnWorkload(WorkloadBase):
         return (x,)
 
 
-class ArgmaxWorkload(_RandnWorkload):
+class ArgmaxTest(_RandnTest):
     """Workload definition for ArgmaxFwdOp."""
 
 
-class ArgminWorkload(_RandnWorkload):
+class ArgminTest(_RandnTest):
     """Workload definition for ArgminFwdOp."""
-
-
-# Backward-compatible aliases for existing consumers
-ArgmaxTest = ArgmaxWorkload
-ArgminTest = ArgminWorkload

--- a/workloads/ops/argreduce.py
+++ b/workloads/ops/argreduce.py
@@ -3,8 +3,8 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class ArgmaxTest(WorkloadBase):
-    """Workload definition for ArgmaxFwdOp (spec interface: shape + dtype)."""
+class _RandnWorkload(WorkloadBase):
+    """Base for workloads that generate inputs via torch.randn."""
 
     def __init__(self, shape: tuple, dtype: torch.dtype):
         self.shape = shape
@@ -15,13 +15,14 @@ class ArgmaxTest(WorkloadBase):
         return (x,)
 
 
-class ArgminTest(WorkloadBase):
-    """Workload definition for ArgminFwdOp (spec interface: shape + dtype)."""
+class ArgmaxWorkload(_RandnWorkload):
+    """Workload definition for ArgmaxFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
+class ArgminWorkload(_RandnWorkload):
+    """Workload definition for ArgminFwdOp."""
+
+
+# Backward-compatible aliases for existing consumers
+ArgmaxTest = ArgmaxWorkload
+ArgminTest = ArgminWorkload

--- a/workloads/ops/logical_reduce.py
+++ b/workloads/ops/logical_reduce.py
@@ -57,8 +57,9 @@ class CountNonzeroTest(WorkloadBase):
 def _make_logical_input(shape: tuple, dtype: torch.dtype) -> torch.Tensor:
     """Create a tensor with a mix of zeros and non-zeros.
 
-    For 2-D+ inputs the first row is forced to all-zero (meaningful for
-    ``any``) and the second row to all-nonzero (meaningful for ``all``).
+    When the first dimension is large enough (>4), the first row is forced
+    to all-zero (meaningful for ``any``) and the second row to all-nonzero
+    (meaningful for ``all``).
     """
     m = shape[0] if len(shape) >= 1 else 1
 

--- a/workloads/ops/logical_reduce.py
+++ b/workloads/ops/logical_reduce.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class AnyWorkload(WorkloadBase):
+class AnyTest(WorkloadBase):
     """Workload definition for AnyFwdOp.
 
     Generates inputs with a mix of zeros and non-zeros for meaningful
@@ -19,10 +19,10 @@ class AnyWorkload(WorkloadBase):
         return (_make_logical_input(self.shape, self.dtype),)
 
 
-class AllWorkload(WorkloadBase):
+class AllTest(WorkloadBase):
     """Workload definition for AllFwdOp.
 
-    Same input-generation strategy as AnyWorkload (rows with all-True
+    Same input-generation strategy as AnyTest (rows with all-True
     and all-False are forced for meaningful coverage).
     """
 
@@ -34,7 +34,7 @@ class AllWorkload(WorkloadBase):
         return (_make_logical_input(self.shape, self.dtype),)
 
 
-class CountNonzeroWorkload(WorkloadBase):
+class CountNonzeroTest(WorkloadBase):
     """Workload definition for CountNonzeroFwdOp.
 
     Uses the same mixed-zero input strategy as the other logical reduce

--- a/workloads/ops/logical_reduce.py
+++ b/workloads/ops/logical_reduce.py
@@ -1,0 +1,88 @@
+import torch
+
+from workloads.base import WorkloadBase
+
+
+class AnyWorkload(WorkloadBase):
+    """Workload definition for AnyFwdOp.
+
+    Generates inputs with a mix of zeros and non-zeros for meaningful
+    logical reduction testing.  Boolean, integer, float, and complex
+    dtypes are supported.
+    """
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        return (_make_logical_input(self.shape, self.dtype),)
+
+
+class AllWorkload(WorkloadBase):
+    """Workload definition for AllFwdOp.
+
+    Same input-generation strategy as AnyWorkload (rows with all-True
+    and all-False are forced for meaningful coverage).
+    """
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        return (_make_logical_input(self.shape, self.dtype),)
+
+
+class CountNonzeroWorkload(WorkloadBase):
+    """Workload definition for CountNonzeroFwdOp.
+
+    Uses the same mixed-zero input strategy as the other logical reduce
+    workloads.
+    """
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        return (_make_logical_input(self.shape, self.dtype),)
+
+
+# ---------------------------------------------------------------------------
+# Shared input-generation helper
+# ---------------------------------------------------------------------------
+
+
+def _make_logical_input(shape: tuple, dtype: torch.dtype) -> torch.Tensor:
+    """Create a tensor with a mix of zeros and non-zeros.
+
+    For 2-D+ inputs the first row is forced to all-zero (meaningful for
+    ``any``) and the second row to all-nonzero (meaningful for ``all``).
+    """
+    m = shape[0] if len(shape) >= 1 else 1
+
+    if dtype == torch.bool:
+        x = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+        if m > 4:
+            x[0] = False
+            x[1] = True
+    elif dtype in (torch.complex64, torch.complex128):
+        real = torch.randn(*shape, dtype=torch.float32, device="cuda")
+        imag = torch.randn(*shape, dtype=torch.float32, device="cuda")
+        x = torch.complex(real, imag).to(dtype)
+        if m > 4:
+            x[0] = 0 + 0j
+            x[1] = 1 + 1j
+    elif dtype in (torch.int32, torch.int64):
+        x = torch.randint(-5, 6, shape, dtype=dtype, device="cuda")
+        if m > 4:
+            x[0] = 0
+            x[1] = 1
+    else:
+        x = torch.randn(*shape, dtype=dtype, device="cuda")
+        if m > 4:
+            x[0] = 0.0
+            x[1] = 1.0
+
+    return x

--- a/workloads/ops/reduce.py
+++ b/workloads/ops/reduce.py
@@ -1,33 +1,21 @@
 import torch
 
-from workloads.base import WorkloadBase
+from workloads.base import RandnTest, WorkloadBase
 
 
-class _RandnTest(WorkloadBase):
-    """Base for workloads that generate inputs via torch.randn."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class SumTest(_RandnTest):
+class SumTest(RandnTest):
     """Workload definition for SumFwdOp."""
 
 
-class MeanTest(_RandnTest):
+class MeanTest(RandnTest):
     """Workload definition for MeanFwdOp."""
 
 
-class AmaxTest(_RandnTest):
+class AmaxTest(RandnTest):
     """Workload definition for AmaxFwdOp."""
 
 
-class AminTest(_RandnTest):
+class AminTest(RandnTest):
     """Workload definition for AminFwdOp."""
 
 
@@ -46,13 +34,13 @@ class ProdTest(WorkloadBase):
         return (x,)
 
 
-class StdTest(_RandnTest):
+class StdTest(RandnTest):
     """Workload definition for StdFwdOp."""
 
 
-class VarTest(_RandnTest):
+class VarTest(RandnTest):
     """Workload definition for VarFwdOp."""
 
 
-class VarMeanTest(_RandnTest):
+class VarMeanTest(RandnTest):
     """Workload definition for VarMeanFwdOp."""

--- a/workloads/ops/reduce.py
+++ b/workloads/ops/reduce.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class _RandnWorkload(WorkloadBase):
+class _RandnTest(WorkloadBase):
     """Base for workloads that generate inputs via torch.randn."""
 
     def __init__(self, shape: tuple, dtype: torch.dtype):
@@ -15,23 +15,23 @@ class _RandnWorkload(WorkloadBase):
         return (x,)
 
 
-class SumWorkload(_RandnWorkload):
+class SumTest(_RandnTest):
     """Workload definition for SumFwdOp."""
 
 
-class MeanWorkload(_RandnWorkload):
+class MeanTest(_RandnTest):
     """Workload definition for MeanFwdOp."""
 
 
-class AmaxWorkload(_RandnWorkload):
+class AmaxTest(_RandnTest):
     """Workload definition for AmaxFwdOp."""
 
 
-class AminWorkload(_RandnWorkload):
+class AminTest(_RandnTest):
     """Workload definition for AminFwdOp."""
 
 
-class ProdWorkload(WorkloadBase):
+class ProdTest(WorkloadBase):
     """Workload definition for ProdFwdOp.
 
     Uses small-range values (0.99..1.0) to avoid overflow in product reduction.
@@ -46,13 +46,13 @@ class ProdWorkload(WorkloadBase):
         return (x,)
 
 
-class StdWorkload(_RandnWorkload):
+class StdTest(_RandnTest):
     """Workload definition for StdFwdOp."""
 
 
-class VarWorkload(_RandnWorkload):
+class VarTest(_RandnTest):
     """Workload definition for VarFwdOp."""
 
 
-class VarMeanWorkload(_RandnWorkload):
+class VarMeanTest(_RandnTest):
     """Workload definition for VarMeanFwdOp."""

--- a/workloads/ops/reduce.py
+++ b/workloads/ops/reduce.py
@@ -1,0 +1,102 @@
+import torch
+
+from workloads.base import WorkloadBase
+
+
+class SumWorkload(WorkloadBase):
+    """Workload definition for SumFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class MeanWorkload(WorkloadBase):
+    """Workload definition for MeanFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class AmaxWorkload(WorkloadBase):
+    """Workload definition for AmaxFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class AminWorkload(WorkloadBase):
+    """Workload definition for AminFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class ProdWorkload(WorkloadBase):
+    """Workload definition for ProdFwdOp.
+
+    Uses small-range values (0.99..1.0) to avoid overflow in product reduction.
+    """
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.rand(*self.shape, dtype=self.dtype, device="cuda") * 0.01 + 0.99
+        return (x,)
+
+
+class StdWorkload(WorkloadBase):
+    """Workload definition for StdFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class VarWorkload(WorkloadBase):
+    """Workload definition for VarFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class VarMeanWorkload(WorkloadBase):
+    """Workload definition for VarMeanFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)

--- a/workloads/ops/reduce.py
+++ b/workloads/ops/reduce.py
@@ -3,52 +3,32 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class SumWorkload(WorkloadBase):
+class _RandnWorkload(WorkloadBase):
+    """Base for workloads that generate inputs via torch.randn."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class SumWorkload(_RandnWorkload):
     """Workload definition for SumFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class MeanWorkload(WorkloadBase):
+class MeanWorkload(_RandnWorkload):
     """Workload definition for MeanFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class AmaxWorkload(WorkloadBase):
+class AmaxWorkload(_RandnWorkload):
     """Workload definition for AmaxFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class AminWorkload(WorkloadBase):
+class AminWorkload(_RandnWorkload):
     """Workload definition for AminFwdOp."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
 
 
 class ProdWorkload(WorkloadBase):
@@ -66,37 +46,13 @@ class ProdWorkload(WorkloadBase):
         return (x,)
 
 
-class StdWorkload(WorkloadBase):
+class StdWorkload(_RandnWorkload):
     """Workload definition for StdFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class VarWorkload(WorkloadBase):
+class VarWorkload(_RandnWorkload):
     """Workload definition for VarFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class VarMeanWorkload(WorkloadBase):
+class VarMeanWorkload(_RandnWorkload):
     """Workload definition for VarMeanFwdOp."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)

--- a/workloads/ops/vector_norm.py
+++ b/workloads/ops/vector_norm.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class _RandnWorkload(WorkloadBase):
+class _RandnTest(WorkloadBase):
     """Base for workloads that generate inputs via torch.randn."""
 
     def __init__(self, shape: tuple, dtype: torch.dtype):
@@ -15,13 +15,13 @@ class _RandnWorkload(WorkloadBase):
         return (x,)
 
 
-class L1NormWorkload(_RandnWorkload):
+class L1NormTest(_RandnTest):
     """Workload definition for L1NormFwdOp."""
 
 
-class L2NormWorkload(_RandnWorkload):
+class L2NormTest(_RandnTest):
     """Workload definition for L2NormFwdOp."""
 
 
-class InfNormWorkload(_RandnWorkload):
+class InfNormTest(_RandnTest):
     """Workload definition for InfNormFwdOp."""

--- a/workloads/ops/vector_norm.py
+++ b/workloads/ops/vector_norm.py
@@ -3,37 +3,25 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class L1NormWorkload(WorkloadBase):
+class _RandnWorkload(WorkloadBase):
+    """Base for workloads that generate inputs via torch.randn."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class L1NormWorkload(_RandnWorkload):
     """Workload definition for L1NormFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class L2NormWorkload(WorkloadBase):
+class L2NormWorkload(_RandnWorkload):
     """Workload definition for L2NormFwdOp."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class InfNormWorkload(WorkloadBase):
+class InfNormWorkload(_RandnWorkload):
     """Workload definition for InfNormFwdOp."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)

--- a/workloads/ops/vector_norm.py
+++ b/workloads/ops/vector_norm.py
@@ -1,27 +1,13 @@
-import torch
-
-from workloads.base import WorkloadBase
+from workloads.base import RandnTest
 
 
-class _RandnTest(WorkloadBase):
-    """Base for workloads that generate inputs via torch.randn."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class L1NormTest(_RandnTest):
+class L1NormTest(RandnTest):
     """Workload definition for L1NormFwdOp."""
 
 
-class L2NormTest(_RandnTest):
+class L2NormTest(RandnTest):
     """Workload definition for L2NormFwdOp."""
 
 
-class InfNormTest(_RandnTest):
+class InfNormTest(RandnTest):
     """Workload definition for InfNormFwdOp."""

--- a/workloads/ops/vector_norm.py
+++ b/workloads/ops/vector_norm.py
@@ -1,0 +1,39 @@
+import torch
+
+from workloads.base import WorkloadBase
+
+
+class L1NormWorkload(WorkloadBase):
+    """Workload definition for L1NormFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class L2NormWorkload(WorkloadBase):
+    """Workload definition for L2NormFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)
+
+
+class InfNormWorkload(WorkloadBase):
+    """Workload definition for InfNormFwdOp."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
+        return (x,)


### PR DESCRIPTION
## Summary

Create `workloads/ops/` files for the 4 reduction op groups (reduce, argreduce, logical_reduce, vector_norm) and refactor test files to import from them, aligning with the trust model's workloads layer contract.

Closes #825

## Test plan

- [x] **AC-1**: Modified files pass unit tests (`pytest tests/ops/test_{reduce,argreduce,logical_reduce,vector_norm}.py`)
- [x] **AC-2**: `workloads/ops/{reduce,argreduce,logical_reduce,vector_norm}.py` exist, each exporting only `WorkloadBase` subclasses with `gen_inputs()`
- [x] **AC-3**: Test files import workload classes from `workloads/ops/`, not defining `gen_inputs()` inline
- [x] **AC-4**: No `ref_program` or test-layer logic in `workloads/ops/` files

Tests: 413/413 passed, 0 failed

## Changes

- New `workloads/ops/reduce.py` — workload classes for sum/mean/amax/amin/prod/std/var/var_mean
- New `workloads/ops/logical_reduce.py` — workload classes for all/any/count_nonzero
- New `workloads/ops/vector_norm.py` — workload classes for l1_norm/l2_norm/inf_norm
- Refactored `tests/ops/test_reduce.py`, `test_argreduce.py`, `test_logical_reduce.py`, `test_vector_norm.py` to inherit from workload classes

## Follow-up

- #897 — Extract `_LogicalTest` base class in `logical_reduce.py` to deduplicate identical `__init__`/`gen_inputs` across `AnyTest`, `AllTest`, `CountNonzeroTest`

Suggestions: consolidate cross-module `_RandnTest` duplication; fix `_make_logical_input` docstring (says "2-D+" but applies to 1-D too)