### PR TITLE
[Feat][Ops] Default _cache_key in Op base + empty-static_dims runtime warn

### DIFF
--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -1,0 +1,121 @@
+"""Tests for tileops.ops.op_base Op._cache_key default + runtime warnings."""
+
+import warnings
+
+import pytest
+
+from tileops.ops import op_base
+from tileops.ops.op_base import Op
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_types():
+    """Clear the module-level dedup set so each test sees a fresh warn state."""
+    op_base._EMPTY_STATIC_DIMS_WARNED.clear()
+    yield
+    op_base._EMPTY_STATIC_DIMS_WARNED.clear()
+
+
+def _make_op_subclass(*, static_axes=frozenset(), override_cache_key=False):
+    """Build a minimal concrete Op subclass for testing.
+
+    ``static_axes`` populates ``_static_axes``.
+    ``override_cache_key=True`` attaches a subclass-level override.
+    """
+    attrs = {
+        "_static_axes": static_axes,
+        "default_kernel_map": property(lambda self: {}),
+        "forward": lambda self, *a, **kw: None,
+    }
+    if override_cache_key:
+        attrs["_cache_key"] = lambda self, *shapes: ("overridden",)
+    return type("TestOp", (Op,), attrs)
+
+
+class TestCacheKeyDefault:
+    def test_static_axes_exclude_single_input(self):
+        """_static_axes=[(0,1)] on a 3D input excludes axis 1 from the key."""
+        Cls = _make_op_subclass(static_axes=frozenset({(0, 1)}))
+        op = Cls()
+        key = op._cache_key((2, 4, 8))
+        assert key == (2, 8)
+
+    def test_static_axes_across_multiple_inputs(self):
+        """_static_axes can reference axes in different input positions."""
+        Cls = _make_op_subclass(static_axes=frozenset({(0, 1), (1, 0)}))
+        op = Cls()
+        key = op._cache_key((2, 4, 8), (16, 32))
+        # Input 0: exclude axis 1 -> (2, 8); Input 1: exclude axis 0 -> (32,)
+        assert key == (2, 8, 32)
+
+    def test_empty_static_axes_returns_full_shape(self):
+        """With no static axes, the key concatenates all input shape values."""
+        Cls = _make_op_subclass(static_axes=frozenset())
+        op = Cls()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # warning tested separately
+            key = op._cache_key((2, 4, 8), (3, 5))
+        assert key == (2, 4, 8, 3, 5)
+
+
+class TestCacheKeyWarning:
+    def test_empty_static_axes_warns_once_per_type(self):
+        """Default path with empty _static_axes warns exactly once per subclass,
+        even across multiple instances and repeated calls."""
+        Cls = _make_op_subclass(static_axes=frozenset())
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Cls()._cache_key((2, 4))
+            Cls()._cache_key((3, 5))
+            Cls()._cache_key((7, 9))
+            Cls()._cache_key((11, 13))
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 1
+        assert "TestOp" in str(user_warnings[0].message)
+        assert "_cache_key" in str(user_warnings[0].message)
+
+    def test_override_suppresses_warning(self):
+        """When the subclass overrides _cache_key, no warning fires."""
+        Cls = _make_op_subclass(
+            static_axes=frozenset(), override_cache_key=True
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = Cls()._cache_key((2, 4))
+
+        assert result == ("overridden",)
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert user_warnings == []
+
+    def test_populated_static_axes_suppresses_warning(self):
+        """Non-empty _static_axes means the user committed at ctor; no warning
+        fires regardless of whether _cache_key was overridden."""
+        Cls = _make_op_subclass(static_axes=frozenset({(0, 0)}))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Cls()._cache_key((2, 4))
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert user_warnings == []
+
+    def test_distinct_subclasses_each_warn_once(self):
+        """Two different subclasses each warn once; the dedup set is keyed by
+        type, not globally suppressed after the first warning."""
+        ClsA = _make_op_subclass(static_axes=frozenset())
+        ClsB = _make_op_subclass(static_axes=frozenset())
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ClsA()._cache_key((1,))
+            ClsA()._cache_key((2,))  # no re-warn for A
+            ClsB()._cache_key((3,))  # fresh warn for B
+            ClsB()._cache_key((4,))  # no re-warn for B
+
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user_warnings) == 2

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -1,10 +1,14 @@
+import warnings
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, FrozenSet, Hashable, Optional, Tuple, Union
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
+
+# Module-level dedup for empty-static_dims warnings; keyed by Op subclass.
+_EMPTY_STATIC_DIMS_WARNED: set = set()
 
 
 class Op(ABC):
