### PR TITLE
[Refactor][Reduction] Extract _LogicalTest base class for logical reduce workloads

### DIFF
--- a/workloads/ops/logical_reduce.py
+++ b/workloads/ops/logical_reduce.py
@@ -3,8 +3,8 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class AnyTest(WorkloadBase):
-    """Workload definition for AnyFwdOp.
+class _LogicalTest(WorkloadBase):
+    """Shared workload base for logical reduce ops (any, all, count_nonzero).
 
     Generates inputs with a mix of zeros and non-zeros for meaningful
     logical reduction testing.  Boolean, integer, float, and complex
@@ -19,34 +19,16 @@ class AnyTest(WorkloadBase):
         return (_make_logical_input(self.shape, self.dtype),)
 
 
-class AllTest(WorkloadBase):
-    """Workload definition for AllFwdOp.
-
-    Same input-generation strategy as AnyTest (rows with all-True
-    and all-False are forced for meaningful coverage).
-    """
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        return (_make_logical_input(self.shape, self.dtype),)
+class AnyTest(_LogicalTest):
+    """Workload definition for AnyFwdOp."""
 
 
-class CountNonzeroTest(WorkloadBase):
-    """Workload definition for CountNonzeroFwdOp.
+class AllTest(_LogicalTest):
+    """Workload definition for AllFwdOp."""
 
-    Uses the same mixed-zero input strategy as the other logical reduce
-    workloads.
-    """
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        return (_make_logical_input(self.shape, self.dtype),)
+class CountNonzeroTest(_LogicalTest):
+    """Workload definition for CountNonzeroFwdOp."""
 
 
 # ---------------------------------------------------------------------------

--- a/workloads/ops/logical_reduce.py
+++ b/workloads/ops/logical_reduce.py
@@ -7,7 +7,7 @@ class _LogicalTest(WorkloadBase):
     """Shared workload base for logical reduce ops (any, all, count_nonzero).
 
     Generates inputs with a mix of zeros and non-zeros for meaningful
-    logical reduction testing.  Boolean, integer, float, and complex
+    logical reduction testing. Boolean, integer, float, and complex
     dtypes are supported.
     """
 


### PR DESCRIPTION
## Summary

Extract a `_LogicalTest` base class in `workloads/ops/logical_reduce.py` to eliminate duplicated `__init__` and `gen_inputs` across `AnyTest`, `AllTest`, and `CountNonzeroTest`.

Closes #897

## Test plan

| AC | Status | Description |
|----|--------|-------------|
| AC-1 | pass | AnyTest, AllTest, CountNonzeroTest inherit from _LogicalTest with no duplicated __init__/gen_inputs |
| AC-2 | pass | pytest tests/ops/test_logical_reduce.py passes |

**114/114** tests passed (test_logical_reduce.py)

## Follow-up

- #908 — Extract RandnTest base class for softmax workloads (consistency gap from PR #893)

Suggestions: double space in `_LogicalTest` docstring (cosmetic)