### PR TITLE
[Refactor][Softmax] Inherit from RandnTest to eliminate duplicated init/gen_inputs

### DIFF
--- a/workloads/ops/softmax.py
+++ b/workloads/ops/softmax.py
@@ -1,39 +1,13 @@
-import torch
-
-from workloads.base import WorkloadBase
+from workloads.base import RandnTest
 
 
-class SoftmaxTest(WorkloadBase):
+class SoftmaxTest(RandnTest):
     """Workload definition for SoftmaxFwdOp (spec interface: shape + dtype)."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class LogSoftmaxTest(WorkloadBase):
+class LogSoftmaxTest(RandnTest):
     """Workload definition for LogSoftmaxFwdOp (spec interface: shape + dtype)."""
 
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
 
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)
-
-
-class LogSumExpTest(WorkloadBase):
+class LogSumExpTest(RandnTest):
     """Workload definition for LogSumExpFwdOp (spec interface: shape + dtype)."""
-
-    def __init__(self, shape: tuple, dtype: torch.dtype):
-        self.shape = shape
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.shape, dtype=self.dtype, device="cuda")
-        return (x,)


### PR DESCRIPTION
## Summary

Make `SoftmaxTest`, `LogSoftmaxTest`, and `LogSumExpTest` inherit from `RandnTest` to eliminate duplicated `__init__` and `gen_inputs` methods.

Closes #908

## Test plan

- [x] AC-1: `SoftmaxTest`, `LogSoftmaxTest`, `LogSumExpTest` inherit from `RandnTest` with no duplicated `__init__`/`gen_inputs`
  - Evidence: `workloads/ops/softmax.py` now imports `RandnTest` and defines all three classes as docstring-only subclasses; `RandnTest` provides the shared `__init__(shape, dtype)` and `gen_inputs()` implementation.
- [x] AC-2: `pytest tests/ops/test_softmax.py` passes
  - Evidence: 117 passed, 386 warnings in 10.19s.