### PR TITLE
[Fix][CI] restore fork PR gpu-smoke fast path

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -412,12 +412,43 @@ jobs:
             PIP_CACHE_DIR="${RUNTIME_ROOT}/pip/cache"
             WHEEL_DIR="${RUNTIME_ROOT}/wheels"
             VENV_PATH="${RUNTIME_ROOT}/venv"
+
+            # Diagnostic: log the trusted venv probe so FORK_CAN_COPY_TRUSTED_VENV
+            # decisions are traceable in CI logs. This surfaces permission issues
+            # (runner tool_cache owned by a different user), missing paths, or
+            # partial venvs where bin/python exists but is not executable.
+            echo "=== Trusted venv probe ==="
+            echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH}"
+            if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
+              echo "Trusted venv directory exists:"
+              ls -la "${TRUSTED_VENV_PATH}" || true
+              if [[ -d "${TRUSTED_VENV_PATH}/bin" ]]; then
+                echo "Trusted venv bin/ contents:"
+                ls -la "${TRUSTED_VENV_PATH}/bin" | head -20 || true
+              else
+                echo "Trusted venv bin/ does not exist"
+              fi
+            else
+              echo "Trusted venv directory does not exist"
+              echo "Sibling venvs under ${{ runner.tool_cache }}:"
+              ls -la "${{ runner.tool_cache }}" 2>/dev/null | grep -E "tileops_ci_venv" || echo "  (none)"
+            fi
+            python_bin="${TRUSTED_VENV_PATH}/bin/python"
+            if [[ -e "${python_bin}" ]]; then
+              echo "python_bin exists=true executable=$([[ -x "${python_bin}" ]] && echo true || echo false) readable=$([[ -r "${python_bin}" ]] && echo true || echo false)"
+              stat "${python_bin}" || true
+            else
+              echo "python_bin exists=false"
+            fi
+            echo "=========================="
+
             if [[ -x "${TRUSTED_VENV_PATH}/bin/python" ]]; then
               FORK_CAN_COPY_TRUSTED_VENV="true"
               VENV_REUSED="true"
             else
               VENV_REUSED="false"
             fi
+            echo "FORK_CAN_COPY_TRUSTED_VENV decision: ${FORK_CAN_COPY_TRUSTED_VENV} (path=${TRUSTED_VENV_PATH})"
             mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
             # Copy trusted compile caches into the isolated per-run dir.
@@ -562,18 +593,22 @@ jobs:
             # TileLang cache keys include the library's mtime (kernel_cache.py); a fresh
             # pip install produces a new mtime, causing all rsync'd cache entries to miss.
             # See: https://github.com/tile-ai/TileOPs/issues/594
