### PR TITLE
[Refactor][Validator] Support import aliases and module-qualified calls in L4 bench validation

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -814,31 +814,85 @@ def _ast_manifest_call_usage(
     matched_calls: set[str] = set()
     bindings = _resolve_constant_str_bindings(tree)
 
+    # Maps local_name (as used in code) → canonical target name.
+    # e.g. "lw" → "load_workloads", "MB" → "eval_roofline" (via indirect).
+    _alias_to_target: dict[str, str] = {}
+
+    # Modules that provide indirect helpers, mapped via ``from X import Y``.
+    # e.g. ``from benchmarks import benchmark`` → module_aliases["benchmark"]
+    # = "benchmarks.benchmark".
+    _module_aliases: dict[str, str] = {}
+
+    _DIRECT_MODULES = {"tileops.manifest"}
+    _INDIRECT_MODULE = "benchmarks.benchmark"
+
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if node.module == "tileops.manifest" and node.names:
+            if node.module in _DIRECT_MODULES and node.names:
                 for alias in node.names:
                     if alias.name in target_names:
                         imported.add(alias.name)
+                        local = alias.asname or alias.name
+                        _alias_to_target[local] = alias.name
             # Indirect helpers live in benchmarks.benchmark.
-            if node.module == "benchmarks.benchmark" and node.names:
+            if node.module == _INDIRECT_MODULE and node.names:
                 for alias in node.names:
                     equiv = _INDIRECT_EQUIV.get(alias.name)
                     if equiv and equiv in target_names:
                         imported.add(equiv)
-        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            func_name = node.func.id
-            # Direct call (load_workloads / eval_roofline).
-            if func_name in target_names and _call_uses_expected_op_name(
+                        local = alias.asname or alias.name
+                        _alias_to_target[local] = equiv
+            # ``from benchmarks import benchmark`` — module import.
+            if (
+                node.module
+                and node.names
+                and not any(alias.name in target_names for alias in node.names)
+                and not any(alias.name in _INDIRECT_EQUIV for alias in node.names)
+            ):
+                for alias in node.names:
+                    full_module = f"{node.module}.{alias.name}"
+                    if full_module in (_INDIRECT_MODULE, *_DIRECT_MODULES):
+                        local = alias.asname or alias.name
+                        _module_aliases[local] = full_module
+
+        elif isinstance(node, ast.Call):
+            resolved_target: str | None = None
+
+            if isinstance(node.func, ast.Name):
+                func_name = node.func.id
+                # Check alias mapping first.
+                if func_name in _alias_to_target:
+                    resolved_target = _alias_to_target[func_name]
+                # Direct call (load_workloads / eval_roofline).
+                elif func_name in target_names:
+                    resolved_target = func_name
+                else:
+                    # Indirect call (workloads_to_params / ManifestBenchmark).
+                    equiv = _INDIRECT_EQUIV.get(func_name)
+                    if equiv and equiv in target_names:
+                        resolved_target = equiv
+
+            elif isinstance(node.func, ast.Attribute):
+                # e.g. benchmark.workloads_to_params(...)
+                attr_name = node.func.attr
+                if isinstance(node.func.value, ast.Name):
+                    mod_local = node.func.value.id
+                    mod_full = _module_aliases.get(mod_local)
+                    if mod_full == _INDIRECT_MODULE:
+                        equiv = _INDIRECT_EQUIV.get(attr_name)
+                        if equiv and equiv in target_names:
+                            imported.add(equiv)
+                            resolved_target = equiv
+                    elif mod_full in _DIRECT_MODULES:
+                        if attr_name in target_names:
+                            imported.add(attr_name)
+                            resolved_target = attr_name
+
+            if resolved_target and _call_uses_expected_op_name(
                 node, op_name, bindings,
             ):
-                matched_calls.add(func_name)
-            # Indirect call (workloads_to_params / ManifestBenchmark).
-            equiv = _INDIRECT_EQUIV.get(func_name)
-            if equiv and equiv in target_names and _call_uses_expected_op_name(
-                node, op_name, bindings,
-            ):
-                matched_calls.add(equiv)
+                matched_calls.add(resolved_target)
+
     return {name: (name in imported and name in matched_calls) for name in target_names}
 
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -855,6 +855,14 @@ def _ast_manifest_call_usage(
                         local = alias.asname or alias.name
                         _module_aliases[local] = full_module
 
+        elif isinstance(node, ast.Import):
+            # ``import benchmarks.benchmark as bb`` or
+            # ``import tileops.manifest as tm`` — bare import statements.
+            for alias in node.names:
+                if alias.name in (_INDIRECT_MODULE, *_DIRECT_MODULES):
+                    local = alias.asname or alias.name
+                    _module_aliases[local] = alias.name
+
         elif isinstance(node, ast.Call):
             resolved_target: str | None = None
 
@@ -873,20 +881,56 @@ def _ast_manifest_call_usage(
                         resolved_target = equiv
 
             elif isinstance(node.func, ast.Attribute):
-                # e.g. benchmark.workloads_to_params(...)
+                # e.g. benchmark.workloads_to_params(...) or
+                # tileops.manifest.load_workloads(...)
                 attr_name = node.func.attr
-                if isinstance(node.func.value, ast.Name):
-                    mod_local = node.func.value.id
-                    mod_full = _module_aliases.get(mod_local)
-                    if mod_full == _INDIRECT_MODULE:
-                        equiv = _INDIRECT_EQUIV.get(attr_name)
-                        if equiv and equiv in target_names:
-                            imported.add(equiv)
-                            resolved_target = equiv
-                    elif mod_full in _DIRECT_MODULES:
-                        if attr_name in target_names:
-                            imported.add(attr_name)
-                            resolved_target = attr_name
+
+                # Resolve the dotted chain preceding the final attribute.
+                # For ``bb.func()`` this yields ``("bb",)``; for
+                # ``tileops.manifest.func()`` it yields ``("tileops", "manifest")``.
+                parts: list[str] = []
+                cursor: ast.expr = node.func.value
+                while isinstance(cursor, ast.Attribute):
+                    parts.append(cursor.attr)
+                    cursor = cursor.value
+                if isinstance(cursor, ast.Name):
+                    parts.append(cursor.id)
+                parts.reverse()  # now left-to-right
+
+                mod_full: str | None = None
+                if len(parts) == 1:
+                    mod_full = _module_aliases.get(parts[0])
+                elif len(parts) >= 2:
+                    # Try progressively longer prefixes against the alias map.
+                    # e.g. for ``tileops.manifest.func()``, try "tileops"
+                    # first (might map to "tileops.manifest" if aliased), then
+                    # "tileops.manifest" as a literal key.
+                    for i in range(1, len(parts) + 1):
+                        prefix = ".".join(parts[:i])
+                        mapped = _module_aliases.get(prefix)
+                        if mapped:
+                            # Append remaining parts that weren't consumed.
+                            suffix = ".".join(parts[i:])
+                            mod_full = f"{mapped}.{suffix}" if suffix else mapped
+                            break
+                    if mod_full is None:
+                        # No alias found — try the entire chain as-is (bare
+                        # ``import tileops.manifest`` with no alias creates
+                        # a binding for the top-level name only, but the call
+                        # uses the full dotted path).
+                        mod_full = ".".join(parts)
+                        if mod_full not in (_INDIRECT_MODULE, *_DIRECT_MODULES):
+                            mod_full = None
+
+                if mod_full == _INDIRECT_MODULE:
+                    equiv = _INDIRECT_EQUIV.get(attr_name)
+                    if equiv and equiv in target_names:
+                        imported.add(equiv)
+                        resolved_target = equiv
+                elif mod_full in _DIRECT_MODULES:
+                    if attr_name in target_names:
+                        imported.add(attr_name)
+                        resolved_target = attr_name
 
             if resolved_target and _call_uses_expected_op_name(
                 node, op_name, bindings,

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -913,14 +913,11 @@ def _ast_manifest_call_usage(
                             suffix = ".".join(parts[i:])
                             mod_full = f"{mapped}.{suffix}" if suffix else mapped
                             break
-                    if mod_full is None:
-                        # No alias found — try the entire chain as-is (bare
-                        # ``import tileops.manifest`` with no alias creates
-                        # a binding for the top-level name only, but the call
-                        # uses the full dotted path).
-                        mod_full = ".".join(parts)
-                        if mod_full not in (_INDIRECT_MODULE, *_DIRECT_MODULES):
-                            mod_full = None
+                    # No fallback: if no alias matched, the module was never
+                    # imported, so mod_full stays None.  A bare
+                    # ``import tileops.manifest`` already registers
+                    # "tileops.manifest" in _module_aliases (line above),
+                    # which the progressive prefix search finds.
 
                 if mod_full == _INDIRECT_MODULE:
                     equiv = _INDIRECT_EQUIV.get(attr_name)

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -766,6 +766,51 @@ class TestBench:
         errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert errors == []
 
+    def test_bench_ast_import_indirect_module_alias_passes(self, validator, tmp_path):
+        """ast.Import with alias: 'import benchmarks.benchmark as bb' passes L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            import benchmarks.benchmark as bb
+            params = bb.workloads_to_params('test_op')
+            bb.ManifestBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_ast_import_direct_module_alias_passes(self, validator, tmp_path):
+        """ast.Import with alias: 'import tileops.manifest as tm' passes L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            import tileops.manifest as tm
+            workloads = tm.load_workloads('test_op')
+            tm.eval_roofline('test_op')
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_ast_import_no_alias_qualified_passes(self, validator, tmp_path):
+        """ast.Import without alias: 'import tileops.manifest' uses full chain."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            import tileops.manifest
+            workloads = tileops.manifest.load_workloads('test_op')
+            tileops.manifest.eval_roofline('test_op')
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_ast_import_wrong_op_name_fails(self, validator, tmp_path):
+        """ast.Import with alias but wrong op name must still fail."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            import benchmarks.benchmark as bb
+            params = bb.workloads_to_params('wrong_op')
+            bb.ManifestBenchmark('wrong_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert any("load_workloads" in e for e in errors)
+        assert any("eval_roofline" in e for e in errors)
+
     def test_bench_wrong_alias_fails(self, validator, tmp_path):
         """Aliased imports called with wrong op name must still fail."""
         bench_file = tmp_path / "bench_test.py"

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -824,6 +824,28 @@ class TestBench:
         assert any("load_workloads" in e for e in errors)
         assert any("eval_roofline" in e for e in errors)
 
+    def test_bench_qualified_direct_call_without_import_fails(self, validator, tmp_path):
+        """tileops.manifest.load_workloads() without any import must fail L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            workloads = tileops.manifest.load_workloads('test_op')
+            tileops.manifest.eval_roofline('test_op')
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert any("load_workloads" in e for e in errors)
+        assert any("eval_roofline" in e for e in errors)
+
+    def test_bench_qualified_indirect_call_without_import_fails(self, validator, tmp_path):
+        """benchmarks.benchmark.workloads_to_params() without any import must fail L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            params = benchmarks.benchmark.workloads_to_params('test_op')
+            benchmarks.benchmark.ManifestBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert any("load_workloads" in e for e in errors)
+        assert any("eval_roofline" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # --check-op: force all levels on a specific op, ignoring status

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -732,6 +732,53 @@ class TestBench:
         assert any("load_workloads" in e for e in errors)
         assert any("eval_roofline" in e for e in errors)
 
+    def test_bench_aliased_indirect_import_passes(self, validator, tmp_path):
+        """Aliased imports like 'import ManifestBenchmark as MB' pass L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import ManifestBenchmark as MB
+            from benchmarks.benchmark import workloads_to_params as wtp
+            params = wtp('test_op')
+            MB('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_aliased_direct_import_passes(self, validator, tmp_path):
+        """Aliased direct imports like 'import load_workloads as lw' pass L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from tileops.manifest import load_workloads as lw, eval_roofline as er
+            workloads = lw('test_op')
+            er('test_op')
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_module_qualified_call_passes(self, validator, tmp_path):
+        """Module-qualified calls like benchmark.workloads_to_params pass L4."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks import benchmark
+            params = benchmark.workloads_to_params('test_op')
+            benchmark.ManifestBenchmark('test_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert errors == []
+
+    def test_bench_wrong_alias_fails(self, validator, tmp_path):
+        """Aliased imports called with wrong op name must still fail."""
+        bench_file = tmp_path / "bench_test.py"
+        bench_file.write_text(textwrap.dedent("""\
+            from benchmarks.benchmark import ManifestBenchmark as MB
+            from benchmarks.benchmark import workloads_to_params as wtp
+            params = wtp('wrong_op')
+            MB('wrong_op', params[0])
+        """))
+        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        assert any("load_workloads" in e for e in errors)
+        assert any("eval_roofline" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # --check-op: force all levels on a specific op, ignoring status


### PR DESCRIPTION
## Summary

Make the bench AST validator robust to import aliases and module-qualified attribute access for `ManifestBenchmark`, `workloads_to_params`, `load_workloads`, and `eval_roofline`.

Closes #917

## Test plan

- [x] AC-1: `from benchmarks.benchmark import ManifestBenchmark as MB; MB('OpName', w)` passes L4 validation
- [x] AC-2: `from benchmarks.benchmark import workloads_to_params as wtp; wtp('OpName')` passes L4 validation
- [x] AC-3: Existing 87 validator tests still pass (97 total with new tests)
- [x] AC-4: 10 new tests covering alias and attribute-access patterns

## Verification

- 97 tests pass, 0 failures
- `pre-commit run --all-files` passes clean
- All 4 acceptance criteria verified by automated reviewer