### PR TITLE
[Refactor][Benchmark] Add explicit type parameters to BenchmarkBase subclasses

### DIFF
--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_dsa_decode import DsaDecodeTest
 
@@ -57,7 +57,7 @@ class _DsaDecodeTestBaseline(DsaDecodeTest):
         return o.to(torch.float16)
 
 
-class DsaDecodeBenchmark(BenchmarkBase):
+class DsaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_dsa_decode import DsaDecodeTest
 
@@ -57,7 +57,7 @@ class _DsaDecodeTestBaseline(DsaDecodeTest):
         return o.to(torch.float16)
 
 
-class DsaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DsaDecodeBenchmark(BenchmarkBase[_DsaDecodeTestBaseline]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -57,7 +57,7 @@ class _DsaDecodeTestBaseline(DsaDecodeTest):
         return o.to(torch.float16)
 
 
-class DsaDecodeBenchmark(BenchmarkBase[_DsaDecodeTestBaseline]):
+class DsaDecodeBenchmark(BenchmarkBase[DsaDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from einops import einsum, rearrange
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_mla_decode import MlaDecodeTest
 
@@ -57,7 +57,7 @@ class _MlaDecodeTestBaseline(MlaDecodeTest):
         return out
 
 
-class MlaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MlaDecodeBenchmark(BenchmarkBase[MlaDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from einops import einsum, rearrange
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_mla_decode import MlaDecodeTest
 
@@ -57,7 +57,7 @@ class _MlaDecodeTestBaseline(MlaDecodeTest):
         return out
 
 
-class MlaDecodeBenchmark(BenchmarkBase):
+class MlaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import NSAFwdVarlenOp
 from workloads.attention.deepseek_nsa import NsaFwdTest
 
@@ -36,7 +36,7 @@ class _NsaFwdTestBaseline(NsaFwdTest):
         )
 
 
-class NsaFwdBenchmark(BenchmarkBase):
+class NsaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import NSAFwdVarlenOp
 from workloads.attention.deepseek_nsa import NsaFwdTest
 
@@ -36,7 +36,7 @@ class _NsaFwdTestBaseline(NsaFwdTest):
         )
 
 
-class NsaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class NsaFwdBenchmark(BenchmarkBase[NsaFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa_cmp.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa_cmp.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import NSACmpFwdVarlenOp
 from workloads.attention.deepseek_nsa_cmp import NsaCmpFwdTest
 from workloads.nsa_utils import prepare_chunk_offsets
@@ -72,7 +72,7 @@ class _NsaCmpFwdTestBaseline(NsaCmpFwdTest):
                                                       offsets)
 
 
-class NsaCmpFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class NsaCmpFwdBenchmark(BenchmarkBase[NsaCmpFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa_cmp.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa_cmp.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import NSACmpFwdVarlenOp
 from workloads.attention.deepseek_nsa_cmp import NsaCmpFwdTest
 from workloads.nsa_utils import prepare_chunk_offsets
@@ -72,7 +72,7 @@ class _NsaCmpFwdTestBaseline(NsaCmpFwdTest):
                                                       offsets)
 
 
-class NsaCmpFwdBenchmark(BenchmarkBase):
+class NsaCmpFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa_topk.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa_topk.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import NSATopkVarlenOp
 from workloads.attention.deepseek_nsa_topk import NsaTopkTest
 
@@ -145,7 +145,7 @@ class _NsaTopkTestBaseline(NsaTopkTest):
                                 offsets, token_indices, chunk_offsets)
 
 
-class NsaTopkBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class NsaTopkBenchmark(BenchmarkBase[NsaTopkTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_deepseek_nsa_topk.py
+++ b/benchmarks/ops/attention/bench_deepseek_nsa_topk.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import NSATopkVarlenOp
 from workloads.attention.deepseek_nsa_topk import NsaTopkTest
 
@@ -145,7 +145,7 @@ class _NsaTopkTestBaseline(NsaTopkTest):
                                 offsets, token_indices, chunk_offsets)
 
 
-class NsaTopkBenchmark(BenchmarkBase):
+class NsaTopkBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from workloads.attention.gqa import (
     GqaBwdTest,
@@ -12,7 +12,7 @@ from workloads.attention.gqa import (
 )
 
 
-class GqaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaFwdBenchmark(BenchmarkBase[GqaFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -27,7 +27,7 @@ class GqaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
         return 2 * (query_size + kv_size) * t.dtype.itemsize
 
 
-class GqaBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaBwdBenchmark(BenchmarkBase[GqaBwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 from workloads.attention.gqa import (
     GqaBwdTest,
@@ -12,7 +12,7 @@ from workloads.attention.gqa import (
 )
 
 
-class GqaFwdBenchmark(BenchmarkBase):
+class GqaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -27,7 +27,7 @@ class GqaFwdBenchmark(BenchmarkBase):
         return 2 * (query_size + kv_size) * t.dtype.itemsize
 
 
-class GqaBwdBenchmark(BenchmarkBase):
+class GqaBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa_decode import GqaDecodeTest
 
@@ -23,7 +23,7 @@ class _GqaDecodeTestBaseline(GqaDecodeTest):
         return output
 
 
-class GqaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaDecodeBenchmark(BenchmarkBase[GqaDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa_decode import GqaDecodeTest
 
@@ -23,7 +23,7 @@ class _GqaDecodeTestBaseline(GqaDecodeTest):
         return output
 
 
-class GqaDecodeBenchmark(BenchmarkBase):
+class GqaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.gqa_decode_paged import GqaDecodePagedTest
 
@@ -47,7 +47,7 @@ class _GqaDecodePagedTestBaseline(GqaDecodePagedTest):
         return torch.cat(out_list, dim=0)
 
 
-class GqaDecodePagedBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaDecodePagedBenchmark(BenchmarkBase[GqaDecodePagedTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.gqa_decode_paged import GqaDecodePagedTest
 
@@ -47,7 +47,7 @@ class _GqaDecodePagedTestBaseline(GqaDecodePagedTest):
         return torch.cat(out_list, dim=0)
 
 
-class GqaDecodePagedBenchmark(BenchmarkBase):
+class GqaDecodePagedBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -5,12 +5,12 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GqaSlidingWindowFwdOp
 from workloads.attention.gqa_sliding_window import GqaSlidingWindowFwdTest
 
 
-class GqaSlidingWindowFwdBenchmark(BenchmarkBase):
+class GqaSlidingWindowFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         """Approximate FLOPs for QK^T and PV GEMMs."""

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -5,12 +5,12 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GqaSlidingWindowFwdOp
 from workloads.attention.gqa_sliding_window import GqaSlidingWindowFwdTest
 
 
-class GqaSlidingWindowFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaSlidingWindowFwdBenchmark(BenchmarkBase[GqaSlidingWindowFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         """Approximate FLOPs for QK^T and PV GEMMs."""

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GqaSlidingWindowVarlenFwdOp
 from workloads.attention.gqa_sliding_window_varlen import GqaSlidingWindowVarlenFwdTest
 
@@ -18,7 +18,7 @@ _GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = [
 ]
 
 
-class GqaSlidingWindowVarlenFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GqaSlidingWindowVarlenFwdBenchmark(BenchmarkBase[GqaSlidingWindowVarlenFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         """Approximate FLOPs for QK^T and PV GEMMs, summed over all samples."""

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GqaSlidingWindowVarlenFwdOp
 from workloads.attention.gqa_sliding_window_varlen import GqaSlidingWindowVarlenFwdTest
 
@@ -18,7 +18,7 @@ _GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = [
 ]
 
 
-class GqaSlidingWindowVarlenFwdBenchmark(BenchmarkBase):
+class GqaSlidingWindowVarlenFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         """Approximate FLOPs for QK^T and PV GEMMs, summed over all samples."""

--- a/benchmarks/ops/attention/bench_mean_pooling.py
+++ b/benchmarks/ops/attention/bench_mean_pooling.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MeanPoolingForwardOp
 from workloads.attention.mean_pooling import MeanPoolingTest
 from workloads.nsa_utils import prepare_chunk_indices
@@ -44,7 +44,7 @@ class _MeanPoolingTestBaseline(MeanPoolingTest):
         return output
 
 
-class MeanPoolingBenchmark(BenchmarkBase):
+class MeanPoolingBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mean_pooling.py
+++ b/benchmarks/ops/attention/bench_mean_pooling.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MeanPoolingForwardOp
 from workloads.attention.mean_pooling import MeanPoolingTest
 from workloads.nsa_utils import prepare_chunk_indices
@@ -44,7 +44,7 @@ class _MeanPoolingTestBaseline(MeanPoolingTest):
         return output
 
 
-class MeanPoolingBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MeanPoolingBenchmark(BenchmarkBase[MeanPoolingTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import (
     MhaBwdTest,
@@ -12,7 +12,7 @@ from workloads.attention.mha import (
 )
 
 
-class MhaFwdBenchmark(BenchmarkBase):
+class MhaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -25,7 +25,7 @@ class MhaFwdBenchmark(BenchmarkBase):
         return 4 * t.batch * t.heads * t.seq_len * t.dim * t.dtype.itemsize
 
 
-class MhaBwdBenchmark(BenchmarkBase):
+class MhaBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import (
     MhaBwdTest,
@@ -12,7 +12,7 @@ from workloads.attention.mha import (
 )
 
 
-class MhaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MhaFwdBenchmark(BenchmarkBase[MhaFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -25,7 +25,7 @@ class MhaFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
         return 4 * t.batch * t.heads * t.seq_len * t.dim * t.dtype.itemsize
 
 
-class MhaBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MhaBwdBenchmark(BenchmarkBase[MhaBwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.mha_decode import MhaDecodeTest
 
@@ -23,7 +23,7 @@ class _MhaDecodeTestBaseline(MhaDecodeTest):
         return output
 
 
-class MhaDecodeBenchmark(BenchmarkBase):
+class MhaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.mha_decode import MhaDecodeTest
 
@@ -23,7 +23,7 @@ class _MhaDecodeTestBaseline(MhaDecodeTest):
         return output
 
 
-class MhaDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MhaDecodeBenchmark(BenchmarkBase[MhaDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.mha_decode_paged import MhaDecodePagedTest
 
@@ -45,7 +45,7 @@ class _MhaDecodePagedTestBaseline(MhaDecodePagedTest):
         return torch.cat(out_list, dim=0)
 
 
-class MhaDecodePagedBenchmark(BenchmarkBase):
+class MhaDecodePagedBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.mha_decode_paged import MhaDecodePagedTest
 
@@ -45,7 +45,7 @@ class _MhaDecodePagedTestBaseline(MhaDecodePagedTest):
         return torch.cat(out_list, dim=0)
 
 
-class MhaDecodePagedBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MhaDecodePagedBenchmark(BenchmarkBase[MhaDecodePagedTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
 from tileops.kernels.elementwise import (
     ErfKernel,
     MishKernel,
@@ -65,7 +65,7 @@ class UnaryBenchCase:
         return (torch.randn(self.n_total, device="cuda", dtype=self.dtype),)
 
 
-class UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class UnaryBenchmark(BenchmarkBase[InputGeneratingWorkload]):
     """Bandwidth-oriented benchmark for unary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -13,12 +13,12 @@ compares against PyTorch baseline to determine optimal DEFAULT_STRATEGY.
 """
 
 from math import prod
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.elementwise import (
     ErfKernel,
     MishKernel,
@@ -53,6 +53,16 @@ _UNARY_STRATEGIES = ("direct", "explicit_parallel", "register_copy")
 # ---------------------------------------------------------------------------
 
 
+@runtime_checkable
+class _UnaryWorkload(Protocol):
+    """Structural type for unary benchmark workloads."""
+
+    n_total: int
+    dtype: torch.dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]: ...
+
+
 class UnaryBenchCase:
     """Minimal test harness for unary benchmarks."""
 
@@ -65,7 +75,7 @@ class UnaryBenchCase:
         return (torch.randn(self.n_total, device="cuda", dtype=self.dtype),)
 
 
-class UnaryBenchmark(BenchmarkBase[InputGeneratingWorkload]):
+class UnaryBenchmark(BenchmarkBase[_UnaryWorkload]):
     """Bandwidth-oriented benchmark for unary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.kernels.elementwise import (
     ErfKernel,
     MishKernel,
@@ -65,7 +65,7 @@ class UnaryBenchCase:
         return (torch.randn(self.n_total, device="cuda", dtype=self.dtype),)
 
 
-class UnaryBenchmark(BenchmarkBase):
+class UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for unary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -13,7 +13,7 @@ compares against PyTorch baseline to determine optimal DEFAULT_STRATEGY.
 """
 
 from math import prod
-from typing import Optional, Protocol, runtime_checkable
+from typing import Optional, Protocol
 
 import pytest
 import torch
@@ -53,7 +53,6 @@ _UNARY_STRATEGIES = ("direct", "explicit_parallel", "register_copy")
 # ---------------------------------------------------------------------------
 
 
-@runtime_checkable
 class _UnaryWorkload(Protocol):
     """Structural type for unary benchmark workloads."""
 

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroFwdOp
@@ -15,7 +15,7 @@ _ADA_OP_NAME = "AdaLayerNormFwdOp"
 _ADA_ZERO_OP_NAME = "AdaLayerNormZeroFwdOp"
 
 
-class AdaLayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class AdaLayerNormBenchmark(BenchmarkBase[AdaLayerNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -34,7 +34,7 @@ class AdaLayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
         return self._get_roofline()[1]
 
 
-class AdaLayerNormZeroBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class AdaLayerNormZeroBenchmark(BenchmarkBase[AdaLayerNormZeroTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroFwdOp
@@ -15,7 +15,7 @@ _ADA_OP_NAME = "AdaLayerNormFwdOp"
 _ADA_ZERO_OP_NAME = "AdaLayerNormZeroFwdOp"
 
 
-class AdaLayerNormBenchmark(BenchmarkBase):
+class AdaLayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -34,7 +34,7 @@ class AdaLayerNormBenchmark(BenchmarkBase):
         return self._get_roofline()[1]
 
 
-class AdaLayerNormZeroBenchmark(BenchmarkBase):
+class AdaLayerNormZeroBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -12,7 +12,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.batch_norm import BatchNormBwdTest, BatchNormFwdTest
@@ -24,7 +24,7 @@ _BWD_OP_NAME = "BatchNormBwdOp"
 # Benchmark classes
 # ---------------------------------------------------------------------------
 
-class BatchNormFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BatchNormFwdBenchmark(BenchmarkBase[BatchNormFwdTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -49,7 +49,7 @@ class BatchNormFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
         return self._get_roofline()[1]
 
 
-class BatchNormBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BatchNormBwdBenchmark(BenchmarkBase[BatchNormBwdTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -12,7 +12,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.batch_norm import BatchNormBwdTest, BatchNormFwdTest
@@ -24,7 +24,7 @@ _BWD_OP_NAME = "BatchNormBwdOp"
 # Benchmark classes
 # ---------------------------------------------------------------------------
 
-class BatchNormFwdBenchmark(BenchmarkBase):
+class BatchNormFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -49,7 +49,7 @@ class BatchNormFwdBenchmark(BenchmarkBase):
         return self._get_roofline()[1]
 
 
-class BatchNormBwdBenchmark(BenchmarkBase):
+class BatchNormBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_binary_arith.py
+++ b/benchmarks/ops/bench_binary_arith.py
@@ -17,7 +17,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import AddOp, WhereOp
 from workloads.binary_arith import AddSameShapeTest
 from workloads.workload_base import FixtureBase
@@ -85,7 +85,7 @@ class BinaryBenchCase:
         return a, b
 
 
-class BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BinaryBenchmark(BenchmarkBase[BinaryBenchCase]):
     """Bandwidth-oriented benchmark for binary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -114,7 +114,7 @@ class WhereBenchCase:
         return cond, x, y
 
 
-class WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class WhereBenchmark(BenchmarkBase[WhereBenchCase]):
     """Benchmark for where op."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_arith.py
+++ b/benchmarks/ops/bench_binary_arith.py
@@ -17,7 +17,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import AddOp, WhereOp
 from workloads.binary_arith import AddSameShapeTest
 from workloads.workload_base import FixtureBase
@@ -85,7 +85,7 @@ class BinaryBenchCase:
         return a, b
 
 
-class BinaryBenchmark(BenchmarkBase):
+class BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for binary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -114,7 +114,7 @@ class WhereBenchCase:
         return cond, x, y
 
 
-class WhereBenchmark(BenchmarkBase):
+class WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Benchmark for where op."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_arith.py
+++ b/benchmarks/ops/bench_binary_arith.py
@@ -12,7 +12,7 @@ against PyTorch baseline.
 """
 
 from math import prod
-from typing import Optional
+from typing import Any, Optional, Protocol
 
 import pytest
 import torch
@@ -68,6 +68,20 @@ _BROADCAST_PATTERNS = {
 # ---------------------------------------------------------------------------
 
 
+class BinaryWorkload(Protocol):
+    """Structural type for binary benchmark workloads.
+
+    Requires ``n_total``, ``dtype``, and ``gen_inputs``.  Attributes
+    ``a_shape`` / ``b_shape`` are optional — ``BinaryBenchmark`` falls
+    back to ``n_total`` when they are absent.
+    """
+
+    n_total: int
+    dtype: torch.dtype
+
+    def gen_inputs(self) -> Any: ...
+
+
 class BinaryBenchCase:
     """Minimal test harness for binary benchmarks."""
 
@@ -85,7 +99,7 @@ class BinaryBenchCase:
         return a, b
 
 
-class BinaryBenchmark(BenchmarkBase[BinaryBenchCase]):
+class BinaryBenchmark(BenchmarkBase[BinaryWorkload]):
     """Bandwidth-oriented benchmark for binary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -95,8 +109,8 @@ class BinaryBenchmark(BenchmarkBase[BinaryBenchCase]):
         t = self.workload
         elem_bytes = t.dtype.itemsize
         # Read a + read b + write output
-        a_elems = prod(t.a_shape) if hasattr(t, "a_shape") else t.n_total
-        b_elems = prod(t.b_shape) if hasattr(t, "b_shape") else t.n_total
+        a_elems = prod(getattr(t, "a_shape", (t.n_total,)))
+        b_elems = prod(getattr(t, "b_shape", (t.n_total,)))
         return (a_elems + b_elems + t.n_total) * elem_bytes
 
 

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
     BitwiseAndOp,
     BitwiseOrOp,
@@ -63,7 +63,7 @@ class BinaryBenchCase:
         return self._gen_inputs(self.shape, self.dtype)
 
 
-class BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BinaryBenchmark(BenchmarkBase[BinaryBenchCase]):
     """Bandwidth-oriented benchmark for binary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -90,7 +90,7 @@ class FusedGatedBenchCase:
         return (torch.randn(self.M, 2 * self.N, device="cuda", dtype=self.dtype),)
 
 
-class FusedGatedBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FusedGatedBenchmark(BenchmarkBase[FusedGatedBenchCase]):
     """Bandwidth-oriented benchmark for fused gated ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -461,7 +461,7 @@ class BroadcastBenchCase:
         return self._gen_inputs(self.a_shape, self.b_shape, self.dtype)
 
 
-class BroadcastBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BroadcastBenchmark(BenchmarkBase[BroadcastBenchCase]):
     """Bandwidth-oriented benchmark for broadcast binary ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import (
     BitwiseAndOp,
     BitwiseOrOp,
@@ -63,7 +63,7 @@ class BinaryBenchCase:
         return self._gen_inputs(self.shape, self.dtype)
 
 
-class BinaryBenchmark(BenchmarkBase):
+class BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for binary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -90,7 +90,7 @@ class FusedGatedBenchCase:
         return (torch.randn(self.M, 2 * self.N, device="cuda", dtype=self.dtype),)
 
 
-class FusedGatedBenchmark(BenchmarkBase):
+class FusedGatedBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for fused gated ops."""
 
     def calculate_flops(self) -> Optional[float]:
@@ -461,7 +461,7 @@ class BroadcastBenchCase:
         return self._gen_inputs(self.a_shape, self.b_shape, self.dtype)
 
 
-class BroadcastBenchmark(BenchmarkBase):
+class BroadcastBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for broadcast binary ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_strategy.py
+++ b/benchmarks/ops/bench_binary_strategy.py
@@ -14,7 +14,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import AddOp
 from workloads.workload_base import FixtureBase
 
@@ -50,7 +50,7 @@ class BinaryStrategyBenchCase:
         return a, b
 
 
-class BinaryStrategyBenchmark(BenchmarkBase[InputGeneratingWorkload]):
+class BinaryStrategyBenchmark(BenchmarkBase[BinaryStrategyBenchCase]):
     """Bandwidth-oriented benchmark for binary elementwise strategy comparison."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_strategy.py
+++ b/benchmarks/ops/bench_binary_strategy.py
@@ -14,7 +14,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
 from tileops.ops.elementwise import AddOp
 from workloads.workload_base import FixtureBase
 
@@ -50,7 +50,7 @@ class BinaryStrategyBenchCase:
         return a, b
 
 
-class BinaryStrategyBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class BinaryStrategyBenchmark(BenchmarkBase[InputGeneratingWorkload]):
     """Bandwidth-oriented benchmark for binary elementwise strategy comparison."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_binary_strategy.py
+++ b/benchmarks/ops/bench_binary_strategy.py
@@ -14,7 +14,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import AddOp
 from workloads.workload_base import FixtureBase
 
@@ -50,7 +50,7 @@ class BinaryStrategyBenchCase:
         return a, b
 
 
-class BinaryStrategyBenchmark(BenchmarkBase):
+class BinaryStrategyBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for binary elementwise strategy comparison."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
 
 
@@ -56,7 +56,7 @@ class Conv1dBenchCase:
         )
 
 
-class Conv1dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Conv1dBenchmark(BenchmarkBase[Conv1dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -189,7 +189,7 @@ class Conv2dBenchCase:
         )
 
 
-class Conv2dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Conv2dBenchmark(BenchmarkBase[Conv2dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -327,7 +327,7 @@ class Conv3dBenchCase:
         )
 
 
-class Conv3dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Conv3dBenchmark(BenchmarkBase[Conv3dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
 
 
@@ -56,7 +56,7 @@ class Conv1dBenchCase:
         )
 
 
-class Conv1dBenchmark(BenchmarkBase):
+class Conv1dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -189,7 +189,7 @@ class Conv2dBenchCase:
         )
 
 
-class Conv2dBenchmark(BenchmarkBase):
+class Conv2dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -327,7 +327,7 @@ class Conv3dBenchCase:
         )
 
 
-class Conv3dBenchmark(BenchmarkBase):
+class Conv3dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from workloads.workload_base import FixtureBase, WorkloadBase
 
 
@@ -48,7 +48,7 @@ class CumulativeBenchTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class CumulativeBenchmark(BenchmarkBase):
+class CumulativeBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         # Approximate: inclusive scan performs N-1 ops per row, rounded up to M*N

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from workloads.workload_base import FixtureBase, WorkloadBase
 
 
@@ -48,7 +48,7 @@ class CumulativeBenchTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class CumulativeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class CumulativeBenchmark(BenchmarkBase[CumulativeBenchTest]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         # Approximate: inclusive scan performs N-1 ops per row, rounded up to M*N

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
 from workloads.deltanet import DeltaNetFwdTest
 from workloads.workload_base import FixtureBase
@@ -172,7 +172,7 @@ def _to_fla_layout(q, k, v, beta):
 # Forward benchmark
 # =============================================================================
 
-class DeltaNetFwdBenchmark(BenchmarkBase):
+class DeltaNetFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -246,7 +246,7 @@ def test_deltanet_vs_fla_fwd(
 # Backward benchmark
 # =============================================================================
 
-class DeltaNetBwdBenchmark(BenchmarkBase):
+class DeltaNetBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -339,7 +339,7 @@ def test_deltanet_vs_fla_bwd(
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)
 # =============================================================================
 
-class DeltaNetFwdBwdBenchmark(BenchmarkBase):
+class DeltaNetFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
 from workloads.deltanet import DeltaNetFwdTest
 from workloads.workload_base import FixtureBase
@@ -172,7 +172,7 @@ def _to_fla_layout(q, k, v, beta):
 # Forward benchmark
 # =============================================================================
 
-class DeltaNetFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DeltaNetFwdBenchmark(BenchmarkBase[DeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -246,7 +246,7 @@ def test_deltanet_vs_fla_fwd(
 # Backward benchmark
 # =============================================================================
 
-class DeltaNetBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DeltaNetBwdBenchmark(BenchmarkBase[DeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -339,7 +339,7 @@ def test_deltanet_vs_fla_bwd(
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)
 # =============================================================================
 
-class DeltaNetFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DeltaNetFwdBwdBenchmark(BenchmarkBase[DeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import DeltaNetDecodeOp
 from workloads.deltanet import DeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
@@ -50,7 +50,7 @@ class _DeltaNetDecodeTestBaseline(DeltaNetDecodeTest):
         return o.to(self.dtype), new_state.to(self.dtype)
 
 
-class DeltaNetDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DeltaNetDecodeBenchmark(BenchmarkBase[DeltaNetDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import DeltaNetDecodeOp
 from workloads.deltanet import DeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
@@ -50,7 +50,7 @@ class _DeltaNetDecodeTestBaseline(DeltaNetDecodeTest):
         return o.to(self.dtype), new_state.to(self.dtype)
 
 
-class DeltaNetDecodeBenchmark(BenchmarkBase):
+class DeltaNetDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.dropout import DropoutOp
 from workloads.workload_base import FixtureBase
 
@@ -30,7 +30,7 @@ class DropoutBenchCase:
         return (torch.randn(self.shape, device="cuda", dtype=self.dtype),)
 
 
-class DropoutBenchmark(BenchmarkBase):
+class DropoutBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         # RNG + compare + scale — not compute-bound, return element count
         return self.workload.n_total

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.dropout import DropoutOp
 from workloads.workload_base import FixtureBase
 
@@ -30,7 +30,7 @@ class DropoutBenchCase:
         return (torch.randn(self.shape, device="cuda", dtype=self.dtype),)
 
 
-class DropoutBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DropoutBenchmark(BenchmarkBase[DropoutBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         # RNG + compare + scale — not compute-bound, return element count
         return self.workload.n_total

--- a/benchmarks/ops/bench_elementwise_fp8.py
+++ b/benchmarks/ops/bench_elementwise_fp8.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import AddOp, ExpOp, ReluOp, SiluAndMulOp
 from workloads.workload_base import FixtureBase
 
@@ -38,7 +38,7 @@ class Fp8UnaryBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8UnaryBenchmark(BenchmarkBase):
+class Fp8UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -58,7 +58,7 @@ class Fp8BinaryBenchCase:
         return a, b
 
 
-class Fp8BinaryBenchmark(BenchmarkBase):
+class Fp8BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -78,7 +78,7 @@ class Fp8FusedGatedBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8FusedGatedBenchmark(BenchmarkBase):
+class Fp8FusedGatedBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         # FIXME(ying): hardcoded for silu (4 FLOPs/elem + 1 mul with value = 5).
         # Must update when benchmarking other activations (e.g. gelu).

--- a/benchmarks/ops/bench_elementwise_fp8.py
+++ b/benchmarks/ops/bench_elementwise_fp8.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import AddOp, ExpOp, ReluOp, SiluAndMulOp
 from workloads.workload_base import FixtureBase
 
@@ -38,7 +38,7 @@ class Fp8UnaryBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8UnaryBenchmark(BenchmarkBase[Fp8UnaryBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -58,7 +58,7 @@ class Fp8BinaryBenchCase:
         return a, b
 
 
-class Fp8BinaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8BinaryBenchmark(BenchmarkBase[Fp8BinaryBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -78,7 +78,7 @@ class Fp8FusedGatedBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8FusedGatedBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8FusedGatedBenchmark(BenchmarkBase[Fp8FusedGatedBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         # FIXME(ying): hardcoded for silu (4 FLOPs/elem + 1 mul with value = 5).
         # Must update when benchmarking other activations (e.g. gelu).

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
 from tileops.ops.engram_decode import EngramDecodeOp
 from workloads.engram import (
@@ -54,7 +54,7 @@ def engram_gate_conv_fwd_torch(H, k, v, rms_w_h, rms_w_v, conv_w, eps=1e-6):
     )
 
 
-class EngramGateConvFwdBenchmark(BenchmarkBase):
+class EngramGateConvFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -154,7 +154,7 @@ class _EngramGateConvBwdTestBaseline(EngramGateConvBwdTest):
         )
 
 
-class EngramGateConvBwdBenchmark(BenchmarkBase):
+class EngramGateConvBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -254,7 +254,7 @@ def engram_decode_step_torch(
     return y_t.to(h_t.dtype), new_conv_state
 
 
-class EngramDecodeBenchmark(BenchmarkBase):
+class EngramDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.engram import EngramGateConvBwdOp, EngramGateConvFwdOp
 from tileops.ops.engram_decode import EngramDecodeOp
 from workloads.engram import (
@@ -54,7 +54,7 @@ def engram_gate_conv_fwd_torch(H, k, v, rms_w_h, rms_w_v, conv_w, eps=1e-6):
     )
 
 
-class EngramGateConvFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class EngramGateConvFwdBenchmark(BenchmarkBase[EngramGateConvFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -154,7 +154,7 @@ class _EngramGateConvBwdTestBaseline(EngramGateConvBwdTest):
         )
 
 
-class EngramGateConvBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class EngramGateConvBwdBenchmark(BenchmarkBase[EngramGateConvBwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -254,7 +254,7 @@ def engram_decode_step_torch(
     return y_t.to(h_t.dtype), new_conv_state
 
 
-class EngramDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class EngramDecodeBenchmark(BenchmarkBase[EngramDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import FFTC2COp
 from workloads.fft import FFTTest
 from workloads.workload_base import FixtureBase
@@ -35,7 +35,7 @@ class FFTBenchmarkFixture(FixtureBase):
     ]
 
 
-class FFTBenchmark(BenchmarkBase):
+class FFTBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         n = self.workload.n

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import FFTC2COp
 from workloads.fft import FFTTest
 from workloads.workload_base import FixtureBase
@@ -35,7 +35,7 @@ class FFTBenchmarkFixture(FixtureBase):
     ]
 
 
-class FFTBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FFTBenchmark(BenchmarkBase[FFTTest]):
 
     def calculate_flops(self) -> Optional[float]:
         n = self.workload.n

--- a/benchmarks/ops/bench_fp8_lighting_indexer.py
+++ b/benchmarks/ops/bench_fp8_lighting_indexer.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import FP8LightingIndexerOp
 from workloads.fp8_lighting_indexer import FP8LightingIndexerTest
 
@@ -39,7 +39,7 @@ class _FP8LightingIndexerTestBaseline(FP8LightingIndexerTest):
         return (logits,)
 
 
-class FP8LightingIndexerBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FP8LightingIndexerBenchmark(BenchmarkBase[FP8LightingIndexerTest]):
 
     def calculate_flops(self) -> Optional[float]:
         # Flops depend on the actual mask cost which varies per input

--- a/benchmarks/ops/bench_fp8_lighting_indexer.py
+++ b/benchmarks/ops/bench_fp8_lighting_indexer.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import FP8LightingIndexerOp
 from workloads.fp8_lighting_indexer import FP8LightingIndexerTest
 
@@ -39,7 +39,7 @@ class _FP8LightingIndexerTestBaseline(FP8LightingIndexerTest):
         return (logits,)
 
 
-class FP8LightingIndexerBenchmark(BenchmarkBase):
+class FP8LightingIndexerBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         # Flops depend on the actual mask cost which varies per input

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import FP8QuantOp
 from workloads.fp8_quant import FP8QuantTest
 
@@ -20,7 +20,7 @@ class _FP8QuantTestBaseline(FP8QuantTest):
         return scale_tensor.squeeze(dim=-1), output_tensor
 
 
-class FP8QuantBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FP8QuantBenchmark(BenchmarkBase[FP8QuantTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import FP8QuantOp
 from workloads.fp8_quant import FP8QuantTest
 
@@ -20,7 +20,7 @@ class _FP8QuantTestBaseline(FP8QuantTest):
         return scale_tensor.squeeze(dim=-1), output_tensor
 
 
-class FP8QuantBenchmark(BenchmarkBase):
+class FP8QuantBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_fused_add_layer_norm.py
+++ b/benchmarks/ops/bench_fused_add_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
 from workloads.fused_add_layer_norm import FusedAddLayerNormTest
@@ -12,7 +12,7 @@ from workloads.fused_add_layer_norm import FusedAddLayerNormTest
 _OP_NAME = "FusedAddLayerNormFwdOp"
 
 
-class FusedAddLayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FusedAddLayerNormBenchmark(BenchmarkBase[FusedAddLayerNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_fused_add_layer_norm.py
+++ b/benchmarks/ops/bench_fused_add_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
 from workloads.fused_add_layer_norm import FusedAddLayerNormTest
@@ -12,7 +12,7 @@ from workloads.fused_add_layer_norm import FusedAddLayerNormTest
 _OP_NAME = "FusedAddLayerNormFwdOp"
 
 
-class FusedAddLayerNormBenchmark(BenchmarkBase):
+class FusedAddLayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_fused_add_rms_norm.py
+++ b/benchmarks/ops/bench_fused_add_rms_norm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
 from workloads.fused_add_rms_norm import FusedAddRMSNormTest
@@ -11,7 +11,7 @@ from workloads.fused_add_rms_norm import FusedAddRMSNormTest
 _OP_NAME = "FusedAddRMSNormFwdOp"
 
 
-class FusedAddRMSNormBenchmark(BenchmarkBase):
+class FusedAddRMSNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_fused_add_rms_norm.py
+++ b/benchmarks/ops/bench_fused_add_rms_norm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
 from workloads.fused_add_rms_norm import FusedAddRMSNormTest
@@ -11,7 +11,7 @@ from workloads.fused_add_rms_norm import FusedAddRMSNormTest
 _OP_NAME = "FusedAddRMSNormFwdOp"
 
 
-class FusedAddRMSNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FusedAddRMSNormBenchmark(BenchmarkBase[FusedAddRMSNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
 from workloads.gated_deltanet import GatedDeltaNetFwdTest
 from workloads.workload_base import FixtureBase
@@ -194,7 +194,7 @@ def _to_fla_layout(q, k, v, g, beta):
 # Forward benchmark
 # =============================================================================
 
-class GatedDeltaNetFwdBenchmark(BenchmarkBase):
+class GatedDeltaNetFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -279,7 +279,7 @@ def test_gated_deltanet_vs_fla_fwd(
 # Backward benchmark
 # =============================================================================
 
-class GatedDeltaNetBwdBenchmark(BenchmarkBase):
+class GatedDeltaNetBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -385,7 +385,7 @@ def test_gated_deltanet_vs_fla_bwd(
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)
 # =============================================================================
 
-class GatedDeltaNetFwdBwdBenchmark(BenchmarkBase):
+class GatedDeltaNetFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
 from workloads.gated_deltanet import GatedDeltaNetFwdTest
 from workloads.workload_base import FixtureBase
@@ -194,7 +194,7 @@ def _to_fla_layout(q, k, v, g, beta):
 # Forward benchmark
 # =============================================================================
 
-class GatedDeltaNetFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GatedDeltaNetFwdBenchmark(BenchmarkBase[GatedDeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -279,7 +279,7 @@ def test_gated_deltanet_vs_fla_fwd(
 # Backward benchmark
 # =============================================================================
 
-class GatedDeltaNetBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GatedDeltaNetBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -385,7 +385,7 @@ def test_gated_deltanet_vs_fla_bwd(
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)
 # =============================================================================
 
-class GatedDeltaNetFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GatedDeltaNetFwdBwdBenchmark(BenchmarkBase[GatedDeltaNetFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GatedDeltaNetDecodeOp
 from workloads.gated_deltanet import GatedDeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
@@ -60,7 +60,7 @@ except ImportError:
     fused_recurrent_gated_delta_rule = None
 
 
-class GatedDeltaNetDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GatedDeltaNetDecodeBenchmark(BenchmarkBase[GatedDeltaNetDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GatedDeltaNetDecodeOp
 from workloads.gated_deltanet import GatedDeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
@@ -60,7 +60,7 @@ except ImportError:
     fused_recurrent_gated_delta_rule = None
 
 
-class GatedDeltaNetDecodeBenchmark(BenchmarkBase):
+class GatedDeltaNetDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GemmOp
 from workloads.gemm import GemmTest
 
@@ -19,7 +19,7 @@ class _GemmTestBaseline(GemmTest):
         return torch.matmul(a, b)
 
 
-class GemmBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GemmBenchmark(BenchmarkBase[GemmTest]):
 
     def calculate_flops(self) -> Optional[float]:
         return 2.0 * self.workload.m * self.workload.n * self.workload.k

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GemmOp
 from workloads.gemm import GemmTest
 
@@ -19,7 +19,7 @@ class _GemmTestBaseline(GemmTest):
         return torch.matmul(a, b)
 
 
-class GemmBenchmark(BenchmarkBase):
+class GemmBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         return 2.0 * self.workload.m * self.workload.n * self.workload.k

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -15,7 +15,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GLABwdOp, GLAFwdOp
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -117,7 +117,7 @@ class GLATest(WorkloadBase):
 # Forward benchmark
 # =============================================================================
 
-class GLAFwdBenchmark(BenchmarkBase):
+class GLAFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -187,7 +187,7 @@ def test_gla_fwd_bench(
 # Backward benchmark
 # =============================================================================
 
-class GLABwdBenchmark(BenchmarkBase):
+class GLABwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -280,7 +280,7 @@ def test_gla_bwd_bench(
 # Combined fwd+bwd benchmark
 # =============================================================================
 
-class GLAFwdBwdBenchmark(BenchmarkBase):
+class GLAFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -15,7 +15,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GLABwdOp, GLAFwdOp
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -117,7 +117,7 @@ class GLATest(WorkloadBase):
 # Forward benchmark
 # =============================================================================
 
-class GLAFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GLAFwdBenchmark(BenchmarkBase[GLATest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -187,7 +187,7 @@ def test_gla_fwd_bench(
 # Backward benchmark
 # =============================================================================
 
-class GLABwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GLABwdBenchmark(BenchmarkBase[GLATest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -280,7 +280,7 @@ def test_gla_bwd_bench(
 # Combined fwd+bwd benchmark
 # =============================================================================
 
-class GLAFwdBwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GLAFwdBwdBenchmark(BenchmarkBase[GLATest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GLADecodeOp
 from workloads.gla import GLADecodeTest
 from workloads.workload_base import FixtureBase
@@ -60,7 +60,7 @@ except ImportError:
     fused_recurrent_gla = None
 
 
-class GLADecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GLADecodeBenchmark(BenchmarkBase[GLADecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GLADecodeOp
 from workloads.gla import GLADecodeTest
 from workloads.workload_base import FixtureBase
@@ -60,7 +60,7 @@ except ImportError:
     fused_recurrent_gla = None
 
 
-class GLADecodeBenchmark(BenchmarkBase):
+class GLADecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.group_norm import GroupNormFwdOp
 from workloads.group_norm import GroupNormTest
@@ -13,7 +13,7 @@ from workloads.group_norm import GroupNormTest
 _OP_NAME = "GroupNormFwdOp"
 
 
-class GroupNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GroupNormBenchmark(BenchmarkBase[GroupNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.group_norm import GroupNormFwdOp
 from workloads.group_norm import GroupNormTest
@@ -13,7 +13,7 @@ from workloads.group_norm import GroupNormTest
 _OP_NAME = "GroupNormFwdOp"
 
 
-class GroupNormBenchmark(BenchmarkBase):
+class GroupNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GroupedGemmOp
 from workloads.grouped_gemm import (
     GroupedGemmCompleteTest,
@@ -74,7 +74,7 @@ class _GroupedGemmTestBaseline(GroupedGemmTest):
         return output
 
 
-class GroupedGemmBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GroupedGemmBenchmark(BenchmarkBase[GroupedGemmTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -104,7 +104,7 @@ class GroupedGemmBenchmark(BenchmarkBase[BenchmarkWorkload]):
 # Complete (GroupedGemmFunc) benchmark
 # ---------------------------------------------------------------------------
 
-class GroupedGemmCompleteBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GroupedGemmCompleteBenchmark(BenchmarkBase[GroupedGemmCompleteTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import GroupedGemmOp
 from workloads.grouped_gemm import (
     GroupedGemmCompleteTest,
@@ -74,7 +74,7 @@ class _GroupedGemmTestBaseline(GroupedGemmTest):
         return output
 
 
-class GroupedGemmBenchmark(BenchmarkBase):
+class GroupedGemmBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -104,7 +104,7 @@ class GroupedGemmBenchmark(BenchmarkBase):
 # Complete (GroupedGemmFunc) benchmark
 # ---------------------------------------------------------------------------
 
-class GroupedGemmCompleteBenchmark(BenchmarkBase):
+class GroupedGemmCompleteBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import (
     AlibiOp,
     ClampOp,
@@ -47,7 +47,7 @@ class UnaryBenchCase:
         return (torch.randn(self.shape, device="cuda", dtype=self.dtype),)
 
 
-class UnaryBenchmark(BenchmarkBase):
+class UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -119,7 +119,7 @@ class PreluBenchCase:
         return x, weight
 
 
-class PreluBenchmark(BenchmarkBase):
+class PreluBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -175,7 +175,7 @@ class WhereBenchCase:
         return cond, x, y
 
 
-class WhereBenchmark(BenchmarkBase):
+class WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -228,7 +228,7 @@ class MaskedFillBenchCase:
         return x, mask
 
 
-class MaskedFillBenchmark(BenchmarkBase):
+class MaskedFillBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -274,7 +274,7 @@ class GenerativeBenchCase:
         return ()
 
 
-class GenerativeBenchmark(BenchmarkBase):
+class GenerativeBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -364,7 +364,7 @@ class Fp8UnaryBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8UnaryBenchmark(BenchmarkBase):
+class Fp8UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -442,7 +442,7 @@ class Fp8WhereBenchCase:
         return cond, x, y
 
 
-class Fp8WhereBenchmark(BenchmarkBase):
+class Fp8WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -465,7 +465,7 @@ class Fp8MaskedFillBenchCase:
         return x, mask
 
 
-class Fp8MaskedFillBenchmark(BenchmarkBase):
+class Fp8MaskedFillBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
     AlibiOp,
     ClampOp,
@@ -47,7 +47,7 @@ class UnaryBenchCase:
         return (torch.randn(self.shape, device="cuda", dtype=self.dtype),)
 
 
-class UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class UnaryBenchmark(BenchmarkBase[UnaryBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -119,7 +119,7 @@ class PreluBenchCase:
         return x, weight
 
 
-class PreluBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class PreluBenchmark(BenchmarkBase[PreluBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -175,7 +175,7 @@ class WhereBenchCase:
         return cond, x, y
 
 
-class WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class WhereBenchmark(BenchmarkBase[WhereBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -228,7 +228,7 @@ class MaskedFillBenchCase:
         return x, mask
 
 
-class MaskedFillBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MaskedFillBenchmark(BenchmarkBase[MaskedFillBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -274,7 +274,7 @@ class GenerativeBenchCase:
         return ()
 
 
-class GenerativeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class GenerativeBenchmark(BenchmarkBase[GenerativeBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -364,7 +364,7 @@ class Fp8UnaryBenchCase:
         return (x.to(self.dtype),)
 
 
-class Fp8UnaryBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8UnaryBenchmark(BenchmarkBase[Fp8UnaryBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -442,7 +442,7 @@ class Fp8WhereBenchCase:
         return cond, x, y
 
 
-class Fp8WhereBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8WhereBenchmark(BenchmarkBase[Fp8WhereBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 
@@ -465,7 +465,7 @@ class Fp8MaskedFillBenchCase:
         return x, mask
 
 
-class Fp8MaskedFillBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class Fp8MaskedFillBenchmark(BenchmarkBase[Fp8MaskedFillBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         return self.workload.n_total
 

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.instance_norm import InstanceNormFwdOp
 from workloads.instance_norm import InstanceNormTest
@@ -13,7 +13,7 @@ from workloads.instance_norm import InstanceNormTest
 _OP_NAME = "InstanceNormFwdOp"
 
 
-class InstanceNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class InstanceNormBenchmark(BenchmarkBase[InstanceNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.instance_norm import InstanceNormFwdOp
 from workloads.instance_norm import InstanceNormTest
@@ -13,7 +13,7 @@ from workloads.instance_norm import InstanceNormTest
 _OP_NAME = "InstanceNormFwdOp"
 
 
-class InstanceNormBenchmark(BenchmarkBase):
+class InstanceNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.layer_norm import LayerNormFwdOp
 from workloads.layer_norm import LayerNormTest
@@ -12,7 +12,7 @@ from workloads.layer_norm import LayerNormTest
 _OP_NAME = "LayerNormFwdOp"
 
 
-class LayerNormBenchmark(BenchmarkBase):
+class LayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.layer_norm import LayerNormFwdOp
 from workloads.layer_norm import LayerNormTest
@@ -12,7 +12,7 @@ from workloads.layer_norm import LayerNormTest
 _OP_NAME = "LayerNormFwdOp"
 
 
-class LayerNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class LayerNormBenchmark(BenchmarkBase[LayerNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.da_cumsum import DaCumsumFwdOp
 from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
 from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
@@ -39,7 +39,7 @@ def da_cumsum_fwd_ref(
     return dA_cumsum.permute(0, 3, 1, 2).contiguous()
 
 
-class DaCumsumFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class DaCumsumFwdBenchmark(BenchmarkBase[DaCumsumFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -97,7 +97,7 @@ def ssd_chunk_scan_fwd_torch(x, cb, dA_cumsum, C, prev_states, dt):
     return y_off + y_diag
 
 
-class SSDChunkScanFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class SSDChunkScanFwdBenchmark(BenchmarkBase[SSDChunkScanFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -188,7 +188,7 @@ def ssd_chunk_state_fwd_ref(
     return out.permute(0, 1, 2, 4, 3)
 
 
-class SSDChunkStateFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class SSDChunkStateFwdBenchmark(BenchmarkBase[SSDChunkStateFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -264,7 +264,7 @@ def ssd_state_passing_fwd_ref(
     return torch.stack(out, dim=1), s
 
 
-class SSDStatePassingFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class SSDStatePassingFwdBenchmark(BenchmarkBase[SSDStatePassingFwdTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -335,7 +335,7 @@ def ssd_decode_ref(
     return y_out
 
 
-class SSDDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class SSDDecodeBenchmark(BenchmarkBase[SSDDecodeTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.da_cumsum import DaCumsumFwdOp
 from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
 from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
@@ -39,7 +39,7 @@ def da_cumsum_fwd_ref(
     return dA_cumsum.permute(0, 3, 1, 2).contiguous()
 
 
-class DaCumsumFwdBenchmark(BenchmarkBase):
+class DaCumsumFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -97,7 +97,7 @@ def ssd_chunk_scan_fwd_torch(x, cb, dA_cumsum, C, prev_states, dt):
     return y_off + y_diag
 
 
-class SSDChunkScanFwdBenchmark(BenchmarkBase):
+class SSDChunkScanFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -188,7 +188,7 @@ def ssd_chunk_state_fwd_ref(
     return out.permute(0, 1, 2, 4, 3)
 
 
-class SSDChunkStateFwdBenchmark(BenchmarkBase):
+class SSDChunkStateFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -264,7 +264,7 @@ def ssd_state_passing_fwd_ref(
     return torch.stack(out, dim=1), s
 
 
-class SSDStatePassingFwdBenchmark(BenchmarkBase):
+class SSDStatePassingFwdBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -335,7 +335,7 @@ def ssd_decode_ref(
     return y_out
 
 
-class SSDDecodeBenchmark(BenchmarkBase):
+class SSDDecodeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_mhc_post.py
+++ b/benchmarks/ops/bench_mhc_post.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MHCPostOp
 from workloads.mhc import MHCPostTest
 
@@ -23,7 +23,7 @@ class _MHCPostTestBaseline(MHCPostTest):
         return x_out_ref
 
 
-class MHCPostBenchmark(BenchmarkBase):
+class MHCPostBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_mhc_post.py
+++ b/benchmarks/ops/bench_mhc_post.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MHCPostOp
 from workloads.mhc import MHCPostTest
 
@@ -23,7 +23,7 @@ class _MHCPostTestBaseline(MHCPostTest):
         return x_out_ref
 
 
-class MHCPostBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MHCPostBenchmark(BenchmarkBase[MHCPostTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_mhc_pre.py
+++ b/benchmarks/ops/bench_mhc_pre.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import MHCPreOp
 from workloads.mhc import MHCPreTest
 
@@ -64,7 +64,7 @@ class _MHCPreTestBaseline(MHCPreTest):
         return x_res_ref, x_layer_ref
 
 
-class MHCPreBenchmark(BenchmarkBase):
+class MHCPreBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_mhc_pre.py
+++ b/benchmarks/ops/bench_mhc_pre.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import MHCPreOp
 from workloads.mhc import MHCPreTest
 
@@ -64,7 +64,7 @@ class _MHCPreTestBaseline(MHCPreTest):
         return x_res_ref, x_layer_ref
 
 
-class MHCPreBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MHCPreBenchmark(BenchmarkBase[MHCPreTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.moe import FusedMoe, FusedTopKOp
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -105,7 +105,7 @@ class FusedMoeBenchTest(WorkloadBase):
 # ---------------------------------------------------------------------------
 
 
-class FusedMoeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FusedMoeBenchmark(BenchmarkBase[FusedMoeBenchTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.moe import FusedMoe, FusedTopKOp
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -105,7 +105,7 @@ class FusedMoeBenchTest(WorkloadBase):
 # ---------------------------------------------------------------------------
 
 
-class FusedMoeBenchmark(BenchmarkBase):
+class FusedMoeBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.moe import FusedTopKOp
 from workloads.moe import FusedTopKTest
 from workloads.workload_base import FixtureBase
@@ -56,7 +56,7 @@ def fused_topk_torch(
 # ---------------------------------------------------------------------------
 
 
-class FusedTopKBenchmark(BenchmarkBase):
+class FusedTopKBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.moe import FusedTopKOp
 from workloads.moe import FusedTopKTest
 from workloads.workload_base import FixtureBase
@@ -56,7 +56,7 @@ def fused_topk_torch(
 # ---------------------------------------------------------------------------
 
 
-class FusedTopKBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class FusedTopKBenchmark(BenchmarkBase[FusedTopKTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_permute.py
+++ b/benchmarks/ops/bench_moe_permute.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermutePaddedFwdOp
 from workloads.moe import MoePermuteTest
@@ -41,7 +41,7 @@ _OP_NAME = "MoePermutePaddedFwdOp"
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MoePermuteBenchmark(BenchmarkBase[MoePermuteTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_permute.py
+++ b/benchmarks/ops/bench_moe_permute.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermutePaddedFwdOp
 from workloads.moe import MoePermuteTest
@@ -41,7 +41,7 @@ _OP_NAME = "MoePermutePaddedFwdOp"
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteBenchmark(BenchmarkBase):
+class MoePermuteBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     _SGL_KERNEL_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermuteAlignFwdOp
 from workloads.moe import MoePermuteAlignTest
@@ -145,7 +145,7 @@ def _triton_permute_align(
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteAlignBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MoePermuteAlignBenchmark(BenchmarkBase[MoePermuteAlignTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     _SGL_KERNEL_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermuteAlignFwdOp
 from workloads.moe import MoePermuteAlignTest
@@ -145,7 +145,7 @@ def _triton_permute_align(
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteAlignBenchmark(BenchmarkBase):
+class MoePermuteAlignBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermuteNopadFwdOp
 from workloads.workload_base import WorkloadBase
@@ -63,7 +63,7 @@ class MoePermuteNopadTest(WorkloadBase):
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteNopadBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MoePermuteNopadBenchmark(BenchmarkBase[MoePermuteNopadTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoePermuteNopadFwdOp
 from workloads.workload_base import WorkloadBase
@@ -63,7 +63,7 @@ class MoePermuteNopadTest(WorkloadBase):
 # ---------------------------------------------------------------------------
 
 
-class MoePermuteNopadBenchmark(BenchmarkBase):
+class MoePermuteNopadBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.moe import FusedTopKOp, SharedFusedMoE
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -140,7 +140,7 @@ class SharedFusedMoEBenchFixture(FixtureBase):
 # ---------------------------------------------------------------------------
 
 
-class SharedFusedMoEBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class SharedFusedMoEBenchmark(BenchmarkBase[SharedFusedMoEBenchTest]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.moe import FusedTopKOp, SharedFusedMoE
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -140,7 +140,7 @@ class SharedFusedMoEBenchFixture(FixtureBase):
 # ---------------------------------------------------------------------------
 
 
-class SharedFusedMoEBenchmark(BenchmarkBase):
+class SharedFusedMoEBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoeUnpermuteFwdOp
 from workloads.moe import MoeUnpermuteTest
@@ -42,7 +42,7 @@ _OP_NAME = "MoeUnpermuteFwdOp"
 # ---------------------------------------------------------------------------
 
 
-class MoeUnpermuteBenchmark(BenchmarkBase):
+class MoeUnpermuteBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -30,7 +30,7 @@ try:
 except ImportError:
     _VLLM_AVAILABLE = False
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.moe import MoeUnpermuteFwdOp
 from workloads.moe import MoeUnpermuteTest
@@ -42,7 +42,7 @@ _OP_NAME = "MoeUnpermuteFwdOp"
 # ---------------------------------------------------------------------------
 
 
-class MoeUnpermuteBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class MoeUnpermuteBenchmark(BenchmarkBase[MoeUnpermuteTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.ops import AvgPool1dOp, AvgPool2dOp, AvgPool3dOp
 
@@ -48,7 +48,7 @@ class AvgPool1dBenchCase:
         )
 
 
-class AvgPool1dBenchmark(BenchmarkBase):
+class AvgPool1dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -153,7 +153,7 @@ class AvgPool2dBenchCase:
         )
 
 
-class AvgPool2dBenchmark(BenchmarkBase):
+class AvgPool2dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -280,7 +280,7 @@ class AvgPool3dBenchCase:
         )
 
 
-class AvgPool3dBenchmark(BenchmarkBase):
+class AvgPool3dBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.ops import AvgPool1dOp, AvgPool2dOp, AvgPool3dOp
 
@@ -48,7 +48,7 @@ class AvgPool1dBenchCase:
         )
 
 
-class AvgPool1dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class AvgPool1dBenchmark(BenchmarkBase[AvgPool1dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -153,7 +153,7 @@ class AvgPool2dBenchCase:
         )
 
 
-class AvgPool2dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class AvgPool2dBenchmark(BenchmarkBase[AvgPool2dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
@@ -280,7 +280,7 @@ class AvgPool3dBenchCase:
         )
 
 
-class AvgPool3dBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class AvgPool3dBenchmark(BenchmarkBase[AvgPool3dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload

--- a/benchmarks/ops/bench_reduce_multidim.py
+++ b/benchmarks/ops/bench_reduce_multidim.py
@@ -24,7 +24,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from workloads.workload_base import FixtureBase, WorkloadBase
 
 # ===================================================================
@@ -102,7 +102,7 @@ class ReduceMultidimTest(WorkloadBase):
         return ops[self.op_kind](x_f32).to(x.dtype)
 
 
-class ReduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class ReduceMultidimBenchmark(BenchmarkBase[ReduceMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         total_elems = 1
@@ -221,7 +221,7 @@ class ArgreduceMultidimTest(WorkloadBase):
         return x.argmin(dim=self.dim, keepdim=self.keepdim)
 
 
-class ArgreduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class ArgreduceMultidimBenchmark(BenchmarkBase[ArgreduceMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -336,7 +336,7 @@ class LogicalReduceMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class LogicalReduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class LogicalReduceMultidimBenchmark(BenchmarkBase[LogicalReduceMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -455,7 +455,7 @@ class VectorNormMultidimTest(WorkloadBase):
         )
 
 
-class VectorNormMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class VectorNormMultidimBenchmark(BenchmarkBase[VectorNormMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -567,7 +567,7 @@ class CumulativeMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class CumulativeMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class CumulativeMultidimBenchmark(BenchmarkBase[CumulativeMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         return t.M * t.N
@@ -676,7 +676,7 @@ class LogSumExpMultidimTest(WorkloadBase):
         )
 
 
-class LogSumExpMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class LogSumExpMultidimBenchmark(BenchmarkBase[LogSumExpMultidimTest]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         total_elems = 1

--- a/benchmarks/ops/bench_reduce_multidim.py
+++ b/benchmarks/ops/bench_reduce_multidim.py
@@ -24,7 +24,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from workloads.workload_base import FixtureBase, WorkloadBase
 
 # ===================================================================
@@ -102,7 +102,7 @@ class ReduceMultidimTest(WorkloadBase):
         return ops[self.op_kind](x_f32).to(x.dtype)
 
 
-class ReduceMultidimBenchmark(BenchmarkBase):
+class ReduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         total_elems = 1
@@ -221,7 +221,7 @@ class ArgreduceMultidimTest(WorkloadBase):
         return x.argmin(dim=self.dim, keepdim=self.keepdim)
 
 
-class ArgreduceMultidimBenchmark(BenchmarkBase):
+class ArgreduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -336,7 +336,7 @@ class LogicalReduceMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class LogicalReduceMultidimBenchmark(BenchmarkBase):
+class LogicalReduceMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -455,7 +455,7 @@ class VectorNormMultidimTest(WorkloadBase):
         )
 
 
-class VectorNormMultidimBenchmark(BenchmarkBase):
+class VectorNormMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         total_elems = 1
         for s in self.workload.shape:
@@ -567,7 +567,7 @@ class CumulativeMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class CumulativeMultidimBenchmark(BenchmarkBase):
+class CumulativeMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         return t.M * t.N
@@ -676,7 +676,7 @@ class LogSumExpMultidimTest(WorkloadBase):
         )
 
 
-class LogSumExpMultidimBenchmark(BenchmarkBase):
+class LogSumExpMultidimBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         total_elems = 1

--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 from workloads.rms_norm import RMSNormTest
@@ -21,7 +21,7 @@ class _RMSNormTestBaseline(RMSNormTest):
 _OP_NAME = "RMSNormFwdOp"
 
 
-class RMSNormBenchmark(BenchmarkBase):
+class RMSNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import eval_roofline, load_workloads
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 from workloads.rms_norm import RMSNormTest
@@ -21,7 +21,7 @@ class _RMSNormTestBaseline(RMSNormTest):
 _OP_NAME = "RMSNormFwdOp"
 
 
-class RMSNormBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class RMSNormBenchmark(BenchmarkBase[RMSNormTest]):
 
     _roofline_cache: Optional[tuple[float, float]] = None
 

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.rope import RopeNeoxOp
 from workloads.workload_base import FixtureBase
 
@@ -29,7 +29,7 @@ class RopeBenchCase:
         return (torch.randn(self.seq_len, self.head_dim, device="cuda", dtype=self.dtype),)
 
 
-class RopeBenchmark(BenchmarkBase):
+class RopeBenchmark(BenchmarkBase[BenchmarkWorkload]):
     def calculate_flops(self) -> Optional[float]:
         # 4 ops per element: 2 muls + 1 add + 1 negate/select
         return self.workload.n_total * 4

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
 from tileops.ops.rope import RopeNeoxOp
 from workloads.workload_base import FixtureBase
 
@@ -29,7 +29,7 @@ class RopeBenchCase:
         return (torch.randn(self.seq_len, self.head_dim, device="cuda", dtype=self.dtype),)
 
 
-class RopeBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class RopeBenchmark(BenchmarkBase[InputGeneratingWorkload]):
     def calculate_flops(self) -> Optional[float]:
         # 4 ops per element: 2 muls + 1 add + 1 negate/select
         return self.workload.n_total * 4

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, InputGeneratingWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.rope import RopeNeoxOp
 from workloads.workload_base import FixtureBase
 
@@ -29,7 +29,7 @@ class RopeBenchCase:
         return (torch.randn(self.seq_len, self.head_dim, device="cuda", dtype=self.dtype),)
 
 
-class RopeBenchmark(BenchmarkBase[InputGeneratingWorkload]):
+class RopeBenchmark(BenchmarkBase[RopeBenchCase]):
     def calculate_flops(self) -> Optional[float]:
         # 4 ops per element: 2 muls + 1 add + 1 negate/select
         return self.workload.n_total * 4

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import TopkSelectorOp
 from workloads.topk_selector import TopkSelectorTest
 
@@ -19,7 +19,7 @@ class _TopkSelectorTestBaseline(TopkSelectorTest):
         return indexes_ref.permute(0, 1, 3, 2)
 
 
-class TopkSelectorBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class TopkSelectorBenchmark(BenchmarkBase[TopkSelectorTest]):
 
     def calculate_flops(self) -> Optional[float]:
         return None

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops import TopkSelectorOp
 from workloads.topk_selector import TopkSelectorTest
 
@@ -19,7 +19,7 @@ class _TopkSelectorTestBaseline(TopkSelectorTest):
         return indexes_ref.permute(0, 1, 3, 2)
 
 
-class TopkSelectorBenchmark(BenchmarkBase):
+class TopkSelectorBenchmark(BenchmarkBase[BenchmarkWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         return None

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
     BitwiseNotOp,
     ExpOp,
@@ -42,7 +42,7 @@ class UnaryElementwiseBenchCase:
         return self._gen_inputs(self.n_total, self.dtype)
 
 
-class UnaryElementwiseBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class UnaryElementwiseBenchmark(BenchmarkBase[UnaryElementwiseBenchCase]):
     """Bandwidth-oriented benchmark for unary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import (
     BitwiseNotOp,
     ExpOp,
@@ -42,7 +42,7 @@ class UnaryElementwiseBenchCase:
         return self._gen_inputs(self.n_total, self.dtype)
 
 
-class UnaryElementwiseBenchmark(BenchmarkBase):
+class UnaryElementwiseBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for unary elementwise ops."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_unary_strategy.py
+++ b/benchmarks/ops/bench_unary_strategy.py
@@ -21,7 +21,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
 from tileops.ops.elementwise import ReluOp
 from workloads.workload_base import FixtureBase
 
@@ -55,7 +55,7 @@ class UnaryStrategyBenchCase:
         return (torch.randn(self.n_total, device="cuda", dtype=self.dtype),)
 
 
-class UnaryStrategyBenchmark(BenchmarkBase):
+class UnaryStrategyBenchmark(BenchmarkBase[BenchmarkWorkload]):
     """Bandwidth-oriented benchmark for unary elementwise strategy comparison."""
 
     def calculate_flops(self) -> Optional[float]:

--- a/benchmarks/ops/bench_unary_strategy.py
+++ b/benchmarks/ops/bench_unary_strategy.py
@@ -21,7 +21,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, BenchmarkWorkload
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import ReluOp
 from workloads.workload_base import FixtureBase
 
@@ -55,7 +55,7 @@ class UnaryStrategyBenchCase:
         return (torch.randn(self.n_total, device="cuda", dtype=self.dtype),)
 
 
-class UnaryStrategyBenchmark(BenchmarkBase[BenchmarkWorkload]):
+class UnaryStrategyBenchmark(BenchmarkBase[UnaryStrategyBenchCase]):
     """Bandwidth-oriented benchmark for unary elementwise strategy comparison."""
 
     def calculate_flops(self) -> Optional[float]:


### PR DESCRIPTION
## Summary

Add explicit generic type parameters to all 97 `BenchmarkBase` subclasses in `benchmarks/ops/`, replacing raw `BenchmarkBase` with `BenchmarkBase[ConcreteWorkloadType]`.

- Concrete workload types used (imported `*Test` classes, local `*BenchCase` classes)
- Two local protocols introduced for benchmarks with multiple workload types (`_UnaryWorkload`, `BinaryWorkload`)
- Zero pyright regression on changed files vs main

Closes #937

## Test plan

- [x] **AC-1**: All `BenchmarkBase` subclasses have explicit type parameter (97/97)
- [x] **AC-2**: All existing benchmark tests pass (7/7)
- [x] **AC-3**: No raw `BenchmarkBase` (without type parameter) remains in `benchmarks/ops/`

## Follow-up

- #956 — Narrow `gen_inputs` return types across workload protocols