### PR TITLE
[Doc] Fix stale kernel path in manifest.md example

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -244,7 +244,7 @@ source:
 # Multi-kernel op
 source:
   kernel:
-    - tileops/kernels/flash_attn/bwd.py
+    - tileops/kernels/attention/gqa_bwd.py
   kernel_map:
     mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
     mha_bwd_kernel: MhaBwdKernel


### PR DESCRIPTION
## Summary

Update the stale path reference in `docs/manifest.md` so the multi-kernel example points to the correct post-#928 location (`tileops/kernels/attention/gqa_bwd.py` instead of the old `tileops/kernels/flash_attn/bwd.py`).

Closes #929

## Test plan

- [x] **AC-1**: `docs/manifest.md` example uses correct post-#928 kernel paths
  - Evidence: `grep -n gqa_bwd docs/manifest.md` confirms line 247 references `tileops/kernels/attention/gqa_bwd.py`; file exists on disk with all three kernel_map classes verified present.
- [x] **AC-2**: No other stale `kernels/flash_attn`, `kernels/flash_decode`, `kernels/deepseek_mla`, `kernels/deepseek_nsa`, or `kernels/conv/` references remain in `docs/`
  - Evidence: `grep -rn` across `docs/` returned no matches for any stale path pattern.