-            TRUSTED_VENV=$(find "${{ runner.tool_cache }}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -exec test -x '{}/bin/python' \; -print 2>/dev/null | sort -t_ -k5 -r | head -1 || true)
-            if [[ -n "$TRUSTED_VENV" ]]; then
-              TRUSTED_LIB=$(find "$TRUSTED_VENV" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
+            #
+            # Use TRUSTED_VENV_PATH (the hash-matched venv) directly. Picking an
+            # arbitrary venv via `find ... | sort | head -1` can select a stale
+            # venv built against a different pyproject.toml, whose libtilelang.so
+            # mtime does not match any rsync'd cache entry.
+            if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
+              TRUSTED_LIB=$(find "${TRUSTED_VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               FORK_LIB=$(find "${VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               if [[ -n "$TRUSTED_LIB" && -n "$FORK_LIB" ]]; then
                 touch -r "$TRUSTED_LIB" "$FORK_LIB"
-                echo "Synced libtilelang.so mtime for cache key compatibility"
+                echo "Synced libtilelang.so mtime from ${TRUSTED_LIB} to ${FORK_LIB}"
               else
-                echo "Warning: could not locate libtilelang.so for mtime sync"
+                echo "Warning: could not locate libtilelang.so for mtime sync (trusted=${TRUSTED_LIB:-<none>}, fork=${FORK_LIB:-<none>})"
               fi
             else
-              echo "Warning: no trusted venv found for mtime sync"
+              echo "Warning: hash-matched trusted venv ${TRUSTED_VENV_PATH} does not exist; skipping mtime sync"
             fi
           else
             PIP_NO_BUILD_ISOLATION=1 PIP_NO_CACHE_DIR=1 pip install -e '.[dev]'
@@ -637,10 +672,15 @@ jobs:
         run: cat gpu_smoke_report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cache stats
-        if: ${{ always() && needs.security-policy.outputs.is_fork != 'true' }}
+        if: ${{ always() }}
+        env:
+          IS_FORK: ${{ needs.security-policy.outputs.is_fork }}
         run: |
           set -euo pipefail
-          echo "=== Trusted cache stats ==="
+          echo "=== Cache stats (is_fork=${IS_FORK}) ==="
+          echo "VENV_REUSED=${VENV_REUSED:-unknown}"
+          echo "FORK_CAN_COPY_TRUSTED_VENV=${FORK_CAN_COPY_TRUSTED_VENV:-unknown}"
+          echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH:-unknown}"
           for cache_dir in "${TILELANG_CACHE_DIR:-}" "${TRITON_CACHE_DIR:-}" "${WHEEL_DIR:-}"; do
             if [[ -z "${cache_dir}" ]]; then
               continue
@@ -653,6 +693,25 @@ jobs:
               echo "${cache_dir}: does not exist"
             fi
           done
+
+          # Emit a concise cache hit/miss signal so future regressions surface
+          # in CI logs without needing to diff per-run durations manually.
+          # For fork PRs, "hit" means the trusted venv was copied (no cold pip
+          # install); for trusted runs, "hit" means the hash-matched venv was
+          # reused in place.
+          if [[ "${IS_FORK}" == "true" ]]; then
+            if [[ "${FORK_CAN_COPY_TRUSTED_VENV:-false}" == "true" ]]; then
+              echo "CACHE_SIGNAL: fork venv=hit"
+            else
+              echo "CACHE_SIGNAL: fork venv=miss (cold pip install path)"
+            fi
+          else
+            if [[ "${VENV_REUSED:-false}" == "true" ]]; then
+              echo "CACHE_SIGNAL: trusted venv=hit"
+            else
+              echo "CACHE_SIGNAL: trusted venv=miss (fresh venv created)"
+            fi
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -676,7 +676,11 @@ jobs:
         env:
           IS_FORK: ${{ needs.security-policy.outputs.is_fork }}
         run: |
-          set -euo pipefail
+          # Cache stats is informational only. Do NOT use `set -e`: a transient
+          # failure in find/du/wc (e.g. a cache file vanishing mid-scan due to a
+          # concurrent cleanup) must not fail the gpu-smoke job, and must not
+          # skip the CACHE_SIGNAL logging below.
+          set -u
           echo "=== Cache stats (is_fork=${IS_FORK}) ==="
           echo "VENV_REUSED=${VENV_REUSED:-unknown}"
           echo "FORK_CAN_COPY_TRUSTED_VENV=${FORK_CAN_COPY_TRUSTED_VENV:-unknown}"
@@ -686,8 +690,12 @@ jobs:
               continue
             fi
             if [[ -d "${cache_dir}" ]]; then
-              file_count=$(find "${cache_dir}" -type f | wc -l)
-              cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1)
+              # Tolerate errors from find/du/wc; emit "unknown" when a scan
+              # fails rather than aborting the step.
+              file_count=$(find "${cache_dir}" -type f 2>/dev/null | wc -l 2>/dev/null || echo "unknown")
+              cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1 2>/dev/null || echo "unknown")
+              if [[ -z "${file_count}" ]]; then file_count="unknown"; fi
+              if [[ -z "${cache_size}" ]]; then cache_size="unknown"; fi
               echo "${cache_dir}: ${file_count} files, ${cache_size}"
             else
               echo "${cache_dir}: does not exist"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -421,17 +421,25 @@ jobs:
             echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH}"
             if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
               echo "Trusted venv directory exists:"
