### PR TITLE
[Bench] Rewrite reduction bench files to manifest-driven pattern

### DIFF
--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -14,7 +14,7 @@ from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.reduction.all_op import AllFwdOp
 from tileops.ops.reduction.any_op import AnyFwdOp
 from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
-from workloads.ops.logical_reduce import AllTest, AnyTest, CountNonzeroTest
+from workloads.ops.logical_reduce import AllWorkload, AnyWorkload, CountNonzeroWorkload
 
 # ===================================================================
 # Op name constants
@@ -120,7 +120,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ANY_OP)))
 def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AnyTest(shape, dtype)
+    test = AnyWorkload(shape, dtype)
     bm = AnyBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -147,7 +147,7 @@ def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ALL_OP)))
 def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AllTest(shape, dtype)
+    test = AllWorkload(shape, dtype)
     bm = AllBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -174,7 +174,7 @@ def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_COUNT_NONZERO_OP)))
 def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = CountNonzeroTest(shape, dtype)
+    test = CountNonzeroWorkload(shape, dtype)
     bm = CountNonzeroBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -14,7 +14,7 @@ from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.reduction.all_op import AllFwdOp
 from tileops.ops.reduction.any_op import AnyFwdOp
 from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
-from workloads.ops.logical_reduce import AllWorkload, AnyWorkload, CountNonzeroWorkload
+from workloads.ops.logical_reduce import AllTest, AnyTest, CountNonzeroTest
 
 # ===================================================================
 # Op name constants
@@ -120,7 +120,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ANY_OP)))
 def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AnyWorkload(shape, dtype)
+    test = AnyTest(shape, dtype)
     bm = AnyBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -147,7 +147,7 @@ def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ALL_OP)))
 def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AllWorkload(shape, dtype)
+    test = AllTest(shape, dtype)
     bm = AllBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -174,7 +174,7 @@ def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_COUNT_NONZERO_OP)))
 def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = CountNonzeroWorkload(shape, dtype)
+    test = CountNonzeroTest(shape, dtype)
     bm = CountNonzeroBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -1,4 +1,8 @@
-"""Benchmarks for logical reduce ops (any, all, count_nonzero)."""
+"""Benchmarks for logical reduce ops (any, all, count_nonzero).
+
+Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
+Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
+"""
 
 from typing import Optional
 
@@ -6,104 +10,187 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from workloads.base import FixtureBase, WorkloadBase
+from tileops.manifest import eval_roofline, load_workloads
+from tileops.ops.reduction.all_op import AllFwdOp
+from tileops.ops.reduction.any_op import AnyFwdOp
+from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
+from workloads.ops.logical_reduce import AllTest, AnyTest, CountNonzeroTest
+
+# ===================================================================
+# Op name constants
+# ===================================================================
+
+_ANY_OP = "AnyFwdOp"
+_ALL_OP = "AllFwdOp"
+_COUNT_NONZERO_OP = "CountNonzeroFwdOp"
 
 
-class LogicalReduceBenchFixture(FixtureBase):
-    PARAMS = [
-        (
-            "m, n, dtype, op_kind",
-            [
-                # --- any ---
-                pytest.param(1024, 4096, torch.float16, "any", marks=pytest.mark.smoke),
-                pytest.param(1024, 4096, torch.bfloat16, "any", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "any", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.int32, "any", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "any", marks=pytest.mark.full),
-                # --- all ---
-                pytest.param(1024, 4096, torch.float16, "all", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.bfloat16, "all", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "all", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.int32, "all", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "all", marks=pytest.mark.full),
-                # --- count_nonzero ---
-                pytest.param(1024, 4096, torch.float16, "count_nonzero", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.bfloat16, "count_nonzero", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "count_nonzero", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.int32, "count_nonzero", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "count_nonzero", marks=pytest.mark.full),
-            ],
-        ),
-    ]
+# ===================================================================
+# Roofline helper
+# ===================================================================
 
 
-class LogicalReduceBenchTest(WorkloadBase):
-    def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
-        self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        if self.dtype in (torch.int32, torch.int64):
-            x = torch.randint(-5, 6, (self.m, self.n), dtype=self.dtype, device="cuda")
-        elif self.dtype == torch.bool:
-            x = torch.randint(0, 2, (self.m, self.n), dtype=torch.bool, device="cuda")
-        else:
-            x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
-
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        if self.op_kind == "any":
-            return x.bool().any(dim=-1)
-        elif self.op_kind == "all":
-            return x.bool().all(dim=-1)
-        elif self.op_kind == "count_nonzero":
-            return torch.count_nonzero(x, dim=-1).to(torch.int64)
-        raise ValueError(f"Unknown op_kind: {self.op_kind}")
+def _roofline_vars(workload) -> dict:
+    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
+    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
+    N = workload.shape[-1]
+    M = 1
+    for s in workload.shape[:-1]:
+        M *= s
+    return dict(M=M, N=N, elem_bytes=elem_bytes)
 
 
-class LogicalReduceBenchmark(BenchmarkBase):
+# ===================================================================
+# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# ===================================================================
+
+
+class AnyBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _ANY_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        # Logical reduce: N comparisons per row, M rows
-        return t.m * t.n
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Output bytes: bool (1 byte) for any/all, int64 (8 bytes) for count_nonzero
-        out_elem_bytes = 8 if t.op_kind == "count_nonzero" else 1
-        # Read x (M*N) + write output (M * out_elem_bytes)
-        return t.m * t.n * elem_bytes + t.m * out_elem_bytes
+        return self._get_roofline()[1]
 
 
-def _make_op(dtype: torch.dtype, op_kind: str):
-    """Create the appropriate Op for the given op_kind."""
-    from tileops.ops.reduction.all_op import AllFwdOp
-    from tileops.ops.reduction.any_op import AnyFwdOp
-    from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
+class AllBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
 
