### PR TITLE
[Refactor][Benchmark] Extract ManifestBenchmark base class and shared helpers

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -267,7 +267,7 @@ class BenchmarkBase(ABC):
 # ---------------------------------------------------------------------------
 
 
-def roofline_vars(workload: WorkloadBase) -> dict:
+def roofline_vars(workload: WorkloadBase) -> dict[str, int | float]:
     """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes).
 
     Standard extraction for reduction-family ops where the manifest roofline
@@ -283,7 +283,7 @@ def roofline_vars(workload: WorkloadBase) -> dict:
     return dict(M=M, N=N, elem_bytes=elem_bytes)
 
 
-def workloads_to_params(op_name: str):
+def workloads_to_params(op_name: str) -> list:
     """Convert manifest workload dicts for *op_name* to pytest params: (shape, dtype).
 
     Returns a list of ``pytest.param(shape, dtype, id=...)`` suitable for

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -5,9 +5,11 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Callable, Optional, Tuple
 
+import pytest
 import torch
 from torch.autograd.profiler import DeviceType
 
+from tileops.manifest import eval_roofline, load_workloads
 from workloads.base import WorkloadBase
 
 _logger = logging.getLogger("tileops.bench")
@@ -258,6 +260,86 @@ class BenchmarkBase(ABC):
         if memory is not None:
             result["bandwidth_tbs"] = memory / latency * 1e-9
         return result
+
+
+# ---------------------------------------------------------------------------
+# Manifest-driven benchmark helpers
+# ---------------------------------------------------------------------------
+
+
+def roofline_vars(workload: WorkloadBase) -> dict:
+    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes).
+
+    Standard extraction for reduction-family ops where the manifest roofline
+    expressions use ``M``, ``N``, and ``elem_bytes``.  Ops with non-standard
+    variable requirements should override
+    :meth:`ManifestBenchmark._roofline_vars` instead of using this directly.
+    """
+    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
+    N = workload.shape[-1]
+    M = 1
+    for s in workload.shape[:-1]:
+        M *= s
+    return dict(M=M, N=N, elem_bytes=elem_bytes)
+
+
+def workloads_to_params(op_name: str):
+    """Convert manifest workload dicts for *op_name* to pytest params: (shape, dtype).
+
+    Returns a list of ``pytest.param(shape, dtype, id=...)`` suitable for
+    ``@pytest.mark.parametrize("shape, dtype", ...)``.
+    """
+    workloads = load_workloads(op_name)
+    params = []
+    for w in workloads:
+        shape = tuple(w["x_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(
+                shape, dtype,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+class ManifestBenchmark(BenchmarkBase):
+    """Generic benchmark that derives FLOP/memory counts from ops_manifest.yaml.
+
+    Accepts an op name, calls ``eval_roofline()`` with auto-extracted roofline
+    vars, and caches the result.  Subclass and override ``_roofline_vars()``
+    for ops with non-standard variable extraction.
+
+    Usage::
+
+        bm = ManifestBenchmark("SoftmaxFwdOp", workload)
+        result = bm.profile(op, *inputs)
+    """
+
+    def __init__(self, op_name: str, workload: WorkloadBase):
+        super().__init__(workload)
+        self._op_name = op_name
+        self._roofline_cache: Optional[tuple[float, float]] = None
+
+    def _roofline_vars(self) -> dict:
+        """Extract roofline variable bindings from the workload.
+
+        Override this for ops whose manifest roofline expressions require
+        variables beyond the standard ``M``, ``N``, ``elem_bytes``.
+        """
+        return roofline_vars(self.workload)
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = eval_roofline(
+                self._op_name, **self._roofline_vars())
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
 
 
 def _extract_op_config(op: object) -> Optional[dict]:

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -4,13 +4,10 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
 """
 
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.manifest import eval_roofline, load_workloads
+from benchmarks.benchmark import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.argmax import ArgmaxFwdOp
 from tileops.ops.reduction.argmin import ArgminFwdOp
 from workloads.ops.argreduce import ArgmaxTest, ArgminTest
@@ -19,77 +16,15 @@ _ARGMAX_OP = "ArgmaxFwdOp"
 _ARGMIN_OP = "ArgminFwdOp"
 
 