-              ls -la "${TRUSTED_VENV_PATH}" || true
+              # find + -printf keeps shellcheck SC2012 clean vs `ls -la`.
+              find "${TRUSTED_VENV_PATH}" -maxdepth 1 -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null || true
               if [[ -d "${TRUSTED_VENV_PATH}/bin" ]]; then
-                echo "Trusted venv bin/ contents:"
-                ls -la "${TRUSTED_VENV_PATH}/bin" | head -20 || true
+                echo "Trusted venv bin/ contents (up to 20 entries):"
+                find "${TRUSTED_VENV_PATH}/bin" -maxdepth 1 -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null | head -20 || true
               else
                 echo "Trusted venv bin/ does not exist"
               fi
             else
               echo "Trusted venv directory does not exist"
               echo "Sibling venvs under ${{ runner.tool_cache }}:"
-              ls -la "${{ runner.tool_cache }}" 2>/dev/null | grep -E "tileops_ci_venv" || echo "  (none)"
+              # Use find + -printf (not `ls | grep`) so actionlint+shellcheck
+              # (SC2010/SC2012) stays clean while listing hash-suffixed venvs.
+              sibling_list=$(find "${{ runner.tool_cache }}" -maxdepth 1 -name "tileops_ci_venv_*" -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null || true)
+              if [[ -n "${sibling_list}" ]]; then
+                printf '%s\n' "${sibling_list}"
+              else
+                echo "  (none)"
+              fi
             fi
             python_bin="${TRUSTED_VENV_PATH}/bin/python"
             if [[ -e "${python_bin}" ]]; then

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -699,9 +699,11 @@ jobs:
             fi
             if [[ -d "${cache_dir}" ]]; then
               # Tolerate errors from find/du/wc; emit "unknown" when a scan
-              # fails rather than aborting the step.
-              file_count=$(find "${cache_dir}" -type f 2>/dev/null | wc -l 2>/dev/null || echo "unknown")
-              cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1 2>/dev/null || echo "unknown")
+              # fails rather than aborting the step. Enable pipefail inside
+              # the subshell so a find/du failure upstream of wc/cut
+              # propagates to the || fallback instead of being masked.
+              file_count=$(set -o pipefail; find "${cache_dir}" -type f 2>/dev/null | wc -l 2>/dev/null) || file_count="unknown"
+              cache_size=$(set -o pipefail; du -sh "${cache_dir}" 2>/dev/null | cut -f1 2>/dev/null) || cache_size="unknown"
               if [[ -z "${file_count}" ]]; then file_count="unknown"; fi
               if [[ -z "${cache_size}" ]]; then cache_size="unknown"; fi
               echo "${cache_dir}: ${file_count} files, ${cache_size}"


### PR DESCRIPTION
## Summary

Restore fork PR `gpu-smoke` to <15min by fixing two issues in `.github/workflows/gpu-smoke.yml`:

1. **Fork PRs can copy the trusted venv when it exists** — add diagnostic logging around the `FORK_CAN_COPY_TRUSTED_VENV` decision (path, exists, executable) so cache-miss regressions are visible.
2. **`libtilelang.so` mtime sync targets the hash-matched trusted venv** — replace the arbitrary `find ... | sort | head -1` selection with `TRUSTED_VENV_PATH`, ensuring mtime sync uses the venv whose hash matches the current environment.

Constraints honored:
- Fork PRs never write to persistent shared state (security model intact).
- Trusted (non-fork) CI path is not regressed.

Closes #971

## Test plan

- [x] AC-1: Fork PR gpu-smoke completes in <15min when trusted venv exists and kernel cache is warm — **pass**
- [x] AC-2: `FORK_CAN_COPY_TRUSTED_VENV` decision is logged with diagnostic info (path, exists, executable) — **pass**
- [x] AC-3: `libtilelang.so` mtime sync uses the hash-matched trusted venv, not an arbitrary one — **pass**

Smoke tests: `timeout 900 python -m pytest -q tests -m smoke --tb=short --disable-warnings` → 1342 passed, 11 skipped, 950 deselected, elapsed 162s.