-    op_map = {
-        "any": AnyFwdOp,
-        "all": AllFwdOp,
-        "count_nonzero": CountNonzeroFwdOp,
-    }
-    cls = op_map[op_kind]
-    return cls(dtype=dtype)
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _ALL_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
 
 
-@LogicalReduceBenchFixture
-def test_logical_reduce_bench(m: int, n: int, dtype: torch.dtype, op_kind: str) -> None:
-    test = LogicalReduceBenchTest(m, n, dtype, op_kind)
-    bm = LogicalReduceBenchmark(test)
+class CountNonzeroBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _COUNT_NONZERO_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+# ===================================================================
+# Manifest-driven parametrize helper
+# ===================================================================
+
+
+def _workloads_to_params(workloads):
+    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
+    params = []
+    for w in workloads:
+        shape = tuple(w["x_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(
+                shape, dtype,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+# ===================================================================
+# Any benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ANY_OP)))
+def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = AnyTest(shape, dtype)
+    bm = AnyBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = _make_op(dtype, op_kind)
-    result = bm.profile(op, *inputs)
+    op = AnyFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    def baseline_fn(x):
+        return x.bool().any(dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# All benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ALL_OP)))
+def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = AllTest(shape, dtype)
+    bm = AllBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = AllFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.bool().all(dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# CountNonzero benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_COUNT_NONZERO_OP)))
+def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = CountNonzeroTest(shape, dtype)
+    bm = CountNonzeroBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = CountNonzeroFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch.count_nonzero(x, dim=-1).to(torch.int64)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -41,7 +41,7 @@ def _roofline_vars(workload) -> dict:
 
 
 # ===================================================================
-# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# Benchmark classes — use manifest roofline for FLOP/memory counts
 # ===================================================================
 
 

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -62,7 +62,7 @@ def _roofline_vars(workload) -> dict:
 
 
 # ===================================================================
-# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# Benchmark classes — use manifest roofline for FLOP/memory counts
 # ===================================================================
 
 

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -22,14 +22,14 @@ from tileops.ops.reduction.reduce import (
     VarMeanFwdOp,
 )
 from workloads.ops.reduce import (
-    AmaxTest,
-    AminTest,
-    MeanTest,
-    ProdTest,
-    StdTest,
-    SumTest,
-    VarMeanTest,
-    VarTest,
+    AmaxWorkload,
+    AminWorkload,
+    MeanWorkload,
+    ProdWorkload,
+    StdWorkload,
+    SumWorkload,
+    VarMeanWorkload,
+    VarWorkload,
 )
 
 # ===================================================================
@@ -221,7 +221,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_SUM_OP)))
 def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = SumTest(shape, dtype)
+    test = SumWorkload(shape, dtype)
     bm = SumBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -248,7 +248,7 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_MEAN_OP)))
 def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = MeanTest(shape, dtype)
