### PR TITLE
[BugFix][Argreduce] Fix dim=0 reduction on 3D tensors

### DIFF
--- a/benchmarks/ops/bench_reduce_multidim.py
+++ b/benchmarks/ops/bench_reduce_multidim.py
@@ -8,10 +8,8 @@ Groups 1 (reduce), 3 (logical), and 4 (vector norm) use true multi-dim
 reduction (e.g. dim=[0, 2]).
 
 Groups 2 (argreduce) and 5 (cumulative) are architecturally single-dim:
-  - Argreduce (argmax/argmin): accepts only scalar dim (int). The kernel
-    currently supports dim=-1 and dim=1 on 3D tensors but NOT dim=0
-    (compilation fails with "Check failed: CanProveEqual(abs(source->scale), 1)").
-    We benchmark dim=1 and dim=2 on 3D tensors as the closest coverage.
+  - Argreduce (argmax/argmin): accepts only scalar dim (int).
+    We benchmark dim=0, dim=1, and dim=2 on 3D tensors.
   - Cumulative (cumsum/cumprod): only accepts (M, N, dtype) and always
     operates on dim=-1. We benchmark 3D-shaped inputs reshaped to 2D.
 These two groups cannot provide true multi-dim reduction cases.
@@ -157,10 +155,7 @@ def test_reduce_multidim_bench(
 # ===================================================================
 # 2. Argreduce (argmax, argmin) — non-last-axis dims on 3D tensor
 #    ArgmaxFwdOp/ArgminFwdOp only accept scalar dim (int), not a list.
-#    The kernel does not support dim=0 on 3D tensors (compilation fails
-#    with TVM "Check failed: CanProveEqual(abs(source->scale), 1)").
-#    We cover dim=1 and dim=2 on a 3D tensor to exercise non-last and
-#    last axis, which is the closest multi-dim-relevant coverage.
+#    We cover dim=0, dim=1, and dim=2 on a 3D tensor.
 # ===================================================================
 
 
@@ -169,6 +164,15 @@ class ArgreduceMultidimFixture(FixtureBase):
         (
             "shape, dim, keepdim, dtype, op_kind",
             [
+                # dim=0: reduce across batch — LLaMA-7B (batch=4, seq=128, hidden=4096)
+                pytest.param(
+                    (4, 128, 4096), 0, False, torch.float16, "argmax",
+                    id="argmax-7B-dim0-nokeepdim",
+                ),
+                pytest.param(
+                    (4, 128, 4096), 0, True, torch.float16, "argmin",
+                    id="argmin-7B-dim0-keepdim",
+                ),
                 # dim=1: reduce across seq — LLaMA-7B (batch=4, seq=128, hidden=4096)
                 pytest.param(
                     (4, 128, 4096), 1, False, torch.float16, "argmin",

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -88,6 +88,20 @@ class Argreduce4DFixture(FixtureBase):
     ]
 
 
+class Argreduce4DDim0Fixture(FixtureBase):
+    """dim=0 reduction on 4D tensors — regression coverage for 3D+ contract."""
+
+    PARAMS = [
+        (
+            "b0, b1, b2, n, dtype",
+            [
+                pytest.param(2, 4, 8, 256, torch.float16, marks=pytest.mark.smoke),
+                pytest.param(2, 4, 8, 256, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
 class Argreduce1DFixture(FixtureBase):
     PARAMS = [
         (
@@ -109,6 +123,8 @@ class SpecArgreduceFixture(FixtureBase):
                 pytest.param((128, 512), -1, False, torch.float16, marks=pytest.mark.smoke),
                 pytest.param((128, 512), -1, True, torch.float16, marks=pytest.mark.full),
                 pytest.param((512, 4, 32), 0, False, torch.float16, marks=pytest.mark.full),
+                pytest.param((2, 4, 8, 256), 0, False, torch.float16, marks=pytest.mark.full),
+                pytest.param((2, 4, 8, 256), 0, True, torch.float16, marks=pytest.mark.full),
                 pytest.param((4, 32, 512), 1, False, torch.float16, marks=pytest.mark.full),
                 pytest.param((4, 32, 512), -1, False, torch.bfloat16, marks=pytest.mark.full),
                 pytest.param((4, 32, 512), -1, True, torch.bfloat16, marks=pytest.mark.full),
@@ -240,6 +256,34 @@ def test_argmax_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     assert torch.equal(y, ref), f"3D dim=0 keepdim argmax mismatch: {(y != ref).sum().item()}"
 
 
+@Argreduce4DDim0Fixture
+def test_argmax_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> None:
+    """Argmax along dim=0 on 4D tensors (outermost-dim reduction, 3D+ regression)."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=0)
+    ref = x.argmax(dim=0)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"4D dim=0 argmax mismatch: {(y != ref).sum().item()}"
+
+
+@Argreduce4DDim0Fixture
+def test_argmax_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> None:
+    """Argmax along dim=0 with keepdim=True on 4D tensors."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
+    ref = x.argmax(dim=0, keepdim=True)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"4D dim=0 keepdim argmax mismatch: {(y != ref).sum().item()}"
+
+
 @SpecArgreduceFixture
 def test_argmax_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dtype) -> None:
     """Spec interface: ArgmaxFwdOp with dim + keepdim."""
@@ -343,6 +387,34 @@ def test_argmin_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D dim=0 keepdim argmin mismatch: {(y != ref).sum().item()}"
+
+
+@Argreduce4DDim0Fixture
+def test_argmin_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> None:
+    """Argmin along dim=0 on 4D tensors (outermost-dim reduction, 3D+ regression)."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=0)
+    ref = x.argmin(dim=0)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"4D dim=0 argmin mismatch: {(y != ref).sum().item()}"
+
+
+@Argreduce4DDim0Fixture
+def test_argmin_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> None:
+    """Argmin along dim=0 with keepdim=True on 4D tensors."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
+    ref = x.argmin(dim=0, keepdim=True)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"4D dim=0 keepdim argmin mismatch: {(y != ref).sum().item()}"
 
 
 @SpecArgreduceFixture

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -60,6 +60,22 @@ class Argreduce3DFixture(FixtureBase):
     ]
 
 
+class Argreduce3DDim0Fixture(FixtureBase):
+    """dim=0 reduction on 3D tensors — small outermost dim triggers
+    the TileLang layout constraint (N << N_padded)."""
+
+    PARAMS = [
+        (
+            "batch, seq, hidden, dtype",
+            [
+                pytest.param(4, 8, 256, torch.float16, marks=pytest.mark.smoke),
+                pytest.param(4, 8, 256, torch.bfloat16, marks=pytest.mark.full),
+                pytest.param(4, 8, 256, torch.float32, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
 class Argreduce4DFixture(FixtureBase):
     PARAMS = [
         (
@@ -196,6 +212,34 @@ def test_argmax_1d(n: int, dtype: torch.dtype) -> None:
     assert torch.equal(y.view_as(ref), ref), "1D argmax mismatch"
 
 
+@Argreduce3DDim0Fixture
+def test_argmax_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Argmax along dim=0 on 3D tensors (outermost-dim reduction)."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=0)
+    ref = x.argmax(dim=0)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"3D dim=0 argmax mismatch: {(y != ref).sum().item()}"
+
+
+@Argreduce3DDim0Fixture
+def test_argmax_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Argmax along dim=0 with keepdim=True on 3D tensors."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
+    ref = x.argmax(dim=0, keepdim=True)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"3D dim=0 keepdim argmax mismatch: {(y != ref).sum().item()}"
+
+
 @SpecArgreduceFixture
 def test_argmax_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dtype) -> None:
     """Spec interface: ArgmaxFwdOp with dim + keepdim."""
@@ -271,6 +315,34 @@ def test_argmin_1d(n: int, dtype: torch.dtype) -> None:
     y = op(x)
     assert y.dtype == torch.int64
     assert torch.equal(y.view_as(ref), ref), "1D argmin mismatch"
+
+
+@Argreduce3DDim0Fixture
+def test_argmin_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Argmin along dim=0 on 3D tensors (outermost-dim reduction)."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=0)
+    ref = x.argmin(dim=0)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"3D dim=0 argmin mismatch: {(y != ref).sum().item()}"
+
+
+@Argreduce3DDim0Fixture
+def test_argmin_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+    """Argmin along dim=0 with keepdim=True on 3D tensors."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
+    ref = x.argmin(dim=0, keepdim=True)
+    y = op(x)
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert y.dtype == torch.int64
+    assert torch.equal(y, ref), f"3D dim=0 keepdim argmin mismatch: {(y != ref).sum().item()}"
 
 
 @SpecArgreduceFixture

--- a/tileops/kernels/reduction/argreduce/fwd.py
+++ b/tileops/kernels/reduction/argreduce/fwd.py
@@ -184,18 +184,21 @@ class ArgreduceKernel(Kernel):
     def default_config(self) -> dict:
         """Select default block_m based on shared memory budget.
 
-        Also enforces a TileLang layout-inference constraint:
-        ``block_m * N_padded <= 2 * threads`` (each thread handles at most 2
-        elements during the shared-memory copy).  This matters when the
-        reduction dimension is small (e.g. dim=0 on a 3D tensor), causing
-        ``N_padded`` to be much larger than ``N``.
+        When the original reduction dimension *N* is smaller than the
+        alignment boundary (``DEFAULT_ALIGNMENT``), padding inflates the row
+        width and TileLang's copy-layout inference requires
+        ``block_m * N_padded <= 2 * threads``.  For large *N* (>= alignment)
+        the rows are dense and the layout works at any block_m that fits in
+        shared memory, so the constraint is skipped.
         """
         smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
         max_block_m_smem = (48 * 1024) // smem_per_row
         threads = 128
-        # TileLang layout constraint: block_m * N_padded <= 2 * threads
-        max_block_m_layout = (2 * threads) // self.N_padded
-        max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
+        max_block_m = max_block_m_smem
+        if self.N < DEFAULT_ALIGNMENT:
+            # TileLang layout constraint: only needed when heavy padding
+            max_block_m_layout = (2 * threads) // self.N_padded
+            max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
         block_m = 1
         for bm in [1, 2, 4, 8]:
             if bm <= max_block_m:
@@ -209,9 +212,11 @@ class ArgreduceKernel(Kernel):
         threads_list = [128, 256]
         configs = []
         for threads in threads_list:
-            # TileLang layout constraint: block_m * N_padded <= 2 * threads
-            max_block_m_layout = (2 * threads) // self.N_padded
-            max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
+            max_block_m = max_block_m_smem
+            if self.N < DEFAULT_ALIGNMENT:
+                # TileLang layout constraint: only needed when heavy padding
+                max_block_m_layout = (2 * threads) // self.N_padded
+                max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
             for bm in [1, 2, 4, 8]:
                 if bm <= max_block_m:
                     configs.append({"block_m": bm, "threads": threads})

--- a/tileops/kernels/reduction/argreduce/fwd.py
+++ b/tileops/kernels/reduction/argreduce/fwd.py
@@ -17,7 +17,11 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
+from tileops.kernels.reduction._primitives import (
+    DEFAULT_ALIGNMENT,
+    SHARED_MEMORY_BUDGET_BYTES,
+    align_up,
+)
 
 __all__ = ["ArgreduceKernel"]
 
@@ -192,7 +196,14 @@ class ArgreduceKernel(Kernel):
         shared memory, so the constraint is skipped.
         """
         smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m_smem = (48 * 1024) // smem_per_row
+        max_block_m_smem = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
+        if max_block_m_smem == 0:
+            raise ValueError(
+                f"A single row requires {smem_per_row} bytes of shared memory, "
+                f"which exceeds the {SHARED_MEMORY_BUDGET_BYTES}-byte budget "
+                f"(N_padded={self.N_padded}, dtype={self.dtype}). "
+                f"Reduce the reduction dimension or use a dtype with smaller element size."
+            )
         threads = 128
         max_block_m = max_block_m_smem
         if self.N < DEFAULT_ALIGNMENT:
@@ -208,7 +219,14 @@ class ArgreduceKernel(Kernel):
     @property
     def autotune_configs(self) -> list[dict]:
         smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m_smem = (48 * 1024) // smem_per_row
+        max_block_m_smem = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
+        if max_block_m_smem == 0:
+            raise ValueError(
+                f"A single row requires {smem_per_row} bytes of shared memory, "
+                f"which exceeds the {SHARED_MEMORY_BUDGET_BYTES}-byte budget "
+                f"(N_padded={self.N_padded}, dtype={self.dtype}). "
+                f"Reduce the reduction dimension or use a dtype with smaller element size."
+            )
         threads_list = [128, 256]
         configs = []
         for threads in threads_list:

--- a/tileops/kernels/reduction/argreduce/fwd.py
+++ b/tileops/kernels/reduction/argreduce/fwd.py
@@ -10,7 +10,6 @@ Output is always int64 (index values).
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -183,23 +182,40 @@ class ArgreduceKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget."""
+        """Select default block_m based on shared memory budget.
+
+        Also enforces a TileLang layout-inference constraint:
+        ``block_m * N_padded <= 2 * threads`` (each thread handles at most 2
+        elements during the shared-memory copy).  This matters when the
+        reduction dimension is small (e.g. dim=0 on a 3D tensor), causing
+        ``N_padded`` to be much larger than ``N``.
+        """
         smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
+        max_block_m_smem = (48 * 1024) // smem_per_row
+        threads = 128
+        # TileLang layout constraint: block_m * N_padded <= 2 * threads
+        max_block_m_layout = (2 * threads) // self.N_padded
+        max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
         block_m = 1
         for bm in [1, 2, 4, 8]:
             if bm <= max_block_m:
                 block_m = bm
-        return {"block_m": block_m, "threads": 128}
+        return {"block_m": block_m, "threads": threads}
 
     @property
     def autotune_configs(self) -> list[dict]:
         smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
+        max_block_m_smem = (48 * 1024) // smem_per_row
         threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        configs = []
+        for threads in threads_list:
+            # TileLang layout constraint: block_m * N_padded <= 2 * threads
+            max_block_m_layout = (2 * threads) // self.N_padded
+            max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
+            for bm in [1, 2, 4, 8]:
+                if bm <= max_block_m:
+                    configs.append({"block_m": bm, "threads": threads})
+        return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the argmax/argmin kernel.


### PR DESCRIPTION
## Summary

Fix the argreduce kernel so `dim=0` compiles and runs correctly on 3D+ tensors. The root cause was an unconstrained `block_m` tile size that violated the TVM `CanProveEqual(abs(source->scale), 1)` assertion when reducing along the outermost dimension.

Closes #899

## Changes

- **`tileops/kernels/reduction/argreduce/fwd.py`** — Constrain `block_m` for small-N cases to fix dim=0 index/scale computation on 3D tensors.
- **`tests/ops/test_argreduce.py`** — Add unit tests for argmax/argmin with dim=0 on 3D tensors.
- **`benchmarks/ops/bench_reduce_multidim.py`** — Re-add dim=0 benchmark cases.

## Test plan

- [x] AC-1: `ArgmaxFwdOp(dtype=float16, dim=0, keepdim=False)` compiles and runs on a 3D tensor without error
  - Evidence: `pytest tests/ops/test_argreduce.py -k '3d_dim0 or spec_dim[shape2-0-False-dtype2]'` — 14 passed
- [x] AC-2: Unit tests pass for argmax/argmin with dim=0 on 3D tensors
  - Evidence: `pytest tests/ops/test_argreduce.py` — 62 passed (full suite)
- [x] AC-3: dim=0 benchmark cases added to `bench_reduce_multidim.py` and run without error
  - Evidence: `pytest benchmarks/ops/bench_reduce_multidim.py -k argreduce` — 6 passed

## Benchmark

argreduce benchmark pytest subset: 6/6 passing; dim=0 subset: 2/2 passing