-def _roofline_vars(shape, dtype) -> dict:
-    """Extract roofline variables from shape + dtype → M, N, elem_bytes."""
-    elem_bytes = torch.tensor([], dtype=dtype).element_size()
-    N = shape[-1]
-    M = 1
-    for s in shape[:-1]:
-        M *= s
-    return dict(M=M, N=N, elem_bytes=elem_bytes)
-
-
-class ArgmaxBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _ARGMAX_OP, **_roofline_vars(self.workload.shape, self.workload.dtype))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class ArgminBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _ARGMIN_OP, **_roofline_vars(self.workload.shape, self.workload.dtype))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-# ===================================================================
-# Manifest-driven parametrize helper
-# ===================================================================
-
-
-def _workloads_to_params(workloads):
-    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
-    params = []
-    for w in workloads:
-        shape = tuple(w["x_shape"])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                shape, dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
 # ===================================================================
 # Argmax benchmarks
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ARGMAX_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ARGMAX_OP))
 def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     workload = ArgmaxTest(shape, dtype)
-    bm = ArgmaxBenchmark(workload)
+    bm = ManifestBenchmark(_ARGMAX_OP, workload)
     inputs = workload.gen_inputs()
 
     op = ArgmaxFwdOp(dtype=dtype)
@@ -119,10 +54,10 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ARGMIN_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ARGMIN_OP))
 def test_argmin_bench(shape: tuple, dtype: torch.dtype) -> None:
     workload = ArgminTest(shape, dtype)
-    bm = ArgminBenchmark(workload)
+    bm = ManifestBenchmark(_ARGMIN_OP, workload)
     inputs = workload.gen_inputs()
 
     op = ArgminFwdOp(dtype=dtype)

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -4,13 +4,10 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
 """
 
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.manifest import eval_roofline, load_workloads
+from benchmarks.benchmark import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.all_op import AllFwdOp
 from tileops.ops.reduction.any_op import AnyFwdOp
 from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
@@ -26,102 +23,14 @@ _COUNT_NONZERO_OP = "CountNonzeroFwdOp"
 
 
 # ===================================================================
-# Roofline helper
-# ===================================================================
-
-
-def _roofline_vars(workload) -> dict:
-    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
-    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
-    N = workload.shape[-1]
-    M = 1
-    for s in workload.shape[:-1]:
-        M *= s
-    return dict(M=M, N=N, elem_bytes=elem_bytes)
-
-
-# ===================================================================
-# Benchmark classes — use manifest roofline for FLOP/memory counts
-# ===================================================================
-
-
-class AnyBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _ANY_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class AllBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _ALL_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class CountNonzeroBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _COUNT_NONZERO_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-# ===================================================================
-# Manifest-driven parametrize helper
-# ===================================================================
-
-
-def _workloads_to_params(workloads):
-    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
-    params = []
-    for w in workloads:
-        shape = tuple(w["x_shape"])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                shape, dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
-# ===================================================================
 # Any benchmarks
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ANY_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ANY_OP))
 def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = AnyTest(shape, dtype)
-    bm = AnyBenchmark(test)
+    bm = ManifestBenchmark(_ANY_OP, test)
     inputs = test.gen_inputs()
 
     op = AnyFwdOp(dtype=dtype)
@@ -145,10 +54,10 @@ def test_any_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_ALL_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ALL_OP))
 def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = AllTest(shape, dtype)
-    bm = AllBenchmark(test)
+    bm = ManifestBenchmark(_ALL_OP, test)
     inputs = test.gen_inputs()
 
     op = AllFwdOp(dtype=dtype)
@@ -172,10 +81,10 @@ def test_all_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_COUNT_NONZERO_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_COUNT_NONZERO_OP))
 def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = CountNonzeroTest(shape, dtype)
-    bm = CountNonzeroBenchmark(test)
+    bm = ManifestBenchmark(_COUNT_NONZERO_OP, test)
     inputs = test.gen_inputs()
 
     op = CountNonzeroFwdOp(dtype=dtype)

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -4,13 +4,10 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
 """
 
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.manifest import eval_roofline, load_workloads
+from benchmarks.benchmark import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.reduce import (
     AmaxFwdOp,
     AminFwdOp,
@@ -47,182 +44,14 @@ _VAR_MEAN_OP = "VarMeanFwdOp"
 
 
 # ===================================================================
-# Roofline helper
-# ===================================================================
-
-
-def _roofline_vars(workload) -> dict:
-    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
-    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
-    N = workload.shape[-1]
-    M = 1
-    for s in workload.shape[:-1]:
-        M *= s
-    return dict(M=M, N=N, elem_bytes=elem_bytes)
-
-
-# ===================================================================
-# Benchmark classes — use manifest roofline for FLOP/memory counts
-# ===================================================================
-
-
-class SumBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _SUM_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class MeanBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _MEAN_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class AmaxBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _AMAX_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class AminBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _AMIN_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class ProdBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _PROD_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class StdBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _STD_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class VarBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _VAR_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class VarMeanBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _VAR_MEAN_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-# ===================================================================
-# Manifest-driven parametrize helper
-# ===================================================================
-
-
-def _workloads_to_params(workloads):
-    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
-    params = []
-    for w in workloads:
-        shape = tuple(w["x_shape"])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                shape, dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
-# ===================================================================
 # Sum benchmarks
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_SUM_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_SUM_OP))
 def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = SumTest(shape, dtype)