+    test = MeanWorkload(shape, dtype)
     bm = MeanBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -275,7 +275,7 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMAX_OP)))
 def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AmaxTest(shape, dtype)
+    test = AmaxWorkload(shape, dtype)
     bm = AmaxBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -302,7 +302,7 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMIN_OP)))
 def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AminTest(shape, dtype)
+    test = AminWorkload(shape, dtype)
     bm = AminBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -329,7 +329,7 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_PROD_OP)))
 def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = ProdTest(shape, dtype)
+    test = ProdWorkload(shape, dtype)
     bm = ProdBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -356,7 +356,7 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_STD_OP)))
 def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = StdTest(shape, dtype)
+    test = StdWorkload(shape, dtype)
     bm = StdBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -383,7 +383,7 @@ def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_OP)))
 def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = VarTest(shape, dtype)
+    test = VarWorkload(shape, dtype)
     bm = VarBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -410,7 +410,7 @@ def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_MEAN_OP)))
 def test_var_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = VarMeanTest(shape, dtype)
+    test = VarMeanWorkload(shape, dtype)
     bm = VarMeanBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -1,4 +1,8 @@
-"""Benchmarks for the 8 basic reduce ops."""
+"""Benchmarks for the 8 basic reduce ops.
+
+Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
+Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
+"""
 
 from typing import Optional
 
@@ -6,122 +10,425 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from workloads.base import FixtureBase, WorkloadBase
+from tileops.manifest import eval_roofline, load_workloads
+from tileops.ops.reduction.reduce import (
+    AmaxFwdOp,
+    AminFwdOp,
+    MeanFwdOp,
+    ProdFwdOp,
+    StdFwdOp,
+    SumFwdOp,
+    VarFwdOp,
+    VarMeanFwdOp,
+)
+from workloads.ops.reduce import (
+    AmaxTest,
+    AminTest,
+    MeanTest,
+    ProdTest,
+    StdTest,
+    SumTest,
+    VarMeanTest,
+    VarTest,
+)
+
+# ===================================================================
+# Op name constants
+# ===================================================================
+
+_SUM_OP = "SumFwdOp"
+_MEAN_OP = "MeanFwdOp"
+_AMAX_OP = "AmaxFwdOp"
+_AMIN_OP = "AminFwdOp"
+_PROD_OP = "ProdFwdOp"
+_STD_OP = "StdFwdOp"
+_VAR_OP = "VarFwdOp"
+_VAR_MEAN_OP = "VarMeanFwdOp"
 
 
-class ReduceBenchFixture(FixtureBase):
-    PARAMS = [
-        (
-            "m, n, dtype, op_kind",
-            [
-                pytest.param(1024, 4096, torch.float16, "sum"),
-                pytest.param(1024, 4096, torch.bfloat16, "sum"),
-                pytest.param(4096, 4096, torch.float16, "sum"),
-                pytest.param(1024, 4096, torch.float16, "mean"),
-                pytest.param(1024, 4096, torch.float16, "amax"),
-                pytest.param(1024, 4096, torch.float16, "amin"),
-                pytest.param(1024, 4096, torch.float16, "prod"),
-                pytest.param(1024, 4096, torch.float16, "std"),
-                pytest.param(1024, 4096, torch.float16, "var"),
-                pytest.param(1024, 4096, torch.float16, "var_mean"),
-            ],
-        ),
-    ]
+# ===================================================================
+# Roofline helper
+# ===================================================================
 
 
-class ReduceBenchTest(WorkloadBase):
-    def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
-        self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        if self.op_kind == "prod":
-            x = torch.rand(self.m, self.n, dtype=self.dtype, device="cuda") * 0.01 + 0.99
-        else:
-            x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
-
-    def ref_program(self, x: torch.Tensor) -> object:
-        x_f32 = x.float()
-        if self.op_kind == "sum":
-            return x_f32.sum(dim=-1).to(x.dtype)
-        elif self.op_kind == "mean":
-            return x_f32.mean(dim=-1).to(x.dtype)
-        elif self.op_kind == "amax":
-            return x_f32.amax(dim=-1).to(x.dtype)
-        elif self.op_kind == "amin":
-            return x_f32.amin(dim=-1).to(x.dtype)
-        elif self.op_kind == "prod":
-            return x_f32.prod(dim=-1).to(x.dtype)
-        elif self.op_kind == "std":
-            return x_f32.std(dim=-1, correction=1).to(x.dtype)
-        elif self.op_kind == "var":
-            return x_f32.var(dim=-1, correction=1).to(x.dtype)
-        elif self.op_kind == "var_mean":
-            v = x_f32.var(dim=-1, correction=1).to(x.dtype)
-            m = x_f32.mean(dim=-1).to(x.dtype)
-            return (v, m)
-        raise ValueError(f"Unknown op_kind: {self.op_kind}")
+def _roofline_vars(workload) -> dict:
+    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
+    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
+    N = workload.shape[-1]
+    M = 1
+    for s in workload.shape[:-1]:
+        M *= s
+    return dict(M=M, N=N, elem_bytes=elem_bytes)
 
 
-class ReduceBenchmark(BenchmarkBase):
+# ===================================================================
+# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# ===================================================================
+
+
+class SumBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _SUM_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        # Approximate: N operations per row for reduce, M rows
-        if t.op_kind in ("std", "var", "var_mean"):
-            return 3 * t.m * t.n  # sum + sq_diff + sum
-        return t.m * t.n
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + write output (M) -- or (2*M) for var_mean
-        out_elems = 2 * t.m if t.op_kind == "var_mean" else t.m
-        return (t.m * t.n + out_elems) * elem_bytes
+        return self._get_roofline()[1]
 
 
-def _make_op(dtype, op_kind):
-    """Create the appropriate Op for the given op_kind."""
-    from tileops.ops.reduction.reduce import (
-        AmaxFwdOp,
-        AminFwdOp,
-        MeanFwdOp,
-        ProdFwdOp,
-        StdFwdOp,
-        SumFwdOp,
-        VarFwdOp,
-        VarMeanFwdOp,
-    )
+class MeanBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
 
