### PR TITLE
[Test][TOOLING] enforce hard tier validation rules for smoke/full

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,28 @@ NON_RUNTIME_OPS_TIER_FILES = {
     "tests/ops/test_elementwise_config_dtype.py",
 }
 
+def _get_callspec_params(item: pytest.Item) -> dict | None:
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return None
+    return getattr(callspec, "params", None)
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, dict):
+        return tuple(sorted((key, _freeze_value(val)) for key, val in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set):
+        return tuple(sorted(_freeze_value(item) for item in value))
+    return value
+
+
+def _without_dtype(params: dict) -> tuple[tuple[str, object], ...]:
+    return tuple(
+        sorted((key, _freeze_value(value)) for key, value in params.items() if key != "dtype")
+    )
+
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Validate explicit test tier assignments."""
@@ -78,14 +100,52 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                         f"as the first {len(valid_smoke_items)} non-xfail cases of each test"
                     )
 
+        dtype_supported: set[object] = set()
+        dtype_smoke: set[object] = set()
+        smoke_signatures: set[tuple[tuple[str, object], ...]] = set()
+        dtype_cases_present = False
+
+        for item in non_xfail_items:
+            params = _get_callspec_params(item)
+            if not params or "dtype" not in params:
+                continue
+
+            dtype_cases_present = True
+            dtype_supported.add(params["dtype"])
+
+            if item.get_closest_marker("smoke") is not None:
+                dtype_smoke.add(params["dtype"])
+                smoke_signatures.add(_without_dtype(params))
+
+        if dtype_cases_present:
+            missing_smoke_dtypes = dtype_supported - dtype_smoke
+            if missing_smoke_dtypes:
+                tier_errors.append(
+                    f"{non_xfail_items[0].nodeid}: each dtype must have at least one smoke case; "
+                    f"missing smoke for {sorted(str(dtype) for dtype in missing_smoke_dtypes)}"
+                )
+
+            for item in non_xfail_items:
+                if item.get_closest_marker("full") is None:
+                    continue
+
+                params = _get_callspec_params(item)
+                if not params or "dtype" not in params:
+                    continue
+
+                if _without_dtype(params) in smoke_signatures:
+                    tier_errors.append(
+                        f"{item.nodeid}: full cases must not differ from a smoke case only by dtype"
+                    )
+
         first_tuned_item: pytest.Item | None = None
         full_tuned_items: list[pytest.Item] = []
         for item in group:
-            callspec = getattr(item, "callspec", None)
-            if callspec is None or "tune" not in callspec.params:
+            params = _get_callspec_params(item)
+            if params is None or "tune" not in params:
                 continue
 
-            tune = callspec.params["tune"]
+            tune = params["tune"]
             is_smoke = item.get_closest_marker("smoke") is not None
             if is_smoke and tune is True:
                 tier_errors.append(f"{item.nodeid}: smoke cases must use tune=False")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def _freeze_value(value: object) -> object:
     if isinstance(value, (list, tuple)):
         return tuple(_freeze_value(item) for item in value)
     if isinstance(value, set):
-        return tuple(sorted(_freeze_value(item) for item in value))
+        return tuple(sorted((_freeze_value(item) for item in value), key=str))
     return value
 
 

--- a/tests/test_tier_validation.py
+++ b/tests/test_tier_validation.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from tests.conftest import pytest_collection_modifyitems
 
@@ -30,6 +31,7 @@ def _make_item(
     originalname: str = "test_op",
     path: str = "tests/ops/test_foo.py",
     markers: list[str] | None = None,
+    dtype: object | None = None,
     tune: bool | None = None,
 ) -> MagicMock:
     """Build a lightweight mock pytest.Item for tier validation tests."""
@@ -51,6 +53,8 @@ def _make_item(
     item.get_closest_marker = _get_closest_marker
 
     params: dict[str, object] = {}
+    if dtype is not None:
+        params["dtype"] = dtype
     if tune is not None:
         params["tune"] = tune
 
@@ -282,4 +286,112 @@ class TestNonRuntimeOpsFileExemption:
             ),
         ]
 
+# ===================================================================
+# AC-6: Every dtype needs smoke coverage
+# ===================================================================
+
+
+@pytest.mark.smoke
+class TestPerDtypeSmokeCoverage:
+    """Every dtype present in parametrized ops tests must have a smoke case."""
+
+    def test_each_dtype_has_smoke_case(self):
+        items = [
+            _make_item(
+                name="test_op[fp16]",
+                markers=["smoke"],
+                dtype=torch.float16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[bf16]",
+                markers=["smoke"],
+                dtype=torch.bfloat16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[fp32]",
+                markers=["smoke"],
+                dtype=torch.float32,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[fp16-full]",
+                markers=["full"],
+                dtype=torch.float16,
+                tune=True,
+            ),
+        ]
+        pytest_collection_modifyitems(items)
+
+    def test_missing_dtype_smoke_raises(self):
+        items = [
+            _make_item(
+                name="test_op[fp16]",
+                markers=["smoke"],
+                dtype=torch.float16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[bf16]",
+                markers=["full"],
+                dtype=torch.bfloat16,
+                tune=False,
+            ),
+        ]
+        with pytest.raises(pytest.UsageError, match="each dtype must have at least one smoke"):
+            pytest_collection_modifyitems(items)
+
+
+# ===================================================================
+# AC-7: full must not only differ from smoke by dtype
+# ===================================================================
+
+
+@pytest.mark.smoke
+class TestFullNotDtypeOnly:
+    """A full case cannot duplicate a smoke case except for dtype."""
+
+    def test_full_with_same_signature_except_dtype_raises(self):
+        items = [
+            _make_item(
+                name="test_op[fp16]",
+                markers=["smoke"],
+                dtype=torch.float16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[bf16]",
+                markers=["full"],
+                dtype=torch.bfloat16,
+                tune=False,
+            ),
+        ]
+        with pytest.raises(
+            pytest.UsageError,
+            match="must not differ from a smoke case only by dtype",
+        ):
+            pytest_collection_modifyitems(items)
+
+    def test_full_with_distinct_non_dtype_params_passes(self):
+        items = [
+            _make_item(
+                name="test_op[fp16-typical]",
+                markers=["smoke"],
+                dtype=torch.float16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[bf16-typical]",
+                markers=["smoke"],
+                dtype=torch.bfloat16,
+                tune=False,
+            ),
+            _make_item(
+                name="test_op[fp16-tuned]",
+                markers=["full"],
+                dtype=torch.float16,
+                tune=True,
+            ),
+        ]
         pytest_collection_modifyitems(items)

--- a/tests/test_tier_validation.py
+++ b/tests/test_tier_validation.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from tests.conftest import pytest_collection_modifyitems
+from tests.conftest import _freeze_value, pytest_collection_modifyitems
 
 # ---------------------------------------------------------------------------
 # Helpers to build mock pytest.Items
@@ -64,6 +64,15 @@ def _make_item(
         item.callspec = None
 
     return item
+
+
+@pytest.mark.full
+class TestFreezeValue:
+    """Regression coverage for stable signatures built from set values."""
+
+    def test_set_with_non_comparable_values_is_sorted_stably(self):
+        frozen = _freeze_value({torch.float16, None, 1})
+        assert frozen == tuple(sorted((torch.float16, None, 1), key=str))
 
 
 # ===================================================================
@@ -285,6 +294,7 @@ class TestNonRuntimeOpsFileExemption:
                 tune=True,
             ),
         ]
+        pytest_collection_modifyitems(items)
 
 # ===================================================================
 # AC-6: Every dtype needs smoke coverage


### PR DESCRIPTION
## Summary
- enforce hard smoke/full tier validation rules for parametrized tests/ops tests with dtype
- preserve and reuse the existing tune=True validation path in tests/conftest.py
- add focused tier-validation tests for per-dtype smoke coverage and dtype-only full-case rejection

## What This PR Implements
This PR intentionally covers only the mechanically enforceable subset from issue #944:
- every dtype present in a parametrized tests/ops test must have at least one smoke case
- all smoke cases must form a contiguous prefix of non-xfail cases
- all smoke cases must use tune=False when tune exists
- a full case must not differ from an existing smoke case only by dtype
- the first tune=True case remains the unique full tuned case

## Validation
- python -m pytest tests/test_tier_validation.py -q

## Notes
- Full-repo python -m pytest tests --collect-only -q now surfaces many existing label-policy violations in the current tree. That follow-up cleanup belongs to the open issue set around #944, #945, and #946.

Closes #944