### PR TITLE
[Test][CI] Temporarily skip known failures under TileLang 5f70374c

### DIFF
--- a/tests/ops/attention/test_deepseek_dsa_decode.py
+++ b/tests/ops/attention/test_deepseek_dsa_decode.py
@@ -71,7 +71,7 @@ def test_sparse_mla_decode(batch: int, heads: int, seq_len_q: int, seq_len_kv: i
                            dim_tail: int, topk: int, stride_kv: int, heads_kv: int,
                            q_start_index_s: int, sm_scale: float, dtype: torch.dtype,
                            tune: bool) -> None:
-    pytest.skip("Temporarily skipping known DeepSeek DSA decode failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known DeepSeek DSA decode failure under TileLang 5f70374c (#999).")
     test = DsaDecodeTest(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype)

--- a/tests/ops/attention/test_deepseek_dsa_decode.py
+++ b/tests/ops/attention/test_deepseek_dsa_decode.py
@@ -71,6 +71,7 @@ def test_sparse_mla_decode(batch: int, heads: int, seq_len_q: int, seq_len_kv: i
                            dim_tail: int, topk: int, stride_kv: int, heads_kv: int,
                            q_start_index_s: int, sm_scale: float, dtype: torch.dtype,
                            tune: bool) -> None:
+    pytest.skip("Temporarily skipping known DeepSeek DSA decode failure in ded6 validation.")
     test = DsaDecodeTest(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype)

--- a/tests/ops/attention/test_deepseek_mla_decode.py
+++ b/tests/ops/attention/test_deepseek_mla_decode.py
@@ -65,7 +65,7 @@ class MlaDecodeFixture(FixtureBase):
 @MlaDecodeFixture
 def test_mla_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dim_pe: int, dtype: torch.dtype, tune: bool):
-    pytest.skip("Temporarily skipping known DeepSeek MLA decode failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known DeepSeek MLA decode failure under TileLang 5f70374c (#999).")
     test = MlaDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype)
     op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype, tune=tune)

--- a/tests/ops/attention/test_deepseek_mla_decode.py
+++ b/tests/ops/attention/test_deepseek_mla_decode.py
@@ -65,6 +65,7 @@ class MlaDecodeFixture(FixtureBase):
 @MlaDecodeFixture
 def test_mla_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dim_pe: int, dtype: torch.dtype, tune: bool):
+    pytest.skip("Temporarily skipping known DeepSeek MLA decode failure in ded6 validation.")
     test = MlaDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype)
     op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype, tune=tune)

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -78,6 +78,7 @@ def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, 
 @GroupedQueryAttentionBwdFixture
 def test_gqa_bwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
+    pytest.skip("Temporarily skipping known GQA backward failures in ded6 validation.")
     test = GroupedQueryAttentionBwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -78,7 +78,7 @@ def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, 
 @GroupedQueryAttentionBwdFixture
 def test_gqa_bwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
-    pytest.skip("Temporarily skipping known GQA backward failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known GQA backward failures under TileLang 5f70374c (#999).")
     test = GroupedQueryAttentionBwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -35,7 +35,7 @@ class GroupedQueryAttentionDecodeFixture(FixtureBase):
 @GroupedQueryAttentionDecodeFixture
 def test_gqa_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dtype: torch.dtype, tune: bool) -> None:
-    pytest.skip("Temporarily skipping known GQA decode failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known GQA decode failures under TileLang 5f70374c (#999).")
     test = GroupedQueryAttentionDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dtype)
     op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -35,6 +35,7 @@ class GroupedQueryAttentionDecodeFixture(FixtureBase):
 @GroupedQueryAttentionDecodeFixture
 def test_gqa_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                     dtype: torch.dtype, tune: bool) -> None:
+    pytest.skip("Temporarily skipping known GQA decode failures in ded6 validation.")
     test = GroupedQueryAttentionDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dtype)
     op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -106,6 +106,7 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
 @MhaBwdFixture
 def test_mha_bwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
+    pytest.skip("Temporarily skipping known MHA backward failures in ded6 validation.")
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -106,7 +106,7 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
 @MhaBwdFixture
 def test_mha_bwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
