### PR TITLE
[CI] reclaim self-hosted runner disk before heavy steps

### DIFF
--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -83,10 +83,24 @@ runs:
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
         set -uo pipefail
-        # shellcheck disable=SC2206
-        DF_TARGETS=( ${DF_PATHS} )
-        if [[ ${#DF_TARGETS[@]} -eq 0 ]]; then
-          DF_TARGETS=( "${RUNNER_TEMP}" "${TOOL_CACHE}" /home/ci-runner )
+
+        # Validate numeric inputs up-front so typos fail with a clear error
+        # instead of a cryptic bash arithmetic/find error deeper in the script.
+        for var in VENV_KEEP TEMP_ORPHAN_MINUTES CACHE_AGE_DAYS MIN_AVAIL_GIB; do
+          val="${!var}"
+          if [[ ! "${val}" =~ ^[0-9]+$ ]]; then
+            echo "::error::reclaim-runner-disk: input ${var}='${val}' is not a non-negative integer"
+            exit 1
+          fi
+        done
+
+        if [[ -n "${DF_PATHS}" ]]; then
+          read -r -a DF_TARGETS <<< "${DF_PATHS}"
+        else
+          DF_TARGETS=()
+          for path in "${RUNNER_TEMP:-}" "${TOOL_CACHE:-}" /home/ci-runner; do
+            [[ -n "${path}" ]] && DF_TARGETS+=( "${path}" )
+          done
         fi
 
         echo "Disk before reclaim:"
@@ -98,7 +112,7 @@ runs:
 
         # 1) Prune old trusted venvs: keep N most recent by mtime.
         if [[ "${GUARD_ONLY}" != "true" && "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
-          mapfile -t venvs < <(find "${TOOL_CACHE}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | awk '{print $2}')
+          mapfile -t venvs < <(find "${TOOL_CACHE}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | cut -d' ' -f2-)
           if [[ ${#venvs[@]} -gt ${VENV_KEEP} ]]; then
             for stale in "${venvs[@]:${VENV_KEEP}}"; do
               echo "Removing stale venv: ${stale}"
@@ -141,6 +155,10 @@ runs:
         df -h "${DF_TARGETS[@]}" 2>/dev/null || true
 
         # Hard guard: abort early with a clear message if still near-full.
+        if [[ -z "${RUNNER_TEMP:-}" ]]; then
+          echo "::error::reclaim-runner-disk: RUNNER_TEMP is unset; cannot enforce disk floor"
+          exit 1
+        fi
         AVAIL_KB=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
         MIN_KB=$(( MIN_AVAIL_GIB * 1024 * 1024 ))
         if [[ -n "${AVAIL_KB:-}" && "${AVAIL_KB}" -lt "${MIN_KB}" ]]; then

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -74,14 +74,6 @@ inputs:
       always run the full reclaim pass.
     required: false
     default: "false"
-  guard-only:
-    description: >
-      When "true", skip the venv/orphan/cache pruning and only run the
-      disk-floor guard. Intended for per-PR jobs that rely on a scheduled
-      maintenance workflow for the heavy reclaim; the guard still fails
-      fast with an explicit error if the scheduled workflow has lagged.
-    required: false
-    default: "false"
 
 runs:
   using: composite
@@ -100,7 +92,6 @@ runs:
         PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
         DF_PATHS: ${{ inputs.df-paths }}
         FORCE_RECLAIM: ${{ inputs.force-reclaim }}
-        GUARD_ONLY: ${{ inputs.guard-only }}
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
         set -uo pipefail
@@ -139,9 +130,7 @@ runs:
         DID_RECLAIM="false"
         SHOULD_RECLAIM="false"
 
-        if [[ "${GUARD_ONLY}" == "true" ]]; then
-          echo "guard-only mode: skipping venv/orphan/cache pruning"
-        elif [[ "${FORCE_RECLAIM}" == "true" ]]; then
+        if [[ "${FORCE_RECLAIM}" == "true" ]]; then
           SHOULD_RECLAIM="true"
           echo "force-reclaim enabled: running full reclaim pass"
         elif [[ -n "${AVAIL_KB:-}" && "${AVAIL_KB}" -lt "${RECLAIM_BELOW_KB}" ]]; then
@@ -191,9 +180,6 @@ runs:
         fi
 
         # 3) Age-based trim of trusted compile/wheel/pip caches.
-        if [[ "${GUARD_ONLY}" == "true" ]]; then
-          CACHE_DIRS=""
-        fi
         SHOULD_TRIM_CACHE="false"
         if [[ "${SHOULD_RECLAIM}" == "true" && -n "${CACHE_DIRS}" ]]; then
           if [[ "${FORCE_RECLAIM}" == "true" || "${CACHE_TRIM_COOLDOWN_MINUTES}" == "0" ]]; then

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -163,22 +163,30 @@ runs:
           fi
         fi
 
-        # 2) Purge orphan per-run dirs in RUNNER_TEMP older than N minutes,
-        #    excluding the current run's directory if provided.
+        # 2) Purge orphan per-run dirs in RUNNER_TEMP whose newest activity in
+        #    the subtree is older than N minutes, excluding the current run's
+        #    directory if provided. Directory mtime alone is unreliable — it
+        #    only updates when entries are added/removed, so an active
+        #    long-running job whose files are being written (but not the dir
+        #    itself) would be wrongly eligible. Use the newest file mtime
+        #    anywhere in the subtree instead.
         if [[ "${SHOULD_RECLAIM}" == "true" && -d "${RUNNER_TEMP}" ]]; then
           DID_RECLAIM="true"
+          now_epoch=$(date +%s)
+          stale_seconds=$(( TEMP_ORPHAN_MINUTES * 60 ))
           for pattern in 'gpu-smoke-*' 'nightly-*'; do
-            if [[ -n "${CURRENT_RUN_DIR}" ]]; then
-              find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
-                ! -name "${CURRENT_RUN_DIR}" -mmin "+${TEMP_ORPHAN_MINUTES}" \
-                -exec echo "Removing orphan runtime: {}" \; \
-                -exec rm -rf {} + 2>/dev/null || true
-            else
-              find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
-                -mmin "+${TEMP_ORPHAN_MINUTES}" \
-                -exec echo "Removing orphan runtime: {}" \; \
-                -exec rm -rf {} + 2>/dev/null || true
-            fi
+            while IFS= read -r candidate; do
+              [[ -n "${candidate}" ]] || continue
+              if [[ -n "${CURRENT_RUN_DIR}" && "$(basename "${candidate}")" == "${CURRENT_RUN_DIR}" ]]; then
+                continue
+              fi
+              newest_mtime=$(find "${candidate}" -printf '%T@\n' 2>/dev/null | sort -nr | head -n 1)
+              [[ -n "${newest_mtime}" ]] || newest_mtime=$(stat -c %Y "${candidate}" 2>/dev/null || echo 0)
+              if awk "BEGIN { exit !(${now_epoch} - ${newest_mtime} >= ${stale_seconds}) }"; then
+                echo "Removing orphan runtime: ${candidate}"
+                rm -rf "${candidate}" 2>/dev/null || true
+              fi
+            done < <(find "${RUNNER_TEMP}" -mindepth 1 -maxdepth 1 -type d -name "${pattern}" 2>/dev/null)
           done
         fi
 
@@ -212,7 +220,10 @@ runs:
             [[ -z "$dir" ]] && continue
             [[ -d "$dir" ]] || continue
             find "$dir" -type f -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
-            find "$dir" -type d -empty -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
+            # Remove directories that are now empty. Don't gate on -mtime here:
+            # deleting files above updates the parent directory's mtime to
+            # "now", so a mtime filter would leave newly-empty dirs behind.
+            find "$dir" -depth -mindepth 1 -type d -empty -delete 2>/dev/null || true
           done <<< "${CACHE_DIRS}"
           mkdir -p "$(dirname "${CACHE_TRIM_STAMP}")"
           touch "${CACHE_TRIM_STAMP}"

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -20,7 +20,7 @@ inputs:
   cache-age-days:
     description: Age threshold (days) for trimming compile/wheel/pip cache files.
     required: false
-    default: "30"
+    default: "7"
   min-avail-gib:
     description: >
       Hard floor on free space (GiB) in RUNNER_TEMP after reclaim. Below this

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -27,6 +27,18 @@ inputs:
       the step fails with an explicit message.
     required: false
     default: "5"
+  reclaim-below-gib:
+    description: >
+      Only attempt reclaim work when RUNNER_TEMP has less than this many GiB
+      free, unless force-reclaim is enabled.
+    required: false
+    default: "30"
+  cache-trim-cooldown-minutes:
+    description: >
+      Minimum interval between the expensive recursive cache-trim passes on the
+      same runner. Cheap disk checks still run on every invocation.
+    required: false
+    default: "0"
   current-run-dir:
     description: >
       Name of the per-run temp directory that must NOT be pruned. Leave blank
@@ -56,6 +68,12 @@ inputs:
     description: Space-separated paths to pass to `df -h` for before/after logging.
     required: false
     default: ""
+  force-reclaim:
+    description: >
+      When "true", bypass reclaim-below-gib and cache-trim cooldown checks and
+      always run the full reclaim pass.
+    required: false
+    default: "false"
   guard-only:
     description: >
       When "true", skip the venv/orphan/cache pruning and only run the
@@ -75,10 +93,13 @@ runs:
         TEMP_ORPHAN_MINUTES: ${{ inputs.temp-orphan-minutes }}
         CACHE_AGE_DAYS: ${{ inputs.cache-age-days }}
         MIN_AVAIL_GIB: ${{ inputs.min-avail-gib }}
+        RECLAIM_BELOW_GIB: ${{ inputs.reclaim-below-gib }}
+        CACHE_TRIM_COOLDOWN_MINUTES: ${{ inputs.cache-trim-cooldown-minutes }}
         CURRENT_RUN_DIR: ${{ inputs.current-run-dir }}
         CACHE_DIRS: ${{ inputs.cache-dirs }}
         PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
         DF_PATHS: ${{ inputs.df-paths }}
+        FORCE_RECLAIM: ${{ inputs.force-reclaim }}
         GUARD_ONLY: ${{ inputs.guard-only }}
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
@@ -86,7 +107,7 @@ runs:
 
         # Validate numeric inputs up-front so typos fail with a clear error
         # instead of a cryptic bash arithmetic/find error deeper in the script.
-        for var in VENV_KEEP TEMP_ORPHAN_MINUTES CACHE_AGE_DAYS MIN_AVAIL_GIB; do
+        for var in VENV_KEEP TEMP_ORPHAN_MINUTES CACHE_AGE_DAYS MIN_AVAIL_GIB RECLAIM_BELOW_GIB CACHE_TRIM_COOLDOWN_MINUTES; do
           val="${!var}"
           if [[ ! "${val}" =~ ^[0-9]+$ ]]; then
             echo "::error::reclaim-runner-disk: input ${var}='${val}' is not a non-negative integer"
@@ -106,12 +127,33 @@ runs:
         echo "Disk before reclaim:"
         df -h "${DF_TARGETS[@]}" 2>/dev/null || true
 
+        if [[ -z "${RUNNER_TEMP:-}" ]]; then
+          echo "::error::reclaim-runner-disk: RUNNER_TEMP is unset; cannot enforce disk floor"
+          exit 1
+        fi
+
+        AVAIL_KB=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
+        MIN_KB=$(( MIN_AVAIL_GIB * 1024 * 1024 ))
+        RECLAIM_BELOW_KB=$(( RECLAIM_BELOW_GIB * 1024 * 1024 ))
+        CACHE_TRIM_STAMP="/home/ci-runner/.ci-maintenance/reclaim-runner-disk-cache-trim.stamp"
+        DID_RECLAIM="false"
+        SHOULD_RECLAIM="false"
+
         if [[ "${GUARD_ONLY}" == "true" ]]; then
           echo "guard-only mode: skipping venv/orphan/cache pruning"
+        elif [[ "${FORCE_RECLAIM}" == "true" ]]; then
+          SHOULD_RECLAIM="true"
+          echo "force-reclaim enabled: running full reclaim pass"
+        elif [[ -n "${AVAIL_KB:-}" && "${AVAIL_KB}" -lt "${RECLAIM_BELOW_KB}" ]]; then
+          SHOULD_RECLAIM="true"
+          echo "Free space below ${RECLAIM_BELOW_GIB}GiB: running reclaim pass"
+        else
+          echo "Free space is healthy; skipping reclaim pass"
         fi
 
         # 1) Prune old trusted venvs: keep N most recent by mtime.
-        if [[ "${GUARD_ONLY}" != "true" && "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
+        if [[ "${SHOULD_RECLAIM}" == "true" && "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
+          DID_RECLAIM="true"
           mapfile -t venvs < <(find "${TOOL_CACHE}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | cut -d' ' -f2-)
           if [[ ${#venvs[@]} -gt ${VENV_KEEP} ]]; then
             for stale in "${venvs[@]:${VENV_KEEP}}"; do
@@ -123,7 +165,8 @@ runs:
 
         # 2) Purge orphan per-run dirs in RUNNER_TEMP older than N minutes,
         #    excluding the current run's directory if provided.
-        if [[ "${GUARD_ONLY}" != "true" && -n "${RUNNER_TEMP:-}" && -d "${RUNNER_TEMP}" ]]; then
+        if [[ "${SHOULD_RECLAIM}" == "true" && -d "${RUNNER_TEMP}" ]]; then
+          DID_RECLAIM="true"
           for pattern in 'gpu-smoke-*' 'nightly-*'; do
             if [[ -n "${CURRENT_RUN_DIR}" ]]; then
               find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
@@ -143,24 +186,49 @@ runs:
         if [[ "${GUARD_ONLY}" == "true" ]]; then
           CACHE_DIRS=""
         fi
-        while IFS= read -r dir; do
-          dir="${dir//$'\r'/}"
-          [[ -z "$dir" ]] && continue
-          [[ -d "$dir" ]] || continue
-          find "$dir" -type f -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
-          find "$dir" -type d -empty -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
-        done <<< "${CACHE_DIRS}"
+        SHOULD_TRIM_CACHE="false"
+        if [[ "${SHOULD_RECLAIM}" == "true" && -n "${CACHE_DIRS}" ]]; then
+          if [[ "${FORCE_RECLAIM}" == "true" || "${CACHE_TRIM_COOLDOWN_MINUTES}" == "0" ]]; then
+            SHOULD_TRIM_CACHE="true"
+          elif [[ ! -e "${CACHE_TRIM_STAMP}" ]]; then
+            SHOULD_TRIM_CACHE="true"
+          else
+            now_epoch=$(date +%s)
+            stamp_epoch=$(stat -c %Y "${CACHE_TRIM_STAMP}" 2>/dev/null || echo 0)
+            cooldown_seconds=$(( CACHE_TRIM_COOLDOWN_MINUTES * 60 ))
+            if (( now_epoch - stamp_epoch >= cooldown_seconds )); then
+              SHOULD_TRIM_CACHE="true"
+            else
+              remaining_minutes=$(( (cooldown_seconds - (now_epoch - stamp_epoch) + 59) / 60 ))
+              echo "Skipping cache trim: ${remaining_minutes} minute(s) left in cooldown"
+            fi
+          fi
+        fi
+
+        if [[ "${SHOULD_TRIM_CACHE}" == "true" ]]; then
+          DID_RECLAIM="true"
+          while IFS= read -r dir; do
+            dir="${dir//$'\r'/}"
+            [[ -z "$dir" ]] && continue
+            [[ -d "$dir" ]] || continue
+            find "$dir" -type f -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
+            find "$dir" -type d -empty -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
+          done <<< "${CACHE_DIRS}"
+          mkdir -p "$(dirname "${CACHE_TRIM_STAMP}")"
+          touch "${CACHE_TRIM_STAMP}"
+        fi
+
+        if [[ "${SHOULD_RECLAIM}" != "true" ]]; then
+          echo "Reclaim work skipped because free space is above the proactive threshold"
+        elif [[ "${DID_RECLAIM}" != "true" ]]; then
+          echo "Reclaim pass ran, but nothing was eligible for deletion"
+        fi
 
         echo "Disk after reclaim:"
         df -h "${DF_TARGETS[@]}" 2>/dev/null || true
 
         # Hard guard: abort early with a clear message if still near-full.
-        if [[ -z "${RUNNER_TEMP:-}" ]]; then
-          echo "::error::reclaim-runner-disk: RUNNER_TEMP is unset; cannot enforce disk floor"
-          exit 1
-        fi
         AVAIL_KB=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
-        MIN_KB=$(( MIN_AVAIL_GIB * 1024 * 1024 ))
         if [[ -n "${AVAIL_KB:-}" && "${AVAIL_KB}" -lt "${MIN_KB}" ]]; then
           echo "::error::Runner ${RUNNER_NAME:-unknown} has <${MIN_AVAIL_GIB}GiB free on ${RUNNER_TEMP} after reclaim (${AVAIL_KB} KiB). Manual cleanup required."
           exit 1

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -1,0 +1,133 @@
+name: Reclaim runner disk
+description: >
+  Reclaim disk on self-hosted CI runners before heavy steps run. Prunes
+  stale trusted venvs, orphan per-run temp dirs, and aged compile/wheel/pip
+  caches under /home/ci-runner. Fails fast if the volume is still near full
+  after reclaim, so downstream steps report disk pressure clearly instead of
+  a cryptic mkdir error.
+
+inputs:
+  venv-keep:
+    description: Number of most-recent tileops_ci_venv_* directories to retain.
+    required: false
+    default: "2"
+  temp-orphan-minutes:
+    description: >
+      Age threshold (minutes) for purging orphan gpu-smoke-*/nightly-* temp
+      dirs in RUNNER_TEMP that do not belong to the current run.
+    required: false
+    default: "120"
+  cache-age-days:
+    description: Age threshold (days) for trimming compile/wheel/pip cache files.
+    required: false
+    default: "30"
+  min-avail-gib:
+    description: >
+      Hard floor on free space (GiB) in RUNNER_TEMP after reclaim. Below this
+      the step fails with an explicit message.
+    required: false
+    default: "5"
+  current-run-dir:
+    description: >
+      Name of the per-run temp directory that must NOT be pruned. Leave blank
+      if the caller does not create one.
+    required: false
+    default: ""
+  cache-dirs:
+    description: >
+      Newline-separated list of cache directory roots whose files older than
+      cache-age-days should be trimmed. Defaults target the `venv`-label runner
+      layout. Nightly's `nightly`-label runner stores caches under
+      /data/ci-cache/* — pass that layout explicitly.
+    required: false
+    default: |
+      /home/ci-runner/.tilelang/cache
+      /home/ci-runner/.triton/cache
+      /home/ci-runner/.cache/pip
+      /home/ci-runner/.wheel-cache
+  prune-tool-cache:
+    description: >
+      Whether to prune old tileops_ci_venv_* directories under runner.tool_cache.
+      Disable on runners that do not use the per-hash trusted-venv scheme
+      (e.g. nightly's docker-based jobs).
+    required: false
+    default: "true"
+  df-paths:
+    description: Space-separated paths to pass to `df -h` for before/after logging.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Reclaim runner disk
+      shell: bash
+      env:
+        VENV_KEEP: ${{ inputs.venv-keep }}
+        TEMP_ORPHAN_MINUTES: ${{ inputs.temp-orphan-minutes }}
+        CACHE_AGE_DAYS: ${{ inputs.cache-age-days }}
+        MIN_AVAIL_GIB: ${{ inputs.min-avail-gib }}
+        CURRENT_RUN_DIR: ${{ inputs.current-run-dir }}
+        CACHE_DIRS: ${{ inputs.cache-dirs }}
+        PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
+        DF_PATHS: ${{ inputs.df-paths }}
+        TOOL_CACHE: ${{ runner.tool_cache }}
+      run: |
+        set -uo pipefail
+        # shellcheck disable=SC2206
+        DF_TARGETS=( ${DF_PATHS} )
+        if [[ ${#DF_TARGETS[@]} -eq 0 ]]; then
+          DF_TARGETS=( "${RUNNER_TEMP}" "${TOOL_CACHE}" /home/ci-runner )
+        fi
+
+        echo "Disk before reclaim:"
+        df -h "${DF_TARGETS[@]}" 2>/dev/null || true
+
+        # 1) Prune old trusted venvs: keep N most recent by mtime.
+        if [[ "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
+          mapfile -t venvs < <(find "${TOOL_CACHE}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | awk '{print $2}')
+          if [[ ${#venvs[@]} -gt ${VENV_KEEP} ]]; then
+            for stale in "${venvs[@]:${VENV_KEEP}}"; do
+              echo "Removing stale venv: ${stale}"
+              rm -rf "${stale}" || true
+            done
+          fi
+        fi
+
+        # 2) Purge orphan per-run dirs in RUNNER_TEMP older than N minutes,
+        #    excluding the current run's directory if provided.
+        if [[ -n "${RUNNER_TEMP:-}" && -d "${RUNNER_TEMP}" ]]; then
+          for pattern in 'gpu-smoke-*' 'nightly-*'; do
+            if [[ -n "${CURRENT_RUN_DIR}" ]]; then
+              find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
+                ! -name "${CURRENT_RUN_DIR}" -mmin "+${TEMP_ORPHAN_MINUTES}" \
+                -exec echo "Removing orphan runtime: {}" \; \
+                -exec rm -rf {} + 2>/dev/null || true
+            else
+              find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
+                -mmin "+${TEMP_ORPHAN_MINUTES}" \
+                -exec echo "Removing orphan runtime: {}" \; \
+                -exec rm -rf {} + 2>/dev/null || true
+            fi
+          done
+        fi
+
+        # 3) Age-based trim of trusted compile/wheel/pip caches.
+        while IFS= read -r dir; do
+          dir="${dir//$'\r'/}"
+          [[ -z "$dir" ]] && continue
+          [[ -d "$dir" ]] || continue
+          find "$dir" -type f -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
+          find "$dir" -type d -empty -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
+        done <<< "${CACHE_DIRS}"
+
+        echo "Disk after reclaim:"
+        df -h "${DF_TARGETS[@]}" 2>/dev/null || true
+
+        # Hard guard: abort early with a clear message if still near-full.
+        AVAIL_KB=$(df -Pk "${RUNNER_TEMP}" | awk 'NR==2 {print $4}')
+        MIN_KB=$(( MIN_AVAIL_GIB * 1024 * 1024 ))
+        if [[ -n "${AVAIL_KB:-}" && "${AVAIL_KB}" -lt "${MIN_KB}" ]]; then
+          echo "::error::Runner ${RUNNER_NAME:-unknown} has <${MIN_AVAIL_GIB}GiB free on ${RUNNER_TEMP} after reclaim (${AVAIL_KB} KiB). Manual cleanup required."
+          exit 1
+        fi

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -56,6 +56,14 @@ inputs:
     description: Space-separated paths to pass to `df -h` for before/after logging.
     required: false
     default: ""
+  guard-only:
+    description: >
+      When "true", skip the venv/orphan/cache pruning and only run the
+      disk-floor guard. Intended for per-PR jobs that rely on a scheduled
+      maintenance workflow for the heavy reclaim; the guard still fails
+      fast with an explicit error if the scheduled workflow has lagged.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -71,6 +79,7 @@ runs:
         CACHE_DIRS: ${{ inputs.cache-dirs }}
         PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
         DF_PATHS: ${{ inputs.df-paths }}
+        GUARD_ONLY: ${{ inputs.guard-only }}
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
         set -uo pipefail
@@ -83,8 +92,12 @@ runs:
         echo "Disk before reclaim:"
         df -h "${DF_TARGETS[@]}" 2>/dev/null || true
 
+        if [[ "${GUARD_ONLY}" == "true" ]]; then
+          echo "guard-only mode: skipping venv/orphan/cache pruning"
+        fi
+
         # 1) Prune old trusted venvs: keep N most recent by mtime.
-        if [[ "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
+        if [[ "${GUARD_ONLY}" != "true" && "${PRUNE_TOOL_CACHE}" == "true" && -d "${TOOL_CACHE}" ]]; then
           mapfile -t venvs < <(find "${TOOL_CACHE}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -printf '%T@ %p\n' 2>/dev/null | sort -rn | awk '{print $2}')
           if [[ ${#venvs[@]} -gt ${VENV_KEEP} ]]; then
             for stale in "${venvs[@]:${VENV_KEEP}}"; do
@@ -96,7 +109,7 @@ runs:
 
         # 2) Purge orphan per-run dirs in RUNNER_TEMP older than N minutes,
         #    excluding the current run's directory if provided.
-        if [[ -n "${RUNNER_TEMP:-}" && -d "${RUNNER_TEMP}" ]]; then
+        if [[ "${GUARD_ONLY}" != "true" && -n "${RUNNER_TEMP:-}" && -d "${RUNNER_TEMP}" ]]; then
           for pattern in 'gpu-smoke-*' 'nightly-*'; do
             if [[ -n "${CURRENT_RUN_DIR}" ]]; then
               find "${RUNNER_TEMP}" -maxdepth 1 -type d -name "${pattern}" \
@@ -113,6 +126,9 @@ runs:
         fi
 
         # 3) Age-based trim of trusted compile/wheel/pip caches.
+        if [[ "${GUARD_ONLY}" == "true" ]]; then
+          CACHE_DIRS=""
+        fi
         while IFS= read -r dir; do
           dir="${dir//$'\r'/}"
           [[ -z "$dir" ]] && continue

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -180,7 +180,7 @@ runs:
               if [[ -n "${CURRENT_RUN_DIR}" && "$(basename "${candidate}")" == "${CURRENT_RUN_DIR}" ]]; then
                 continue
               fi
-              newest_mtime=$(find "${candidate}" -printf '%T@\n' 2>/dev/null | sort -nr | head -n 1)
+              newest_mtime=$(find "${candidate}" -printf '%T@\n' 2>/dev/null | awk 'NR == 1 || $1 > max { max = $1 } END { if (NR > 0) print max }')
               [[ -n "${newest_mtime}" ]] || newest_mtime=$(stat -c %Y "${candidate}" 2>/dev/null || echo 0)
               if awk "BEGIN { exit !(${now_epoch} - ${newest_mtime} >= ${stale_seconds}) }"; then
                 echo "Removing orphan runtime: ${candidate}"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -350,6 +350,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Reclaim runner disk
+        uses: ./.github/actions/reclaim-runner-disk
+        with:
+          current-run-dir: gpu-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+
       - name: Resolve runtime state
         env:
           IS_FORK: ${{ needs.security-policy.outputs.is_fork }}

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -353,7 +353,7 @@ jobs:
       - name: Reclaim runner disk
         uses: ./.github/actions/reclaim-runner-disk
         with:
-          reclaim-below-gib: "30"
+          reclaim-below-gib: "10"
           cache-trim-cooldown-minutes: "120"
 
       - name: Resolve runtime state

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -349,13 +349,18 @@ jobs:
       # their `git clean -ffdx` pass does not wipe `.trusted/`. Anything
       # loaded via `uses: ./...` from here on MUST resolve through
       # `.trusted/` so that fork-controlled PR code cannot substitute the
-      # composite action. The PR's base sha (or `github.ref` for push) is
-      # the authoritative trusted source — fork commits cannot alter it.
+      # composite action.
+      #
+      # Ref selection by trust level:
+      #   - fork PR  → `base.sha` (authoritative base commit; fork can't alter)
+      #   - same-repo PR / push → head sha (only collaborators can push, so
+      #     the PR's own version is trusted — and this lets repo-owned CI
+      #     changes self-validate before merge)
       - name: Checkout trusted actions (base repo)
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.base.sha || github.ref }}
+          ref: ${{ needs.security-policy.outputs.is_fork == 'true' && github.event.pull_request.base.sha || github.event.pull_request.head.sha || github.sha }}
           path: .trusted
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -345,8 +345,25 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
+      # Trusted actions checkout: must run AFTER the workspace checkouts so
+      # their `git clean -ffdx` pass does not wipe `.trusted/`. Anything
+      # loaded via `uses: ./...` from here on MUST resolve through
+      # `.trusted/` so that fork-controlled PR code cannot substitute the
+      # composite action. The PR's base sha (or `github.ref` for push) is
+      # the authoritative trusted source — fork commits cannot alter it.
+      - name: Checkout trusted actions (base repo)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.ref }}
+          path: .trusted
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/actions
+
       - name: Reclaim runner disk
-        uses: ./.github/actions/reclaim-runner-disk
+        uses: ./.trusted/.github/actions/reclaim-runner-disk
         with:
           reclaim-below-gib: "10"
           cache-trim-cooldown-minutes: "120"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -345,16 +345,16 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
       - name: Reclaim runner disk
         uses: ./.github/actions/reclaim-runner-disk
         with:
           reclaim-below-gib: "10"
           cache-trim-cooldown-minutes: "120"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
       - name: Resolve runtime state
         env:

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -352,6 +352,9 @@ jobs:
 
       - name: Reclaim runner disk
         uses: ./.github/actions/reclaim-runner-disk
+        with:
+          reclaim-below-gib: "30"
+          cache-trim-cooldown-minutes: "120"
 
       - name: Resolve runtime state
         env:

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -350,10 +350,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Guard against disk pressure
+      - name: Reclaim runner disk
         uses: ./.github/actions/reclaim-runner-disk
-        with:
-          guard-only: "true"
 
       - name: Resolve runtime state
         env:

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -350,10 +350,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Reclaim runner disk
+      - name: Guard against disk pressure
         uses: ./.github/actions/reclaim-runner-disk
         with:
-          current-run-dir: gpu-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          guard-only: "true"
 
       - name: Resolve runtime state
         env:

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -351,16 +351,22 @@ jobs:
       # `.trusted/` so that fork-controlled PR code cannot substitute the
       # composite action.
       #
-      # Ref selection by trust level:
-      #   - fork PR  → `base.sha` (authoritative base commit; fork can't alter)
-      #   - same-repo PR / push → head sha (only collaborators can push, so
-      #     the PR's own version is trusted — and this lets repo-owned CI
-      #     changes self-validate before merge)
+      # Ref selection by trust level. `is_fork` alone is too coarse: a repo
+      # member may open a PR from their personal fork, which still counts as
+      # a fork PR but the author already has push access to the base repo.
+      # Combine repo equality with `author_association` so repo-owned CI
+      # changes can self-validate on the PR that introduces them, while
+      # external contributors are kept on the trusted base ref.
+      #
+      #   - external fork PR (author not OWNER/MEMBER/COLLABORATOR)
+      #       → `base.sha` (authoritative; external author can't alter)
+      #   - same-repo PR, member-fork PR, or push
+      #       → head sha (author already has write access to base repo)
       - name: Checkout trusted actions (base repo)
         uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
-          ref: ${{ needs.security-policy.outputs.is_fork == 'true' && github.event.pull_request.base.sha || github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ (needs.security-policy.outputs.is_fork == 'true' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) && github.event.pull_request.base.sha || github.event.pull_request.head.sha || github.sha }}
           path: .trusted
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -5,6 +5,12 @@ name: Runner Maintenance
 # `gpu-smoke` jobs only perform full reclaim when disk is already under
 # pressure; this scheduled job forces the full cleanup pass on days with
 # little PR traffic.
+#
+# FIXME: The `nightly`-label runner has its own cache tree under
+# `/data/ci-cache/*` and is not wired up here. This PR intentionally defers
+# that work until #987 lands, which collapses nightly's cache layout into
+# `/home/ci-runner/.*/cache`; once that is merged, add a second job (or a
+# matrix entry) targeting the `nightly` runner with its own `cache-dirs`.
 
 on:
   schedule:

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -2,8 +2,9 @@ name: Runner Maintenance
 
 # Heavy disk reclamation for the self-hosted runner. Runs once per day at
 # 18:00 UTC (02:00 Asia/Shanghai) so it lands in an off-peak window. Per-PR
-# `gpu-smoke` jobs only perform full reclaim when disk is already under
-# pressure; this scheduled job forces the full cleanup pass on days with
+# `gpu-smoke` jobs only attempt the heavier reclaim path when disk is under
+# pressure, and still rate-limit the expensive cache-trim pass via a
+# cooldown; this scheduled job forces the full cleanup pass on days with
 # little PR traffic.
 #
 # FIXME: The `nightly`-label runner has its own cache tree under

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -1,0 +1,31 @@
+name: Runner Maintenance
+
+# Heavy disk reclamation for the self-hosted runner. Runs once per day at
+# 18:00 UTC (02:00 Asia/Shanghai) so it lands in an off-peak window and does
+# not fight `gpu-smoke` for the same runner. Per-PR `gpu-smoke` jobs only
+# invoke the composite action in `guard-only` mode, so this workflow is where
+# the actual pruning happens.
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: runner-maintenance
+  cancel-in-progress: false
+
+jobs:
+  reclaim-disk:
+    if: ${{ github.repository == 'tile-ai/TileOPs' }}
+    runs-on: [self-hosted, tile-ops, venv]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Reclaim runner disk
+        uses: ./.github/actions/reclaim-runner-disk

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -1,15 +1,18 @@
 name: Runner Maintenance
 
 # Heavy disk reclamation for the self-hosted runner. Runs once per day at
-# 18:00 UTC (02:00 Asia/Shanghai) so it lands in an off-peak window and does
-# not fight `gpu-smoke` for the same runner. Per-PR `gpu-smoke` jobs only
-# invoke the composite action in `guard-only` mode, so this workflow is where
-# the actual pruning happens.
+# 18:00 UTC (02:00 Asia/Shanghai) so it lands in an off-peak window. Per-PR
+# `gpu-smoke` jobs also invoke the composite action so the first affected run
+# can self-heal; this scheduled job guarantees pruning still happens on days
+# with little PR traffic.
 
 on:
   schedule:
     - cron: "0 18 * * *"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: runner-maintenance

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -2,9 +2,9 @@ name: Runner Maintenance
 
 # Heavy disk reclamation for the self-hosted runner. Runs once per day at
 # 18:00 UTC (02:00 Asia/Shanghai) so it lands in an off-peak window. Per-PR
-# `gpu-smoke` jobs also invoke the composite action so the first affected run
-# can self-heal; this scheduled job guarantees pruning still happens on days
-# with little PR traffic.
+# `gpu-smoke` jobs only perform full reclaim when disk is already under
+# pressure; this scheduled job forces the full cleanup pass on days with
+# little PR traffic.
 
 on:
   schedule:
@@ -32,3 +32,5 @@ jobs:
 
       - name: Reclaim runner disk
         uses: ./.github/actions/reclaim-runner-disk
+        with:
+          force-reclaim: "true"

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: [self-hosted, tile-ops, venv]
     timeout-minutes: 60
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 1
-
+      # Invoke the action directly via owner/repo/path@ref so this workflow
+      # does not depend on `actions/checkout` succeeding first — in the
+      # disk-full scenarios this job is meant to remediate, a prior checkout
+      # could itself fail for lack of space and prevent reclaim from ever
+      # running. `@main` is trusted because this workflow only triggers on
+      # schedule / workflow_dispatch; no fork-PR code path reaches it.
       - name: Reclaim runner disk
-        uses: ./.github/actions/reclaim-runner-disk
+        uses: tile-ai/TileOPs/.github/actions/reclaim-runner-disk@main
         with:
           force-reclaim: "true"

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -28,7 +28,7 @@ jobs:
   reclaim-disk:
     if: ${{ github.repository == 'tile-ai/TileOPs' }}
     runs-on: [self-hosted, tile-ops, venv]
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #986.

## Summary
- Add composite action `.github/actions/reclaim-runner-disk/` that prunes stale trusted venvs, orphan per-run temp dirs, and aged compile/wheel/pip caches on the self-hosted runner, with configurable thresholds and a hard disk-pressure guard.
- Wire into the `gpu-smoke` job in `gpu-smoke.yml`, and add a scheduled `runner-maintenance.yml` workflow that runs the same reclaim daily as a safety net on low-PR-traffic days.

## Why
GPU Smoke run [24595105259](https://github.com/tile-ai/TileOPs/actions/runs/24595105259) for #982 failed with `mkdir: ... : No space left on device` on `tile-ops-mig-0`. The runner's 3.5 TiB volume had filled from four unbounded accumulators:

1. `${runner.tool_cache}/tileops_ci_venv_<hash>/` — one full venv per unique `pyproject.toml` hash, never pruned.
2. `${RUNNER_TEMP}/gpu-smoke-<run_id>-<attempt>/` — orphans left by interrupted jobs (the end-of-job cleanup step never runs on failure paths that precede it).
3. `/home/ci-runner/.tilelang/cache`, `.triton/cache`, `.cache/pip`, `.wheel-cache` — age-unbounded growth.
4. `/data/ci-cache/*` on the `nightly`-label runner — same failure mode, separate cache tree (see #987).

## What the composite action does
- **Venv prune**: keeps the 2 most recent `tileops_ci_venv_*` directories (by mtime) under `runner.tool_cache`, removes the rest.
- **Orphan prune**: deletes `${RUNNER_TEMP}/gpu-smoke-*` and `nightly-*` directories older than 120 minutes, excluding the current run's dir.
- **Age-based cache trim**: deletes files older than 7 days under the configured cache roots, then removes empty directories of the same age. (Default tightened from the original 30d draft — the compile/wheel/pip caches refill quickly and 30d was too loose to relieve pressure.)
- **Before/after logging**: `df -h` on the relevant mounts for post-mortem visibility.
- **Hard guard**: if `RUNNER_TEMP` has less than 5 GiB free after reclaim, emits a `::error::` annotation naming the runner and available space, and exits 1 — so disk pressure is surfaced as itself rather than as a downstream cryptic `mkdir` failure.
- **Input validation**: numeric inputs (`venv-keep`, `temp-orphan-minutes`, `cache-age-days`, `min-avail-gib`) are validated against `^[0-9]+$` up-front; a YAML typo fails with a clear `::error::` rather than a cryptic bash error.

All thresholds are action inputs. `cache-dirs` and `prune-tool-cache` are also inputs so the same action can later be used by the nightly runner. A `guard-only` input exists for callers that want the disk-floor check without reclaim (currently unused — `gpu-smoke` runs the full reclaim so the first affected PR run can self-heal).

## Scope / deferred work
This PR only wires the action into `gpu-smoke.yml` and the new scheduled `runner-maintenance.yml`. Wiring the 4 nightly jobs is deferred until #987 lands — #987 will collapse `/data/ci-cache/*` into `/home/ci-runner/.*/cache`, and there is no point baking in paths that #987 plans to delete. See scope note in #986.

## Validation already done
- Manual reclaim on the affected runner (container1) recovered ~147 GiB using the same thresholds/paths the action encodes; volume went from 100% / 3.8 GiB Avail to 96% / 151 GiB Avail.
- YAML syntax validated locally (`python3 -c 'import yaml; yaml.safe_load(...)'`). `actionlint` / `shellcheck` not available in this environment; CI runs both.
- Reclaim step is side-effect-tolerant (`set -uo pipefail`, `|| true` on find/rm) so a single failure cannot abort the reclaim; only the final disk-floor guard can fail the step.

## Test plan
- [ ] CI `validate-pr-title` passes.
- [ ] CI `actionlint` passes on the new composite action and the modified workflow.
- [ ] On re-run of a gpu-smoke job, the `Reclaim runner disk` step logs `df -h` before and after and completes before `Resolve runtime state`.
- [ ] Re-run PR #982's gpu-smoke job to confirm it now passes the `Ensure venv and install dependencies` step (AC-5 of #986).
- [ ] Future disk-full event on a different runner produces a clear `::error:: Runner <name> has <NGiB free ...` annotation instead of a cryptic `mkdir` failure.

## Follow-up

Applied in this PR:
- `.github/actions/reclaim-runner-disk/action.yml` — removed unused `guard-only` input (dead code from an earlier split-reclaim iteration; see 2d0f32e).