-    op_map = {
-        "sum": SumFwdOp,
-        "mean": MeanFwdOp,
-        "amax": AmaxFwdOp,
-        "amin": AminFwdOp,
-        "prod": ProdFwdOp,
-        "std": StdFwdOp,
-        "var": VarFwdOp,
-        "var_mean": VarMeanFwdOp,
-    }
-    cls = op_map[op_kind]
-    if op_kind in ("std", "var", "var_mean"):
-        return cls(dtype=dtype, correction=1)
-    return cls(dtype=dtype)
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _MEAN_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
 
 
-@ReduceBenchFixture
-def test_reduce_bench(m: int, n: int, dtype: torch.dtype, op_kind: str) -> None:
-    test = ReduceBenchTest(m, n, dtype, op_kind)
-    bm = ReduceBenchmark(test)
+class AmaxBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _AMAX_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+class AminBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _AMIN_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+class ProdBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _PROD_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+class StdBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _STD_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+class VarBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _VAR_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+class VarMeanBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _VAR_MEAN_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+# ===================================================================
+# Manifest-driven parametrize helper
+# ===================================================================
+
+
+def _workloads_to_params(workloads):
+    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
+    params = []
+    for w in workloads:
+        shape = tuple(w["x_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(
+                shape, dtype,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+# ===================================================================
+# Sum benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_SUM_OP)))
+def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = SumTest(shape, dtype)
+    bm = SumBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = _make_op(dtype, op_kind)
-    result = bm.profile(op, *inputs)
+    op = SumFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    def baseline_fn(x):
+        return x.float().sum(dim=-1).to(x.dtype)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Mean benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_MEAN_OP)))
+def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = MeanTest(shape, dtype)
+    bm = MeanBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = MeanFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.float().mean(dim=-1).to(x.dtype)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Amax benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMAX_OP)))
+def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = AmaxTest(shape, dtype)
+    bm = AmaxBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = AmaxFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.amax(dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Amin benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMIN_OP)))
+def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = AminTest(shape, dtype)
+    bm = AminBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = AminFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.amin(dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Prod benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_PROD_OP)))
+def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = ProdTest(shape, dtype)
+    bm = ProdBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = ProdFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.float().prod(dim=-1).to(x.dtype)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Std benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_STD_OP)))
+def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = StdTest(shape, dtype)
+    bm = StdBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = StdFwdOp(dtype=dtype, correction=1)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.float().std(dim=-1, correction=1).to(x.dtype)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Var benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_OP)))
+def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = VarTest(shape, dtype)
+    bm = VarBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = VarFwdOp(dtype=dtype, correction=1)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return x.float().var(dim=-1, correction=1).to(x.dtype)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# VarMean benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_MEAN_OP)))
+def test_var_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = VarMeanTest(shape, dtype)
+    bm = VarMeanBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = VarMeanFwdOp(dtype=dtype, correction=1)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        v = x.float().var(dim=-1, correction=1).to(x.dtype)
+        m = x.float().mean(dim=-1).to(x.dtype)
+        return (v, m)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -22,14 +22,14 @@ from tileops.ops.reduction.reduce import (
     VarMeanFwdOp,
 )
 from workloads.ops.reduce import (
-    AmaxWorkload,
-    AminWorkload,
-    MeanWorkload,
-    ProdWorkload,
-    StdWorkload,
-    SumWorkload,
-    VarMeanWorkload,
-    VarWorkload,
+    AmaxTest,
+    AminTest,
+    MeanTest,
+    ProdTest,
+    StdTest,
+    SumTest,
+    VarMeanTest,
+    VarTest,
 )
 
 # ===================================================================
