### PR TITLE
[Fix][CI] treat autotuner cache as atomic in reclaim-runner-disk

### DIFF
--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -48,15 +48,34 @@ inputs:
   cache-dirs:
     description: >
       Newline-separated list of cache directory roots whose files older than
-      cache-age-days should be trimmed. Defaults target the `venv`-label runner
-      layout. Nightly's `nightly`-label runner stores caches under
-      /data/ci-cache/* — pass that layout explicitly.
+      cache-age-days should be trimmed at file granularity. Defaults target
+      the `venv`-label runner layout. Nightly's `nightly`-label runner stores
+      caches under /data/ci-cache/* — pass that layout explicitly.
+      Do NOT include atomic cache roots here (see atomic-cache-dirs); file-
+      level trim on an atomic root can produce a half-dead "directory exists
+      but sentinel missing" state that crashes downstream consumers.
     required: false
     default: |
-      /home/ci-runner/.tilelang/cache
       /home/ci-runner/.triton/cache
       /home/ci-runner/.cache/pip
       /home/ci-runner/.wheel-cache
+  atomic-cache-dirs:
+    description: >
+      Newline-separated list of cache directory roots whose first-level
+      subdirectories are *atomic units*: consumers assume "directory exists
+      => contents complete" and the subdir is only valid when the sentinel
+      file (best_config.json, hardcoded) is present. These roots get two
+      passes instead of file-level trim:
+        1. Unconditional sentinel-repair: remove any first-level subdir
+           missing the sentinel (self-heals half-dead state from prior runs).
+        2. Age-based atomic-trim: if the newest file in a first-level subdir
+           is older than cache-age-days, delete the whole subdir — never
+           individual files inside it.
+      Default targets the tilelang autotuner cache, which stores per-shape
+      tuning artefacts alongside a best_config.json sentinel.
+    required: false
+    default: |
+      /home/ci-runner/.tilelang/cache/autotuner
   prune-tool-cache:
     description: >
       Whether to prune old tileops_ci_venv_* directories under runner.tool_cache.
@@ -89,12 +108,28 @@ runs:
         CACHE_TRIM_COOLDOWN_MINUTES: ${{ inputs.cache-trim-cooldown-minutes }}
         CURRENT_RUN_DIR: ${{ inputs.current-run-dir }}
         CACHE_DIRS: ${{ inputs.cache-dirs }}
+        ATOMIC_CACHE_DIRS: ${{ inputs.atomic-cache-dirs }}
         PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
         DF_PATHS: ${{ inputs.df-paths }}
         FORCE_RECLAIM: ${{ inputs.force-reclaim }}
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
         set -uo pipefail
+
+        # The reclaim primitives (sentinel-repair, atomic-trim, trim-files)
+        # live in scripts/reclaim_cache.sh so they can be exercised under
+        # pytest without a self-hosted runner. This composite action is a
+        # thin policy wrapper — gating (when to run), not mechanism (how
+        # to trim).
+        #
+        # ${GITHUB_ACTION_PATH} resolves to
+        #   .../.github/actions/reclaim-runner-disk
+        # so the script lives three levels up under scripts/.
+        RECLAIM_SCRIPT="${GITHUB_ACTION_PATH}/../../../scripts/reclaim_cache.sh"
+        if [[ ! -x "${RECLAIM_SCRIPT}" ]]; then
+          echo "::error::reclaim-runner-disk: expected ${RECLAIM_SCRIPT} to be executable"
+          exit 1
+        fi
 
         # Validate numeric inputs up-front so typos fail with a clear error
         # instead of a cryptic bash arithmetic/find error deeper in the script.
@@ -129,6 +164,25 @@ runs:
         CACHE_TRIM_STAMP="/home/ci-runner/.ci-maintenance/reclaim-runner-disk-cache-trim.stamp"
         DID_RECLAIM="false"
         SHOULD_RECLAIM="false"
+
+        # 0) Unconditional sentinel-repair on atomic cache roots.
+        #    Runs regardless of SHOULD_RECLAIM so that half-dead state
+        #    left by an earlier file-level trim (directory exists but
+        #    best_config.json missing) is healed on the *next* invocation,
+        #    not only when disk pressure crosses the reclaim threshold.
+        #    The per-subdir cost is a single readdir + stat, so this is
+        #    safe to run every time.
+        if [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
+          ATOMIC_ARGS=()
+          while IFS= read -r dir; do
+            dir="${dir//$'\r'/}"
+            [[ -z "$dir" ]] && continue
+            ATOMIC_ARGS+=( "$dir" )
+          done <<< "${ATOMIC_CACHE_DIRS}"
+          if (( ${#ATOMIC_ARGS[@]} > 0 )); then
+            bash "${RECLAIM_SCRIPT}" sentinel-repair "${ATOMIC_ARGS[@]}" || true
+          fi
+        fi
 
         if [[ "${FORCE_RECLAIM}" == "true" ]]; then
           SHOULD_RECLAIM="true"
@@ -179,9 +233,10 @@ runs:
           done
         fi
 
-        # 3) Age-based trim of trusted compile/wheel/pip caches.
+        # 3) Age-based trim of trusted compile/wheel/pip caches, plus
+        #    atomic-granularity trim of atomic cache roots.
         SHOULD_TRIM_CACHE="false"
-        if [[ "${SHOULD_RECLAIM}" == "true" && -n "${CACHE_DIRS}" ]]; then
+        if [[ "${SHOULD_RECLAIM}" == "true" && ( -n "${CACHE_DIRS}" || -n "${ATOMIC_CACHE_DIRS}" ) ]]; then
           if [[ "${FORCE_RECLAIM}" == "true" || "${CACHE_TRIM_COOLDOWN_MINUTES}" == "0" ]]; then
             SHOULD_TRIM_CACHE="true"
           elif [[ ! -e "${CACHE_TRIM_STAMP}" ]]; then
@@ -201,16 +256,36 @@ runs:
 
         if [[ "${SHOULD_TRIM_CACHE}" == "true" ]]; then
           DID_RECLAIM="true"
-          while IFS= read -r dir; do
-            dir="${dir//$'\r'/}"
-            [[ -z "$dir" ]] && continue
-            [[ -d "$dir" ]] || continue
-            find "$dir" -type f -mtime "+${CACHE_AGE_DAYS}" -delete 2>/dev/null || true
-            # Remove directories that are now empty. Don't gate on -mtime here:
-            # deleting files above updates the parent directory's mtime to
-            # "now", so a mtime filter would leave newly-empty dirs behind.
-            find "$dir" -depth -mindepth 1 -type d -empty -delete 2>/dev/null || true
-          done <<< "${CACHE_DIRS}"
+
+          # File-level trim for non-atomic roots (triton cache, pip, wheel).
+          if [[ -n "${CACHE_DIRS}" ]]; then
+            FILE_TRIM_ARGS=()
+            while IFS= read -r dir; do
+              dir="${dir//$'\r'/}"
+              [[ -z "$dir" ]] && continue
+              FILE_TRIM_ARGS+=( "$dir" )
+            done <<< "${CACHE_DIRS}"
+            if (( ${#FILE_TRIM_ARGS[@]} > 0 )); then
+              bash "${RECLAIM_SCRIPT}" trim-files "${CACHE_AGE_DAYS}" "${FILE_TRIM_ARGS[@]}" || true
+            fi
+          fi
+
+          # Whole-subdir trim for atomic roots (tilelang autotuner).
+          # Atomic roots are NEVER file-trimmed: doing so can strand a
+          # subdir without its best_config.json sentinel and crash the
+          # next consumer.
+          if [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
+            ATOMIC_TRIM_ARGS=()
+            while IFS= read -r dir; do
+              dir="${dir//$'\r'/}"
+              [[ -z "$dir" ]] && continue
+              ATOMIC_TRIM_ARGS+=( "$dir" )
+            done <<< "${ATOMIC_CACHE_DIRS}"
+            if (( ${#ATOMIC_TRIM_ARGS[@]} > 0 )); then
+              bash "${RECLAIM_SCRIPT}" atomic-trim "${CACHE_AGE_DAYS}" "${ATOMIC_TRIM_ARGS[@]}" || true
+            fi
+          fi
+
           mkdir -p "$(dirname "${CACHE_TRIM_STAMP}")"
           touch "${CACHE_TRIM_STAMP}"
         fi

--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -59,6 +59,7 @@ inputs:
       /home/ci-runner/.triton/cache
       /home/ci-runner/.cache/pip
       /home/ci-runner/.wheel-cache
+      /home/ci-runner/.tilelang/cache/tmp
   atomic-cache-dirs:
     description: >
       Newline-separated list of cache directory roots whose first-level
@@ -117,19 +118,42 @@ runs:
         set -uo pipefail
 
         # The reclaim primitives (sentinel-repair, atomic-trim, trim-files)
-        # live in scripts/reclaim_cache.sh so they can be exercised under
-        # pytest without a self-hosted runner. This composite action is a
-        # thin policy wrapper — gating (when to run), not mechanism (how
-        # to trim).
+        # live in reclaim_cache.sh (colocated with this action.yml) so
+        # they can be exercised under pytest without a self-hosted
+        # runner, *and* so the gpu-smoke trusted-action sparse-checkout
+        # (which only pulls `.github/actions`) still picks them up.
+        # This composite action is a thin policy wrapper — gating (when
+        # to run), not mechanism (how to trim).
         #
         # ${GITHUB_ACTION_PATH} resolves to
         #   .../.github/actions/reclaim-runner-disk
-        # so the script lives three levels up under scripts/.
-        RECLAIM_SCRIPT="${GITHUB_ACTION_PATH}/../../../scripts/reclaim_cache.sh"
-        if [[ ! -x "${RECLAIM_SCRIPT}" ]]; then
-          echo "::error::reclaim-runner-disk: expected ${RECLAIM_SCRIPT} to be executable"
+        # and the script sits alongside action.yml so the trusted-action
+        # sparse-checkout (which only pulls .github/actions) still picks
+        # it up on the gpu-smoke job.
+        RECLAIM_SCRIPT="${GITHUB_ACTION_PATH}/reclaim_cache.sh"
+        if [[ ! -f "${RECLAIM_SCRIPT}" || ! -r "${RECLAIM_SCRIPT}" ]]; then
+          echo "::error::reclaim-runner-disk: expected ${RECLAIM_SCRIPT} to exist and be readable"
           exit 1
         fi
+
+        # Parse a newline-separated input (as received from YAML `|` block
+        # scalars) into a bash array, stripping CR and skipping blank
+        # lines. Usage:
+        #   parse_list_into_array TARGET_ARRAY <<< "${INPUT_VAR}"
+        # The named array is declared via `declare -n`; callers must have
+        # declared the target array with `local -a`/`declare -a` first, or
+        # let this helper create it implicitly (we do the latter — the
+        # helper resets the target to a fresh empty array on each call).
+        parse_list_into_array() {
+          local -n _target_array="$1"
+          _target_array=()
+          local _line
+          while IFS= read -r _line; do
+            _line="${_line//$'\r'/}"
+            [[ -z "$_line" ]] && continue
+            _target_array+=( "$_line" )
+          done
+        }
 
         # Validate numeric inputs up-front so typos fail with a clear error
         # instead of a cryptic bash arithmetic/find error deeper in the script.
@@ -173,12 +197,7 @@ runs:
         #    The per-subdir cost is a single readdir + stat, so this is
         #    safe to run every time.
         if [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
-          ATOMIC_ARGS=()
-          while IFS= read -r dir; do
-            dir="${dir//$'\r'/}"
-            [[ -z "$dir" ]] && continue
-            ATOMIC_ARGS+=( "$dir" )
-          done <<< "${ATOMIC_CACHE_DIRS}"
+          parse_list_into_array ATOMIC_ARGS <<< "${ATOMIC_CACHE_DIRS}"
           if (( ${#ATOMIC_ARGS[@]} > 0 )); then
             bash "${RECLAIM_SCRIPT}" sentinel-repair "${ATOMIC_ARGS[@]}" || true
           fi
@@ -259,12 +278,7 @@ runs:
 
           # File-level trim for non-atomic roots (triton cache, pip, wheel).
           if [[ -n "${CACHE_DIRS}" ]]; then
-            FILE_TRIM_ARGS=()
-            while IFS= read -r dir; do
-              dir="${dir//$'\r'/}"
-              [[ -z "$dir" ]] && continue
-              FILE_TRIM_ARGS+=( "$dir" )
-            done <<< "${CACHE_DIRS}"
+            parse_list_into_array FILE_TRIM_ARGS <<< "${CACHE_DIRS}"
             if (( ${#FILE_TRIM_ARGS[@]} > 0 )); then
               bash "${RECLAIM_SCRIPT}" trim-files "${CACHE_AGE_DAYS}" "${FILE_TRIM_ARGS[@]}" || true
             fi
@@ -275,12 +289,7 @@ runs:
           # subdir without its best_config.json sentinel and crash the
           # next consumer.
           if [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
-            ATOMIC_TRIM_ARGS=()
-            while IFS= read -r dir; do
-              dir="${dir//$'\r'/}"
-              [[ -z "$dir" ]] && continue
-              ATOMIC_TRIM_ARGS+=( "$dir" )
-            done <<< "${ATOMIC_CACHE_DIRS}"
+            parse_list_into_array ATOMIC_TRIM_ARGS <<< "${ATOMIC_CACHE_DIRS}"
             if (( ${#ATOMIC_TRIM_ARGS[@]} > 0 )); then
               bash "${RECLAIM_SCRIPT}" atomic-trim "${CACHE_AGE_DAYS}" "${ATOMIC_TRIM_ARGS[@]}" || true
             fi

--- a/.github/actions/reclaim-runner-disk/reclaim_cache.sh
+++ b/.github/actions/reclaim-runner-disk/reclaim_cache.sh
@@ -98,12 +98,14 @@ atomic_trim() {
         [[ -z "$root" ]] && continue
         [[ -d "$root" ]] || continue
         while IFS= read -r -d '' subdir; do
-            # Use the newest mtime anywhere in the subtree. Directory
-            # mtime alone is unreliable (only bumped on entry add/del)
-            # so a subdir whose files are being actively rewritten
-            # would look stale. `find -printf %T@` on all entries
-            # (files + dirs) piped to awk gives a robust newest-mtime.
-            newest_mtime=$(find "$subdir" -printf '%T@\n' 2>/dev/null \
+            # Use the newest FILE mtime anywhere in the subtree — directory
+            # mtimes must not participate. Rationale: a cache restore/extract
+            # can bump the subdir's own mtime to "now" while every regular
+            # file inside is still at its original (old) timestamp; counting
+            # the dir mtime would wrongly mark the subdir as fresh and defeat
+            # age-based reclaim. Only fall back to the subdir mtime when the
+            # subtree has no regular files at all.
+            newest_mtime=$(find "$subdir" -type f -printf '%T@\n' 2>/dev/null \
                 | awk 'NR == 1 || $1 > max { max = $1 } END { if (NR > 0) printf "%d\n", max }')
             if [[ -z "$newest_mtime" ]]; then
                 newest_mtime=$(stat -c %Y "$subdir" 2>/dev/null || echo 0)

--- a/.github/actions/reclaim-runner-disk/reclaim_cache.sh
+++ b/.github/actions/reclaim-runner-disk/reclaim_cache.sh
@@ -81,8 +81,19 @@ atomic_trim() {
     local age_days="$1"
     shift
     local now_epoch cutoff root subdir newest_mtime
+    # Validate age_days is a plain non-negative integer before feeding it
+    # into arithmetic. Bash defaults to base-8 for literals with a leading
+    # zero, so a caller-supplied value like "08"/"09" (e.g. from a
+    # zero-padded workflow input) would abort the whole trim with
+    # "value too great for base". We fail *open* — log and return 0 —
+    # so a bad input can't crash the wider reclaim pass, and we force
+    # base-10 parsing via `10#...` for defence in depth.
+    if [[ ! "$age_days" =~ ^[0-9]+$ ]]; then
+        _log "atomic-trim: ignoring invalid age_days='${age_days}' (expected non-negative integer)"
+        return 0
+    fi
     now_epoch=$(date +%s)
-    cutoff=$(( now_epoch - age_days * 86400 ))
+    cutoff=$(( now_epoch - 10#${age_days} * 86400 ))
     for root in "$@"; do
         [[ -z "$root" ]] && continue
         [[ -d "$root" ]] || continue
@@ -116,6 +127,15 @@ trim_files() {
     local age_days="$1"
     shift
     local root
+    # Same validation as atomic_trim: refuse non-integer age_days and fail
+    # open. `find -mtime` itself is tolerant of leading-zero strings, but
+    # we keep the contract identical across subcommands so a caller that
+    # passes a bogus value gets the same behaviour everywhere.
+    if [[ ! "$age_days" =~ ^[0-9]+$ ]]; then
+        _log "trim-files: ignoring invalid age_days='${age_days}' (expected non-negative integer)"
+        return 0
+    fi
+    age_days=$(( 10#${age_days} ))
     for root in "$@"; do
         [[ -z "$root" ]] && continue
         [[ -d "$root" ]] || continue

--- a/scripts/reclaim_cache.sh
+++ b/scripts/reclaim_cache.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# reclaim_cache.sh — cache-reclaim primitives used by the
+# .github/actions/reclaim-runner-disk composite action.
+#
+# The action.yml composite used to embed all reclaim logic inline, which
+# meant the cache-trim paths could only be exercised on a self-hosted
+# runner. That made it impossible to catch regressions at PR time; a bad
+# trim rule only surfaced after merge when it had already corrupted the
+# live cache. This script exposes the trim primitives as
+# pytest-driveable subcommands so tests/test_reclaim_action.py can
+# validate behaviour against a tmp_path fixture.
+#
+# The core safety invariant this script enforces is that some cache
+# roots (notably /home/ci-runner/.tilelang/cache/autotuner) store
+# *atomic* first-level subdirectories: consumers assume "directory
+# exists => contents complete" and the directory is only valid if the
+# sentinel file (best_config.json) is present. File-level `-mtime`
+# trimming on these roots can delete the sentinel while leaving the
+# rest of the directory in place, producing a half-dead state that
+# crashes the next consumer. The atomic-trim and sentinel-repair
+# subcommands here operate at whole-subdir granularity and never touch
+# individual files inside an atomic root.
+#
+# Subcommands:
+#
+#   sentinel-repair <root> [<root>...]
+#       For each atomic root, delete any first-level subdirectory that
+#       does not contain ${SENTINEL_FILENAME:-best_config.json}. This
+#       self-heals half-dead state left by older reclaim passes.
+#
+#   atomic-trim <age-days> <root> [<root>...]
+#       For each atomic root, compute the newest file mtime anywhere
+#       inside each first-level subdirectory. If that mtime is older
+#       than <age-days> days, delete the whole subdirectory. Never
+#       trims individual files inside atomic roots.
+#
+#   trim-files <age-days> <root> [<root>...]
+#       File-level `-mtime +N -delete` trim for non-atomic cache
+#       roots, followed by empty-directory cleanup. This is the legacy
+#       behaviour used for /home/ci-runner/.triton/cache,
+#       /home/ci-runner/.cache/pip, /home/ci-runner/.wheel-cache, etc.
+#
+# All subcommands are idempotent, tolerate missing roots (skipped
+# silently), and never exit non-zero for per-directory errors so a
+# transient `rm` failure cannot abort the whole reclaim step.
+
+set -uo pipefail
+
+SENTINEL_FILENAME="${SENTINEL_FILENAME:-best_config.json}"
+
+_log() {
+    echo "$@"
+}
+
+# sentinel_repair <root> [<root>...]
+#
+# Delete any first-level subdirectory of each root that is missing the
+# sentinel file. Roots that do not exist are skipped. The sentinel
+# filename is read from ${SENTINEL_FILENAME:-best_config.json}.
+sentinel_repair() {
+    local root subdir
+    for root in "$@"; do
+        [[ -z "$root" ]] && continue
+        [[ -d "$root" ]] || continue
+        while IFS= read -r -d '' subdir; do
+            if [[ ! -e "${subdir}/${SENTINEL_FILENAME}" ]]; then
+                _log "sentinel-repair: removing ${subdir} (missing ${SENTINEL_FILENAME})"
+                rm -rf "$subdir" 2>/dev/null || true
+            fi
+        done < <(find "$root" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+    done
+}
+
+# atomic_trim <age-days> <root> [<root>...]
+#
+# For each first-level subdirectory of each root, compute the newest
+# file mtime in the whole subtree. If that mtime is older than
+# <age-days> days, delete the whole subdirectory. Never deletes
+# individual files; the unit of trim is the subdirectory.
+atomic_trim() {
+    local age_days="$1"
+    shift
+    local now_epoch cutoff root subdir newest_mtime
+    now_epoch=$(date +%s)
+    cutoff=$(( now_epoch - age_days * 86400 ))
+    for root in "$@"; do
+        [[ -z "$root" ]] && continue
+        [[ -d "$root" ]] || continue
+        while IFS= read -r -d '' subdir; do
+            # Use the newest mtime anywhere in the subtree. Directory
+            # mtime alone is unreliable (only bumped on entry add/del)
+            # so a subdir whose files are being actively rewritten
+            # would look stale. `find -printf %T@` on all entries
+            # (files + dirs) piped to awk gives a robust newest-mtime.
+            newest_mtime=$(find "$subdir" -printf '%T@\n' 2>/dev/null \
+                | awk 'NR == 1 || $1 > max { max = $1 } END { if (NR > 0) printf "%d\n", max }')
+            if [[ -z "$newest_mtime" ]]; then
+                newest_mtime=$(stat -c %Y "$subdir" 2>/dev/null || echo 0)
+            fi
+            if (( newest_mtime < cutoff )); then
+                _log "atomic-trim: removing ${subdir} (newest mtime ${newest_mtime} < cutoff ${cutoff})"
+                rm -rf "$subdir" 2>/dev/null || true
+            fi
+        done < <(find "$root" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+    done
+}
+
+# trim_files <age-days> <root> [<root>...]
+#
+# File-level age-based trim for non-atomic caches. Deletes files older
+# than <age-days>, then deletes any now-empty directories. Empty-dir
+# cleanup does NOT gate on -mtime because file deletion bumps the
+# parent directory's mtime to "now" and a mtime filter would leave the
+# newly-empty dirs behind.
+trim_files() {
+    local age_days="$1"
+    shift
+    local root
+    for root in "$@"; do
+        [[ -z "$root" ]] && continue
+        [[ -d "$root" ]] || continue
+        find "$root" -type f -mtime "+${age_days}" -delete 2>/dev/null || true
+        find "$root" -depth -mindepth 1 -type d -empty -delete 2>/dev/null || true
+    done
+}
+
+_usage() {
+    cat >&2 <<'EOF'
+usage: reclaim_cache.sh <subcommand> [args...]
+
+subcommands:
+  sentinel-repair <root> [<root>...]
+  atomic-trim <age-days> <root> [<root>...]
+  trim-files <age-days> <root> [<root>...]
+EOF
+    exit 2
+}
+
+main() {
+    [[ $# -ge 1 ]] || _usage
+    local cmd="$1"
+    shift
+    case "$cmd" in
+        sentinel-repair)
+            sentinel_repair "$@"
+            ;;
+        atomic-trim)
+            [[ $# -ge 2 ]] || _usage
+            atomic_trim "$@"
+            ;;
+        trim-files)
+            [[ $# -ge 2 ]] || _usage
+            trim_files "$@"
+            ;;
+        *)
+            _usage
+            ;;
+    esac
+}
+
+# Allow sourcing the file in tests without executing main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_reclaim_action.py
+++ b/tests/test_reclaim_action.py
@@ -1,0 +1,247 @@
+"""Unit tests for scripts/reclaim_cache.sh.
+
+Covers the sentinel-repair + atomic-trim primitives that protect caches
+whose consumers assume "directory exists => contents complete" (the
+tilelang autotuner cache in particular). See issue #989.
+
+Required cases per milestone plan:
+  - half_dead       : atomic subdir with files but no sentinel is removed
+                      on a single invocation (AC-2, AC-3).
+  - atomic_stale    : atomic subdir whose newest file is older than
+                      cache-age-days is removed whole-directory.
+  - atomic_fresh    : fresh atomic subdirs are preserved.
+  - invariant       : atomic roots never have their *individual files*
+                      trimmed, even when file-level trim runs (AC-4).
+
+Runs on every PR (smoke tier), so does not depend on a self-hosted
+runner or the Tilelang runtime. Must stay fast and hermetic.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RECLAIM_SCRIPT = REPO_ROOT / "scripts" / "reclaim_cache.sh"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _age_path(path: Path, *, days: float) -> None:
+    """Backdate mtime+atime of every file under ``path`` by ``days`` days."""
+    past = time.time() - days * 86400
+    if path.is_file():
+        os.utime(path, (past, past))
+        return
+    for entry in path.rglob("*"):
+        try:
+            os.utime(entry, (past, past), follow_symlinks=False)
+        except (FileNotFoundError, PermissionError):
+            continue
+    os.utime(path, (past, past))
+
+
+def _run(subcommand: str, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    cmd = ["bash", str(RECLAIM_SCRIPT), subcommand, *args]
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, env=merged_env, check=False
+    )
+    assert result.returncode == 0, (
+        f"{cmd!r} exited {result.returncode}\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _make_autotuner_subdir(
+    root: Path, name: str, *, with_sentinel: bool, sentinel: str = "best_config.json"
+) -> Path:
+    subdir = root / name
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "kernel.cu").write_text("// cached kernel\n")
+    (subdir / "kernel.so").write_bytes(b"\x7fELF")
+    if with_sentinel:
+        (subdir / sentinel).write_text('{"block": [128, 64]}\n')
+    return subdir
+
+
+# ---------------------------------------------------------------------------
+# sentinel-repair
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_repair_removes_half_dead_subdir(tmp_path: Path) -> None:
+    """half_dead case: subdir missing best_config.json must be removed."""
+    root = tmp_path / "autotuner"
+    half_dead = _make_autotuner_subdir(root, "halfdead_sig", with_sentinel=False)
+    healthy = _make_autotuner_subdir(root, "healthy_sig", with_sentinel=True)
+
+    _run("sentinel-repair", str(root))
+
+    assert not half_dead.exists(), "half-dead subdir should have been removed"
+    assert healthy.exists(), "healthy subdir with sentinel must be preserved"
+    assert (healthy / "best_config.json").exists()
+
+
+def test_sentinel_repair_is_idempotent(tmp_path: Path) -> None:
+    """Running sentinel-repair twice on a clean tree must not regress."""
+    root = tmp_path / "autotuner"
+    healthy = _make_autotuner_subdir(root, "healthy_sig", with_sentinel=True)
+
+    _run("sentinel-repair", str(root))
+    _run("sentinel-repair", str(root))
+
+    assert healthy.exists()
+    assert (healthy / "best_config.json").exists()
+
+
+def test_sentinel_repair_tolerates_missing_root(tmp_path: Path) -> None:
+    """A non-existent cache root must be a no-op, not an error."""
+    missing = tmp_path / "does-not-exist"
+    _run("sentinel-repair", str(missing))  # asserts rc==0
+
+
+def test_sentinel_repair_honours_custom_sentinel_filename(tmp_path: Path) -> None:
+    """The sentinel filename is overridable via $SENTINEL_FILENAME (used in tests)."""
+    root = tmp_path / "autotuner"
+    subdir = _make_autotuner_subdir(root, "sig", with_sentinel=False, sentinel="SENTINEL")
+    (subdir / "SENTINEL").write_text("ok\n")
+
+    _run("sentinel-repair", str(root), env={"SENTINEL_FILENAME": "SENTINEL"})
+
+    assert subdir.exists(), "subdir with the custom sentinel must be preserved"
+
+
+def test_no_half_dead_after_reclaim(tmp_path: Path) -> None:
+    """AC-2: after a full reclaim sequence no autotuner subdir is left
+    in the half-dead state (exists but missing best_config.json)."""
+    root = tmp_path / "autotuner"
+    _make_autotuner_subdir(root, "halfdead_a", with_sentinel=False)
+    _make_autotuner_subdir(root, "halfdead_b", with_sentinel=False)
+    _make_autotuner_subdir(root, "healthy", with_sentinel=True)
+
+    # Full reclaim order: sentinel-repair → atomic-trim.
+    _run("sentinel-repair", str(root))
+    _run("atomic-trim", "7", str(root))
+
+    for subdir in root.iterdir():
+        if subdir.is_dir():
+            assert (subdir / "best_config.json").exists(), (
+                f"{subdir} is half-dead after reclaim"
+            )
+
+
+# ---------------------------------------------------------------------------
+# atomic-trim
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_trim_removes_stale_subdir_whole(tmp_path: Path) -> None:
+    """atomic_stale case: subdir whose newest file is older than the
+    cutoff is removed as a whole unit."""
+    root = tmp_path / "autotuner"
+    stale = _make_autotuner_subdir(root, "stale_sig", with_sentinel=True)
+    _age_path(stale, days=30)
+
+    _run("atomic-trim", "7", str(root))
+
+    assert not stale.exists(), "stale atomic subdir must be removed whole-directory"
+
+
+def test_atomic_trim_preserves_fresh_subdir(tmp_path: Path) -> None:
+    """atomic_fresh case: subdirs within the age window are kept intact."""
+    root = tmp_path / "autotuner"
+    fresh = _make_autotuner_subdir(root, "fresh_sig", with_sentinel=True)
+
+    _run("atomic-trim", "7", str(root))
+
+    assert fresh.exists()
+    # All files preserved, not just the directory.
+    assert (fresh / "best_config.json").exists()
+    assert (fresh / "kernel.cu").exists()
+    assert (fresh / "kernel.so").exists()
+
+
+def test_atomic_trim_never_trims_individual_files(tmp_path: Path) -> None:
+    """invariant: even when *some* files inside an atomic subdir are old,
+    atomic-trim must not delete individual files — the unit of deletion
+    is the whole subdirectory. The subdir is kept whenever *any* entry
+    inside it is within the age window."""
+    root = tmp_path / "autotuner"
+    subdir = _make_autotuner_subdir(root, "mixed_sig", with_sentinel=True)
+    # Age just the kernel files, leave best_config.json fresh.
+    _age_path(subdir / "kernel.cu", days=30)
+    _age_path(subdir / "kernel.so", days=30)
+
+    _run("atomic-trim", "7", str(root))
+
+    assert subdir.exists(), "subdir with at least one fresh file must survive"
+    assert (subdir / "kernel.cu").exists(), "individual files inside atomic root must never be trimmed"
+    assert (subdir / "kernel.so").exists()
+    assert (subdir / "best_config.json").exists()
+
+
+def test_atomic_trim_tolerates_missing_root(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    _run("atomic-trim", "7", str(missing))
+
+
+def test_atomic_trim_handles_empty_root(tmp_path: Path) -> None:
+    root = tmp_path / "autotuner"
+    root.mkdir()
+    _run("atomic-trim", "7", str(root))
+    assert root.exists(), "the cache root itself is never removed"
+
+
+# ---------------------------------------------------------------------------
+# trim-files (non-atomic roots, legacy behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_trim_files_removes_old_files_but_leaves_atomic_roots_alone(
+    tmp_path: Path,
+) -> None:
+    """invariant: file-level trim is only applied to the roots passed
+    in. Callers must keep atomic roots out of the trim-files list —
+    which this test reinforces by exercising a non-atomic root and
+    asserting that a neighbouring autotuner root (*not* passed in) is
+    untouched even if its files are ancient."""
+    triton_root = tmp_path / "triton-cache"
+    triton_root.mkdir()
+    old_file = triton_root / "old.bin"
+    old_file.write_bytes(b"\x00")
+    _age_path(old_file, days=30)
+    fresh_file = triton_root / "fresh.bin"
+    fresh_file.write_bytes(b"\x01")
+
+    # A *separate* autotuner root the action would NOT pass to trim-files.
+    autotuner_root = tmp_path / "autotuner"
+    subdir = _make_autotuner_subdir(autotuner_root, "sig", with_sentinel=True)
+    _age_path(subdir, days=30)
+
+    _run("trim-files", "7", str(triton_root))
+
+    # Non-atomic root: old files pruned, fresh files kept.
+    assert not old_file.exists()
+    assert fresh_file.exists()
+    # Atomic root untouched — trim-files must NOT be called on it.
+    assert subdir.exists()
+    assert (subdir / "best_config.json").exists()
+    assert (subdir / "kernel.cu").exists()
+
+
+def test_trim_files_tolerates_missing_root(tmp_path: Path) -> None:
+    _run("trim-files", "7", str(tmp_path / "nope"))

--- a/tests/test_reclaim_action.py
+++ b/tests/test_reclaim_action.py
@@ -196,6 +196,35 @@ def test_atomic_trim_never_trims_individual_files(tmp_path: Path) -> None:
     assert (subdir / "best_config.json").exists()
 
 
+def test_atomic_trim_uses_file_mtime_not_dir_mtime(tmp_path: Path) -> None:
+    """Directory mtime must not make a stale subdir look fresh.
+
+    A cache restore/extract can bump the subdir's own mtime to "now" while
+    every regular file inside keeps its original (old) timestamp. atomic-trim
+    must decide staleness from the newest FILE mtime in the subtree, not the
+    directory mtime, otherwise age-based reclaim is defeated.
+    """
+    root = tmp_path / "autotuner"
+    root.mkdir()
+    stale = root / "deadbeef"
+    stale.mkdir()
+    (stale / "best_config.json").write_text("{}")
+    (stale / "kernel.so").write_text("x")
+
+    # Backdate only the files; deliberately leave the subdir mtime at "now".
+    past = time.time() - 30 * 86400
+    for entry in stale.iterdir():
+        os.utime(entry, (past, past))
+    os.utime(stale, (time.time(), time.time()))
+
+    _run("atomic-trim", "7", str(root))
+
+    assert not stale.exists(), (
+        "atomic-trim regressed: stale subdir kept alive by dir mtime. "
+        "Newest-mtime logic must restrict to -type f."
+    )
+
+
 def test_atomic_trim_tolerates_missing_root(tmp_path: Path) -> None:
     missing = tmp_path / "nope"
     _run("atomic-trim", "7", str(missing))

--- a/tests/test_reclaim_action.py
+++ b/tests/test_reclaim_action.py
@@ -1,4 +1,4 @@
-"""Unit tests for scripts/reclaim_cache.sh.
+"""Unit tests for .github/actions/reclaim-runner-disk/reclaim_cache.sh.
 
 Covers the sentinel-repair + atomic-trim primitives that protect caches
 whose consumers assume "directory exists => contents complete" (the
@@ -29,7 +29,9 @@ import pytest
 pytestmark = pytest.mark.smoke
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-RECLAIM_SCRIPT = REPO_ROOT / "scripts" / "reclaim_cache.sh"
+# Script is colocated with the composite action so the gpu-smoke
+# `.trusted/.github/actions` sparse-checkout picks it up; see action.yml.
+RECLAIM_SCRIPT = REPO_ROOT / ".github" / "actions" / "reclaim-runner-disk" / "reclaim_cache.sh"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `reclaim-runner-disk` to treat the tilelang autotuner cache as atomic. Previously, file-level mtime trim could delete `best_config.json` while leaving its sibling kernel artifacts, leaving a "directory exists, sentinel missing" half-dead state that made consumers reuse incomplete caches and caused main's GPU Smoke full-tier to fail without manual SSH cleanup.

After this change:
- `scripts/reclaim_cache.sh` owns the reclaim logic (testable from pytest, no self-hosted runner needed). `action.yml` delegates to it.
- New `atomic-cache-dirs` input (default: `/home/ci-runner/.tilelang/cache/autotuner`). First-level children of atomic roots are the unit of trim — all-or-nothing.
- Unconditional sentinel-repair pass runs first: for each atomic root, any first-level subdir missing `best_config.json` is removed. Heals inherited half-dead state.
- Atomic trim pass: newest-file mtime per first-level subdir; if older than `cache-age-days`, delete the whole subdir. Never trims individual files inside atomic roots.
- `tests/test_reclaim_action.py` (smoke tier) covers half-dead, atomic-stale, atomic-fresh, and invariant cases.

Closes #989

## Test plan

- [x] AC-1: Modified files pass unit tests. `pytest tests/test_reclaim_action.py -v` -> 12 passed; `pre-commit run --files ...` -> all hooks passed.
- [x] AC-2: `reclaim-runner-disk` never leaves an autotuner subdir half-dead. `test_no_half_dead_after_reclaim` PASSED — seeds two half-dead + one healthy subdir, runs sentinel-repair + atomic-trim(7d), asserts every survivor has `best_config.json`.
- [x] AC-3: Sentinel repair self-heals pre-existing corruption in a single invocation. `test_sentinel_repair_removes_half_dead_subdir` PASSED — single `bash scripts/reclaim_cache.sh sentinel-repair <root>` call removes half-dead subdir and preserves healthy one.
- [x] AC-4: PR CI (smoke tier) fails if reclaim regresses to file-level trim on atomic root. `pytest tests/test_reclaim_action.py -m smoke --co -q` -> 12 tests collected under `smoke` (module-level marker). Guard tests: `test_atomic_trim_never_trims_individual_files`, `test_trim_files_removes_old_files_but_leaves_atomic_roots_alone`.
- [ ] AC-5: Post-merge scheduled runner-maintenance + main push GPU Smoke full-tier pass without manual cleanup. Structurally verified — unconditional sentinel-repair in `action.yml` (step 0, runs before `SHOULD_RECLAIM` gating) guarantees first post-merge invocation heals inherited half-dead state. Final confirmation is post-merge observation.

## Follow-up

No follow-up issues or suggestions.