-    bm = SumBenchmark(test)
+    bm = ManifestBenchmark(_SUM_OP, test)
     inputs = test.gen_inputs()
 
     op = SumFwdOp(dtype=dtype)
@@ -246,10 +75,10 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_MEAN_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_MEAN_OP))
 def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = MeanTest(shape, dtype)
-    bm = MeanBenchmark(test)
+    bm = ManifestBenchmark(_MEAN_OP, test)
     inputs = test.gen_inputs()
 
     op = MeanFwdOp(dtype=dtype)
@@ -273,10 +102,10 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMAX_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_AMAX_OP))
 def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = AmaxTest(shape, dtype)
-    bm = AmaxBenchmark(test)
+    bm = ManifestBenchmark(_AMAX_OP, test)
     inputs = test.gen_inputs()
 
     op = AmaxFwdOp(dtype=dtype)
@@ -300,10 +129,10 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_AMIN_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_AMIN_OP))
 def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = AminTest(shape, dtype)
-    bm = AminBenchmark(test)
+    bm = ManifestBenchmark(_AMIN_OP, test)
     inputs = test.gen_inputs()
 
     op = AminFwdOp(dtype=dtype)
@@ -327,10 +156,10 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_PROD_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_PROD_OP))
 def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = ProdTest(shape, dtype)
-    bm = ProdBenchmark(test)
+    bm = ManifestBenchmark(_PROD_OP, test)
     inputs = test.gen_inputs()
 
     op = ProdFwdOp(dtype=dtype)
@@ -354,10 +183,10 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_STD_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_STD_OP))
 def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = StdTest(shape, dtype)
-    bm = StdBenchmark(test)
+    bm = ManifestBenchmark(_STD_OP, test)
     inputs = test.gen_inputs()
 
     op = StdFwdOp(dtype=dtype, correction=1)
@@ -381,10 +210,10 @@ def test_std_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_VAR_OP))
 def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = VarTest(shape, dtype)
-    bm = VarBenchmark(test)
+    bm = ManifestBenchmark(_VAR_OP, test)
     inputs = test.gen_inputs()
 
     op = VarFwdOp(dtype=dtype, correction=1)
@@ -408,10 +237,10 @@ def test_var_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_VAR_MEAN_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_VAR_MEAN_OP))
 def test_var_mean_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = VarMeanTest(shape, dtype)