@@ -221,7 +221,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_SUM_OP)))
 def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = SumWorkload(shape, dtype)
+    test = SumTest(shape, dtype)
     bm = SumBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -248,7 +248,7 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_MEAN_OP)))
 def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = MeanWorkload(shape, dtype)
+    test = MeanTest(shape, dtype)
     bm = MeanBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -275,7 +275,7 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMAX_OP)))
 def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AmaxWorkload(shape, dtype)
+    test = AmaxTest(shape, dtype)
     bm = AmaxBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -302,7 +302,7 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMIN_OP)))
 def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = AminWorkload(shape, dtype)
+    test = AminTest(shape, dtype)
     bm = AminBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -329,7 +329,7 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_PROD_OP)))
 def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = ProdWorkload(shape, dtype)
+    test = ProdTest(shape, dtype)
     bm = ProdBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -356,7 +356,7 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_STD_OP)))
 def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = StdWorkload(shape, dtype)
+    test = StdTest(shape, dtype)
     bm = StdBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -383,7 +383,7 @@ def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_OP)))
 def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = VarWorkload(shape, dtype)
+    test = VarTest(shape, dtype)
     bm = VarBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -410,7 +410,7 @@ def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_MEAN_OP)))
 def test_var_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = VarMeanWorkload(shape, dtype)
+    test = VarMeanTest(shape, dtype)
     bm = VarMeanBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -1,4 +1,8 @@
-"""Benchmarks for vector norm ops (l1_norm, l2_norm, inf_norm)."""
+"""Benchmarks for vector norm ops (l1_norm, l2_norm, inf_norm).
+
+Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
+Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
+"""
 
 from typing import Optional
 
@@ -6,95 +10,187 @@ import pytest
 import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from workloads.base import FixtureBase, WorkloadBase
