### PR TITLE
[Refactor][Naming] Add Fwd direction suffix to all elementwise ops and kernels

### DIFF
--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -20,12 +20,12 @@ import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.elementwise import (
-    ErfKernel,
-    MishKernel,
-    ReluKernel,
+    ErfFwdKernel,
+    MishFwdKernel,
+    ReluFwdKernel,
     _make_unary_explicit,
 )
-from tileops.ops.elementwise import ErfOp, GeluOp, MishOp, ReluOp
+from tileops.ops.elementwise import ErfFwdOp, GeluFwdOp, MishFwdOp, ReluFwdOp
 from workloads.activation import ReluTest
 from workloads.workload_base import FixtureBase
 
@@ -106,7 +106,7 @@ def test_r2_small_tensor_unary(n_total: int, dtype: torch.dtype) -> None:
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -151,7 +151,7 @@ def test_r3_jit_compilation_cost(n_total: int) -> None:
     # Cold: time the first call including JIT compilation
     torch.cuda.synchronize()
     t0 = time.perf_counter()
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     _ = op(x)
     torch.cuda.synchronize()
     cold_ms = (time.perf_counter() - t0) * 1000.0
@@ -209,7 +209,7 @@ def test_r4_default_strategy_unary(
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = ReluOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_strategy_unary",
@@ -251,7 +251,7 @@ def test_r4_default_strategy_gelu(
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GeluOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    op = GeluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_strategy_gelu",
@@ -296,7 +296,7 @@ def test_r5_boundary_guard(n_total: int, align_label: str) -> None:
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = ReluOp(N_total=n_total, dtype=dtype, strategy="explicit_parallel")
+    op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy="explicit_parallel")
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r5_boundary",
@@ -312,9 +312,9 @@ def test_r5_boundary_guard(n_total: int, align_label: str) -> None:
 
 
 _R6_KERNEL_OPS = [
-    ("relu", ReluKernel),
-    ("erf", ErfKernel),
-    ("mish", MishKernel),
+    ("relu", ReluFwdKernel),
+    ("erf", ErfFwdKernel),
+    ("mish", MishFwdKernel),
 ]
 
 _R6_THREADS = [128, 256]
@@ -430,7 +430,7 @@ def test_r7_dtype_npt(
 
     # Build kernel directly with the desired threads/npt so block_size is correct
     kernel_fn = _make_unary_explicit(
-        n_total, dtype_str, ReluKernel.op_func,
+        n_total, dtype_str, ReluFwdKernel.op_func,
         threads=threads, num_per_thread=num_per_thread,
     )
     compiled = kernel_fn(threads, num_per_thread)
@@ -461,7 +461,7 @@ def test_relu_bench(n_total: int, dtype: torch.dtype) -> None:
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_binary_arith.py
+++ b/benchmarks/ops/bench_binary_arith.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops.elementwise import AddOp, WhereOp
+from tileops.ops.elementwise import AddFwdOp, WhereFwdOp
 from workloads.binary_arith import AddSameShapeTest
 from workloads.workload_base import FixtureBase
 
@@ -180,7 +180,7 @@ def test_r1_vectorization(
     bm = BinaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AddOp(
+    op = AddFwdOp(
         a_shape=a_shape, b_shape=b_shape, dtype=dtype,
         strategy="explicit_parallel",
     )
@@ -236,7 +236,7 @@ def test_r2_small_tensor_binary(
     bm = BinaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AddOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r2_small_tensor_binary",
@@ -309,7 +309,7 @@ def test_r4_default_strategy_binary(
     bm = BinaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AddOp(
+    op = AddFwdOp(
         a_shape=a_shape, b_shape=b_shape, dtype=dtype, strategy=strategy,
     )
     result = bm.profile(op, *inputs)
@@ -359,7 +359,7 @@ def test_r4_where_bench(
     bm = WhereBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = WhereOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(N_total=n_total, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_where",
@@ -401,7 +401,7 @@ def test_add_bench(n_total: int, dtype: torch.dtype) -> None:
     inputs = test.gen_inputs()
 
     shape = (n_total,)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -13,24 +13,24 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
-    BitwiseAndOp,
-    BitwiseOrOp,
-    BitwiseXorOp,
-    DivOp,
-    EqOp,
-    FloorDivideOp,
-    GeluAndMulOp,
-    GeluTanhAndMulOp,
-    LerpOp,
-    LogicalAndOp,
-    LogicalOrOp,
-    MaximumOp,
-    MinimumOp,
-    MulOp,
-    PowOp,
-    RemainderOp,
-    SiluAndMulOp,
-    SubOp,
+    BitwiseAndFwdOp,
+    BitwiseOrFwdOp,
+    BitwiseXorFwdOp,
+    DivFwdOp,
+    EqFwdOp,
+    FloorDivideFwdOp,
+    GeluAndMulFwdOp,
+    GeluTanhAndMulFwdOp,
+    LerpFwdOp,
+    LogicalAndFwdOp,
+    LogicalOrFwdOp,
+    MaximumFwdOp,
+    MinimumFwdOp,
+    MulFwdOp,
+    PowFwdOp,
+    RemainderFwdOp,
+    SiluAndMulFwdOp,
+    SubFwdOp,
 )
 from workloads.workload_base import FixtureBase
 
@@ -142,37 +142,37 @@ class BinaryArithBenchFixture(FixtureBase):
     PARAMS = [
         ("op_name, shape, dtype, output_dtype, op_cls, baseline_fn, gen_inputs", [
             # sub
-            pytest.param("sub", _SHAPES[0], torch.float16, torch.float16, SubOp, torch.sub, _randn_pair, marks=pytest.mark.smoke),
-            pytest.param("sub", _SHAPES[1], torch.float16, torch.float16, SubOp, torch.sub, _randn_pair, marks=pytest.mark.full),
-            pytest.param("sub", _SHAPES[2], torch.float16, torch.float16, SubOp, torch.sub, _randn_pair, marks=pytest.mark.full),
+            pytest.param("sub", _SHAPES[0], torch.float16, torch.float16, SubFwdOp, torch.sub, _randn_pair, marks=pytest.mark.smoke),
+            pytest.param("sub", _SHAPES[1], torch.float16, torch.float16, SubFwdOp, torch.sub, _randn_pair, marks=pytest.mark.full),
+            pytest.param("sub", _SHAPES[2], torch.float16, torch.float16, SubFwdOp, torch.sub, _randn_pair, marks=pytest.mark.full),
             # mul
-            pytest.param("mul", _SHAPES[0], torch.float16, torch.float16, MulOp, torch.mul, _randn_pair, marks=pytest.mark.smoke),
-            pytest.param("mul", _SHAPES[1], torch.float16, torch.float16, MulOp, torch.mul, _randn_pair, marks=pytest.mark.full),
-            pytest.param("mul", _SHAPES[2], torch.float16, torch.float16, MulOp, torch.mul, _randn_pair, marks=pytest.mark.full),
+            pytest.param("mul", _SHAPES[0], torch.float16, torch.float16, MulFwdOp, torch.mul, _randn_pair, marks=pytest.mark.smoke),
+            pytest.param("mul", _SHAPES[1], torch.float16, torch.float16, MulFwdOp, torch.mul, _randn_pair, marks=pytest.mark.full),
+            pytest.param("mul", _SHAPES[2], torch.float16, torch.float16, MulFwdOp, torch.mul, _randn_pair, marks=pytest.mark.full),
             # div
-            pytest.param("div", _SHAPES[0], torch.float16, torch.float16, DivOp, torch.div, _positive_pair, marks=pytest.mark.smoke),
-            pytest.param("div", _SHAPES[1], torch.float16, torch.float16, DivOp, torch.div, _positive_pair, marks=pytest.mark.full),
-            pytest.param("div", _SHAPES[2], torch.float16, torch.float16, DivOp, torch.div, _positive_pair, marks=pytest.mark.full),
+            pytest.param("div", _SHAPES[0], torch.float16, torch.float16, DivFwdOp, torch.div, _positive_pair, marks=pytest.mark.smoke),
+            pytest.param("div", _SHAPES[1], torch.float16, torch.float16, DivFwdOp, torch.div, _positive_pair, marks=pytest.mark.full),
+            pytest.param("div", _SHAPES[2], torch.float16, torch.float16, DivFwdOp, torch.div, _positive_pair, marks=pytest.mark.full),
             # remainder
-            pytest.param("remainder", _SHAPES[0], torch.float16, torch.float16, RemainderOp, torch.remainder, _positive_pair, marks=pytest.mark.smoke),
-            pytest.param("remainder", _SHAPES[1], torch.float16, torch.float16, RemainderOp, torch.remainder, _positive_pair, marks=pytest.mark.full),
+            pytest.param("remainder", _SHAPES[0], torch.float16, torch.float16, RemainderFwdOp, torch.remainder, _positive_pair, marks=pytest.mark.smoke),
+            pytest.param("remainder", _SHAPES[1], torch.float16, torch.float16, RemainderFwdOp, torch.remainder, _positive_pair, marks=pytest.mark.full),
             # pow
-            pytest.param("pow", _SHAPES[0], torch.float16, torch.float16, PowOp, torch.pow, _positive_pair, marks=pytest.mark.smoke),
-            pytest.param("pow", _SHAPES[1], torch.float16, torch.float16, PowOp, torch.pow, _positive_pair, marks=pytest.mark.full),
+            pytest.param("pow", _SHAPES[0], torch.float16, torch.float16, PowFwdOp, torch.pow, _positive_pair, marks=pytest.mark.smoke),
+            pytest.param("pow", _SHAPES[1], torch.float16, torch.float16, PowFwdOp, torch.pow, _positive_pair, marks=pytest.mark.full),
             # floor_divide
-            pytest.param("floor_divide", _SHAPES[0], torch.float16, torch.float16, FloorDivideOp, torch.floor_divide, _positive_pair, marks=pytest.mark.smoke),
-            pytest.param("floor_divide", _SHAPES[1], torch.float16, torch.float16, FloorDivideOp, torch.floor_divide, _positive_pair, marks=pytest.mark.full),
+            pytest.param("floor_divide", _SHAPES[0], torch.float16, torch.float16, FloorDivideFwdOp, torch.floor_divide, _positive_pair, marks=pytest.mark.smoke),
+            pytest.param("floor_divide", _SHAPES[1], torch.float16, torch.float16, FloorDivideFwdOp, torch.floor_divide, _positive_pair, marks=pytest.mark.full),
             # lerp (weight=0.5 default)
-            pytest.param("lerp", _SHAPES[0], torch.float16, torch.float16, LerpOp, lambda a, b: torch.lerp(a, b, 0.5), _randn_pair, marks=pytest.mark.smoke),
-            pytest.param("lerp", _SHAPES[1], torch.float16, torch.float16, LerpOp, lambda a, b: torch.lerp(a, b, 0.5), _randn_pair, marks=pytest.mark.full),
+            pytest.param("lerp", _SHAPES[0], torch.float16, torch.float16, LerpFwdOp, lambda a, b: torch.lerp(a, b, 0.5), _randn_pair, marks=pytest.mark.smoke),
+            pytest.param("lerp", _SHAPES[1], torch.float16, torch.float16, LerpFwdOp, lambda a, b: torch.lerp(a, b, 0.5), _randn_pair, marks=pytest.mark.full),
             # maximum
-            pytest.param("maximum", _SHAPES[0], torch.float16, torch.float16, MaximumOp, torch.maximum, _randn_pair, marks=pytest.mark.smoke),
-            pytest.param("maximum", _SHAPES[1], torch.float16, torch.float16, MaximumOp, torch.maximum, _randn_pair, marks=pytest.mark.full),
-            pytest.param("maximum", _SHAPES[2], torch.float16, torch.float16, MaximumOp, torch.maximum, _randn_pair, marks=pytest.mark.full),
+            pytest.param("maximum", _SHAPES[0], torch.float16, torch.float16, MaximumFwdOp, torch.maximum, _randn_pair, marks=pytest.mark.smoke),
+            pytest.param("maximum", _SHAPES[1], torch.float16, torch.float16, MaximumFwdOp, torch.maximum, _randn_pair, marks=pytest.mark.full),
+            pytest.param("maximum", _SHAPES[2], torch.float16, torch.float16, MaximumFwdOp, torch.maximum, _randn_pair, marks=pytest.mark.full),
             # minimum
-            pytest.param("minimum", _SHAPES[0], torch.float16, torch.float16, MinimumOp, torch.minimum, _randn_pair, marks=pytest.mark.smoke),
-            pytest.param("minimum", _SHAPES[1], torch.float16, torch.float16, MinimumOp, torch.minimum, _randn_pair, marks=pytest.mark.full),
-            pytest.param("minimum", _SHAPES[2], torch.float16, torch.float16, MinimumOp, torch.minimum, _randn_pair, marks=pytest.mark.full),
+            pytest.param("minimum", _SHAPES[0], torch.float16, torch.float16, MinimumFwdOp, torch.minimum, _randn_pair, marks=pytest.mark.smoke),
+            pytest.param("minimum", _SHAPES[1], torch.float16, torch.float16, MinimumFwdOp, torch.minimum, _randn_pair, marks=pytest.mark.full),
+            pytest.param("minimum", _SHAPES[2], torch.float16, torch.float16, MinimumFwdOp, torch.minimum, _randn_pair, marks=pytest.mark.full),
         ]),
     ]
 
@@ -219,11 +219,11 @@ class ComparisonBenchFixture(FixtureBase):
 
 
 _CMP_OPS = {
-    "eq": EqOp, "ne": __import__("tileops.ops.elementwise", fromlist=["NeOp"]).NeOp,
-    "gt": __import__("tileops.ops.elementwise", fromlist=["GtOp"]).GtOp,
-    "lt": __import__("tileops.ops.elementwise", fromlist=["LtOp"]).LtOp,
-    "ge": __import__("tileops.ops.elementwise", fromlist=["GeOp"]).GeOp,
-    "le": __import__("tileops.ops.elementwise", fromlist=["LeOp"]).LeOp,
+    "eq": EqFwdOp, "ne": __import__("tileops.ops.elementwise", fromlist=["NeFwdOp"]).NeFwdOp,
+    "gt": __import__("tileops.ops.elementwise", fromlist=["GtFwdOp"]).GtFwdOp,
+    "lt": __import__("tileops.ops.elementwise", fromlist=["LtFwdOp"]).LtFwdOp,
+    "ge": __import__("tileops.ops.elementwise", fromlist=["GeFwdOp"]).GeFwdOp,
+    "le": __import__("tileops.ops.elementwise", fromlist=["LeFwdOp"]).LeFwdOp,
 }
 
 
@@ -254,10 +254,10 @@ def test_comparison_bench(
 class LogicalBenchFixture(FixtureBase):
     PARAMS = [
         ("op_name, shape, dtype, op_cls, baseline_fn", [
-            pytest.param("logical_and", _SHAPES[0], torch.float16, LogicalAndOp, torch.logical_and, marks=pytest.mark.smoke),
-            pytest.param("logical_and", _SHAPES[1], torch.float16, LogicalAndOp, torch.logical_and, marks=pytest.mark.full),
-            pytest.param("logical_or", _SHAPES[0], torch.float16, LogicalOrOp, torch.logical_or, marks=pytest.mark.smoke),
-            pytest.param("logical_or", _SHAPES[1], torch.float16, LogicalOrOp, torch.logical_or, marks=pytest.mark.full),
+            pytest.param("logical_and", _SHAPES[0], torch.float16, LogicalAndFwdOp, torch.logical_and, marks=pytest.mark.smoke),
+            pytest.param("logical_and", _SHAPES[1], torch.float16, LogicalAndFwdOp, torch.logical_and, marks=pytest.mark.full),
+            pytest.param("logical_or", _SHAPES[0], torch.float16, LogicalOrFwdOp, torch.logical_or, marks=pytest.mark.smoke),
+            pytest.param("logical_or", _SHAPES[1], torch.float16, LogicalOrFwdOp, torch.logical_or, marks=pytest.mark.full),
         ]),
     ]
 
@@ -292,10 +292,10 @@ def test_logical_bench(
 class BitwiseBenchFixture(FixtureBase):
     PARAMS = [
         ("op_name, shape, op_cls, baseline_fn", [
-            pytest.param("bitwise_and", _SHAPES[0], BitwiseAndOp, torch.bitwise_and, marks=pytest.mark.smoke),
-            pytest.param("bitwise_and", _SHAPES[1], BitwiseAndOp, torch.bitwise_and, marks=pytest.mark.full),
-            pytest.param("bitwise_or", _SHAPES[0], BitwiseOrOp, torch.bitwise_or, marks=pytest.mark.full),
-            pytest.param("bitwise_xor", _SHAPES[0], BitwiseXorOp, torch.bitwise_xor, marks=pytest.mark.full),
+            pytest.param("bitwise_and", _SHAPES[0], BitwiseAndFwdOp, torch.bitwise_and, marks=pytest.mark.smoke),
+            pytest.param("bitwise_and", _SHAPES[1], BitwiseAndFwdOp, torch.bitwise_and, marks=pytest.mark.full),
+            pytest.param("bitwise_or", _SHAPES[0], BitwiseOrFwdOp, torch.bitwise_or, marks=pytest.mark.full),
+            pytest.param("bitwise_xor", _SHAPES[0], BitwiseXorFwdOp, torch.bitwise_xor, marks=pytest.mark.full),
         ]),
     ]
 
@@ -328,12 +328,12 @@ def test_bitwise_bench(
 class FusedGatedBenchFixture(FixtureBase):
     PARAMS = [
         ("op_name, M, N, dtype, op_cls", [
-            pytest.param("gelu_and_mul", 1024, 4096, torch.float16, GeluAndMulOp, marks=pytest.mark.smoke),
-            pytest.param("gelu_and_mul", 1024, 10240, torch.float16, GeluAndMulOp, marks=pytest.mark.full),
-            pytest.param("gelu_and_mul", 1024, 20480, torch.float16, GeluAndMulOp, marks=pytest.mark.full),
-            pytest.param("gelu_tanh_and_mul", 1024, 4096, torch.float16, GeluTanhAndMulOp, marks=pytest.mark.smoke),
-            pytest.param("gelu_tanh_and_mul", 1024, 10240, torch.float16, GeluTanhAndMulOp, marks=pytest.mark.full),
-            pytest.param("gelu_tanh_and_mul", 1024, 20480, torch.float16, GeluTanhAndMulOp, marks=pytest.mark.full),
+            pytest.param("gelu_and_mul", 1024, 4096, torch.float16, GeluAndMulFwdOp, marks=pytest.mark.smoke),
+            pytest.param("gelu_and_mul", 1024, 10240, torch.float16, GeluAndMulFwdOp, marks=pytest.mark.full),
+            pytest.param("gelu_and_mul", 1024, 20480, torch.float16, GeluAndMulFwdOp, marks=pytest.mark.full),
+            pytest.param("gelu_tanh_and_mul", 1024, 4096, torch.float16, GeluTanhAndMulFwdOp, marks=pytest.mark.smoke),
+            pytest.param("gelu_tanh_and_mul", 1024, 10240, torch.float16, GeluTanhAndMulFwdOp, marks=pytest.mark.full),
+            pytest.param("gelu_tanh_and_mul", 1024, 20480, torch.float16, GeluTanhAndMulFwdOp, marks=pytest.mark.full),
         ]),
     ]
 
@@ -383,9 +383,9 @@ def test_fused_gated_bench(
 _STRATEGY_SHAPES = [(1024, 4096), (1024, 10240), (4096, 4096)]
 _STRATEGY_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 _STRATEGY_OPS = [
-    ("silu_and_mul", SiluAndMulOp),
-    ("gelu_and_mul", GeluAndMulOp),
-    ("gelu_tanh_and_mul", GeluTanhAndMulOp),
+    ("silu_and_mul", SiluAndMulFwdOp),
+    ("gelu_and_mul", GeluAndMulFwdOp),
+    ("gelu_tanh_and_mul", GeluTanhAndMulFwdOp),
 ]
 
 
@@ -491,17 +491,17 @@ class BroadcastBenchFixture(FixtureBase):
     PARAMS = [
         ("op_name, a_shape, b_shape, dtype, op_cls, baseline_fn, gen_inputs", [
             # sub — bias-add pattern
-            pytest.param("sub", *_BROADCAST_SHAPES[0], torch.float16, SubOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.smoke),
-            pytest.param("sub", *_BROADCAST_SHAPES[1], torch.float16, SubOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.full),
-            pytest.param("sub", *_BROADCAST_SHAPES[2], torch.float16, SubOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("sub", *_BROADCAST_SHAPES[0], torch.float16, SubFwdOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.smoke),
+            pytest.param("sub", *_BROADCAST_SHAPES[1], torch.float16, SubFwdOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("sub", *_BROADCAST_SHAPES[2], torch.float16, SubFwdOp, torch.sub, _randn_broadcast_pair, marks=pytest.mark.full),
             # mul — bias-add pattern
-            pytest.param("mul", *_BROADCAST_SHAPES[0], torch.float16, MulOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
-            pytest.param("mul", *_BROADCAST_SHAPES[1], torch.float16, MulOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
-            pytest.param("mul", *_BROADCAST_SHAPES[2], torch.float16, MulOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("mul", *_BROADCAST_SHAPES[0], torch.float16, MulFwdOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("mul", *_BROADCAST_SHAPES[1], torch.float16, MulFwdOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("mul", *_BROADCAST_SHAPES[2], torch.float16, MulFwdOp, torch.mul, _randn_broadcast_pair, marks=pytest.mark.full),
             # div — bias-add pattern
-            pytest.param("div", *_BROADCAST_SHAPES[0], torch.float16, DivOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
-            pytest.param("div", *_BROADCAST_SHAPES[1], torch.float16, DivOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
-            pytest.param("div", *_BROADCAST_SHAPES[2], torch.float16, DivOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("div", *_BROADCAST_SHAPES[0], torch.float16, DivFwdOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("div", *_BROADCAST_SHAPES[1], torch.float16, DivFwdOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
+            pytest.param("div", *_BROADCAST_SHAPES[2], torch.float16, DivFwdOp, torch.div, _positive_broadcast_pair, marks=pytest.mark.full),
         ]),
     ]
 

--- a/benchmarks/ops/bench_binary_strategy.py
+++ b/benchmarks/ops/bench_binary_strategy.py
@@ -15,7 +15,7 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops.elementwise import AddOp
+from tileops.ops.elementwise import AddFwdOp
 from workloads.workload_base import FixtureBase
 
 # DNN-realistic 2D shapes — same-shape (no broadcast) for clean strategy comparison
@@ -163,7 +163,7 @@ def test_binary_strategy_bench(
     inputs = test.gen_inputs()
 
     shape = (n_total,)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=dtype, strategy=strategy)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype, strategy=strategy)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "binary_strategy",

--- a/benchmarks/ops/bench_elementwise_fp8.py
+++ b/benchmarks/ops/bench_elementwise_fp8.py
@@ -80,8 +80,11 @@ class Fp8FusedGatedBenchCase:
 
 class Fp8FusedGatedBenchmark(BenchmarkBase[Fp8FusedGatedBenchCase]):
     def calculate_flops(self) -> Optional[float]:
-        # FIXME(ying): hardcoded for silu (4 FLOPs/elem + 1 mul with value = 5).
-        # Must update when benchmarking other activations (e.g. gelu).
+        # FIXME(staged-rollout): hardcoded silu FLOPs in Fp8FusedGatedBenchmark
+        #
+        # Broken invariant: calculate_flops assumes silu (5 FLOPs/elem), wrong for other activations
+        # Why: only silu is benchmarked currently, other activations not yet added
+        # Cleanup: implement per-activation FLOPs lookup when benchmarking gelu/other activations
         return self.workload.M * self.workload.N * 5
 
     def calculate_memory(self) -> Optional[float]:

--- a/benchmarks/ops/bench_elementwise_fp8.py
+++ b/benchmarks/ops/bench_elementwise_fp8.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops.elementwise import AddOp, ExpOp, ReluOp, SiluAndMulOp
+from tileops.ops.elementwise import AddFwdOp, ExpFwdOp, ReluFwdOp, SiluAndMulFwdOp
 from workloads.workload_base import FixtureBase
 
 # Shapes modeled on real LLM workloads: batch × seq_len × hidden_dim
@@ -95,8 +95,8 @@ class Fp8FusedGatedBenchmark(BenchmarkBase[Fp8FusedGatedBenchCase]):
 
 _unary_params = []
 for _op_name, _op_cls, _bl_fn in [
-    ("relu_fp8", ReluOp, torch.relu),
-    ("exp_fp8", ExpOp, torch.exp),
+    ("relu_fp8", ReluFwdOp, torch.relu),
+    ("exp_fp8", ExpFwdOp, torch.exp),
 ]:
     for _shape in _SHAPES_1D:
         for _dt in _FP8_DTYPES:
@@ -151,7 +151,7 @@ def test_fp8_binary_bench(op_name, n_total, dtype):
     bm = Fp8BinaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AddOp(a_shape=(n_total,), b_shape=(n_total,), dtype=dtype)
+    op = AddFwdOp(a_shape=(n_total,), b_shape=(n_total,), dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op_name, locals(), result, tag="tileops")
 
@@ -194,7 +194,7 @@ def test_fp8_fused_gated_bench(op_name, M, N, dtype):
     bm = Fp8FusedGatedBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = SiluAndMulOp(M=M, N=N, dtype=dtype)
+    op = SiluAndMulFwdOp(M=M, N=N, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op_name, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -13,17 +13,17 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
-    AlibiOp,
-    ClampOp,
-    EluOp,
-    HardtanhOp,
-    LeakyReluOp,
-    MaskedFillOp,
-    NanToNumOp,
-    PreluOp,
-    SinusoidalOp,
-    SoftplusOp,
-    WhereOp,
+    AlibiFwdOp,
+    ClampFwdOp,
+    EluFwdOp,
+    HardtanhFwdOp,
+    LeakyReluFwdOp,
+    MaskedFillFwdOp,
+    NanToNumFwdOp,
+    PreluFwdOp,
+    SinusoidalFwdOp,
+    SoftplusFwdOp,
+    WhereFwdOp,
 )
 from workloads.workload_base import FixtureBase
 
@@ -74,12 +74,12 @@ class UnaryIndependentBenchFixture(FixtureBase):
 
 
 _UNARY_OPS = {
-    "leaky_relu": (LeakyReluOp, lambda x: F.leaky_relu(x, 0.01), {}),
-    "elu": (EluOp, lambda x: F.elu(x, 1.0), {}),
-    "hardtanh": (HardtanhOp, lambda x: F.hardtanh(x, -1.0, 1.0), {"min_val": -1.0, "max_val": 1.0}),
-    "softplus": (SoftplusOp, lambda x: F.softplus(x, 1.0, 20.0), {}),
-    "clamp": (ClampOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
-    "nan_to_num": (NanToNumOp, lambda x: torch.nan_to_num(x, 0.0, 1e4, -1e4), {}),
+    "leaky_relu": (LeakyReluFwdOp, lambda x: F.leaky_relu(x, 0.01), {}),
+    "elu": (EluFwdOp, lambda x: F.elu(x, 1.0), {}),
+    "hardtanh": (HardtanhFwdOp, lambda x: F.hardtanh(x, -1.0, 1.0), {"min_val": -1.0, "max_val": 1.0}),
+    "softplus": (SoftplusFwdOp, lambda x: F.softplus(x, 1.0, 20.0), {}),
+    "clamp": (ClampFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
+    "nan_to_num": (NanToNumFwdOp, lambda x: torch.nan_to_num(x, 0.0, 1e4, -1e4), {}),
 }
 
 
@@ -150,7 +150,7 @@ def test_prelu_bench(shape: tuple, num_channels: int, dtype: torch.dtype) -> Non
     # PReLU shape convention: (batch, channels, spatial)
     prelu_shape = (1, num_channels, shape[0])
     n_total = prod(shape)
-    op = PreluOp(shape=prelu_shape, dtype=dtype, num_channels=num_channels)
+    op = PreluFwdOp(shape=prelu_shape, dtype=dtype, num_channels=num_channels)
     result = bm.profile(op, x.reshape(prelu_shape), weight)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -204,7 +204,7 @@ def test_where_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = WhereBenchmark(test)
     cond, x, y = test.gen_inputs()
 
-    op = WhereOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(N_total=n_total, dtype=dtype)
     result = bm.profile(op, cond, x, y)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -248,7 +248,7 @@ def test_masked_fill_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = MaskedFillBenchmark(test)
     x, mask = test.gen_inputs()
 
-    op = MaskedFillOp(N_total=n_total, dtype=dtype, fill_value=-65000.0)
+    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=-65000.0)
     result = bm.profile(op, x, mask)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -327,12 +327,12 @@ def test_generative_bench(op_name: str, seq_len: int, dim: int, dtype: torch.dty
     if op_name == "alibi":
         # ALiBi outputs (num_heads, seq_len, seq_len); override n_total
         test.n_total = dim * seq_len * seq_len
-        op = AlibiOp(seq_len=seq_len, num_heads=dim, dtype=dtype)
+        op = AlibiFwdOp(seq_len=seq_len, num_heads=dim, dtype=dtype)
 
         def baseline_fn():
             return _alibi_reference(seq_len, dim, dtype)
     else:
-        op = SinusoidalOp(seq_len=seq_len, d_model=dim, dtype=dtype)
+        op = SinusoidalFwdOp(seq_len=seq_len, d_model=dim, dtype=dtype)
 
         def baseline_fn():
             return _sinusoidal_reference(seq_len, dim, dtype)
@@ -374,9 +374,9 @@ class Fp8UnaryBenchmark(BenchmarkBase[Fp8UnaryBenchCase]):
 
 
 _FP8_UNARY_OPS = {
-    "leaky_relu": (LeakyReluOp, lambda x: F.leaky_relu(x, 0.01), {}),
-    "elu": (EluOp, lambda x: F.elu(x, 1.0), {}),
-    "clamp": (ClampOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
+    "leaky_relu": (LeakyReluFwdOp, lambda x: F.leaky_relu(x, 0.01), {}),
+    "elu": (EluFwdOp, lambda x: F.elu(x, 1.0), {}),
+    "clamp": (ClampFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
 }
 
 
@@ -503,7 +503,7 @@ def test_fp8_selection_bench(
         bm = Fp8WhereBenchmark(test)
         cond, x, y = test.gen_inputs()
 
-        op = WhereOp(N_total=n_total, dtype=dtype)
+        op = WhereFwdOp(N_total=n_total, dtype=dtype)
         result = bm.profile(op, cond, x, y)
         BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -518,7 +518,7 @@ def test_fp8_selection_bench(
         bm = Fp8MaskedFillBenchmark(test)
         x, mask = test.gen_inputs()
 
-        op = MaskedFillOp(N_total=n_total, dtype=dtype, fill_value=-100.0)
+        op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=-100.0)
         result = bm.profile(op, x, mask)
         BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_moe_kernel_breakdown.py
+++ b/benchmarks/ops/bench_moe_kernel_breakdown.py
@@ -26,7 +26,7 @@ from tileops.kernels.moe.moe_grouped_gemm_nopad import (
     _moe_grouped_gemm_kernel,
     _tile_scheduler_kernel,
 )
-from tileops.ops.elementwise import SiluAndMulOp
+from tileops.ops.elementwise import SiluAndMulFwdOp
 from tileops.ops.grouped_gemm import GroupedGemmOp
 from tileops.ops.moe import (
     FusedTopKOp,
@@ -101,7 +101,7 @@ def profile_padded(T, E, K, H, F, scoring_func, renormalize):
     topk_op    = FusedTopKOp(T, E, K, scoring_func, renormalize)
     permute_op = MoePermutePaddedFwdOp(T, K, E, H, DTYPE, block_m=_BLOCK_M)
     gemm_gu    = GroupedGemmOp(padded, E, F * 2, H, DTYPE)
-    silu_op    = SiluAndMulOp(M=padded, N=F, dtype=DTYPE)
+    silu_op    = SiluAndMulFwdOp(M=padded, N=F, dtype=DTYPE)
     gemm_dn    = GroupedGemmOp(padded, E, H, F, DTYPE)
     unp_op     = MoeUnpermuteFwdOp(T, K, H, DTYPE, padded_batch_sum=padded)
 
@@ -146,7 +146,7 @@ def profile_nopad(T, E, K, H, F, scoring_func, renormalize):
     topk_op    = FusedTopKOp(T, E, K, scoring_func, renormalize)
     permute_op = MoePermuteNopadFwdOp(T, K, E, H, DTYPE)
     unp_op     = MoeUnpermuteFwdOp(T, K, H, DTYPE, padded_batch_sum=numel)
-    silu_op    = SiluAndMulOp(M=numel, N=F, dtype=DTYPE)
+    silu_op    = SiluAndMulFwdOp(M=numel, N=F, dtype=DTYPE)
 
     # Build tile scheduler + GEMM kernels directly (nopad internal)
     block_m, block_n, block_k, num_stages, threads = 64, 256, 64, 2, 128

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -12,11 +12,11 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
-    BitwiseNotOp,
-    ExpOp,
-    GeluOp,
-    IsnanOp,
-    LogicalNotOp,
+    BitwiseNotFwdOp,
+    ExpFwdOp,
+    GeluFwdOp,
+    IsnanFwdOp,
+    LogicalNotFwdOp,
 )
 from workloads.workload_base import FixtureBase
 
@@ -84,87 +84,87 @@ class UnaryElementwiseBenchFixture(FixtureBase):
         ("op_name, n_total, dtype, output_dtype, op_cls, baseline_fn, gen_inputs", [
             pytest.param(
                 "exp", _SHAPES[0], torch.float16, torch.float16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "exp", _SHAPES[1], torch.float16, torch.float16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "exp", _SHAPES[2], torch.float16, torch.float16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "exp", _SHAPES[0], torch.bfloat16, torch.bfloat16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "exp", _SHAPES[1], torch.bfloat16, torch.bfloat16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "exp", _SHAPES[2], torch.bfloat16, torch.bfloat16,
-                ExpOp, torch.exp, _randn,
+                ExpFwdOp, torch.exp, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[0], torch.float16, torch.float16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[1], torch.float16, torch.float16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[2], torch.float16, torch.float16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[0], torch.bfloat16, torch.bfloat16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[1], torch.bfloat16, torch.bfloat16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "gelu", _SHAPES[2], torch.bfloat16, torch.bfloat16,
-                GeluOp, F.gelu, _randn,
+                GeluFwdOp, F.gelu, _randn,
             ),
             pytest.param(
                 "logical_not", _SHAPES[0], torch.float16, torch.bool,
-                LogicalNotOp, torch.logical_not, _logical_inputs,
+                LogicalNotFwdOp, torch.logical_not, _logical_inputs,
             ),
             pytest.param(
                 "logical_not", _SHAPES[1], torch.float16, torch.bool,
-                LogicalNotOp, torch.logical_not, _logical_inputs,
+                LogicalNotFwdOp, torch.logical_not, _logical_inputs,
             ),
             pytest.param(
                 "logical_not", _SHAPES[2], torch.float16, torch.bool,
-                LogicalNotOp, torch.logical_not, _logical_inputs,
+                LogicalNotFwdOp, torch.logical_not, _logical_inputs,
             ),
             pytest.param(
                 "bitwise_not", _SHAPES[0], torch.int32, torch.int32,
-                BitwiseNotOp, torch.bitwise_not, _bitwise_inputs,
+                BitwiseNotFwdOp, torch.bitwise_not, _bitwise_inputs,
             ),
             pytest.param(
                 "bitwise_not", _SHAPES[1], torch.int32, torch.int32,
-                BitwiseNotOp, torch.bitwise_not, _bitwise_inputs,
+                BitwiseNotFwdOp, torch.bitwise_not, _bitwise_inputs,
             ),
             pytest.param(
                 "bitwise_not", _SHAPES[2], torch.int32, torch.int32,
-                BitwiseNotOp, torch.bitwise_not, _bitwise_inputs,
+                BitwiseNotFwdOp, torch.bitwise_not, _bitwise_inputs,
             ),
             pytest.param(
                 "isnan", _SHAPES[0], torch.float16, torch.bool,
-                IsnanOp, torch.isnan, _special_inputs,
+                IsnanFwdOp, torch.isnan, _special_inputs,
             ),
             pytest.param(
                 "isnan", _SHAPES[1], torch.float16, torch.bool,
-                IsnanOp, torch.isnan, _special_inputs,
+                IsnanFwdOp, torch.isnan, _special_inputs,
             ),
             pytest.param(
                 "isnan", _SHAPES[2], torch.float16, torch.bool,
-                IsnanOp, torch.isnan, _special_inputs,
+                IsnanFwdOp, torch.isnan, _special_inputs,
             ),
         ]),
     ]

--- a/benchmarks/ops/bench_unary_strategy.py
+++ b/benchmarks/ops/bench_unary_strategy.py
@@ -22,7 +22,7 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops.elementwise import ReluOp
+from tileops.ops.elementwise import ReluFwdOp
 from workloads.workload_base import FixtureBase
 
 # DNN-realistic 2D shapes flattened to 1D total element counts
@@ -201,7 +201,7 @@ def test_unary_strategy_bench(
     bm = UnaryStrategyBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = ReluOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "unary_strategy",

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.elementwise import ReluOp
+from tileops.ops.elementwise import ReluFwdOp
 from workloads.activation import ReluTest as _ReluTestWorkload
 
 
@@ -43,7 +43,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @ReluFixture
 def test_relu_op(n_total: int, dtype: torch.dtype) -> None:
     test = ReluTest(n_total, dtype)
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -62,7 +62,7 @@ class ReluStrategyFixture(FixtureBase):
 def test_relu_strategies(n_total: int, dtype: torch.dtype, strategy: str) -> None:
     """Verify all 3 unary strategies produce correct results."""
     test = ReluTest(n_total, dtype)
-    op = ReluOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -129,59 +129,59 @@ def _make_activation_test(n_total, dtype, gen_fn, ref_fn, op_cls):
 
 @ActivationFixture
 def test_gelu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import GeluOp
+    from tileops.ops.elementwise import GeluFwdOp
     _make_activation_test(n_total, dtype, _randn,
-                          F.gelu, GeluOp)
+                          F.gelu, GeluFwdOp)
 
 
 @ActivationFixture
 def test_silu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import SiluOp
-    _make_activation_test(n_total, dtype, _randn, F.silu, SiluOp)
+    from tileops.ops.elementwise import SiluFwdOp
+    _make_activation_test(n_total, dtype, _randn, F.silu, SiluFwdOp)
 
 
 @ActivationFixture
 def test_sigmoid(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import SigmoidOp
-    _make_activation_test(n_total, dtype, _randn, torch.sigmoid, SigmoidOp)
+    from tileops.ops.elementwise import SigmoidFwdOp
+    _make_activation_test(n_total, dtype, _randn, torch.sigmoid, SigmoidFwdOp)
 
 
 @ActivationFixture
 def test_tanh(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import TanhOp
-    _make_activation_test(n_total, dtype, _randn, torch.tanh, TanhOp)
+    from tileops.ops.elementwise import TanhFwdOp
+    _make_activation_test(n_total, dtype, _randn, torch.tanh, TanhFwdOp)
 
 
 @ActivationFixture
 def test_hardswish(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import HardswishOp
-    _make_activation_test(n_total, dtype, _randn, F.hardswish, HardswishOp)
+    from tileops.ops.elementwise import HardswishFwdOp
+    _make_activation_test(n_total, dtype, _randn, F.hardswish, HardswishFwdOp)
 
 
 @ActivationFixture
 def test_hardsigmoid(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import HardsigmoidOp
-    _make_activation_test(n_total, dtype, _randn, F.hardsigmoid, HardsigmoidOp)
+    from tileops.ops.elementwise import HardsigmoidFwdOp
+    _make_activation_test(n_total, dtype, _randn, F.hardsigmoid, HardsigmoidFwdOp)
 
 
 @ActivationFixture
 def test_mish(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import MishOp
-    _make_activation_test(n_total, dtype, _randn, F.mish, MishOp)
+    from tileops.ops.elementwise import MishFwdOp
+    _make_activation_test(n_total, dtype, _randn, F.mish, MishFwdOp)
 
 
 @ActivationFixture
 def test_selu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import SeluOp
-    _make_activation_test(n_total, dtype, _randn, F.selu, SeluOp)
+    from tileops.ops.elementwise import SeluFwdOp
+    _make_activation_test(n_total, dtype, _randn, F.selu, SeluFwdOp)
 
 
 @pytest.mark.smoke
 def test_activation_rejects_non_float_dtype() -> None:
-    from tileops.kernels.elementwise import GeluKernel
+    from tileops.kernels.elementwise import GeluFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        GeluKernel(N_total=16, dtype=torch.int32)
+        GeluFwdKernel(N_total=16, dtype=torch.int32)
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +192,7 @@ def test_activation_rejects_non_float_dtype() -> None:
 @ActivationEdgeFixture
 def test_sigmoid_edge(n_total: int, dtype: torch.dtype) -> None:
     """Edge: sigmoid of large negative -> ~0, large positive -> ~1."""
-    from tileops.ops.elementwise import SigmoidOp
+    from tileops.ops.elementwise import SigmoidFwdOp
 
     def _extreme(n, dtype):
         x = torch.zeros(n, device="cuda", dtype=dtype)
@@ -200,13 +200,13 @@ def test_sigmoid_edge(n_total: int, dtype: torch.dtype) -> None:
         x[n // 2:] = 50.0
         return x
 
-    _make_activation_test(n_total, dtype, _extreme, torch.sigmoid, SigmoidOp)
+    _make_activation_test(n_total, dtype, _extreme, torch.sigmoid, SigmoidFwdOp)
 
 
 @ActivationEdgeFixture
 def test_tanh_edge(n_total: int, dtype: torch.dtype) -> None:
     """Edge: tanh saturates to +/-1 for large inputs."""
-    from tileops.ops.elementwise import TanhOp
+    from tileops.ops.elementwise import TanhFwdOp
 
     def _extreme(n, dtype):
         x = torch.zeros(n, device="cuda", dtype=dtype)
@@ -214,7 +214,7 @@ def test_tanh_edge(n_total: int, dtype: torch.dtype) -> None:
         x[n // 2:] = 50.0
         return x
 
-    _make_activation_test(n_total, dtype, _extreme, torch.tanh, TanhOp)
+    _make_activation_test(n_total, dtype, _extreme, torch.tanh, TanhFwdOp)
 
 
 # ===========================================================================
@@ -224,41 +224,41 @@ def test_tanh_edge(n_total: int, dtype: torch.dtype) -> None:
 
 @ActivationFixture
 def test_leaky_relu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import LeakyReluOp
+    from tileops.ops.elementwise import LeakyReluFwdOp
     _make_activation_test(
         n_total, dtype, _randn,
         lambda x: F.leaky_relu(x.float(), 0.01).to(x.dtype),
-        LeakyReluOp,
+        LeakyReluFwdOp,
     )
 
 
 @ActivationFixture
 def test_elu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import EluOp
+    from tileops.ops.elementwise import EluFwdOp
     _make_activation_test(
         n_total, dtype, _randn,
         lambda x: F.elu(x.float(), 1.0).to(x.dtype),
-        EluOp,
+        EluFwdOp,
     )
 
 
 @ActivationFixture
 def test_hardtanh(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import HardtanhOp
+    from tileops.ops.elementwise import HardtanhFwdOp
     _make_activation_test(
         n_total, dtype, _randn,
         lambda x: F.hardtanh(x.float(), -1.0, 1.0).to(x.dtype),
-        HardtanhOp,
+        HardtanhFwdOp,
     )
 
 
 @ActivationFixture
 def test_softplus(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import SoftplusOp
+    from tileops.ops.elementwise import SoftplusFwdOp
     _make_activation_test(
         n_total, dtype, _randn,
         lambda x: F.softplus(x.float(), 1.0, 20.0).to(x.dtype),
-        SoftplusOp,
+        SoftplusFwdOp,
     )
 
 
@@ -274,7 +274,7 @@ class PreluFixture(FixtureBase):
 
 @PreluFixture
 def test_prelu(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import PreluOp
+    from tileops.ops.elementwise import PreluFwdOp
 
     C = 64
     H = n_total // C
@@ -284,7 +284,7 @@ def test_prelu(n_total: int, dtype: torch.dtype) -> None:
     weight = torch.randn(C, device="cuda", dtype=dtype).abs() * 0.1 + 0.01
     ref = F.prelu(x.float(), weight.float()).to(dtype)
 
-    op = PreluOp(shape=shape, dtype=dtype, num_channels=C)
+    op = PreluFwdOp(shape=shape, dtype=dtype, num_channels=C)
     out = op(x, weight)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -293,13 +293,13 @@ def test_prelu(n_total: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for PreluOp.")
+    print("All checks passed for PreluFwdOp.")
 
 
 @pytest.mark.smoke
 def test_prelu_batch_dim() -> None:
     """PReLU with a leading batch dimension: shape (2, 4, 8)."""
-    from tileops.ops.elementwise import PreluOp
+    from tileops.ops.elementwise import PreluFwdOp
 
     dtype = torch.float32
     shape = (2, 4, 8)
@@ -307,17 +307,17 @@ def test_prelu_batch_dim() -> None:
     x = torch.randn(shape, device="cuda", dtype=dtype)
     weight = torch.tensor([0.1, 0.2, 0.3, 0.4], device="cuda", dtype=dtype)
     ref = F.prelu(x, weight)
-    op = PreluOp(shape=shape, dtype=dtype, num_channels=C)
+    op = PreluFwdOp(shape=shape, dtype=dtype, num_channels=C)
     out = op(x, weight)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for PreluOp batch-dim.")
+    print("All checks passed for PreluFwdOp batch-dim.")
 
 
 @pytest.mark.smoke
 def test_independent_activation_rejects_non_float_dtype() -> None:
-    from tileops.kernels.elementwise import LeakyReluKernel
+    from tileops.kernels.elementwise import LeakyReluFwdKernel
     with pytest.raises(ValueError, match="only supports dtypes"):
-        LeakyReluKernel(N_total=16, dtype=torch.int32)
+        LeakyReluFwdKernel(N_total=16, dtype=torch.int32)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -10,16 +10,16 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.elementwise import (
-    AddOp,
-    DivOp,
-    FloorDivideOp,
-    LerpOp,
-    MaximumOp,
-    MinimumOp,
-    MulOp,
-    PowOp,
-    RemainderOp,
-    SubOp,
+    AddFwdOp,
+    DivFwdOp,
+    FloorDivideFwdOp,
+    LerpFwdOp,
+    MaximumFwdOp,
+    MinimumFwdOp,
+    MulFwdOp,
+    PowFwdOp,
+    RemainderFwdOp,
+    SubFwdOp,
     coalesce_broadcast_dims,
 )
 from workloads.binary_arith import AddSameShapeTest as _AddSameShapeTestWorkload
@@ -109,7 +109,7 @@ class AddSameShapeFixture(FixtureBase):
 def test_add_same_shape(n_total: int, dtype: torch.dtype) -> None:
     test = AddSameShapeTest(n_total, dtype)
     shape = (n_total,)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -157,7 +157,7 @@ class AddBroadcastTest(TestBase):
 @AddBroadcastFixture
 def test_add_broadcast(a_shape, b_shape, dtype: torch.dtype) -> None:
     test = AddBroadcastTest(a_shape, b_shape, dtype)
-    op = AddOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -178,33 +178,33 @@ _BROADCAST_PATTERNS = [
 
 # (op_name, op_cls, ref_fn, gen_a, gen_b)
 _ARITH_BROADCAST_OPS = [
-    ("sub", SubOp, lambda a, b: (a.float() - b.float()).to(a.dtype),
+    ("sub", SubFwdOp, lambda a, b: (a.float() - b.float()).to(a.dtype),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda")),
-    ("mul", MulOp, lambda a, b: (a.float() * b.float()).to(a.dtype),
+    ("mul", MulFwdOp, lambda a, b: (a.float() * b.float()).to(a.dtype),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda")),
-    ("div", DivOp, lambda a, b: (a.float() / b.float()).to(a.dtype),
+    ("div", DivFwdOp, lambda a, b: (a.float() / b.float()).to(a.dtype),
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1),
-    ("remainder", RemainderOp,
+    ("remainder", RemainderFwdOp,
      lambda a, b: a - torch.floor(a.float() / b.float()).to(a.dtype) * b,
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1),
-    ("pow", PowOp, lambda a, b: torch.pow(a.float(), b.float()).to(a.dtype),
+    ("pow", PowFwdOp, lambda a, b: torch.pow(a.float(), b.float()).to(a.dtype),
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.5,
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") * 2.0),
-    ("floor_divide", FloorDivideOp,
+    ("floor_divide", FloorDivideFwdOp,
      lambda a, b: torch.floor(a.float() / b.float()).to(a.dtype),
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
      lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1),
-    ("lerp", LerpOp, lambda a, b: torch.lerp(a.float(), b.float(), 0.5).to(a.dtype),
+    ("lerp", LerpFwdOp, lambda a, b: torch.lerp(a.float(), b.float(), 0.5).to(a.dtype),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda")),
-    ("maximum", MaximumOp, lambda a, b: torch.maximum(a.float(), b.float()).to(a.dtype),
+    ("maximum", MaximumFwdOp, lambda a, b: torch.maximum(a.float(), b.float()).to(a.dtype),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda")),
-    ("minimum", MinimumOp, lambda a, b: torch.minimum(a.float(), b.float()).to(a.dtype),
+    ("minimum", MinimumFwdOp, lambda a, b: torch.minimum(a.float(), b.float()).to(a.dtype),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
      lambda s, d: torch.randn(*s, dtype=d, device="cuda")),
 ]
@@ -253,7 +253,7 @@ def test_add_strategies(n_total: int, dtype: torch.dtype, strategy: str) -> None
     """Verify both binary strategies produce correct results."""
     test = AddSameShapeTest(n_total, dtype)
     shape = (n_total,)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=dtype, strategy=strategy)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype, strategy=strategy)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -316,7 +316,7 @@ class SubFixture(FixtureBase):
 def test_sub_op(n_total: int, dtype: torch.dtype) -> None:
     test = BinarySameShapeTest(n_total, dtype, lambda a, b: a - b)
     shape = (n_total,)
-    op = SubOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = SubFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -340,7 +340,7 @@ class MulFixture(FixtureBase):
 def test_mul_op(n_total: int, dtype: torch.dtype) -> None:
     test = BinarySameShapeTest(n_total, dtype, lambda a, b: a * b)
     shape = (n_total,)
-    op = MulOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MulFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -364,7 +364,7 @@ class DivFixture(FixtureBase):
 def test_div_op(n_total: int, dtype: torch.dtype) -> None:
     test = BinaryPositiveTest(n_total, dtype, lambda a, b: a / b)
     shape = (n_total,)
-    op = DivOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = DivFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -406,7 +406,7 @@ class RemainderTest(TestBase):
 def test_remainder_op(n_total: int, dtype: torch.dtype) -> None:
     test = RemainderTest(n_total, dtype)
     shape = (n_total,)
-    op = RemainderOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = RemainderFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -446,7 +446,7 @@ class PowPositiveTest(TestBase):
 def test_pow_op(n_total: int, dtype: torch.dtype) -> None:
     test = PowPositiveTest(n_total, dtype)
     shape = (n_total,)
-    op = PowOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = PowFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -487,7 +487,7 @@ class FloorDivideTest(TestBase):
 def test_floor_divide_op(n_total: int, dtype: torch.dtype) -> None:
     test = FloorDivideTest(n_total, dtype)
     shape = (n_total,)
-    op = FloorDivideOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = FloorDivideFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     # Floor divide in reduced precision can differ by 1; use atol=1.0
     atol = 1.0 if dtype != torch.float32 else 1e-5
     test.check(op, *test.gen_inputs(), atol=atol, rtol=0.0)
@@ -538,7 +538,7 @@ def test_lerp_op(n_total: int, dtype: torch.dtype) -> None:
     for weight in [0.0, 0.3, 0.5, 0.7, 1.0]:
         test = LerpTest(n_total, dtype, weight=weight)
         shape = (n_total,)
-        op = LerpOp(a_shape=shape, b_shape=shape, dtype=dtype, weight=weight)
+        op = LerpFwdOp(a_shape=shape, b_shape=shape, dtype=dtype, weight=weight)
         test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
@@ -561,7 +561,7 @@ class MaximumFixture(FixtureBase):
 def test_maximum_op(n_total: int, dtype: torch.dtype) -> None:
     test = BinarySameShapeTest(n_total, dtype, lambda a, b: torch.maximum(a, b))
     shape = (n_total,)
-    op = MaximumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MaximumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -585,7 +585,7 @@ class MinimumFixture(FixtureBase):
 def test_minimum_op(n_total: int, dtype: torch.dtype) -> None:
     test = BinarySameShapeTest(n_total, dtype, lambda a, b: torch.minimum(a, b))
     shape = (n_total,)
-    op = MinimumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MinimumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -612,7 +612,7 @@ def test_maximum_nan_propagation(dtype: torch.dtype) -> None:
     a = torch.tensor([nan, 1.0, nan, 2.0], dtype=dtype, device="cuda")
     b = torch.tensor([3.0, nan, nan, 1.0], dtype=dtype, device="cuda")
     shape = (4,)
-    op = MaximumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MaximumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.maximum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -634,7 +634,7 @@ def test_minimum_nan_propagation(dtype: torch.dtype) -> None:
     a = torch.tensor([nan, 1.0, nan, 2.0], dtype=dtype, device="cuda")
     b = torch.tensor([3.0, nan, nan, 1.0], dtype=dtype, device="cuda")
     shape = (4,)
-    op = MinimumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MinimumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.minimum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -674,7 +674,7 @@ def test_maximum_signed_zero(dtype: torch.dtype) -> None:
     a = torch.stack([pos_zero, neg_zero, pos_zero, neg_zero])
     b = torch.stack([neg_zero, pos_zero, pos_zero, neg_zero])
     shape = (4,)
-    op = MaximumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MaximumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.maximum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -699,7 +699,7 @@ def test_minimum_signed_zero(dtype: torch.dtype) -> None:
     a = torch.stack([neg_zero, pos_zero, neg_zero, pos_zero])
     b = torch.stack([pos_zero, neg_zero, neg_zero, pos_zero])
     shape = (4,)
-    op = MinimumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MinimumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.minimum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -722,7 +722,7 @@ def test_maximum_signed_zero_with_nan(dtype: torch.dtype) -> None:
     a = torch.tensor([nan, 1.0, -0.0, 0.0, nan, 3.0], dtype=dtype, device="cuda")
     b = torch.tensor([1.0, nan, 0.0, -0.0, -0.0, 2.0], dtype=dtype, device="cuda")
     shape = (6,)
-    op = MaximumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MaximumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.maximum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -748,7 +748,7 @@ def test_minimum_signed_zero_with_nan(dtype: torch.dtype) -> None:
     a = torch.tensor([nan, -0.0, 0.0, 1.0, nan, 2.0], dtype=dtype, device="cuda")
     b = torch.tensor([1.0, nan, -0.0, 0.0, 0.0, 3.0], dtype=dtype, device="cuda")
     shape = (6,)
-    op = MinimumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MinimumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.minimum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -776,7 +776,7 @@ class EdgeCaseFixture(FixtureBase):
         ("op_cls, ref_fn, gen_fn", [
             # div: avoid div-by-zero
             pytest.param(
-                DivOp,
+                DivFwdOp,
                 lambda a, b: a / b,
                 lambda n, d: (
                     torch.randn(n, dtype=d, device="cuda"),
@@ -786,7 +786,7 @@ class EdgeCaseFixture(FixtureBase):
             ),
             # remainder: positive inputs
             pytest.param(
-                RemainderOp,
+                RemainderFwdOp,
                 lambda a, b: a % b,
                 lambda n, d: (
                     torch.rand(n, dtype=d, device="cuda") + 0.1,
@@ -796,7 +796,7 @@ class EdgeCaseFixture(FixtureBase):
             ),
             # floor_divide: positive inputs
             pytest.param(
-                FloorDivideOp,
+                FloorDivideFwdOp,
                 lambda a, b: torch.floor(a / b),
                 lambda n, d: (
                     torch.rand(n, dtype=d, device="cuda") + 0.1,
@@ -806,7 +806,7 @@ class EdgeCaseFixture(FixtureBase):
             ),
             # pow: positive base, small exponent
             pytest.param(
-                PowOp,
+                PowFwdOp,
                 lambda a, b: torch.pow(a, b),
                 lambda n, d: (
                     torch.rand(n, dtype=d, device="cuda") + 0.5,
@@ -816,7 +816,7 @@ class EdgeCaseFixture(FixtureBase):
             ),
             # maximum: mixed sign
             pytest.param(
-                MaximumOp,
+                MaximumFwdOp,
                 lambda a, b: torch.maximum(a, b),
                 lambda n, d: (
                     torch.randn(n, dtype=d, device="cuda"),
@@ -850,13 +850,13 @@ def test_binary_arith_edge_cases(op_cls, ref_fn, gen_fn) -> None:
 class FloatOnlyBinaryRejectFixture(FixtureBase):
     PARAMS = [
         ("op_cls, dtype", [
-            pytest.param(DivOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(RemainderOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(PowOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(FloorDivideOp, torch.int64, marks=pytest.mark.smoke),
-            pytest.param(LerpOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MaximumOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MinimumOp, torch.int64, marks=pytest.mark.smoke),
+            pytest.param(DivFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(RemainderFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(PowFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(FloorDivideFwdOp, torch.int64, marks=pytest.mark.smoke),
+            pytest.param(LerpFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(MaximumFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(MinimumFwdOp, torch.int64, marks=pytest.mark.smoke),
         ]),
     ]
 
@@ -872,7 +872,7 @@ def test_float_only_binary_ops_reject_integer_dtype(op_cls, dtype: torch.dtype) 
 @pytest.mark.smoke
 def test_binary_op_rejects_runtime_dtype_mismatch() -> None:
     """Runtime inputs should fail fast instead of reaching backend lowering."""
-    op = SubOp(a_shape=(16,), b_shape=(16,), dtype=torch.float16)
+    op = SubFwdOp(a_shape=(16,), b_shape=(16,), dtype=torch.float16)
     a = torch.randn(16, device="cuda", dtype=torch.float32)
     b = torch.randn(16, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="Expected a.dtype"):
@@ -889,7 +889,7 @@ def test_binary_kernel_has_autotune_configs() -> None:
     """BinaryKernel subclasses must expose autotune_configs with >= 3 entries."""
 
     shape = (4096,)
-    for op_cls in (MaximumOp, MinimumOp, AddOp, SubOp, MulOp):
+    for op_cls in (MaximumFwdOp, MinimumFwdOp, AddFwdOp, SubFwdOp, MulFwdOp):
         op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.float16)
         # Access autotune_configs from the underlying kernel object
         kernel = op.kernel
@@ -910,7 +910,7 @@ def test_binary_kernel_has_autotune_configs() -> None:
 def test_binary_kernel_autotune_configs_distinct() -> None:
     """autotune_configs entries must be distinct (no duplicates)."""
     shape = (4096,)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=torch.float16)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=torch.float16)
     configs = op.kernel.autotune_configs
     config_tuples = [(c["threads"], c["num_per_thread"]) for c in configs]
     assert len(config_tuples) == len(set(config_tuples)), (
@@ -939,7 +939,7 @@ def test_maximum_optimized_large(n_total: int, dtype: torch.dtype) -> None:
     shape = (n_total,)
     a = torch.randn(*shape, device="cuda", dtype=dtype)
     b = torch.randn(*shape, device="cuda", dtype=dtype)
-    op = MaximumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MaximumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.maximum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -952,7 +952,7 @@ def test_minimum_optimized_large(n_total: int, dtype: torch.dtype) -> None:
     shape = (n_total,)
     a = torch.randn(*shape, device="cuda", dtype=dtype)
     b = torch.randn(*shape, device="cuda", dtype=dtype)
-    op = MinimumOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = MinimumFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.minimum(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -977,8 +977,8 @@ def test_register_copy_downgrades_on_broadcast() -> None:
     dtype = torch.float16
 
     for op_cls, ref_fn in [
-        (AddOp, lambda a, b: a + b),
-        (MaximumOp, lambda a, b: torch.maximum(a, b)),
+        (AddFwdOp, lambda a, b: a + b),
+        (MaximumFwdOp, lambda a, b: torch.maximum(a, b)),
     ]:
         op = op_cls(
             a_shape=a_shape, b_shape=b_shape, dtype=dtype,
@@ -1013,7 +1013,7 @@ def test_binary_tune_true_does_not_crash() -> None:
     shape = (4096,)
     dtype = torch.float16
 
-    for op_cls in (AddOp, MaximumOp, MinimumOp):
+    for op_cls in (AddFwdOp, MaximumFwdOp, MinimumFwdOp):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             op = op_cls(a_shape=shape, b_shape=shape, dtype=dtype, tune=True)

--- a/tests/ops/test_bitwise.py
+++ b/tests/ops/test_bitwise.py
@@ -9,7 +9,12 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, exact_compare
-from tileops.ops.elementwise import BitwiseAndOp, BitwiseNotOp, BitwiseOrOp, BitwiseXorOp
+from tileops.ops.elementwise import (
+    BitwiseAndFwdOp,
+    BitwiseNotFwdOp,
+    BitwiseOrFwdOp,
+    BitwiseXorFwdOp,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -58,7 +63,7 @@ class BitwiseAndFixture(FixtureBase):
 def test_bitwise_and_op(n_total: int) -> None:
     test = BitwiseTest(n_total, torch.bitwise_and)
     shape = (n_total,)
-    op = BitwiseAndOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    op = BitwiseAndFwdOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -80,7 +85,7 @@ class BitwiseOrFixture(FixtureBase):
 def test_bitwise_or_op(n_total: int) -> None:
     test = BitwiseTest(n_total, torch.bitwise_or)
     shape = (n_total,)
-    op = BitwiseOrOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    op = BitwiseOrFwdOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -102,7 +107,7 @@ class BitwiseXorFixture(FixtureBase):
 def test_bitwise_xor_op(n_total: int) -> None:
     test = BitwiseTest(n_total, torch.bitwise_xor)
     shape = (n_total,)
-    op = BitwiseXorOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    op = BitwiseXorFwdOp(a_shape=shape, b_shape=shape, dtype=torch.int32)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -117,9 +122,9 @@ _BROADCAST_PATTERNS = [
 ]
 
 _BITWISE_OPS = [
-    ("bitwise_and", BitwiseAndOp, torch.bitwise_and),
-    ("bitwise_or", BitwiseOrOp, torch.bitwise_or),
-    ("bitwise_xor", BitwiseXorOp, torch.bitwise_xor),
+    ("bitwise_and", BitwiseAndFwdOp, torch.bitwise_and),
+    ("bitwise_or", BitwiseOrFwdOp, torch.bitwise_or),
+    ("bitwise_xor", BitwiseXorFwdOp, torch.bitwise_xor),
 ]
 
 
@@ -191,7 +196,7 @@ class BitwiseNotTest(TestBase):
 @BitwiseFixture
 def test_bitwise_not(n_total: int, dtype: torch.dtype) -> None:
     test = BitwiseNotTest(n_total, dtype)
-    op = BitwiseNotOp(N_total=n_total, dtype=dtype)
+    op = BitwiseNotFwdOp(N_total=n_total, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=exact_compare)
 
 
@@ -201,10 +206,10 @@ def test_bitwise_not(n_total: int, dtype: torch.dtype) -> None:
     pytest.param(torch.float32, marks=pytest.mark.smoke),
 ])
 def test_bitwise_not_rejects_float_dtype(dtype: torch.dtype) -> None:
-    from tileops.kernels.elementwise import BitwiseNotKernel
+    from tileops.kernels.elementwise import BitwiseNotFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        BitwiseNotKernel(N_total=16, dtype=dtype)
+        BitwiseNotFwdKernel(N_total=16, dtype=dtype)
 
 
 # ---------------------------------------------------------------------------
@@ -215,11 +220,11 @@ def test_bitwise_not_rejects_float_dtype(dtype: torch.dtype) -> None:
 class BitwiseBinaryRejectFixture(FixtureBase):
     PARAMS = [
         ("op_cls, dtype", [
-            pytest.param(BitwiseAndOp, torch.float16, marks=pytest.mark.smoke),
-            pytest.param(BitwiseAndOp, torch.bfloat16, marks=pytest.mark.smoke),
-            pytest.param(BitwiseAndOp, torch.float32, marks=pytest.mark.smoke),
-            pytest.param(BitwiseOrOp, torch.float16, marks=pytest.mark.full),
-            pytest.param(BitwiseXorOp, torch.float16, marks=pytest.mark.full),
+            pytest.param(BitwiseAndFwdOp, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(BitwiseAndFwdOp, torch.bfloat16, marks=pytest.mark.smoke),
+            pytest.param(BitwiseAndFwdOp, torch.float32, marks=pytest.mark.smoke),
+            pytest.param(BitwiseOrFwdOp, torch.float16, marks=pytest.mark.full),
+            pytest.param(BitwiseXorFwdOp, torch.float16, marks=pytest.mark.full),
         ]),
     ]
 

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.elementwise import EqOp, GeOp, GtOp, LeOp, LtOp, NeOp
+from tileops.ops.elementwise import EqFwdOp, GeFwdOp, GtFwdOp, LeFwdOp, LtFwdOp, NeFwdOp
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -59,7 +59,7 @@ class EqFixture(FixtureBase):
 def test_eq_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.eq)
     shape = (n_total,)
-    op = EqOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = EqFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -82,7 +82,7 @@ class NeFixture(FixtureBase):
 def test_ne_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.ne)
     shape = (n_total,)
-    op = NeOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = NeFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -105,7 +105,7 @@ class GtFixture(FixtureBase):
 def test_gt_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.gt)
     shape = (n_total,)
-    op = GtOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = GtFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -128,7 +128,7 @@ class LtFixture(FixtureBase):
 def test_lt_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.lt)
     shape = (n_total,)
-    op = LtOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = LtFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -151,7 +151,7 @@ class GeFixture(FixtureBase):
 def test_ge_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.ge)
     shape = (n_total,)
-    op = GeOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = GeFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -174,7 +174,7 @@ class LeFixture(FixtureBase):
 def test_le_op(n_total: int, dtype: torch.dtype) -> None:
     test = ComparisonTest(n_total, dtype, torch.le)
     shape = (n_total,)
-    op = LeOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = LeFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -189,12 +189,12 @@ _BROADCAST_PATTERNS = [
 ]
 
 _CMP_OPS = [
-    ("eq", EqOp, torch.eq),
-    ("ne", NeOp, torch.ne),
-    ("gt", GtOp, torch.gt),
-    ("lt", LtOp, torch.lt),
-    ("ge", GeOp, torch.ge),
-    ("le", LeOp, torch.le),
+    ("eq", EqFwdOp, torch.eq),
+    ("ne", NeFwdOp, torch.ne),
+    ("gt", GtFwdOp, torch.gt),
+    ("lt", LtFwdOp, torch.lt),
+    ("ge", GeFwdOp, torch.ge),
+    ("le", LeFwdOp, torch.le),
 ]
 
 
@@ -245,7 +245,7 @@ def test_eq_edge_case(n_total: int, dtype: torch.dtype) -> None:
     # Make some elements differ
     b[::2] = torch.randn(n_total // 2, dtype=dtype, device="cuda")
     shape = (n_total,)
-    op = EqOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = EqFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = torch.eq(a, b)
     with torch.no_grad():
         out = op(a, b)
@@ -261,13 +261,13 @@ def test_eq_edge_case(n_total: int, dtype: torch.dtype) -> None:
 class ComparisonRejectFixture(FixtureBase):
     PARAMS = [
         ("op_cls, dtype", [
-            pytest.param(EqOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(EqOp, torch.int64, marks=pytest.mark.smoke),
-            pytest.param(NeOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(GtOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(LtOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(GeOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(LeOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(EqFwdOp, torch.int32, marks=pytest.mark.smoke),
+            pytest.param(EqFwdOp, torch.int64, marks=pytest.mark.smoke),
+            pytest.param(NeFwdOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(GtFwdOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(LtFwdOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(GeFwdOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(LeFwdOp, torch.int32, marks=pytest.mark.full),
         ]),
     ]
 

--- a/tests/ops/test_elementwise_caching_autotune.py
+++ b/tests/ops/test_elementwise_caching_autotune.py
@@ -223,7 +223,7 @@ class TestAutotuneConfigs:
     @pytest.mark.full
     def test_binary_autotune_configs_still_works(self):
         """BinaryKernel autotune_configs must still work (no regression)."""
-        k = AddFwdKernel(N, torch.float16, [N], [1], [1], N, N)
+        k = AddFwdKernel(N, torch.float16, (N,), (1,), (1,), N, N)
         configs = k.autotune_configs
         assert configs is not None
         assert len(configs) >= 3

--- a/tests/ops/test_elementwise_caching_autotune.py
+++ b/tests/ops/test_elementwise_caching_autotune.py
@@ -12,29 +12,29 @@ import pytest
 import torch
 
 from tileops.kernels.elementwise import (
-    AbsKernel,
+    AbsFwdKernel,
     # Concrete binary
-    AddKernel,
-    AlibiKernel,
-    ClampKernel,
-    EluKernel,
-    GeluAndMulKernel,
-    GeluTanhAndMulKernel,
-    HardtanhKernel,
+    AddFwdKernel,
+    AlibiFwdKernel,
+    ClampFwdKernel,
+    EluFwdKernel,
+    GeluAndMulFwdKernel,
+    GeluTanhAndMulFwdKernel,
+    HardtanhFwdKernel,
     # Custom kernels
-    LeakyReluKernel,
-    MaskedFillKernel,
-    NanToNumKernel,
-    PreluKernel,
+    LeakyReluFwdKernel,
+    MaskedFillFwdKernel,
+    NanToNumFwdKernel,
+    PreluFwdKernel,
     # Concrete unary
-    ReluKernel,
-    SigmoidKernel,
+    ReluFwdKernel,
+    SigmoidFwdKernel,
     # Concrete fused gated
-    SiluAndMulKernel,
-    SinusoidalKernel,
-    SoftplusKernel,
+    SiluAndMulFwdKernel,
+    SinusoidalFwdKernel,
+    SoftplusFwdKernel,
     # Base classes
-    WhereKernel,
+    WhereFwdKernel,
 )
 
 N = 2048  # small enough for fast tests
@@ -49,7 +49,7 @@ class TestUnaryCaching:
     """UnaryKernel subclasses should have _compiled_fn after __init__."""
 
     @pytest.mark.full
-    @pytest.mark.parametrize("kernel_cls", [ReluKernel, SigmoidKernel, AbsKernel])
+    @pytest.mark.parametrize("kernel_cls", [ReluFwdKernel, SigmoidFwdKernel, AbsFwdKernel])
     def test_unary_has_compiled_fn(self, kernel_cls):
         k = kernel_cls(N, torch.float16)
         assert hasattr(k, "_compiled_fn"), (
@@ -60,7 +60,7 @@ class TestUnaryCaching:
     @pytest.mark.full
     def test_unary_forward_uses_cached_fn(self):
         """forward() should use _compiled_fn, not re-lookup the kernel."""
-        k = ReluKernel(N, torch.float16)
+        k = ReluFwdKernel(N, torch.float16)
         fn1 = k._compiled_fn
         x = torch.randn(N, dtype=torch.float16, device="cuda")
         _ = k(x)
@@ -70,7 +70,7 @@ class TestUnaryCaching:
     @pytest.mark.full
     def test_unary_direct_strategy_caching(self):
         """Direct strategy kernels should also cache _compiled_fn."""
-        k = ReluKernel(N, torch.float16, strategy="direct")
+        k = ReluFwdKernel(N, torch.float16, strategy="direct")
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
@@ -85,7 +85,7 @@ class TestFusedGatedCaching:
 
     @pytest.mark.full
     @pytest.mark.parametrize("kernel_cls", [
-        SiluAndMulKernel, GeluAndMulKernel, GeluTanhAndMulKernel,
+        SiluAndMulFwdKernel, GeluAndMulFwdKernel, GeluTanhAndMulFwdKernel,
     ])
     def test_fused_gated_has_compiled_fn(self, kernel_cls):
         k = kernel_cls(32, 64, torch.float16)
@@ -96,7 +96,7 @@ class TestFusedGatedCaching:
 
     @pytest.mark.full
     def test_fused_gated_forward_uses_cached_fn(self):
-        k = SiluAndMulKernel(32, 64, torch.float16)
+        k = SiluAndMulFwdKernel(32, 64, torch.float16)
         fn1 = k._compiled_fn
         x = torch.randn(32, 128, dtype=torch.float16, device="cuda")
         _ = k(x)
@@ -113,67 +113,67 @@ class TestCustomKernelCaching:
 
     @pytest.mark.full
     def test_leaky_relu_caching(self):
-        k = LeakyReluKernel(N, torch.float16)
+        k = LeakyReluFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_elu_caching(self):
-        k = EluKernel(N, torch.float16)
+        k = EluFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_hardtanh_caching(self):
-        k = HardtanhKernel(N, torch.float16)
+        k = HardtanhFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_softplus_caching(self):
-        k = SoftplusKernel(N, torch.float16)
+        k = SoftplusFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_prelu_caching(self):
-        k = PreluKernel(N, 4, 512, torch.float16)
+        k = PreluFwdKernel(N, 4, 512, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_where_caching(self):
-        k = WhereKernel(N, torch.float16)
+        k = WhereFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_clamp_caching(self):
-        k = ClampKernel(N, torch.float16, min_val=-1.0, max_val=1.0)
+        k = ClampFwdKernel(N, torch.float16, min_val=-1.0, max_val=1.0)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_masked_fill_caching(self):
-        k = MaskedFillKernel(N, torch.float16, fill_value=0.0)
+        k = MaskedFillFwdKernel(N, torch.float16, fill_value=0.0)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_nan_to_num_caching(self):
-        k = NanToNumKernel(N, torch.float16)
+        k = NanToNumFwdKernel(N, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_alibi_caching(self):
-        k = AlibiKernel(32, 4, torch.float16)
+        k = AlibiFwdKernel(32, 4, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
     @pytest.mark.full
     def test_sinusoidal_caching(self):
-        k = SinusoidalKernel(32, 64, torch.float16)
+        k = SinusoidalFwdKernel(32, 64, torch.float16)
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 
@@ -189,7 +189,7 @@ class TestAutotuneConfigs:
     @pytest.mark.full
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
     def test_unary_autotune_configs_count(self, dtype):
-        k = ReluKernel(N, dtype)
+        k = ReluFwdKernel(N, dtype)
         configs = k.autotune_configs
         assert configs is not None, "UnaryKernel.autotune_configs should not be None"
         assert len(configs) >= 3, f"Expected >= 3 configs, got {len(configs)}"
@@ -201,7 +201,7 @@ class TestAutotuneConfigs:
     @pytest.mark.full
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
     def test_fused_gated_autotune_configs_count(self, dtype):
-        k = SiluAndMulKernel(32, 64, dtype)
+        k = SiluAndMulFwdKernel(32, 64, dtype)
         configs = k.autotune_configs
         assert configs is not None, "FusedGatedKernel.autotune_configs should not be None"
         assert len(configs) >= 3, f"Expected >= 3 configs, got {len(configs)}"
@@ -212,7 +212,7 @@ class TestAutotuneConfigs:
     @pytest.mark.full
     def test_unary_fp8_autotune_configs(self):
         """fp8 unary should have specific fp8-appropriate configs."""
-        k = ReluKernel(N, torch.float8_e4m3fn)
+        k = ReluFwdKernel(N, torch.float8_e4m3fn)
         configs = k.autotune_configs
         assert configs is not None
         assert len(configs) >= 3
@@ -223,7 +223,7 @@ class TestAutotuneConfigs:
     @pytest.mark.full
     def test_binary_autotune_configs_still_works(self):
         """BinaryKernel autotune_configs must still work (no regression)."""
-        k = AddKernel(N, torch.float16, [N], [1], [1], N, N)
+        k = AddFwdKernel(N, torch.float16, [N], [1], [1], N, N)
         configs = k.autotune_configs
         assert configs is not None
         assert len(configs) >= 3
@@ -239,7 +239,7 @@ class TestCachingCorrectness:
 
     @pytest.mark.full
     def test_unary_relu_correctness(self):
-        k = ReluKernel(N, torch.float16)
+        k = ReluFwdKernel(N, torch.float16)
         x = torch.randn(N, dtype=torch.float16, device="cuda")
         out = k(x)
         ref = torch.relu(x.float()).to(torch.float16)
@@ -248,7 +248,7 @@ class TestCachingCorrectness:
     @pytest.mark.full
     def test_fused_gated_silu_correctness(self):
         M, Nhalf = 32, 64
-        k = SiluAndMulKernel(M, Nhalf, torch.float16)
+        k = SiluAndMulFwdKernel(M, Nhalf, torch.float16)
         x = torch.randn(M, 2 * Nhalf, dtype=torch.float16, device="cuda")
         out = k(x)
         gate = x[:, :Nhalf].float()
@@ -258,7 +258,7 @@ class TestCachingCorrectness:
 
     @pytest.mark.full
     def test_custom_leaky_relu_correctness(self):
-        k = LeakyReluKernel(N, torch.float16, negative_slope=0.01)
+        k = LeakyReluFwdKernel(N, torch.float16, negative_slope=0.01)
         x = torch.randn(N, dtype=torch.float16, device="cuda")
         out = k(x)
         ref = torch.nn.functional.leaky_relu(x.float(), 0.01).to(torch.float16)

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -14,61 +14,61 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase, exact_compare
 from tileops.ops.elementwise import (
-    AbsOp,
-    AddOp,
-    BitwiseAndOp,
-    BitwiseNotOp,
-    BitwiseOrOp,
-    BitwiseXorOp,
-    CeilOp,
-    CosOp,
-    DivOp,
-    EqOp,
-    ErfOp,
-    Expm1Op,
-    ExpOp,
-    FloorDivideOp,
-    FloorOp,
-    GeluAndMulOp,
-    GeluOp,
-    GeluTanhAndMulOp,
-    GeOp,
-    GtOp,
-    HardsigmoidOp,
-    HardswishOp,
-    IsfiniteOp,
-    IsinfOp,
-    IsnanOp,
-    LeOp,
-    LerpOp,
-    Log1pOp,
-    LogicalAndOp,
-    LogicalNotOp,
-    LogicalOrOp,
-    LogOp,
-    LtOp,
-    MaximumOp,
-    MinimumOp,
-    MishOp,
-    MulOp,
-    NegOp,
-    NeOp,
-    PowOp,
-    ReciprocalOp,
-    ReluOp,
-    RemainderOp,
-    RoundOp,
-    RsqrtOp,
-    SeluOp,
-    SigmoidOp,
-    SignOp,
-    SiluAndMulOp,
-    SiluOp,
-    SinOp,
-    SqrtOp,
-    SubOp,
-    TanhOp,
-    TruncOp,
+    AbsFwdOp,
+    AddFwdOp,
+    BitwiseAndFwdOp,
+    BitwiseNotFwdOp,
+    BitwiseOrFwdOp,
+    BitwiseXorFwdOp,
+    CeilFwdOp,
+    CosFwdOp,
+    DivFwdOp,
+    EqFwdOp,
+    ErfFwdOp,
+    ExpFwdOp,
+    Expm1FwdOp,
+    FloorDivideFwdOp,
+    FloorFwdOp,
+    GeFwdOp,
+    GeluAndMulFwdOp,
+    GeluFwdOp,
+    GeluTanhAndMulFwdOp,
+    GtFwdOp,
+    HardsigmoidFwdOp,
+    HardswishFwdOp,
+    IsfiniteFwdOp,
+    IsinfFwdOp,
+    IsnanFwdOp,
+    LeFwdOp,
+    LerpFwdOp,
+    Log1pFwdOp,
+    LogFwdOp,
+    LogicalAndFwdOp,
+    LogicalNotFwdOp,
+    LogicalOrFwdOp,
+    LtFwdOp,
+    MaximumFwdOp,
+    MinimumFwdOp,
+    MishFwdOp,
+    MulFwdOp,
+    NeFwdOp,
+    NegFwdOp,
+    PowFwdOp,
+    ReciprocalFwdOp,
+    ReluFwdOp,
+    RemainderFwdOp,
+    RoundFwdOp,
+    RsqrtFwdOp,
+    SeluFwdOp,
+    SigmoidFwdOp,
+    SignFwdOp,
+    SiluAndMulFwdOp,
+    SiluFwdOp,
+    SinFwdOp,
+    SqrtFwdOp,
+    SubFwdOp,
+    TanhFwdOp,
+    TruncFwdOp,
 )
 
 
@@ -109,7 +109,7 @@ class ReluCompileTest(TestBase):
 @ReluCompileFixture
 def test_relu_compile(n_total, dtype):
     test = ReluCompileTest(n_total, dtype)
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=1e-3, rtol=1e-3)
@@ -147,7 +147,7 @@ class AddCompileTest(TestBase):
 @AddCompileFixture
 def test_add_compile(a_shape, b_shape, dtype):
     test = AddCompileTest(a_shape, b_shape, dtype)
-    op = AddOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=1e-3, rtol=1e-3)
@@ -186,7 +186,7 @@ class EqCompileTest(TestBase):
 @EqCompileFixture
 def test_eq_compile(a_shape, b_shape, dtype):
     test = EqCompileTest(a_shape, b_shape, dtype)
-    op = EqOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    op = EqFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, compare=exact_compare)
@@ -224,7 +224,7 @@ class SiluAndMulCompileTest(TestBase):
 @SiluAndMulCompileFixture
 def test_silu_and_mul_compile(M, N, dtype):
     test = SiluAndMulCompileTest(M, N, dtype)
-    op = SiluAndMulOp(M=M, N=N, dtype=dtype)
+    op = SiluAndMulFwdOp(M=M, N=N, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=1e-2, rtol=1e-2)
@@ -258,7 +258,7 @@ class AbsCompileTest(TestBase):
 @AbsCompileFixture
 def test_abs_compile(n_total, dtype):
     test = AbsCompileTest(n_total, dtype)
-    op = AbsOp(N_total=n_total, dtype=dtype)
+    op = AbsFwdOp(N_total=n_total, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=1e-3, rtol=1e-3)
@@ -287,7 +287,7 @@ class SignCompileTest(TestBase):
 @SignCompileFixture
 def test_sign_compile(n_total, dtype):
     test = SignCompileTest(n_total, dtype)
-    op = SignOp(N_total=n_total, dtype=dtype)
+    op = SignFwdOp(N_total=n_total, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=1e-3, rtol=1e-3)
@@ -309,7 +309,7 @@ class FakeUnaryFixture(FixtureBase):
 @FakeUnaryFixture
 def test_register_fake_unary_shape_dtype(n_total, dtype):
     """Verify register_fake returns correct shape and dtype for unary ops."""
-    op = ReluOp(N_total=n_total, dtype=dtype)
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
     x = torch.randn(n_total, dtype=dtype, device="cuda")
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(x)
@@ -328,7 +328,7 @@ class FakeComparisonFixture(FixtureBase):
 @FakeComparisonFixture
 def test_register_fake_comparison_bool_dtype(shape, dtype):
     """Verify register_fake returns torch.bool for comparison ops."""
-    op = EqOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = EqFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     a = torch.randn(shape, dtype=dtype, device="cuda")
     b = torch.randn(shape, dtype=dtype, device="cuda")
     compiled_op = torch.compile(op, fullgraph=True)
@@ -347,7 +347,7 @@ class FakeFusedGatedFixture(FixtureBase):
 @FakeFusedGatedFixture
 def test_register_fake_fused_gated_shape(M, N, dtype):
     """Verify register_fake returns correct shape for fused gated ops."""
-    op = SiluAndMulOp(M=M, N=N, dtype=dtype)
+    op = SiluAndMulFwdOp(M=M, N=N, dtype=dtype)
     x = torch.randn(M, 2 * N, dtype=dtype, device="cuda")
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(x)
@@ -376,29 +376,29 @@ def _positive_input(n, dtype):
 
 
 _UNARY_FLOAT_OPS = [
-    pytest.param(ExpOp, torch.exp, None, "exp", marks=pytest.mark.full),
-    pytest.param(LogOp, lambda x: torch.log(x.float()).to(x.dtype), _positive_input, "log", marks=pytest.mark.full),
-    pytest.param(SqrtOp, lambda x: torch.sqrt(x.float()).to(x.dtype), _positive_input, "sqrt", marks=pytest.mark.full),
-    pytest.param(RsqrtOp, lambda x: torch.rsqrt(x.float()).to(x.dtype), _positive_input, "rsqrt", marks=pytest.mark.full),
-    pytest.param(NegOp, torch.neg, None, "neg", marks=pytest.mark.full),
-    pytest.param(ReciprocalOp, lambda x: torch.reciprocal(x.float()).to(x.dtype), None, "reciprocal", marks=pytest.mark.full),
-    pytest.param(SinOp, lambda x: torch.sin(x.float()).to(x.dtype), None, "sin", marks=pytest.mark.full),
-    pytest.param(CosOp, lambda x: torch.cos(x.float()).to(x.dtype), None, "cos", marks=pytest.mark.full),
-    pytest.param(FloorOp, lambda x: torch.floor(x.float()).to(x.dtype), None, "floor", marks=pytest.mark.full),
-    pytest.param(CeilOp, lambda x: torch.ceil(x.float()).to(x.dtype), None, "ceil", marks=pytest.mark.full),
-    pytest.param(RoundOp, lambda x: torch.round(x.float()).to(x.dtype), None, "round", marks=pytest.mark.full),
-    pytest.param(TruncOp, lambda x: torch.trunc(x.float()).to(x.dtype), None, "trunc", marks=pytest.mark.full),
-    pytest.param(ErfOp, lambda x: torch.erf(x.float()).to(x.dtype), None, "erf", marks=pytest.mark.full),
-    pytest.param(Log1pOp, lambda x: torch.log1p(x.float()).to(x.dtype), _positive_input, "log1p", marks=pytest.mark.full),
-    pytest.param(Expm1Op, lambda x: torch.expm1(x.float()).to(x.dtype), None, "expm1", marks=pytest.mark.full),
-    pytest.param(GeluOp, lambda x: torch.nn.functional.gelu(x.float()).to(x.dtype), None, "gelu", marks=pytest.mark.full),
-    pytest.param(SiluOp, lambda x: torch.nn.functional.silu(x.float()).to(x.dtype), None, "silu", marks=pytest.mark.full),
-    pytest.param(SigmoidOp, lambda x: torch.sigmoid(x.float()).to(x.dtype), None, "sigmoid", marks=pytest.mark.full),
-    pytest.param(TanhOp, lambda x: torch.tanh(x.float()).to(x.dtype), None, "tanh", marks=pytest.mark.full),
-    pytest.param(HardswishOp, lambda x: torch.nn.functional.hardswish(x.float()).to(x.dtype), None, "hardswish", marks=pytest.mark.full),
-    pytest.param(HardsigmoidOp, lambda x: torch.nn.functional.hardsigmoid(x.float()).to(x.dtype), None, "hardsigmoid", marks=pytest.mark.full),
-    pytest.param(MishOp, lambda x: torch.nn.functional.mish(x.float()).to(x.dtype), None, "mish", marks=pytest.mark.full),
-    pytest.param(SeluOp, lambda x: torch.nn.functional.selu(x.float()).to(x.dtype), None, "selu", marks=pytest.mark.full),
+    pytest.param(ExpFwdOp, torch.exp, None, "exp", marks=pytest.mark.full),
+    pytest.param(LogFwdOp, lambda x: torch.log(x.float()).to(x.dtype), _positive_input, "log", marks=pytest.mark.full),
+    pytest.param(SqrtFwdOp, lambda x: torch.sqrt(x.float()).to(x.dtype), _positive_input, "sqrt", marks=pytest.mark.full),
+    pytest.param(RsqrtFwdOp, lambda x: torch.rsqrt(x.float()).to(x.dtype), _positive_input, "rsqrt", marks=pytest.mark.full),
+    pytest.param(NegFwdOp, torch.neg, None, "neg", marks=pytest.mark.full),
+    pytest.param(ReciprocalFwdOp, lambda x: torch.reciprocal(x.float()).to(x.dtype), None, "reciprocal", marks=pytest.mark.full),
+    pytest.param(SinFwdOp, lambda x: torch.sin(x.float()).to(x.dtype), None, "sin", marks=pytest.mark.full),
+    pytest.param(CosFwdOp, lambda x: torch.cos(x.float()).to(x.dtype), None, "cos", marks=pytest.mark.full),
+    pytest.param(FloorFwdOp, lambda x: torch.floor(x.float()).to(x.dtype), None, "floor", marks=pytest.mark.full),
+    pytest.param(CeilFwdOp, lambda x: torch.ceil(x.float()).to(x.dtype), None, "ceil", marks=pytest.mark.full),
+    pytest.param(RoundFwdOp, lambda x: torch.round(x.float()).to(x.dtype), None, "round", marks=pytest.mark.full),
+    pytest.param(TruncFwdOp, lambda x: torch.trunc(x.float()).to(x.dtype), None, "trunc", marks=pytest.mark.full),
+    pytest.param(ErfFwdOp, lambda x: torch.erf(x.float()).to(x.dtype), None, "erf", marks=pytest.mark.full),
+    pytest.param(Log1pFwdOp, lambda x: torch.log1p(x.float()).to(x.dtype), _positive_input, "log1p", marks=pytest.mark.full),
+    pytest.param(Expm1FwdOp, lambda x: torch.expm1(x.float()).to(x.dtype), None, "expm1", marks=pytest.mark.full),
+    pytest.param(GeluFwdOp, lambda x: torch.nn.functional.gelu(x.float()).to(x.dtype), None, "gelu", marks=pytest.mark.full),
+    pytest.param(SiluFwdOp, lambda x: torch.nn.functional.silu(x.float()).to(x.dtype), None, "silu", marks=pytest.mark.full),
+    pytest.param(SigmoidFwdOp, lambda x: torch.sigmoid(x.float()).to(x.dtype), None, "sigmoid", marks=pytest.mark.full),
+    pytest.param(TanhFwdOp, lambda x: torch.tanh(x.float()).to(x.dtype), None, "tanh", marks=pytest.mark.full),
+    pytest.param(HardswishFwdOp, lambda x: torch.nn.functional.hardswish(x.float()).to(x.dtype), None, "hardswish", marks=pytest.mark.full),
+    pytest.param(HardsigmoidFwdOp, lambda x: torch.nn.functional.hardsigmoid(x.float()).to(x.dtype), None, "hardsigmoid", marks=pytest.mark.full),
+    pytest.param(MishFwdOp, lambda x: torch.nn.functional.mish(x.float()).to(x.dtype), None, "mish", marks=pytest.mark.full),
+    pytest.param(SeluFwdOp, lambda x: torch.nn.functional.selu(x.float()).to(x.dtype), None, "selu", marks=pytest.mark.full),
 ]
 
 
@@ -417,10 +417,10 @@ def test_unary_float_compile(op_cls, ref_fn, input_fn, name):
 # --- Unary bool-output ops ---
 
 _UNARY_BOOL_OPS = [
-    pytest.param(LogicalNotOp, lambda x: ~(x != 0), torch.float16, "logical_not", marks=pytest.mark.full),
-    pytest.param(IsnanOp, torch.isnan, torch.float16, "isnan", marks=pytest.mark.full),
-    pytest.param(IsinfOp, torch.isinf, torch.float16, "isinf", marks=pytest.mark.full),
-    pytest.param(IsfiniteOp, torch.isfinite, torch.float16, "isfinite", marks=pytest.mark.full),
+    pytest.param(LogicalNotFwdOp, lambda x: ~(x != 0), torch.float16, "logical_not", marks=pytest.mark.full),
+    pytest.param(IsnanFwdOp, torch.isnan, torch.float16, "isnan", marks=pytest.mark.full),
+    pytest.param(IsinfFwdOp, torch.isinf, torch.float16, "isinf", marks=pytest.mark.full),
+    pytest.param(IsfiniteFwdOp, torch.isfinite, torch.float16, "isfinite", marks=pytest.mark.full),
 ]
 
 
@@ -441,10 +441,10 @@ def test_unary_bool_compile(op_cls, ref_fn, dtype, name):
 
 @pytest.mark.full
 def test_bitwise_not_compile():
-    """Compile-smoke for BitwiseNotOp."""
+    """Compile-smoke for BitwiseNotFwdOp."""
     n = _N
     x_int = torch.randint(0, 256, (n,), dtype=torch.uint8, device="cuda")
-    op = BitwiseNotOp(N_total=n, dtype=torch.uint8)
+    op = BitwiseNotFwdOp(N_total=n, dtype=torch.uint8)
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(x_int)
     ref = ~x_int
@@ -454,13 +454,13 @@ def test_bitwise_not_compile():
 # --- Remaining binary same-dtype ops ---
 
 _BINARY_ARITH_OPS = [
-    pytest.param(SubOp, lambda a, b: (a.float() - b.float()).half(), "sub", marks=pytest.mark.full),
-    pytest.param(MulOp, lambda a, b: (a.float() * b.float()).half(), "mul", marks=pytest.mark.full),
-    pytest.param(DivOp, lambda a, b: (a.float() / b.float()).half(), "div", marks=pytest.mark.full),
-    pytest.param(RemainderOp, lambda a, b: a - torch.floor(a.float() / b.float()).half() * b, "remainder", marks=pytest.mark.full),
-    pytest.param(FloorDivideOp, lambda a, b: torch.floor(a.float() / b.float()).half(), "floor_divide", marks=pytest.mark.full),
-    pytest.param(MaximumOp, lambda a, b: torch.maximum(a.float(), b.float()).half(), "maximum", marks=pytest.mark.full),
-    pytest.param(MinimumOp, lambda a, b: torch.minimum(a.float(), b.float()).half(), "minimum", marks=pytest.mark.full),
+    pytest.param(SubFwdOp, lambda a, b: (a.float() - b.float()).half(), "sub", marks=pytest.mark.full),
+    pytest.param(MulFwdOp, lambda a, b: (a.float() * b.float()).half(), "mul", marks=pytest.mark.full),
+    pytest.param(DivFwdOp, lambda a, b: (a.float() / b.float()).half(), "div", marks=pytest.mark.full),
+    pytest.param(RemainderFwdOp, lambda a, b: a - torch.floor(a.float() / b.float()).half() * b, "remainder", marks=pytest.mark.full),
+    pytest.param(FloorDivideFwdOp, lambda a, b: torch.floor(a.float() / b.float()).half(), "floor_divide", marks=pytest.mark.full),
+    pytest.param(MaximumFwdOp, lambda a, b: torch.maximum(a.float(), b.float()).half(), "maximum", marks=pytest.mark.full),
+    pytest.param(MinimumFwdOp, lambda a, b: torch.minimum(a.float(), b.float()).half(), "minimum", marks=pytest.mark.full),
 ]
 
 
@@ -479,12 +479,12 @@ def test_binary_arith_compile(op_cls, ref_fn, name):
 
 @pytest.mark.full
 def test_pow_compile():
-    """Compile-smoke for PowOp with positive inputs to avoid NaN domain issues."""
+    """Compile-smoke for PowFwdOp with positive inputs to avoid NaN domain issues."""
     shape = _SMALL
     # Use positive base and small positive exponent to stay in valid domain
     a = torch.rand(shape, dtype=_DTYPE, device="cuda").clamp(min=0.1) * 5.0
     b = torch.rand(shape, dtype=_DTYPE, device="cuda") * 2.0
-    op = PowOp(a_shape=shape, b_shape=shape, dtype=_DTYPE)
+    op = PowFwdOp(a_shape=shape, b_shape=shape, dtype=_DTYPE)
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(a, b)
     ref = torch.pow(a.float(), b.float()).half()
@@ -495,11 +495,11 @@ def test_pow_compile():
 
 @pytest.mark.full
 def test_lerp_compile():
-    """Compile-smoke for LerpOp."""
+    """Compile-smoke for LerpFwdOp."""
     shape = _SMALL
     a = torch.randn(shape, dtype=_DTYPE, device="cuda")
     b = torch.randn(shape, dtype=_DTYPE, device="cuda")
-    op = LerpOp(a_shape=shape, b_shape=shape, dtype=_DTYPE, weight=0.3)
+    op = LerpFwdOp(a_shape=shape, b_shape=shape, dtype=_DTYPE, weight=0.3)
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(a, b)
     ref = torch.lerp(a.float(), b.float(), 0.3).half()
@@ -509,11 +509,11 @@ def test_lerp_compile():
 # --- Remaining comparison ops ---
 
 _COMPARISON_OPS = [
-    pytest.param(NeOp, lambda a, b: a != b, "ne", marks=pytest.mark.full),
-    pytest.param(GtOp, lambda a, b: a > b, "gt", marks=pytest.mark.full),
-    pytest.param(LtOp, lambda a, b: a < b, "lt", marks=pytest.mark.full),
-    pytest.param(GeOp, lambda a, b: a >= b, "ge", marks=pytest.mark.full),
-    pytest.param(LeOp, lambda a, b: a <= b, "le", marks=pytest.mark.full),
+    pytest.param(NeFwdOp, lambda a, b: a != b, "ne", marks=pytest.mark.full),
+    pytest.param(GtFwdOp, lambda a, b: a > b, "gt", marks=pytest.mark.full),
+    pytest.param(LtFwdOp, lambda a, b: a < b, "lt", marks=pytest.mark.full),
+    pytest.param(GeFwdOp, lambda a, b: a >= b, "ge", marks=pytest.mark.full),
+    pytest.param(LeFwdOp, lambda a, b: a <= b, "le", marks=pytest.mark.full),
 ]
 
 
@@ -534,8 +534,8 @@ def test_comparison_compile(op_cls, ref_fn, name):
 # --- Logical binary ops ---
 
 _LOGICAL_OPS = [
-    pytest.param(LogicalAndOp, lambda a, b: (a != 0) & (b != 0), "logical_and", marks=pytest.mark.full),
-    pytest.param(LogicalOrOp, lambda a, b: (a != 0) | (b != 0), "logical_or", marks=pytest.mark.full),
+    pytest.param(LogicalAndFwdOp, lambda a, b: (a != 0) & (b != 0), "logical_and", marks=pytest.mark.full),
+    pytest.param(LogicalOrFwdOp, lambda a, b: (a != 0) | (b != 0), "logical_or", marks=pytest.mark.full),
 ]
 
 
@@ -556,9 +556,9 @@ def test_logical_binary_compile(op_cls, ref_fn, name):
 # --- Bitwise binary ops ---
 
 _BITWISE_BINARY_OPS = [
-    pytest.param(BitwiseAndOp, lambda a, b: a & b, "bitwise_and", marks=pytest.mark.full),
-    pytest.param(BitwiseOrOp, lambda a, b: a | b, "bitwise_or", marks=pytest.mark.full),
-    pytest.param(BitwiseXorOp, lambda a, b: a ^ b, "bitwise_xor", marks=pytest.mark.full),
+    pytest.param(BitwiseAndFwdOp, lambda a, b: a & b, "bitwise_and", marks=pytest.mark.full),
+    pytest.param(BitwiseOrFwdOp, lambda a, b: a | b, "bitwise_or", marks=pytest.mark.full),
+    pytest.param(BitwiseXorFwdOp, lambda a, b: a ^ b, "bitwise_xor", marks=pytest.mark.full),
 ]
 
 
@@ -578,8 +578,8 @@ def test_bitwise_binary_compile(op_cls, ref_fn, name):
 # --- Remaining fused gated ops ---
 
 _FUSED_GATED_OPS = [
-    pytest.param(GeluAndMulOp, "gelu_and_mul", marks=pytest.mark.full),
-    pytest.param(GeluTanhAndMulOp, "gelu_tanh_and_mul", marks=pytest.mark.full),
+    pytest.param(GeluAndMulFwdOp, "gelu_and_mul", marks=pytest.mark.full),
+    pytest.param(GeluTanhAndMulFwdOp, "gelu_tanh_and_mul", marks=pytest.mark.full),
 ]
 
 

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -6,22 +6,22 @@ import pytest
 import torch
 
 from tileops.kernels.elementwise import (
-    AddKernel,
-    EluKernel,
-    EqKernel,
-    GeKernel,
-    GtKernel,
-    HardtanhKernel,
+    AddFwdKernel,
+    EluFwdKernel,
+    EqFwdKernel,
+    GeFwdKernel,
+    GtFwdKernel,
+    HardtanhFwdKernel,
     # Independent kernels (custom-signature)
-    LeakyReluKernel,
-    LeKernel,
-    LogicalAndKernel,
-    LogicalOrKernel,
-    LtKernel,
-    NeKernel,
-    PreluKernel,
-    ReluKernel,
-    SiluAndMulKernel,
+    LeakyReluFwdKernel,
+    LeFwdKernel,
+    LogicalAndFwdKernel,
+    LogicalOrFwdKernel,
+    LtFwdKernel,
+    NeFwdKernel,
+    PreluFwdKernel,
+    ReluFwdKernel,
+    SiluAndMulFwdKernel,
 )
 
 # ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ from tileops.kernels.elementwise import (
 # ---------------------------------------------------------------------------
 
 
-INDEPENDENT_KERNELS_SIMPLE = [LeakyReluKernel, EluKernel, HardtanhKernel]
+INDEPENDENT_KERNELS_SIMPLE = [LeakyReluFwdKernel, EluFwdKernel, HardtanhFwdKernel]
 
 
 @pytest.mark.full
@@ -64,7 +64,7 @@ def test_independent_kernels_use_expected_default_npt(kernel_cls, dtype, expecte
 )
 def test_prelu_preserves_dtype_driven_default_npt(dtype, expected_npt):
     """Prelu is the custom-signature outlier and should keep the same dtype mapping."""
-    kernel = PreluKernel.__new__(PreluKernel)
+    kernel = PreluFwdKernel.__new__(PreluFwdKernel)
     kernel.dtype = dtype
     assert kernel.default_config["num_per_thread"] == expected_npt
 
@@ -74,8 +74,8 @@ def test_prelu_preserves_dtype_driven_default_npt(dtype, expected_npt):
 # ---------------------------------------------------------------------------
 
 
-COMPARISON_KERNELS = [EqKernel, NeKernel, GtKernel, LtKernel, GeKernel, LeKernel]
-LOGICAL_BINARY_KERNELS = [LogicalAndKernel, LogicalOrKernel]
+COMPARISON_KERNELS = [EqFwdKernel, NeFwdKernel, GtFwdKernel, LtFwdKernel, GeFwdKernel, LeFwdKernel]
+LOGICAL_BINARY_KERNELS = [LogicalAndFwdKernel, LogicalOrFwdKernel]
 
 
 @pytest.mark.full
@@ -98,10 +98,10 @@ def test_bool_like_elementwise_kernels_expose_torch_dtype_output(kernel_cls):
 def test_unary_kernel_sets_output_dtype_in_init():
     """Unary kernels should initialize `output_dtype` during construction."""
     with (
-        patch.object(ReluKernel, "_build_kernel", return_value=None),
-        patch.object(ReluKernel, "init_config"),
+        patch.object(ReluFwdKernel, "_build_kernel", return_value=None),
+        patch.object(ReluFwdKernel, "init_config"),
     ):
-        kernel = ReluKernel(N_total=1024, dtype=torch.float16)
+        kernel = ReluFwdKernel(N_total=1024, dtype=torch.float16)
     assert kernel.output_dtype == torch.float16
 
 
@@ -109,10 +109,10 @@ def test_unary_kernel_sets_output_dtype_in_init():
 def test_binary_kernel_sets_output_dtype_in_init():
     """Binary kernels should initialize `output_dtype` during construction."""
     with (
-        patch.object(AddKernel, "_build_kernel", return_value=None),
-        patch.object(AddKernel, "init_config"),
+        patch.object(AddFwdKernel, "_build_kernel", return_value=None),
+        patch.object(AddFwdKernel, "init_config"),
     ):
-        kernel = AddKernel(
+        kernel = AddFwdKernel(
             N_total=1024, dtype=torch.float16,
             coalesced_shape=(1024,), a_strides=(1,), b_strides=(1,),
             a_numel=1024, b_numel=1024,
@@ -124,10 +124,10 @@ def test_binary_kernel_sets_output_dtype_in_init():
 def test_fused_gated_kernel_sets_output_dtype_in_init():
     """Fused-gated kernels should initialize `output_dtype` during construction."""
     with (
-        patch.object(SiluAndMulKernel, "_build_kernel", return_value=None),
-        patch.object(SiluAndMulKernel, "init_config"),
+        patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
+        patch.object(SiluAndMulFwdKernel, "init_config"),
     ):
-        kernel = SiluAndMulKernel(M=32, N=1024, dtype=torch.float16)
+        kernel = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16)
     assert kernel.output_dtype == torch.float16
 
 
@@ -135,11 +135,11 @@ def test_fused_gated_kernel_sets_output_dtype_in_init():
 def test_unary_default_config_preserves_strategy_npt_split():
     """Unary kernels should keep the explicit_parallel/register_copy npt split."""
     with (
-        patch.object(ReluKernel, "_build_kernel", return_value=None),
-        patch.object(ReluKernel, "init_config"),
+        patch.object(ReluFwdKernel, "_build_kernel", return_value=None),
+        patch.object(ReluFwdKernel, "init_config"),
     ):
-        explicit = ReluKernel(N_total=1024, dtype=torch.float16, strategy="explicit_parallel")
-        register = ReluKernel(N_total=1024, dtype=torch.float16, strategy="register_copy")
+        explicit = ReluFwdKernel(N_total=1024, dtype=torch.float16, strategy="explicit_parallel")
+        register = ReluFwdKernel(N_total=1024, dtype=torch.float16, strategy="register_copy")
     assert explicit.default_config["num_per_thread"] == 4
     assert register.default_config["num_per_thread"] == 8
 
@@ -157,11 +157,11 @@ def test_binary_default_config_preserves_strategy_npt_split():
         "b_numel": 1024,
     }
     with (
-        patch.object(AddKernel, "_build_kernel", return_value=None),
-        patch.object(AddKernel, "init_config"),
+        patch.object(AddFwdKernel, "_build_kernel", return_value=None),
+        patch.object(AddFwdKernel, "init_config"),
     ):
-        explicit = AddKernel(strategy="explicit_parallel", **common_kwargs)
-        register = AddKernel(strategy="register_copy", **common_kwargs)
+        explicit = AddFwdKernel(strategy="explicit_parallel", **common_kwargs)
+        register = AddFwdKernel(strategy="register_copy", **common_kwargs)
     assert explicit.default_config["num_per_thread"] == 4
     assert register.default_config["num_per_thread"] == 8
 
@@ -170,10 +170,10 @@ def test_binary_default_config_preserves_strategy_npt_split():
 def test_fused_gated_default_config_preserves_strategy_npt_split():
     """Fused-gated kernels should keep the direct/explicit_parallel npt split."""
     with (
-        patch.object(SiluAndMulKernel, "_build_kernel", return_value=None),
-        patch.object(SiluAndMulKernel, "init_config"),
+        patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
+        patch.object(SiluAndMulFwdKernel, "init_config"),
     ):
-        direct = SiluAndMulKernel(M=32, N=1024, dtype=torch.float16, strategy="direct")
-        explicit = SiluAndMulKernel(M=32, N=1024, dtype=torch.float16, strategy="explicit_parallel")
+        direct = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="direct")
+        explicit = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="explicit_parallel")
     assert direct.default_config["num_per_thread"] == 8
     assert explicit.default_config["num_per_thread"] == 4

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -40,18 +40,18 @@ class Fp8DtypeAcceptanceFixture(FixtureBase):
 @Fp8DtypeAcceptanceFixture
 def test_unary_kernel_accepts_fp8(dtype):
     """UnaryKernel base class can be instantiated with fp8 dtype."""
-    from tileops.kernels.elementwise import ReluKernel
+    from tileops.kernels.elementwise import ReluFwdKernel
 
-    kernel = ReluKernel(N_total=_N, dtype=dtype)
+    kernel = ReluFwdKernel(N_total=_N, dtype=dtype)
     assert kernel.dtype == dtype
 
 
 @Fp8DtypeAcceptanceFixture
 def test_binary_kernel_accepts_fp8(dtype):
     """BinaryKernel base class can be instantiated with fp8 dtype."""
-    from tileops.kernels.elementwise import AddKernel
+    from tileops.kernels.elementwise import AddFwdKernel
 
-    kernel = AddKernel(
+    kernel = AddFwdKernel(
         N_total=_N, dtype=dtype,
         coalesced_shape=(_N,), a_strides=(1,), b_strides=(1,),
         a_numel=_N, b_numel=_N,
@@ -62,10 +62,10 @@ def test_binary_kernel_accepts_fp8(dtype):
 @Fp8DtypeAcceptanceFixture
 def test_fused_gated_kernel_accepts_fp8(dtype):
     """FusedGatedKernel base class can be instantiated with fp8 dtype."""
-    from tileops.kernels.elementwise import SiluAndMulKernel
+    from tileops.kernels.elementwise import SiluAndMulFwdKernel
 
     M, N = 64, 128
-    kernel = SiluAndMulKernel(M=M, N=N, dtype=dtype)
+    kernel = SiluAndMulFwdKernel(M=M, N=N, dtype=dtype)
     assert kernel.dtype == dtype
 
 
@@ -77,9 +77,9 @@ def test_fused_gated_kernel_accepts_fp8(dtype):
 @Fp8DtypeAcceptanceFixture
 def test_fp8_default_config_npt16(dtype):
     """fp8 default_config returns num_per_thread=16 for 128-bit alignment."""
-    from tileops.kernels.elementwise import ReluKernel
+    from tileops.kernels.elementwise import ReluFwdKernel
 
-    kernel = ReluKernel(N_total=_N, dtype=dtype)
+    kernel = ReluFwdKernel(N_total=_N, dtype=dtype)
     assert kernel.config["num_per_thread"] == 16
 
 
@@ -91,11 +91,11 @@ def test_fp8_default_config_npt16(dtype):
 @pytest.mark.smoke
 def test_unary_kernel_forward_e5m2_dtype():
     """UnaryKernel.forward() returns float8_e5m2, not float16."""
-    from tileops.kernels.elementwise import ExpKernel
+    from tileops.kernels.elementwise import ExpFwdKernel
 
     n = _N
     dtype = torch.float8_e5m2
-    kernel = ExpKernel(N_total=n, dtype=dtype)
+    kernel = ExpFwdKernel(N_total=n, dtype=dtype)
     x = (torch.randn(n, dtype=torch.float16, device="cuda") * 0.5).to(dtype)
     out = kernel(x)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -104,11 +104,11 @@ def test_unary_kernel_forward_e5m2_dtype():
 @pytest.mark.smoke
 def test_binary_kernel_forward_e5m2_dtype():
     """BinaryKernel.forward() returns float8_e5m2, not float16."""
-    from tileops.kernels.elementwise import AddKernel
+    from tileops.kernels.elementwise import AddFwdKernel
 
     n = _N
     dtype = torch.float8_e5m2
-    kernel = AddKernel(
+    kernel = AddFwdKernel(
         N_total=n, dtype=dtype,
         coalesced_shape=(n,), a_strides=(1,), b_strides=(1,),
         a_numel=n, b_numel=n,
@@ -122,11 +122,11 @@ def test_binary_kernel_forward_e5m2_dtype():
 @pytest.mark.smoke
 def test_fused_gated_kernel_forward_e5m2_dtype():
     """FusedGatedKernel.forward() returns float8_e5m2, not float16."""
-    from tileops.kernels.elementwise import SiluAndMulKernel
+    from tileops.kernels.elementwise import SiluAndMulFwdKernel
 
     M, N = 64, 128
     dtype = torch.float8_e5m2
-    kernel = SiluAndMulKernel(M=M, N=N, dtype=dtype)
+    kernel = SiluAndMulFwdKernel(M=M, N=N, dtype=dtype)
     x = (torch.randn(M, 2 * N, dtype=torch.float16, device="cuda") * 0.5).to(dtype)
     out = kernel(x)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -141,7 +141,7 @@ def test_fused_gated_direct_e5m2_preserves_inf():
     The fix routes e5m2 through an fp16 output buffer (matching
     explicit_parallel) so PyTorch's .to() preserves Inf/NaN.
     """
-    from tileops.kernels.elementwise import SiluAndMulKernel
+    from tileops.kernels.elementwise import SiluAndMulFwdKernel
 
     M, N = 1, 16
     dtype = torch.float8_e5m2
@@ -150,7 +150,7 @@ def test_fused_gated_direct_e5m2_preserves_inf():
     value_fp16 = torch.full((M, N), 50000.0, dtype=torch.float16, device="cuda")
     x_fp16 = torch.cat([gate_fp16, value_fp16], dim=1)
     x = x_fp16.to(dtype)
-    kernel = SiluAndMulKernel(M=M, N=N, dtype=dtype, strategy="direct")
+    kernel = SiluAndMulFwdKernel(M=M, N=N, dtype=dtype, strategy="direct")
     out = kernel(x)
     out_fp32 = out.to(torch.float32)
     assert torch.any(torch.isinf(out_fp32)), (
@@ -162,11 +162,11 @@ def test_fused_gated_direct_e5m2_preserves_inf():
 @pytest.mark.smoke
 def test_unary_kernel_forward_e5m2_preserves_inf():
     """UnaryKernel.forward() preserves Inf for e5m2 (direct kernel call)."""
-    from tileops.kernels.elementwise import ExpKernel
+    from tileops.kernels.elementwise import ExpFwdKernel
 
     n = _N
     dtype = torch.float8_e5m2
-    kernel = ExpKernel(N_total=n, dtype=dtype)
+    kernel = ExpFwdKernel(N_total=n, dtype=dtype)
     # exp(16) overflows to Inf in fp16
     x = torch.full((n,), 16.0, dtype=torch.float16, device="cuda").to(dtype)
     out = kernel(x)
@@ -209,11 +209,11 @@ class Fp8ReluTest(TestBase):
 @Fp8UnaryFixture
 def test_relu_fp8(dtype):
     """ReLU correctness with fp8 input/output."""
-    from tileops.ops.elementwise import ReluOp
+    from tileops.ops.elementwise import ReluFwdOp
 
     n = _N
     test = Fp8ReluTest(n, dtype)
-    op = ReluOp(N_total=n, dtype=dtype)
+    op = ReluFwdOp(N_total=n, dtype=dtype)
     inputs = test.gen_inputs()
     test.check(op, *inputs, atol=0, rtol=0, compare=exact_compare)
 
@@ -240,11 +240,11 @@ class Fp8AddTest(TestBase):
 @Fp8BinaryFixture
 def test_add_fp8(dtype):
     """Add correctness with fp8, including broadcast."""
-    from tileops.ops.elementwise import AddOp
+    from tileops.ops.elementwise import AddFwdOp
 
     shape = (128, 128)
     test = Fp8AddTest(shape, dtype)
-    op = AddOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     inputs = test.gen_inputs()
     test.check(op, *inputs, atol=0, rtol=0, compare=exact_compare)
 
@@ -252,13 +252,13 @@ def test_add_fp8(dtype):
 @Fp8BinaryFixture
 def test_add_fp8_broadcast(dtype):
     """Add correctness with fp8 and row broadcast."""
-    from tileops.ops.elementwise import AddOp
+    from tileops.ops.elementwise import AddFwdOp
 
     a_shape = (128, 128)
     b_shape = (1, 128)
     a = (torch.randn(a_shape, dtype=torch.float16, device="cuda") * 0.5).to(dtype)
     b = (torch.randn(b_shape, dtype=torch.float16, device="cuda") * 0.5).to(dtype)
-    op = AddOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
     ref = (a.to(torch.float16) + b.to(torch.float16)).to(dtype)
     out = op(a, b)
     assert torch.equal(out, ref)
@@ -289,11 +289,11 @@ class Fp8SiluAndMulTest(TestBase):
 @Fp8FusedGatedFixture
 def test_silu_and_mul_fp8(dtype):
     """SiLU-and-Mul correctness with fp8."""
-    from tileops.ops.elementwise import SiluAndMulOp
+    from tileops.ops.elementwise import SiluAndMulFwdOp
 
     M, N = 64, 128
     test = Fp8SiluAndMulTest(M, N, dtype)
-    op = SiluAndMulOp(M=M, N=N, dtype=dtype)
+    op = SiluAndMulFwdOp(M=M, N=N, dtype=dtype)
     inputs = test.gen_inputs()
     out = op(*inputs)
     ref = test.ref_program(*inputs)
@@ -315,7 +315,7 @@ def test_e4m3fn_saturates_on_overflow():
     Per NVIDIA spec, e4m3fn has no Inf representation. Values exceeding
     the max representable magnitude clamp to +/-448.0.
     """
-    from tileops.ops.elementwise import AddOp
+    from tileops.ops.elementwise import AddFwdOp
 
     # Create values near e4m3fn max (448.0)
     n = 1024
@@ -326,7 +326,7 @@ def test_e4m3fn_saturates_on_overflow():
     dtype = torch.float8_e4m3fn
     a = a_fp16.to(dtype)
     b = b_fp16.to(dtype)
-    op = AddOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
     out = op(a, b)
     out_fp32 = out.to(torch.float32)
     # Result should be 448.0 (saturated max), not Inf
@@ -346,7 +346,7 @@ def test_e5m2_overflow_produces_inf():
     The kernel produces fp16 output to preserve Inf, then the Op layer
     casts to e5m2 via PyTorch's non-saturating conversion.
     """
-    from tileops.ops.elementwise import AddOp
+    from tileops.ops.elementwise import AddFwdOp
 
     n = 1024
     a_shape = (n,)
@@ -356,7 +356,7 @@ def test_e5m2_overflow_produces_inf():
     b_fp16 = torch.full((n,), 40000.0, dtype=torch.float16, device="cuda")
     a = a_fp16.to(dtype)
     b = b_fp16.to(dtype)
-    op = AddOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
+    op = AddFwdOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
     out = op(a, b)
     out_fp32 = out.to(torch.float32)
     # e5m2 supports Inf, so overflowed values should be Inf
@@ -368,14 +368,14 @@ def test_e5m2_overflow_produces_inf():
 @pytest.mark.smoke
 def test_e5m2_exp_overflow_produces_inf():
     """e5m2 exp(large) should produce Inf, matching PyTorch reference."""
-    from tileops.ops.elementwise import ExpOp
+    from tileops.ops.elementwise import ExpFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     # exp(16) in fp16 overflows to Inf
     x_fp16 = torch.full((n,), 16.0, dtype=torch.float16, device="cuda")
     x = x_fp16.to(dtype)
-    op = ExpOp(N_total=n, dtype=dtype)
+    op = ExpFwdOp(N_total=n, dtype=dtype)
     out = op(x)
     ref = torch.exp(x.to(torch.float16)).to(dtype)
     assert torch.equal(out, ref), (
@@ -387,14 +387,14 @@ def test_e5m2_exp_overflow_produces_inf():
 @pytest.mark.smoke
 def test_e5m2_div_by_zero_produces_inf():
     """e5m2 1/0 should produce Inf, matching PyTorch reference."""
-    from tileops.ops.elementwise import DivOp
+    from tileops.ops.elementwise import DivFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     a_shape = (n,)
     a = torch.ones(n, dtype=torch.float16, device="cuda").to(dtype)
     b = torch.zeros(n, dtype=torch.float16, device="cuda").to(dtype)
-    op = DivOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
+    op = DivFwdOp(a_shape=a_shape, b_shape=a_shape, dtype=dtype)
     out = op(a, b)
     out_fp32 = out.to(torch.float32)
     assert torch.all(torch.isinf(out_fp32)), (
@@ -405,12 +405,12 @@ def test_e5m2_div_by_zero_produces_inf():
 @pytest.mark.smoke
 def test_e5m2_log_zero_produces_neg_inf():
     """e5m2 log(0) should produce -Inf, matching PyTorch reference."""
-    from tileops.ops.elementwise import LogOp
+    from tileops.ops.elementwise import LogFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     x = torch.zeros(n, dtype=torch.float16, device="cuda").to(dtype)
-    op = LogOp(N_total=n, dtype=dtype)
+    op = LogFwdOp(N_total=n, dtype=dtype)
     out = op(x)
     ref = torch.log(x.to(torch.float16)).to(dtype)
     assert torch.equal(out, ref), (
@@ -422,13 +422,13 @@ def test_e5m2_log_zero_produces_neg_inf():
 @pytest.mark.smoke
 def test_e4m3fn_exp_overflow_saturates():
     """e4m3fn exp(large) should saturate to 448.0, not produce Inf."""
-    from tileops.ops.elementwise import ExpOp
+    from tileops.ops.elementwise import ExpFwdOp
 
     n = 1024
     dtype = torch.float8_e4m3fn
     x_fp16 = torch.full((n,), 10.0, dtype=torch.float16, device="cuda")
     x = x_fp16.to(dtype)
-    op = ExpOp(N_total=n, dtype=dtype)
+    op = ExpFwdOp(N_total=n, dtype=dtype)
     out = op(x)
     out_fp32 = out.to(torch.float32)
     e4m3_max = torch.finfo(torch.float8_e4m3fn).max
@@ -450,14 +450,14 @@ def test_fp8_accumulation_in_higher_precision():
     SiLU involves sigmoid which requires higher precision. The result
     should match fp16 computation cast back to fp8, not direct fp8 arithmetic.
     """
-    from tileops.ops.elementwise import SiluOp
+    from tileops.ops.elementwise import SiluFwdOp
 
     n = _N
     dtype = torch.float8_e4m3fn
     # Values in a range where fp8 precision matters
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = SiluOp(N_total=n, dtype=dtype)
+    op = SiluFwdOp(N_total=n, dtype=dtype)
     out = op(x)
     # Reference: compute in fp16, cast back to fp8
     ref = torch.nn.functional.silu(x.to(torch.float16)).to(dtype)
@@ -529,20 +529,20 @@ def test_wrap_fp8_accumulation_arity2():
 
 @pytest.mark.smoke
 def test_bitwise_kernel_rejects_fp8():
-    """BitwiseNotKernel raises ValueError for fp8 (not in _BITWISE_DTYPES)."""
-    from tileops.kernels.elementwise import BitwiseNotKernel
+    """BitwiseNotFwdKernel raises ValueError for fp8 (not in _BITWISE_DTYPES)."""
+    from tileops.kernels.elementwise import BitwiseNotFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        BitwiseNotKernel(N_total=_N, dtype=torch.float8_e4m3fn)
+        BitwiseNotFwdKernel(N_total=_N, dtype=torch.float8_e4m3fn)
 
 
 @pytest.mark.smoke
 def test_binary_bitwise_kernel_rejects_fp8():
-    """BitwiseAndKernel raises ValueError for fp8 (not in _BITWISE_DTYPES)."""
-    from tileops.kernels.elementwise import BitwiseAndKernel
+    """BitwiseAndFwdKernel raises ValueError for fp8 (not in _BITWISE_DTYPES)."""
+    from tileops.kernels.elementwise import BitwiseAndFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        BitwiseAndKernel(
+        BitwiseAndFwdKernel(
             N_total=_N, dtype=torch.float8_e4m3fn,
             coalesced_shape=(_N,), a_strides=(1,), b_strides=(1,),
             a_numel=_N, b_numel=_N,

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -39,17 +39,17 @@ class Fp8DtypeFixture(FixtureBase):
 # ---------------------------------------------------------------------------
 
 _AC1_KERNELS = [
-    pytest.param("LeakyReluKernel", {"N_total": _N}, id="leaky_relu"),
-    pytest.param("EluKernel", {"N_total": _N}, id="elu"),
-    pytest.param("HardtanhKernel", {"N_total": _N}, id="hardtanh"),
-    pytest.param("SoftplusKernel", {"N_total": _N}, id="softplus"),
-    pytest.param("ClampKernel", {"N_total": _N, "min_val": -1.0, "max_val": 1.0}, id="clamp"),
-    pytest.param("WhereKernel", {"N_total": _N}, id="where"),
-    pytest.param("MaskedFillKernel", {"N_total": _N, "fill_value": 0.0}, id="masked_fill"),
-    pytest.param("NanToNumKernel", {"N_total": _N}, id="nan_to_num"),
-    pytest.param("PreluKernel", {"N_total": _N, "C": 16, "inner_size": _N // 16}, id="prelu"),
-    pytest.param("AlibiKernel", {"seq_len": 32, "num_heads": 8}, id="alibi"),
-    pytest.param("SinusoidalKernel", {"seq_len": 32, "d_model": 64}, id="sinusoidal"),
+    pytest.param("LeakyReluFwdKernel", {"N_total": _N}, id="leaky_relu"),
+    pytest.param("EluFwdKernel", {"N_total": _N}, id="elu"),
+    pytest.param("HardtanhFwdKernel", {"N_total": _N}, id="hardtanh"),
+    pytest.param("SoftplusFwdKernel", {"N_total": _N}, id="softplus"),
+    pytest.param("ClampFwdKernel", {"N_total": _N, "min_val": -1.0, "max_val": 1.0}, id="clamp"),
+    pytest.param("WhereFwdKernel", {"N_total": _N}, id="where"),
+    pytest.param("MaskedFillFwdKernel", {"N_total": _N, "fill_value": 0.0}, id="masked_fill"),
+    pytest.param("NanToNumFwdKernel", {"N_total": _N}, id="nan_to_num"),
+    pytest.param("PreluFwdKernel", {"N_total": _N, "C": 16, "inner_size": _N // 16}, id="prelu"),
+    pytest.param("AlibiFwdKernel", {"seq_len": 32, "num_heads": 8}, id="alibi"),
+    pytest.param("SinusoidalFwdKernel", {"seq_len": 32, "d_model": 64}, id="sinusoidal"),
 ]
 
 
@@ -70,17 +70,17 @@ def test_kernel_accepts_fp8(dtype, kernel_name, extra_kwargs):
 
 @pytest.mark.smoke
 def test_masked_fill_kernel_clamps_overflow_fill_value():
-    """MaskedFillKernel clamps fill_value exceeding e4m3fn max (448)."""
+    """MaskedFillFwdKernel clamps fill_value exceeding e4m3fn max (448)."""
     dtype = torch.float8_e4m3fn
-    kernel = _kern_mod.MaskedFillKernel(N_total=_N, dtype=dtype, fill_value=1e4)
+    kernel = _kern_mod.MaskedFillFwdKernel(N_total=_N, dtype=dtype, fill_value=1e4)
     assert kernel.fill_value == torch.finfo(dtype).max
 
 
 @pytest.mark.smoke
 def test_nan_to_num_kernel_clamps_overflow_defaults():
-    """NanToNumKernel clamps default posinf_val/neginf_val for e4m3fn."""
+    """NanToNumFwdKernel clamps default posinf_val/neginf_val for e4m3fn."""
     dtype = torch.float8_e4m3fn
-    kernel = _kern_mod.NanToNumKernel(N_total=_N, dtype=dtype)
+    kernel = _kern_mod.NanToNumFwdKernel(N_total=_N, dtype=dtype)
     finfo = torch.finfo(dtype)
     assert kernel.posinf_val == finfo.max
     assert kernel.neginf_val == finfo.min
@@ -91,9 +91,9 @@ def test_nan_to_num_kernel_clamps_overflow_defaults():
 # ---------------------------------------------------------------------------
 
 _AC2_KERNELS = [
-    pytest.param("LeakyReluKernel", {"N_total": _N}, id="leaky_relu"),
-    pytest.param("EluKernel", {"N_total": _N}, id="elu"),
-    pytest.param("ClampKernel", {"N_total": _N, "min_val": -1.0, "max_val": 1.0}, id="clamp"),
+    pytest.param("LeakyReluFwdKernel", {"N_total": _N}, id="leaky_relu"),
+    pytest.param("EluFwdKernel", {"N_total": _N}, id="elu"),
+    pytest.param("ClampFwdKernel", {"N_total": _N, "min_val": -1.0, "max_val": 1.0}, id="clamp"),
 ]
 
 
@@ -120,13 +120,13 @@ def test_fp8_default_config_npt16(dtype, kernel_name, extra_kwargs):
 @Fp8DtypeFixture
 def test_leaky_relu_fp8_correctness(dtype):
     """LeakyReLU correctness with fp8 input/output."""
-    from tileops.ops.elementwise import LeakyReluOp
+    from tileops.ops.elementwise import LeakyReluFwdOp
 
     n = _N
     negative_slope = 0.01
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = LeakyReluOp(N_total=n, dtype=dtype, negative_slope=negative_slope)
+    op = LeakyReluFwdOp(N_total=n, dtype=dtype, negative_slope=negative_slope)
     out = op(x)
     ref = torch.nn.functional.leaky_relu(x.to(torch.float16), negative_slope).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -139,14 +139,14 @@ def test_leaky_relu_fp8_correctness(dtype):
 @Fp8DtypeFixture
 def test_elu_fp8_correctness(dtype):
     """ELU correctness with fp8 input/output."""
-    from tileops.ops.elementwise import EluOp
+    from tileops.ops.elementwise import EluFwdOp
 
     n = _N
     alpha = 1.0
     # Use small values to stay within fp8 range
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 1.0
     x = x_fp16.to(dtype)
-    op = EluOp(N_total=n, dtype=dtype, alpha=alpha)
+    op = EluFwdOp(N_total=n, dtype=dtype, alpha=alpha)
     out = op(x)
     ref = torch.nn.functional.elu(x.to(torch.float16), alpha).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -159,14 +159,14 @@ def test_elu_fp8_correctness(dtype):
 @Fp8DtypeFixture
 def test_clamp_fp8_correctness(dtype):
     """Clamp correctness with fp8 input/output."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     n = _N
     min_val = -0.5
     max_val = 0.5
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = ClampOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
+    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), min_val, max_val).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -179,9 +179,9 @@ def test_clamp_fp8_correctness(dtype):
 @Fp8DtypeFixture
 def test_alibi_fp8_output_dtype(dtype):
     """ALiBi fp8 output has correct dtype."""
-    from tileops.ops.elementwise import AlibiOp
+    from tileops.ops.elementwise import AlibiFwdOp
 
-    op = AlibiOp(seq_len=32, num_heads=8, dtype=dtype)
+    op = AlibiFwdOp(seq_len=32, num_heads=8, dtype=dtype)
     out = op()
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
     assert out.shape == (8, 32, 32)
@@ -190,9 +190,9 @@ def test_alibi_fp8_output_dtype(dtype):
 @Fp8DtypeFixture
 def test_sinusoidal_fp8_output_dtype(dtype):
     """Sinusoidal fp8 output has correct dtype."""
-    from tileops.ops.elementwise import SinusoidalOp
+    from tileops.ops.elementwise import SinusoidalFwdOp
 
-    op = SinusoidalOp(seq_len=32, d_model=64, dtype=dtype)
+    op = SinusoidalFwdOp(seq_len=32, d_model=64, dtype=dtype)
     out = op()
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
     assert out.shape == (32, 64)
@@ -201,14 +201,14 @@ def test_sinusoidal_fp8_output_dtype(dtype):
 @Fp8DtypeFixture
 def test_masked_fill_fp8_correctness(dtype):
     """MaskedFill correctness with fp8, including e5m2 post-cast path."""
-    from tileops.ops.elementwise import MaskedFillOp
+    from tileops.ops.elementwise import MaskedFillFwdOp
 
     n = _N
     fill_value = -1.0
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
     mask = torch.rand(n, device="cuda") > 0.5
-    op = MaskedFillOp(N_total=n, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillFwdOp(N_total=n, dtype=dtype, fill_value=fill_value)
     out = op(x, mask)
     ref = x.to(torch.float16).masked_fill(mask, fill_value).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -226,14 +226,14 @@ def test_masked_fill_fp8_correctness(dtype):
 @pytest.mark.smoke
 def test_leaky_relu_e4m3fn_saturation():
     """LeakyReLU e4m3fn saturates to max value on overflow."""
-    from tileops.ops.elementwise import LeakyReluOp
+    from tileops.ops.elementwise import LeakyReluFwdOp
 
     n = 1024
     dtype = torch.float8_e4m3fn
     # Large positive values that are already at e4m3fn max
     x_fp16 = torch.full((n,), 448.0, dtype=torch.float16, device="cuda")
     x = x_fp16.to(dtype)
-    op = LeakyReluOp(N_total=n, dtype=dtype, negative_slope=0.01)
+    op = LeakyReluFwdOp(N_total=n, dtype=dtype, negative_slope=0.01)
     out = op(x)
     out_fp32 = out.to(torch.float32)
     e4m3_max = torch.finfo(torch.float8_e4m3fn).max
@@ -246,13 +246,13 @@ def test_leaky_relu_e4m3fn_saturation():
 @pytest.mark.smoke
 def test_clamp_e5m2_preserves_values():
     """Clamp e5m2 preserves values within range correctly."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 0.5
     x = x_fp16.to(dtype)
-    op = ClampOp(N_total=n, dtype=dtype, min_val=-1.0, max_val=1.0)
+    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=-1.0, max_val=1.0)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), -1.0, 1.0).to(dtype)
     assert out.dtype == dtype
@@ -262,12 +262,12 @@ def test_clamp_e5m2_preserves_values():
 @pytest.mark.smoke
 def test_elu_e5m2_output_dtype():
     """ELU e5m2 forward returns e5m2 dtype, not fp16."""
-    from tileops.ops.elementwise import EluOp
+    from tileops.ops.elementwise import EluFwdOp
 
     n = _N
     dtype = torch.float8_e5m2
     x = (torch.randn(n, dtype=torch.float16, device="cuda") * 0.5).to(dtype)
-    op = EluOp(N_total=n, dtype=dtype)
+    op = EluFwdOp(N_total=n, dtype=dtype)
     out = op(x)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
 
@@ -275,37 +275,37 @@ def test_elu_e5m2_output_dtype():
 @pytest.mark.smoke
 def test_masked_fill_e5m2_overflow_fill_value():
     """MaskedFill rejects fill_value that exceeds effective kernel dtype range."""
-    from tileops.ops.elementwise import MaskedFillOp
+    from tileops.ops.elementwise import MaskedFillFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     fill_value = 1e5
     with pytest.raises(ValueError, match="fill_value=.*not representable"):
-        MaskedFillOp(N_total=n, dtype=dtype, fill_value=fill_value)
+        MaskedFillFwdOp(N_total=n, dtype=dtype, fill_value=fill_value)
 
 
 @pytest.mark.smoke
 def test_nan_to_num_e5m2_overflow_scalar_params_rejected():
     """NanToNum rejects replacement values that exceed effective kernel dtype range."""
-    from tileops.ops.elementwise import NanToNumOp
+    from tileops.ops.elementwise import NanToNumFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     with pytest.raises(ValueError, match="posinf_val=.*not representable"):
-        NanToNumOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1e5, neginf_val=-1.0)
+        NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1e5, neginf_val=-1.0)
     with pytest.raises(ValueError, match="neginf_val=.*not representable"):
-        NanToNumOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1.0, neginf_val=-1e5)
+        NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1.0, neginf_val=-1e5)
 
 
 @pytest.mark.smoke
 def test_leaky_relu_e5m2_overflow_negative_slope_rejected():
     """LeakyReLU rejects negative_slope that exceeds effective kernel dtype range."""
-    from tileops.ops.elementwise import LeakyReluOp
+    from tileops.ops.elementwise import LeakyReluFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     with pytest.raises(ValueError, match="negative_slope=.*not representable"):
-        LeakyReluOp(N_total=n, dtype=dtype, negative_slope=1e5)
+        LeakyReluFwdOp(N_total=n, dtype=dtype, negative_slope=1e5)
 
 
 # ---------------------------------------------------------------------------
@@ -322,13 +322,13 @@ class UnalignedFp8Fixture(FixtureBase):
 @UnalignedFp8Fixture
 def test_leaky_relu_fp8_unaligned_n(dtype):
     """LeakyReLU fp8 correctness with non-aligned N (tail block guard)."""
-    from tileops.ops.elementwise import LeakyReluOp
+    from tileops.ops.elementwise import LeakyReluFwdOp
 
     n = _N_UNALIGNED
     negative_slope = 0.01
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = LeakyReluOp(N_total=n, dtype=dtype, negative_slope=negative_slope)
+    op = LeakyReluFwdOp(N_total=n, dtype=dtype, negative_slope=negative_slope)
     out = op(x)
     ref = torch.nn.functional.leaky_relu(x.to(torch.float16), negative_slope).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -341,13 +341,13 @@ def test_leaky_relu_fp8_unaligned_n(dtype):
 @UnalignedFp8Fixture
 def test_elu_fp8_unaligned_n(dtype):
     """ELU fp8 correctness with non-aligned N (tail block guard)."""
-    from tileops.ops.elementwise import EluOp
+    from tileops.ops.elementwise import EluFwdOp
 
     n = _N_UNALIGNED
     alpha = 1.0
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 1.0
     x = x_fp16.to(dtype)
-    op = EluOp(N_total=n, dtype=dtype, alpha=alpha)
+    op = EluFwdOp(N_total=n, dtype=dtype, alpha=alpha)
     out = op(x)
     ref = torch.nn.functional.elu(x.to(torch.float16), alpha).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -360,14 +360,14 @@ def test_elu_fp8_unaligned_n(dtype):
 @UnalignedFp8Fixture
 def test_clamp_fp8_unaligned_n(dtype):
     """Clamp fp8 correctness with non-aligned N (tail block guard)."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     n = _N_UNALIGNED
     min_val = -0.5
     max_val = 0.5
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = ClampOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
+    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), min_val, max_val).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -10,9 +10,9 @@ import torch.nn.functional as F
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.elementwise import (
     FusedGatedKernel,
-    SiluAndMulKernel,
+    SiluAndMulFwdKernel,
 )
-from tileops.ops.elementwise import GeluAndMulOp, GeluTanhAndMulOp, SiluAndMulOp
+from tileops.ops.elementwise import GeluAndMulFwdOp, GeluTanhAndMulFwdOp, SiluAndMulFwdOp
 
 # ---------------------------------------------------------------------------
 # SiluAndMul
@@ -61,7 +61,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @SiluAndMulFixture
 def test_silu_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = SiluAndMulTest(m, n, dtype)
-    op = SiluAndMulOp(M=m, N=n, dtype=dtype)
+    op = SiluAndMulFwdOp(M=m, N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -103,7 +103,7 @@ class GeluAndMulTest(TestBase):
 @GeluAndMulFixture
 def test_gelu_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = GeluAndMulTest(m, n, dtype)
-    op = GeluAndMulOp(M=m, N=n, dtype=dtype)
+    op = GeluAndMulFwdOp(M=m, N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -145,7 +145,7 @@ class GeluTanhAndMulTest(TestBase):
 @GeluTanhAndMulFixture
 def test_gelu_tanh_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = GeluTanhAndMulTest(m, n, dtype)
-    op = GeluTanhAndMulOp(M=m, N=n, dtype=dtype)
+    op = GeluTanhAndMulFwdOp(M=m, N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -154,13 +154,13 @@ def test_gelu_tanh_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
 def test_fused_gated_rejects_integer_dtype() -> None:
     """Fused gated ops are float-only and must reject integer dtypes early."""
     with pytest.raises(ValueError, match="does not support dtype"):
-        GeluAndMulOp(M=16, N=16, dtype=torch.int32)
+        GeluAndMulFwdOp(M=16, N=16, dtype=torch.int32)
 
 
 @pytest.mark.smoke
 def test_fused_gated_rejects_runtime_dtype_mismatch() -> None:
     """Runtime inputs should match the construction-time dtype contract."""
-    op = SiluAndMulOp(M=16, N=8, dtype=torch.float16)
+    op = SiluAndMulFwdOp(M=16, N=8, dtype=torch.float16)
     x = torch.randn(16, 16, device="cuda", dtype=torch.float32)
     with pytest.raises(ValueError, match="Expected x.dtype"):
         op(x)
@@ -185,7 +185,7 @@ def test_fused_gated_kernel_has_strategies() -> None:
 def test_fused_gated_kernel_rejects_unknown_strategy() -> None:
     """FusedGatedKernel must reject unknown strategy names."""
     with pytest.raises(ValueError, match="Unknown strategy"):
-        SiluAndMulKernel(M=16, N=16, dtype=torch.float16, strategy="nonexistent")
+        SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16, strategy="nonexistent")
 
 
 class FusedGatedDirectStrategyFixture(FixtureBase):
@@ -202,7 +202,7 @@ class FusedGatedDirectStrategyFixture(FixtureBase):
 def test_silu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
     """SiluAndMul with strategy='direct' produces correct results."""
     test = SiluAndMulTest(m, n, dtype)
-    op = SiluAndMulOp(M=m, N=n, dtype=dtype, strategy="direct")
+    op = SiluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -211,7 +211,7 @@ def test_silu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> Non
 def test_gelu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
     """GeluAndMul with strategy='direct' produces correct results."""
     test = GeluAndMulTest(m, n, dtype)
-    op = GeluAndMulOp(M=m, N=n, dtype=dtype, strategy="direct")
+    op = GeluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -220,7 +220,7 @@ def test_gelu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> Non
 def test_gelu_tanh_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
     """GeluTanhAndMul with strategy='direct' produces correct results."""
     test = GeluTanhAndMulTest(m, n, dtype)
-    op = GeluTanhAndMulOp(M=m, N=n, dtype=dtype, strategy="direct")
+    op = GeluTanhAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -234,9 +234,9 @@ def test_fused_gated_default_strategy_is_explicit_parallel() -> None:
 @pytest.mark.smoke
 def test_fused_gated_kernel_stores_strategy() -> None:
     """FusedGatedKernel.strategy should record the chosen strategy."""
-    k = SiluAndMulKernel(M=16, N=16, dtype=torch.float16, strategy="direct")
+    k = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16, strategy="direct")
     assert k.strategy == "direct"
-    k2 = SiluAndMulKernel(M=16, N=16, dtype=torch.float16)
+    k2 = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16)
     assert k2.strategy == FusedGatedKernel.DEFAULT_STRATEGY
 
 

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, exact_compare
-from tileops.ops.elementwise import LogicalAndOp, LogicalNotOp, LogicalOrOp
+from tileops.ops.elementwise import LogicalAndFwdOp, LogicalNotFwdOp, LogicalOrFwdOp
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -61,7 +61,7 @@ class LogicalAndFixture(FixtureBase):
 def test_logical_and_op(n_total: int, dtype: torch.dtype) -> None:
     test = LogicalTest(n_total, dtype, torch.logical_and)
     shape = (n_total,)
-    op = LogicalAndOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = LogicalAndFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -83,7 +83,7 @@ class LogicalOrFixture(FixtureBase):
 def test_logical_or_op(n_total: int, dtype: torch.dtype) -> None:
     test = LogicalTest(n_total, dtype, torch.logical_or)
     shape = (n_total,)
-    op = LogicalOrOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = LogicalOrFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_bool_compare)
 
 
@@ -98,8 +98,8 @@ _BROADCAST_PATTERNS = [
 ]
 
 _LOGICAL_OPS = [
-    ("logical_and", LogicalAndOp, torch.logical_and),
-    ("logical_or", LogicalOrOp, torch.logical_or),
+    ("logical_and", LogicalAndFwdOp, torch.logical_and),
+    ("logical_or", LogicalOrFwdOp, torch.logical_or),
 ]
 
 
@@ -182,7 +182,7 @@ class LogicalNotTest(TestBase):
 @LogicalFixture
 def test_logical_not(n_total: int, dtype: torch.dtype) -> None:
     test = LogicalNotTest(n_total, dtype)
-    op = LogicalNotOp(N_total=n_total, dtype=dtype)
+    op = LogicalNotFwdOp(N_total=n_total, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=exact_compare)
 
 

--- a/tests/ops/test_special_elementwise.py
+++ b/tests/ops/test_special_elementwise.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, exact_compare
-from tileops.ops.elementwise import IsfiniteOp, IsinfOp, IsnanOp
+from tileops.ops.elementwise import IsfiniteFwdOp, IsinfFwdOp, IsnanFwdOp
 
 
 class SpecialFixture(FixtureBase):
@@ -63,17 +63,17 @@ def _make_special_test(n_total, dtype, op_cls, ref_fn, gen_fn=None) -> None:
 
 @SpecialFixture
 def test_isnan(n_total: int, dtype: torch.dtype) -> None:
-    _make_special_test(n_total, dtype, IsnanOp, torch.isnan)
+    _make_special_test(n_total, dtype, IsnanFwdOp, torch.isnan)
 
 
 @SpecialFixture
 def test_isinf(n_total: int, dtype: torch.dtype) -> None:
-    _make_special_test(n_total, dtype, IsinfOp, torch.isinf)
+    _make_special_test(n_total, dtype, IsinfFwdOp, torch.isinf)
 
 
 @SpecialFixture
 def test_isfinite(n_total: int, dtype: torch.dtype) -> None:
-    _make_special_test(n_total, dtype, IsfiniteOp, torch.isfinite)
+    _make_special_test(n_total, dtype, IsfiniteFwdOp, torch.isfinite)
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +87,7 @@ def test_isnan_edge(n_total: int, dtype: torch.dtype) -> None:
     def _all_nan(n, dtype):
         return torch.full((n,), float("nan"), device="cuda", dtype=dtype)
 
-    _make_special_test(n_total, dtype, IsnanOp, torch.isnan, gen_fn=_all_nan)
+    _make_special_test(n_total, dtype, IsnanFwdOp, torch.isnan, gen_fn=_all_nan)
 
 
 @SpecialEdgeFixture
@@ -98,7 +98,7 @@ def test_isinf_edge(n_total: int, dtype: torch.dtype) -> None:
         x[:n // 2] = float("-inf")
         return x
 
-    _make_special_test(n_total, dtype, IsinfOp, torch.isinf, gen_fn=_all_inf)
+    _make_special_test(n_total, dtype, IsinfFwdOp, torch.isinf, gen_fn=_all_inf)
 
 
 @SpecialEdgeFixture
@@ -107,15 +107,15 @@ def test_isfinite_edge(n_total: int, dtype: torch.dtype) -> None:
     def _all_finite(n, dtype):
         return torch.randn(n, device="cuda", dtype=dtype)
 
-    _make_special_test(n_total, dtype, IsfiniteOp, torch.isfinite, gen_fn=_all_finite)
+    _make_special_test(n_total, dtype, IsfiniteFwdOp, torch.isfinite, gen_fn=_all_finite)
 
 
 @pytest.mark.smoke
 def test_special_predicates_reject_non_float_dtype() -> None:
-    from tileops.kernels.elementwise import IsnanKernel
+    from tileops.kernels.elementwise import IsnanFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        IsnanKernel(N_total=16, dtype=torch.int32)
+        IsnanFwdKernel(N_total=16, dtype=torch.int32)
 
 
 # ===========================================================================
@@ -150,27 +150,27 @@ class IndependentEdgeFixture(FixtureBase):
 
 @IndependentFixture
 def test_where(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import WhereOp
+    from tileops.ops.elementwise import WhereFwdOp
 
     cond = torch.randint(0, 2, (n_total,), device="cuda").bool()
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(N_total=n_total, dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
-    print("All checks passed for WhereOp.")
+    print("All checks passed for WhereFwdOp.")
 
 
 # --- L1: clamp ---
 
 @IndependentFixture
 def test_clamp(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, -0.5, 0.5)
-    op = ClampOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
+    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
     out = op(x)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -179,21 +179,21 @@ def test_clamp(n_total: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for ClampOp.")
+    print("All checks passed for ClampFwdOp.")
 
 
 # --- L1: masked_fill ---
 
 @IndependentFixture
 def test_masked_fill(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import MaskedFillOp
+    from tileops.ops.elementwise import MaskedFillFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.randint(0, 2, (n_total,), device="cuda").bool()
     # Use -100.0 to avoid fp16 overflow (fp16 max ~65504)
     fill_value = -100.0
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
     out = op(x, mask)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -202,14 +202,14 @@ def test_masked_fill(n_total: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for MaskedFillOp.")
+    print("All checks passed for MaskedFillFwdOp.")
 
 
 # --- L1: nan_to_num ---
 
 @IndependentFixture
 def test_nan_to_num(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import NanToNumOp
+    from tileops.ops.elementwise import NanToNumFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     quarter = n_total // 4
@@ -217,7 +217,7 @@ def test_nan_to_num(n_total: int, dtype: torch.dtype) -> None:
     x[quarter:2 * quarter] = float("inf")
     x[2 * quarter:3 * quarter] = float("-inf")
     ref = torch.nan_to_num(x, nan=0.0, posinf=1e4, neginf=-1e4)
-    op = NanToNumOp(N_total=n_total, dtype=dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4)
+    op = NanToNumFwdOp(N_total=n_total, dtype=dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4)
     out = op(x)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -226,7 +226,7 @@ def test_nan_to_num(n_total: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol, equal_nan=True)
-    print("All checks passed for NanToNumOp.")
+    print("All checks passed for NanToNumFwdOp.")
 
 
 # --- L1: alibi ---
@@ -242,9 +242,9 @@ class AlibiFixture(FixtureBase):
 
 @AlibiFixture
 def test_alibi(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import AlibiOp
+    from tileops.ops.elementwise import AlibiFwdOp
 
-    op = AlibiOp(seq_len=seq_len, num_heads=num_heads, dtype=dtype)
+    op = AlibiFwdOp(seq_len=seq_len, num_heads=num_heads, dtype=dtype)
     out = op()
 
     # Reference: slope_h = 2^(-8*(h+1)/H), bias = -slope * |i - j|
@@ -258,7 +258,7 @@ def test_alibi(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
 
     tol = {"atol": 1e-2, "rtol": 1e-2} if dtype == torch.float16 else {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for AlibiOp.")
+    print("All checks passed for AlibiFwdOp.")
 
 
 # --- L1: sinusoidal ---
@@ -275,9 +275,9 @@ class SinusoidalFixture(FixtureBase):
 @SinusoidalFixture
 def test_sinusoidal(seq_len: int, d_model: int, dtype: torch.dtype) -> None:
 
-    from tileops.ops.elementwise import SinusoidalOp
+    from tileops.ops.elementwise import SinusoidalFwdOp
 
-    op = SinusoidalOp(seq_len=seq_len, d_model=d_model, dtype=dtype)
+    op = SinusoidalFwdOp(seq_len=seq_len, d_model=d_model, dtype=dtype)
     out = op()
 
     # Reference
@@ -294,7 +294,7 @@ def test_sinusoidal(seq_len: int, d_model: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for SinusoidalOp.")
+    print("All checks passed for SinusoidalFwdOp.")
 
 
 # ===========================================================================
@@ -315,11 +315,11 @@ class ClampDtypeSizeFixture(FixtureBase):
 
 @ClampDtypeSizeFixture
 def test_clamp_dtype_size(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, -0.5, 0.5)
-    op = ClampOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
+    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
     out = op(x)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -328,7 +328,7 @@ def test_clamp_dtype_size(n_total: int, dtype: torch.dtype) -> None:
     else:
         tol = {"atol": 1e-5, "rtol": 1e-5}
     torch.testing.assert_close(out, ref, **tol)
-    print("All checks passed for ClampOp dtype/size variant.")
+    print("All checks passed for ClampFwdOp dtype/size variant.")
 
 
 # ===========================================================================
@@ -339,107 +339,107 @@ def test_clamp_dtype_size(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_clamp_min_gt_max(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min > max -- PyTorch clamp semantics: min wins (output = min_val)."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     # When min > max, PyTorch clamp returns min_val for all elements
     ref = torch.clamp(x, min=0.5, max=-0.5)
-    op = ClampOp(N_total=n_total, dtype=dtype, min_val=0.5, max_val=-0.5)
+    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=0.5, max_val=-0.5)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for ClampOp min>max edge case.")
+    print("All checks passed for ClampFwdOp min>max edge case.")
 
 
 @IndependentEdgeFixture
 def test_clamp_upper_only(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min=None, max=0.5 (upper bound only)."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, min=None, max=0.5)
-    op = ClampOp(N_total=n_total, dtype=dtype, min_val=None, max_val=0.5)
+    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=None, max_val=0.5)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for ClampOp upper-only edge case.")
+    print("All checks passed for ClampFwdOp upper-only edge case.")
 
 
 @IndependentEdgeFixture
 def test_clamp_lower_only(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min=-0.5, max=None (lower bound only)."""
-    from tileops.ops.elementwise import ClampOp
+    from tileops.ops.elementwise import ClampFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, min=-0.5, max=None)
-    op = ClampOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=None)
+    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=None)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for ClampOp lower-only edge case.")
+    print("All checks passed for ClampFwdOp lower-only edge case.")
 
 
 @IndependentEdgeFixture
 def test_masked_fill_all_true(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all True mask -> all values replaced."""
-    from tileops.ops.elementwise import MaskedFillOp
+    from tileops.ops.elementwise import MaskedFillFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.ones(n_total, device="cuda", dtype=torch.bool)
     fill_value = -1e9
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
     out = op(x, mask)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for MaskedFillOp all-true edge case.")
+    print("All checks passed for MaskedFillFwdOp all-true edge case.")
 
 
 @IndependentEdgeFixture
 def test_masked_fill_all_false(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all False mask -> input unchanged."""
-    from tileops.ops.elementwise import MaskedFillOp
+    from tileops.ops.elementwise import MaskedFillFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.zeros(n_total, device="cuda", dtype=torch.bool)
     fill_value = -1e9
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
     out = op(x, mask)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
-    print("All checks passed for MaskedFillOp all-false edge case.")
+    print("All checks passed for MaskedFillFwdOp all-false edge case.")
 
 
 @IndependentEdgeFixture
 def test_where_all_true(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all True cond -> output = x."""
-    from tileops.ops.elementwise import WhereOp
+    from tileops.ops.elementwise import WhereFwdOp
 
     cond = torch.ones(n_total, device="cuda", dtype=torch.bool)
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(N_total=n_total, dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
-    print("All checks passed for WhereOp all-true edge case.")
+    print("All checks passed for WhereFwdOp all-true edge case.")
 
 
 @IndependentEdgeFixture
 def test_where_all_false(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all False cond -> output = y."""
-    from tileops.ops.elementwise import WhereOp
+    from tileops.ops.elementwise import WhereFwdOp
 
     cond = torch.zeros(n_total, device="cuda", dtype=torch.bool)
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(N_total=n_total, dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
-    print("All checks passed for WhereOp all-false edge case.")
+    print("All checks passed for WhereFwdOp all-false edge case.")
 
 
 @IndependentEdgeFixture
 def test_nan_to_num_edge(n_total: int, dtype: torch.dtype) -> None:
     """Edge: explicit [NaN, Inf, -Inf, 1.0] pattern."""
-    from tileops.ops.elementwise import NanToNumOp
+    from tileops.ops.elementwise import NanToNumFwdOp
 
     x = torch.zeros(n_total, device="cuda", dtype=dtype)
     # Fill pattern: NaN, Inf, -Inf, 1.0, repeating
@@ -453,17 +453,17 @@ def test_nan_to_num_edge(n_total: int, dtype: torch.dtype) -> None:
             x[k + 3] = 1.0
 
     ref = torch.nan_to_num(x, nan=0.0, posinf=1e4, neginf=-1e4)
-    op = NanToNumOp(N_total=n_total, dtype=dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4)
+    op = NanToNumFwdOp(N_total=n_total, dtype=dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5, equal_nan=True)
-    print("All checks passed for NanToNumOp edge case.")
+    print("All checks passed for NanToNumFwdOp edge case.")
 
 
 @pytest.mark.smoke
 def test_independent_special_rejects_non_float_dtype() -> None:
-    from tileops.kernels.elementwise import ClampKernel
+    from tileops.kernels.elementwise import ClampFwdKernel
     with pytest.raises(ValueError, match="only supports dtypes"):
-        ClampKernel(N_total=16, dtype=torch.int32)
+        ClampFwdKernel(N_total=16, dtype=torch.int32)
 
 
 # ===========================================================================
@@ -473,10 +473,10 @@ def test_independent_special_rejects_non_float_dtype() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("EluOp", {"alpha": 1.0}, id="elu"),
-    pytest.param("HardtanhOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
-    pytest.param("SoftplusOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
-    pytest.param("ClampOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
+    pytest.param("EluFwdOp", {"alpha": 1.0}, id="elu"),
+    pytest.param("HardtanhFwdOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
+    pytest.param("SoftplusFwdOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
+    pytest.param("ClampFwdOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
 ])
 def test_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
     """forward() must raise ValueError when input dtype mismatches."""
@@ -490,10 +490,10 @@ def test_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("EluOp", {"alpha": 1.0}, id="elu"),
-    pytest.param("HardtanhOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
-    pytest.param("SoftplusOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
-    pytest.param("ClampOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
+    pytest.param("EluFwdOp", {"alpha": 1.0}, id="elu"),
+    pytest.param("HardtanhFwdOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
+    pytest.param("SoftplusFwdOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
+    pytest.param("ClampFwdOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
 ])
 def test_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
     """forward() must raise ValueError when input numel mismatches."""
@@ -507,10 +507,10 @@ def test_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("MaskedFillOp", {"fill_value": -100.0}, id="masked_fill"),
+    pytest.param("MaskedFillFwdOp", {"fill_value": -100.0}, id="masked_fill"),
 ])
 def test_masked_fill_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
-    """MaskedFillOp forward() must raise ValueError when input dtype mismatches."""
+    """MaskedFillFwdOp forward() must raise ValueError when input dtype mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
     op = cls(N_total=1024, dtype=torch.float16, **kwargs)
@@ -522,10 +522,10 @@ def test_masked_fill_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> N
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("MaskedFillOp", {"fill_value": -100.0}, id="masked_fill"),
+    pytest.param("MaskedFillFwdOp", {"fill_value": -100.0}, id="masked_fill"),
 ])
 def test_masked_fill_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
-    """MaskedFillOp forward() must raise ValueError when input numel mismatches."""
+    """MaskedFillFwdOp forward() must raise ValueError when input numel mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
     op = cls(N_total=1024, dtype=torch.float16, **kwargs)
@@ -542,65 +542,65 @@ def test_masked_fill_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> N
 
 @pytest.mark.smoke
 def test_elu_rejects_unrepresentable_alpha() -> None:
-    """EluOp must reject alpha that overflows the kernel dtype."""
-    from tileops.ops.elementwise import EluOp
+    """EluFwdOp must reject alpha that overflows the kernel dtype."""
+    from tileops.ops.elementwise import EluFwdOp
     with pytest.raises((ValueError, TypeError)):
-        EluOp(N_total=1024, dtype=torch.float16, alpha=1e6)
+        EluFwdOp(N_total=1024, dtype=torch.float16, alpha=1e6)
 
 
 @pytest.mark.smoke
 def test_hardtanh_rejects_unrepresentable_min_val() -> None:
-    """HardtanhOp must reject min_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import HardtanhOp
+    """HardtanhFwdOp must reject min_val that overflows the kernel dtype."""
+    from tileops.ops.elementwise import HardtanhFwdOp
     with pytest.raises((ValueError, TypeError)):
-        HardtanhOp(N_total=1024, dtype=torch.float16, min_val=1e6)
+        HardtanhFwdOp(N_total=1024, dtype=torch.float16, min_val=1e6)
 
 
 @pytest.mark.smoke
 def test_hardtanh_rejects_unrepresentable_max_val() -> None:
-    """HardtanhOp must reject max_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import HardtanhOp
+    """HardtanhFwdOp must reject max_val that overflows the kernel dtype."""
+    from tileops.ops.elementwise import HardtanhFwdOp
     with pytest.raises((ValueError, TypeError)):
-        HardtanhOp(N_total=1024, dtype=torch.float16, max_val=1e6)
+        HardtanhFwdOp(N_total=1024, dtype=torch.float16, max_val=1e6)
 
 
 @pytest.mark.smoke
 def test_softplus_rejects_unrepresentable_beta() -> None:
-    """SoftplusOp must reject beta that overflows the kernel dtype."""
-    from tileops.ops.elementwise import SoftplusOp
+    """SoftplusFwdOp must reject beta that overflows the kernel dtype."""
+    from tileops.ops.elementwise import SoftplusFwdOp
     with pytest.raises((ValueError, TypeError)):
-        SoftplusOp(N_total=1024, dtype=torch.float16, beta=1e6)
+        SoftplusFwdOp(N_total=1024, dtype=torch.float16, beta=1e6)
 
 
 @pytest.mark.smoke
 def test_softplus_rejects_unrepresentable_threshold() -> None:
-    """SoftplusOp must reject threshold that overflows the kernel dtype."""
-    from tileops.ops.elementwise import SoftplusOp
+    """SoftplusFwdOp must reject threshold that overflows the kernel dtype."""
+    from tileops.ops.elementwise import SoftplusFwdOp
     with pytest.raises((ValueError, TypeError)):
-        SoftplusOp(N_total=1024, dtype=torch.float16, threshold=1e6)
+        SoftplusFwdOp(N_total=1024, dtype=torch.float16, threshold=1e6)
 
 
 @pytest.mark.smoke
 def test_clamp_rejects_unrepresentable_min_val() -> None:
-    """ClampOp must reject min_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import ClampOp
+    """ClampFwdOp must reject min_val that overflows the kernel dtype."""
+    from tileops.ops.elementwise import ClampFwdOp
     with pytest.raises((ValueError, TypeError)):
-        ClampOp(N_total=1024, dtype=torch.float16, min_val=1e6)
+        ClampFwdOp(N_total=1024, dtype=torch.float16, min_val=1e6)
 
 
 @pytest.mark.smoke
 def test_clamp_rejects_unrepresentable_max_val() -> None:
-    """ClampOp must reject max_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import ClampOp
+    """ClampFwdOp must reject max_val that overflows the kernel dtype."""
+    from tileops.ops.elementwise import ClampFwdOp
     with pytest.raises((ValueError, TypeError)):
-        ClampOp(N_total=1024, dtype=torch.float16, max_val=1e6)
+        ClampFwdOp(N_total=1024, dtype=torch.float16, max_val=1e6)
 
 
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_cpu_mask() -> None:
-    """MaskedFillOp forward() must raise ValueError when mask is not on CUDA."""
-    from tileops.ops.elementwise import MaskedFillOp
-    op = MaskedFillOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    """MaskedFillFwdOp forward() must raise ValueError when mask is not on CUDA."""
+    from tileops.ops.elementwise import MaskedFillFwdOp
+    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
     mask = torch.ones(1024, dtype=torch.bool)  # CPU mask
     with pytest.raises(ValueError, match="Mask must be a CUDA tensor"):
@@ -609,9 +609,9 @@ def test_masked_fill_forward_rejects_cpu_mask() -> None:
 
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_non_bool_mask() -> None:
-    """MaskedFillOp forward() must raise ValueError when mask dtype is not bool."""
-    from tileops.ops.elementwise import MaskedFillOp
-    op = MaskedFillOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    """MaskedFillFwdOp forward() must raise ValueError when mask dtype is not bool."""
+    from tileops.ops.elementwise import MaskedFillFwdOp
+    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
     mask = torch.ones(1024, device="cuda", dtype=torch.float32)  # wrong dtype
     with pytest.raises(ValueError, match="mask.dtype"):
@@ -620,9 +620,9 @@ def test_masked_fill_forward_rejects_non_bool_mask() -> None:
 
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_wrong_mask_numel() -> None:
-    """MaskedFillOp forward() must raise ValueError when mask numel mismatches."""
-    from tileops.ops.elementwise import MaskedFillOp
-    op = MaskedFillOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    """MaskedFillFwdOp forward() must raise ValueError when mask numel mismatches."""
+    from tileops.ops.elementwise import MaskedFillFwdOp
+    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
     mask = torch.ones(512, device="cuda", dtype=torch.bool)  # wrong numel
     with pytest.raises(ValueError, match="elements"):
@@ -631,18 +631,18 @@ def test_masked_fill_forward_rejects_wrong_mask_numel() -> None:
 
 @pytest.mark.smoke
 def test_elu_rejects_infinite_alpha() -> None:
-    """EluOp must reject infinite alpha."""
-    from tileops.ops.elementwise import EluOp
+    """EluFwdOp must reject infinite alpha."""
+    from tileops.ops.elementwise import EluFwdOp
     with pytest.raises(ValueError, match="finite"):
-        EluOp(N_total=1024, dtype=torch.float32, alpha=float("inf"))
+        EluFwdOp(N_total=1024, dtype=torch.float32, alpha=float("inf"))
 
 
 @pytest.mark.smoke
 def test_softplus_rejects_non_numeric_beta() -> None:
-    """SoftplusOp must reject non-numeric beta."""
-    from tileops.ops.elementwise import SoftplusOp
+    """SoftplusFwdOp must reject non-numeric beta."""
+    from tileops.ops.elementwise import SoftplusFwdOp
     with pytest.raises(TypeError, match="int/float"):
-        SoftplusOp(N_total=1024, dtype=torch.float32, beta="bad")
+        SoftplusFwdOp(N_total=1024, dtype=torch.float32, beta="bad")
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_unary_math.py
+++ b/tests/ops/test_unary_math.py
@@ -9,23 +9,23 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.elementwise import (
-    AbsOp,
-    CeilOp,
-    CosOp,
-    ErfOp,
-    Expm1Op,
-    ExpOp,
-    FloorOp,
-    Log1pOp,
-    LogOp,
-    NegOp,
-    ReciprocalOp,
-    RoundOp,
-    RsqrtOp,
-    SignOp,
-    SinOp,
-    SqrtOp,
-    TruncOp,
+    AbsFwdOp,
+    CeilFwdOp,
+    CosFwdOp,
+    ErfFwdOp,
+    ExpFwdOp,
+    Expm1FwdOp,
+    FloorFwdOp,
+    Log1pFwdOp,
+    LogFwdOp,
+    NegFwdOp,
+    ReciprocalFwdOp,
+    RoundFwdOp,
+    RsqrtFwdOp,
+    SignFwdOp,
+    SinFwdOp,
+    SqrtFwdOp,
+    TruncFwdOp,
 )
 
 
@@ -110,52 +110,52 @@ def _make_math_test(n_total, dtype, gen_fn, ref_fn, op_cls):
 
 @MathFixture
 def test_exp(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.exp, ExpOp)
+    _make_math_test(n_total, dtype, _randn, torch.exp, ExpFwdOp)
 
 
 @MathFixture
 def test_log(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _positive, torch.log, LogOp)
+    _make_math_test(n_total, dtype, _positive, torch.log, LogFwdOp)
 
 
 @MathFixture
 def test_sqrt(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _positive, torch.sqrt, SqrtOp)
+    _make_math_test(n_total, dtype, _positive, torch.sqrt, SqrtFwdOp)
 
 
 @MathFixture
 def test_rsqrt(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _positive, torch.rsqrt, RsqrtOp)
+    _make_math_test(n_total, dtype, _positive, torch.rsqrt, RsqrtFwdOp)
 
 
 @MathFixture
 def test_abs(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.abs, AbsOp)
+    _make_math_test(n_total, dtype, _randn, torch.abs, AbsFwdOp)
 
 
 @MathFixture
 def test_neg(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.neg, NegOp)
+    _make_math_test(n_total, dtype, _randn, torch.neg, NegFwdOp)
 
 
 @MathFixture
 def test_reciprocal(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _nonzero, torch.reciprocal, ReciprocalOp)
+    _make_math_test(n_total, dtype, _nonzero, torch.reciprocal, ReciprocalFwdOp)
 
 
 @MathFixture
 def test_sign(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.sign, SignOp)
+    _make_math_test(n_total, dtype, _randn, torch.sign, SignFwdOp)
 
 
 @MathFixture
 def test_sin(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.sin, SinOp)
+    _make_math_test(n_total, dtype, _randn, torch.sin, SinFwdOp)
 
 
 @MathFixture
 def test_cos(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.cos, CosOp)
+    _make_math_test(n_total, dtype, _randn, torch.cos, CosFwdOp)
 
 
 @MathFixture
@@ -165,7 +165,7 @@ def test_floor(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         _randn,
         lambda x: torch.floor(x.float()).to(x.dtype),
-        FloorOp,
+        FloorFwdOp,
     )
 
 
@@ -176,7 +176,7 @@ def test_ceil(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         _randn,
         lambda x: torch.ceil(x.float()).to(x.dtype),
-        CeilOp,
+        CeilFwdOp,
     )
 
 
@@ -187,7 +187,7 @@ def test_round(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         _randn,
         lambda x: torch.round(x.float()).to(x.dtype),
-        RoundOp,
+        RoundFwdOp,
     )
 
 
@@ -198,13 +198,13 @@ def test_trunc(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         _randn,
         lambda x: torch.trunc(x.float()).to(x.dtype),
-        TruncOp,
+        TruncFwdOp,
     )
 
 
 @MathFixture
 def test_erf(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.erf, ErfOp)
+    _make_math_test(n_total, dtype, _randn, torch.erf, ErfFwdOp)
 
 
 @MathFixture
@@ -212,20 +212,20 @@ def test_log1p(n_total: int, dtype: torch.dtype) -> None:
     def _gen(n, gen_dtype):
         return torch.rand(n, device="cuda", dtype=gen_dtype).clamp(min=0.01)
 
-    _make_math_test(n_total, dtype, _gen, torch.log1p, Log1pOp)
+    _make_math_test(n_total, dtype, _gen, torch.log1p, Log1pFwdOp)
 
 
 @MathFixture
 def test_expm1(n_total: int, dtype: torch.dtype) -> None:
-    _make_math_test(n_total, dtype, _randn, torch.expm1, Expm1Op)
+    _make_math_test(n_total, dtype, _randn, torch.expm1, Expm1FwdOp)
 
 
 @pytest.mark.smoke
 def test_math_ops_reject_non_float_dtype() -> None:
-    from tileops.kernels.elementwise import ExpKernel
+    from tileops.kernels.elementwise import ExpFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
-        ExpKernel(N_total=16, dtype=torch.int32)
+        ExpFwdKernel(N_total=16, dtype=torch.int32)
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +240,7 @@ def test_sqrt_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([-1.0, 0.0, 1e-38, 1.0], n, d),
         torch.sqrt,
-        SqrtOp,
+        SqrtFwdOp,
     )
 
 
@@ -251,7 +251,7 @@ def test_rsqrt_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([-1.0, 0.0, 1e-38, 1.0], n, d),
         torch.rsqrt,
-        RsqrtOp,
+        RsqrtFwdOp,
     )
 
 
@@ -262,7 +262,7 @@ def test_log_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([-1.0, 0.0, 1e-38, 1.0], n, d),
         torch.log,
-        LogOp,
+        LogFwdOp,
     )
 
 
@@ -273,7 +273,7 @@ def test_log1p_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([-2.0, -1.0, 0.0, 1e-7], n, d),
         torch.log1p,
-        Log1pOp,
+        Log1pFwdOp,
     )
 
 
@@ -284,7 +284,7 @@ def test_exp_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([0.0, 88.8, -88.8, 200.0], n, d),
         torch.exp,
-        ExpOp,
+        ExpFwdOp,
     )
 
 
@@ -295,7 +295,7 @@ def test_expm1_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([0.0, 88.8, -88.8, 1e-7], n, d),
         torch.expm1,
-        Expm1Op,
+        Expm1FwdOp,
     )
 
 
@@ -306,7 +306,7 @@ def test_erf_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([0.0, 3.0, -3.0, 100.0], n, d),
         torch.erf,
-        ErfOp,
+        ErfFwdOp,
     )
 
 
@@ -317,7 +317,7 @@ def test_reciprocal_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([0.0, 1.0, -1.0, 1e-38], n, d),
         torch.reciprocal,
-        ReciprocalOp,
+        ReciprocalFwdOp,
     )
 
 
@@ -328,7 +328,7 @@ def test_sign_edge(n_total: int, dtype: torch.dtype) -> None:
         dtype,
         lambda n, d: _repeat_values([-5.0, 0.0, 3.0, float("nan")], n, d),
         torch.sign,
-        SignOp,
+        SignFwdOp,
     )
 
 

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -46,82 +46,82 @@ __all__ = [
     "FusedGatedKernel",
     "UnaryKernel",
     # --- unary: existing ---
-    "ReluKernel",
+    "ReluFwdKernel",
     # --- unary: math (17) ---
-    "AbsKernel",
-    "CeilKernel",
-    "CosKernel",
-    "ErfKernel",
-    "ExpKernel",
-    "Expm1Kernel",
-    "FloorKernel",
-    "Log1pKernel",
-    "LogKernel",
-    "NegKernel",
-    "ReciprocalKernel",
-    "RoundKernel",
-    "RsqrtKernel",
-    "SignKernel",
-    "SinKernel",
-    "SqrtKernel",
-    "TruncKernel",
+    "AbsFwdKernel",
+    "CeilFwdKernel",
+    "CosFwdKernel",
+    "ErfFwdKernel",
+    "ExpFwdKernel",
+    "Expm1FwdKernel",
+    "FloorFwdKernel",
+    "Log1pFwdKernel",
+    "LogFwdKernel",
+    "NegFwdKernel",
+    "ReciprocalFwdKernel",
+    "RoundFwdKernel",
+    "RsqrtFwdKernel",
+    "SignFwdKernel",
+    "SinFwdKernel",
+    "SqrtFwdKernel",
+    "TruncFwdKernel",
     # --- unary: activations (8) ---
-    "GeluKernel",
-    "HardsigmoidKernel",
-    "HardswishKernel",
-    "MishKernel",
-    "SeluKernel",
-    "SigmoidKernel",
-    "SiluKernel",
-    "TanhKernel",
+    "GeluFwdKernel",
+    "HardsigmoidFwdKernel",
+    "HardswishFwdKernel",
+    "MishFwdKernel",
+    "SeluFwdKernel",
+    "SigmoidFwdKernel",
+    "SiluFwdKernel",
+    "TanhFwdKernel",
     # --- unary: logical / bitwise (2) ---
-    "BitwiseNotKernel",
-    "LogicalNotKernel",
+    "BitwiseNotFwdKernel",
+    "LogicalNotFwdKernel",
     # --- unary: special predicates (3) ---
-    "IsfiniteKernel",
-    "IsinfKernel",
-    "IsnanKernel",
+    "IsfiniteFwdKernel",
+    "IsinfFwdKernel",
+    "IsnanFwdKernel",
     # --- binary arithmetic ---
-    "AddKernel",
-    "SubKernel",
-    "MulKernel",
-    "DivKernel",
-    "RemainderKernel",
-    "PowKernel",
-    "FloorDivideKernel",
-    "LerpKernel",
-    "MaximumKernel",
-    "MinimumKernel",
+    "AddFwdKernel",
+    "SubFwdKernel",
+    "MulFwdKernel",
+    "DivFwdKernel",
+    "RemainderFwdKernel",
+    "PowFwdKernel",
+    "FloorDivideFwdKernel",
+    "LerpFwdKernel",
+    "MaximumFwdKernel",
+    "MinimumFwdKernel",
     # --- comparison (OUTPUT_DTYPE = torch.int8, cast to bool by Op layer) ---
-    "EqKernel",
-    "NeKernel",
-    "GtKernel",
-    "LtKernel",
-    "GeKernel",
-    "LeKernel",
+    "EqFwdKernel",
+    "NeFwdKernel",
+    "GtFwdKernel",
+    "LtFwdKernel",
+    "GeFwdKernel",
+    "LeFwdKernel",
     # --- logical (OUTPUT_DTYPE = torch.int8, cast to bool by Op layer) ---
-    "LogicalAndKernel",
-    "LogicalOrKernel",
+    "LogicalAndFwdKernel",
+    "LogicalOrFwdKernel",
     # --- bitwise ---
-    "BitwiseAndKernel",
-    "BitwiseOrKernel",
-    "BitwiseXorKernel",
+    "BitwiseAndFwdKernel",
+    "BitwiseOrFwdKernel",
+    "BitwiseXorFwdKernel",
     # --- fused gated ---
-    "SiluAndMulKernel",
-    "GeluAndMulKernel",
-    "GeluTanhAndMulKernel",
+    "SiluAndMulFwdKernel",
+    "GeluAndMulFwdKernel",
+    "GeluTanhAndMulFwdKernel",
     # --- independent (custom-signature) ---
-    "LeakyReluKernel",
-    "EluKernel",
-    "HardtanhKernel",
-    "SoftplusKernel",
-    "PreluKernel",
-    "WhereKernel",
-    "ClampKernel",
-    "MaskedFillKernel",
-    "NanToNumKernel",
-    "AlibiKernel",
-    "SinusoidalKernel",
+    "LeakyReluFwdKernel",
+    "EluFwdKernel",
+    "HardtanhFwdKernel",
+    "SoftplusFwdKernel",
+    "PreluFwdKernel",
+    "WhereFwdKernel",
+    "ClampFwdKernel",
+    "MaskedFillFwdKernel",
+    "NanToNumFwdKernel",
+    "AlibiFwdKernel",
+    "SinusoidalFwdKernel",
 ]
 
 _BITWISE_DTYPES = (
@@ -1132,7 +1132,7 @@ class LogicalUnaryKernel(UnaryKernel):
     OUTPUT_DTYPE = torch.bool
 
 
-class ReluKernel(FloatUnaryKernel):
+class ReluFwdKernel(FloatUnaryKernel):
     """ReLU: y = max(x, 0)."""
 
     @staticmethod
@@ -1140,7 +1140,7 @@ class ReluKernel(FloatUnaryKernel):
         return T.if_then_else(x > T.cast(0, x.dtype), x, T.cast(0, x.dtype))
 
 
-class AddKernel(BinaryKernel):
+class AddFwdKernel(BinaryKernel):
     """Element-wise addition: y = a + b."""
 
     @staticmethod
@@ -1148,7 +1148,7 @@ class AddKernel(BinaryKernel):
         return a + b
 
 
-class SubKernel(BinaryKernel):
+class SubFwdKernel(BinaryKernel):
     """Element-wise subtraction: y = a - b."""
 
     @staticmethod
@@ -1156,7 +1156,7 @@ class SubKernel(BinaryKernel):
         return a - b
 
 
-class MulKernel(BinaryKernel):
+class MulFwdKernel(BinaryKernel):
     """Element-wise multiplication: y = a * b."""
 
     @staticmethod
@@ -1164,7 +1164,7 @@ class MulKernel(BinaryKernel):
         return a * b
 
 
-class DivKernel(BinaryKernel):
+class DivFwdKernel(BinaryKernel):
     """Element-wise division: y = a / b."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1174,7 +1174,7 @@ class DivKernel(BinaryKernel):
         return a / b
 
 
-class RemainderKernel(BinaryKernel):
+class RemainderFwdKernel(BinaryKernel):
     """Element-wise remainder: y = a - floor(a / b) * b.
 
     Matches PyTorch remainder semantics for floating-point inputs.
@@ -1198,7 +1198,7 @@ class RemainderKernel(BinaryKernel):
         return a - floored * b
 
 
-class PowKernel(BinaryKernel):
+class PowFwdKernel(BinaryKernel):
     """Element-wise power: y = a ** b."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1210,7 +1210,7 @@ class PowKernel(BinaryKernel):
         return T.Cast(a.dtype, T.pow(a_f32, b_f32))
 
 
-class FloorDivideKernel(BinaryKernel):
+class FloorDivideFwdKernel(BinaryKernel):
     """Element-wise floor division: y = floor(a / b).
 
     Division and floor are computed in fp32 to avoid two sources of error:
@@ -1228,7 +1228,7 @@ class FloorDivideKernel(BinaryKernel):
         return T.Cast(a.dtype, T.floor(a_f32 / b_f32))
 
 
-class LerpKernel(BinaryKernel):
+class LerpFwdKernel(BinaryKernel):
     """Element-wise lerp: y = a + weight * (b - a).
 
     PyTorch lerp is ternary (a, b, weight). Here weight is a compile-time
@@ -1299,7 +1299,7 @@ class LerpKernel(BinaryKernel):
             raise ValueError(f"Unknown strategy: {strategy}")
 
 
-class MaximumKernel(BinaryKernel):
+class MaximumFwdKernel(BinaryKernel):
     """Element-wise maximum: y = max(a, b) with NaN propagation.
 
     Matches torch.maximum semantics:
@@ -1326,7 +1326,7 @@ class MaximumKernel(BinaryKernel):
         return result
 
 
-class MinimumKernel(BinaryKernel):
+class MinimumFwdKernel(BinaryKernel):
     """Element-wise minimum: y = min(a, b) with NaN propagation.
 
     Matches torch.minimum semantics:
@@ -1335,7 +1335,7 @@ class MinimumKernel(BinaryKernel):
 
     Performance: uses T.min for the fast path (correct signed-zero on CUDA
     -- fminf returns -0 for min(-0,+0)) plus two isnan guards for NaN
-    propagation. See MaximumKernel for full rationale.
+    propagation. See MaximumFwdKernel for full rationale.
     """
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1358,7 +1358,7 @@ class MinimumKernel(BinaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class EqKernel(BinaryKernel):
+class EqFwdKernel(BinaryKernel):
     """Element-wise equality: y = (a == b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1371,7 +1371,7 @@ class EqKernel(BinaryKernel):
         return T.if_then_else(a == b, one, zero)
 
 
-class NeKernel(BinaryKernel):
+class NeFwdKernel(BinaryKernel):
     """Element-wise not-equal: y = (a != b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1384,7 +1384,7 @@ class NeKernel(BinaryKernel):
         return T.if_then_else(a != b, one, zero)
 
 
-class GtKernel(BinaryKernel):
+class GtFwdKernel(BinaryKernel):
     """Element-wise greater-than: y = (a > b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1397,7 +1397,7 @@ class GtKernel(BinaryKernel):
         return T.if_then_else(a > b, one, zero)
 
 
-class LtKernel(BinaryKernel):
+class LtFwdKernel(BinaryKernel):
     """Element-wise less-than: y = (a < b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1410,7 +1410,7 @@ class LtKernel(BinaryKernel):
         return T.if_then_else(a < b, one, zero)
 
 
-class GeKernel(BinaryKernel):
+class GeFwdKernel(BinaryKernel):
     """Element-wise greater-equal: y = (a >= b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1423,7 +1423,7 @@ class GeKernel(BinaryKernel):
         return T.if_then_else(a >= b, one, zero)
 
 
-class LeKernel(BinaryKernel):
+class LeFwdKernel(BinaryKernel):
     """Element-wise less-equal: y = (a <= b), stored as int8 (1/0)."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1441,7 +1441,7 @@ class LeKernel(BinaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class LogicalAndKernel(BinaryKernel):
+class LogicalAndFwdKernel(BinaryKernel):
     """Element-wise logical AND with non-zero truthiness, stored as int8."""
 
     SUPPORTED_DTYPES = _LOGICAL_DTYPES
@@ -1456,7 +1456,7 @@ class LogicalAndKernel(BinaryKernel):
         return T.if_then_else(a_nonzero & b_nonzero, one, zero)
 
 
-class LogicalOrKernel(BinaryKernel):
+class LogicalOrFwdKernel(BinaryKernel):
     """Element-wise logical OR with non-zero truthiness, stored as int8."""
 
     SUPPORTED_DTYPES = _LOGICAL_DTYPES
@@ -1476,7 +1476,7 @@ class LogicalOrKernel(BinaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class BitwiseAndKernel(BinaryKernel):
+class BitwiseAndFwdKernel(BinaryKernel):
     """Element-wise bitwise AND: y = a & b (integer inputs)."""
 
     SUPPORTED_DTYPES = _BITWISE_DTYPES
@@ -1486,7 +1486,7 @@ class BitwiseAndKernel(BinaryKernel):
         return a & b
 
 
-class BitwiseOrKernel(BinaryKernel):
+class BitwiseOrFwdKernel(BinaryKernel):
     """Element-wise bitwise OR: y = a | b (integer inputs)."""
 
     SUPPORTED_DTYPES = _BITWISE_DTYPES
@@ -1496,7 +1496,7 @@ class BitwiseOrKernel(BinaryKernel):
         return a | b
 
 
-class BitwiseXorKernel(BinaryKernel):
+class BitwiseXorFwdKernel(BinaryKernel):
     """Element-wise bitwise XOR: y = a ^ b (integer inputs)."""
 
     SUPPORTED_DTYPES = _BITWISE_DTYPES
@@ -1511,7 +1511,7 @@ class BitwiseXorKernel(BinaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class SiluAndMulKernel(FusedGatedKernel):
+class SiluAndMulFwdKernel(FusedGatedKernel):
     """SiLU-and-Mul: y = silu(gate) * value = (gate * sigmoid(gate)) * value."""
 
     SUPPORTED_DTYPES = _FLOAT_DTYPES
@@ -1521,7 +1521,7 @@ class SiluAndMulKernel(FusedGatedKernel):
         return x * T.sigmoid(x)
 
 
-class GeluAndMulKernel(FusedGatedKernel):
+class GeluAndMulFwdKernel(FusedGatedKernel):
     """GELU-and-Mul: y = gelu(gate) * value.
 
     Uses exact GELU: gelu(x) = x * 0.5 * (1 + erf(x / sqrt(2))).
@@ -1540,7 +1540,7 @@ class GeluAndMulKernel(FusedGatedKernel):
         return x * half * (one + erf_val)
 
 
-class GeluTanhAndMulKernel(FusedGatedKernel):
+class GeluTanhAndMulFwdKernel(FusedGatedKernel):
     """GELU-Tanh-and-Mul: y = gelu_tanh(gate) * value.
 
     Uses tanh approximation: gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3))).
@@ -1565,7 +1565,7 @@ class GeluTanhAndMulKernel(FusedGatedKernel):
 # ---------------------------------------------------------------------------
 
 
-class ExpKernel(FloatUnaryKernel):
+class ExpFwdKernel(FloatUnaryKernel):
     """Element-wise exp(x)."""
 
     @staticmethod
@@ -1573,7 +1573,7 @@ class ExpKernel(FloatUnaryKernel):
         return T.exp(T.cast(x, "float32"))
 
 
-class LogKernel(FloatUnaryKernel):
+class LogFwdKernel(FloatUnaryKernel):
     """Element-wise log(x)."""
 
     @staticmethod
@@ -1581,7 +1581,7 @@ class LogKernel(FloatUnaryKernel):
         return T.log(T.cast(x, "float32"))
 
 
-class SqrtKernel(FloatUnaryKernel):
+class SqrtFwdKernel(FloatUnaryKernel):
     """Element-wise sqrt(x)."""
 
     @staticmethod
@@ -1589,7 +1589,7 @@ class SqrtKernel(FloatUnaryKernel):
         return T.sqrt(T.cast(x, "float32"))
 
 
-class RsqrtKernel(FloatUnaryKernel):
+class RsqrtFwdKernel(FloatUnaryKernel):
     """Element-wise 1/sqrt(x)."""
 
     @staticmethod
@@ -1597,7 +1597,7 @@ class RsqrtKernel(FloatUnaryKernel):
         return T.rsqrt(T.cast(x, "float32"))
 
 
-class AbsKernel(FloatUnaryKernel):
+class AbsFwdKernel(FloatUnaryKernel):
     """Element-wise |x|."""
 
     @staticmethod
@@ -1605,7 +1605,7 @@ class AbsKernel(FloatUnaryKernel):
         return T.abs(x)
 
 
-class NegKernel(FloatUnaryKernel):
+class NegFwdKernel(FloatUnaryKernel):
     """Element-wise -x."""
 
     @staticmethod
@@ -1613,7 +1613,7 @@ class NegKernel(FloatUnaryKernel):
         return -x
 
 
-class ReciprocalKernel(FloatUnaryKernel):
+class ReciprocalFwdKernel(FloatUnaryKernel):
     """Element-wise 1/x."""
 
     @staticmethod
@@ -1621,7 +1621,7 @@ class ReciprocalKernel(FloatUnaryKernel):
         return T.cast(1.0, "float32") / x
 
 
-class SignKernel(FloatUnaryKernel):
+class SignFwdKernel(FloatUnaryKernel):
     """Element-wise sign(x): -1, 0, or +1."""
 
     @staticmethod
@@ -1636,7 +1636,7 @@ class SignKernel(FloatUnaryKernel):
         )
 
 
-class SinKernel(FloatUnaryKernel):
+class SinFwdKernel(FloatUnaryKernel):
     """Element-wise sin(x)."""
 
     @staticmethod
@@ -1644,7 +1644,7 @@ class SinKernel(FloatUnaryKernel):
         return T.sin(T.cast(x, "float32"))
 
 
-class CosKernel(FloatUnaryKernel):
+class CosFwdKernel(FloatUnaryKernel):
     """Element-wise cos(x)."""
 
     @staticmethod
@@ -1652,7 +1652,7 @@ class CosKernel(FloatUnaryKernel):
         return T.cos(T.cast(x, "float32"))
 
 
-class FloorKernel(FloatUnaryKernel):
+class FloorFwdKernel(FloatUnaryKernel):
     """Element-wise floor(x).
 
     Casts to fp32 before calling ``T.floor`` because ``hfloor`` is not
@@ -1664,7 +1664,7 @@ class FloorKernel(FloatUnaryKernel):
         return T.floor(T.cast(x, "float32"))
 
 
-class CeilKernel(FloatUnaryKernel):
+class CeilFwdKernel(FloatUnaryKernel):
     """Element-wise ceil(x).
 
     Casts to fp32 before calling ``T.ceil`` because ``hceil`` is not
@@ -1676,7 +1676,7 @@ class CeilKernel(FloatUnaryKernel):
         return T.ceil(T.cast(x, "float32"))
 
 
-class RoundKernel(FloatUnaryKernel):
+class RoundFwdKernel(FloatUnaryKernel):
     """Element-wise round(x) with banker's rounding (round-to-nearest-even).
 
     Uses ``T.nearbyint`` (maps to ``nearbyintf`` in CUDA) to match
@@ -1689,7 +1689,7 @@ class RoundKernel(FloatUnaryKernel):
         return T.nearbyint(T.cast(x, "float32"))
 
 
-class TruncKernel(FloatUnaryKernel):
+class TruncFwdKernel(FloatUnaryKernel):
     """Element-wise trunc(x) -- integer part toward zero.
 
     Casts to fp32 before calling ``T.trunc`` because ``htrunc`` is not
@@ -1701,7 +1701,7 @@ class TruncKernel(FloatUnaryKernel):
         return T.trunc(T.cast(x, "float32"))
 
 
-class ErfKernel(FloatUnaryKernel):
+class ErfFwdKernel(FloatUnaryKernel):
     """Element-wise erf(x).
 
     Casts to fp32 before calling ``T.erf`` because the half-precision
@@ -1713,7 +1713,7 @@ class ErfKernel(FloatUnaryKernel):
         return T.erf(T.cast(x, "float32"))
 
 
-class Log1pKernel(FloatUnaryKernel):
+class Log1pFwdKernel(FloatUnaryKernel):
     """Element-wise log(1 + x).
 
     Uses composite ``log(1 + x)`` because ``T.log1p`` is not lowered
@@ -1725,7 +1725,7 @@ class Log1pKernel(FloatUnaryKernel):
         return T.log(T.cast(1.0, "float32") + x)
 
 
-class Expm1Kernel(FloatUnaryKernel):
+class Expm1FwdKernel(FloatUnaryKernel):
     """Element-wise exp(x) - 1."""
 
     @staticmethod
@@ -1738,7 +1738,7 @@ class Expm1Kernel(FloatUnaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class GeluKernel(FloatUnaryKernel):
+class GeluFwdKernel(FloatUnaryKernel):
     """Element-wise GELU using the standard erf formulation."""
 
     @staticmethod
@@ -1749,7 +1749,7 @@ class GeluKernel(FloatUnaryKernel):
         return half * x * (one + T.erf(T.cast(x, "float32") * inv_sqrt_2))
 
 
-class SiluKernel(FloatUnaryKernel):
+class SiluFwdKernel(FloatUnaryKernel):
     """Element-wise SiLU (Swish): x * sigmoid(x)."""
 
     @staticmethod
@@ -1757,7 +1757,7 @@ class SiluKernel(FloatUnaryKernel):
         return x * T.sigmoid(x)
 
 
-class SigmoidKernel(FloatUnaryKernel):
+class SigmoidFwdKernel(FloatUnaryKernel):
     """Element-wise sigmoid(x)."""
 
     @staticmethod
@@ -1765,7 +1765,7 @@ class SigmoidKernel(FloatUnaryKernel):
         return T.sigmoid(x)
 
 
-class TanhKernel(FloatUnaryKernel):
+class TanhFwdKernel(FloatUnaryKernel):
     """Element-wise tanh(x)."""
 
     @staticmethod
@@ -1773,7 +1773,7 @@ class TanhKernel(FloatUnaryKernel):
         return T.tanh(T.cast(x, "float32"))
 
 
-class HardswishKernel(FloatUnaryKernel):
+class HardswishFwdKernel(FloatUnaryKernel):
     """Element-wise HardSwish: x * clamp(x + 3, 0, 6) / 6."""
 
     @staticmethod
@@ -1785,7 +1785,7 @@ class HardswishKernel(FloatUnaryKernel):
         return x * clamped / six
 
 
-class HardsigmoidKernel(FloatUnaryKernel):
+class HardsigmoidFwdKernel(FloatUnaryKernel):
     """Element-wise HardSigmoid: clamp(x + 3, 0, 6) / 6."""
 
     @staticmethod
@@ -1796,7 +1796,7 @@ class HardsigmoidKernel(FloatUnaryKernel):
         return T.min(T.max(x + three, zero), six) / six
 
 
-class MishKernel(FloatUnaryKernel):
+class MishFwdKernel(FloatUnaryKernel):
     """Element-wise Mish: x * tanh(softplus(x)) = x * tanh(log(1 + exp(x)))."""
 
     @staticmethod
@@ -1805,7 +1805,7 @@ class MishKernel(FloatUnaryKernel):
         return x * T.tanh(T.log(one + T.exp(x)))
 
 
-class SeluKernel(FloatUnaryKernel):
+class SeluFwdKernel(FloatUnaryKernel):
     """Element-wise SELU: scale * (max(0,x) + min(0, alpha*(exp(x)-1))).
 
     alpha = 1.6732632423543772, scale = 1.0507009873554805
@@ -1826,7 +1826,7 @@ class SeluKernel(FloatUnaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class LogicalNotKernel(LogicalUnaryKernel):
+class LogicalNotFwdKernel(LogicalUnaryKernel):
     """Element-wise logical NOT with torch-style bool output."""
 
     @staticmethod
@@ -1834,7 +1834,7 @@ class LogicalNotKernel(LogicalUnaryKernel):
         return x == T.cast(0, x.dtype)
 
 
-class BitwiseNotKernel(UnaryKernel):
+class BitwiseNotFwdKernel(UnaryKernel):
     """Element-wise bitwise NOT (~x) for bool/integer inputs.
 
     Uses XOR with ``-1`` (all-ones) because ``T.bitwise_not`` fails on
@@ -1858,7 +1858,7 @@ class BitwiseNotKernel(UnaryKernel):
 # ---------------------------------------------------------------------------
 
 
-class IsnanKernel(FloatPredicateKernel):
+class IsnanFwdKernel(FloatPredicateKernel):
     """Element-wise isnan with torch-style bool output."""
 
     @staticmethod
@@ -1866,7 +1866,7 @@ class IsnanKernel(FloatPredicateKernel):
         return T.isnan(T.cast(x, "float32"))
 
 
-class IsinfKernel(FloatPredicateKernel):
+class IsinfFwdKernel(FloatPredicateKernel):
     """Element-wise isinf with torch-style bool output."""
 
     @staticmethod
@@ -1874,7 +1874,7 @@ class IsinfKernel(FloatPredicateKernel):
         return T.isinf(T.cast(x, "float32"))
 
 
-class IsfiniteKernel(FloatPredicateKernel):
+class IsfiniteFwdKernel(FloatPredicateKernel):
     """Element-wise isfinite with torch-style bool output."""
 
     @staticmethod
@@ -2046,7 +2046,7 @@ def _make_leaky_relu_kernel(N, dtype, negative_slope, output_dtype=None,
     return kernel
 
 
-class LeakyReluKernel(ParametricUnaryKernel):
+class LeakyReluFwdKernel(ParametricUnaryKernel):
     """Leaky ReLU: y = x if x > 0 else negative_slope * x."""
 
     def __init__(self, N_total, dtype, negative_slope=0.01, config=None, tune=False):
@@ -2119,7 +2119,7 @@ def _make_elu_kernel(N, dtype, alpha, output_dtype=None, is_fp8=False,
     return kernel
 
 
-class EluKernel(ParametricUnaryKernel):
+class EluFwdKernel(ParametricUnaryKernel):
     """ELU: y = x if x > 0 else alpha * (exp(x) - 1)."""
 
     def __init__(self, N_total, dtype, alpha=1.0, config=None, tune=False):
@@ -2188,7 +2188,7 @@ def _make_hardtanh_kernel(N, dtype, min_val, max_val, output_dtype=None,
     return kernel
 
 
-class HardtanhKernel(ParametricUnaryKernel):
+class HardtanhFwdKernel(ParametricUnaryKernel):
     """Hardtanh: y = clamp(x, min_val, max_val)."""
 
     def __init__(self, N_total, dtype, min_val=-1.0, max_val=1.0, config=None, tune=False):
@@ -2266,7 +2266,7 @@ def _make_softplus_kernel(N, dtype, beta, threshold, output_dtype=None,
     return kernel
 
 
-class SoftplusKernel(ParametricUnaryKernel):
+class SoftplusFwdKernel(ParametricUnaryKernel):
     """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x."""
 
     def __init__(self, N_total, dtype, beta=1.0, threshold=20.0, config=None, tune=False):
@@ -2354,7 +2354,7 @@ def _make_prelu_kernel(N, C, inner_size, dtype, output_dtype=None,
     return kernel
 
 
-class PreluKernel(ParametricUnaryKernel):
+class PreluFwdKernel(ParametricUnaryKernel):
     """PReLU: y = x if x > 0 else weight[channel] * x."""
 
     def __init__(self, N_total, C, inner_size, dtype, config=None, tune=False):
@@ -2441,7 +2441,7 @@ def _make_where_kernel(N, dtype, is_fp8=False, threads=256, npt=8):
     return kernel
 
 
-class WhereKernel(ParametricUnaryKernel):
+class WhereFwdKernel(ParametricUnaryKernel):
     """Where: out = cond ? x : y."""
 
     _DEFAULT_THREADS = 512
@@ -2517,7 +2517,7 @@ def _make_clamp_kernel(N, dtype, has_min, has_max, min_val, max_val,
     return kernel
 
 
-class ClampKernel(ParametricUnaryKernel):
+class ClampFwdKernel(ParametricUnaryKernel):
     """Clamp: y = clamp(x, min, max) with optional bounds."""
 
     def __init__(self, N_total, dtype, min_val=None, max_val=None, config=None, tune=False):
@@ -2608,7 +2608,7 @@ def _make_masked_fill_kernel(N, dtype, fill_value, output_dtype=None,
     return kernel
 
 
-class MaskedFillKernel(ParametricUnaryKernel):
+class MaskedFillFwdKernel(ParametricUnaryKernel):
     """MaskedFill: out = mask ? fill_value : x."""
 
     _DEFAULT_THREADS = 512
@@ -2707,7 +2707,7 @@ def _make_nan_to_num_kernel(N, dtype, nan_val, posinf_val, neginf_val,
     return kernel
 
 
-class NanToNumKernel(ParametricUnaryKernel):
+class NanToNumFwdKernel(ParametricUnaryKernel):
     """NanToNum: replace NaN, +Inf, -Inf with specified values."""
 
     def __init__(self, N_total, dtype, nan_val=0.0, posinf_val=1e4, neginf_val=-1e4,
@@ -2767,7 +2767,7 @@ def _make_alibi_kernel(seq_len, num_heads, dtype, threads=256, npt=8):
     return kernel
 
 
-class AlibiKernel(Kernel):
+class AlibiFwdKernel(Kernel):
     """ALiBi position encoding: bias[h, i, j] = -slope_h * |i - j|.
 
     Generates the full (num_heads, seq_len, seq_len) bias tensor.
@@ -2856,7 +2856,7 @@ def _make_sinusoidal_kernel(seq_len, d_model, dtype, threads=256, npt=8):
     return kernel
 
 
-class SinusoidalKernel(Kernel):
+class SinusoidalFwdKernel(Kernel):
     """Sinusoidal positional encoding from "Attention Is All You Need".
 
     PE(pos, 2i) = sin(pos / 10000^(2i/d_model))

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -23,72 +23,72 @@ from typing import Dict, List, Optional
 import torch
 
 from tileops.kernels.elementwise import (
-    AbsKernel,
-    AddKernel,
-    AlibiKernel,
-    BitwiseAndKernel,
-    BitwiseNotKernel,
-    BitwiseOrKernel,
-    BitwiseXorKernel,
-    CeilKernel,
-    ClampKernel,
-    CosKernel,
-    DivKernel,
-    EluKernel,
-    EqKernel,
-    ErfKernel,
-    ExpKernel,
-    Expm1Kernel,
-    FloorDivideKernel,
-    FloorKernel,
-    GeKernel,
-    GeluAndMulKernel,
-    GeluKernel,
-    GeluTanhAndMulKernel,
-    GtKernel,
-    HardsigmoidKernel,
-    HardswishKernel,
-    HardtanhKernel,
-    IsfiniteKernel,
-    IsinfKernel,
-    IsnanKernel,
-    LeakyReluKernel,
-    LeKernel,
-    LerpKernel,
-    Log1pKernel,
-    LogicalAndKernel,
-    LogicalNotKernel,
-    LogicalOrKernel,
-    LogKernel,
-    LtKernel,
-    MaskedFillKernel,
-    MaximumKernel,
-    MinimumKernel,
-    MishKernel,
-    MulKernel,
-    NanToNumKernel,
-    NegKernel,
-    NeKernel,
-    PowKernel,
-    PreluKernel,
-    ReciprocalKernel,
-    ReluKernel,
-    RemainderKernel,
-    RoundKernel,
-    RsqrtKernel,
-    SeluKernel,
-    SigmoidKernel,
-    SignKernel,
-    SiluAndMulKernel,
-    SiluKernel,
-    SinKernel,
-    SinusoidalKernel,
-    SoftplusKernel,
-    SqrtKernel,
-    SubKernel,
-    TanhKernel,
-    TruncKernel,
-    WhereKernel,
+    AbsFwdKernel,
+    AddFwdKernel,
+    AlibiFwdKernel,
+    BitwiseAndFwdKernel,
+    BitwiseNotFwdKernel,
+    BitwiseOrFwdKernel,
+    BitwiseXorFwdKernel,
+    CeilFwdKernel,
+    ClampFwdKernel,
+    CosFwdKernel,
+    DivFwdKernel,
+    EluFwdKernel,
+    EqFwdKernel,
+    ErfFwdKernel,
+    ExpFwdKernel,
+    Expm1FwdKernel,
+    FloorDivideFwdKernel,
+    FloorFwdKernel,
+    GeFwdKernel,
+    GeluAndMulFwdKernel,
+    GeluFwdKernel,
+    GeluTanhAndMulFwdKernel,
+    GtFwdKernel,
+    HardsigmoidFwdKernel,
+    HardswishFwdKernel,
+    HardtanhFwdKernel,
+    IsfiniteFwdKernel,
+    IsinfFwdKernel,
+    IsnanFwdKernel,
+    LeakyReluFwdKernel,
+    LeFwdKernel,
+    LerpFwdKernel,
+    Log1pFwdKernel,
+    LogFwdKernel,
+    LogicalAndFwdKernel,
+    LogicalNotFwdKernel,
+    LogicalOrFwdKernel,
+    LtFwdKernel,
+    MaskedFillFwdKernel,
+    MaximumFwdKernel,
+    MinimumFwdKernel,
+    MishFwdKernel,
+    MulFwdKernel,
+    NanToNumFwdKernel,
+    NeFwdKernel,
+    NegFwdKernel,
+    PowFwdKernel,
+    PreluFwdKernel,
+    ReciprocalFwdKernel,
+    ReluFwdKernel,
+    RemainderFwdKernel,
+    RoundFwdKernel,
+    RsqrtFwdKernel,
+    SeluFwdKernel,
+    SigmoidFwdKernel,
+    SignFwdKernel,
+    SiluAndMulFwdKernel,
+    SiluFwdKernel,
+    SinFwdKernel,
+    SinusoidalFwdKernel,
+    SoftplusFwdKernel,
+    SqrtFwdKernel,
+    SubFwdKernel,
+    TanhFwdKernel,
+    TruncFwdKernel,
+    WhereFwdKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 
@@ -341,83 +341,83 @@ __all__ = [
     "BinaryOp",
     "FusedGatedOp",
     # Unary
-    "ReluOp",
+    "ReluFwdOp",
     # Binary arithmetic
-    "AddOp",
-    "SubOp",
-    "MulOp",
-    "DivOp",
-    "RemainderOp",
-    "PowOp",
-    "FloorDivideOp",
-    "LerpOp",
-    "MaximumOp",
-    "MinimumOp",
+    "AddFwdOp",
+    "SubFwdOp",
+    "MulFwdOp",
+    "DivFwdOp",
+    "RemainderFwdOp",
+    "PowFwdOp",
+    "FloorDivideFwdOp",
+    "LerpFwdOp",
+    "MaximumFwdOp",
+    "MinimumFwdOp",
     # Comparison (output bool)
-    "EqOp",
-    "NeOp",
-    "GtOp",
-    "LtOp",
-    "GeOp",
-    "LeOp",
+    "EqFwdOp",
+    "NeFwdOp",
+    "GtFwdOp",
+    "LtFwdOp",
+    "GeFwdOp",
+    "LeFwdOp",
     # Logical (output bool)
-    "LogicalAndOp",
-    "LogicalOrOp",
+    "LogicalAndFwdOp",
+    "LogicalOrFwdOp",
     # Bitwise
-    "BitwiseAndOp",
-    "BitwiseOrOp",
-    "BitwiseXorOp",
+    "BitwiseAndFwdOp",
+    "BitwiseOrFwdOp",
+    "BitwiseXorFwdOp",
     # Fused gated
-    "SiluAndMulOp",
-    "GeluAndMulOp",
-    "GeluTanhAndMulOp",
+    "SiluAndMulFwdOp",
+    "GeluAndMulFwdOp",
+    "GeluTanhAndMulFwdOp",
     # --- math (17) ---
-    "AbsOp",
-    "CeilOp",
-    "CosOp",
-    "ErfOp",
-    "ExpOp",
-    "Expm1Op",
-    "FloorOp",
-    "Log1pOp",
-    "LogOp",
-    "NegOp",
-    "ReciprocalOp",
-    "RoundOp",
-    "RsqrtOp",
-    "SignOp",
-    "SinOp",
-    "SqrtOp",
-    "TruncOp",
+    "AbsFwdOp",
+    "CeilFwdOp",
+    "CosFwdOp",
+    "ErfFwdOp",
+    "ExpFwdOp",
+    "Expm1FwdOp",
+    "FloorFwdOp",
+    "Log1pFwdOp",
+    "LogFwdOp",
+    "NegFwdOp",
+    "ReciprocalFwdOp",
+    "RoundFwdOp",
+    "RsqrtFwdOp",
+    "SignFwdOp",
+    "SinFwdOp",
+    "SqrtFwdOp",
+    "TruncFwdOp",
     # --- activations (8) ---
-    "GeluOp",
-    "HardsigmoidOp",
-    "HardswishOp",
-    "MishOp",
-    "SeluOp",
-    "SigmoidOp",
-    "SiluOp",
-    "TanhOp",
+    "GeluFwdOp",
+    "HardsigmoidFwdOp",
+    "HardswishFwdOp",
+    "MishFwdOp",
+    "SeluFwdOp",
+    "SigmoidFwdOp",
+    "SiluFwdOp",
+    "TanhFwdOp",
     # --- logical (1) ---
-    "LogicalNotOp",
+    "LogicalNotFwdOp",
     # --- bitwise (1) ---
-    "BitwiseNotOp",
+    "BitwiseNotFwdOp",
     # --- special predicates (3) ---
-    "IsfiniteOp",
-    "IsinfOp",
-    "IsnanOp",
+    "IsfiniteFwdOp",
+    "IsinfFwdOp",
+    "IsnanFwdOp",
     # --- independent (custom-signature, 11) ---
-    "LeakyReluOp",
-    "EluOp",
-    "HardtanhOp",
-    "SoftplusOp",
-    "PreluOp",
-    "WhereOp",
-    "ClampOp",
-    "MaskedFillOp",
-    "NanToNumOp",
-    "AlibiOp",
-    "SinusoidalOp",
+    "LeakyReluFwdOp",
+    "EluFwdOp",
+    "HardtanhFwdOp",
+    "SoftplusFwdOp",
+    "PreluFwdOp",
+    "WhereFwdOp",
+    "ClampFwdOp",
+    "MaskedFillFwdOp",
+    "NanToNumFwdOp",
+    "AlibiFwdOp",
+    "SinusoidalFwdOp",
 ]
 
 
@@ -756,63 +756,63 @@ class FusedGatedOp(Op):
 # ---------------------------------------------------------------------------
 
 
-class ReluOp(UnaryOp):
+class ReluFwdOp(UnaryOp):
     """ReLU activation: y = max(x, 0)."""
 
     _op_name = "relu"
-    kernel_cls = ReluKernel
+    kernel_cls = ReluFwdKernel
 
 
-class AddOp(BinaryOp):
+class AddFwdOp(BinaryOp):
     """Element-wise addition with broadcast: y = a + b."""
 
     _op_name = "add"
-    kernel_cls = AddKernel
+    kernel_cls = AddFwdKernel
 
 
-class SubOp(BinaryOp):
+class SubFwdOp(BinaryOp):
     """Element-wise subtraction with broadcast: y = a - b."""
 
     _op_name = "sub"
-    kernel_cls = SubKernel
+    kernel_cls = SubFwdKernel
 
 
-class MulOp(BinaryOp):
+class MulFwdOp(BinaryOp):
     """Element-wise multiplication with broadcast: y = a * b."""
 
     _op_name = "mul"
-    kernel_cls = MulKernel
+    kernel_cls = MulFwdKernel
 
 
-class DivOp(BinaryOp):
+class DivFwdOp(BinaryOp):
     """Element-wise division with broadcast: y = a / b."""
 
     _op_name = "div"
-    kernel_cls = DivKernel
+    kernel_cls = DivFwdKernel
 
 
-class RemainderOp(BinaryOp):
+class RemainderFwdOp(BinaryOp):
     """Element-wise remainder with broadcast: y = a % b."""
 
     _op_name = "remainder"
-    kernel_cls = RemainderKernel
+    kernel_cls = RemainderFwdKernel
 
 
-class PowOp(BinaryOp):
+class PowFwdOp(BinaryOp):
     """Element-wise power with broadcast: y = a ** b."""
 
     _op_name = "pow"
-    kernel_cls = PowKernel
+    kernel_cls = PowFwdKernel
 
 
-class FloorDivideOp(BinaryOp):
+class FloorDivideFwdOp(BinaryOp):
     """Element-wise floor division with broadcast: y = floor(a / b)."""
 
     _op_name = "floor_divide"
-    kernel_cls = FloorDivideKernel
+    kernel_cls = FloorDivideFwdKernel
 
 
-class LerpOp(BinaryOp):
+class LerpFwdOp(BinaryOp):
     """Element-wise lerp with broadcast: y = a + weight * (b - a).
 
     Unlike ``torch.lerp(a, b, weight)`` where weight is a runtime parameter,
@@ -831,7 +831,7 @@ class LerpOp(BinaryOp):
     """
 
     _op_name = "lerp"
-    kernel_cls = LerpKernel
+    kernel_cls = LerpFwdKernel
 
     def __init__(
         self,
@@ -874,18 +874,18 @@ class LerpOp(BinaryOp):
         _OP_REGISTRY[self._instance_key] = self
 
 
-class MaximumOp(BinaryOp):
+class MaximumFwdOp(BinaryOp):
     """Element-wise maximum with broadcast: y = max(a, b)."""
 
     _op_name = "maximum"
-    kernel_cls = MaximumKernel
+    kernel_cls = MaximumFwdKernel
 
 
-class MinimumOp(BinaryOp):
+class MinimumFwdOp(BinaryOp):
     """Element-wise minimum with broadcast: y = min(a, b)."""
 
     _op_name = "minimum"
-    kernel_cls = MinimumKernel
+    kernel_cls = MinimumFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -911,46 +911,46 @@ class _BoolOutputBinaryOp(BinaryOp):
         return result.to(torch.bool)
 
 
-class EqOp(_BoolOutputBinaryOp):
+class EqFwdOp(_BoolOutputBinaryOp):
     """Element-wise equality with broadcast: y = (a == b)."""
 
     _op_name = "eq"
-    kernel_cls = EqKernel
+    kernel_cls = EqFwdKernel
 
 
-class NeOp(_BoolOutputBinaryOp):
+class NeFwdOp(_BoolOutputBinaryOp):
     """Element-wise not-equal with broadcast: y = (a != b)."""
 
     _op_name = "ne"
-    kernel_cls = NeKernel
+    kernel_cls = NeFwdKernel
 
 
-class GtOp(_BoolOutputBinaryOp):
+class GtFwdOp(_BoolOutputBinaryOp):
     """Element-wise greater-than with broadcast: y = (a > b)."""
 
     _op_name = "gt"
-    kernel_cls = GtKernel
+    kernel_cls = GtFwdKernel
 
 
-class LtOp(_BoolOutputBinaryOp):
+class LtFwdOp(_BoolOutputBinaryOp):
     """Element-wise less-than with broadcast: y = (a < b)."""
 
     _op_name = "lt"
-    kernel_cls = LtKernel
+    kernel_cls = LtFwdKernel
 
 
-class GeOp(_BoolOutputBinaryOp):
+class GeFwdOp(_BoolOutputBinaryOp):
     """Element-wise greater-equal with broadcast: y = (a >= b)."""
 
     _op_name = "ge"
-    kernel_cls = GeKernel
+    kernel_cls = GeFwdKernel
 
 
-class LeOp(_BoolOutputBinaryOp):
+class LeFwdOp(_BoolOutputBinaryOp):
     """Element-wise less-equal with broadcast: y = (a <= b)."""
 
     _op_name = "le"
-    kernel_cls = LeKernel
+    kernel_cls = LeFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -958,18 +958,18 @@ class LeOp(_BoolOutputBinaryOp):
 # ---------------------------------------------------------------------------
 
 
-class LogicalAndOp(_BoolOutputBinaryOp):
+class LogicalAndFwdOp(_BoolOutputBinaryOp):
     """Element-wise logical AND with broadcast using non-zero truthiness."""
 
     _op_name = "logical_and"
-    kernel_cls = LogicalAndKernel
+    kernel_cls = LogicalAndFwdKernel
 
 
-class LogicalOrOp(_BoolOutputBinaryOp):
+class LogicalOrFwdOp(_BoolOutputBinaryOp):
     """Element-wise logical OR with broadcast using non-zero truthiness."""
 
     _op_name = "logical_or"
-    kernel_cls = LogicalOrKernel
+    kernel_cls = LogicalOrFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -977,25 +977,25 @@ class LogicalOrOp(_BoolOutputBinaryOp):
 # ---------------------------------------------------------------------------
 
 
-class BitwiseAndOp(BinaryOp):
+class BitwiseAndFwdOp(BinaryOp):
     """Element-wise bitwise AND with broadcast: y = a & b."""
 
     _op_name = "bitwise_and"
-    kernel_cls = BitwiseAndKernel
+    kernel_cls = BitwiseAndFwdKernel
 
 
-class BitwiseOrOp(BinaryOp):
+class BitwiseOrFwdOp(BinaryOp):
     """Element-wise bitwise OR with broadcast: y = a | b."""
 
     _op_name = "bitwise_or"
-    kernel_cls = BitwiseOrKernel
+    kernel_cls = BitwiseOrFwdKernel
 
 
-class BitwiseXorOp(BinaryOp):
+class BitwiseXorFwdOp(BinaryOp):
     """Element-wise bitwise XOR with broadcast: y = a ^ b."""
 
     _op_name = "bitwise_xor"
-    kernel_cls = BitwiseXorKernel
+    kernel_cls = BitwiseXorFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1003,25 +1003,25 @@ class BitwiseXorOp(BinaryOp):
 # ---------------------------------------------------------------------------
 
 
-class SiluAndMulOp(FusedGatedOp):
+class SiluAndMulFwdOp(FusedGatedOp):
     """SiLU-and-Mul: y = silu(gate) * value."""
 
     _op_name = "silu_and_mul"
-    kernel_cls = SiluAndMulKernel
+    kernel_cls = SiluAndMulFwdKernel
 
 
-class GeluAndMulOp(FusedGatedOp):
+class GeluAndMulFwdOp(FusedGatedOp):
     """GELU-and-Mul: y = gelu(gate) * value (exact GELU)."""
 
     _op_name = "gelu_and_mul"
-    kernel_cls = GeluAndMulKernel
+    kernel_cls = GeluAndMulFwdKernel
 
 
-class GeluTanhAndMulOp(FusedGatedOp):
+class GeluTanhAndMulFwdOp(FusedGatedOp):
     """GELU-Tanh-and-Mul: y = gelu_tanh(gate) * value (tanh approximation)."""
 
     _op_name = "gelu_tanh_and_mul"
-    kernel_cls = GeluTanhAndMulKernel
+    kernel_cls = GeluTanhAndMulFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1029,123 +1029,123 @@ class GeluTanhAndMulOp(FusedGatedOp):
 # ---------------------------------------------------------------------------
 
 
-class ExpOp(UnaryOp):
+class ExpFwdOp(UnaryOp):
     """Element-wise exp(x)."""
 
     _op_name = "exp"
-    kernel_cls = ExpKernel
+    kernel_cls = ExpFwdKernel
 
 
-class LogOp(UnaryOp):
+class LogFwdOp(UnaryOp):
     """Element-wise log(x)."""
 
     _op_name = "log"
-    kernel_cls = LogKernel
+    kernel_cls = LogFwdKernel
 
 
-class SqrtOp(UnaryOp):
+class SqrtFwdOp(UnaryOp):
     """Element-wise sqrt(x)."""
 
     _op_name = "sqrt"
-    kernel_cls = SqrtKernel
+    kernel_cls = SqrtFwdKernel
 
 
-class RsqrtOp(UnaryOp):
+class RsqrtFwdOp(UnaryOp):
     """Element-wise 1/sqrt(x)."""
 
     _op_name = "rsqrt"
-    kernel_cls = RsqrtKernel
+    kernel_cls = RsqrtFwdKernel
 
 
-class AbsOp(UnaryOp):
+class AbsFwdOp(UnaryOp):
     """Element-wise |x|."""
 
     _op_name = "abs"
-    kernel_cls = AbsKernel
+    kernel_cls = AbsFwdKernel
 
 
-class NegOp(UnaryOp):
+class NegFwdOp(UnaryOp):
     """Element-wise -x."""
 
     _op_name = "neg"
-    kernel_cls = NegKernel
+    kernel_cls = NegFwdKernel
 
 
-class ReciprocalOp(UnaryOp):
+class ReciprocalFwdOp(UnaryOp):
     """Element-wise 1/x."""
 
     _op_name = "reciprocal"
-    kernel_cls = ReciprocalKernel
+    kernel_cls = ReciprocalFwdKernel
 
 
-class SignOp(UnaryOp):
+class SignFwdOp(UnaryOp):
     """Element-wise sign(x): -1, 0, or +1."""
 
     _op_name = "sign"
-    kernel_cls = SignKernel
+    kernel_cls = SignFwdKernel
 
 
-class SinOp(UnaryOp):
+class SinFwdOp(UnaryOp):
     """Element-wise sin(x)."""
 
     _op_name = "sin"
-    kernel_cls = SinKernel
+    kernel_cls = SinFwdKernel
 
 
-class CosOp(UnaryOp):
+class CosFwdOp(UnaryOp):
     """Element-wise cos(x)."""
 
     _op_name = "cos"
-    kernel_cls = CosKernel
+    kernel_cls = CosFwdKernel
 
 
-class FloorOp(UnaryOp):
+class FloorFwdOp(UnaryOp):
     """Element-wise floor(x)."""
 
     _op_name = "floor"
-    kernel_cls = FloorKernel
+    kernel_cls = FloorFwdKernel
 
 
-class CeilOp(UnaryOp):
+class CeilFwdOp(UnaryOp):
     """Element-wise ceil(x)."""
 
     _op_name = "ceil"
-    kernel_cls = CeilKernel
+    kernel_cls = CeilFwdKernel
 
 
-class RoundOp(UnaryOp):
+class RoundFwdOp(UnaryOp):
     """Element-wise round(x)."""
 
     _op_name = "round"
-    kernel_cls = RoundKernel
+    kernel_cls = RoundFwdKernel
 
 
-class TruncOp(UnaryOp):
+class TruncFwdOp(UnaryOp):
     """Element-wise trunc(x)."""
 
     _op_name = "trunc"
-    kernel_cls = TruncKernel
+    kernel_cls = TruncFwdKernel
 
 
-class ErfOp(UnaryOp):
+class ErfFwdOp(UnaryOp):
     """Element-wise erf(x)."""
 
     _op_name = "erf"
-    kernel_cls = ErfKernel
+    kernel_cls = ErfFwdKernel
 
 
-class Log1pOp(UnaryOp):
+class Log1pFwdOp(UnaryOp):
     """Element-wise log(1 + x)."""
 
     _op_name = "log1p"
-    kernel_cls = Log1pKernel
+    kernel_cls = Log1pFwdKernel
 
 
-class Expm1Op(UnaryOp):
+class Expm1FwdOp(UnaryOp):
     """Element-wise exp(x) - 1."""
 
     _op_name = "expm1"
-    kernel_cls = Expm1Kernel
+    kernel_cls = Expm1FwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1153,60 +1153,60 @@ class Expm1Op(UnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class GeluOp(UnaryOp):
+class GeluFwdOp(UnaryOp):
     """Element-wise GELU using the standard erf formulation."""
 
     _op_name = "gelu"
-    kernel_cls = GeluKernel
+    kernel_cls = GeluFwdKernel
 
 
-class SiluOp(UnaryOp):
+class SiluFwdOp(UnaryOp):
     """Element-wise SiLU (Swish): x * sigmoid(x)."""
 
     _op_name = "silu"
-    kernel_cls = SiluKernel
+    kernel_cls = SiluFwdKernel
 
 
-class SigmoidOp(UnaryOp):
+class SigmoidFwdOp(UnaryOp):
     """Element-wise sigmoid(x)."""
 
     _op_name = "sigmoid"
-    kernel_cls = SigmoidKernel
+    kernel_cls = SigmoidFwdKernel
 
 
-class TanhOp(UnaryOp):
+class TanhFwdOp(UnaryOp):
     """Element-wise tanh(x)."""
 
     _op_name = "tanh"
-    kernel_cls = TanhKernel
+    kernel_cls = TanhFwdKernel
 
 
-class HardswishOp(UnaryOp):
+class HardswishFwdOp(UnaryOp):
     """Element-wise HardSwish: x * clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardswish"
-    kernel_cls = HardswishKernel
+    kernel_cls = HardswishFwdKernel
 
 
-class HardsigmoidOp(UnaryOp):
+class HardsigmoidFwdOp(UnaryOp):
     """Element-wise HardSigmoid: clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardsigmoid"
-    kernel_cls = HardsigmoidKernel
+    kernel_cls = HardsigmoidFwdKernel
 
 
-class MishOp(UnaryOp):
+class MishFwdOp(UnaryOp):
     """Element-wise Mish: x * tanh(softplus(x))."""
 
     _op_name = "mish"
-    kernel_cls = MishKernel
+    kernel_cls = MishFwdKernel
 
 
-class SeluOp(UnaryOp):
+class SeluFwdOp(UnaryOp):
     """Element-wise SELU."""
 
     _op_name = "selu"
-    kernel_cls = SeluKernel
+    kernel_cls = SeluFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1214,11 +1214,11 @@ class SeluOp(UnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class LogicalNotOp(UnaryOp):
+class LogicalNotFwdOp(UnaryOp):
     """Element-wise logical NOT with bool output."""
 
     _op_name = "logical_not"
-    kernel_cls = LogicalNotKernel
+    kernel_cls = LogicalNotFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1226,11 +1226,11 @@ class LogicalNotOp(UnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class BitwiseNotOp(UnaryOp):
+class BitwiseNotFwdOp(UnaryOp):
     """Element-wise bitwise NOT (~x) for bool/integer inputs."""
 
     _op_name = "bitwise_not"
-    kernel_cls = BitwiseNotKernel
+    kernel_cls = BitwiseNotFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1238,25 +1238,25 @@ class BitwiseNotOp(UnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class IsnanOp(UnaryOp):
+class IsnanFwdOp(UnaryOp):
     """Element-wise isnan with bool output."""
 
     _op_name = "isnan"
-    kernel_cls = IsnanKernel
+    kernel_cls = IsnanFwdKernel
 
 
-class IsinfOp(UnaryOp):
+class IsinfFwdOp(UnaryOp):
     """Element-wise isinf with bool output."""
 
     _op_name = "isinf"
-    kernel_cls = IsinfKernel
+    kernel_cls = IsinfFwdKernel
 
 
-class IsfiniteOp(UnaryOp):
+class IsfiniteFwdOp(UnaryOp):
     """Element-wise isfinite with bool output."""
 
     _op_name = "isfinite"
-    kernel_cls = IsfiniteKernel
+    kernel_cls = IsfiniteFwdKernel
 
 
 # ---------------------------------------------------------------------------
@@ -1264,7 +1264,7 @@ class IsfiniteOp(UnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class LeakyReluOp(Op):
+class LeakyReluFwdOp(Op):
     """Leaky ReLU: y = x if x > 0 else negative_slope * x.
 
     Args:
@@ -1281,13 +1281,13 @@ class LeakyReluOp(Op):
         self.N_total = N_total
         self.dtype = dtype
         self.negative_slope = negative_slope
-        self.kernel = LeakyReluKernel(N_total, dtype, negative_slope=negative_slope)
+        self.kernel = LeakyReluFwdKernel(N_total, dtype, negative_slope=negative_slope)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"leaky_relu": LeakyReluKernel}
+        return {"leaky_relu": LeakyReluFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1307,7 +1307,7 @@ class LeakyReluOp(Op):
         return self._eager_forward(x)
 
 
-class EluOp(Op):
+class EluFwdOp(Op):
     """ELU: y = x if x > 0 else alpha * (exp(x) - 1).
 
     Args:
@@ -1324,13 +1324,13 @@ class EluOp(Op):
         self.N_total = N_total
         self.dtype = dtype
         self.alpha = alpha
-        self.kernel = EluKernel(N_total, dtype, alpha=alpha)
+        self.kernel = EluFwdKernel(N_total, dtype, alpha=alpha)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"elu": EluKernel}
+        return {"elu": EluFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1350,7 +1350,7 @@ class EluOp(Op):
         return self._eager_forward(x)
 
 
-class HardtanhOp(Op):
+class HardtanhFwdOp(Op):
     """Hardtanh: y = clamp(x, min_val, max_val).
 
     Args:
@@ -1371,13 +1371,13 @@ class HardtanhOp(Op):
         self.dtype = dtype
         self.min_val = min_val
         self.max_val = max_val
-        self.kernel = HardtanhKernel(N_total, dtype, min_val=min_val, max_val=max_val)
+        self.kernel = HardtanhFwdKernel(N_total, dtype, min_val=min_val, max_val=max_val)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"hardtanh": HardtanhKernel}
+        return {"hardtanh": HardtanhFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1397,7 +1397,7 @@ class HardtanhOp(Op):
         return self._eager_forward(x)
 
 
-class SoftplusOp(Op):
+class SoftplusFwdOp(Op):
     """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x.
 
     Args:
@@ -1418,13 +1418,13 @@ class SoftplusOp(Op):
         self.dtype = dtype
         self.beta = beta
         self.threshold = threshold
-        self.kernel = SoftplusKernel(N_total, dtype, beta=beta, threshold=threshold)
+        self.kernel = SoftplusFwdKernel(N_total, dtype, beta=beta, threshold=threshold)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"softplus": SoftplusKernel}
+        return {"softplus": SoftplusFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1444,7 +1444,7 @@ class SoftplusOp(Op):
         return self._eager_forward(x)
 
 
-class PreluOp(Op):
+class PreluFwdOp(Op):
     """PReLU: y = x if x > 0 else weight[channel] * x.
 
     Channel dimension follows PyTorch convention: dimension 1 for inputs
@@ -1468,13 +1468,13 @@ class PreluOp(Op):
         # PyTorch PReLU: channel dim is 1 for ndim>=2, else 0
         inner_size = (prod(shape[2:]) if len(shape) > 2 else 1) if len(shape) >= 2 else 1
         self.inner_size = inner_size
-        self.kernel = PreluKernel(N_total, num_channels, inner_size, dtype)
+        self.kernel = PreluFwdKernel(N_total, num_channels, inner_size, dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"prelu": PreluKernel}
+        return {"prelu": PreluFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1496,7 +1496,7 @@ class PreluOp(Op):
         return self._eager_forward(x, weight)
 
 
-class WhereOp(Op):
+class WhereFwdOp(Op):
     """Where: out = cond ? x : y.
 
     Args:
@@ -1510,13 +1510,13 @@ class WhereOp(Op):
     def __init__(self, N_total: int, dtype: torch.dtype):
         self.N_total = N_total
         self.dtype = dtype
-        self.kernel = WhereKernel(N_total, dtype)
+        self.kernel = WhereFwdKernel(N_total, dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"where": WhereKernel}
+        return {"where": WhereFwdKernel}
 
     def _eager_forward(
         self, cond: torch.Tensor, x: torch.Tensor, y: torch.Tensor,
@@ -1544,7 +1544,7 @@ class WhereOp(Op):
         return self._eager_forward(cond, x, y)
 
 
-class ClampOp(Op):
+class ClampFwdOp(Op):
     """Clamp: y = clamp(x, min, max) with optional bounds.
 
     Args:
@@ -1567,13 +1567,13 @@ class ClampOp(Op):
         self.dtype = dtype
         self.min_val = min_val
         self.max_val = max_val
-        self.kernel = ClampKernel(N_total, dtype, min_val=min_val, max_val=max_val)
+        self.kernel = ClampFwdKernel(N_total, dtype, min_val=min_val, max_val=max_val)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"clamp": ClampKernel}
+        return {"clamp": ClampFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1593,7 +1593,7 @@ class ClampOp(Op):
         return self._eager_forward(x)
 
 
-class MaskedFillOp(Op):
+class MaskedFillFwdOp(Op):
     """MaskedFill: out = mask ? fill_value : x.
 
     Args:
@@ -1610,13 +1610,13 @@ class MaskedFillOp(Op):
         self.N_total = N_total
         self.dtype = dtype
         self.fill_value = fill_value
-        self.kernel = MaskedFillKernel(N_total, dtype, fill_value)
+        self.kernel = MaskedFillFwdKernel(N_total, dtype, fill_value)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {"masked_fill": MaskedFillKernel}
+        return {"masked_fill": MaskedFillFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1648,7 +1648,7 @@ class MaskedFillOp(Op):
         return self._eager_forward(x, mask)
 
 
-class NanToNumOp(Op):
+class NanToNumFwdOp(Op):
     """NanToNum: replace NaN, +Inf, -Inf with specified values.
 
     Args:
@@ -1672,7 +1672,7 @@ class NanToNumOp(Op):
         self.nan_val = nan_val
         self.posinf_val = posinf_val
         self.neginf_val = neginf_val
-        self.kernel = NanToNumKernel(
+        self.kernel = NanToNumFwdKernel(
             N_total, dtype, nan_val=nan_val, posinf_val=posinf_val, neginf_val=neginf_val,
         )
         self._instance_key = id(self)
@@ -1680,7 +1680,7 @@ class NanToNumOp(Op):
 
     @property
     def default_kernel_map(self):
-        return {"nan_to_num": NanToNumKernel}
+        return {"nan_to_num": NanToNumFwdKernel}
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1700,7 +1700,7 @@ class NanToNumOp(Op):
         return self._eager_forward(x)
 
 
-class AlibiOp(Op):
+class AlibiFwdOp(Op):
     """ALiBi position encoding: bias[h, i, j] = -slope_h * |i - j|.
 
     Generates the full (num_heads, seq_len, seq_len) bias tensor.
@@ -1718,7 +1718,7 @@ class AlibiOp(Op):
         self.seq_len = seq_len
         self.num_heads = num_heads
         self.dtype = dtype
-        self.kernel = AlibiKernel(seq_len, num_heads, dtype)
+        self.kernel = AlibiFwdKernel(seq_len, num_heads, dtype)
         # Scalar tensor used as device/dtype carrier for torch.compile tracing
         self._device_carrier = torch.empty((), dtype=dtype, device="cuda")
         self._instance_key = id(self)
@@ -1726,7 +1726,7 @@ class AlibiOp(Op):
 
     @property
     def default_kernel_map(self):
-        return {"alibi": AlibiKernel}
+        return {"alibi": AlibiFwdKernel}
 
     def _eager_forward(self) -> torch.Tensor:
         out = self.kernel()
@@ -1744,7 +1744,7 @@ class AlibiOp(Op):
         return self._eager_forward()
 
 
-class SinusoidalOp(Op):
+class SinusoidalFwdOp(Op):
     """Sinusoidal positional encoding from "Attention Is All You Need".
 
     Generates the full (seq_len, d_model) encoding tensor.
@@ -1762,7 +1762,7 @@ class SinusoidalOp(Op):
         self.seq_len = seq_len
         self.d_model = d_model
         self.dtype = dtype
-        self.kernel = SinusoidalKernel(seq_len, d_model, dtype)
+        self.kernel = SinusoidalFwdKernel(seq_len, d_model, dtype)
         # Scalar tensor used as device/dtype carrier for torch.compile tracing
         self._device_carrier = torch.empty((), dtype=dtype, device="cuda")
         self._instance_key = id(self)
@@ -1770,7 +1770,7 @@ class SinusoidalOp(Op):
 
     @property
     def default_kernel_map(self):
-        return {"sinusoidal": SinusoidalKernel}
+        return {"sinusoidal": SinusoidalFwdKernel}
 
     def _eager_forward(self) -> torch.Tensor:
         out = self.kernel()
@@ -1794,66 +1794,66 @@ class SinusoidalOp(Op):
 
 # --- Unary ops: float-preserving output (1 + 17 + 8 + 1 = 27 ops) ---
 for _cls in [
-    ReluOp,
+    ReluFwdOp,
     # math (17)
-    ExpOp, LogOp, SqrtOp, RsqrtOp, AbsOp, NegOp, ReciprocalOp, SignOp,
-    SinOp, CosOp, FloorOp, CeilOp, RoundOp, TruncOp, ErfOp, Log1pOp, Expm1Op,
+    ExpFwdOp, LogFwdOp, SqrtFwdOp, RsqrtFwdOp, AbsFwdOp, NegFwdOp, ReciprocalFwdOp, SignFwdOp,
+    SinFwdOp, CosFwdOp, FloorFwdOp, CeilFwdOp, RoundFwdOp, TruncFwdOp, ErfFwdOp, Log1pFwdOp, Expm1FwdOp,
     # activations (8)
-    GeluOp, SiluOp, SigmoidOp, TanhOp, HardswishOp, HardsigmoidOp, MishOp, SeluOp,
+    GeluFwdOp, SiluFwdOp, SigmoidFwdOp, TanhFwdOp, HardswishFwdOp, HardsigmoidFwdOp, MishFwdOp, SeluFwdOp,
     # bitwise (1) -- output same dtype as input
-    BitwiseNotOp,
+    BitwiseNotFwdOp,
 ]:
     _register_unary_custom_op(_cls)
 
 # --- Unary ops: bool output (4 ops) ---
-for _cls in [LogicalNotOp, IsnanOp, IsinfOp, IsfiniteOp]:
+for _cls in [LogicalNotFwdOp, IsnanFwdOp, IsinfFwdOp, IsfiniteFwdOp]:
     _register_unary_custom_op(_cls, output_dtype_override=torch.bool)
 
 # --- Binary ops: same-dtype output (10 + 3 = 13 ops) ---
 for _cls in [
     # arithmetic (10)
-    AddOp, SubOp, MulOp, DivOp, RemainderOp, PowOp, FloorDivideOp,
-    LerpOp, MaximumOp, MinimumOp,
+    AddFwdOp, SubFwdOp, MulFwdOp, DivFwdOp, RemainderFwdOp, PowFwdOp, FloorDivideFwdOp,
+    LerpFwdOp, MaximumFwdOp, MinimumFwdOp,
     # bitwise (3)
-    BitwiseAndOp, BitwiseOrOp, BitwiseXorOp,
+    BitwiseAndFwdOp, BitwiseOrFwdOp, BitwiseXorFwdOp,
 ]:
     _register_binary_custom_op(_cls)
 
 # --- Binary ops: bool output (comparison 6 + logical 2 = 8 ops) ---
 for _cls in [
-    EqOp, NeOp, GtOp, LtOp, GeOp, LeOp,
-    LogicalAndOp, LogicalOrOp,
+    EqFwdOp, NeFwdOp, GtFwdOp, LtFwdOp, GeFwdOp, LeFwdOp,
+    LogicalAndFwdOp, LogicalOrFwdOp,
 ]:
     _register_binary_custom_op(_cls, output_bool=True)
 
 # --- Fused gated ops (3 ops) ---
-for _cls in [SiluAndMulOp, GeluAndMulOp, GeluTanhAndMulOp]:
+for _cls in [SiluAndMulFwdOp, GeluAndMulFwdOp, GeluTanhAndMulFwdOp]:
     _register_fused_gated_custom_op(_cls)
 
 # --- Independent unary-like ops (6 ops: x -> y with baked params) ---
 for _cls in [
-    LeakyReluOp, EluOp, HardtanhOp, SoftplusOp, ClampOp, NanToNumOp,
+    LeakyReluFwdOp, EluFwdOp, HardtanhFwdOp, SoftplusFwdOp, ClampFwdOp, NanToNumFwdOp,
 ]:
     _register_unary_custom_op(_cls)
 
 # --- PReLU op (1 op: x, weight -> y) ---
-_register_prelu_custom_op(PreluOp)
+_register_prelu_custom_op(PreluFwdOp)
 
 # --- Where op (1 op: cond, x, y -> out) ---
-_register_where_custom_op(WhereOp)
+_register_where_custom_op(WhereFwdOp)
 
 # --- MaskedFill op (1 op: x, mask -> y) ---
-_register_masked_fill_custom_op(MaskedFillOp)
+_register_masked_fill_custom_op(MaskedFillFwdOp)
 
 # --- Generative ops (2 ops: no tensor input -> out) ---
 _register_generative_custom_op(
-    AlibiOp,
+    AlibiFwdOp,
     out_shape_fn=lambda carrier, num_heads, seq_len: carrier.new_empty(
         (num_heads, seq_len, seq_len),
     ),
 )
 _register_generative_custom_op(
-    SinusoidalOp,
+    SinusoidalFwdOp,
     out_shape_fn=lambda carrier, seq_len, d_model: carrier.new_empty(
         (seq_len, d_model),
     ),

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -6,7 +6,7 @@ Three Op template base classes:
 - FusedGatedOp: wraps FusedGatedKernel with (M, 2N) layout
 
 torch.compile support:
-- All 55 concrete ops are registered via @torch.library.custom_op at module load time
+- All 66 concrete ops are registered via @torch.library.custom_op at module load time
 - Three factory functions (_register_unary_custom_op, _register_binary_custom_op,
   _register_fused_gated_custom_op) register every op; instances are looked up at
   runtime via _OP_REGISTRY keyed by id(instance)
@@ -1789,7 +1789,7 @@ class SinusoidalFwdOp(Op):
 
 
 # ---------------------------------------------------------------------------
-# torch.compile registration for all 55 concrete ops
+# torch.compile registration for all 66 concrete ops
 # ---------------------------------------------------------------------------
 
 # --- Unary ops: float-preserving output (1 + 17 + 8 + 1 = 27 ops) ---

--- a/tileops/ops/moe/fused_moe_experts.py
+++ b/tileops/ops/moe/fused_moe_experts.py
@@ -25,7 +25,7 @@ import torch
 
 from tileops.kernels.grouped_gemm import _DEFAULT_CONFIGS as _GEMM_DEFAULT_CONFIGS
 from tileops.kernels.kernel_base import Kernel
-from tileops.ops.elementwise import SiluAndMulOp
+from tileops.ops.elementwise import SiluAndMulFwdOp
 from tileops.ops.grouped_gemm import GroupedGemmOp
 from tileops.ops.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
 from tileops.ops.moe.permute_nopad import MoePermuteNopadFwdOp
@@ -101,7 +101,7 @@ class FusedMoeExpertsFwdOp(Op):
             k=hidden_size,
             dtype=dtype,
         )
-        self._silu_and_mul = SiluAndMulOp(
+        self._silu_and_mul = SiluAndMulFwdOp(
             M=numel,
             N=ffn_size,
             dtype=dtype,
@@ -220,7 +220,7 @@ class FusedMoeExpertsPaddedFwdOp(Op):
             k=hidden_size,
             dtype=dtype,
         )
-        self._silu_and_mul = SiluAndMulOp(
+        self._silu_and_mul = SiluAndMulFwdOp(
             M=_padded_batch_sum,
             N=ffn_size,
             dtype=dtype,


### PR DESCRIPTION
## Summary

Rename all elementwise op and kernel classes to include the `Fwd` direction suffix, aligning with the naming convention used by non-elementwise ops (e.g., `RMSNormFwdOp`, `GemmFwdKernel`). This makes the codebase consistent and prepares for future backward-pass implementations.

- 66 Op classes renamed: `{Name}Op` -> `{Name}FwdOp`
- 66 Kernel classes renamed: `{Name}Kernel` -> `{Name}FwdKernel`
- All imports updated across tests, benchmarks, and internal references

Closes #977

## Test plan

- [x] **AC-1**: All elementwise ops follow `{Name}FwdOp` pattern — AST scan of `tileops/ops/elementwise.py` found 66 `*FwdOp` classes and 0 legacy elementwise concrete `*Op` classes.
- [x] **AC-2**: All elementwise kernels follow `{Name}FwdKernel` pattern — AST scan of `tileops/kernels/elementwise.py` found 66 `*FwdKernel` classes and 0 legacy elementwise concrete `*Kernel` classes.
- [x] **AC-3**: Manifest keys match class names — `ops_manifest.yaml` contains no legacy elementwise op/kernel class-name references.
- [x] **AC-4**: All tests pass — `python -m pytest -q tests` => 2242 passed, 22 skipped; `pre-commit run --all-files` passed.

## Follow-up

No follow-up issues or suggestions.