-    bm = VarMeanBenchmark(test)
+    bm = ManifestBenchmark(_VAR_MEAN_OP, test)
     inputs = test.gen_inputs()
 
     op = VarMeanFwdOp(dtype=dtype, correction=1)

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -4,14 +4,11 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
 """
 
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.manifest import eval_roofline, load_workloads
+from benchmarks.benchmark import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.log_softmax import LogSoftmaxFwdOp
 from tileops.ops.reduction.logsumexp import LogSumExpFwdOp
 from tileops.ops.reduction.softmax import SoftmaxFwdOp
@@ -22,7 +19,7 @@ from workloads.ops.softmax import (
 )
 
 # ===================================================================
-# Benchmark classes — use manifest roofline for FLOP/memory counts
+# Op name constants
 # ===================================================================
 
 _SOFTMAX_OP = "SoftmaxFwdOp"
@@ -30,93 +27,15 @@ _LOG_SOFTMAX_OP = "LogSoftmaxFwdOp"
 _LOGSUMEXP_OP = "LogSumExpFwdOp"
 
 
-def _roofline_vars(workload) -> dict:
-    """Extract roofline variables from a workload (shape + dtype → M, N, elem_bytes)."""
-    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
-    N = workload.shape[-1]
-    M = 1
-    for s in workload.shape[:-1]:
-        M *= s
-    return dict(M=M, N=N, elem_bytes=elem_bytes)
-
-
-class SoftmaxBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _SOFTMAX_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class LogSoftmaxBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _LOG_SOFTMAX_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class LogSumExpBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _LOGSUMEXP_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-# ===================================================================
-# Manifest-driven parametrize helper
-# ===================================================================
-
-
-def _workloads_to_params(workloads):
-    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
-    params = []
-    for w in workloads:
-        shape = tuple(w["x_shape"])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                shape, dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
 # ===================================================================
 # Softmax benchmarks
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_SOFTMAX_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_SOFTMAX_OP))
 def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = SoftmaxTest(shape, dtype)
-    bm = SoftmaxBenchmark(test)
+    bm = ManifestBenchmark(_SOFTMAX_OP, test)
     inputs = test.gen_inputs()
 
     op = SoftmaxFwdOp(dtype=dtype, dim=-1, tune=True)
@@ -140,10 +59,10 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_LOG_SOFTMAX_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_LOG_SOFTMAX_OP))
 def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = LogSoftmaxTest(shape, dtype)
-    bm = LogSoftmaxBenchmark(test)
+    bm = ManifestBenchmark(_LOG_SOFTMAX_OP, test)
     inputs = test.gen_inputs()
 
     op = LogSoftmaxFwdOp(dtype=dtype, dim=-1, tune=True)
@@ -167,10 +86,10 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_LOGSUMEXP_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_LOGSUMEXP_OP))
 def test_logsumexp_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = LogSumExpTest(shape, dtype)
-    bm = LogSumExpBenchmark(test)
+    bm = ManifestBenchmark(_LOGSUMEXP_OP, test)
     inputs = test.gen_inputs()
 
     op = LogSumExpFwdOp(dtype=dtype, dim=-1, tune=True)

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -4,13 +4,10 @@ Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
 Workload shapes and roofline formulas are loaded from ops_manifest.yaml.
 """
 
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
-from tileops.manifest import eval_roofline, load_workloads
+from benchmarks.benchmark import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.inf_norm import InfNormFwdOp
 from tileops.ops.reduction.l1_norm import L1NormFwdOp
 from tileops.ops.reduction.l2_norm import L2NormFwdOp
@@ -26,102 +23,14 @@ _INF_NORM_OP = "InfNormFwdOp"
 
 
 # ===================================================================
-# Roofline helper
-# ===================================================================
-
-
-def _roofline_vars(workload) -> dict:
-    """Extract roofline variables from a workload (shape + dtype -> M, N, elem_bytes)."""
-    elem_bytes = torch.tensor([], dtype=workload.dtype).element_size()
-    N = workload.shape[-1]
-    M = 1
-    for s in workload.shape[:-1]:
-        M *= s
-    return dict(M=M, N=N, elem_bytes=elem_bytes)
-
-
-# ===================================================================
-# Benchmark classes — use manifest roofline for FLOP/memory counts
-# ===================================================================
-
-
-class L1NormBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _L1_NORM_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class L2NormBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _L2_NORM_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-class InfNormBenchmark(BenchmarkBase):
-    _roofline_cache: Optional[tuple[float, float]] = None
-
-    def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = eval_roofline(
-                _INF_NORM_OP, **_roofline_vars(self.workload))
-        return self._roofline_cache
-
-    def calculate_flops(self) -> Optional[float]:
-        return self._get_roofline()[0]
-
-    def calculate_memory(self) -> Optional[float]:
-        return self._get_roofline()[1]
-
-
-# ===================================================================
-# Manifest-driven parametrize helper
-# ===================================================================
-
-
-def _workloads_to_params(workloads):
-    """Convert manifest workload dicts to pytest params: (shape, dtype)."""
-    params = []
-    for w in workloads:
-        shape = tuple(w["x_shape"])
-        label = w.get("label", "x".join(str(s) for s in shape))
-        for dtype_str in w["dtypes"]:
-            dtype = getattr(torch, dtype_str)
-            params.append(pytest.param(
-                shape, dtype,
-                id=f"{label}-{dtype_str}",
-            ))
-    return params
-
-
-# ===================================================================
 # L1 Norm benchmarks
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L1_NORM_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_L1_NORM_OP))
 def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = L1NormTest(shape, dtype)
