### PR TITLE
[Perf][Kernel] Optimise large-N tiled softmax to match PyTorch

### DIFF
--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -117,12 +117,17 @@ def compute_tile_n(
     The tile_n is the largest multiple of *alignment* such that
     ``num_buffers * block_m * tile_n * elem_bytes <= budget``.
 
-    When a divisor of *N_padded* exists close to the maximum (>= 75% of
-    the budget-derived cap), that divisor is preferred so the kernel
-    avoids remainder handling.  Otherwise the full budget-derived cap is
-    returned and the tiled kernel handles the single remainder tile via
-    masked loads --- this is cheaper than the extra iterations caused by
-    a small divisor.
+    When a divisor of *N_padded* exists that does not increase the
+    number of tiles compared to the budget-derived cap, that divisor is
+    preferred so the kernel avoids remainder handling.  This is
+    important when the cap is close to *N_padded*: e.g. for
+    N_padded=32768 with cap=32512, the cap gives 2 tiles where tile 1
+    has only 256 valid columns (99.2% waste), while divisor=16384 also
+    gives 2 tiles with zero waste.
+
+    When every divisor requires strictly more tiles, the full
+    budget-derived cap is returned and the tiled kernel handles the
+    single remainder tile via masked loads.
 
     If N_padded already fits (with *num_buffers* copies), returns N_padded
     (no tiling needed).
@@ -168,15 +173,22 @@ def compute_tile_n(
             best_dividing = candidate
             break
 
-    # Use the divisor only when it utilises at least 75% of the shared
-    # memory budget.  For shapes with sparse divisors (e.g. N_padded
-    # with large prime factors), the best divisor can be far smaller
-    # than tile_n_max, causing excessive kernel passes.  In that case,
-    # prefer tile_n_max and let the tiled kernel handle the single
-    # remainder tile via masked loads, which is cheaper than the extra
-    # iterations from a small tile.
-    if best_dividing >= tile_n_max * 3 // 4:
-        return best_dividing
+    # Accept the divisor when it does not increase the number of
+    # N-tiles.  Each tile incurs a global-memory pass in both passes of
+    # the 2-pass softmax, so fewer tiles is always cheaper.  When the
+    # divisor gives the same tile count as tile_n_max, prefer the
+    # divisor because it eliminates the nearly-empty remainder tile
+    # (e.g. N_padded=32768, tile_n_max=32512 → 2 tiles with a 256-col
+    # remainder vs divisor=16384 → 2 even tiles with zero waste).
+    #
+    # When the divisor requires strictly more tiles (e.g. smaller
+    # divisors of N_padded), stick with tile_n_max and handle the
+    # single remainder tile via masked loads.
+    if best_dividing > 0:
+        div_tiles = N_padded // best_dividing  # exact division
+        max_tiles = (N_padded + tile_n_max - 1) // tile_n_max
+        if div_tiles <= max_tiles:
+            return best_dividing
     return tile_n_max
 
 

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -114,16 +114,16 @@ def compute_tile_n(
 ) -> int:
     """Compute the tile_n (column chunk) for shared memory, preferring divisibility.
 
-    The tile_n is the largest multiple of *alignment* such that
-    ``num_buffers * block_m * tile_n * elem_bytes <= budget``.
-
-    When a divisor of *N_padded* exists that does not increase the
-    number of tiles compared to the budget-derived cap, that divisor is
-    preferred so the kernel avoids remainder handling.  This is
-    important when the cap is close to *N_padded*: e.g. for
-    N_padded=32768 with cap=32512, the cap gives 2 tiles where tile 1
-    has only 256 valid columns (99.2% waste), while divisor=16384 also
-    gives 2 tiles with zero waste.
+    The budget-derived cap (``tile_n_max``) is the largest multiple of
+    *alignment* such that
+    ``num_buffers * block_m * tile_n_max * elem_bytes <= budget``.
+    The return value may be a smaller divisor of *N_padded* when that
+    divisor does not increase the number of N-tiles, because an exact
+    division eliminates the nearly-empty remainder tile and reduces
+    wasted memory traffic.  For example, N_padded=32768 with
+    tile_n_max=32512 gives 2 tiles where tile 2 has only 256 valid
+    columns (99.2% waste), while divisor=16384 also gives 2 tiles with
+    zero waste.
 
     When every divisor requires strictly more tiles, the full
     budget-derived cap is returned and the tiled kernel handles the

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -13,7 +13,9 @@ import tilelang.language as T
 __all__ = [
     "align_up",
     "compute_tile_n",
+    "device_smem_budget",
     "DEFAULT_ALIGNMENT",
+    "MAX_SINGLE_TILE_COLS",
     "SHARED_MEMORY_BUDGET_BYTES",
     "make_reduce_epilogue",
     "make_welford_update",
@@ -25,9 +27,41 @@ __all__ = [
 # shared memory instructions.  Sub-categories may override this default.
 DEFAULT_ALIGNMENT: int = 256
 
+# Maximum column count for a single fragment/shared-memory tile.
+# TileLang's vectorizer fails when the *column dimension* of a
+# fragment or shared buffer reaches 32768 (a LLVM scalable-vector
+# boundary).  Empirical testing on H200 (SM90) confirms that
+# 32512 columns compile and execute correctly, while 32768 triggers
+# the "scalable vector" error.  We use 32512 (= 32768 - 256) as the
+# safe upper bound.
+MAX_SINGLE_TILE_COLS: int = 32512
+
 # Default shared memory budget per SM (48 KiB) used to compute the maximum
 # block_m that fits within a single thread block's shared memory allocation.
 SHARED_MEMORY_BUDGET_BYTES: int = 48 * 1024
+
+
+def device_smem_budget(device_index: int = 0) -> int:
+    """Return the opt-in shared memory budget for the current CUDA device.
+
+    Modern GPUs (SM80+) support shared memory well beyond the 48 KiB
+    default.  TileLang automatically configures
+    ``cudaFuncSetAttribute`` when a kernel allocates more than 48 KiB,
+    so it is safe to use the full opt-in budget.
+
+    Falls back to ``SHARED_MEMORY_BUDGET_BYTES`` (48 KiB) if the
+    device properties cannot be queried.
+    """
+    try:
+        import torch
+
+        props = torch.cuda.get_device_properties(device_index)
+        smem_optin = getattr(props, "shared_memory_per_block_optin", 0)
+        if smem_optin > 0:
+            return smem_optin
+        return getattr(props, "shared_memory_per_block", SHARED_MEMORY_BUDGET_BYTES)
+    except Exception:
+        return SHARED_MEMORY_BUDGET_BYTES
 
 
 def align_up(n: int, alignment: int) -> int:
@@ -88,14 +122,26 @@ def compute_tile_n(
 
     # Largest multiple of alignment that fits in shared memory
     max_cols = budget // (num_buffers * per_buffer)
-    tile_n = (max_cols // alignment) * alignment
-    if tile_n == 0:
+    tile_n_max = (max_cols // alignment) * alignment
+    if tile_n_max == 0:
         raise ValueError(
             f"Cannot fit even {alignment} columns in {budget} bytes "
             f"with block_m={block_m}, elem_bytes={elem_bytes}, "
             f"num_buffers={num_buffers}."
         )
-    return tile_n
+
+    # Prefer the largest tile_n that evenly divides N_padded, so that
+    # num_tiles * tile_n == N_padded and no host-side padding is needed.
+    # Search downward from tile_n_max in alignment-sized steps.
+    best_dividing = 0
+    for candidate in range(tile_n_max, 0, -alignment):
+        if N_padded % candidate == 0:
+            best_dividing = candidate
+            break
+
+    # If we found a divisor, use it. Otherwise fall back to max (caller
+    # must handle the remainder with host-side padding).
+    return best_dividing if best_dividing > 0 else tile_n_max
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -112,7 +112,7 @@ def compute_tile_n(
     budget: int = SHARED_MEMORY_BUDGET_BYTES,
     num_buffers: int = 1,
 ) -> int:
-    """Compute the largest tile_n (column chunk) that fits in shared memory.
+    """Compute the tile_n (column chunk) for shared memory, preferring divisibility.
 
     The tile_n is the largest multiple of *alignment* such that
     ``num_buffers * block_m * tile_n * elem_bytes <= budget``.

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -117,6 +117,13 @@ def compute_tile_n(
     The tile_n is the largest multiple of *alignment* such that
     ``num_buffers * block_m * tile_n * elem_bytes <= budget``.
 
+    When a divisor of *N_padded* exists close to the maximum (>= 75% of
+    the budget-derived cap), that divisor is preferred so the kernel
+    avoids remainder handling.  Otherwise the full budget-derived cap is
+    returned and the tiled kernel handles the single remainder tile via
+    masked loads --- this is cheaper than the extra iterations caused by
+    a small divisor.
+
     If N_padded already fits (with *num_buffers* copies), returns N_padded
     (no tiling needed).
 
@@ -161,9 +168,16 @@ def compute_tile_n(
             best_dividing = candidate
             break
 
-    # If we found a divisor, use it. Otherwise fall back to max (the
-    # tiled kernel handles the remainder via masked loads).
-    return best_dividing if best_dividing > 0 else tile_n_max
+    # Use the divisor only when it utilises at least 75% of the shared
+    # memory budget.  For shapes with sparse divisors (e.g. N_padded
+    # with large prime factors), the best divisor can be far smaller
+    # than tile_n_max, causing excessive kernel passes.  In that case,
+    # prefer tile_n_max and let the tiled kernel handle the single
+    # remainder tile via masked loads, which is cheaper than the extra
+    # iterations from a small tile.
+    if best_dividing >= tile_n_max * 3 // 4:
+        return best_dividing
+    return tile_n_max
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -41,26 +41,37 @@ MAX_SINGLE_TILE_COLS: int = 32512
 SHARED_MEMORY_BUDGET_BYTES: int = 48 * 1024
 
 
-def device_smem_budget(device_index: int = 0) -> int:
-    """Return the opt-in shared memory budget for the current CUDA device.
+def device_smem_budget(device_index: int | None = None) -> int:
+    """Return the opt-in shared memory budget for a CUDA device.
+
+    If ``device_index`` is ``None``, the current CUDA device is used.
 
     Modern GPUs (SM80+) support shared memory well beyond the 48 KiB
     default.  TileLang automatically configures
     ``cudaFuncSetAttribute`` when a kernel allocates more than 48 KiB,
     so it is safe to use the full opt-in budget.
 
-    Falls back to ``SHARED_MEMORY_BUDGET_BYTES`` (48 KiB) if the
-    device properties cannot be queried.
+    Falls back to ``SHARED_MEMORY_BUDGET_BYTES`` (48 KiB) only if
+    CUDA/device properties are unavailable.
     """
     try:
         import torch
+    except Exception:
+        return SHARED_MEMORY_BUDGET_BYTES
+
+    try:
+        if not torch.cuda.is_available():
+            return SHARED_MEMORY_BUDGET_BYTES
+
+        if device_index is None:
+            device_index = torch.cuda.current_device()
 
         props = torch.cuda.get_device_properties(device_index)
         smem_optin = getattr(props, "shared_memory_per_block_optin", 0)
         if smem_optin > 0:
             return smem_optin
         return getattr(props, "shared_memory_per_block", SHARED_MEMORY_BUDGET_BYTES)
-    except Exception:
+    except (RuntimeError, AssertionError):
         return SHARED_MEMORY_BUDGET_BYTES
 
 
@@ -131,7 +142,7 @@ def compute_tile_n(
         )
 
     # Prefer the largest tile_n that evenly divides N_padded, so that
-    # num_tiles * tile_n == N_padded and no host-side padding is needed.
+    # num_tiles * tile_n == N_padded and no remainder tile is needed.
     # Search downward from tile_n_max in alignment-sized steps.
     best_dividing = 0
     for candidate in range(tile_n_max, 0, -alignment):
@@ -139,8 +150,8 @@ def compute_tile_n(
             best_dividing = candidate
             break
 
-    # If we found a divisor, use it. Otherwise fall back to max (caller
-    # must handle the remainder with host-side padding).
+    # If we found a divisor, use it. Otherwise fall back to max (the
+    # tiled kernel handles the remainder via masked loads).
     return best_dividing if best_dividing > 0 else tile_n_max
 
 

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -52,15 +52,24 @@ def device_smem_budget(device_index: int | None = None) -> int:
     so it is safe to use the full opt-in budget.
 
     Falls back to ``SHARED_MEMORY_BUDGET_BYTES`` (48 KiB) only if
-    CUDA/device properties are unavailable.
+    CUDA/device properties are unavailable.  Invalid explicit device
+    indices are not silently masked -- only the ``None`` (auto-detect)
+    case falls back gracefully.
     """
+    explicit = device_index is not None
     try:
         import torch
     except Exception:
+        if explicit:
+            raise
         return SHARED_MEMORY_BUDGET_BYTES
 
     try:
         if not torch.cuda.is_available():
+            if explicit:
+                raise RuntimeError(
+                    f"CUDA is not available but explicit device_index={device_index} was requested"
+                )
             return SHARED_MEMORY_BUDGET_BYTES
 
         if device_index is None:
@@ -72,6 +81,8 @@ def device_smem_budget(device_index: int | None = None) -> int:
             return smem_optin
         return getattr(props, "shared_memory_per_block", SHARED_MEMORY_BUDGET_BYTES)
     except (RuntimeError, AssertionError):
+        if explicit:
+            raise
         return SHARED_MEMORY_BUDGET_BYTES
 
 

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -44,9 +44,10 @@ def _logsumexp_kernel_single(M: int, N: int, dtype: str):
     """Build a single-tile logsumexp kernel (N fits in smem).
 
     Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
-    ``DEFAULT_ALIGNMENT``, the kernel fills shared memory with ``-inf``
-    and loads only the valid ``N`` columns (kernel-side boundary handling).
-    When ``N`` is already aligned, the fast ``T.copy`` path is used.
+    ``DEFAULT_ALIGNMENT``, the kernel uses element-wise ``T.if_then_else``
+    loads that substitute ``-inf`` for out-of-bounds columns (kernel-side
+    boundary handling).  When ``N`` is already aligned, the fast ``T.copy``
+    path is used.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -22,9 +22,10 @@ import torch
 from tileops.kernels.kernel import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
-    SHARED_MEMORY_BUDGET_BYTES,
+    MAX_SINGLE_TILE_COLS,
     align_up,
     compute_tile_n,
+    device_smem_budget,
 )
 
 __all__ = ["LogSumExpKernel"]
@@ -247,6 +248,7 @@ class LogSumExpKernel(Kernel):
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
+        self._smem_budget = device_smem_budget()
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
@@ -285,24 +287,63 @@ class LogSumExpKernel(Kernel):
         self.config["tile_n"] = self._tile_n
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
-        """Return tile_n for a given block_m (0 means no tiling needed)."""
-        tile_n = compute_tile_n(block_m, self._elem_bytes, self.N_padded)
-        return 0 if tile_n == self.N_padded else tile_n
+        """Return tile_n for a given block_m (0 means no tiling needed).
+
+        Uses the device's actual shared memory budget (not the
+        conservative 48 KiB default) so that large-N workloads can
+        use fewer, larger tiles or even the single-tile fast path.
+
+        Both paths are subject to the MAX_SINGLE_TILE_COLS column
+        cap (TileLang's vectorizer fails at the 32768 column boundary).
+        """
+        budget = self._smem_budget
+        # Single-tile path: cap by column count and smem budget.
+        if self.N_padded <= MAX_SINGLE_TILE_COLS:
+            tile_n = compute_tile_n(block_m, self._elem_bytes, self.N_padded, budget=budget)
+            if tile_n == self.N_padded:
+                return 0
+        # Tiled path (logsumexp uses 1 shared buffer).
+        # Cap the smem budget so tile_n stays within the column limit.
+        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
+        effective_budget = min(budget, col_budget)
+        return compute_tile_n(
+            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
+        )
 
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget."""
-        smem_per_row = self.N_padded * self._elem_bytes
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row if smem_per_row > 0 else 16
-        if max_block_m == 0:
-            block_m = 1
-        else:
-            block_m = 1
-            for bm in [1, 2, 4, 8, 16]:
-                if bm <= max_block_m:
-                    block_m = bm
-        tile_n = self._tile_n_for_block_m(block_m)
-        return {"block_m": block_m, "threads": 256, "tile_n": tile_n}
+        """Select default block_m based on shared memory budget.
+
+        For the single-tile path (tile_n == 0), prefer the largest
+        block_m that fits in shared memory.
+
+        For the tiled path, prefer the block_m that minimises the
+        number of N-tiles (maximises tile_n) to reduce global memory
+        passes.  Among configs with equal tile count, prefer smaller
+        block_m for better occupancy.
+        """
+        best_bm = 1
+        best_tile_n = self._tile_n_for_block_m(1)
+
+        for bm in [2, 4, 8, 16]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn == 0:
+                # Single-tile is always better: prefer larger block_m
+                best_bm = bm
+                best_tile_n = tn
+            elif best_tile_n == 0:
+                pass
+            else:
+                best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
+                curr_num = (self.N_padded + tn - 1) // tn
+                if curr_num < best_num:
+                    best_bm = bm
+                    best_tile_n = tn
+
+        return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -312,14 +353,15 @@ class LogSumExpKernel(Kernel):
         block_m and threads to the autotuner.
         """
         tile_n = getattr(self, "_tile_n", self.default_config["tile_n"])
+        budget = self._smem_budget
         smem_per_row = self.N_padded * self._elem_bytes
-        max_block_m_no_tile = SHARED_MEMORY_BUDGET_BYTES // smem_per_row if smem_per_row > 0 else 16
+        max_block_m_no_tile = budget // smem_per_row if smem_per_row > 0 else 16
         threads_list = [128, 256]
 
         configs = []
         for bm in [1, 2, 4, 8, 16]:
             try:
-                compute_tile_n(bm, self._elem_bytes, self.N_padded)
+                compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
             except ValueError:
                 continue
             bm_tile_n = self._tile_n_for_block_m(bm)
@@ -336,16 +378,18 @@ class LogSumExpKernel(Kernel):
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the logsumexp kernel."""
+        """Run the logsumexp kernel.
+
+        Accepts an ``(M, N)`` tensor (unpadded) or ``(M, N_padded)``
+        (pre-padded).  Any alignment padding required by T.copy() is
+        handled here, keeping the Op layer free of host-side ``F.pad``.
+        """
+        # Pad to N_padded if the caller passed the raw (M, N) tensor.
+        if x.shape[-1] < self.N_padded:
+            pad_cols = self.N_padded - x.shape[-1]
+            x = torch.nn.functional.pad(x, (0, pad_cols), value=float("-inf"))
+
         tile_n = self._tile_n
-
-        # For the tiled path, the input may need extra padding beyond N_padded
-        # to make columns a multiple of tile_n.
-        total_cols = _compute_padded_cols(self.N, tile_n)
-        if x.shape[1] < total_cols:
-            import torch.nn.functional as _F
-
-            x = _F.pad(x, (0, total_cols - x.shape[1]), value=float("-inf"))
 
         return _logsumexp_fwd_wrapped(
             self.M,

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -8,8 +8,9 @@ N_padded does not fit in shared memory.  Uses the online softmax recurrence
 (track running max and rescaled running sum) across N-tiles.
 
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions. Padded columns are filled with -infinity so they
-contribute 0 to exp-sums and never win the max reduction.
+memory instructions.  Boundary handling for non-aligned N is performed
+inside the kernel via masked loads and -inf fills, eliminating host-side
+``F.pad`` from the forward path.
 """
 
 import functools
@@ -36,16 +37,24 @@ __all__ = ["LogSumExpKernel"]
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _logsumexp_kernel_single(M: int, N: int, dtype: str):
-    """Build a single-tile logsumexp kernel (N fits in smem)."""
+    """Build a single-tile logsumexp kernel (N fits in smem).
+
+    Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
+    ``DEFAULT_ALIGNMENT``, the kernel fills shared memory with ``-inf``
+    and loads only the valid ``N`` columns (kernel-side boundary handling).
+    When ``N`` is already aligned, the fast ``T.copy`` path is used.
+    """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
+    _neg_inf = float("-inf")
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M, N), dtype],
             y: T.Tensor[(M,), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -55,11 +64,20 @@ def _logsumexp_kernel_single(M: int, N: int, dtype: str):
                 row_max = T.alloc_fragment((block_m,), "float32")
                 row_sum = T.alloc_fragment((block_m,), "float32")
 
-                T.copy(x[pid_m * block_m, 0], shared_buf)
-                T.copy(shared_buf, x_local)
-
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                if _needs_pad:
+                    # Kernel-side boundary handling: element-wise load
+                    # with T.if_then_else masking for padding columns.
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.if_then_else(
+                            j < N,
+                            T.cast(x[pid_m * block_m + i, j], "float32"),
+                            T.cast(_neg_inf, "float32"),
+                        )
+                else:
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 T.fill(row_max, -T.infinity("float32"))
                 T.reduce_max(x_f32, row_max, dim=1, clear=False)
@@ -84,7 +102,7 @@ def _logsumexp_kernel_single(M: int, N: int, dtype: str):
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
     """Build a multi-tile logsumexp kernel.
 
@@ -92,18 +110,20 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
       Single pass: compute running max and rescaled running sum.
       Then: logsumexp = max + log(sum).
 
-    The input tensor column count is total_cols = num_tiles * tile_n,
-    which may be larger than N_padded. Extra columns must be -inf padded.
+    The input tensor has the raw shape ``(M, N)`` (no host-side padding).
+    Boundary handling for the last tile is performed via masked loads.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
     total_cols = num_tiles * tile_n
+    _needs_mask = total_cols > N
+    _neg_inf = float("-inf")
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, total_cols), dtype],
+            x: T.Tensor[(M, N), dtype],
             y: T.Tensor[(M,), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -121,11 +141,20 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
                 T.fill(row_sum, 0.0)
 
                 for t in T.Serial(num_tiles):
-                    T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                    T.copy(shared_buf, tile_local)
-
-                    for i, j in T.Parallel(block_m, tile_n):
-                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                    if _needs_mask:
+                        # Kernel-side boundary: load into fragment with
+                        # T.if_then_else masking for out-of-range columns.
+                        for i, j in T.Parallel(block_m, tile_n):
+                            tile_f32[i, j] = T.if_then_else(
+                                t * tile_n + j < N,
+                                T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
+                                T.cast(_neg_inf, "float32"),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                        T.copy(shared_buf, tile_local)
+                        for i, j in T.Parallel(block_m, tile_n):
+                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                     T.fill(tile_max, -T.infinity("float32"))
                     T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -160,7 +189,7 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _logsumexp_kernel(M: int, N: int, dtype: str, tile_n: int = 0):
     """Build the appropriate logsumexp kernel."""
     if tile_n == 0:
@@ -218,6 +247,10 @@ class LogSumExpKernel(Kernel):
 
     For large N that does not fit in shared memory, tiles over N using
     the online softmax recurrence (running max + rescaled sum).
+
+    Boundary handling for non-aligned N is performed inside the kernel
+    via masked loads and ``-inf`` fills, so no host-side ``F.pad`` is
+    needed.
 
     Args:
         M: Number of rows (product of all dims except last).
@@ -380,15 +413,10 @@ class LogSumExpKernel(Kernel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the logsumexp kernel.
 
-        Accepts an ``(M, N)`` tensor (unpadded) or ``(M, N_padded)``
-        (pre-padded).  Any alignment padding required by T.copy() is
-        handled here, keeping the Op layer free of host-side ``F.pad``.
+        Accepts an ``(M, N)`` tensor.  Boundary handling for non-aligned
+        ``N`` is performed inside the GPU kernel (masked loads + ``-inf``
+        fill), so no host-side ``F.pad`` is needed.
         """
-        # Pad to N_padded if the caller passed the raw (M, N) tensor.
-        if x.shape[-1] < self.N_padded:
-            pad_cols = self.N_padded - x.shape[-1]
-            x = torch.nn.functional.pad(x, (0, pad_cols), value=float("-inf"))
-
         tile_n = self._tile_n
 
         return _logsumexp_fwd_wrapped(

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -10,7 +10,9 @@ N_padded does not fit in shared memory.  Uses the online softmax recurrence
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.  Boundary handling for non-aligned N is performed
 inside the kernel via masked loads and -inf fills, eliminating host-side
-``F.pad`` from the forward path.
+``F.pad`` from the forward path.  In the multi-tile path, only the last
+tile uses element-wise masked loads; all preceding tiles use the fast
+vectorized T.copy path since their columns are fully in-bounds.
 """
 
 import functools
@@ -142,14 +144,24 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
 
                 for t in T.Serial(num_tiles):
                     if _needs_mask:
-                        # Kernel-side boundary: load into fragment with
-                        # T.if_then_else masking for out-of-range columns.
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.if_then_else(
-                                t * tile_n + j < N,
-                                T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
-                                T.cast(_neg_inf, "float32"),
-                            )
+                        # Only the last tile may have out-of-bounds columns.
+                        # Use fast vectorized T.copy for all earlier tiles,
+                        # and element-wise T.if_then_else only for the last.
+                        with T.If(t < num_tiles - 1):
+                            with T.Then():
+                                T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                                T.copy(shared_buf, tile_local)
+                                for i, j in T.Parallel(block_m, tile_n):
+                                    tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                            with T.Else():
+                                for i, j in T.Parallel(block_m, tile_n):
+                                    tile_f32[i, j] = T.if_then_else(
+                                        t * tile_n + j < N,
+                                        T.cast(
+                                            x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                        ),
+                                        T.cast(_neg_inf, "float32"),
+                                    )
                     else:
                         T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                         T.copy(shared_buf, tile_local)

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -69,10 +69,11 @@ def _logsumexp_kernel_single(M: int, N: int, dtype: str):
 
                 if _needs_pad:
                     # Kernel-side boundary handling: element-wise load
-                    # with T.if_then_else masking for padding columns.
+                    # with T.if_then_else masking for padding columns
+                    # and row-tail safety (M % block_m != 0).
                     for i, j in T.Parallel(block_m, N_padded):
                         x_f32[i, j] = T.if_then_else(
-                            j < N,
+                            T.And(pid_m * block_m + i < M, j < N),
                             T.cast(x[pid_m * block_m + i, j], "float32"),
                             T.cast(_neg_inf, "float32"),
                         )
@@ -157,7 +158,7 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
                             with T.Else():
                                 for i, j in T.Parallel(block_m, tile_n):
                                     tile_f32[i, j] = T.if_then_else(
-                                        t * tile_n + j < N,
+                                        T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                         T.cast(
                                             x[pid_m * block_m + i, t * tile_n + j], "float32"
                                         ),

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -271,6 +271,8 @@ class LogSumExpKernel(Kernel):
         dtype: Data type (float32, float16, or bfloat16).
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
+        device_index: CUDA device index for shared memory budget query.
+            When ``None``, ``torch.cuda.current_device()`` is used.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -283,6 +285,7 @@ class LogSumExpKernel(Kernel):
         dtype: torch.dtype,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: int | None = None,
     ):
         super().__init__()
         if op_kind != "logsumexp":
@@ -293,7 +296,7 @@ class LogSumExpKernel(Kernel):
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
-        self._smem_budget = device_smem_budget()
+        self._smem_budget = device_smem_budget(device_index)
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -45,9 +45,10 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
     """Build a single-tile softmax/log_softmax kernel (N fits in smem).
 
     Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
-    ``DEFAULT_ALIGNMENT``, the kernel fills shared memory with ``-inf``
-    and loads only the valid ``N`` columns (kernel-side boundary handling).
-    When ``N`` is already aligned, the fast ``T.copy`` path is used.
+    ``DEFAULT_ALIGNMENT``, the kernel uses element-wise ``T.if_then_else``
+    loads that substitute ``-inf`` for out-of-bounds columns (kernel-side
+    boundary handling).  When ``N`` is already aligned, the fast ``T.copy``
+    path is used.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
@@ -136,13 +137,23 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     T.fill(row_max, -T.infinity("float32"))
                     T.reduce_max(x_f32, row_max, dim=1, clear=False)
 
+                    # Compute exp(x - max) into a separate fragment so x_f32
+                    # retains the original values for the stable log_softmax
+                    # formula: (x - max) - log(sum(exp(x - max))).
+                    exp_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                     for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
-                    T.reduce_sum(x_f32, row_sum, dim=1)
+                        exp_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                    T.reduce_sum(exp_f32, row_sum, dim=1)
 
+                    log_sum = T.alloc_fragment((block_m,), "float32")
+                    for i in T.Parallel(block_m):
+                        log_sum[i] = T.log(row_sum[i])
+
+                    # log_softmax = (x - max) - log(sum), avoids log(0) on
+                    # padding columns (they stay at -inf via subtraction).
                     out_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                     for i, j in T.Parallel(block_m, N_padded):
-                        out_f32[i, j] = T.log(x_f32[i, j] / row_sum[i])
+                        out_f32[i, j] = x_f32[i, j] - row_max[i] - log_sum[i]
 
                     for i, j in T.Parallel(block_m, N_padded):
                         x_local[i, j] = out_f32[i, j]

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -74,10 +74,11 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
 
                     if _needs_pad:
                         # Kernel-side boundary handling: element-wise load
-                        # with T.if_then_else masking for padding columns.
+                        # with T.if_then_else masking for padding columns
+                        # and row-tail safety (M % block_m != 0).
                         for i, j in T.Parallel(block_m, N_padded):
                             x_f32[i, j] = T.if_then_else(
-                                j < N,
+                                T.And(pid_m * block_m + i < M, j < N),
                                 T.cast(x[pid_m * block_m + i, j], "float32"),
                                 T.cast(_neg_inf, "float32"),
                             )
@@ -124,7 +125,7 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     if _needs_pad:
                         for i, j in T.Parallel(block_m, N_padded):
                             x_f32[i, j] = T.if_then_else(
-                                j < N,
+                                T.And(pid_m * block_m + i < M, j < N),
                                 T.cast(x[pid_m * block_m + i, j], "float32"),
                                 T.cast(_neg_inf, "float32"),
                             )
@@ -238,7 +239,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Else():
                                     for i, j in T.Parallel(block_m, tile_n):
                                         tile_f32[i, j] = T.if_then_else(
-                                            t * tile_n + j < N,
+                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                             T.cast(
                                                 x[pid_m * block_m + i, t * tile_n + j], "float32"
                                             ),
@@ -298,7 +299,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Else():
                                     for i, j in T.Parallel(block_m, tile_n):
                                         p2_f32[i, j] = T.if_then_else(
-                                            t * tile_n + j < N,
+                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                             T.exp(
                                                 T.cast(
                                                     x[pid_m * block_m + i, t * tile_n + j],
@@ -360,7 +361,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Else():
                                     for i, j in T.Parallel(block_m, tile_n):
                                         tile_f32[i, j] = T.if_then_else(
-                                            t * tile_n + j < N,
+                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                             T.cast(
                                                 x[pid_m * block_m + i, t * tile_n + j], "float32"
                                             ),
@@ -415,7 +416,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Else():
                                     for i, j in T.Parallel(block_m, tile_n):
                                         p2_f32[i, j] = T.if_then_else(
-                                            t * tile_n + j < N,
+                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                             T.cast(
                                                 x[pid_m * block_m + i, t * tile_n + j], "float32"
                                             )

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -722,9 +722,9 @@ class SoftmaxKernel(Kernel):
             x,
         )
 
-        # Trim back to N_padded if needed (only when tile_n does not
-        # divide N_padded, which the divisor-aware compute_tile_n avoids
-        # for all practical cases).
+        # Trim back to N_padded if needed (when tile_n does not divide
+        # N_padded, e.g. compute_tile_n chose tile_n_max over a small
+        # divisor for better shared memory utilisation).
         if y.shape[1] > self.N_padded:
             y = y[:, : self.N_padded]
 

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -23,9 +23,10 @@ import torch
 from tileops.kernels.kernel import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
-    SHARED_MEMORY_BUDGET_BYTES,
+    MAX_SINGLE_TILE_COLS,
     align_up,
     compute_tile_n,
+    device_smem_budget,
 )
 
 __all__ = ["SoftmaxKernel"]
@@ -199,6 +200,12 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 row_sum[i] * T.exp(prev_max[i] - row_max[i]) + tile_sum[i]
                             )
 
+                    # Precompute reciprocal to replace division with
+                    # multiplication in the per-element normalisation.
+                    inv_sum = T.alloc_fragment((block_m,), "float32")
+                    for i in T.Parallel(block_m):
+                        inv_sum[i] = 1.0 / row_sum[i]
+
                     # --- Pass 2: dedicated shared + register fragments ---
                     # TileLang's allocator aliases both shared buffers and
                     # register fragments across T.Serial loop boundaries.
@@ -209,21 +216,20 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     p2_shared = T.alloc_shared((block_m, tile_n), dtype)
                     p2_local = T.alloc_fragment((block_m, tile_n), dtype)
                     p2_f32 = T.alloc_fragment((block_m, tile_n), "float32")
-                    p2_out = T.alloc_fragment((block_m, tile_n), "float32")
 
-                    # Pass 2: normalize
+                    # Pass 2: normalize (cast + compute fused, write-back
+                    # reuses p2_f32 -> p2_local to avoid an extra fragment)
                     for t in T.Serial(num_tiles):
                         T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                         T.copy(p2_shared, p2_local)
 
                         for i, j in T.Parallel(block_m, tile_n):
-                            p2_f32[i, j] = T.cast(p2_local[i, j], "float32")
+                            p2_f32[i, j] = T.exp(
+                                T.cast(p2_local[i, j], "float32") - row_max[i]
+                            ) * inv_sum[i]
 
                         for i, j in T.Parallel(block_m, tile_n):
-                            p2_out[i, j] = T.exp(p2_f32[i, j] - row_max[i]) / row_sum[i]
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_local[i, j] = p2_out[i, j]
+                            p2_local[i, j] = p2_f32[i, j]
                         T.copy(p2_local, p2_shared)
                         T.copy(p2_shared, y[pid_m * block_m, t * tile_n])
 
@@ -287,21 +293,19 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     p2_shared = T.alloc_shared((block_m, tile_n), dtype)
                     p2_local = T.alloc_fragment((block_m, tile_n), dtype)
                     p2_f32 = T.alloc_fragment((block_m, tile_n), "float32")
-                    p2_out = T.alloc_fragment((block_m, tile_n), "float32")
 
-                    # Pass 2: log-normalize
+                    # Pass 2: log-normalize (cast + compute fused)
                     for t in T.Serial(num_tiles):
                         T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                         T.copy(p2_shared, p2_local)
 
                         for i, j in T.Parallel(block_m, tile_n):
-                            p2_f32[i, j] = T.cast(p2_local[i, j], "float32")
+                            p2_f32[i, j] = (
+                                T.cast(p2_local[i, j], "float32") - row_max[i] - log_sum[i]
+                            )
 
                         for i, j in T.Parallel(block_m, tile_n):
-                            p2_out[i, j] = p2_f32[i, j] - row_max[i] - log_sum[i]
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_local[i, j] = p2_out[i, j]
+                            p2_local[i, j] = p2_f32[i, j]
                         T.copy(p2_local, p2_shared)
                         T.copy(p2_shared, y[pid_m * block_m, t * tile_n])
 
@@ -411,6 +415,7 @@ class SoftmaxKernel(Kernel):
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
+        self._smem_budget = device_smem_budget()
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
@@ -455,32 +460,78 @@ class SoftmaxKernel(Kernel):
     _NUM_SHARED_BUFFERS = 2
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
-        """Return tile_n for a given block_m (0 means no tiling needed)."""
-        # First check if N fits in a single buffer (no tiling → single-tile path,
-        # which only allocates 1 shared buffer).
-        single = compute_tile_n(block_m, self._elem_bytes, self.N_padded)
-        if single == self.N_padded:
-            return 0
+        """Return tile_n for a given block_m (0 means no tiling needed).
+
+        Uses the device's actual shared memory budget (not the
+        conservative 48 KiB default) so that large-N workloads can
+        use fewer, larger tiles or even the single-tile fast path.
+
+        Both paths are subject to the MAX_SINGLE_TILE_COLS column
+        cap (TileLang's vectorizer fails at the 32768 column boundary).
+        """
+        budget = self._smem_budget
+        # Single-tile path requires the full row in register fragments.
+        # Cap by column count (vectorizer limit) and smem budget.
+        if self.N_padded <= MAX_SINGLE_TILE_COLS:
+            single = compute_tile_n(
+                block_m, self._elem_bytes, self.N_padded, budget=budget,
+            )
+            if single == self.N_padded:
+                return 0
         # Tiled path: budget must accommodate num_buffers shared allocations.
+        # Cap the smem budget so tile_n stays within the column limit.
+        col_budget = MAX_SINGLE_TILE_COLS * self._NUM_SHARED_BUFFERS * block_m * self._elem_bytes
+        effective_budget = min(budget, col_budget)
         return compute_tile_n(
             block_m, self._elem_bytes, self.N_padded,
             num_buffers=self._NUM_SHARED_BUFFERS,
+            budget=effective_budget,
         )
 
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget."""
-        smem_per_row = self.N_padded * self._elem_bytes
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row if smem_per_row > 0 else 16
-        if max_block_m == 0:
-            block_m = 1
-        else:
-            block_m = 1
-            for bm in [1, 2, 4, 8, 16]:
-                if bm <= max_block_m:
-                    block_m = bm
-        tile_n = self._tile_n_for_block_m(block_m)
-        return {"block_m": block_m, "threads": 256, "tile_n": tile_n}
+        """Select default block_m based on shared memory budget.
+
+        For the single-tile path (tile_n == 0), prefer the largest
+        block_m that fits in shared memory -- row-level parallelism is
+        free when the full row is in registers.
+
+        For the tiled path, prefer the block_m that **minimises the
+        number of N-tiles** (i.e. maximises tile_n).  Fewer tiles means
+        fewer global memory passes in the 2-pass algorithm, which
+        dominates latency on bandwidth-bound workloads.  Among configs
+        with equal tile count, prefer *smaller* block_m: the tiled
+        kernel is bandwidth-bound, and smaller shared-memory footprint
+        per block improves occupancy.
+        """
+        best_bm = 1
+        best_tile_n = self._tile_n_for_block_m(1)
+
+        for bm in [2, 4, 8, 16]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn == 0 and best_tile_n == 0:
+                # Both single-tile: prefer larger block_m (row reuse is free)
+                best_bm = bm
+                best_tile_n = tn
+            elif tn == 0 and best_tile_n != 0:
+                # Switching from tiled to single-tile is always better
+                best_bm = bm
+                best_tile_n = tn
+            elif tn != 0 and best_tile_n == 0:
+                # Don't give up single-tile for tiled
+                pass
+            else:
+                # Both tiled: prefer strictly fewer tiles only.
+                best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
+                curr_num = (self.N_padded + tn - 1) // tn
+                if curr_num < best_num:
+                    best_bm = bm
+                    best_tile_n = tn
+
+        return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -492,14 +543,15 @@ class SoftmaxKernel(Kernel):
         """
         # Use the same tile_n that the kernel was built with
         tile_n = getattr(self, "_tile_n", self.default_config["tile_n"])
+        budget = self._smem_budget
         smem_per_row = self.N_padded * self._elem_bytes
-        max_block_m_no_tile = SHARED_MEMORY_BUDGET_BYTES // smem_per_row if smem_per_row > 0 else 16
+        max_block_m_no_tile = budget // smem_per_row if smem_per_row > 0 else 16
         threads_list = [128, 256]
 
         configs = []
         for bm in [1, 2, 4, 8, 16]:
             try:
-                compute_tile_n(bm, self._elem_bytes, self.N_padded)
+                compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
             except ValueError:
                 continue
             bm_tile_n = self._tile_n_for_block_m(bm)
@@ -517,16 +569,18 @@ class SoftmaxKernel(Kernel):
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the softmax/log_softmax kernel."""
+        """Run the softmax/log_softmax kernel.
+
+        Accepts an ``(M, N)`` tensor (unpadded) or ``(M, N_padded)``
+        (pre-padded).  Any alignment padding required by T.copy() is
+        handled here, keeping the Op layer free of host-side ``F.pad``.
+        """
+        # Pad to N_padded if the caller passed the raw (M, N) tensor.
+        if x.shape[-1] < self.N_padded:
+            pad_cols = self.N_padded - x.shape[-1]
+            x = torch.nn.functional.pad(x, (0, pad_cols), value=float("-inf"))
+
         tile_n = self._tile_n
-
-        # For the tiled path, the input may need extra padding beyond N_padded
-        # to make columns a multiple of tile_n.
-        total_cols = _compute_padded_cols(self.N, tile_n)
-        if x.shape[1] < total_cols:
-            import torch.nn.functional as _F
-
-            x = _F.pad(x, (0, total_cols - x.shape[1]), value=float("-inf"))
 
         y = _softmax_fwd_wrapped(
             self.M,
@@ -539,7 +593,9 @@ class SoftmaxKernel(Kernel):
             x,
         )
 
-        # Trim back to N_padded (the op layer will trim to N)
+        # Trim back to N_padded if needed (only when tile_n does not
+        # divide N_padded, which the divisor-aware compute_tile_n avoids
+        # for all practical cases).
         if y.shape[1] > self.N_padded:
             y = y[:, : self.N_padded]
 

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -9,8 +9,9 @@ N_padded does not fit in shared memory.  Uses the online softmax recurrence
 (track running max and rescaled running sum) across N-tiles.
 
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions. Padded columns are filled with -infinity so they
-contribute 0 to exp-sums and never win the max reduction.
+memory instructions.  Boundary handling for non-aligned N is performed
+inside the kernel via masked loads and -inf fills, eliminating host-side
+``F.pad`` from the forward path.
 """
 
 import functools
@@ -37,10 +38,20 @@ __all__ = ["SoftmaxKernel"]
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
-    """Build a single-tile softmax/log_softmax kernel (N fits in smem)."""
+    """Build a single-tile softmax/log_softmax kernel (N fits in smem).
+
+    Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
+    ``DEFAULT_ALIGNMENT``, the kernel fills shared memory with ``-inf``
+    and loads only the valid ``N`` columns (kernel-side boundary handling).
+    When ``N`` is already aligned, the fast ``T.copy`` path is used.
+    """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
+    # Reinterpret -inf as the target dtype at Python level (compile-time
+    # constant) to avoid runtime reinterpret inside the kernel.
+    _neg_inf = float("-inf")
 
     if op_kind == "softmax":
 
@@ -48,7 +59,7 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
         def _func(block_m, threads):
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -58,11 +69,20 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     row_max = T.alloc_fragment((block_m,), "float32")
                     row_sum = T.alloc_fragment((block_m,), "float32")
 
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                    if _needs_pad:
+                        # Kernel-side boundary handling: element-wise load
+                        # with T.if_then_else masking for padding columns.
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                j < N,
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(_neg_inf, "float32"),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, x_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     T.fill(row_max, -T.infinity("float32"))
                     T.reduce_max(x_f32, row_max, dim=1, clear=False)
@@ -88,7 +108,7 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
         def _func(block_m, threads):
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -98,11 +118,18 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     row_max = T.alloc_fragment((block_m,), "float32")
                     row_sum = T.alloc_fragment((block_m,), "float32")
 
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                    if _needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                j < N,
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(_neg_inf, "float32"),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, x_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     T.fill(row_max, -T.infinity("float32"))
                     T.reduce_max(x_f32, row_max, dim=1, clear=False)
@@ -130,7 +157,7 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int):
     """Build a multi-tile softmax/log_softmax kernel.
 
@@ -138,8 +165,10 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
       Pass 1 (all tiles): compute running max and rescaled running sum.
       Pass 2 (all tiles): normalize using global max and sum.
 
-    The input/output tensor column count is total_cols = num_tiles * tile_n,
-    which may be larger than N_padded. Extra columns must be -inf padded.
+    The input tensor has the raw shape ``(M, N)`` (no host-side padding).
+    Boundary handling for the last tile (where ``t * tile_n + j`` may
+    exceed ``N``) is performed inside the kernel via ``T.if_then_else``
+    masked loads.  Output columns are ``total_cols = num_tiles * tile_n``.
 
     NOTE: Pass 2 uses a dedicated shared memory buffer AND dedicated register
     fragments. TileLang's allocator may alias both shared buffers and register
@@ -151,6 +180,11 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     num_tiles = (N_padded + tile_n - 1) // tile_n
     total_cols = num_tiles * tile_n
+    # The last tile may extend beyond N; boundary masking is needed when
+    # total_cols > N (which is always true when N is not aligned, and also
+    # when tile_n does not evenly divide N_padded).
+    _needs_mask = total_cols > N
+    _neg_inf = float("-inf")
 
     if op_kind == "softmax":
 
@@ -158,7 +192,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
         def _func(block_m, threads):
             @T.prim_func
             def main(
-                x: T.Tensor[(M, total_cols), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, total_cols), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -178,11 +212,20 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
 
                     # Pass 1: compute global max and sum using online recurrence
                     for t in T.Serial(num_tiles):
-                        T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                        T.copy(shared_buf, tile_local)
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                        if _needs_mask:
+                            # Kernel-side boundary: load into fragment with
+                            # T.if_then_else masking for out-of-range columns.
+                            for i, j in T.Parallel(block_m, tile_n):
+                                tile_f32[i, j] = T.if_then_else(
+                                    t * tile_n + j < N,
+                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
+                                    T.cast(_neg_inf, "float32"),
+                                )
+                        else:
+                            T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                            T.copy(shared_buf, tile_local)
+                            for i, j in T.Parallel(block_m, tile_n):
+                                tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                         T.fill(tile_max, -T.infinity("float32"))
                         T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -220,13 +263,23 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     # Pass 2: normalize (cast + compute fused, write-back
                     # reuses p2_f32 -> p2_local to avoid an extra fragment)
                     for t in T.Serial(num_tiles):
-                        T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                        T.copy(p2_shared, p2_local)
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_f32[i, j] = T.exp(
-                                T.cast(p2_local[i, j], "float32") - row_max[i]
-                            ) * inv_sum[i]
+                        if _needs_mask:
+                            for i, j in T.Parallel(block_m, tile_n):
+                                p2_f32[i, j] = T.if_then_else(
+                                    t * tile_n + j < N,
+                                    T.exp(
+                                        T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
+                                        - row_max[i]
+                                    ) * inv_sum[i],
+                                    0.0,
+                                )
+                        else:
+                            T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
+                            T.copy(p2_shared, p2_local)
+                            for i, j in T.Parallel(block_m, tile_n):
+                                p2_f32[i, j] = T.exp(
+                                    T.cast(p2_local[i, j], "float32") - row_max[i]
+                                ) * inv_sum[i]
 
                         for i, j in T.Parallel(block_m, tile_n):
                             p2_local[i, j] = p2_f32[i, j]
@@ -241,7 +294,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
         def _func(block_m, threads):
             @T.prim_func
             def main(
-                x: T.Tensor[(M, total_cols), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, total_cols), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -261,11 +314,18 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
 
                     # Pass 1: compute global max and sum
                     for t in T.Serial(num_tiles):
-                        T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                        T.copy(shared_buf, tile_local)
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                        if _needs_mask:
+                            for i, j in T.Parallel(block_m, tile_n):
+                                tile_f32[i, j] = T.if_then_else(
+                                    t * tile_n + j < N,
+                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
+                                    T.cast(_neg_inf, "float32"),
+                                )
+                        else:
+                            T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                            T.copy(shared_buf, tile_local)
+                            for i, j in T.Parallel(block_m, tile_n):
+                                tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                         T.fill(tile_max, -T.infinity("float32"))
                         T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -289,20 +349,28 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                         log_sum[i] = T.log(row_sum[i])
 
                     # --- Pass 2: dedicated shared + register fragments ---
-                    # (Same aliasing workaround as softmax — see note above.)
+                    # (Same aliasing workaround as softmax -- see note above.)
                     p2_shared = T.alloc_shared((block_m, tile_n), dtype)
                     p2_local = T.alloc_fragment((block_m, tile_n), dtype)
                     p2_f32 = T.alloc_fragment((block_m, tile_n), "float32")
 
                     # Pass 2: log-normalize (cast + compute fused)
                     for t in T.Serial(num_tiles):
-                        T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                        T.copy(p2_shared, p2_local)
-
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_f32[i, j] = (
-                                T.cast(p2_local[i, j], "float32") - row_max[i] - log_sum[i]
-                            )
+                        if _needs_mask:
+                            for i, j in T.Parallel(block_m, tile_n):
+                                p2_f32[i, j] = T.if_then_else(
+                                    t * tile_n + j < N,
+                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
+                                    - row_max[i] - log_sum[i],
+                                    T.cast(_neg_inf, "float32"),
+                                )
+                        else:
+                            T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
+                            T.copy(p2_shared, p2_local)
+                            for i, j in T.Parallel(block_m, tile_n):
+                                p2_f32[i, j] = (
+                                    T.cast(p2_local[i, j], "float32") - row_max[i] - log_sum[i]
+                                )
 
                         for i, j in T.Parallel(block_m, tile_n):
                             p2_local[i, j] = p2_f32[i, j]
@@ -319,7 +387,7 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=32)
+@functools.lru_cache(maxsize=64)
 def _softmax_kernel(M: int, N: int, op_kind: str, dtype: str, tile_n: int = 0):
     """Build the appropriate softmax kernel.
 
@@ -383,6 +451,10 @@ class SoftmaxKernel(Kernel):
 
     For large N that does not fit in shared memory, tiles over N using
     the online softmax recurrence (running max + rescaled sum).
+
+    Boundary handling for non-aligned N is performed inside the kernel
+    via masked loads and ``-inf`` fills, so no host-side ``F.pad`` is
+    needed.
 
     Args:
         M: Number of rows (product of all dims except last).
@@ -456,7 +528,7 @@ class SoftmaxKernel(Kernel):
         self.config["tile_n"] = self._tile_n
 
     # Tiled softmax/log_softmax allocates 2 shared buffers (one per pass)
-    # due to TileLang allocator aliasing — see _softmax_kernel_tiled docstring.
+    # due to TileLang allocator aliasing -- see _softmax_kernel_tiled docstring.
     _NUM_SHARED_BUFFERS = 2
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
@@ -571,15 +643,10 @@ class SoftmaxKernel(Kernel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the softmax/log_softmax kernel.
 
-        Accepts an ``(M, N)`` tensor (unpadded) or ``(M, N_padded)``
-        (pre-padded).  Any alignment padding required by T.copy() is
-        handled here, keeping the Op layer free of host-side ``F.pad``.
+        Accepts an ``(M, N)`` tensor.  Boundary handling for non-aligned
+        ``N`` is performed inside the GPU kernel (masked loads + ``-inf``
+        fill), so no host-side ``F.pad`` is needed.
         """
-        # Pad to N_padded if the caller passed the raw (M, N) tensor.
-        if x.shape[-1] < self.N_padded:
-            pad_cols = self.N_padded - x.shape[-1]
-            x = torch.nn.functional.pad(x, (0, pad_cols), value=float("-inf"))
-
         tile_n = self._tile_n
 
         y = _softmax_fwd_wrapped(

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -11,7 +11,9 @@ N_padded does not fit in shared memory.  Uses the online softmax recurrence
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.  Boundary handling for non-aligned N is performed
 inside the kernel via masked loads and -inf fills, eliminating host-side
-``F.pad`` from the forward path.
+``F.pad`` from the forward path.  In the multi-tile path, only the last
+tile uses element-wise masked loads; all preceding tiles use the fast
+vectorized T.copy path since their columns are fully in-bounds.
 """
 
 import functools
@@ -213,14 +215,24 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     # Pass 1: compute global max and sum using online recurrence
                     for t in T.Serial(num_tiles):
                         if _needs_mask:
-                            # Kernel-side boundary: load into fragment with
-                            # T.if_then_else masking for out-of-range columns.
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.if_then_else(
-                                    t * tile_n + j < N,
-                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
-                                    T.cast(_neg_inf, "float32"),
-                                )
+                            # Only the last tile may have out-of-bounds columns.
+                            # Use fast vectorized T.copy for all earlier tiles,
+                            # and element-wise T.if_then_else only for the last.
+                            with T.If(t < num_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                                    T.copy(shared_buf, tile_local)
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                                with T.Else():
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            t * tile_n + j < N,
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                            ),
+                                            T.cast(_neg_inf, "float32"),
+                                        )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                             T.copy(shared_buf, tile_local)
@@ -264,15 +276,28 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     # reuses p2_f32 -> p2_local to avoid an extra fragment)
                     for t in T.Serial(num_tiles):
                         if _needs_mask:
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = T.if_then_else(
-                                    t * tile_n + j < N,
-                                    T.exp(
-                                        T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
-                                        - row_max[i]
-                                    ) * inv_sum[i],
-                                    0.0,
-                                )
+                            with T.If(t < num_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
+                                    T.copy(p2_shared, p2_local)
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        p2_f32[i, j] = T.exp(
+                                            T.cast(p2_local[i, j], "float32") - row_max[i]
+                                        ) * inv_sum[i]
+                                with T.Else():
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        p2_f32[i, j] = T.if_then_else(
+                                            t * tile_n + j < N,
+                                            T.exp(
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j],
+                                                    "float32",
+                                                )
+                                                - row_max[i]
+                                            )
+                                            * inv_sum[i],
+                                            0.0,
+                                        )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                             T.copy(p2_shared, p2_local)
@@ -315,12 +340,21 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     # Pass 1: compute global max and sum
                     for t in T.Serial(num_tiles):
                         if _needs_mask:
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.if_then_else(
-                                    t * tile_n + j < N,
-                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32"),
-                                    T.cast(_neg_inf, "float32"),
-                                )
+                            with T.If(t < num_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
+                                    T.copy(shared_buf, tile_local)
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                                with T.Else():
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            t * tile_n + j < N,
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                            ),
+                                            T.cast(_neg_inf, "float32"),
+                                        )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                             T.copy(shared_buf, tile_local)
@@ -357,13 +391,27 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                     # Pass 2: log-normalize (cast + compute fused)
                     for t in T.Serial(num_tiles):
                         if _needs_mask:
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = T.if_then_else(
-                                    t * tile_n + j < N,
-                                    T.cast(x[pid_m * block_m + i, t * tile_n + j], "float32")
-                                    - row_max[i] - log_sum[i],
-                                    T.cast(_neg_inf, "float32"),
-                                )
+                            with T.If(t < num_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
+                                    T.copy(p2_shared, p2_local)
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        p2_f32[i, j] = (
+                                            T.cast(p2_local[i, j], "float32")
+                                            - row_max[i]
+                                            - log_sum[i]
+                                        )
+                                with T.Else():
+                                    for i, j in T.Parallel(block_m, tile_n):
+                                        p2_f32[i, j] = T.if_then_else(
+                                            t * tile_n + j < N,
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                            )
+                                            - row_max[i]
+                                            - log_sum[i],
+                                            T.cast(_neg_inf, "float32"),
+                                        )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                             T.copy(p2_shared, p2_local)

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -51,8 +51,8 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _needs_pad = N_padded != N
-    # Reinterpret -inf as the target dtype at Python level (compile-time
-    # constant) to avoid runtime reinterpret inside the kernel.
+    # Compile-time Python constant used for padding; it is still cast to
+    # the kernel dtype where needed inside the generated kernel.
     _neg_inf = float("-inf")
 
     if op_kind == "softmax":

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -511,6 +511,8 @@ class SoftmaxKernel(Kernel):
         dtype: Data type (float32, float16, or bfloat16).
         config: Optional kernel configuration dict.
         tune: Whether to autotune (default False).
+        device_index: CUDA device index for shared memory budget query.
+            When ``None``, ``torch.cuda.current_device()`` is used.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -523,6 +525,7 @@ class SoftmaxKernel(Kernel):
         dtype: torch.dtype,
         config: Optional[dict] = None,
         tune: bool = False,
+        device_index: int | None = None,
     ):
         super().__init__()
         if op_kind not in ("softmax", "log_softmax"):
@@ -535,7 +538,7 @@ class SoftmaxKernel(Kernel):
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
-        self._smem_budget = device_smem_budget()
+        self._smem_budget = device_smem_budget(device_index)
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -1,7 +1,8 @@
 """Base class for softmax-family operators (L2 Op layer).
 
-Provides the shared validate -> reshape -> pad -> kernel -> trim -> reshape
-pattern for softmax, log_softmax, and logsumexp ops.
+Provides the shared validate -> reshape -> kernel -> trim -> reshape
+pattern for softmax, log_softmax, and logsumexp ops.  Alignment padding
+is handled inside the kernel via masked loads, not on the host.
 
 Construction: ``op(dtype=..., dim=-1)``.  M and N are derived
 from the input tensor at forward time, and kernels are cached by

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -99,7 +99,7 @@ class _SoftmaxBaseOp(Op):
             N = x.shape[-1]
             M = prod(x.shape[:-1])
             x = x.reshape(M, N)
-            kernel = self._get_or_create_kernel(M, N)
+            kernel = self._get_or_create_kernel(M, N, device_index=x.device.index)
             # Alignment padding is handled by the kernel's forward().
             y = kernel(x)
             N_padded = align_up(N, DEFAULT_ALIGNMENT)
@@ -127,8 +127,8 @@ class _SoftmaxBaseOp(Op):
 
         x = x.contiguous().reshape(M, N)
 
-        # Get or create cached kernel for this (M, N).
-        kernel = self._get_or_create_kernel(M, N)
+        # Get or create cached kernel for this (M, N, device).
+        kernel = self._get_or_create_kernel(M, N, device_index=x.device.index)
 
         # Alignment padding is handled by the kernel's forward().
         y = kernel(x)
@@ -140,13 +140,14 @@ class _SoftmaxBaseOp(Op):
 
         return self._reshape_output(y, orig_shape, dim, needs_transpose)
 
-    def _get_or_create_kernel(self, M: int, N: int) -> object:
-        """Return a cached kernel for (M, N), creating one if needed."""
-        key = (M, N)
+    def _get_or_create_kernel(self, M: int, N: int, device_index: int | None = None) -> object:
+        """Return a cached kernel for (M, N, device_index), creating one if needed."""
+        key = (M, N, device_index)
         if key not in self._kernel_cache:
             kernel_cls = self.kernel_map[self._kernel_key]
             self._kernel_cache[key] = kernel_cls(
-                M, N, self._op_kind, self.dtype, tune=self._tune
+                M, N, self._op_kind, self.dtype, tune=self._tune,
+                device_index=device_index,
             )
         return self._kernel_cache[key]
 

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -12,7 +12,6 @@ from math import prod
 from typing import Dict, List, Optional, Union
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel import Kernel
 from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
@@ -100,10 +99,9 @@ class _SoftmaxBaseOp(Op):
             M = prod(x.shape[:-1])
             x = x.reshape(M, N)
             kernel = self._get_or_create_kernel(M, N)
-            N_padded = align_up(N, DEFAULT_ALIGNMENT)
-            if N_padded != N:
-                x = F.pad(x, (0, N_padded - N), value=float("-inf"))
+            # Alignment padding is handled by the kernel's forward().
             y = kernel(x)
+            N_padded = align_up(N, DEFAULT_ALIGNMENT)
             if N_padded != N:
                 y = y[:, :N] if y.ndim == 2 else y
             return restore_multidim_shape(y, orig_shape, dims, self.keepdim)
@@ -131,14 +129,11 @@ class _SoftmaxBaseOp(Op):
         # Get or create cached kernel for this (M, N).
         kernel = self._get_or_create_kernel(M, N)
 
-        # Pad hidden dim to alignment.
-        N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        if N_padded != N:
-            x = F.pad(x, (0, N_padded - N), value=float("-inf"))
-
+        # Alignment padding is handled by the kernel's forward().
         y = kernel(x)
 
-        # Trim padding.
+        # Trim padding (kernel output may still be N_padded-wide).
+        N_padded = align_up(N, DEFAULT_ALIGNMENT)
         if N_padded != N:
             y = y[:, :N] if y.ndim == 2 else y
 


### PR DESCRIPTION
## Summary

Bring the large-N tiled softmax path to within 1.5x of PyTorch performance for manifest-declared workloads (N=32768, N=102400).

- Eliminate host-side `F.pad` from the softmax-family forward path by moving boundary handling into the kernel (masked loads with M+N guards)
- Optimise tile loop scheduling: vectorized `T.copy` for full tiles, `T.if_then_else` only for the last partial tile
- Fix `compute_tile_n` divisor selection to avoid near-empty remainder tiles
- Thread tensor device into `device_smem_budget()` for multi-GPU correctness

Closes #808

## Test plan

- [x] **AC-1**: bf16 N=32768 softmax latency within 1.5x of PyTorch — 0.8135x (faster than PyTorch)
- [x] **AC-2**: Host-side `F.pad` eliminated from the forward path — monkeypatch probe confirms 0 pad calls
- [x] **AC-3**: All existing softmax-family tests pass — 151 passed
- [x] **AC-4**: Benchmark numbers included in PR description (see below)

## Benchmark

**Environment**: NVIDIA H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.8

| Workload | Shape | dtype | TileOPs (ms) | PyTorch (ms) | Ratio | Config |
|---|---|---|---:|---:|---:|---|
| attn-weights-32k | (32, 32, 32768) | bfloat16 | 0.1237 | 0.1521 | **0.81x** | block_m=2, tile_n=16384 |
| lm-head-logits | (4, 102400) | float16 | 0.0357 | 0.0557 | **0.64x** | block_m=1, tile_n=25600 |
| lm-head-logits | (4, 102400) | bfloat16 | 0.0379 | 0.0574 | **0.66x** | block_m=1, tile_n=25600 |

**Takeaways:**
- All three manifest workloads are now **faster** than PyTorch (0.64x–0.81x), exceeding the ≤1.5x target by a wide margin
- The key win comes from eliminating host-side `F.pad` (removed a full tensor copy) and using divisor-aware `tile_n` selection to avoid near-empty remainder tiles
- `block_m=2` for the 32k workload gives better occupancy than `block_m=1`; the 102k workload stays at `block_m=1` since it's already bandwidth-bound
- Multi-tile masked loads use `T.copy` for all full tiles and only fall back to element-wise `T.if_then_else` on the last tile, preserving vectorized throughput
- M-dimension row guards (`T.And(row < M, col < N)`) ensure correctness when `M % block_m != 0`, with no measurable perf impact on aligned shapes

**Benchmark command:**
```bash
PYTHONPATH="$PWD" python -m pytest benchmarks/ops/bench_softmax.py -v -k "attn-weights-32k or lm-head-logits"
```

## Follow-up

- #906 — Add non-aligned M×N edge-case tests for softmax-family kernels
- #907 — Apply kernel-side boundary handling to other reduction ops and integrate tile_n into autotuner

Execution order: {#906, #907} (parallel, independent)