-    pytest.skip("Temporarily skipping known MHA backward failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known MHA backward failures under TileLang 5f70374c (#999).")
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tests/ops/attention/test_mha_decode.py
+++ b/tests/ops/attention/test_mha_decode.py
@@ -34,7 +34,7 @@ class MhaDecodeFixture(FixtureBase):
 def test_mha_decode(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: torch.dtype,
                     tune: bool) -> None:
     if s_kv == 8192:
-        pytest.skip("Temporarily skipping known long-context MHA decode failures in ded6 validation.")
+        pytest.skip("Temporarily skipping known long-context MHA decode failures under TileLang 5f70374c (#999).")
     test = MhaDecodeTest(b, h, s_q, s_kv, d, dtype)
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=2e-3, rtol=1e-5)

--- a/tests/ops/attention/test_mha_decode.py
+++ b/tests/ops/attention/test_mha_decode.py
@@ -33,6 +33,8 @@ class MhaDecodeFixture(FixtureBase):
 @MhaDecodeFixture
 def test_mha_decode(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: torch.dtype,
                     tune: bool) -> None:
+    if s_kv == 8192:
+        pytest.skip("Temporarily skipping known long-context MHA decode failures in ded6 validation.")
     test = MhaDecodeTest(b, h, s_q, s_kv, d, dtype)
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=2e-3, rtol=1e-5)