-    bm = L1NormBenchmark(test)
+    bm = ManifestBenchmark(_L1_NORM_OP, test)
     inputs = test.gen_inputs()
 
     op = L1NormFwdOp(dtype=dtype)
@@ -145,10 +54,10 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_L2_NORM_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_L2_NORM_OP))
 def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = L2NormTest(shape, dtype)
-    bm = L2NormBenchmark(test)
+    bm = ManifestBenchmark(_L2_NORM_OP, test)
     inputs = test.gen_inputs()
 
     op = L2NormFwdOp(dtype=dtype)
@@ -172,10 +81,10 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", _workloads_to_params(load_workloads(_INF_NORM_OP)))
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_INF_NORM_OP))
 def test_inf_norm_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = InfNormTest(shape, dtype)
-    bm = InfNormBenchmark(test)
+    bm = ManifestBenchmark(_INF_NORM_OP, test)
     inputs = test.gen_inputs()
 
     op = InfNormFwdOp(dtype=dtype)

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -793,7 +793,23 @@ def _ast_manifest_call_usage(
     op_name: str,
     target_names: set[str],
 ) -> dict[str, bool]:
-    """Check whether target functions are imported and called with this op name."""
+    """Check whether target functions are imported and called with this op name.
+
+    Recognises two patterns:
+
+    1. **Direct** — ``from tileops.manifest import load_workloads`` /
+       ``eval_roofline`` called with the op name.
+    2. **Indirect via benchmarks.benchmark** — ``workloads_to_params``
+       (wraps ``load_workloads``) and ``ManifestBenchmark`` (wraps
+       ``eval_roofline``) imported from ``benchmarks.benchmark`` and
+       called with the op name as the first argument.
+    """
+    # Maps from the indirect helper name → the direct target it satisfies.
+    _INDIRECT_EQUIV: dict[str, str] = {
+        "workloads_to_params": "load_workloads",
+        "ManifestBenchmark": "eval_roofline",
+    }
+
     imported: set[str] = set()
     matched_calls: set[str] = set()
     bindings = _resolve_constant_str_bindings(tree)