@@ -43,6 +47,12 @@ class Op(ABC):
     device: Optional[Union[torch.device, str]] = 'cuda'
     input_shapes: Optional[list[tuple]] = None
 
+    # Set of (input_index, axis) pairs identifying static (ctor-committed) axes.
+    # `input_index` is the position in *input_shapes; `axis` is a non-negative
+    # axis index within that shape. Subclasses set this to reflect their
+    # manifest `static_dims`. Default empty = no committed axes.
+    _static_axes: FrozenSet[Tuple[int, int]] = frozenset()
+
     @property
     @abstractmethod
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -77,3 +87,41 @@ class Op(ABC):
     def __call__(self, *args: object, **kwargs: object) -> Union[torch.Tensor, Tuple]:
         """Make the op callable - delegates to forward()"""
         return self.forward(*args, **kwargs)
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Return a cache key for kernel dispatch given forward-time input shapes.
+
+        Default implementation returns the tuple of non-static-axis sizes across
+        all input shapes, using ``self._static_axes`` to decide which axes are
+        committed at ctor. This is always correct for any Op, but may
+        over-fragment the kernel cache when ``_static_axes`` is empty (one
+        compile per distinct input shape).
+
+        Override in subclasses to project the shape onto whatever the kernel
+        actually depends on — for example, flattening leading dims to a single
+        product when the kernel treats input as 2D.
+
+        When ``_static_axes`` is empty AND the subclass does not override
+        ``_cache_key``, a ``UserWarning`` is emitted once per subclass type to
+        surface the missing override.
+        """
+        if not self._static_axes and type(self)._cache_key is Op._cache_key:
+            cls = type(self)
+            if cls not in _EMPTY_STATIC_DIMS_WARNED:
+                _EMPTY_STATIC_DIMS_WARNED.add(cls)
+                warnings.warn(
+                    f"{cls.__name__}: Op._cache_key() called with empty "
+                    f"_static_axes and no subclass override. The default "
+                    f"keys the kernel cache by the full input shape, which "
+                    f"produces one compile per distinct shape under dynamic "
+                    f"inputs. Override _cache_key to project onto whatever "
+                    f"the kernel math actually depends on.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        return tuple(
+            s
+            for i, shape in enumerate(input_shapes)
+            for axis, s in enumerate(shape)
+            if (i, axis) not in self._static_axes
+        )


### PR DESCRIPTION
## Summary

Third and final installment of the `static_dims` design rewrite (see #976 for docs + validator; this PR lands the runtime).

Adds to `Op` base class in `tileops/ops/op_base.py`:

- `_static_axes: frozenset[tuple[int, int]]` class attribute (default empty). Subclasses set this to the `(input_index, axis)` pairs they commit at ctor — corresponding to manifest `static_dims` entries.
- `_cache_key(*input_shapes) -> Hashable` method. Default returns the tuple of non-static-axis sizes across all input shapes. Always correct; subclasses override when kernel math permits coarser keying.
- Once-per-type `UserWarning` when the default `_cache_key` is invoked with empty `_static_axes` and no subclass override. Module-level dedup via `_EMPTY_STATIC_DIMS_WARNED` set keyed on `type(self)`.

New `tests/test_op_base.py` (7 tests, `pytest.mark.smoke`):
- `_static_axes` exclusion for single- and multi-input ops (AC-3)
- Empty-axes full-shape fallback (AC-4)
- Once-per-type warn dedup across multiple instances and calls (AC-5)
- Override in subclass suppresses warn (AC-6)
- Populated axes suppress warn (AC-7)
- Distinct subclasses each warn once (guards dedup-key correctness)

Depends on #982 landing (renames `init_dims` → `static_dims` in docs/manifest/validator); this PR's semantics line up with #982's spec.

Does not retrofit concrete ops under `tileops/ops/*` to set `_static_axes` — that is a per-op/per-family follow-up, and in the fully realized flow will be populated by codegen.

Closes #985.

## Test plan

- [x] AC-2: `Op._cache_key(self, *input_shapes) -> Hashable` exists on the base class with documented behavior
- [x] AC-3: Default returns non-static-axis sizes when `_static_axes` is populated
- [x] AC-4: Default returns full shape tuple when `_static_axes` is empty
- [x] AC-5: Warn fires exactly once per subclass when default is invoked with empty axes and no override
- [x] AC-6: Warn suppressed when subclass overrides `_cache_key`
- [x] AC-7: Warn suppressed when `_static_axes` is non-empty
- [x] AC-8: `tests/test_op_base.py` passes all 7 tests
- [x] AC-9: No changes outside `tileops/ops/op_base.py` and `tests/test_op_base.py`