+from tileops.manifest import eval_roofline, load_workloads
+from tileops.ops.reduction.inf_norm import InfNormFwdOp
+from tileops.ops.reduction.l1_norm import L1NormFwdOp
+from tileops.ops.reduction.l2_norm import L2NormFwdOp
+from workloads.ops.vector_norm import InfNormTest, L1NormTest, L2NormTest
+
+# ===================================================================
+# Op name constants
+# ===================================================================
+
+_L1_NORM_OP = "L1NormFwdOp"
+_L2_NORM_OP = "L2NormFwdOp"
+_INF_NORM_OP = "InfNormFwdOp"
 
 
-class VectorNormBenchFixture(FixtureBase):
-    PARAMS = [
-        (
-            "m, n, dtype, op_kind",
-            [
-                # --- l1 ---
-                pytest.param(1024, 4096, torch.float16, "l1", marks=pytest.mark.smoke),
-                pytest.param(1024, 4096, torch.bfloat16, "l1", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "l1", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "l1", marks=pytest.mark.full),
-                # --- l2 ---
-                pytest.param(1024, 4096, torch.float16, "l2", marks=pytest.mark.smoke),
-                pytest.param(1024, 4096, torch.bfloat16, "l2", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "l2", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "l2", marks=pytest.mark.full),
-                # --- inf ---
-                pytest.param(1024, 4096, torch.float16, "inf", marks=pytest.mark.smoke),
-                pytest.param(1024, 4096, torch.bfloat16, "inf", marks=pytest.mark.full),
-                pytest.param(1024, 4096, torch.float32, "inf", marks=pytest.mark.full),
-                pytest.param(4096, 4096, torch.float16, "inf", marks=pytest.mark.full),
-            ],
-        ),
-    ]
+# ===================================================================
+# Roofline helper
+# ===================================================================
 
 
-# Map op_kind to the ord parameter for torch.linalg.vector_norm
-_ORD_MAP = {"l1": 1, "l2": 2, "inf": float("inf")}
+def _roofline_vars(workload) -> dict:
+    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
+    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
+    N = workload.shape[-1]
+    M = 1
+    for s in workload.shape[:-1]:
+        M *= s
+    return dict(M=M, N=N, elem_bytes=elem_bytes)
 
 
-class VectorNormBenchTest(WorkloadBase):
-    def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
-        self.m = m
-        self.n = n
-        self.dtype = dtype
-        self.op_kind = op_kind
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.m, self.n, dtype=self.dtype, device="cuda")
-        return (x,)
-
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        ord_val = _ORD_MAP[self.op_kind]
-        return torch.linalg.vector_norm(x, ord=ord_val, dim=-1)
+# ===================================================================
+# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# ===================================================================
 
 
-class VectorNormBenchmark(BenchmarkBase):
+class L1NormBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _L1_NORM_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        # l1: N abs + N-1 adds per row
-        # l2: N muls + N-1 adds + 1 sqrt per row
-        # inf: N abs + N-1 comparisons per row
-        return t.m * t.n
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + write output (M)
-        return t.m * t.n * elem_bytes + t.m * elem_bytes
+        return self._get_roofline()[1]
 
 
-def _make_op(dtype: torch.dtype, op_kind: str):
-    """Create the appropriate Op for the given op_kind."""
-    from tileops.ops.reduction.inf_norm import InfNormFwdOp
-    from tileops.ops.reduction.l1_norm import L1NormFwdOp
-    from tileops.ops.reduction.l2_norm import L2NormFwdOp
+class L2NormBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
 
-    op_map = {
-        "l1": L1NormFwdOp,
-        "l2": L2NormFwdOp,
-        "inf": InfNormFwdOp,
-    }
-    cls = op_map[op_kind]
-    return cls(dtype=dtype)
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _L2_NORM_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
 
 
-@VectorNormBenchFixture
-def test_vector_norm_bench(m: int, n: int, dtype: torch.dtype, op_kind: str) -> None:
-    test = VectorNormBenchTest(m, n, dtype, op_kind)
-    bm = VectorNormBenchmark(test)
+class InfNormBenchmark(BenchmarkBase):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                _INF_NORM_OP, **_roofline_vars(self.workload))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+# ===================================================================
+# Manifest-driven parametrize helper
+# ===================================================================
+
+
+def _workloads_to_params(workloads):
+    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
+    params = []
+    for w in workloads:
+        shape = tuple(w["x_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(
+                shape, dtype,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+# ===================================================================
+# L1 Norm benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L1_NORM_OP)))
+def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = L1NormTest(shape, dtype)
+    bm = L1NormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = _make_op(dtype, op_kind)
-    result = bm.profile(op, *inputs)
+    op = L1NormFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    def baseline_fn(x):
+        return torch.linalg.vector_norm(x, ord=1, dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# L2 Norm benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L2_NORM_OP)))
+def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = L2NormTest(shape, dtype)
+    bm = L2NormBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = L2NormFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch.linalg.vector_norm(x, ord=2, dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===================================================================
+# Inf Norm benchmarks
+# ===================================================================
+
+
+@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_INF_NORM_OP)))
+def test_inf_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
+    test = InfNormTest(shape, dtype)
+    bm = InfNormBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = InfNormFwdOp(dtype=dtype)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch.linalg.vector_norm(x, ord=float("inf"), dim=-1)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -134,7 +134,7 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(x, ord=1, dim=-1)
+        return torch.linalg.vector_norm(x.float(), ord=1, dim=-1).to(x.dtype)
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
@@ -161,7 +161,7 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(x, ord=2, dim=-1)
+        return torch.linalg.vector_norm(x.float(), ord=2, dim=-1).to(x.dtype)
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
@@ -188,7 +188,7 @@ def test_inf_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(x, ord=float("inf"), dim=-1)
+        return torch.linalg.vector_norm(x.float(), ord=float("inf"), dim=-1).to(x.dtype)
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -14,7 +14,7 @@ from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.reduction.inf_norm import InfNormFwdOp
 from tileops.ops.reduction.l1_norm import L1NormFwdOp
 from tileops.ops.reduction.l2_norm import L2NormFwdOp
-from workloads.ops.vector_norm import InfNormTest, L1NormTest, L2NormTest
+from workloads.ops.vector_norm import InfNormWorkload, L1NormWorkload, L2NormWorkload
 
 # ===================================================================
 # Op name constants
@@ -120,7 +120,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L1_NORM_OP)))
 def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = L1NormTest(shape, dtype)
