### PR TITLE
[Refactor][Manifest] Update convolution kernel paths to flat module

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2305,7 +2305,7 @@ ops:
       bytes: "(N * C_in * L_in + C_out * C_in_g * kW + N * C_out * L_out) * elem_bytes"
 
     source:
-      kernel: tileops/kernels/convolution/conv1d.py
+      kernel: tileops/kernels/convolution.py
       op: tileops/ops/convolution.py
       test: tests/ops/test_convolution.py
       bench: benchmarks/ops/bench_convolution.py
@@ -2354,7 +2354,7 @@ ops:
       bytes: "(N * C_in * L_in + C_out * C_in_g * kW + C_out + N * C_out * L_out) * elem_bytes"
 
     source:
-      kernel: tileops/kernels/convolution/conv1d.py
+      kernel: tileops/kernels/convolution.py
       op: tileops/ops/convolution.py
       test: tests/ops/test_convolution.py
       bench: benchmarks/ops/bench_convolution.py


### PR DESCRIPTION
## Summary

Update all convolution `source.kernel` paths in `ops_manifest.yaml` from `tileops/kernels/convolution/*.py` to `tileops/kernels/convolution.py`, completing the flat-module migration started in PR #930.

Closes #934

## Test plan

| AC | Description | Status | Evidence |
|----|------------|--------|----------|
| AC-1 | Modified files pass existing tests | PASS | 87 tests passed (validate_manifest.py) |
| AC-2 | All convolution entries reference `tileops/kernels/convolution.py` | PASS | 2 entries found, 0 legacy paths |
| AC-3 | `python scripts/validate_manifest.py` passes | PASS | All manifest checks passed (26 pre-existing warnings) |

### Validation commands

```bash
python scripts/validate_manifest.py
python -m pytest -q tests/test_validate_manifest.py
```

## Constraints

- Manifest-only change per trust model (no kernel or op code changes)
- Depends on PR #930 (flat convolution module) being merged first