### PR TITLE
[Perf][Kernel] Eliminate F.pad and add tile_n autotuner dimension for reduction ops

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -488,7 +488,7 @@ class BenchmarkReport:
                     row = [str(entry["params"].get(k, "")) for k in param_keys]
                     for rk in result_keys:
                         val = entry["result"].get(rk)
-                        row.append(f"{val:.2f}" if val is not None else "N/A")
+                        row.append(f"{val:.4f}" if val is not None else "N/A")
                     if has_config:
                         cfg = entry.get("config")
                         row.append(str(cfg) if cfg else "")

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -56,11 +56,12 @@ Contiguous conversion is the family base class's responsibility. Concrete ops sh
 
 ## Principle 5: Class Variable Protocol
 
-| Variable           | Required?  | Defined At              | Purpose                                            |
-| ------------------ | ---------- | ----------------------- | -------------------------------------------------- |
-| `SUPPORTED_DTYPES` | Yes        | Every concrete Op       | Runtime dtype check + manifest validation          |
-| `ALIGNMENT`        | Per-family | Intermediate base class | Padding alignment (256 for row-reduction/row-norm) |
-| `_op_name`         | Yes        | Every concrete Op       | `torch.library.custom_op` registration, logging    |
+| Variable                  | Required?  | Defined At              | Purpose                                                                                                   |
+| ------------------------- | ---------- | ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `SUPPORTED_DTYPES`        | Yes        | Every concrete Op       | Runtime dtype check + manifest validation                                                                 |
+| `ALIGNMENT`               | Per-family | Intermediate base class | Padding alignment (256 for row-reduction/row-norm)                                                        |
+| `_op_name`                | Yes        | Every concrete Op       | `torch.library.custom_op` registration, logging                                                           |
+| `_kernel_handles_padding` | Per-family | Intermediate base class | When `True`, kernel accepts raw `(M, N)` with masked loads — host-side pad/trim is skipped in `forward()` |
 
 Single-kernel ops declare a kernel key and kernel class attribute. Multi-kernel ops define `default_kernel_map` returning a dict. See [Kernel Dispatch](#kernel-dispatch-kernel_map).
 

--- a/tileops/kernels/reduction/cumulative/fwd.py
+++ b/tileops/kernels/reduction/cumulative/fwd.py
@@ -8,7 +8,12 @@ a per-row running accumulator.  The tiled approach reduces shared memory
 usage (``block_m * block_n`` instead of ``block_m * N_padded``) and
 improves memory access patterns for better GPU utilization.
 
-Both operate on 2D (M, N_padded) tensors; the Op layer handles reshape.
+Accepts raw ``(M, N)`` input tensors.  Boundary handling for non-aligned
+N is performed inside the kernel via masked loads with identity-element
+fills (0 for cumsum, 1 for cumprod), eliminating host-side ``F.pad``
+from the forward path.  Output is ``(M, N_padded)`` and the Op layer
+trims back to N columns.
+
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.
 """
@@ -39,11 +44,16 @@ _DEFAULT_BLOCK_N: int = 128
 def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
     """Build a TileLang inclusive prefix scan kernel.
 
+    Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
+    ``block_n`` (which must divide ``N_padded``), the last tile uses
+    element-wise ``T.if_then_else`` loads that substitute the identity
+    element (0 for sum, 1 for prod) for out-of-bounds columns.  Preceding
+    tiles use the fast vectorized ``T.copy`` path since their columns are
+    fully in-bounds.
+
     Uses a tiled approach: the N dimension is divided into tiles of
     ``block_n`` elements. Each tile is loaded via shared memory, scanned
-    sequentially with the running accumulator, and written back.  This
-    reduces register pressure and shared memory usage compared to loading
-    the full row, enabling larger ``block_m`` values and better occupancy.
+    sequentially with the running accumulator, and written back.
 
     Args:
         M: Number of rows (product of all leading dimensions).
@@ -55,16 +65,20 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
         A TileLang JIT-compiled kernel factory accepting (block_m, block_n, threads).
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _identity = 0.0 if op_kind == "sum" else 1.0
 
     if op_kind == "sum":
 
         @tilelang.jit(out_idx=[1])
         def _func(block_m, block_n, threads):
             n_tiles = N_padded // block_n
+            # The last tile may have out-of-bounds columns when N is not
+            # a multiple of block_n.
+            _needs_mask = (n_tiles * block_n) > N
 
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -80,12 +94,31 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
 
                     # Process N dimension in tiles
                     for tile_idx in T.Serial(n_tiles):
-                        # Load tile via shared memory
-                        T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
-
-                        # Cast to fp32
-                        for i, j in T.Parallel(block_m, block_n):
-                            tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
+                        if _needs_mask:
+                            # Fast path for all tiles except the last
+                            with T.If(tile_idx < n_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
+                                    for i, j in T.Parallel(block_m, block_n):
+                                        tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
+                                with T.Else():
+                                    # Last tile: masked load
+                                    for i, j in T.Parallel(block_m, block_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            T.And(
+                                                pid_m * block_m + i < M,
+                                                tile_idx * block_n + j < N,
+                                            ),
+                                            T.cast(
+                                                x[pid_m * block_m + i, tile_idx * block_n + j],
+                                                "float32",
+                                            ),
+                                            T.cast(0.0, "float32"),
+                                        )
+                        else:
+                            T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
+                            for i, j in T.Parallel(block_m, block_n):
+                                tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
 
                         # Inclusive prefix sum within tile
                         for i in T.Parallel(block_m):
@@ -105,10 +138,11 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
         @tilelang.jit(out_idx=[1])
         def _func(block_m, block_n, threads):
             n_tiles = N_padded // block_n
+            _needs_mask = (n_tiles * block_n) > N
 
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 y: T.Tensor[(M, N_padded), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -124,12 +158,29 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
 
                     # Process N dimension in tiles
                     for tile_idx in T.Serial(n_tiles):
-                        # Load tile via shared memory
-                        T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
-
-                        # Cast to fp32
-                        for i, j in T.Parallel(block_m, block_n):
-                            tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
+                        if _needs_mask:
+                            with T.If(tile_idx < n_tiles - 1):
+                                with T.Then():
+                                    T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
+                                    for i, j in T.Parallel(block_m, block_n):
+                                        tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
+                                with T.Else():
+                                    for i, j in T.Parallel(block_m, block_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            T.And(
+                                                pid_m * block_m + i < M,
+                                                tile_idx * block_n + j < N,
+                                            ),
+                                            T.cast(
+                                                x[pid_m * block_m + i, tile_idx * block_n + j],
+                                                "float32",
+                                            ),
+                                            T.cast(1.0, "float32"),
+                                        )
+                        else:
+                            T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
+                            for i, j in T.Parallel(block_m, block_n):
+                                tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
 
                         # Inclusive prefix product within tile
                         for i in T.Parallel(block_m):
@@ -184,6 +235,11 @@ class CumulativeKernel(Kernel):
     memory copies. Uses a tiled sequential scan loop along the last
     dimension: the N dimension is divided into tiles of ``block_n``
     elements, reducing shared memory usage and improving occupancy.
+
+    Boundary handling for non-aligned N is performed inside the kernel via
+    masked loads with identity-element fills (0 for sum, 1 for prod), so
+    no host-side ``F.pad`` is needed.  The ``forward()`` method accepts
+    raw ``(M, N)`` tensors and returns ``(M, N_padded)`` output.
 
     Args:
         M: Number of rows (product of all dims except last).
@@ -259,7 +315,8 @@ class CumulativeKernel(Kernel):
         """Run the cumulative scan kernel.
 
         Args:
-            x: Input tensor of shape (M, N_padded).
+            x: Input tensor of shape (M, N).  Alignment padding is
+                handled internally via masked loads.
 
         Returns:
             Output tensor of shape (M, N_padded).

--- a/tileops/kernels/reduction/cumulative/fwd.py
+++ b/tileops/kernels/reduction/cumulative/fwd.py
@@ -113,7 +113,7 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
                                                 x[pid_m * block_m + i, tile_idx * block_n + j],
                                                 "float32",
                                             ),
-                                            T.cast(0.0, "float32"),
+                                            T.cast(_identity, "float32"),
                                         )
                         else:
                             T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
@@ -175,7 +175,7 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
                                                 x[pid_m * block_m + i, tile_idx * block_n + j],
                                                 "float32",
                                             ),
-                                            T.cast(1.0, "float32"),
+                                            T.cast(_identity, "float32"),
                                         )
                         else:
                             T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)

--- a/tileops/kernels/reduction/cumulative/fwd.py
+++ b/tileops/kernels/reduction/cumulative/fwd.py
@@ -95,14 +95,14 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
                     # Process N dimension in tiles
                     for tile_idx in T.Serial(n_tiles):
                         if _needs_mask:
-                            # Fast path for all tiles except the last
-                            with T.If(tile_idx < n_tiles - 1):
+                            # Fast path when current tile is fully in-bounds
+                            with T.If((tile_idx + 1) * block_n <= N):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
                                     for i, j in T.Parallel(block_m, block_n):
                                         tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
                                 with T.Else():
-                                    # Last tile: masked load
+                                    # Partially OOB tile: masked load
                                     for i, j in T.Parallel(block_m, block_n):
                                         tile_f32[i, j] = T.if_then_else(
                                             T.And(
@@ -159,12 +159,14 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
                     # Process N dimension in tiles
                     for tile_idx in T.Serial(n_tiles):
                         if _needs_mask:
-                            with T.If(tile_idx < n_tiles - 1):
+                            # Fast path when current tile is fully in-bounds
+                            with T.If((tile_idx + 1) * block_n <= N):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, tile_idx * block_n], shared_in)
                                     for i, j in T.Parallel(block_m, block_n):
                                         tile_f32[i, j] = T.cast(shared_in[i, j], "float32")
                                 with T.Else():
+                                    # Partially OOB tile: masked load
                                     for i, j in T.Parallel(block_m, block_n):
                                         tile_f32[i, j] = T.if_then_else(
                                             T.And(

--- a/tileops/kernels/reduction/reduce/fwd.py
+++ b/tileops/kernels/reduction/reduce/fwd.py
@@ -4,7 +4,12 @@ Two kernel families:
   - _simple_reduce_kernel: single-pass reduce for sum/mean/amin/amax/prod.
   - _welford_reduce_kernel: two-pass Welford for std/var/var_mean.
 
-Both operate on 2D (M, N_padded) tensors; the Op layer handles reshape.
+Both accept raw ``(M, N)`` tensors.  Boundary handling for non-aligned N
+is performed inside the kernel via masked loads with identity-element fills,
+eliminating host-side ``F.pad`` from the forward path.  When ``N`` is already
+a multiple of ``DEFAULT_ALIGNMENT``, the fast vectorized ``T.copy`` path is
+used.
+
 256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
 memory instructions.
 """
@@ -39,9 +44,27 @@ _WELFORD_KINDS = {"std", "var", "var_mean"}
 # ---------------------------------------------------------------------------
 
 
+def _pad_value_for_op(op_kind: str) -> float:
+    """Return the identity element for padding columns of the given op."""
+    if op_kind == "prod":
+        return 1.0
+    if op_kind == "amin":
+        return float("inf")
+    if op_kind == "amax":
+        return float("-inf")
+    # sum, mean, std, var, var_mean: zero padding
+    return 0.0
+
+
 @functools.lru_cache(maxsize=32)
 def _simple_reduce_kernel(M, N, op_kind, dtype):
     """Build a simple reduce kernel for sum/mean/amax/amin/prod.
+
+    Accepts an ``(M, N)`` input tensor.  When ``N`` is not a multiple of
+    ``DEFAULT_ALIGNMENT``, the kernel uses element-wise ``T.if_then_else``
+    loads that substitute the identity element for out-of-bounds columns
+    (kernel-side boundary handling).  When ``N`` is already aligned, the
+    fast ``T.copy`` path is used.
 
     For prod, we compute exp(sum(log(abs(x)))) * sign, which is numerically
     more stable than direct T.reduce_prod for large N.
@@ -51,11 +74,14 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
     if op_kind == "prod":
         return _prod_reduce_kernel(M, N, dtype)
 
+    _needs_pad = N_padded != N
+    _pad_val = _pad_value_for_op(op_kind)
+
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M, N), dtype],
             out: T.Tensor[(M,), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -64,12 +90,23 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
                 acc = T.alloc_fragment((block_m,), "float32")
                 out_local = T.alloc_fragment((block_m,), dtype)
 
-                # Load via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                if _needs_pad:
+                    # Kernel-side boundary handling: element-wise load
+                    # with T.if_then_else masking for padding columns
+                    # and row-tail safety (M % block_m != 0).
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < N),
+                            T.cast(x[pid_m * block_m + i, j], "float32"),
+                            T.cast(_pad_val, "float32"),
+                        )
+                else:
+                    # Load via shared memory (fast vectorized path)
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                # Cast to fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    # Cast to fp32
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Reduce
                 if op_kind == "sum":
@@ -102,14 +139,20 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
 
 @functools.lru_cache(maxsize=32)
 def _prod_reduce_kernel(M, N, dtype):
-    """Product reduce via log-sum-exp: exp(sum(log(|x|))) * sign."""
+    """Product reduce via log-sum-exp: exp(sum(log(|x|))) * sign.
+
+    Accepts an ``(M, N)`` input tensor.  Padding columns are filled with
+    ``1.0`` (the identity for product) via ``T.if_then_else`` when ``N``
+    is not a multiple of ``DEFAULT_ALIGNMENT``.
+    """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M, N), dtype],
             out: T.Tensor[(M,), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -121,14 +164,24 @@ def _prod_reduce_kernel(M, N, dtype):
                 acc_sign = T.alloc_fragment((block_m,), "float32")
                 out_local = T.alloc_fragment((block_m,), dtype)
 
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                if _needs_pad:
+                    # Kernel-side boundary handling: fill out-of-bounds
+                    # columns with 1.0 (identity for product).
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < N),
+                            T.cast(x[pid_m * block_m + i, j], "float32"),
+                            T.cast(1.0, "float32"),
+                        )
+                else:
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Compute log(|x|) and count negatives
-                # Padded positions have x=0; set log_abs to 0 (log(1)=0, so
-                # they contribute a factor of 1 to the product).
+                # Padded positions are 1.0, so log(1.0)=0 (neutral for sum)
+                # and sign_neg=0 (non-negative).
                 for i, j in T.Parallel(block_m, N_padded):
                     abs_val = T.abs(x_f32[i, j])
                     # Use a small epsilon to avoid log(0)
@@ -136,19 +189,10 @@ def _prod_reduce_kernel(M, N, dtype):
                     # 1 if negative, 0 if non-negative
                     sign_neg[i, j] = T.if_then_else(x_f32[i, j] < 0.0, 1.0, 0.0)
 
-                # Zero out padded positions for log_abs (they are 0 from input
-                # padding but log(0) is -inf, so override them)
-                # Padding positions have x=0 after F.pad in Op, so abs_val=0,
-                # log_abs=-inf. We need them to be 0 (neutral for sum).
-                # But since padded x = 0, the product is 0 anyway for non-pad-safe ops.
-                # The Op layer sets padded elements to 1.0 for prod.
-
                 T.reduce_sum(log_abs, acc_log, dim=1)
                 T.reduce_sum(sign_neg, acc_sign, dim=1)
 
                 for i in T.Parallel(block_m):
-                    # Subtract padding contribution (padding elements set to 1.0,
-                    # so log(1.0)=0 -- no correction needed if Op pads with 1.0)
                     prod_val = T.exp(acc_log[i])
                     # If odd number of negatives, negate
                     # Use fmod to check parity
@@ -170,8 +214,15 @@ def _prod_reduce_kernel(M, N, dtype):
 
 @functools.lru_cache(maxsize=32)
 def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
-    """Build a Welford-based reduce kernel for std/var/var_mean."""
+    """Build a Welford-based reduce kernel for std/var/var_mean.
+
+    Accepts an ``(M, N)`` input tensor.  Padding columns are filled with
+    ``0.0`` via masked loads when ``N`` is not aligned.  The padding
+    correction (subtracting ``pad_count * mean^2`` from the variance sum)
+    is applied analytically, so the result is exact regardless of padding.
+    """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
 
     out_idx = [1, 2] if op_kind == "var_mean" else [1]
 
@@ -181,7 +232,7 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
 
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 out_var: T.Tensor[(M,), dtype],
                 out_mean: T.Tensor[(M,), dtype],
             ):
@@ -195,10 +246,18 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     out_v = T.alloc_fragment((block_m,), dtype)
                     out_m = T.alloc_fragment((block_m,), dtype)
 
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    if _needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(0.0, "float32"),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                     # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
@@ -226,7 +285,7 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
             # std or var (single output)
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
                 out: T.Tensor[(M,), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -238,10 +297,18 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     var_sum = T.alloc_fragment((block_m,), "float32")
                     out_local = T.alloc_fragment((block_m,), dtype)
 
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    if _needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(0.0, "float32"),
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                     # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
@@ -340,6 +407,10 @@ class ReduceKernel(Kernel):
 
     Supports SM80+ architectures. Uses 256-element alignment for shared memory
     copies. Dispatches to simple or Welford kernel based on op_kind.
+
+    Boundary handling for non-aligned N is performed inside the kernel via
+    masked loads with identity-element fills, so no host-side ``F.pad`` is
+    needed.  The ``forward()`` method accepts raw ``(M, N)`` tensors.
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -543,7 +543,6 @@ class LogSumExpKernel(Kernel):
                 self.kernel = _logsumexp_kernel(
                     self.M, self.N, self.dtype_str, self._tile_n,
                 )
-        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the logsumexp kernel.

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -407,9 +407,12 @@ class LogSumExpKernel(Kernel):
     def _tile_n_candidates(self) -> list[int]:
         """Return candidate tile_n values for autotune exploration.
 
-        Includes the heuristic tile_n plus divisors of N_padded that fit
-        within the shared memory budget.  tile_n=0 means single-tile.
-        All candidates are de-duplicated and sorted descending for
+        Includes the heuristic tile_n (from block_m=1) plus alternative
+        tile_n values derived from ``_tile_n_for_block_m(2)`` and
+        ``_tile_n_for_block_m(4)``, with a half-step fallback aligned to
+        ``DEFAULT_ALIGNMENT`` when block_m exploration yields no
+        alternatives.  tile_n=0 means single-tile (no tiling).  All
+        candidates are de-duplicated and sorted descending for
         deterministic ordering.
 
         Each distinct tile_n value requires a full kernel recompilation,

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -327,9 +327,16 @@ class LogSumExpKernel(Kernel):
         # self.config["tile_n"], and rebuilt the kernel.  Only apply
         # the post-init tile_n fixup for user-provided configs.
         if not tune:
-            new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
-            if new_tile_n != self._tile_n:
-                self._tile_n = new_tile_n
+            # If the caller supplied an explicit tile_n (e.g. from a
+            # previous autotuner result), honour it.  Only fall back to
+            # the heuristic when tile_n was not provided.
+            caller_tile_n = config.get("tile_n") if config is not None else None
+            if caller_tile_n is not None:
+                target_tile_n = caller_tile_n
+            else:
+                target_tile_n = self._tile_n_for_block_m(self.config["block_m"])
+            if target_tile_n != self._tile_n:
+                self._tile_n = target_tile_n
                 self.kernel = _logsumexp_kernel(
                     self.M,
                     self.N,

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -278,6 +278,7 @@ class LogSumExpKernel(Kernel):
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
+    _MAX_TILE_N_CANDIDATES = 3
 
     def __init__(
         self,
@@ -401,21 +402,47 @@ class LogSumExpKernel(Kernel):
 
         Includes the heuristic tile_n plus divisors of N_padded that fit
         within the shared memory budget.  tile_n=0 means single-tile.
+        All candidates are de-duplicated and sorted descending for
+        deterministic ordering.
 
         Each distinct tile_n value requires a full kernel recompilation,
         which is expensive for large-N workloads (compilations can take
-        minutes each).  To keep autotuner wall time practical:
+        minutes each).  To keep autotuner wall time practical we cap
+        the total number of tile_n candidates at ``_MAX_TILE_N_CANDIDATES``
+        (currently 3).
 
         - When the heuristic default tile_n is 0 (single-tile / small N),
           return ``[0]`` -- the autotuner varies only block_m and threads.
-        - Otherwise return only the heuristic default tile_n (block_m=1).
-          The autotuner still explores block_m and threads within that
-          tile_n regime, which is the highest-impact search axis.
+        - Otherwise collect distinct tile_n values from block_m=1..4 and
+          return up to ``_MAX_TILE_N_CANDIDATES`` candidates (always
+          including the heuristic default).
         """
         default_tn = self._tile_n_for_block_m(1)
         if default_tn == 0:
             return [0]
-        return [default_tn]
+
+        candidates: set[int] = {default_tn}
+        # Explore tile_n values implied by small block_m values.
+        # Higher block_m → smaller tile_n (more N-tiles but better row reuse).
+        for bm in (2, 4):
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn > 0 and tn != default_tn:
+                candidates.add(tn)
+
+        # Also try half of the default tile_n (rounded to alignment) as a
+        # search point when block_m exploration didn't yield alternatives.
+        if len(candidates) < 2:
+            from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT
+            half_tn = (default_tn // 2 // DEFAULT_ALIGNMENT) * DEFAULT_ALIGNMENT
+            if half_tn > 0 and half_tn != default_tn:
+                candidates.add(half_tn)
+
+        # Cap to avoid excessive compilation time.
+        sorted_candidates = sorted(candidates, reverse=True)
+        return sorted_candidates[:self._MAX_TILE_N_CANDIDATES]
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -432,23 +459,26 @@ class LogSumExpKernel(Kernel):
 
         configs = []
         for tile_n in self._tile_n_candidates():
-            # In the tiled regime (tile_n > 0), only explore the default
-            # block_m=1 config.  Large-tile kernels cause NVCC/cicc to
-            # spend 10+ minutes per config variant, making multi-config
-            # autotuning impractical.  The autotuner still varies threads.
-            bm_candidates = [1, 2, 4, 8, 16] if tile_n == 0 else [1]
-            for bm in bm_candidates:
-                try:
-                    compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
-                except ValueError:
-                    continue
-                bm_tile_n = self._tile_n_for_block_m(bm)
-                if bm_tile_n != tile_n:
-                    continue
-                if tile_n == 0 and bm > max_block_m_no_tile:
-                    continue
+            if tile_n == 0:
+                # Single-tile regime: explore multiple block_m values.
+                for bm in [1, 2, 4, 8, 16]:
+                    try:
+                        compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
+                    except ValueError:
+                        continue
+                    bm_tile_n = self._tile_n_for_block_m(bm)
+                    if bm_tile_n != 0:
+                        continue
+                    if bm > max_block_m_no_tile:
+                        continue
+                    for t in threads_list:
+                        configs.append({"block_m": bm, "threads": t, "tile_n": 0})
+            else:
+                # Tiled regime: use block_m=1 with each tile_n candidate.
+                # Each distinct tile_n triggers a kernel recompilation, so
+                # we only vary threads within each tile_n regime.
                 for t in threads_list:
-                    configs.append({"block_m": bm, "threads": t, "tile_n": tile_n})
+                    configs.append({"block_m": 1, "threads": t, "tile_n": tile_n})
 
         if not configs:
             configs = [{"block_m": 1, "threads": 256, "tile_n": self._tile_n}]

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -322,19 +322,20 @@ class LogSumExpKernel(Kernel):
 
         self.init_config(config, tune)
 
-        # If a user-provided config picked a block_m mapping to a different
-        # tile_n, rebuild the kernel for the new tile_n. _logsumexp_kernel is
-        # lru_cache'd, so this is cheap on the common path.
-        new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
-        if new_tile_n != self._tile_n:
-            self._tile_n = new_tile_n
-            self.kernel = _logsumexp_kernel(
-                self.M,
-                self.N,
-                self.dtype_str,
-                self._tile_n,
-            )
-        self.config["tile_n"] = self._tile_n
+        # When tune=True, autotune() already set self._tile_n and
+        # self.config["tile_n"], and rebuilt the kernel.  Only apply
+        # the post-init tile_n fixup for user-provided configs.
+        if not tune:
+            new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
+            if new_tile_n != self._tile_n:
+                self._tile_n = new_tile_n
+                self.kernel = _logsumexp_kernel(
+                    self.M,
+                    self.N,
+                    self.dtype_str,
+                    self._tile_n,
+                )
+            self.config["tile_n"] = self._tile_n
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
         """Return tile_n for a given block_m (0 means no tiling needed).
@@ -395,37 +396,103 @@ class LogSumExpKernel(Kernel):
 
         return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
 
+    def _tile_n_candidates(self) -> list[int]:
+        """Return candidate tile_n values for autotune exploration.
+
+        Includes the heuristic tile_n plus divisors of N_padded that fit
+        within the shared memory budget.  tile_n=0 means single-tile.
+        """
+        candidates = set()
+        for bm in [1, 2, 4, 8, 16]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            candidates.add(tn)
+        return sorted(candidates)
+
     @property
     def autotune_configs(self) -> list[dict]:
-        """Generate autotune configs (block_m, threads only).
+        """Generate autotune configs including tile_n candidates.
 
-        tile_n is baked into the kernel at build time, so we only expose
-        block_m and threads to the autotuner.
+        tile_n is baked into the kernel at build time, so the autotuner
+        rebuilds the kernel for each tile_n value.  Configs include
+        ``tile_n`` alongside ``block_m`` and ``threads``.
         """
-        tile_n = getattr(self, "_tile_n", self.default_config["tile_n"])
         budget = self._smem_budget
         smem_per_row = self.N_padded * self._elem_bytes
         max_block_m_no_tile = budget // smem_per_row if smem_per_row > 0 else 16
         threads_list = [128, 256]
 
         configs = []
-        for bm in [1, 2, 4, 8, 16]:
-            try:
-                compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
-            except ValueError:
-                continue
-            bm_tile_n = self._tile_n_for_block_m(bm)
-            if bm_tile_n != tile_n:
-                continue
-            if tile_n == 0 and bm > max_block_m_no_tile:
-                continue
-            for t in threads_list:
-                configs.append({"block_m": bm, "threads": t})
+        for tile_n in self._tile_n_candidates():
+            for bm in [1, 2, 4, 8, 16]:
+                try:
+                    compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
+                except ValueError:
+                    continue
+                bm_tile_n = self._tile_n_for_block_m(bm)
+                if bm_tile_n != tile_n:
+                    continue
+                if tile_n == 0 and bm > max_block_m_no_tile:
+                    continue
+                for t in threads_list:
+                    configs.append({"block_m": bm, "threads": t, "tile_n": tile_n})
 
         if not configs:
-            configs = [{"block_m": 1, "threads": 256}]
+            configs = [{"block_m": 1, "threads": 256, "tile_n": self._tile_n}]
 
         return configs
+
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+        """Autotune across tile_n candidates by rebuilding the kernel per regime.
+
+        Groups configs by tile_n, benchmarks each group with its own kernel,
+        and picks the overall best (block_m, threads, tile_n) config.
+        """
+        from tilelang.autotuner import autotune as tl_autotune
+
+        configs = self.autotune_configs
+        if not configs:
+            return
+
+        # Group configs by tile_n
+        by_tile_n: dict[int, list[dict]] = {}
+        for cfg in configs:
+            tn = cfg["tile_n"]
+            by_tile_n.setdefault(tn, []).append(
+                {"block_m": cfg["block_m"], "threads": cfg["threads"]}
+            )
+
+        best_time = float("inf")
+        best_config = None
+
+        for tile_n, group_cfgs in by_tile_n.items():
+            kernel = _logsumexp_kernel(
+                self.M, self.N, self.dtype_str, tile_n,
+            )
+            autotune_kwargs: dict = dict(
+                configs=group_cfgs, warmup=warmup, rep=rep,
+            )
+            if self.autotune_supply_prog is not None:
+                autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+            autotuned = tl_autotune(**autotune_kwargs)(kernel)
+            tuned = autotuned()
+            latency = tuned.latency
+            if latency < best_time:
+                best_time = latency
+                best_config = {**tuned.config, "tile_n": tile_n}
+
+        if best_config is not None:
+            self.config = best_config
+            # Rebuild kernel for the winning tile_n
+            winning_tile_n = best_config["tile_n"]
+            if winning_tile_n != self._tile_n:
+                self._tile_n = winning_tile_n
+                self.kernel = _logsumexp_kernel(
+                    self.M, self.N, self.dtype_str, self._tile_n,
+                )
+        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the logsumexp kernel.

--- a/tileops/kernels/reduction/softmax/logsumexp_fwd.py
+++ b/tileops/kernels/reduction/softmax/logsumexp_fwd.py
@@ -401,15 +401,21 @@ class LogSumExpKernel(Kernel):
 
         Includes the heuristic tile_n plus divisors of N_padded that fit
         within the shared memory budget.  tile_n=0 means single-tile.
+
+        Each distinct tile_n value requires a full kernel recompilation,
+        which is expensive for large-N workloads (compilations can take
+        minutes each).  To keep autotuner wall time practical:
+
+        - When the heuristic default tile_n is 0 (single-tile / small N),
+          return ``[0]`` -- the autotuner varies only block_m and threads.
+        - Otherwise return only the heuristic default tile_n (block_m=1).
+          The autotuner still explores block_m and threads within that
+          tile_n regime, which is the highest-impact search axis.
         """
-        candidates = set()
-        for bm in [1, 2, 4, 8, 16]:
-            try:
-                tn = self._tile_n_for_block_m(bm)
-            except ValueError:
-                continue
-            candidates.add(tn)
-        return sorted(candidates)
+        default_tn = self._tile_n_for_block_m(1)
+        if default_tn == 0:
+            return [0]
+        return [default_tn]
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -426,7 +432,12 @@ class LogSumExpKernel(Kernel):
 
         configs = []
         for tile_n in self._tile_n_candidates():
-            for bm in [1, 2, 4, 8, 16]:
+            # In the tiled regime (tile_n > 0), only explore the default
+            # block_m=1 config.  Large-tile kernels cause NVCC/cicc to
+            # spend 10+ minutes per config variant, making multi-config
+            # autotuning impractical.  The autotuner still varies threads.
+            bm_candidates = [1, 2, 4, 8, 16] if tile_n == 0 else [1]
+            for bm in bm_candidates:
                 try:
                     compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
                 except ValueError:

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -676,15 +676,21 @@ class SoftmaxKernel(Kernel):
         within the shared memory budget (accounting for num_buffers).
         tile_n=0 means single-tile (no tiling).  All candidates are
         de-duplicated and sorted for deterministic ordering.
+
+        Each distinct tile_n value requires a full kernel recompilation,
+        which is expensive for large-N workloads (compilations can take
+        minutes each).  To keep autotuner wall time practical:
+
+        - When the heuristic default tile_n is 0 (single-tile / small N),
+          return ``[0]`` -- the autotuner varies only block_m and threads.
+        - Otherwise return only the heuristic default tile_n (block_m=1).
+          The autotuner still explores block_m and threads within that
+          tile_n regime, which is the highest-impact search axis.
         """
-        candidates = set()
-        for bm in [1, 2, 4, 8, 16]:
-            try:
-                tn = self._tile_n_for_block_m(bm)
-            except ValueError:
-                continue
-            candidates.add(tn)
-        return sorted(candidates)
+        default_tn = self._tile_n_for_block_m(1)
+        if default_tn == 0:
+            return [0]
+        return [default_tn]
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -701,7 +707,12 @@ class SoftmaxKernel(Kernel):
 
         configs = []
         for tile_n in self._tile_n_candidates():
-            for bm in [1, 2, 4, 8, 16]:
+            # In the tiled regime (tile_n > 0), only explore the default
+            # block_m=1 config.  Large-tile kernels cause NVCC/cicc to
+            # spend 10+ minutes per config variant, making multi-config
+            # autotuning impractical.  The autotuner still varies threads.
+            bm_candidates = [1, 2, 4, 8, 16] if tile_n == 0 else [1]
+            for bm in bm_candidates:
                 try:
                     compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
                 except ValueError:

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -575,20 +575,21 @@ class SoftmaxKernel(Kernel):
 
         self.init_config(config, tune)
 
-        # If a user-provided config picked a block_m mapping to a different
-        # tile_n, rebuild the kernel for the new tile_n. _softmax_kernel is
-        # lru_cache'd, so this is cheap on the common path.
-        new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
-        if new_tile_n != self._tile_n:
-            self._tile_n = new_tile_n
-            self.kernel = _softmax_kernel(
-                self.M,
-                self.N,
-                self.op_kind,
-                self.dtype_str,
-                self._tile_n,
-            )
-        self.config["tile_n"] = self._tile_n
+        # When tune=True, autotune() already set self._tile_n and
+        # self.config["tile_n"], and rebuilt the kernel.  Only apply
+        # the post-init tile_n fixup for user-provided configs.
+        if not tune:
+            new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
+            if new_tile_n != self._tile_n:
+                self._tile_n = new_tile_n
+                self.kernel = _softmax_kernel(
+                    self.M,
+                    self.N,
+                    self.op_kind,
+                    self.dtype_str,
+                    self._tile_n,
+                )
+            self.config["tile_n"] = self._tile_n
 
     # Tiled softmax/log_softmax allocates 2 shared buffers (one per pass)
     # due to TileLang allocator aliasing -- see _softmax_kernel_tiled docstring.
@@ -668,40 +669,106 @@ class SoftmaxKernel(Kernel):
 
         return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
 
+    def _tile_n_candidates(self) -> list[int]:
+        """Return candidate tile_n values for autotune exploration.
+
+        Includes the heuristic tile_n plus divisors of N_padded that fit
+        within the shared memory budget (accounting for num_buffers).
+        tile_n=0 means single-tile (no tiling).  All candidates are
+        de-duplicated and sorted for deterministic ordering.
+        """
+        candidates = set()
+        for bm in [1, 2, 4, 8, 16]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            candidates.add(tn)
+        return sorted(candidates)
+
     @property
     def autotune_configs(self) -> list[dict]:
-        """Generate autotune configs (block_m, threads only).
+        """Generate autotune configs including tile_n candidates.
 
-        tile_n is baked into the kernel at build time, so we only expose
-        block_m and threads to the autotuner. All configs must be compatible
-        with the kernel's tile_n.
+        tile_n is baked into the kernel at build time, so the autotuner
+        rebuilds the kernel for each tile_n value.  Configs include
+        ``tile_n`` alongside ``block_m`` and ``threads``.
         """
-        # Use the same tile_n that the kernel was built with
-        tile_n = getattr(self, "_tile_n", self.default_config["tile_n"])
         budget = self._smem_budget
         smem_per_row = self.N_padded * self._elem_bytes
         max_block_m_no_tile = budget // smem_per_row if smem_per_row > 0 else 16
         threads_list = [128, 256]
 
         configs = []
-        for bm in [1, 2, 4, 8, 16]:
-            try:
-                compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
-            except ValueError:
-                continue
-            bm_tile_n = self._tile_n_for_block_m(bm)
-            # Only include configs compatible with the built kernel's tile_n
-            if bm_tile_n != tile_n:
-                continue
-            if tile_n == 0 and bm > max_block_m_no_tile:
-                continue
-            for t in threads_list:
-                configs.append({"block_m": bm, "threads": t})
+        for tile_n in self._tile_n_candidates():
+            for bm in [1, 2, 4, 8, 16]:
+                try:
+                    compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
+                except ValueError:
+                    continue
+                bm_tile_n = self._tile_n_for_block_m(bm)
+                # Only include block_m values compatible with this tile_n
+                if bm_tile_n != tile_n:
+                    continue
+                if tile_n == 0 and bm > max_block_m_no_tile:
+                    continue
+                for t in threads_list:
+                    configs.append({"block_m": bm, "threads": t, "tile_n": tile_n})
 
         if not configs:
-            configs = [{"block_m": 1, "threads": 256}]
+            configs = [{"block_m": 1, "threads": 256, "tile_n": self._tile_n}]
 
         return configs
+
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+        """Autotune across tile_n candidates by rebuilding the kernel per regime.
+
+        Groups configs by tile_n, benchmarks each group with its own kernel,
+        and picks the overall best (block_m, threads, tile_n) config.
+        """
+        from tilelang.autotuner import autotune as tl_autotune
+
+        configs = self.autotune_configs
+        if not configs:
+            return
+
+        # Group configs by tile_n
+        by_tile_n: dict[int, list[dict]] = {}
+        for cfg in configs:
+            tn = cfg["tile_n"]
+            by_tile_n.setdefault(tn, []).append(
+                {"block_m": cfg["block_m"], "threads": cfg["threads"]}
+            )
+
+        best_time = float("inf")
+        best_config = None
+
+        for tile_n, group_cfgs in by_tile_n.items():
+            kernel = _softmax_kernel(
+                self.M, self.N, self.op_kind, self.dtype_str, tile_n,
+            )
+            autotune_kwargs: dict = dict(
+                configs=group_cfgs, warmup=warmup, rep=rep,
+            )
+            if self.autotune_supply_prog is not None:
+                autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+            autotuned = tl_autotune(**autotune_kwargs)(kernel)
+            tuned = autotuned()
+            latency = tuned.latency
+            if latency < best_time:
+                best_time = latency
+                best_config = {**tuned.config, "tile_n": tile_n}
+
+        if best_config is not None:
+            self.config = best_config
+            # Rebuild kernel for the winning tile_n
+            winning_tile_n = best_config["tile_n"]
+            if winning_tile_n != self._tile_n:
+                self._tile_n = winning_tile_n
+                self.kernel = _softmax_kernel(
+                    self.M, self.N, self.op_kind, self.dtype_str, self._tile_n,
+                )
+        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the softmax/log_softmax kernel.

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -579,9 +579,16 @@ class SoftmaxKernel(Kernel):
         # self.config["tile_n"], and rebuilt the kernel.  Only apply
         # the post-init tile_n fixup for user-provided configs.
         if not tune:
-            new_tile_n = self._tile_n_for_block_m(self.config["block_m"])
-            if new_tile_n != self._tile_n:
-                self._tile_n = new_tile_n
+            # If the caller supplied an explicit tile_n (e.g. from a
+            # previous autotuner result), honour it.  Only fall back to
+            # the heuristic when tile_n was not provided.
+            caller_tile_n = config.get("tile_n") if config is not None else None
+            if caller_tile_n is not None:
+                target_tile_n = caller_tile_n
+            else:
+                target_tile_n = self._tile_n_for_block_m(self.config["block_m"])
+            if target_tile_n != self._tile_n:
+                self._tile_n = target_tile_n
                 self.kernel = _softmax_kernel(
                     self.M,
                     self.N,

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -594,6 +594,7 @@ class SoftmaxKernel(Kernel):
     # Tiled softmax/log_softmax allocates 2 shared buffers (one per pass)
     # due to TileLang allocator aliasing -- see _softmax_kernel_tiled docstring.
     _NUM_SHARED_BUFFERS = 2
+    _MAX_TILE_N_CANDIDATES = 3
 
     def _tile_n_for_block_m(self, block_m: int) -> int:
         """Return tile_n for a given block_m (0 means no tiling needed).
@@ -675,22 +676,46 @@ class SoftmaxKernel(Kernel):
         Includes the heuristic tile_n plus divisors of N_padded that fit
         within the shared memory budget (accounting for num_buffers).
         tile_n=0 means single-tile (no tiling).  All candidates are
-        de-duplicated and sorted for deterministic ordering.
+        de-duplicated and sorted descending for deterministic ordering.
 
         Each distinct tile_n value requires a full kernel recompilation,
         which is expensive for large-N workloads (compilations can take
-        minutes each).  To keep autotuner wall time practical:
+        minutes each).  To keep autotuner wall time practical we cap
+        the total number of tile_n candidates at ``_MAX_TILE_N_CANDIDATES``
+        (currently 3).
 
         - When the heuristic default tile_n is 0 (single-tile / small N),
           return ``[0]`` -- the autotuner varies only block_m and threads.
-        - Otherwise return only the heuristic default tile_n (block_m=1).
-          The autotuner still explores block_m and threads within that
-          tile_n regime, which is the highest-impact search axis.
+        - Otherwise collect distinct tile_n values from block_m=1..4 and
+          return up to ``_MAX_TILE_N_CANDIDATES`` candidates (always
+          including the heuristic default).
         """
         default_tn = self._tile_n_for_block_m(1)
         if default_tn == 0:
             return [0]
-        return [default_tn]
+
+        candidates: set[int] = {default_tn}
+        # Explore tile_n values implied by small block_m values.
+        # Higher block_m → smaller tile_n (more N-tiles but better row reuse).
+        for bm in (2, 4):
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn > 0 and tn != default_tn:
+                candidates.add(tn)
+
+        # Also try half of the default tile_n (rounded to alignment) as a
+        # search point when block_m exploration didn't yield alternatives.
+        if len(candidates) < 2:
+            from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT
+            half_tn = (default_tn // 2 // DEFAULT_ALIGNMENT) * DEFAULT_ALIGNMENT
+            if half_tn > 0 and half_tn != default_tn:
+                candidates.add(half_tn)
+
+        # Cap to avoid excessive compilation time.
+        sorted_candidates = sorted(candidates, reverse=True)
+        return sorted_candidates[:self._MAX_TILE_N_CANDIDATES]
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -707,24 +732,26 @@ class SoftmaxKernel(Kernel):
 
         configs = []
         for tile_n in self._tile_n_candidates():
-            # In the tiled regime (tile_n > 0), only explore the default
-            # block_m=1 config.  Large-tile kernels cause NVCC/cicc to
-            # spend 10+ minutes per config variant, making multi-config
-            # autotuning impractical.  The autotuner still varies threads.
-            bm_candidates = [1, 2, 4, 8, 16] if tile_n == 0 else [1]
-            for bm in bm_candidates:
-                try:
-                    compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
-                except ValueError:
-                    continue
-                bm_tile_n = self._tile_n_for_block_m(bm)
-                # Only include block_m values compatible with this tile_n
-                if bm_tile_n != tile_n:
-                    continue
-                if tile_n == 0 and bm > max_block_m_no_tile:
-                    continue
+            if tile_n == 0:
+                # Single-tile regime: explore multiple block_m values.
+                for bm in [1, 2, 4, 8, 16]:
+                    try:
+                        compute_tile_n(bm, self._elem_bytes, self.N_padded, budget=budget)
+                    except ValueError:
+                        continue
+                    bm_tile_n = self._tile_n_for_block_m(bm)
+                    if bm_tile_n != 0:
+                        continue
+                    if bm > max_block_m_no_tile:
+                        continue
+                    for t in threads_list:
+                        configs.append({"block_m": bm, "threads": t, "tile_n": 0})
+            else:
+                # Tiled regime: use block_m=1 with each tile_n candidate.
+                # Each distinct tile_n triggers a kernel recompilation, so
+                # we only vary threads within each tile_n regime.
                 for t in threads_list:
-                    configs.append({"block_m": bm, "threads": t, "tile_n": tile_n})
+                    configs.append({"block_m": 1, "threads": t, "tile_n": tile_n})
 
         if not configs:
             configs = [{"block_m": 1, "threads": 256, "tile_n": self._tile_n}]

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -680,10 +680,13 @@ class SoftmaxKernel(Kernel):
     def _tile_n_candidates(self) -> list[int]:
         """Return candidate tile_n values for autotune exploration.
 
-        Includes the heuristic tile_n plus divisors of N_padded that fit
-        within the shared memory budget (accounting for num_buffers).
-        tile_n=0 means single-tile (no tiling).  All candidates are
-        de-duplicated and sorted descending for deterministic ordering.
+        Includes the heuristic tile_n (from block_m=1) plus alternative
+        tile_n values derived from ``_tile_n_for_block_m(2)`` and
+        ``_tile_n_for_block_m(4)``, with a half-step fallback aligned to
+        ``DEFAULT_ALIGNMENT`` when block_m exploration yields no
+        alternatives.  tile_n=0 means single-tile (no tiling).  All
+        candidates are de-duplicated and sorted descending for
+        deterministic ordering.
 
         Each distinct tile_n value requires a full kernel recompilation,
         which is expensive for large-N workloads (compilations can take

--- a/tileops/kernels/reduction/softmax/softmax_fwd.py
+++ b/tileops/kernels/reduction/softmax/softmax_fwd.py
@@ -816,7 +816,6 @@ class SoftmaxKernel(Kernel):
                 self.kernel = _softmax_kernel(
                     self.M, self.N, self.op_kind, self.dtype_str, self._tile_n,
                 )
-        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the softmax/log_softmax kernel.

--- a/tileops/ops/reduction/cumprod.py
+++ b/tileops/ops/reduction/cumprod.py
@@ -3,14 +3,14 @@
 Provides:
   - CumprodFwdOp: y = cumprod(x, dim=-1)
 
-Follows the validate -> reshape -> pad -> kernel -> trim -> reshape pattern
+Follows the validate -> reshape -> kernel -> trim -> reshape pattern
 and supports 1D-4D input with dim=-1. Output has the same shape as input.
+Alignment padding is handled inside the kernel via masked loads.
 """
 
 from typing import Dict, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel import Kernel
 from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
@@ -90,13 +90,10 @@ class CumprodFwdOp(Op):
         if M_actual != self.M:
             raise ValueError(f"Expected M={self.M} (product of leading dims), got {M_actual}")
 
-        # Pad hidden dim to alignment (use 1.0 for prod to keep identity)
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N), value=1.0)
-
+        # Alignment padding is handled inside the kernel via masked loads.
         y = self.kernel(x)
 
-        # Trim padding and restore original shape
+        # Trim padding (kernel output is N_padded-wide) and restore shape
         if self.N_padded != self.N:
             y = y[:, : self.N]
         return y.reshape(orig_shape)

--- a/tileops/ops/reduction/cumsum.py
+++ b/tileops/ops/reduction/cumsum.py
@@ -3,14 +3,14 @@
 Provides:
   - CumsumFwdOp: y = cumsum(x, dim=-1)
 
-Follows the validate -> reshape -> pad -> kernel -> trim -> reshape pattern
+Follows the validate -> reshape -> kernel -> trim -> reshape pattern
 and supports 1D-4D input with dim=-1. Output has the same shape as input.
+Alignment padding is handled inside the kernel via masked loads.
 """
 
 from typing import Dict, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel import Kernel
 from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
@@ -90,13 +90,10 @@ class CumsumFwdOp(Op):
         if M_actual != self.M:
             raise ValueError(f"Expected M={self.M} (product of leading dims), got {M_actual}")
 
-        # Pad hidden dim to alignment
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-
+        # Alignment padding is handled inside the kernel via masked loads.
         y = self.kernel(x)
 
-        # Trim padding and restore original shape
+        # Trim padding (kernel output is N_padded-wide) and restore shape
         if self.N_padded != self.N:
             y = y[:, : self.N]
         return y.reshape(orig_shape)

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -2,9 +2,14 @@
 
 Each op reduces along the configured ``dim`` and supports arbitrary-rank input.
 The ``dim`` parameter accepts ``int`` or ``list[int]`` for multi-dim reduction.
-The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment,
-calls the kernel, trims padding, and reshapes the output back.  Kernels are
-cached by ``(M, N)`` so that the same op instance can handle varying shapes.
+The Op layer validates inputs, reshapes to 2D (M, N), and calls the kernel.
+For simple and Welford reduce ops, alignment padding is handled inside the
+kernel via masked loads with identity-element fills, eliminating host-side
+``F.pad`` from the forward path.  Other ops that inherit ``_ReduceOpBase``
+(argreduce, logical, vector_norm) continue to use host-side padding until
+their kernels are converted.
+Kernels are cached by ``(M, N)`` so that the same op instance can handle
+varying shapes.
 """
 
 from math import prod
@@ -63,6 +68,7 @@ class _ReduceOpBase(Op):
     _op_kind: str = ""  # overridden by subclasses
     _kernel_key: str = "reduce"  # overridden by subclasses for different kernel families
     _kernel_cls: type = ReduceKernel  # overridden by subclasses for different kernel classes
+    _kernel_handles_padding: bool = False  # True when kernel accepts (M, N) with masked loads
 
     def __init__(
         self,
@@ -110,11 +116,16 @@ class _ReduceOpBase(Op):
         return {self._kernel_key: self._kernel_cls}
 
     # ------------------------------------------------------------------
-    # Pad value (subclasses may override)
+    # Pad value (subclasses may override; used only when
+    # _kernel_handles_padding is False)
     # ------------------------------------------------------------------
 
     def _pad_value(self) -> float:
-        """Return the identity element used when padding to alignment."""
+        """Return the identity element used when padding to alignment.
+
+        Only used when ``_kernel_handles_padding`` is ``False`` (i.e. the
+        kernel expects pre-padded input from the Op layer).
+        """
         return 0.0
 
     # ------------------------------------------------------------------
@@ -179,11 +190,16 @@ class _ReduceOpBase(Op):
     def _prepare_input(
         self, x: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Size, object, object]:
-        """Validate, derive M/N, transpose, reshape to 2D, pad.
+        """Validate, derive M/N, transpose, reshape to 2D, optionally pad.
 
-        Returns ``(x_2d_padded, orig_shape, dim_info, kernel)`` where
+        Returns ``(x_2d, orig_shape, dim_info, kernel)`` where
         *dim_info* is either an ``int`` (single-dim) or ``list[int]``
         (multi-dim).
+
+        When ``_kernel_handles_padding`` is ``True``, the raw ``(M, N)``
+        tensor is passed through -- the kernel handles alignment internally
+        via masked loads.  Otherwise, host-side ``F.pad`` is applied for
+        backward compatibility with kernels that expect ``(M, N_padded)``.
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
@@ -202,11 +218,12 @@ class _ReduceOpBase(Op):
             M = prod(x.shape[:-1])
             x = x.reshape(M, N)
             kernel = self._get_or_create_kernel(M, N)
-            N_padded = align_up(N, DEFAULT_ALIGNMENT)
-            if N_padded != N:
-                pv = self._pad_value()
-                pad = (0, N_padded - N)
-                x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
+            if not self._kernel_handles_padding:
+                N_padded = align_up(N, DEFAULT_ALIGNMENT)
+                if N_padded != N:
+                    pv = self._pad_value()
+                    pad = (0, N_padded - N)
+                    x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
             return x, orig_shape, dims, kernel
 
         # --- single-dim path ---
@@ -227,11 +244,12 @@ class _ReduceOpBase(Op):
 
         kernel = self._get_or_create_kernel(M, N)
 
-        N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        if N_padded != N:
-            pv = self._pad_value()
-            pad = (0, N_padded - N)
-            x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
+        if not self._kernel_handles_padding:
+            N_padded = align_up(N, DEFAULT_ALIGNMENT)
+            if N_padded != N:
+                pv = self._pad_value()
+                pad = (0, N_padded - N)
+                x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
 
         return x, orig_shape, dim, kernel
 
@@ -272,6 +290,9 @@ class _SimpleReduceOp(_ReduceOpBase):
     derived from the input tensor at forward time, and kernels are cached
     by ``(M, N)`` to avoid rebuilds.
 
+    Alignment padding is handled inside the kernel via masked loads with
+    identity-element fills, so no host-side ``F.pad`` is needed.
+
     Args:
         dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default -1).  Accepts ``int`` or
@@ -281,15 +302,7 @@ class _SimpleReduceOp(_ReduceOpBase):
         tune: Whether to autotune (default False).
     """
 
-    def _pad_value(self) -> float:
-        """Return the identity element used when padding to alignment."""
-        if self._op_kind == "prod":
-            return 1.0
-        if self._op_kind == "amin":
-            return float("inf")
-        if self._op_kind == "amax":
-            return float("-inf")
-        return 0.0
+    _kernel_handles_padding = True
 
 
 class SumFwdOp(_SimpleReduceOp):
@@ -334,6 +347,9 @@ class _WelfordReduceOp(_ReduceOpBase):
     M and N are derived from the input tensor at forward time, and kernels
     are cached by ``(M, N)`` to avoid rebuilds.
 
+    Alignment padding is handled inside the kernel via masked loads,
+    so no host-side ``F.pad`` is needed.
+
     Args:
         dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default -1).  Accepts ``int`` or
@@ -343,6 +359,8 @@ class _WelfordReduceOp(_ReduceOpBase):
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
+
+    _kernel_handles_padding = True
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Eliminate host-side `F.pad` from remaining reduction ops (reduce, cumsum, cumprod forward paths) and make `tile_n` a first-class autotuner search dimension for tiled softmax/logsumexp kernels.

Closes #907

## Test plan

| AC | Description | Status | Evidence |
| --- | --- | --- | --- |
| AC-1 | Host-side `F.pad` eliminated from `reduce.py`, `cumsum.py`, `cumprod.py` forward paths | pass | Runtime probe with `F.pad` monkeypatched to raise on unaligned inputs: CumsumFwdOp(M=3,N=513), CumprodFwdOp(M=3,N=513), SumFwdOp, VarFwdOp all completed with pad_calls=0 |
| AC-2 | `autotune_configs` for softmax/logsumexp tiled kernels includes tile_n candidates | pass | Kernel inspection on manifest-sized tiled workloads produced 4 autotune configs spanning >=2 distinct tile_n values per workload |
| AC-3 | All existing reduction op tests pass | pass | 773 passed (pytest tests/ops/test_softmax.py + 8 other test files) in 81.41s |
| AC-4 | `tune=True` benchmark on manifest workloads shows equal or better perf vs current heuristic | pass | 11/15 workloads faster with tune=True; remaining 4 equal (same config, within noise floor) |
## Benchmark

**Environment**: NVIDIA H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.8

### Softmax / LogSoftmax / LogSumExp (tile_n autotuning)

| Op | Shape | dtype | TileOPs (ms) | torch (ms) | Speedup |
|---|---|---|---:|---:|---|
| SoftmaxFwdOp | 8x4096 (attn-weights) | fp16 | 0.0171 | 0.0311 | **1.82x** |
| SoftmaxFwdOp | 8x4096 (attn-weights) | bf16 | 0.0174 | 0.0310 | **1.78x** |
| SoftmaxFwdOp | 1x16384 (attn-32k) | bf16 | 0.1721 | 0.1521 | 0.88x |
| SoftmaxFwdOp | 1x25600 (lm-head) | fp16 | 0.0347 | 0.0556 | **1.60x** |
| SoftmaxFwdOp | 1x25600 (lm-head) | bf16 | 0.0365 | 0.0575 | **1.58x** |
| LogSoftmaxFwdOp | 8x4096 (attn-weights) | fp16 | 0.0125 | 0.0269 | **2.15x** |
| LogSoftmaxFwdOp | 8x4096 (attn-weights) | bf16 | 0.0126 | 0.0270 | **2.14x** |
| LogSoftmaxFwdOp | 1x16384 (attn-32k) | bf16 | 0.1455 | 0.1089 | 0.75x |
| LogSoftmaxFwdOp | 1x25600 (lm-head) | fp16 | 0.0297 | 0.0362 | **1.22x** |
| LogSoftmaxFwdOp | 1x25600 (lm-head) | bf16 | 0.0311 | 0.0372 | **1.20x** |
| LogSumExpFwdOp | 8x4096 (attn-weights) | fp16 | 0.0100 | 0.0568 | **5.68x** |
| LogSumExpFwdOp | 8x4096 (attn-weights) | bf16 | 0.0101 | 0.0572 | **5.66x** |
| LogSumExpFwdOp | 1x16384 (attn-32k) | bf16 | 0.0702 | 0.3315 | **4.72x** |
| LogSumExpFwdOp | 1x25600 (lm-head) | fp16 | 0.0142 | 0.0553 | **3.89x** |
| LogSumExpFwdOp | 1x25600 (lm-head) | bf16 | 0.0155 | 0.0553 | **3.57x** |

**Takeaways:**
- LogSumExp sees the largest gains (3.6-5.7x over torch) — torch lacks a fused logsumexp, falls back to log(sum(exp))
- Softmax/LogSoftmax win on multi-row workloads (attn-weights: 1.6-2.2x) where tiled kernel amortizes launch overhead
- Two regressions on single-row tiled regime (attn-32k): Softmax 0.88x, LogSoftmax 0.75x — the tiled path has higher per-tile overhead when M=1; heuristic tile_n selection slightly worse than torch's fused kernel for this geometry
- F.pad elimination not benchmarked separately (no latency delta expected — padding was <1% of total time)

**Benchmark command:**
```bash
PYTHONPATH="$PWD" python -m pytest benchmarks/ops/bench_softmax.py -v
```

## Follow-up

- #920 — TileLang crash on (64, 32768) bf16 reduce (pre-existing, LegalizeNegativeIndex scalable vector error)
- #921 — Improve tile_n heuristic for single-row tiled softmax/logsumexp (0.75-0.88x regression on M=1 geometry)

Suggestions: benchmarks/benchmark.py precision change (:.2f→:.4f) should be split to its own chore PR per trust boundary