@@ -804,12 +820,25 @@ def _ast_manifest_call_usage(
                 for alias in node.names:
                     if alias.name in target_names:
                         imported.add(alias.name)
+            # Indirect helpers live in benchmarks.benchmark.
+            if node.module == "benchmarks.benchmark" and node.names:
+                for alias in node.names:
+                    equiv = _INDIRECT_EQUIV.get(alias.name)
+                    if equiv and equiv in target_names:
+                        imported.add(equiv)
         elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
             func_name = node.func.id
+            # Direct call (load_workloads / eval_roofline).
             if func_name in target_names and _call_uses_expected_op_name(
                 node, op_name, bindings,
             ):
                 matched_calls.add(func_name)
+            # Indirect call (workloads_to_params / ManifestBenchmark).
+            equiv = _INDIRECT_EQUIV.get(func_name)
+            if equiv and equiv in target_names and _call_uses_expected_op_name(
+                node, op_name, bindings,
+            ):
+                matched_calls.add(equiv)
 
     return {name: (name in imported and name in matched_calls) for name in target_names}
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -795,7 +795,7 @@ def _ast_manifest_call_usage(
 ) -> dict[str, bool]:
     """Check whether target functions are imported and called with this op name.
 
-    Recognises two patterns:
+    Recognises three patterns:
 
     1. **Direct** — ``from tileops.manifest import load_workloads`` /
        ``eval_roofline`` called with the op name.
@@ -803,6 +803,9 @@ def _ast_manifest_call_usage(
        (wraps ``load_workloads``) and ``ManifestBenchmark`` (wraps
        ``eval_roofline``) imported from ``benchmarks.benchmark`` and
        called with the op name as the first argument.
+    3. **Subclass** — a local class that inherits from an indirect
+       helper (e.g. ``class Custom(ManifestBenchmark)``) is treated as
+       equivalent to the parent for validation purposes.
     """
     # Maps from the indirect helper name → the direct target it satisfies.
     _INDIRECT_EQUIV: dict[str, str] = {
@@ -813,6 +816,16 @@ def _ast_manifest_call_usage(
     imported: set[str] = set()
     matched_calls: set[str] = set()
     bindings = _resolve_constant_str_bindings(tree)
+
+    # Collect local subclasses of indirect helpers (e.g. class Foo(ManifestBenchmark))
+    # so that calls to those subclasses count the same as the parent.
+    _local_subclass_equiv: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for base in node.bases:
+                base_name = base.id if isinstance(base, ast.Name) else None
+                if base_name and base_name in _INDIRECT_EQUIV:
+                    _local_subclass_equiv[node.name] = _INDIRECT_EQUIV[base_name]
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -839,6 +852,13 @@ def _ast_manifest_call_usage(
                 node, op_name, bindings,
             ):
                 matched_calls.add(equiv)
+            # Local subclass call (e.g. CustomBenchmark(op_name, workload)
+            # where CustomBenchmark inherits from ManifestBenchmark).
+            sub_equiv = _local_subclass_equiv.get(func_name)
+            if sub_equiv and sub_equiv in target_names and _call_uses_expected_op_name(
+                node, op_name, bindings,
+            ):
+                matched_calls.add(sub_equiv)
 
     return {name: (name in imported and name in matched_calls) for name in target_names}
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -803,9 +803,6 @@ def _ast_manifest_call_usage(
        (wraps ``load_workloads``) and ``ManifestBenchmark`` (wraps
        ``eval_roofline``) imported from ``benchmarks.benchmark`` and
        called with the op name as the first argument.
-    3. **Subclass** — a local class that inherits from an indirect
-       helper (e.g. ``class Custom(ManifestBenchmark)``) is treated as
-       equivalent to the parent for validation purposes.
     """
     # Maps from the indirect helper name → the direct target it satisfies.
     _INDIRECT_EQUIV: dict[str, str] = {
@@ -816,16 +813,6 @@ def _ast_manifest_call_usage(
     imported: set[str] = set()
     matched_calls: set[str] = set()
     bindings = _resolve_constant_str_bindings(tree)
-
-    # Collect local subclasses of indirect helpers (e.g. class Foo(ManifestBenchmark))
-    # so that calls to those subclasses count the same as the parent.
-    _local_subclass_equiv: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef):
-            for base in node.bases:
-                base_name = base.id if isinstance(base, ast.Name) else None
-                if base_name and base_name in _INDIRECT_EQUIV:
-                    _local_subclass_equiv[node.name] = _INDIRECT_EQUIV[base_name]
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -852,14 +839,6 @@ def _ast_manifest_call_usage(
                 node, op_name, bindings,
             ):
                 matched_calls.add(equiv)
-            # Local subclass call (e.g. CustomBenchmark(op_name, workload)
-            # where CustomBenchmark inherits from ManifestBenchmark).
-            sub_equiv = _local_subclass_equiv.get(func_name)
-            if sub_equiv and sub_equiv in target_names and _call_uses_expected_op_name(
-                node, op_name, bindings,
-            ):
-                matched_calls.add(sub_equiv)
-
     return {name: (name in imported and name in matched_calls) for name in target_names}
 
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -732,52 +732,6 @@ class TestBench:
         assert any("load_workloads" in e for e in errors)
         assert any("eval_roofline" in e for e in errors)
 
-    def test_bench_local_subclass_passes(self, validator, tmp_path):
-        """A local subclass of ManifestBenchmark counts as eval_roofline usage."""
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(textwrap.dedent("""\
-            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
-
-            class CustomBenchmark(ManifestBenchmark):
-                pass
-
-            params = workloads_to_params('test_op')
-            CustomBenchmark('test_op', params[0])
-        """))
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
-        assert errors == []
-
-    def test_bench_subclass_override_bypass_known_limitation(self, validator, tmp_path):
-        """Known limitation: AST validator cannot detect method overrides.
-
-        A ManifestBenchmark subclass that overrides calculate_flops/calculate_memory
-        to return hardcoded values (bypassing eval_roofline) still passes the
-        validator. This is inherent to static AST analysis — detecting method
-        overrides that break the roofline contract would require runtime inspection
-        or a much more complex analysis that is not worth the maintenance cost.
-        This test documents the limitation as a regression guard.
-        """
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(textwrap.dedent("""\
-            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
-
-            class BypassBenchmark(ManifestBenchmark):
-                def calculate_flops(self):
-                    return 1
-
-                def calculate_memory(self):
-                    return 2
-
-            params = workloads_to_params('test_op')
-            BypassBenchmark('test_op', params[0])
-        """))
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
-        # The validator passes because AST analysis only checks that a
-        # ManifestBenchmark subclass is instantiated with the correct op name.
-        # It cannot detect that calculate_flops/calculate_memory are overridden
-        # to bypass eval_roofline. This is a known, accepted limitation.
-        assert errors == []
-
 
 # ---------------------------------------------------------------------------
 # --check-op: force all levels on a specific op, ignoring status

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -747,6 +747,37 @@ class TestBench:
         errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert errors == []
 
+    def test_bench_subclass_override_bypass_known_limitation(self, validator, tmp_path):
+        """Known limitation: AST validator cannot detect method overrides.
+
+        A ManifestBenchmark subclass that overrides calculate_flops/calculate_memory
+        to return hardcoded values (bypassing eval_roofline) still passes the
+        validator. This is inherent to static AST analysis — detecting method
+        overrides that break the roofline contract would require runtime inspection
+        or a much more complex analysis that is not worth the maintenance cost.
+        This test documents the limitation as a regression guard.
+        """
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
+
+            class BypassBenchmark(ManifestBenchmark):
+                def calculate_flops(self):
+                    return 1
+
+                def calculate_memory(self):
+                    return 2
+
+            params = workloads_to_params('test_op')
+            BypassBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        # The validator passes because AST analysis only checks that a
+        # ManifestBenchmark subclass is instantiated with the correct op name.
+        # It cannot detect that calculate_flops/calculate_memory are overridden
+        # to bypass eval_roofline. This is a known, accepted limitation.
+        assert errors == []
+
 
 # ---------------------------------------------------------------------------
 # --check-op: force all levels on a specific op, ignoring status

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -709,6 +709,44 @@ class TestBench:
         errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert any("syntax error" in e for e in errors)
 
+    def test_bench_indirect_helpers_pass(self, validator, tmp_path):
+        """Importing workloads_to_params/ManifestBenchmark from benchmarks.benchmark passes."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
+            params = workloads_to_params('test_op')
+            ManifestBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_indirect_wrong_op_fails(self, validator, tmp_path):
+        """Indirect helpers called with wrong op name must still fail."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
+            params = workloads_to_params('wrong_op')
+            ManifestBenchmark('wrong_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert any("load_workloads" in e for e in errors)
+        assert any("eval_roofline" in e for e in errors)
+
+    def test_bench_local_subclass_passes(self, validator, tmp_path):
+        """A local subclass of ManifestBenchmark counts as eval_roofline usage."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import workloads_to_params, ManifestBenchmark
+
+            class CustomBenchmark(ManifestBenchmark):
+                pass
+
+            params = workloads_to_params('test_op')
+            CustomBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
 
 # ---------------------------------------------------------------------------
 # --check-op: force all levels on a specific op, ignoring status


### PR DESCRIPTION
## Summary

Extract a generic `ManifestBenchmark` base class and shared helpers (`roofline_vars`, `workloads_to_params`) into `benchmarks/benchmark.py`, so manifest-driven bench files only specify the op name and baseline function per test. This eliminates ~300 lines of duplication across 5 benchmark files.

Closes #904

## Changes

- **benchmarks/benchmark.py** — Add `ManifestBenchmark(op_name)` subclass of `BenchmarkBase` with `roofline_vars(workload)` and `workloads_to_params(op_name)` public helpers
- **benchmarks/ops/bench_{softmax,reduce,argreduce,logical_reduce,vector_norm}.py** — Refactor to use `ManifestBenchmark`, replacing 19 per-op benchmark classes
- **scripts/validate_manifest.py** — Teach AST validator to recognize `ManifestBenchmark` subclasses as satisfying `eval_roofline` requirement
- **tests/test_validate_manifest.py** — Add tests for indirect bench-validator AST paths and a regression test documenting the subclass override limitation

## Test plan

- [x] AC-1: All 5 bench files use `ManifestBenchmark` instead of per-op classes
- [x] AC-2: `_roofline_vars` and `_workloads_to_params` exist only in `benchmarks/benchmark.py`, not duplicated
- [x] AC-3: `pytest --collect-only` passes for all 5 bench files (63 tests collected)
- [x] AC-4: `validate_manifest.py --check-op` produces zero `[bench]` warnings for all 19 affected ops
- [x] 89 validator tests pass, lint clean

## Follow-up

- #917 — Add import alias and attribute access support to bench AST validator
- #918 — Type-narrow roofline_vars parameter from WorkloadBase to typed Protocol