--- a/tests/ops/attention/test_mha_decode_paged.py
+++ b/tests/ops/attention/test_mha_decode_paged.py
@@ -94,6 +94,7 @@ def test_mha_decode_paged_op(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
+    pytest.skip("Temporarily skipping known paged MHA decode failures in ded6 validation.")
     test = MhaDecodePagedTest(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch=batch,

--- a/tests/ops/attention/test_mha_decode_paged.py
+++ b/tests/ops/attention/test_mha_decode_paged.py
@@ -94,7 +94,7 @@ def test_mha_decode_paged_op(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    pytest.skip("Temporarily skipping known paged MHA decode failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known paged MHA decode failures under TileLang 5f70374c (#999).")
     test = MhaDecodePagedTest(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch=batch,

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -8,7 +8,6 @@ from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.convolution import Conv1dKernel, Conv2d1x1Kernel, Conv2dKernel, Conv3dKernel
 from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
 
-
 SKIPPED_CONV2D_CASES = {
     (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False),
     (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False),

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -9,6 +9,19 @@ from tileops.kernels.convolution import Conv1dKernel, Conv2d1x1Kernel, Conv2dKer
 from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
 
 
+SKIPPED_CONV2D_CASES = {
+    (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False),
+    (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False),
+    (1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), torch.float16, False),
+}
+
+SKIPPED_CONV3D_CASES = {
+    (1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False),
+    (1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False),
+    (1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False),
+}
+
+
 class Conv1dFixture(FixtureBase):
     PARAMS = [
         ("n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune", [
@@ -291,18 +304,8 @@ def test_conv2d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    if (
-        (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
-            2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False
-        )
-        or (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
-            2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False
-        )
-        or (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
-            1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), torch.float16, False
-        )
-    ):
-        pytest.skip("Temporarily skipping known Conv2d failures in ded6 validation.")
+    if (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) in SKIPPED_CONV2D_CASES:
+        pytest.skip("Temporarily skipping known Conv2d failures under TileLang 5f70374c (#999).")
     test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
     op = Conv2dOp(
         n=n,
@@ -323,7 +326,7 @@ def test_conv2d(
 
 @pytest.mark.smoke
 def test_conv2d_accepts_zero_bias() -> None:
-    pytest.skip("Temporarily skipping known Conv2d zero-bias failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known Conv2d zero-bias failure under TileLang 5f70374c (#999).")
     op = Conv2dOp(
         n=1,
         c_in=32,
@@ -504,18 +507,8 @@ def test_conv3d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    if (
-        (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
-            1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False
-        )
-        or (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
-            1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False
-        )
-        or (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
-            1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False
-        )
-    ):
-        pytest.skip("Temporarily skipping known Conv3d failures in ded6 validation.")
+    if (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) in SKIPPED_CONV3D_CASES:
+        pytest.skip("Temporarily skipping known Conv3d failures under TileLang 5f70374c (#999).")
     test = Conv3dTest(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
     op = Conv3dOp(
         n=n,
@@ -537,7 +530,7 @@ def test_conv3d(
 
 @pytest.mark.smoke
 def test_conv3d_accepts_zero_bias() -> None:
-    pytest.skip("Temporarily skipping known Conv3d zero-bias failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known Conv3d zero-bias failure under TileLang 5f70374c (#999).")
     op = Conv3dOp(
         n=1,
         c_in=8,

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -291,6 +291,18 @@ def test_conv2d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
+    if (
+        (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
+            2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False
+        )
+        or (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
+            2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False
+        )
+        or (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) == (
+            1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), torch.float16, False
+        )
+    ):
+        pytest.skip("Temporarily skipping known Conv2d failures in ded6 validation.")
     test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
     op = Conv2dOp(
         n=n,
@@ -311,6 +323,7 @@ def test_conv2d(
 
 @pytest.mark.smoke
 def test_conv2d_accepts_zero_bias() -> None:
+    pytest.skip("Temporarily skipping known Conv2d zero-bias failure in ded6 validation.")
     op = Conv2dOp(
         n=1,
         c_in=32,
@@ -491,6 +504,18 @@ def test_conv3d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
+    if (
+        (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
+            1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False
+        )
+        or (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
+            1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False
+        )
+        or (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) == (
+            1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False
+        )
+    ):
+        pytest.skip("Temporarily skipping known Conv3d failures in ded6 validation.")
     test = Conv3dTest(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
     op = Conv3dOp(
         n=n,
@@ -512,6 +537,7 @@ def test_conv3d(
 
 @pytest.mark.smoke
 def test_conv3d_accepts_zero_bias() -> None:
+    pytest.skip("Temporarily skipping known Conv3d zero-bias failure in ded6 validation.")
     op = Conv3dOp(
         n=1,
         c_in=8,

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -63,7 +63,7 @@ def test_binary_kernel_accepts_fp8(dtype):
 def test_fused_gated_kernel_accepts_fp8(dtype):
     """FusedGatedKernel base class can be instantiated with fp8 dtype."""
     if dtype == torch.float8_e4m3fn:
-        pytest.skip("Temporarily skipping known e4m3fn fused-gated fp8 failure in ded6 validation.")
+        pytest.skip("Temporarily skipping known e4m3fn fused-gated fp8 failure under TileLang 5f70374c (#999).")
     from tileops.kernels.elementwise import SiluAndMulFwdKernel
 
     M, N = 64, 128
@@ -292,7 +292,7 @@ class Fp8SiluAndMulTest(TestBase):
 def test_silu_and_mul_fp8(dtype):
     """SiLU-and-Mul correctness with fp8."""
     if dtype == torch.float8_e4m3fn:
-        pytest.skip("Temporarily skipping known e4m3fn silu_and_mul fp8 failure in ded6 validation.")
+        pytest.skip("Temporarily skipping known e4m3fn silu_and_mul fp8 failure under TileLang 5f70374c (#999).")
     from tileops.ops.elementwise import SiluAndMulFwdOp
 
     M, N = 64, 128
@@ -426,7 +426,7 @@ def test_e5m2_log_zero_produces_neg_inf():
 @pytest.mark.smoke
 def test_e4m3fn_exp_overflow_saturates():
     """e4m3fn exp(large) should saturate to 448.0, not produce Inf."""
-    pytest.skip("Temporarily skipping known e4m3fn exp overflow failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known e4m3fn exp overflow failure under TileLang 5f70374c (#999).")
     from tileops.ops.elementwise import ExpFwdOp
 
     n = 1024
@@ -455,7 +455,7 @@ def test_fp8_accumulation_in_higher_precision():
     SiLU involves sigmoid which requires higher precision. The result
     should match fp16 computation cast back to fp8, not direct fp8 arithmetic.
     """
-    pytest.skip("Temporarily skipping known fp8 accumulation failure in ded6 validation.")
+    pytest.skip("Temporarily skipping known fp8 accumulation failure under TileLang 5f70374c (#999).")
     from tileops.ops.elementwise import SiluFwdOp
 
     n = _N

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -62,6 +62,8 @@ def test_binary_kernel_accepts_fp8(dtype):
 @Fp8DtypeAcceptanceFixture
 def test_fused_gated_kernel_accepts_fp8(dtype):
     """FusedGatedKernel base class can be instantiated with fp8 dtype."""
+    if dtype == torch.float8_e4m3fn:
+        pytest.skip("Temporarily skipping known e4m3fn fused-gated fp8 failure in ded6 validation.")
     from tileops.kernels.elementwise import SiluAndMulFwdKernel
 
     M, N = 64, 128
@@ -289,6 +291,8 @@ class Fp8SiluAndMulTest(TestBase):
 @Fp8FusedGatedFixture
 def test_silu_and_mul_fp8(dtype):
     """SiLU-and-Mul correctness with fp8."""
+    if dtype == torch.float8_e4m3fn:
+        pytest.skip("Temporarily skipping known e4m3fn silu_and_mul fp8 failure in ded6 validation.")
     from tileops.ops.elementwise import SiluAndMulFwdOp
 
     M, N = 64, 128
@@ -422,6 +426,7 @@ def test_e5m2_log_zero_produces_neg_inf():
 @pytest.mark.smoke
 def test_e4m3fn_exp_overflow_saturates():
     """e4m3fn exp(large) should saturate to 448.0, not produce Inf."""
+    pytest.skip("Temporarily skipping known e4m3fn exp overflow failure in ded6 validation.")
     from tileops.ops.elementwise import ExpFwdOp
 
     n = 1024
@@ -450,6 +455,7 @@ def test_fp8_accumulation_in_higher_precision():
     SiLU involves sigmoid which requires higher precision. The result
     should match fp16 computation cast back to fp8, not direct fp8 arithmetic.
     """
+    pytest.skip("Temporarily skipping known fp8 accumulation failure in ded6 validation.")
     from tileops.ops.elementwise import SiluFwdOp
 
     n = _N

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -63,6 +63,8 @@ class Ac1Fixture(FixtureBase):
 @Ac1Fixture
 def test_kernel_accepts_fp8(dtype, kernel_name, extra_kwargs):
     """All independent kernels can be instantiated with fp8 dtype."""
+    if dtype == torch.float8_e4m3fn and kernel_name in {"HardtanhFwdKernel", "ClampFwdKernel"}:
+        pytest.skip("Temporarily skipping known independent fp8 kernel acceptance failures in ded6 validation.")
     cls = getattr(_kern_mod, kernel_name)
     kernel = cls(dtype=dtype, **extra_kwargs)
     assert kernel.dtype == dtype
@@ -107,6 +109,8 @@ class Ac2Fixture(FixtureBase):
 @Ac2Fixture
 def test_fp8_default_config_npt16(dtype, kernel_name, extra_kwargs):
     """fp8 default_config returns num_per_thread=16."""
+    if dtype == torch.float8_e4m3fn and kernel_name == "ClampFwdKernel":
+        pytest.skip("Temporarily skipping known independent fp8 config failure in ded6 validation.")
     cls = getattr(_kern_mod, kernel_name)
     kernel = cls(dtype=dtype, **extra_kwargs)
     assert kernel.config["num_per_thread"] == 16
@@ -159,6 +163,8 @@ def test_elu_fp8_correctness(dtype):
 @Fp8DtypeFixture
 def test_clamp_fp8_correctness(dtype):
     """Clamp correctness with fp8 input/output."""
+    if dtype == torch.float8_e4m3fn:
+        pytest.skip("Temporarily skipping known e4m3fn clamp fp8 failure in ded6 validation.")
     from tileops.ops.elementwise import ClampFwdOp
 
     n = _N

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -64,7 +64,7 @@ class Ac1Fixture(FixtureBase):
 def test_kernel_accepts_fp8(dtype, kernel_name, extra_kwargs):
     """All independent kernels can be instantiated with fp8 dtype."""
     if dtype == torch.float8_e4m3fn and kernel_name in {"HardtanhFwdKernel", "ClampFwdKernel"}:
-        pytest.skip("Temporarily skipping known independent fp8 kernel acceptance failures in ded6 validation.")
+        pytest.skip("Temporarily skipping known independent fp8 kernel acceptance failures under TileLang 5f70374c (#999).")
     cls = getattr(_kern_mod, kernel_name)
     kernel = cls(dtype=dtype, **extra_kwargs)
     assert kernel.dtype == dtype
@@ -110,7 +110,7 @@ class Ac2Fixture(FixtureBase):
 def test_fp8_default_config_npt16(dtype, kernel_name, extra_kwargs):
     """fp8 default_config returns num_per_thread=16."""
     if dtype == torch.float8_e4m3fn and kernel_name == "ClampFwdKernel":
-        pytest.skip("Temporarily skipping known independent fp8 config failure in ded6 validation.")
+        pytest.skip("Temporarily skipping known independent fp8 config failure under TileLang 5f70374c (#999).")
     cls = getattr(_kern_mod, kernel_name)
     kernel = cls(dtype=dtype, **extra_kwargs)
     assert kernel.config["num_per_thread"] == 16
@@ -164,7 +164,7 @@ def test_elu_fp8_correctness(dtype):
 def test_clamp_fp8_correctness(dtype):
     """Clamp correctness with fp8 input/output."""
     if dtype == torch.float8_e4m3fn:
-        pytest.skip("Temporarily skipping known e4m3fn clamp fp8 failure in ded6 validation.")
+        pytest.skip("Temporarily skipping known e4m3fn clamp fp8 failure under TileLang 5f70374c (#999).")
     from tileops.ops.elementwise import ClampFwdOp
 
     n = _N

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -79,12 +79,64 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
     PARAMS = [
         ("batch, heads, dim_k, dim_v, dtype, tune", [
             pytest.param(1, 4, 64, 64, torch.float32, False, marks=pytest.mark.smoke),
-            pytest.param(1, 4, 64, 64, torch.float16, False, marks=pytest.mark.smoke),
-            pytest.param(1, 4, 64, 64, torch.bfloat16, False, marks=pytest.mark.smoke),
+            pytest.param(
+                1,
+                4,
+                64,
+                64,
+                torch.float16,
+                False,
+                marks=[
+                    pytest.mark.smoke,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                    ),
+                ],
+            ),
+            pytest.param(
+                1,
+                4,
+                64,
+                64,
+                torch.bfloat16,
+                False,
+                marks=[
+                    pytest.mark.smoke,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                    ),
+                ],
+            ),
             pytest.param(2, 8, 64, 64, torch.float32, False, marks=pytest.mark.full),
             pytest.param(2, 4, 128, 128, torch.float32, False, marks=pytest.mark.full),
-            pytest.param(2, 8, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(2, 8, 64, 64, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(
+                2,
+                8,
+                64,
+                64,
+                torch.float16,
+                False,
+                marks=[
+                    pytest.mark.full,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                    ),
+                ],
+            ),
+            pytest.param(
+                2,
+                8,
+                64,
+                64,
+                torch.bfloat16,
+                False,
+                marks=[
+                    pytest.mark.full,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                    ),
+                ],
+            ),
         ]),
     ]
 

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -89,7 +89,7 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.smoke,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -103,7 +103,7 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.smoke,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -119,7 +119,7 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.full,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -133,7 +133,7 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.full,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures."
+                        reason="Temporarily skipped while isolating low-precision gated deltanet decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -83,7 +83,7 @@ class GLADecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.smoke,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -97,7 +97,7 @@ class GLADecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.smoke,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -113,7 +113,7 @@ class GLADecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.full,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -127,7 +127,7 @@ class GLADecodeFixture(FixtureBase):
                 marks=[
                     pytest.mark.full,
                     pytest.mark.skip(
-                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures under TileLang 5f70374c (#999)."
                     ),
                 ],
             ),
@@ -144,8 +144,10 @@ def test_gla_decode(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    if dtype == torch.float32:
-        pytest.skip("Temporarily skipping known fp32 GLA decode NaN failures in ded6 validation.")
+    pytest.skip(
+        "Temporarily skipping GLA decode correctness coverage under TileLang 5f70374c (#999): "
+        "fp32 currently returns NaNs and fp16/bf16 are tracked separately as low-precision launch failures."
+    )
     torch.manual_seed(42)
     test = GLADecodeTest(batch, heads, dim_k, dim_v, dtype)
     op = GLADecodeOp(batch, heads, dim_k, dim_v, dtype=dtype, tune=tune)
@@ -163,8 +165,10 @@ def test_gla_decode_multi_step(
     tune: bool,
 ) -> None:
     """Test multiple sequential decode steps to verify state propagation."""
-    if dtype == torch.float32:
-        pytest.skip("Temporarily skipping known fp32 GLA multi-step NaN failures in ded6 validation.")
+    pytest.skip(
+        "Temporarily skipping GLA multi-step decode coverage under TileLang 5f70374c (#999): "
+        "fp32 currently returns NaNs and fp16/bf16 are tracked separately as low-precision launch failures."
+    )
     torch.manual_seed(42)
     num_steps = 8
     B, H, DK, DV = batch, heads, dim_k, dim_v

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -73,12 +73,64 @@ class GLADecodeFixture(FixtureBase):
     PARAMS = [
         ("batch, heads, dim_k, dim_v, dtype, tune", [
             pytest.param(1, 4, 64, 64, torch.float32, False, marks=pytest.mark.smoke),
-            pytest.param(1, 4, 64, 64, torch.float16, False, marks=pytest.mark.smoke),
-            pytest.param(1, 4, 64, 64, torch.bfloat16, False, marks=pytest.mark.smoke),
+            pytest.param(
+                1,
+                4,
+                64,
+                64,
+                torch.float16,
+                False,
+                marks=[
+                    pytest.mark.smoke,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                    ),
+                ],
+            ),
+            pytest.param(
+                1,
+                4,
+                64,
+                64,
+                torch.bfloat16,
+                False,
+                marks=[
+                    pytest.mark.smoke,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                    ),
+                ],
+            ),
             pytest.param(2, 8, 64, 64, torch.float32, False, marks=pytest.mark.full),
             pytest.param(2, 4, 128, 128, torch.float32, False, marks=pytest.mark.full),
-            pytest.param(2, 8, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(2, 8, 64, 64, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(
+                2,
+                8,
+                64,
+                64,
+                torch.float16,
+                False,
+                marks=[
+                    pytest.mark.full,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                    ),
+                ],
+            ),
+            pytest.param(
+                2,
+                8,
+                64,
+                64,
+                torch.bfloat16,
+                False,
+                marks=[
+                    pytest.mark.full,
+                    pytest.mark.skip(
+                        reason="Temporarily skipped while isolating low-precision GLA decode failures."
+                    ),
+                ],
+            ),
         ]),
     ]
 
@@ -92,6 +144,8 @@ def test_gla_decode(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
+    if dtype == torch.float32:
+        pytest.skip("Temporarily skipping known fp32 GLA decode NaN failures in ded6 validation.")
     torch.manual_seed(42)
     test = GLADecodeTest(batch, heads, dim_k, dim_v, dtype)
     op = GLADecodeOp(batch, heads, dim_k, dim_v, dtype=dtype, tune=tune)
@@ -109,6 +163,8 @@ def test_gla_decode_multi_step(
     tune: bool,
 ) -> None:
     """Test multiple sequential decode steps to verify state propagation."""
+    if dtype == torch.float32:
+        pytest.skip("Temporarily skipping known fp32 GLA multi-step NaN failures in ded6 validation.")
     torch.manual_seed(42)
     num_steps = 8
     B, H, DK, DV = batch, heads, dim_k, dim_v

--- a/tests/ops/test_mhc_pre.py
+++ b/tests/ops/test_mhc_pre.py
@@ -85,7 +85,7 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
 @MHCPreFixture
 def test_mhc_pre_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
                     tune: bool) -> None:
-    pytest.skip("Temporarily skipping known MHC pre failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known MHC pre failures under TileLang 5f70374c (#999).")
     test = MHCPreTest(batch, n_expand, c_x, dtype)
     op = MHCPreOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)

--- a/tests/ops/test_mhc_pre.py
+++ b/tests/ops/test_mhc_pre.py
@@ -85,6 +85,7 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
 @MHCPreFixture
 def test_mhc_pre_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
                     tune: bool) -> None:
+    pytest.skip("Temporarily skipping known MHC pre failures in ded6 validation.")
     test = MHCPreTest(batch, n_expand, c_x, dtype)
     op = MHCPreOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -373,7 +373,7 @@ def test_rope_non_neox_2d(batch: int, seq_len: int, num_heads: int,
                           head_dim: int, dtype: torch.dtype) -> None:
     from tileops.ops.rope import RopeNonNeoxOp
 
-    pytest.skip("Temporarily skipping known non-neox 2D RoPE failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known non-neox 2D RoPE failures under TileLang 5f70374c (#999).")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)
@@ -522,7 +522,7 @@ def test_rope_non_neox_edge(batch: int, seq_len: int, num_heads: int,
     """Edge cases: seq_len=1 and longer sequences."""
     from tileops.ops.rope import RopeNonNeoxOp
 
-    pytest.skip("Temporarily skipping known non-neox edge RoPE failures in ded6 validation.")
+    pytest.skip("Temporarily skipping known non-neox edge RoPE failures under TileLang 5f70374c (#999).")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -373,6 +373,7 @@ def test_rope_non_neox_2d(batch: int, seq_len: int, num_heads: int,
                           head_dim: int, dtype: torch.dtype) -> None:
     from tileops.ops.rope import RopeNonNeoxOp
 
+    pytest.skip("Temporarily skipping known non-neox 2D RoPE failures in ded6 validation.")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)
@@ -521,6 +522,7 @@ def test_rope_non_neox_edge(batch: int, seq_len: int, num_heads: int,
     """Edge cases: seq_len=1 and longer sequences."""
     from tileops.ops.rope import RopeNonNeoxOp
 
+    pytest.skip("Temporarily skipping known non-neox edge RoPE failures in ded6 validation.")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)


### PR DESCRIPTION
## Summary
- temporarily skip the currently known failing buckets under the validated TileLang `5f70374c48bb1d52e9260e995bf7adbcd64341e5` environment
- keep this PR narrowly focused on test scope reduction only
- leave published dependency / README updates to follow-up issue #1000

## Why
After validating the TileLang `5f70374c48bb1d52e9260e995bf7adbcd64341e5` environment tracked in #999, the remaining full-suite failures are no longer generic runtime instability. They have been isolated into a bounded set of known failing buckets.

This PR keeps CI / validation usable in the short term by temporarily marking those buckets, while the underlying kernels/operators are fixed separately.

Detailed error-cascade isolation remains documented in #980.

## Included temporary skips
- gated deltanet low-precision decode failures
- GLA decode and multi-step correctness coverage, where fp32 currently returns NaNs and fp16/bf16 remain tracked as low-precision launch failures
- attention decode / backward failure buckets still failing under TileLang `5f70374c`
- selected convolution / fp8 / rope / mhc_pre failures

## Validation
Command:
```bash
CUDA_VISIBLE_DEVICES=0 \
TILELANG_CLEANUP_TEMP_FILES=1 \
TMPDIR=/home/ga/tltmp \
/home/ga/TileOPs-upstream-cu128-t210/.venv-cu128-t210-ded6/bin/python -m pytest -q tests
```

Result:
```text
2180 passed, 89 skipped, 16 warnings in 162.99s
```

## Follow-ups
- #980 error cascade / CUDA poisoning investigation record
- #999 validated TileLang `5f70374c` env bring-up tracking
- #1000 published TileLang dependency and README follow-up
