### PR TITLE
[Fix][CI] remove tileops/ops/*.py from fork fast-path allowlist

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -251,7 +251,7 @@ jobs:
             for path in "${changed_files[@]}"; do
               if [[ "$is_fork" == "true" ]]; then
                 case "$path" in
-                  .github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|tileops/ops/*.py|tests/ops/test_*.py|*.md)
+                  .github/ISSUE_TEMPLATE/*|.github/pull_request_template.md|tests/ops/test_*.py|*.md)
                     ;;
                   .github/workflows/*|pyproject.toml|requirements*.txt|requirements*.in|setup.py|setup.cfg|Dockerfile*|scripts/bootstrap*|scripts/install*)
                     allow_fast_path="false"


### PR DESCRIPTION
## Summary

Remove `tileops/ops/*.py` from the fork fast-path allowlist in `.github/workflows/gpu-smoke.yml`.

The allowlist previously treated changes under `tileops/ops/*.py` as narrow enough for targeted testing in fork PRs. That shares the same unsound independence assumption that motivated the earlier cleanup in PR #972: a change to one op file can affect kernel dispatch, shared utilities, or cross-op behavior that targeted tests would miss. After this change, fork edits to `tileops/ops/*.py` fall through to the full-smoke policy, while fork edits under `tests/ops/` continue to qualify for `allow_fast_path`.

Closes #974

## Test plan

- [x] **AC-1**: Modified files pass unit tests
  - Evidence: Scope cross-check: git diff origin/main...HEAD changes only .github/workflows/gpu-smoke.yml (1 insertion, 1 deletion). Self-executed checks: python yaml.safe_load asserted jobs include ci-prereq, security-policy, gpu-smoke; pre-commit run --files .github/workflows/gpu-smoke.yml passed check yaml, trailing whitespace, EOF, merge-conflict, private-key, secrets, and skipped non-applicable hooks; git diff --check origin/main...HEAD exited 0. No Python unit test target applies to a workflow-only policy edit.
- [x] **AC-2**: Fork fast-path allowlist is consistent with the targeted scope policy (no unsound assumptions about op independence)
  - Evidence: Diff removes tileops/ops/*.py from the fork allow_fast_path allowlist at .github/workflows/gpu-smoke.yml:254. Self-executed shell simulation: fork tileops/ops/foo.py resolves allow_fast_path=false, scope=full-smoke, pytest_targets=tests; fork tests/ops/test_foo.py remains allow_fast_path=true, scope=targeted; markdown-only still skips; workflow-only remains high-risk full-smoke. Additional shell pattern check confirmed tileops/ops/*.py would have matched nested paths such as tileops/ops/norm/rms_norm.py before removal, and the current allowlist has zero tileops/ops/*.py occurrences. rg shows allow_fast_path is only used inside the policy selection logic and exported as an output; the GPU run uses skip_gpu_smoke/scope/pytest_targets, so fork op implementation files now align with full-smoke policy without weakening isolation. Code review covered correctness, edge cases, error paths, performance, security, and test coverage; second pass found no findings.

## Notes

- Workflow-only policy edit; no Python code paths touched.
- Verified via self-executed shell simulation of `allow_fast_path` selection for representative fork-PR file sets, plus `rg` confirmation that `allow_fast_path` is consumed only by the policy selection logic (the actual GPU job keys off `skip_gpu_smoke` / `scope` / `pytest_targets`).