### PR TITLE
[Chore] Standardize abbreviation casing in class names and docstrings

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -19,3 +19,14 @@
   ```
 
   Cleanup must describe the invariant to restore, not reference a specific PR. Scan with `grep -rn 'FIXME(staged-rollout)'`.
+
+- **Abbreviation casing in PascalCase symbols**: Standard abbreviations must be fully uppercase — `RMS`, not `Rms`; `SSD`, not `Ssd`; `SSM`, not `Ssm`. Examples: `RMSNormKernel`, `SSDDecodeOp`, `FusedAddRMSNormFwdOp`.
+
+- **Abbreviation casing in filenames**: Filenames use all-lowercase with underscores. Multi-word abbreviations keep all letters lowercase — `rms_norm.py`, `ssd_decode.py`. Do not capitalize a single letter (e.g. `Ssd_decode.py` is wrong).
+
+- **Expand abbreviations on first use in docstrings**: When SSM, SSD, or other domain abbreviations first appear in a module or class docstring, write the full form followed by the abbreviation in parentheses. Subsequent uses in the same file can use the abbreviation alone.
+
+  - SSM → State Space Model (SSM)
+  - SSD → State-Space Dual (SSD)
+
+- **Underscore-separated naming for norm files**: All norm-related filenames use underscore separation — `rms_norm`, `layer_norm`, `batch_norm`, `fused_add_rms_norm`. Do not contract (e.g. `rmsnorm`, `layernorm`, `batchnorm`).

--- a/benchmarks/ops/bench_fused_add_rms_norm.py
+++ b/benchmarks/ops/bench_fused_add_rms_norm.py
@@ -5,13 +5,13 @@ import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
-from tileops.ops.norm.fused_add_rmsnorm import FusedAddRMSNormFwdOp
-from workloads.fused_add_rmsnorm import FusedAddRmsNormTest
+from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
+from workloads.fused_add_rms_norm import FusedAddRMSNormTest
 
 _OP_NAME = "FusedAddRMSNormFwdOp"
 
 
-class FusedAddRmsNormBenchmark(BenchmarkBase):
+class FusedAddRMSNormBenchmark(BenchmarkBase):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -51,9 +51,9 @@ def _manifest_params():
 
 
 @pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
-def test_fused_add_rmsnorm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
-    test = FusedAddRmsNormTest(m, n, dtype)
-    bm = FusedAddRmsNormBenchmark(test)
+def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = FusedAddRMSNormTest(m, n, dtype)
+    bm = FusedAddRMSNormBenchmark(test)
     inputs = test.gen_inputs()
 
     op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -5,21 +5,21 @@ import torch
 
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tileops.ops.da_cumsum import DaCumsumFwdOp
-from tileops.ops.ssd_chunk_scan import SsdChunkScanFwdOp
-from tileops.ops.ssd_chunk_state import SsdChunkStateFwdOp
-from tileops.ops.ssd_decode import SsdDecodeOp
-from tileops.ops.ssd_state_passing import SsdStatePassingFwdOp
+from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
+from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
+from tileops.ops.ssd_decode import SSDDecodeOp
+from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
 from workloads.mamba import (
     DaCumsumFwdFixture,
     DaCumsumFwdTest,
-    SsdChunkScanFwdFixture,
-    SsdChunkScanFwdTest,
-    SsdChunkStateFwdFixture,
-    SsdChunkStateFwdTest,
-    SsdDecodeFixture,
-    SsdDecodeTest,
-    SsdStatePassingFwdFixture,
-    SsdStatePassingFwdTest,
+    SSDChunkScanFwdFixture,
+    SSDChunkScanFwdTest,
+    SSDChunkStateFwdFixture,
+    SSDChunkStateFwdTest,
+    SSDDecodeFixture,
+    SSDDecodeTest,
+    SSDStatePassingFwdFixture,
+    SSDStatePassingFwdTest,
 )
 
 
@@ -97,7 +97,7 @@ def ssd_chunk_scan_fwd_torch(x, cb, dA_cumsum, C, prev_states, dt):
     return y_off + y_diag
 
 
-class SsdChunkScanFwdBenchmark(BenchmarkBase):
+class SSDChunkScanFwdBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -135,13 +135,13 @@ class SsdChunkScanFwdBenchmark(BenchmarkBase):
         return float(reads + writes)
 
 
-@SsdChunkScanFwdFixture
+@SSDChunkScanFwdFixture
 def test_ssd_chunk_scan_fwd_bench(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune):
-    test = SsdChunkScanFwdTest(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype)
-    bm = SsdChunkScanFwdBenchmark(test)
+    test = SSDChunkScanFwdTest(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype)
+    bm = SSDChunkScanFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = SsdChunkScanFwdOp(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune=tune)
+    op = SSDChunkScanFwdOp(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -188,7 +188,7 @@ def ssd_chunk_state_fwd_ref(
     return out.permute(0, 1, 2, 4, 3)
 
 
-class SsdChunkStateFwdBenchmark(BenchmarkBase):
+class SSDChunkStateFwdBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -222,17 +222,17 @@ class SsdChunkStateFwdBenchmark(BenchmarkBase):
         return float(reads + writes)
 
 
-@SsdChunkStateFwdFixture
+@SSDChunkStateFwdFixture
 def test_ssd_chunk_state_fwd_bench(
     batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune, has_seq_idx,
 ):
-    test = SsdChunkStateFwdTest(
+    test = SSDChunkStateFwdTest(
         batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, has_seq_idx,
     )
-    bm = SsdChunkStateFwdBenchmark(test)
+    bm = SSDChunkStateFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = SsdChunkStateFwdOp(
+    op = SSDChunkStateFwdOp(
         batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype,
         has_seq_idx=has_seq_idx, tune=tune,
     )
@@ -264,7 +264,7 @@ def ssd_state_passing_fwd_ref(
     return torch.stack(out, dim=1), s
 
 
-class SsdStatePassingFwdBenchmark(BenchmarkBase):
+class SSDStatePassingFwdBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -287,13 +287,13 @@ class SsdStatePassingFwdBenchmark(BenchmarkBase):
         return float(reads + writes)
 
 
-@SsdStatePassingFwdFixture
+@SSDStatePassingFwdFixture
 def test_ssd_state_passing_fwd_bench(batch, num_chunks, n_heads, d_state, dtype, tune):
-    test = SsdStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
-    bm = SsdStatePassingFwdBenchmark(test)
+    test = SSDStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
+    bm = SSDStatePassingFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = SsdStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
+    op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -335,7 +335,7 @@ def ssd_decode_ref(
     return y_out
 
 
-class SsdDecodeBenchmark(BenchmarkBase):
+class SSDDecodeBenchmark(BenchmarkBase):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -363,10 +363,10 @@ class SsdDecodeBenchmark(BenchmarkBase):
         return float(reads + writes)
 
 
-@SsdDecodeFixture
+@SSDDecodeFixture
 def test_ssd_decode_bench(batch, n_heads, d_head, d_state, n_groups, dtype, tune):
-    test = SsdDecodeTest(batch, n_heads, d_head, d_state, n_groups, dtype)
-    bm = SsdDecodeBenchmark(test)
+    test = SSDDecodeTest(batch, n_heads, d_head, d_state, n_groups, dtype)
+    bm = SSDDecodeBenchmark(test)
     A, dt, x, B_in, C_in, state = test.gen_inputs()
 
     # Clone state before each profile run so both start from identical initial
@@ -374,7 +374,7 @@ def test_ssd_decode_bench(batch, n_heads, d_head, d_state, n_groups, dtype, tune
     state_for_op = state.clone()
     state_bl = state.clone()
 
-    op = SsdDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
+    op = SSDDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
     result = bm.profile(op, A, dt, x, B_in, C_in, state_for_op)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -6,10 +6,10 @@ import torch
 from benchmarks.benchmark import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
-from workloads.rms_norm import RmsNormTest
+from workloads.rms_norm import RMSNormTest
 
 
-class _RmsNormTestBaseline(RmsNormTest):
+class _RMSNormTestBaseline(RMSNormTest):
     """Adds baseline ref_program for benchmark profiling."""
 
     def ref_program(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
@@ -21,7 +21,7 @@ class _RmsNormTestBaseline(RmsNormTest):
 _OP_NAME = "RMSNormFwdOp"
 
 
-class RmsNormBenchmark(BenchmarkBase):
+class RMSNormBenchmark(BenchmarkBase):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -55,8 +55,8 @@ def _manifest_params():
 
 @pytest.mark.parametrize("m, n, dtype, tune", _manifest_params())
 def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
-    test = _RmsNormTestBaseline(m, n, dtype)
-    bm = RmsNormBenchmark(test)
+    test = _RMSNormTestBaseline(m, n, dtype)
+    bm = RMSNormBenchmark(test)
     inputs = test.gen_inputs()
 
     op = RMSNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -2,11 +2,11 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.norm.fused_add_rmsnorm import FusedAddRMSNormFwdOp
-from workloads.fused_add_rmsnorm import FusedAddRmsNormTest as _FusedAddRmsNormTestWorkload
+from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
+from workloads.fused_add_rms_norm import FusedAddRMSNormTest as _FusedAddRMSNormTestWorkload
 
 
-class FusedAddRmsNormTest(_FusedAddRmsNormTestWorkload, TestBase):
+class FusedAddRMSNormTest(_FusedAddRMSNormTestWorkload, TestBase):
     def ref_program(
         self,
         x: torch.Tensor,
@@ -20,7 +20,7 @@ class FusedAddRmsNormTest(_FusedAddRmsNormTestWorkload, TestBase):
         return y, add_result
 
 
-class FusedAddRmsNormFixture(FixtureBase):
+class FusedAddRMSNormFixture(FixtureBase):
     PARAMS = [
         ("m, n, dtype, tune", [
             # Standard aligned shapes -- fp16
@@ -48,15 +48,15 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
         return 1.6e-2, 1.6e-2
 
 
-@FusedAddRmsNormFixture
-def test_fused_add_rmsnorm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
-    test = FusedAddRmsNormTest(m, n, dtype)
+@FusedAddRMSNormFixture
+def test_fused_add_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
+    test = FusedAddRMSNormTest(m, n, dtype)
     op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
-class FusedAddRmsNormNonContigFixture(FixtureBase):
+class FusedAddRMSNormNonContigFixture(FixtureBase):
     PARAMS = [
         ("m, n, dtype", [
             pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
@@ -65,8 +65,8 @@ class FusedAddRmsNormNonContigFixture(FixtureBase):
     ]
 
 
-@FusedAddRmsNormNonContigFixture
-def test_fused_add_rmsnorm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
+@FusedAddRMSNormNonContigFixture
+def test_fused_add_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     """Test with non-contiguous input (sliced tensor)."""
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     r_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
@@ -77,7 +77,7 @@ def test_fused_add_rmsnorm_non_contiguous(m: int, n: int, dtype: torch.dtype) ->
     op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype)
 
     # Reference on contiguous copies
-    test = FusedAddRmsNormTest(m, n, dtype)
+    test = FusedAddRMSNormTest(m, n, dtype)
     y_ref, add_ref = test.ref_program(x.contiguous(), residual.contiguous(), weight)
 
     y, residual_out = op(x, residual, weight)
@@ -88,7 +88,7 @@ def test_fused_add_rmsnorm_non_contiguous(m: int, n: int, dtype: torch.dtype) ->
         f"Non-contiguous residual_out test failed, max err: {(residual_out - add_ref).abs().max()}"
 
 
-class FusedAddRmsNorm3DFixture(FixtureBase):
+class FusedAddRMSNorm3DFixture(FixtureBase):
     PARAMS = [
         ("batch, seq, hidden, dtype", [
             pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
@@ -97,8 +97,8 @@ class FusedAddRmsNorm3DFixture(FixtureBase):
     ]
 
 
-@FusedAddRmsNorm3DFixture
-def test_fused_add_rmsnorm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
+@FusedAddRMSNorm3DFixture
+def test_fused_add_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
     """Test with 3D input (batch, seq, hidden)."""
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     residual = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
@@ -107,7 +107,7 @@ def test_fused_add_rmsnorm_3d(batch: int, seq: int, hidden: int, dtype: torch.dt
     M = batch * seq
     op = FusedAddRMSNormFwdOp(M=M, N=hidden, dtype=dtype)
 
-    test = FusedAddRmsNormTest(M, hidden, dtype)
+    test = FusedAddRMSNormTest(M, hidden, dtype)
     y_ref, add_ref = test.ref_program(x, residual, weight)
 
     y, residual_out = op(x, residual, weight)

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -3,23 +3,23 @@ import torch
 
 from tests.test_base import TestBase, allclose_compare
 from tileops.ops.da_cumsum import DaCumsumFwdOp
-from tileops.ops.ssd_chunk_scan import SsdChunkScanFwdOp
-from tileops.ops.ssd_chunk_state import SsdChunkStateFwdOp
-from tileops.ops.ssd_decode import SsdDecodeOp
-from tileops.ops.ssd_state_passing import SsdStatePassingFwdOp
+from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
+from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
+from tileops.ops.ssd_decode import SSDDecodeOp
+from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
 from workloads.mamba import (
     DaCumsumFwdFixture,
-    SsdChunkScanFwdFixture,
-    SsdChunkStateFwdFixture,
-    SsdDecodeFixture,
-    SsdStatePassingFwdFixture,
+    SSDChunkScanFwdFixture,
+    SSDChunkStateFwdFixture,
+    SSDDecodeFixture,
+    SSDStatePassingFwdFixture,
 )
 from workloads.mamba import DaCumsumFwdTest as _DaCumsumFwdTestWorkload
-from workloads.mamba import SsdChunkScanFwdTest as _SsdChunkScanFwdTestWorkload
-from workloads.mamba import SsdChunkStateFwdTest as _SsdChunkStateFwdTestWorkload
-from workloads.mamba import SsdDecodeTest as _SsdDecodeTestWorkload
+from workloads.mamba import SSDChunkScanFwdTest as _SSDChunkScanFwdTestWorkload
+from workloads.mamba import SSDChunkStateFwdTest as _SSDChunkStateFwdTestWorkload
+from workloads.mamba import SSDDecodeTest as _SSDDecodeTestWorkload
 from workloads.mamba import (
-    SsdStatePassingFwdTest as _SsdStatePassingFwdTestWorkload,
+    SSDStatePassingFwdTest as _SSDStatePassingFwdTestWorkload,
 )
 
 
@@ -77,15 +77,15 @@ def ssd_chunk_scan_fwd_torch(x, cb, dA_cumsum, C, prev_states, dt):
     return y_off + y_diag
 
 
-class SsdChunkScanFwdTest(_SsdChunkScanFwdTestWorkload, TestBase):
+class SSDChunkScanFwdTest(_SSDChunkScanFwdTestWorkload, TestBase):
     def ref_program(self, x, cb, dA_cumsum, C, prev_states, dt):
         return ssd_chunk_scan_fwd_torch(x, cb, dA_cumsum, C, prev_states, dt)
 
 
-@SsdChunkScanFwdFixture
+@SSDChunkScanFwdFixture
 def test_ssd_chunk_scan_fwd(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune):
-    test = SsdChunkScanFwdTest(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype)
-    op = SsdChunkScanFwdOp(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune=tune)
+    test = SSDChunkScanFwdTest(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype)
+    op = SSDChunkScanFwdOp(batch, num_chunks, chunk_len, n_heads, d_head, d_state, dtype, tune=tune)
     inputs = test.gen_inputs()
     atol = 1e-3 if dtype == torch.float16 else 2e-3
     rtol = 1e-5
@@ -129,19 +129,19 @@ def ssd_chunk_state_fwd_ref(
     return out.permute(0, 1, 2, 4, 3)
 
 
-class SsdChunkStateFwdTest(_SsdChunkStateFwdTestWorkload, TestBase):
+class SSDChunkStateFwdTest(_SSDChunkStateFwdTestWorkload, TestBase):
     def ref_program(self, x, Bmat, dt, dA_cumsum, seq_idx):
         return ssd_chunk_state_fwd_ref(x, Bmat, dt, dA_cumsum, self.n_groups, seq_idx=seq_idx)
 
 
-@SsdChunkStateFwdFixture
+@SSDChunkStateFwdFixture
 def test_ssd_chunk_state_fwd(
     batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune, has_seq_idx,
 ):
-    test = SsdChunkStateFwdTest(
+    test = SSDChunkStateFwdTest(
         batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, has_seq_idx,
     )
-    op = SsdChunkStateFwdOp(
+    op = SSDChunkStateFwdOp(
         batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype,
         has_seq_idx=has_seq_idx, tune=tune,
     )
@@ -170,15 +170,15 @@ def ssd_state_passing_fwd_ref(
     return torch.stack(out, dim=1), s
 
 
-class SsdStatePassingFwdTest(_SsdStatePassingFwdTestWorkload, TestBase):
+class SSDStatePassingFwdTest(_SSDStatePassingFwdTestWorkload, TestBase):
     def ref_program(self, states, dA_chunk_cumsum, initial_states):
         return ssd_state_passing_fwd_ref(states, dA_chunk_cumsum, initial_states)
 
 
-@SsdStatePassingFwdFixture
+@SSDStatePassingFwdFixture
 def test_ssd_state_passing_fwd(batch, num_chunks, n_heads, d_state, dtype, tune):
-    test = SsdStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
-    op = SsdStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
+    test = SSDStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
+    op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
     inputs = test.gen_inputs()
     atol = 1e-3 if dtype == torch.float16 else 1.6e-2
     rtol = 1e-3
@@ -217,15 +217,15 @@ def ssd_decode_ref(
     return y_out
 
 
-class SsdDecodeTest(_SsdDecodeTestWorkload, TestBase):
+class SSDDecodeTest(_SSDDecodeTestWorkload, TestBase):
     def ref_program(self, A, dt, x, B_in, C_in, state):
         return ssd_decode_ref(A, dt, x, B_in, C_in, state)
 
 
-@SsdDecodeFixture
+@SSDDecodeFixture
 def test_ssd_decode(batch, n_heads, d_head, d_state, n_groups, dtype, tune):
-    test = SsdDecodeTest(batch, n_heads, d_head, d_state, n_groups, dtype)
-    op = SsdDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
+    test = SSDDecodeTest(batch, n_heads, d_head, d_state, n_groups, dtype)
+    op = SSDDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
     A, dt, x, B_in, C_in, state = test.gen_inputs()
 
     # Run reference on a clone of state so the two runs start from the same point.

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -3,17 +3,17 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
-from workloads.rms_norm import RmsNormTest as _RmsNormTestWorkload
+from workloads.rms_norm import RMSNormTest as _RMSNormTestWorkload
 
 
-class RmsNormTest(_RmsNormTestWorkload, TestBase):
+class RMSNormTest(_RMSNormTestWorkload, TestBase):
     def ref_program(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         x_f32 = x.float()
         rms = torch.sqrt(x_f32.pow(2).mean(dim=-1, keepdim=True) + self.eps)
         return ((x_f32 / rms) * weight.float()).to(x.dtype)
 
 
-class RmsNormFixture(FixtureBase):
+class RMSNormFixture(FixtureBase):
     PARAMS = [
         ("m, n, dtype, tune", [
             # Standard aligned shapes (AC required)
@@ -35,16 +35,16 @@ class RmsNormFixture(FixtureBase):
     ]
 
 
-@RmsNormFixture
+@RMSNormFixture
 def test_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
-    test = RmsNormTest(m, n, dtype)
+    test = RMSNormTest(m, n, dtype)
     op = RMSNormFwdOp(M=m, N=n, dtype=dtype)
     atol = 1e-2 if dtype == torch.float16 else 1.6e-2
     rtol = atol
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
-class RmsNormNonContigFixture(FixtureBase):
+class RMSNormNonContigFixture(FixtureBase):
     PARAMS = [
         ("m, n, dtype", [
             pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
@@ -53,7 +53,7 @@ class RmsNormNonContigFixture(FixtureBase):
     ]
 
 
-@RmsNormNonContigFixture
+@RMSNormNonContigFixture
 def test_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     """Test with non-contiguous input (sliced tensor)."""
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
@@ -75,7 +75,7 @@ def test_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
         f"Non-contiguous test failed, max err: {(y - y_ref).abs().max()}"
 
 
-class RmsNorm3DFixture(FixtureBase):
+class RMSNorm3DFixture(FixtureBase):
     PARAMS = [
         ("batch, seq, hidden, dtype", [
             pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
@@ -84,7 +84,7 @@ class RmsNorm3DFixture(FixtureBase):
     ]
 
 
-@RmsNorm3DFixture
+@RMSNorm3DFixture
 def test_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> None:
     """Test with 3D input (batch, seq, hidden)."""
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -49,7 +49,7 @@ from .norm import (
     BatchNormFwdTrainKernel,
     GroupNormKernel,
     LayerNormKernel,
-    RmsNormKernel,
+    RMSNormKernel,
 )
 from .pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
 from .rope import (
@@ -116,7 +116,7 @@ __all__ = [
     "NSACmpFwdVarlenKernel",
     "NSAFwdVarlenKernel",
     "NSATopkVarlenKernel",
-    "RmsNormKernel",
+    "RMSNormKernel",
     "RopeLlama31Kernel",
     "RopeLongRopeKernel",
     "RopeNeoxKernel",

--- a/tileops/kernels/mamba/__init__.py
+++ b/tileops/kernels/mamba/__init__.py
@@ -1,13 +1,13 @@
 from .da_cumsum import DaCumsumFwdKernel
-from .ssd_chunk_scan import SsdChunkScanFwdKernel
-from .ssd_chunk_state import SsdChunkStateFwdKernel
-from .ssd_decode import SsdDecodeKernel
-from .ssd_state_passing import SsdStatePassingFwdKernel
+from .ssd_chunk_scan import SSDChunkScanFwdKernel
+from .ssd_chunk_state import SSDChunkStateFwdKernel
+from .ssd_decode import SSDDecodeKernel
+from .ssd_state_passing import SSDStatePassingFwdKernel
 
 __all__ = [
     "DaCumsumFwdKernel",
-    "SsdChunkScanFwdKernel",
-    "SsdChunkStateFwdKernel",
-    "SsdDecodeKernel",
-    "SsdStatePassingFwdKernel",
+    "SSDChunkScanFwdKernel",
+    "SSDChunkStateFwdKernel",
+    "SSDDecodeKernel",
+    "SSDStatePassingFwdKernel",
 ]

--- a/tileops/kernels/mamba/da_cumsum.py
+++ b/tileops/kernels/mamba/da_cumsum.py
@@ -3,7 +3,7 @@ Mamba-2 dA_cumsum forward kernel.
 
 Inputs:
   dt:       (batch, seq_len, n_heads)                  -- per-position discretization factor (float32)
-  A:        (n_heads,)                                  -- SSM decay parameter (float32)
+  A:        (n_heads,)                                  -- State Space Model (SSM) decay parameter (float32)
 
 Output:
   dA_cumsum: (batch, n_heads, num_chunks, chunk_len)   -- float32

--- a/tileops/kernels/mamba/ssd_chunk_scan.py
+++ b/tileops/kernels/mamba/ssd_chunk_scan.py
@@ -1,5 +1,5 @@
 """
-Mamba-2 SSD fused chunk output forward kernel (history + intra-chunk paths).
+Mamba-2 State-Space Dual (SSD) fused chunk output forward kernel (history + intra-chunk paths).
 
 Inputs (pre-reshaped to chunked view):
   x:            (batch, num_chunks, chunk_len, n_heads, d_head)
@@ -58,7 +58,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["SsdChunkScanFwdKernel"]
+__all__ = ["SSDChunkScanFwdKernel"]
 
 
 def _ssd_chunk_scan_fwd_kernel(
@@ -309,7 +309,7 @@ def _(
     return x.new_empty((batch, num_chunks, chunk_len, n_heads, d_head), dtype=torch.float32)
 
 
-class SsdChunkScanFwdKernel(Kernel):
+class SSDChunkScanFwdKernel(Kernel):
     """Mamba-2 SSD fused chunk output forward kernel.
 
     Fuses the history (prev_states) contribution and intra-chunk causal decay

--- a/tileops/kernels/mamba/ssd_chunk_state.py
+++ b/tileops/kernels/mamba/ssd_chunk_state.py
@@ -1,11 +1,11 @@
 """
-Mamba-2 SSD chunk state forward kernel.
+Mamba-2 State-Space Dual (SSD) chunk state forward kernel.
 
 Inputs (pre-reshaped to chunked view):
   x:          (batch, seq_len, n_heads, d_head)
               -- input features, seq_len = num_chunks * chunk_len
   Bmat:       (batch, seq_len, n_groups, d_state)
-              -- SSM B matrix, grouped over heads
+              -- State Space Model (SSM) B matrix, grouped over heads
   dt:         (batch, n_heads, num_chunks, chunk_len)
               -- per-position discretization factor (float32)
   dA_cumsum:  (batch, n_heads, num_chunks, chunk_len)
@@ -56,7 +56,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["SsdChunkStateFwdKernel"]
+__all__ = ["SSDChunkStateFwdKernel"]
 
 
 def _ssd_chunk_state_fwd_kernel(
@@ -280,7 +280,7 @@ def _(
     return x.new_empty((batch, num_chunks, n_heads, d_head, d_state), dtype=torch.float32)
 
 
-class SsdChunkStateFwdKernel(Kernel):
+class SSDChunkStateFwdKernel(Kernel):
     """Mamba-2 SSD chunk state forward kernel.
 
     Computes the chunk-end SSM state for each chunk:

--- a/tileops/kernels/mamba/ssd_decode.py
+++ b/tileops/kernels/mamba/ssd_decode.py
@@ -1,7 +1,7 @@
 """
-Mamba-2 SSD recurrent decode (step) kernel.
+Mamba-2 State-Space Dual (SSD) recurrent decode (step) kernel.
 
-Performs a single decode step of the Mamba-2 SSM core, updating the
+Performs a single decode step of the Mamba-2 State Space Model (SSM) core, updating the
 persistent state in-place and computing the output y for the current token.
 
 This corresponds to the step() path in the official Mamba-2 implementation:
@@ -46,7 +46,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["SsdDecodeKernel"]
+__all__ = ["SSDDecodeKernel"]
 
 # =============================================================================
 # Differences vs. the official Mamba-2 step() in mamba_ssm/modules/mamba2.py
@@ -277,7 +277,7 @@ def _(
     return dt.new_empty((batch, n_heads, d_head), dtype=torch.float32)
 
 
-class SsdDecodeKernel(Kernel):
+class SSDDecodeKernel(Kernel):
     """Mamba-2 SSD recurrent decode (step) kernel.
 
     Performs a single decode step: updates the SSM state in-place and

--- a/tileops/kernels/mamba/ssd_state_passing.py
+++ b/tileops/kernels/mamba/ssd_state_passing.py
@@ -1,9 +1,9 @@
 """
-Mamba-2 SSD state passing forward kernel.
+Mamba-2 State-Space Dual (SSD) state passing forward kernel.
 
 Inputs:
   states:            (batch, num_chunks, n_heads, d_state)
-                     -- chunk-local SSM states u_c
+                     -- chunk-local State Space Model (SSM) states u_c
   dA_chunk_cumsum:   (batch, n_heads, num_chunks)
                      -- per-chunk cumulative decay scalar (float32)
   initial_states:    (batch, n_heads, d_state)
@@ -43,7 +43,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["SsdStatePassingFwdKernel"]
+__all__ = ["SSDStatePassingFwdKernel"]
 
 
 def _ssd_state_passing_fwd_kernel(
@@ -189,7 +189,7 @@ def _(
     return out, final
 
 
-class SsdStatePassingFwdKernel(Kernel):
+class SSDStatePassingFwdKernel(Kernel):
     """Mamba-2 SSD state passing forward kernel.
 
     Performs the inter-chunk recurrent scan:

--- a/tileops/kernels/norm/__init__.py
+++ b/tileops/kernels/norm/__init__.py
@@ -1,9 +1,9 @@
 from .ada_layer_norm import AdaLayerNormKernel
 from .batch_norm import BatchNormBwdKernel, BatchNormFwdInferKernel, BatchNormFwdTrainKernel
-from .fused_add_norm import FusedAddLayerNormKernel, FusedAddRmsNormKernel
+from .fused_add_norm import FusedAddLayerNormKernel, FusedAddRMSNormKernel
 from .group_norm import GroupNormKernel
 from .layer_norm import LayerNormKernel
-from .rms_norm import RmsNormKernel
+from .rms_norm import RMSNormKernel
 
 __all__: list[str] = [
     "AdaLayerNormKernel",
@@ -11,8 +11,8 @@ __all__: list[str] = [
     "BatchNormFwdInferKernel",
     "BatchNormFwdTrainKernel",
     "FusedAddLayerNormKernel",
-    "FusedAddRmsNormKernel",
+    "FusedAddRMSNormKernel",
     "GroupNormKernel",
     "LayerNormKernel",
-    "RmsNormKernel",
+    "RMSNormKernel",
 ]

--- a/tileops/kernels/norm/fused_add_norm.py
+++ b/tileops/kernels/norm/fused_add_norm.py
@@ -1,7 +1,7 @@
 """Fused Add + Norm forward kernels using TileLang.
 
 FusedAddLayerNorm: y = LayerNorm(x + residual), also outputs (x + residual)
-FusedAddRmsNorm:   y = RmsNorm(x + residual),   also outputs (x + residual)
+FusedAddRMSNorm:   y = RMSNorm(x + residual),   also outputs (x + residual)
 
 Fusing the residual add into the normalization kernel eliminates one global
 memory round-trip compared to separate add + norm.  Both kernels return dual
@@ -22,7 +22,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["FusedAddLayerNormKernel", "FusedAddRmsNormKernel"]
+__all__ = ["FusedAddLayerNormKernel", "FusedAddRMSNormKernel"]
 
 ALIGNMENT = 256
 
@@ -223,7 +223,7 @@ class FusedAddLayerNormKernel(Kernel):
 
 
 # ---------------------------------------------------------------------------
-# Fused Add + RmsNorm kernel
+# Fused Add + RMSNorm kernel
 # ---------------------------------------------------------------------------
 
 @functools.lru_cache(maxsize=32)
@@ -324,10 +324,10 @@ def _(M, N, eps, dtype_str, block_m, threads, x, residual, weight):
     return [y, residual_out]
 
 
-class FusedAddRmsNormKernel(Kernel):
-    """Fused Add + RmsNorm forward kernel.
+class FusedAddRMSNormKernel(Kernel):
+    """Fused Add + RMSNorm forward kernel.
 
-    Computes ``y = RmsNorm(x + residual)`` and returns both ``y`` and
+    Computes ``y = RMSNorm(x + residual)`` and returns both ``y`` and
     ``x + residual``.  The residual add is fused into the first load pass
     to save one global memory round-trip.
 

--- a/tileops/kernels/norm/rms_norm.py
+++ b/tileops/kernels/norm/rms_norm.py
@@ -17,7 +17,7 @@ import torch
 
 from tileops.kernels.kernel import Kernel
 
-__all__ = ["RmsNormKernel"]
+__all__ = ["RMSNormKernel"]
 
 ALIGNMENT = 256
 
@@ -98,7 +98,7 @@ def _(M, N, eps, dtype_str, block_m, threads, x, weight):
     return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
 
 
-class RmsNormKernel(Kernel):
+class RMSNormKernel(Kernel):
     """RMS Norm kernel.
 
     Supports SM80+ architectures. Uses 256-element alignment (512 bytes for

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -82,10 +82,10 @@ from .rope import (
     RopeNonNeoxOp,
     RopeYarnOp,
 )
-from .ssd_chunk_scan import SsdChunkScanFwdOp
-from .ssd_chunk_state import SsdChunkStateFwdOp
-from .ssd_decode import SsdDecodeOp
-from .ssd_state_passing import SsdStatePassingFwdOp
+from .ssd_chunk_scan import SSDChunkScanFwdOp
+from .ssd_chunk_state import SSDChunkStateFwdOp
+from .ssd_decode import SSDDecodeOp
+from .ssd_state_passing import SSDStatePassingFwdOp
 from .topk_selector import TopkSelectorOp
 
 __all__ = [
@@ -146,10 +146,10 @@ __all__ = [
     "Op",
     "MoePermuteAlignFwdOp",
     "RMSNormFwdOp",
-    "SsdChunkScanFwdOp",
-    "SsdChunkStateFwdOp",
-    "SsdDecodeOp",
-    "SsdStatePassingFwdOp",
+    "SSDChunkScanFwdOp",
+    "SSDChunkStateFwdOp",
+    "SSDDecodeOp",
+    "SSDStatePassingFwdOp",
     "RopeLlama31Op",
     "RopeLongRopeOp",
     "RopeNeoxOp",

--- a/tileops/ops/norm/__init__.py
+++ b/tileops/ops/norm/__init__.py
@@ -3,7 +3,7 @@ from .ada_layer_norm_zero import AdaLayerNormZeroFwdOp
 from .base import RowNormOp
 from .batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from .fused_add_layer_norm import FusedAddLayerNormFwdOp
-from .fused_add_rmsnorm import FusedAddRMSNormFwdOp
+from .fused_add_rms_norm import FusedAddRMSNormFwdOp
 from .group_norm import GroupNormFwdOp
 from .instance_norm import InstanceNormFwdOp
 from .layer_norm import LayerNormFwdOp

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.norm import FusedAddRmsNormKernel
+from tileops.kernels.norm import FusedAddRMSNormKernel
 
 from ..op import Op
 
@@ -71,7 +71,7 @@ class FusedAddRMSNormFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"fused_add_rms_norm": FusedAddRmsNormKernel}
+        return {"fused_add_rms_norm": FusedAddRMSNormKernel}
 
     def forward(
         self,

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -1,6 +1,6 @@
 import torch
 
-from tileops.kernels.norm import RmsNormKernel
+from tileops.kernels.norm import RMSNormKernel
 
 from .base import RowNormOp
 
@@ -14,7 +14,7 @@ class RMSNormFwdOp(RowNormOp):
     """
 
     _kernel_key = "rms_norm"
-    _kernel_cls = RmsNormKernel
+    _kernel_cls = RMSNormKernel
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         self._validate_cuda_dtype("x", x)

--- a/tileops/ops/ssd_chunk_scan.py
+++ b/tileops/ops/ssd_chunk_scan.py
@@ -3,15 +3,15 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.mamba import SsdChunkScanFwdKernel
+from tileops.kernels.mamba import SSDChunkScanFwdKernel
 
 from .op import Op
 
-__all__ = ["SsdChunkScanFwdOp"]
+__all__ = ["SSDChunkScanFwdOp"]
 
 
-class SsdChunkScanFwdOp(Op):
-    """Mamba-2 SSD fused chunk output operator.
+class SSDChunkScanFwdOp(Op):
+    """Mamba-2 State-Space Dual (SSD) fused chunk output operator.
 
     Fuses the history (prev_states) contribution and intra-chunk causal decay
     into a single pass, computing:
@@ -25,7 +25,7 @@ class SsdChunkScanFwdOp(Op):
         chunk_len:  Tokens per chunk.
         n_heads:    Number of heads.
         d_head:     Head dimension.
-        d_state:    SSM state dimension.
+        d_state:    State Space Model (SSM) state dimension.
         dtype:      Data type for inputs (float16 or bfloat16).
         tune:       Whether to autotune tile config on construction.
     """
@@ -56,7 +56,7 @@ class SsdChunkScanFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"ssd_chunk_scan_fwd": SsdChunkScanFwdKernel}
+        return {"ssd_chunk_scan_fwd": SSDChunkScanFwdKernel}
 
     def forward(
         self,

--- a/tileops/ops/ssd_chunk_state.py
+++ b/tileops/ops/ssd_chunk_state.py
@@ -3,17 +3,17 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.mamba import SsdChunkStateFwdKernel
+from tileops.kernels.mamba import SSDChunkStateFwdKernel
 
 from .op import Op
 
-__all__ = ["SsdChunkStateFwdOp"]
+__all__ = ["SSDChunkStateFwdOp"]
 
 
-class SsdChunkStateFwdOp(Op):
-    """Mamba-2 SSD chunk state forward operator.
+class SSDChunkStateFwdOp(Op):
+    """Mamba-2 State-Space Dual (SSD) chunk state forward operator.
 
-    Computes the chunk-end SSM state for each chunk:
+    Computes the chunk-end State Space Model (SSM) state for each chunk:
 
       out[b, c, h, p, n] =
           sum_{l=0}^{Q-1}
@@ -67,7 +67,7 @@ class SsdChunkStateFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"ssd_chunk_state_fwd": SsdChunkStateFwdKernel}
+        return {"ssd_chunk_state_fwd": SSDChunkStateFwdKernel}
 
     def forward(
         self,

--- a/tileops/ops/ssd_decode.py
+++ b/tileops/ops/ssd_decode.py
@@ -3,17 +3,17 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.mamba import SsdDecodeKernel
+from tileops.kernels.mamba import SSDDecodeKernel
 
 from .op import Op
 
-__all__ = ["SsdDecodeOp"]
+__all__ = ["SSDDecodeOp"]
 
 
-class SsdDecodeOp(Op):
-    """Mamba-2 SSD recurrent decode (step) operator.
+class SSDDecodeOp(Op):
+    """Mamba-2 State-Space Dual (SSD) recurrent decode (step) operator.
 
-    Performs a single decode step of the Mamba-2 SSM core: updates the
+    Performs a single decode step of the Mamba-2 State Space Model (SSM) core: updates the
     recurrent state in-place and returns the output y for the current token:
 
       dA[b, h]         = exp(dt[b, h] * A[h])
@@ -63,7 +63,7 @@ class SsdDecodeOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"ssd_decode": SsdDecodeKernel}
+        return {"ssd_decode": SSDDecodeKernel}
 
     def forward(
         self,

--- a/tileops/ops/ssd_state_passing.py
+++ b/tileops/ops/ssd_state_passing.py
@@ -3,15 +3,15 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel import Kernel
-from tileops.kernels.mamba import SsdStatePassingFwdKernel
+from tileops.kernels.mamba import SSDStatePassingFwdKernel
 
 from .op import Op
 
-__all__ = ["SsdStatePassingFwdOp"]
+__all__ = ["SSDStatePassingFwdOp"]
 
 
-class SsdStatePassingFwdOp(Op):
-    """Mamba-2 SSD state passing forward operator.
+class SSDStatePassingFwdOp(Op):
+    """Mamba-2 State-Space Dual (SSD) state passing forward operator.
 
     Performs the inter-chunk recurrent scan:
 
@@ -23,7 +23,7 @@ class SsdStatePassingFwdOp(Op):
         batch:              Batch size.
         num_chunks:         Number of chunks (seq_len / chunk_len).
         n_heads:            Number of heads.
-        d_state:            SSM state dimension.
+        d_state:            State Space Model (SSM) state dimension.
         has_initial_states: Whether to use initial_states as s_{-1}.
         dtype:              Data type for inputs (float16 or bfloat16).
         tune:               Whether to autotune tile config on construction.
@@ -54,7 +54,7 @@ class SsdStatePassingFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"ssd_state_passing_fwd": SsdStatePassingFwdKernel}
+        return {"ssd_state_passing_fwd": SSDStatePassingFwdKernel}
 
     def forward(
         self,

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -311,10 +311,10 @@ ops:
     source:
       kernel: tileops/kernels/norm/fused_add_norm.py
       kernel_map:
-        fused_add_rms_norm: FusedAddRmsNormKernel
-      op: tileops/ops/norm/fused_add_rmsnorm.py
-      test: tests/ops/test_fused_add_rmsnorm.py
-      bench: benchmarks/ops/bench_fused_add_rmsnorm.py
+        fused_add_rms_norm: FusedAddRMSNormKernel
+      op: tileops/ops/norm/fused_add_rms_norm.py
+      test: tests/ops/test_fused_add_rms_norm.py
+      bench: benchmarks/ops/bench_fused_add_rms_norm.py
 
   # ---------------------------------------------------------------------------
   # norm — spatial-norm ops (operate over spatial/channel dims, shape: [N, C, *spatial])

--- a/workloads/fused_add_rms_norm.py
+++ b/workloads/fused_add_rms_norm.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class FusedAddRmsNormTest(WorkloadBase):
+class FusedAddRMSNormTest(WorkloadBase):
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, eps: float = 1e-6):
         self.m = m

--- a/workloads/mamba.py
+++ b/workloads/mamba.py
@@ -38,7 +38,7 @@ class DaCumsumFwdTest(WorkloadBase):
         return dt, A
 
 
-class SsdChunkScanFwdFixture(FixtureBase):
+class SSDChunkScanFwdFixture(FixtureBase):
     @classmethod
     def get_params(cls):
         import pytest
@@ -51,7 +51,7 @@ class SsdChunkScanFwdFixture(FixtureBase):
             ]),
         ]
 
-class SsdChunkScanFwdTest(WorkloadBase):
+class SSDChunkScanFwdTest(WorkloadBase):
     def __init__(
         self,
         batch: int,
@@ -85,7 +85,7 @@ class SsdChunkScanFwdTest(WorkloadBase):
         dt = torch.rand(b, c, L, h, dtype=self.dtype, device="cuda") * 0.1 + 0.01
         return x, cb, dA_cumsum, C, prev_states, dt
 
-class SsdChunkStateFwdFixture(FixtureBase):
+class SSDChunkStateFwdFixture(FixtureBase):
     @classmethod
     def get_params(cls):
         import pytest
@@ -109,7 +109,7 @@ class SsdChunkStateFwdFixture(FixtureBase):
             ]),
         ]
 
-class SsdChunkStateFwdTest(WorkloadBase):
+class SSDChunkStateFwdTest(WorkloadBase):
     def __init__(
         self,
         batch: int,
@@ -150,7 +150,7 @@ class SsdChunkStateFwdTest(WorkloadBase):
             seq_idx[:, seq_len // 2:] = 1
         return x, Bmat, dt, dA_cumsum, seq_idx
 
-class SsdDecodeFixture(FixtureBase):
+class SSDDecodeFixture(FixtureBase):
     @classmethod
     def get_params(cls):
         import pytest
@@ -171,7 +171,7 @@ class SsdDecodeFixture(FixtureBase):
             ]),
         ]
 
-class SsdDecodeTest(WorkloadBase):
+class SSDDecodeTest(WorkloadBase):
     def __init__(
         self,
         batch: int,
@@ -201,7 +201,7 @@ class SsdDecodeTest(WorkloadBase):
         state = torch.randn(b, h, p, n, dtype=torch.float32, device="cuda") * 0.1
         return A, dt, x, B_in, C_in, state
 
-class SsdStatePassingFwdFixture(FixtureBase):
+class SSDStatePassingFwdFixture(FixtureBase):
     @classmethod
     def get_params(cls):
         import pytest
@@ -214,7 +214,7 @@ class SsdStatePassingFwdFixture(FixtureBase):
             ]),
         ]
 
-class SsdStatePassingFwdTest(WorkloadBase):
+class SSDStatePassingFwdTest(WorkloadBase):
     def __init__(
         self,
         batch: int,

--- a/workloads/rms_norm.py
+++ b/workloads/rms_norm.py
@@ -3,7 +3,7 @@ import torch
 from workloads.base import WorkloadBase
 
 
-class RmsNormTest(WorkloadBase):
+class RMSNormTest(WorkloadBase):
 
     def __init__(self, m: int, n: int, dtype: torch.dtype, eps: float = 1e-6):
         self.m = m


### PR DESCRIPTION
## Summary

- Rename `fused_add_rmsnorm` → `fused_add_rms_norm` (op, test, bench, workload files + manifest paths) for consistency with `rms_norm`, `layer_norm`, `batch_norm`
- Standardize abbreviation casing in PascalCase symbols: `Rms` → `RMS` (14 classes), `Ssd` → `SSD` (16 classes)
- Expand abbreviations on first use in docstrings: SSM → State Space Model (SSM), SSD → State-Space Dual (SSD)
- Add naming conventions to `.claude/rules/code-style.md`

## Test plan

- [x] `pytest tests/ops/test_fused_add_rms_norm.py` — 14 passed
- [x] `pytest tests/ops/test_rms_norm.py` — 23 passed
- [x] `pytest tests/ops/test_mamba.py` — 14 passed
- [x] `pytest tests/test_validate_manifest.py` — 87 passed (manifest paths updated)
- [x] Pre-commit lint clean

## Follow-up

No follow-up issues or suggestions.