### PR TITLE
[Fix][CI] Fix moe_fused_topk test and remove unsound targeted scope

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -267,19 +267,6 @@ jobs:
               case "$path" in
                 .github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|.github/workflows/auto-label.yml|.github/workflows/stale-issues.yml|*.md)
                   ;;
-                tileops/ops/*.py)
-                  test_path="tests/ops/test_$(basename "${path%.py}").py"
-                  if [[ -f "$test_path" ]]; then
-                    add_target "$test_path"
-                    if [[ "$scope" == "skip" ]]; then
-                      scope="targeted"
-                    fi
-                  else
-                    scope="full-smoke"
-                    reason="No direct smoke test mapping for $path; falling back to full smoke."
-                    break
-                  fi
-                  ;;
                 tests/ops/test_*.py)
                   add_target "$path"
                   if [[ "$scope" == "skip" ]]; then

--- a/tests/ops/test_moe_fused_topk.py
+++ b/tests/ops/test_moe_fused_topk.py
@@ -81,7 +81,7 @@ class FusedTopKFixture(FixtureBase):
 
 
 def _check(test: FusedTopKTest) -> None:
-    gating = test.gen_inputs()
+    (gating,) = test.gen_inputs()
     op = FusedTopKOp(
         num_tokens=test.num_tokens,
         num_experts=test.num_experts,


### PR DESCRIPTION
Closes #973

## Summary

- Fix `test_moe_fused_topk` broken by #970: unpack `gen_inputs()` tuple (`gating = test.gen_inputs()` → `(gating,) = test.gen_inputs()`)
- Remove unsound `tileops/ops/*.py` targeted scope from `gpu-smoke.yml`: op files share kernels and utilities, so mapping op changes to only the corresponding test file misses cross-op regressions. Op changes now fall through to `full-smoke`.
- Ruleset bypass for `tileops-review` team revoked via GitHub UI (not a code change)

## Test plan

- [ ] All 13 `test_fused_topk` cases pass in CI gpu-smoke
- [ ] `tileops/ops/*.py` changes trigger `full-smoke` scope
- [ ] `tests/ops/test_*.py`-only changes still use `targeted` scope

## Follow-up

- #974 — Review fork PR fast-path allowlist for `tileops/ops/*.py` (same unsound independence assumption)