+    test = L1NormWorkload(shape, dtype)
     bm = L1NormBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -147,7 +147,7 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L2_NORM_OP)))
 def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = L2NormTest(shape, dtype)
+    test = L2NormWorkload(shape, dtype)
     bm = L2NormBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -174,7 +174,7 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_INF_NORM_OP)))
 def test_inf_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = InfNormTest(shape, dtype)
+    test = InfNormWorkload(shape, dtype)
     bm = InfNormBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -14,7 +14,7 @@ from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.reduction.inf_norm import InfNormFwdOp
 from tileops.ops.reduction.l1_norm import L1NormFwdOp
 from tileops.ops.reduction.l2_norm import L2NormFwdOp
-from workloads.ops.vector_norm import InfNormWorkload, L1NormWorkload, L2NormWorkload
+from workloads.ops.vector_norm import InfNormTest, L1NormTest, L2NormTest
 
 # ===================================================================
 # Op name constants
@@ -120,7 +120,7 @@ def _workloads_to_params(workloads):
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L1_NORM_OP)))
 def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = L1NormWorkload(shape, dtype)
+    test = L1NormTest(shape, dtype)
     bm = L1NormBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -147,7 +147,7 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L2_NORM_OP)))
 def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = L2NormWorkload(shape, dtype)
+    test = L2NormTest(shape, dtype)
     bm = L2NormBenchmark(test)
     inputs = test.gen_inputs()
 
@@ -174,7 +174,7 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 
 @pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_INF_NORM_OP)))
 def test_inf_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
-    test = InfNormWorkload(shape, dtype)
+    test = InfNormTest(shape, dtype)
     bm = InfNormBenchmark(test)
     inputs = test.gen_inputs()
 

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -41,7 +41,7 @@ def _roofline_vars(workload) -> dict:
 
 
 # ===================================================================
-# Benchmark classes -- use manifest roofline for FLOP/memory counts
+# Benchmark classes — use manifest roofline for FLOP/memory counts
 # ===================================================================
 
 


### PR DESCRIPTION
## Summary

Rewrite the 4 reduction benchmark files (`bench_reduce.py`, `bench_argreduce.py`, `bench_logical_reduce.py`, `bench_vector_norm.py`) to load workloads from `ops_manifest.yaml` via `load_workloads()`, compute roofline via `eval_roofline()`, and use independent inline PyTorch baselines — eliminating all 32 validator warnings and aligning with the trust model.

Closes #826

## Test plan

- [x] **AC-1**: Modified files pass `pytest --collect-only` — 48 tests collected in 3.00s with 0 collection errors
- [x] **AC-2**: `validate_manifest.py --check-op <op>` produces zero `[bench]` warnings for all 16 reduction ops (SumFwdOp, MeanFwdOp, AmaxFwdOp, AminFwdOp, ProdFwdOp, StdFwdOp, VarFwdOp, VarMeanFwdOp, AnyFwdOp, AllFwdOp, CountNonzeroFwdOp, L1NormFwdOp, L2NormFwdOp, InfNormFwdOp, ArgmaxFwdOp, ArgminFwdOp)
- [x] **AC-3**: No `ref_program` definition or import in the 4 bench files
- [x] **AC-4**: All 4 bench files import `load_workloads` and `eval_roofline` from `tileops.manifest`

## Follow-up

- #904 — Extract shared ManifestBenchmark base class and roofline/workload helpers (reduces ~300 lines of duplication across 5 bench files)