### PR TITLE
[Feat][TOOLING] validator parity for _infer_output_shapes and _validate_dtypes

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -210,15 +210,16 @@ The validator enforces `assert cls.__name__ == manifest_key` — the manifest ke
 
 ## Entry Structure
 
-| Field       | Required | Description                                                   |
-| ----------- | -------- | ------------------------------------------------------------- |
-| `family`    | yes      | Op family. See [below](#family).                              |
-| `ref_api`   | yes      | External API reference, or `"none"` if no direct counterpart. |
-| `status`    | yes      | `spec-only` or `implemented`.                                 |
-| `signature` | yes      | Op interface. See [Signature](#signature).                    |
-| `workloads` | yes      | Benchmark shapes/dtypes.                                      |
-| `roofline`  | yes      | Performance model.                                            |
-| `source`    | yes      | Implementation paths.                                         |
+| Field            | Required | Description                                                                                                                                                                                                                                                   |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `family`         | yes      | Op family. See [below](#family).                                                                                                                                                                                                                              |
+| `ref_api`        | yes      | External API reference, or `"none"` if no direct counterpart.                                                                                                                                                                                                 |
+| `status`         | yes      | `spec-only` or `implemented`.                                                                                                                                                                                                                                 |
+| `signature`      | yes      | Op interface. See [Signature](#signature).                                                                                                                                                                                                                    |
+| `workloads`      | yes      | Benchmark shapes/dtypes.                                                                                                                                                                                                                                      |
+| `roofline`       | yes      | Performance model.                                                                                                                                                                                                                                            |
+| `source`         | yes      | Implementation paths.                                                                                                                                                                                                                                         |
+| `parity_opt_out` | no       | Suppress validator shape/dtype parity warnings for ops whose method genuinely needs GPU execution. Values: `true` (both), or list subset of `[shape_parity, dtype_parity]`. See [ops-design-reference.md § Consistency Enforcement](ops-design-reference.md). |
 
 ### `family`
 

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -90,6 +90,8 @@ Agent reads the manifest and generates code (codegen). [Validator](../scripts/va
 
 Checks beyond this table are tracked as separate issues, not as spec status.
 
+**Parity check coverage.** Both parity checks compare the manifest spec against a concrete method that the op class must define. When the class has not yet been migrated to the codegen protocol (i.e. it does not define `_infer_output_shapes` / `_validate_dtypes`), the validator emits a **warning** naming the missing method — the check is live (the gap is surfaced, never silently passed) but non-fatal while the codegen rollout is in progress. A manifest entry may declare `parity_opt_out: [shape_parity, dtype_parity]` (or `parity_opt_out: true` for both) to suppress this warning for documented GPU-only ops whose method cannot be invoked in a CPU-only validator context. When the class does define the method, the parity check runs and any disagreement is reported as an L2 / L3 error.
+
 ## Naming Conventions
 
 #### Op Classes

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -77,14 +77,16 @@ Agent reads the manifest and generates code (codegen). [Validator](../scripts/va
 
 ### Consistency Enforcement
 
-| Check                                               | Mechanism                          |
-| --------------------------------------------------- | ---------------------------------- |
-| Manifest schema and declared fields are well-formed | Validator (CI), L0 checks          |
-| `__init__` params match manifest `params`           | Validator signature check (L1)     |
-| `static_dims` keys are `__init__` parameters        | Validator signature check (L1)     |
-| `shape_rules` syntax is valid                       | Validator shape_rules parsing (L2) |
-| `dtype`/`dtype_combos` strings are valid            | Validator dtype conformance (L3)   |
-| Empty `static_dims` without `_cache_key` override   | Op base class runtime warning      |
+| Check                                                    | Mechanism                          |
+| -------------------------------------------------------- | ---------------------------------- |
+| Manifest schema and declared fields are well-formed      | Validator (CI), L0 checks          |
+| `__init__` params match manifest `params`                | Validator signature check (L1)     |
+| `static_dims` keys are `__init__` parameters             | Validator signature check (L1)     |
+| `shape_rules` syntax is valid                            | Validator shape_rules parsing (L2) |
+| `_infer_output_shapes` output satisfies `shape_rules`    | Validator infer-shape parity (L2)  |
+| `dtype`/`dtype_combos` strings are valid                 | Validator dtype conformance (L3)   |
+| `_validate_dtypes` matches `dtype_combos` / dtype unions | Validator dtype parity (L3)        |
+| Empty `static_dims` without `_cache_key` override        | Op base class runtime warning      |
 
 Checks beyond this table are tracked as separate issues, not as spec status.
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -991,8 +991,9 @@ def _mock_input_shapes(
             if parts is not None and all(
                 re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts
             ):
-                shapes[name] = _MockShape(dim_sizes.get(p, _MOCK_DIM_SIZE)
-                                           for p in parts)
+                shapes[name] = _MockShape(
+                    dim_sizes.get(p, _MOCK_DIM_SIZE) for p in parts
+                )
                 continue
         # Fallback: 2D shape
         shapes[name] = _MockShape(

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -827,6 +827,13 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
         errors.extend(
             _check_dtype_combos_same_as_identity(op_name, dtype_combos, same_as_map)
         )
+        # Hard data-validation for combo values: every combo entry must
+        # resolve to a concrete torch dtype (or a ``same_as(ref)`` whose
+        # ref resolves to concrete torch dtypes). Runs unconditionally —
+        # independent of whether the op overrides ``_validate_dtypes`` —
+        # so an un-migrated op carrying invalid combo data still surfaces
+        # a hard L3 error rather than only a missing-override warning.
+        errors.extend(check_l3_dtype_combos_data(op_name, sig))
 
     # Validate workload dtypes
     workloads = entry.get("workloads", [])
@@ -853,6 +860,53 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
                     if err:
                         errors.append(err)
 
+    return errors
+
+
+def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
+    """Validate ``dtype_combos`` entries resolve to concrete torch dtypes.
+
+    Manifest-data check, independent of any op class / ``_validate_dtypes``
+    implementation. Every combo value must be either:
+      * a concrete dtype name in ``_TORCH_DTYPES``; or
+      * a ``same_as(ref)`` expression whose ref resolves transitively to
+        concrete dtype names.
+
+    Anything else (e.g. ``"not_a_real_dtype"``, ``same_as(unknown)``) is a
+    hard L3 error — callers must not silently proceed with invalid combo
+    data.
+    """
+    errors: list[str] = []
+    dtype_combos = sig.get("dtype_combos")
+    if not isinstance(dtype_combos, list) or not dtype_combos:
+        return errors
+    dtype_options = _resolve_tensor_dtype_options(sig)
+    if dtype_options is None:
+        # Tensor-level dtype errors already reported in ``check_l3``.
+        return errors
+    for i, combo in enumerate(dtype_combos):
+        if not isinstance(combo, dict):
+            continue
+        for key, val in combo.items():
+            if not isinstance(val, str):
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                    f"{val!r} is not a string"
+                )
+                continue
+            opts = _dtype_options_for_tensor(key, val, dtype_options)
+            if opts is None:
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                    f"{val!r} is not a valid dtype (unresolved "
+                    f"same_as reference or not in torch dtype set)"
+                )
+            elif not all(t in _TORCH_DTYPES for t in opts):
+                bad = [t for t in opts if t not in _TORCH_DTYPES]
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                    f"{val!r} resolves to unknown dtype(s) {bad!r}"
+                )
     return errors
 
 
@@ -1715,10 +1769,15 @@ def _resolve_tensor_dtype_options(
 ) -> dict[str, list[str]] | None:
     """Return dtype options for every declared tensor (inputs + outputs).
 
-    Resolves ``same_as`` references in declaration order; returns None if
-    any tensor's expression cannot be resolved.
+    Resolves ``same_as`` references to a fixpoint: declaration order is
+    irrelevant, so ``x: same_as(y)`` declared before ``y: float16`` still
+    resolves. Returns None only if some tensor's expression is genuinely
+    unresolvable (unknown token, dangling ``same_as`` reference, or a
+    ``same_as`` cycle).
     """
-    resolved: dict[str, list[str]] = {}
+    # Collect every tensor's raw dtype string first, so iteration order
+    # cannot affect the result.
+    pending: dict[str, str] = {}
     for group in ("inputs", "outputs"):
         tensors = sig.get(group) or {}
         if not isinstance(tensors, dict):
@@ -1726,13 +1785,29 @@ def _resolve_tensor_dtype_options(
         for tname, attrs in tensors.items():
             if not isinstance(attrs, dict):
                 return None
-            opts = _dtype_options_for_tensor(
-                tname, attrs.get("dtype", ""), resolved,
-            )
+            pending[tname] = attrs.get("dtype", "")
+
+    resolved: dict[str, list[str]] = {}
+    # Iterate to fixpoint: each pass resolves every tensor whose
+    # dependencies are already known. Bound the loop by len(pending) + 1
+    # — any longer progression implies a cycle (no new resolutions).
+    for _ in range(len(pending) + 1):
+        made_progress = False
+        for tname, dtype_str in list(pending.items()):
+            opts = _dtype_options_for_tensor(tname, dtype_str, resolved)
             if opts is None:
-                return None
+                continue
             resolved[tname] = opts
-    return resolved
+            del pending[tname]
+            made_progress = True
+        if not pending:
+            return resolved
+        if not made_progress:
+            # Remaining tensors reference something unresolvable (unknown
+            # dtype name, dangling ref, or a same_as cycle). Propagate
+            # failure per docstring contract.
+            return None
+    return resolved if not pending else None
 
 
 def _primary_dtype_input(
@@ -1925,45 +2000,42 @@ def check_l3_validate_dtypes_parity(
 
     dtype_combos = sig.get("dtype_combos")
     if isinstance(dtype_combos, list) and dtype_combos:
-        # Upfront validation of dtype_combos values: every entry must be
-        # a concrete torch dtype (in ``_TORCH_DTYPES``) or a resolvable
-        # ``same_as(ref)`` expression that itself resolves to concrete
-        # torch dtypes. Invalid values are manifest data errors — surface
-        # as hard L3 errors rather than letting them fall through to a
-        # parity-skip warning (which would silently disable the check).
-        # The ``cannot build mock tensor`` warning path is reserved for
-        # valid dtype names that the local torch build cannot materialize
-        # (a validator-environment limitation, not a manifest defect).
-        combo_validation_errors: list[str] = []
-        for i, combo in enumerate(dtype_combos):
-            if not isinstance(combo, dict):
-                continue
-            for key, val in combo.items():
-                if not isinstance(val, str):
-                    combo_validation_errors.append(
-                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                        f"{val!r} is not a string"
-                    )
-                    continue
-                opts = _dtype_options_for_tensor(key, val, dtype_options)
-                if opts is None:
-                    combo_validation_errors.append(
-                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                        f"{val!r} is not a valid dtype (unresolved "
-                        f"same_as reference or not in torch dtype set)"
-                    )
-                elif not all(t in _TORCH_DTYPES for t in opts):
-                    bad = [t for t in opts if t not in _TORCH_DTYPES]
-                    combo_validation_errors.append(
-                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                        f"{val!r} resolves to unknown dtype(s) {bad!r}"
-                    )
+        # Combo-data validity: surface invalid entries as hard L3 errors
+        # so downstream parity probing does not run on junk data (which
+        # would otherwise produce a cascade of misleading "rejects" /
+        # "skipped" diagnostics). The same check also runs
+        # unconditionally in ``check_l3`` — the driver dedupes error
+        # strings so users see each message once even when both entry
+        # points are invoked in the same run.
+        combo_validation_errors = check_l3_dtype_combos_data(op_name, sig)
         if combo_validation_errors:
-            # Surface the data errors and stop before any parity probing:
-            # invalid combo entries would otherwise generate a cascade
-            # of misleading "rejects" / "skipped" diagnostics.
             errors.extend(combo_validation_errors)
             return errors
+
+        # Expand ``same_as(ref)`` in combo values to a concrete dtype
+        # before parity probing: ``_combo_accepted`` / ``_make_mock_tensor``
+        # expect literal torch dtype names and would otherwise try to look
+        # up ``same_as(x)`` as a torch attribute. Per R3 + R4 we already
+        # enforce identity (``_check_dtype_combos_same_as_identity``), so
+        # each ``same_as(ref)`` value resolves to the same concrete dtype
+        # the ref carries in the same combo row.
+        expanded_combos: list[dict[str, str]] = []
+        for combo in dtype_combos:
+            if not isinstance(combo, dict):
+                expanded_combos.append({})
+                continue
+            expanded: dict[str, str] = {}
+            for key, val in combo.items():
+                if isinstance(val, str):
+                    m = _SAME_AS_RE.match(val.strip())
+                    if m:
+                        ref = m.group(1)
+                        ref_val = combo.get(ref)
+                        expanded[key] = ref_val if isinstance(ref_val, str) else val
+                        continue
+                expanded[key] = val
+            expanded_combos.append(expanded)
+        dtype_combos = expanded_combos
 
         # Each listed combo should be accepted.
         for i, combo in enumerate(dtype_combos):
@@ -2627,7 +2699,21 @@ def validate_manifest(
                 else:
                     all_warnings.extend(bench_errors)
 
-    return all_errors, all_warnings
+    # Deduplicate aggregate error/warning strings while preserving order.
+    # ``check_l3`` and ``check_l3_validate_dtypes_parity`` both surface
+    # ``dtype_combos`` data errors (each is a valid standalone entry
+    # point); deduping at the driver keeps user-visible reports crisp.
+    def _dedup(items: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in items:
+            if item in seen:
+                continue
+            seen.add(item)
+            out.append(item)
+        return out
+
+    return _dedup(all_errors), _dedup(all_warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -875,6 +875,18 @@ _MOCK_DIM_SIZE = 4
 # sampling, so validation output stays reproducible.
 _MAX_DTYPE_COMBOS = 4096
 
+# Sentinel pool used to probe out-of-union dtype rejection in the
+# no-dtype_combos branch of ``check_l3_validate_dtypes_parity``. Chosen to
+# be common, cheap-to-allocate torch dtypes that are unlikely to appear
+# in every manifest declared union simultaneously — giving the probe at
+# least one out-of-union candidate per input on realistic specs. Probes
+# are bounded by ``_MAX_DTYPE_COMBOS`` so wide unions still stay within
+# CI budget.
+_DTYPE_SENTINELS: tuple[str, ...] = (
+    "float16", "bfloat16", "float32", "float64",
+    "int8", "int16", "int32", "int64",
+)
+
 
 class _MockShape(tuple):
     """Tuple subclass representing a tensor shape, exposed via ``.shape``.
@@ -1628,7 +1640,126 @@ def check_l3_validate_dtypes_parity(
                     f"[dtype] {op_name}: _validate_dtypes rejects valid "
                     f"combo {candidate!r} drawn from manifest dtype unions"
                 )
+
+        # --- Out-of-union negative probe (AC-3 rejection side) ---------
+        # For each input, substitute one dtype outside its declared union
+        # and assert _validate_dtypes rejects it. Candidates are built on
+        # a same_as-honouring baseline so the only deviation is the
+        # out-of-union dtype. Bounded by _MAX_DTYPE_COMBOS.
+        baseline: dict[str, str] | None = None
+        for tup in itertools.product(*input_options):
+            cand = dict(zip(forward_inputs, tup, strict=True))
+            if _honours_same_as(sig, cand):
+                baseline = cand
+                break
+        if baseline is not None:
+            same_as_refs = _same_as_refs(sig)
+            probe_budget = _MAX_DTYPE_COMBOS
+            probed = 0
+            for target in forward_inputs:
+                # Don't directly mutate tensors that are bound by
+                # same_as(ref) — their dtype is controlled by ``ref``.
+                # Instead mutate the ref (or a free tensor) and let
+                # same_as propagation carry the out-of-union dtype.
+                if target in same_as_refs:
+                    continue
+                declared = set(dtype_options.get(target, []))
+                out_of_union = [
+                    d for d in _DTYPE_SENTINELS if d not in declared
+                ]
+                for bad_dtype in out_of_union:
+                    if probed >= probe_budget:
+                        break
+                    probed += 1
+                    candidate = dict(baseline)
+                    candidate[target] = bad_dtype
+                    # Propagate to all same_as(target) tensors so the
+                    # only manifest violation is the out-of-union dtype.
+                    for tname, ref in same_as_refs.items():
+                        if ref == target and tname in candidate:
+                            candidate[tname] = bad_dtype
+                    accepted, reason = _combo_accepted(
+                        cls, forward_inputs, candidate, param_defaults,
+                    )
+                    if reason and reason.startswith(
+                        ("unexpected", "TypeError")
+                    ):
+                        continue
+                    if accepted:
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes "
+                            f"accepts out-of-union dtype "
+                            f"{candidate!r} (input {target!r} declared "
+                            f"{sorted(declared)})"
+                        )
+                if probed >= probe_budget:
+                    break
+
+        # --- same_as identity negative probe (R3 rejection side) -------
+        # For each same_as(ref) input, build a candidate where that
+        # tensor's dtype differs from its ref and assert rejection.
+        # Complements (does not replace) the ``_honours_same_as`` skip
+        # in the union-iteration loop above.
+        if baseline is not None:
+            same_as_refs = _same_as_refs(sig)
+            probed_same_as = 0
+            for tname, ref in same_as_refs.items():
+                if probed_same_as >= _MAX_DTYPE_COMBOS:
+                    break
+                if tname not in baseline or ref not in baseline:
+                    continue
+                ref_dtype = baseline[ref]
+                # Pick any dtype different from the ref. Prefer values in
+                # the tensor's own declared options (so a pure same_as
+                # check is the only violation); fall back to sentinels.
+                own_opts = dtype_options.get(tname, [])
+                alt_dtypes = [d for d in own_opts if d != ref_dtype]
+                if not alt_dtypes:
+                    alt_dtypes = [
+                        d for d in _DTYPE_SENTINELS if d != ref_dtype
+                    ]
+                for alt in alt_dtypes[:1]:  # one probe per same_as edge
+                    probed_same_as += 1
+                    candidate = dict(baseline)
+                    candidate[tname] = alt
+                    accepted, reason = _combo_accepted(
+                        cls, forward_inputs, candidate, param_defaults,
+                    )
+                    if reason and reason.startswith(
+                        ("unexpected", "TypeError")
+                    ):
+                        continue
+                    if accepted:
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes "
+                            f"accepts same_as violation {candidate!r} "
+                            f"(input {tname!r} declared same_as({ref}))"
+                        )
     return errors
+
+
+def _same_as_refs(sig: dict) -> dict[str, str]:
+    """Return ``{tensor: ref}`` for every pure ``same_as(ref)`` input.
+
+    Used by the negative-probe pass in
+    :func:`check_l3_validate_dtypes_parity` to identify edges that must
+    be exercised against a mismatched dtype and to propagate out-of-union
+    substitutions to dependent tensors.
+    """
+    refs: dict[str, str] = {}
+    inputs = sig.get("inputs") or {}
+    if not isinstance(inputs, dict):
+        return refs
+    for tname, attrs in inputs.items():
+        if not isinstance(attrs, dict):
+            continue
+        dstr = attrs.get("dtype", "")
+        tokens = _parse_dtype_expr(dstr)
+        if len(tokens) == 1:
+            m = _SAME_AS_RE.match(tokens[0])
+            if m:
+                refs[tname] = m.group(1)
+    return refs
 
 
 def _honours_same_as(sig: dict, candidate: dict[str, str]) -> bool:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1032,10 +1032,22 @@ def _eval_shape_rule(
     ``all``, ``any``, ``range``, ``set``, ``abs``, ``min``, ``max``) so
     R11 / R11a-style rules that use these helpers can be evaluated
     against the mock context instead of being silently skipped.
+
+    The context names (inputs / outputs / params) are injected into both
+    eval globals and locals. Comprehensions (generator / set / list /
+    dict) create their own enclosing scope at compile time that only
+    sees the eval globals, not the locals dict; passing ctx as globals
+    too lets rules like ``all(d % x.ndim in ... for d in dim)`` resolve
+    ``x`` and ``dim`` inside the generator expression.
     """
+    eval_globals = {"__builtins__": _SHAPE_RULE_BUILTINS}
+    # Ctx names must be visible inside comprehensions, which only see
+    # globals. Merge ctx into globals while keeping locals=ctx so plain
+    # (non-comprehension) lookups behave identically.
+    eval_globals.update(ctx)
     try:
         result = eval(  # noqa: S307 — manifest-controlled
-            rule, {"__builtins__": _SHAPE_RULE_BUILTINS}, ctx,
+            rule, eval_globals, ctx,
         )
     except Exception as exc:  # noqa: BLE001
         return False, f"eval error: {exc.__class__.__name__}: {exc}"

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -21,6 +21,7 @@ The --levels flag selects which checks to run. When omitted, all are enabled.
 from __future__ import annotations
 
 import ast
+import contextlib
 import importlib
 import inspect
 import itertools
@@ -930,16 +931,43 @@ def _extract_shape_tuple_literals(rules: list) -> dict[str, int]:
     return ranks
 
 
+_SHAPE_DECL_RE = re.compile(r"^\s*\[([^\]]*)\]\s*$")
+
+
+def _parse_shape_decl(shape_str: str) -> list[str] | None:
+    """Parse a ``signature.inputs[*].shape`` declaration like ``"[N, C, L]"``.
+
+    Returns the list of dimension identifiers if the declaration is a bare
+    comma-separated identifier list; returns None otherwise (e.g. contains
+    arithmetic, literals, or other expressions that cannot be bound as
+    mock dim names by this tool).
+    """
+    if not isinstance(shape_str, str):
+        return None
+    m = _SHAPE_DECL_RE.match(shape_str)
+    if m is None:
+        return None
+    body = m.group(1)
+    parts = [p.strip() for p in body.split(",") if p.strip()]
+    if not parts:
+        return None
+    if not all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts):
+        return None
+    return parts
+
+
 def _mock_input_shapes(
     sig: dict,
 ) -> tuple[dict[str, _MockShape], dict[str, int]] | None:
     """Derive concrete mock input shapes for every declared input.
 
     Uses rank hints from ``shape_rules`` (literal ``tensor.shape == (...)``
-    forms). Falls back to a default 2D shape when the rank is unknown.
-    Returns (shapes, dim_sizes) where ``dim_sizes`` maps each symbolic
-    dimension name (e.g. ``B``, ``S``, ``H``, ``D``) to the integer size
-    used in the mock shapes, so callers can bind those names into a
+    forms) and from ``signature.inputs[*].shape`` declarations (e.g.
+    ``"[N, C_in, L_in]"``). Falls back to a default 2D shape when the
+    rank is unknown. Returns (shapes, dim_sizes) where ``dim_sizes`` maps
+    each symbolic dimension name (e.g. ``B``, ``S``, ``H``, ``D``, or
+    ``N``, ``C_in``, ``L_in`` from shape declarations) to the integer
+    size used in the mock shapes, so callers can bind those names into a
     shape_rules evaluation context. Returns None only if
     ``signature.inputs`` is malformed.
     """
@@ -948,6 +976,16 @@ def _mock_input_shapes(
         return None
     rules = sig.get("shape_rules") or []
     ranks = _extract_shape_tuple_literals(rules)
+
+    # Extra rank hints from per-tensor shape declarations.
+    shape_decls: dict[str, list[str]] = {}
+    for name, attrs in inputs.items():
+        if not isinstance(attrs, dict):
+            continue
+        parts = _parse_shape_decl(attrs.get("shape", ""))
+        if parts is not None:
+            shape_decls[name] = parts
+            ranks.setdefault(name, len(parts))
 
     shapes: dict[str, _MockShape] = {}
     # Assign dim-name → size map shared across tensors for consistent rules.
@@ -975,6 +1013,28 @@ def _mock_input_shapes(
             ):
                 dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
 
+    # Also bind symbolic dim names from per-tensor shape declarations so
+    # downstream rule/shape-decl checks resolve them against the same mock
+    # sizes used to build the input tensors.
+    for parts in shape_decls.values():
+        for p in parts:
+            if p not in dim_sizes:
+                dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
+    # Also bind symbolic dim names from declared output shapes, so rules
+    # referencing output dim names (via signature.outputs[*].shape) can be
+    # evaluated when shape_rules are absent.
+    outputs_map = sig.get("outputs") or {}
+    if isinstance(outputs_map, dict):
+        for attrs in outputs_map.values():
+            if not isinstance(attrs, dict):
+                continue
+            out_parts = _parse_shape_decl(attrs.get("shape", ""))
+            if out_parts is None:
+                continue
+            for p in out_parts:
+                if p not in dim_sizes:
+                    dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
+
     for name in inputs:
         if name in ranks:
             parts = None
@@ -995,6 +1055,12 @@ def _mock_input_shapes(
                     dim_sizes.get(p, _MOCK_DIM_SIZE) for p in parts
                 )
                 continue
+        # Fallback: per-tensor shape declaration from signature.inputs.
+        if name in shape_decls:
+            shapes[name] = _MockShape(
+                dim_sizes.get(p, _MOCK_DIM_SIZE) for p in shape_decls[name]
+            )
+            continue
         # Fallback: 2D shape
         shapes[name] = _MockShape(
             (_MOCK_DIM_SIZE, _MOCK_DIM_SIZE)
@@ -1113,6 +1179,12 @@ def _eval_shape_rule(
     # globals. Merge ctx into globals while keeping locals=ctx so plain
     # (non-comprehension) lookups behave identically.
     eval_globals.update(ctx)
+    # Defense-in-depth: a manifest identifier literally named
+    # ``__builtins__`` (via a rule context key) would otherwise overwrite
+    # the sandboxed builtins mapping installed above and re-expose the
+    # full unrestricted builtins set. Reinstate the sandbox after the
+    # update so ctx cannot escape it.
+    eval_globals["__builtins__"] = _SHAPE_RULE_BUILTINS
     try:
         result = eval(  # noqa: S307 — manifest-controlled
             rule, eval_globals, ctx,
@@ -1123,6 +1195,39 @@ def _eval_shape_rule(
         return bool(result), None
     except Exception as exc:  # noqa: BLE001
         return False, f"non-boolean result: {exc}"
+
+
+def _build_mock_self(cls: type, param_defaults: dict) -> object:
+    """Build a mock ``self`` instance without running ``__init__``.
+
+    Uses ``cls.__new__(cls)`` so that methods bound to ``cls`` (and any
+    helpers defined on its MRO) remain accessible as ``self.method(...)``
+    calls — a plain :class:`types.SimpleNamespace` cannot satisfy methods
+    that read attributes defined on the class or reach for class helpers
+    during a parity probe.
+
+    ``param_defaults`` is the manifest-derived params map (from
+    ``signature.params``). Each default is installed as an instance
+    attribute so ``self.<param>`` lookups resolve without running any
+    initialization logic. Callers may install additional manifest-derived
+    attributes (e.g. ``dtype``) on the returned object before invoking
+    the target method.
+
+    Falls back to :class:`types.SimpleNamespace` if ``cls.__new__``
+    raises (defensive; Python ``type`` subclasses can override ``__new__``
+    with required positional arguments).
+    """
+    try:
+        instance = cls.__new__(cls)
+    except Exception:  # noqa: BLE001
+        return types.SimpleNamespace(**param_defaults)
+    for k, v in param_defaults.items():
+        # __slots__ or read-only descriptors may reject setattr; ignore
+        # — parity check will surface any resulting AttributeError as a
+        # skip when the target method actually reads ``self.<k>``.
+        with contextlib.suppress(AttributeError, TypeError):
+            setattr(instance, k, v)
+    return instance
 
 
 def check_l2_infer_parity(
@@ -1160,7 +1265,19 @@ def check_l2_infer_parity(
 
     sig = entry.get("signature", {})
     rules = sig.get("shape_rules") or []
-    if not isinstance(rules, list) or not rules:
+    if not isinstance(rules, list):
+        rules = []
+    outputs_map = sig.get("outputs") or {}
+    declared_output_shapes: dict[str, list[str]] = {}
+    if isinstance(outputs_map, dict):
+        for oname, oattrs in outputs_map.items():
+            if not isinstance(oattrs, dict):
+                continue
+            parts = _parse_shape_decl(oattrs.get("shape", ""))
+            if parts is not None:
+                declared_output_shapes[oname] = parts
+    # Nothing to check: neither rules nor declared output shapes.
+    if not rules and not declared_output_shapes:
         return errors
 
     if not _class_overrides_method(cls, "_infer_output_shapes"):
@@ -1186,8 +1303,12 @@ def check_l2_infer_parity(
     params = sig.get("params") or {}
     param_defaults = _param_defaults(params)
 
-    # Build a mock ``self`` carrying param attributes; no __init__ invoked.
-    mock_self = types.SimpleNamespace(**param_defaults)
+    # Build a mock ``self`` via ``cls.__new__(cls)`` so class-defined
+    # helpers and attribute descriptors remain reachable, then install
+    # manifest-derived params as instance attributes without running
+    # __init__. A plain SimpleNamespace would raise AttributeError when
+    # _infer_output_shapes consults an unrelated ``self.<attr>`` helper.
+    mock_self = _build_mock_self(cls, param_defaults)
 
     shape_kwargs = {f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()}
     # First, validate the callable signature independently of the body: a
@@ -1307,6 +1428,37 @@ def check_l2_infer_parity(
                 f"shape_rules[{i}] {rule!r} under mock inputs "
                 f"{shape_kwargs} -> {result}"
             )
+
+    # Compare inferred outputs against per-tensor declared shapes in
+    # signature.outputs[*].shape, independently of shape_rules. This
+    # catches ops whose outputs are only specified via declared shape
+    # fields (no equivalent shape_rule). Expected dim sizes come from
+    # ``dim_sizes``, which was populated from all available symbolic
+    # names (rule literals + input/output shape declarations).
+    for out_name, decl_parts in declared_output_shapes.items():
+        if out_name not in result:
+            continue
+        try:
+            inferred = tuple(result[out_name])
+        except TypeError:
+            continue  # already reported above
+        expected = tuple(
+            dim_sizes.get(p, _MOCK_DIM_SIZE) for p in decl_parts
+        )
+        if len(inferred) != len(expected):
+            errors.append(
+                f"[shape] {op_name}: _infer_output_shapes output "
+                f"{out_name!r} rank {len(inferred)} disagrees with "
+                f"declared shape {decl_parts} (rank {len(expected)}) "
+                f"under mock inputs {shape_kwargs} -> {inferred}"
+            )
+            continue
+        if inferred != expected:
+            errors.append(
+                f"[shape] {op_name}: _infer_output_shapes output "
+                f"{out_name!r}={inferred} disagrees with declared shape "
+                f"{decl_parts}={expected} under mock inputs {shape_kwargs}"
+            )
     return errors
 
 
@@ -1420,7 +1572,10 @@ def _combo_accepted(
             return False, f"cannot build mock tensor for dtype {dtype_name!r}"
         tensors[name] = t
 
-    mock_self = types.SimpleNamespace(**param_defaults)
+    # Build mock self via ``cls.__new__(cls)`` so _validate_dtypes
+    # methods that consult other class helpers or instance attributes
+    # (beyond manifest params) do not falsely raise AttributeError.
+    mock_self = _build_mock_self(cls, param_defaults)
     # Pre-bind the callable signature so only genuine signature mismatches
     # surface as ``TypeError: ...``. TypeError raised from inside the body
     # (e.g. comparing incompatible torch dtypes) is a legitimate rejection
@@ -1520,6 +1675,23 @@ def check_l3_validate_dtypes_parity(
                         f"for dtype_combos[{i}] — {reason}"
                     )
                 continue
+            if reason and reason.startswith("cannot build mock tensor"):
+                # Validator limitation (no torch dtype for this name) — emit
+                # a parity-skip warning rather than reporting a rejection.
+                if warnings is not None:
+                    warnings.append(
+                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
+                        f"for dtype_combos[{i}] — {reason}"
+                    )
+                continue
+            if reason and reason.startswith("combo missing input"):
+                # Manifest error: combo doesn't specify a dtype for every
+                # declared input. Surface as parity error but not a reject.
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}] {combo!r} "
+                    f"{reason}"
+                )
+                continue
             if not accepted:
                 errors.append(
                     f"[dtype] {op_name}: _validate_dtypes rejects "
@@ -1572,6 +1744,61 @@ def check_l3_validate_dtypes_parity(
                 f"[dtype] {op_name}: _validate_dtypes accepts non-listed "
                 f"combo {candidate!r} (not in dtype_combos)"
             )
+
+        # --- Out-of-union negative probe (AC-3 rejection side) ---------
+        # Mirrors the probe in the no-dtype_combos branch. Picks a listed
+        # combo as a baseline (known to be accepted) and substitutes an
+        # out-of-union sentinel for each non-same_as-bound input in turn.
+        # Each resulting candidate must be rejected. Bounded by
+        # _MAX_DTYPE_COMBOS to preserve the Cartesian safety bound.
+        baseline_combo: dict[str, str] | None = None
+        for c in dtype_combos:
+            if isinstance(c, dict) and all(
+                n in c for n in forward_inputs
+            ):
+                baseline_combo = dict(c)
+                break
+        if baseline_combo is not None:
+            same_as_refs = _same_as_refs(sig)
+            probe_budget = _MAX_DTYPE_COMBOS
+            probed = 0
+            for target in forward_inputs:
+                # Skip same_as(ref)-bound tensors: their dtype is
+                # controlled by ``ref``. Mutate the ref instead and let
+                # same_as propagation carry the out-of-union dtype.
+                if target in same_as_refs:
+                    continue
+                declared = set(dtype_options.get(target, []))
+                out_of_union = [
+                    d for d in _DTYPE_SENTINELS if d not in declared
+                ]
+                for bad_dtype in out_of_union:
+                    if probed >= probe_budget:
+                        break
+                    probed += 1
+                    candidate = dict(baseline_combo)
+                    candidate[target] = bad_dtype
+                    for tname, ref in same_as_refs.items():
+                        if ref == target and tname in candidate:
+                            candidate[tname] = bad_dtype
+                    accepted, reason = _combo_accepted(
+                        cls, forward_inputs, candidate, param_defaults,
+                    )
+                    if reason and reason.startswith(
+                        ("unexpected", "TypeError", "cannot build",
+                         "combo missing")
+                    ):
+                        continue
+                    if accepted:
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes "
+                            f"accepts out-of-union dtype "
+                            f"{candidate!r} (input {target!r} declared "
+                            f"{sorted(declared)})"
+                        )
+                if probed >= probe_budget:
+                    break
+
         if not errors and warnings is not None:
             if not checked_any:
                 # No non-listed combo exists in the Cartesian product —

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -860,9 +860,20 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 
 # Default mock sizes for symbolic shape dimensions. Chosen small to keep
-# evaluation cheap; 2 avoids degenerate cases (e.g. shape[0]==1 matching
-# scalar broadcasts) while staying small.
+# evaluation cheap; 4 avoids degenerate cases (e.g. shape[0]==1 matching
+# scalar broadcasts) while staying small. Distinct symbolic dims get
+# ``_MOCK_DIM_SIZE + counter`` so cross-tensor equality checks remain
+# meaningful (see ``_mock_input_shapes``).
 _MOCK_DIM_SIZE = 4
+
+# Safety bound for Cartesian-product enumeration in L3 dtype parity. A
+# pathological future op with many inputs × wide dtype unions could blow
+# CI budgets (each candidate allocates tiny tensors and invokes
+# _validate_dtypes). Current manifest maxes out at ~5 inputs × ~4 options
+# = 1024 combos, so this cap only fires on genuinely outsized specs; when
+# it does we skip the op deterministically with a warning rather than
+# sampling, so validation output stays reproducible.
+_MAX_DTYPE_COMBOS = 4096
 
 
 class _MockShape(tuple):
@@ -928,6 +939,11 @@ def _mock_input_shapes(
 
     shapes: dict[str, _MockShape] = {}
     # Assign dim-name → size map shared across tensors for consistent rules.
+    # Use a global counter keyed on first-seen order so distinct symbolic
+    # dims get distinct sizes across rules (e.g. rule1 ``x.shape == (A, B)``
+    # and rule2 ``y.shape == (C, D)`` produce A=4, B=5, C=6, D=7 rather than
+    # colliding A==C and B==D, which would spuriously satisfy cross-tensor
+    # equality checks).
     dim_sizes: dict[str, int] = {}
     shape_eq_re = re.compile(
         r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
@@ -940,11 +956,12 @@ def _mock_input_shapes(
             continue
         body = m.group(2)
         parts = [p.strip() for p in body.split(",") if p.strip()]
-        for i, p in enumerate(parts):
-            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p):
-                # Give each distinct symbolic dim a unique mock size so
-                # equality checks across tensors are still meaningful.
-                dim_sizes.setdefault(p, _MOCK_DIM_SIZE + i)
+        for p in parts:
+            if (
+                re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p)
+                and p not in dim_sizes
+            ):
+                dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
 
     for name in inputs:
         if name in ranks:
@@ -1061,6 +1078,23 @@ def _eval_shape_rule(
     too lets rules like ``all(d % x.ndim in ... for d in dim)`` resolve
     ``x`` and ``dim`` inside the generator expression.
     """
+    # Defense-in-depth: even though manifest content is trusted (PR review
+    # gates it), parse the rule first and reject any dunder attribute
+    # access. This closes the classic ``().__class__.__mro__[1].
+    # __subclasses__()`` sandbox-escape against the restricted builtins.
+    try:
+        tree = ast.parse(rule, mode="eval")
+    except SyntaxError as exc:
+        return False, f"eval error: SyntaxError: {exc}"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and (
+            node.attr.startswith("__") or node.attr.endswith("__")
+        ):
+            return False, (
+                f"eval error: dunder attribute access not permitted "
+                f"({node.attr!r})"
+            )
+
     eval_globals = {"__builtins__": _SHAPE_RULE_BUILTINS}
     # Ctx names must be visible inside comprehensions, which only see
     # globals. Merge ctx into globals while keeping locals=ctx so plain
@@ -1448,6 +1482,20 @@ def check_l3_validate_dtypes_parity(
         input_options: list[list[str]] = [
             dtype_options.get(name, []) for name in forward_inputs
         ]
+        product_size = 1
+        for opts in input_options:
+            product_size *= max(len(opts), 1)
+        if product_size > _MAX_DTYPE_COMBOS:
+            if warnings is not None:
+                warnings.append(
+                    f"[dtype] {op_name}: Cartesian product of dtype "
+                    f"options ({product_size}) exceeds "
+                    f"_MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; non-listed "
+                    f"rejection check skipped "
+                    f"({len(forward_inputs)} inputs × options "
+                    f"{[len(o) for o in input_options]})"
+                )
+            return errors
         listed_combo_keys = {
             tuple(combo.get(n) for n in forward_inputs)
             for combo in dtype_combos if isinstance(combo, dict)
@@ -1485,6 +1533,19 @@ def check_l3_validate_dtypes_parity(
             dtype_options.get(name, []) for name in forward_inputs
         ]
         if not all(input_options):
+            return errors
+        product_size = 1
+        for opts in input_options:
+            product_size *= len(opts)
+        if product_size > _MAX_DTYPE_COMBOS:
+            if warnings is not None:
+                warnings.append(
+                    f"[dtype] {op_name}: Cartesian product of dtype "
+                    f"options ({product_size}) exceeds "
+                    f"_MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; parity check "
+                    f"skipped ({len(forward_inputs)} inputs × options "
+                    f"{[len(o) for o in input_options]})"
+                )
             return errors
         for tup in itertools.product(*input_options):
             # Only keep combos that honour same_as identity constraints:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -997,6 +997,26 @@ def _class_overrides_method(cls: type, name: str) -> bool:
     return False
 
 
+# Safe builtins allowed in shape_rules eval — matches the R11 / R11a
+# documented helper set (see docs/ops-design-reference.md). Keep this list
+# aligned with manifest spec; widening it changes the rule language.
+_SHAPE_RULE_BUILTINS: dict = {
+    "len": len,
+    "isinstance": isinstance,
+    "int": int,
+    "tuple": tuple,
+    "list": list,
+    "type": type,
+    "all": all,
+    "any": any,
+    "range": range,
+    "set": set,
+    "abs": abs,
+    "min": min,
+    "max": max,
+}
+
+
 def _eval_shape_rule(
     rule: str, ctx: dict,
 ) -> tuple[bool, str | None]:
@@ -1006,9 +1026,17 @@ def _eval_shape_rule(
     rule evaluated to a falsy non-exception value; a non-None reason
     indicates the rule could not be evaluated (treated as skipped, not a
     parity error).
+
+    The eval globals expose the ``_SHAPE_RULE_BUILTINS`` helper set
+    (``len``, ``isinstance``, ``int``, ``tuple``, ``list``, ``type``,
+    ``all``, ``any``, ``range``, ``set``, ``abs``, ``min``, ``max``) so
+    R11 / R11a-style rules that use these helpers can be evaluated
+    against the mock context instead of being silently skipped.
     """
     try:
-        result = eval(rule, {"__builtins__": {}}, ctx)  # noqa: S307 — manifest-controlled
+        result = eval(  # noqa: S307 — manifest-controlled
+            rule, {"__builtins__": _SHAPE_RULE_BUILTINS}, ctx,
+        )
     except Exception as exc:  # noqa: BLE001
         return False, f"eval error: {exc.__class__.__name__}: {exc}"
     try:
@@ -1312,8 +1340,10 @@ def check_l3_validate_dtypes_parity(
                     f"dtype_combos[{i}] {combo!r} listed in manifest"
                 )
 
-        # A non-listed combo drawn from the inputs' union must be rejected.
-        # Build the union of each input independently and exclude listed combos.
+        # Every non-listed combo drawn from the inputs' union must be
+        # rejected. Enumerate the full Cartesian product and report any
+        # non-listed combo that ``_validate_dtypes`` accepts. Breaking on
+        # the first rejection would miss a later accepted combo.
         input_options: list[list[str]] = [
             dtype_options.get(name, []) for name in forward_inputs
         ]
@@ -1335,15 +1365,15 @@ def check_l3_validate_dtypes_parity(
                 continue
             if not accepted:
                 rejected_at_least_one = True
-                break
-            # Accepted non-listed combo — parity violation.
+                continue
+            # Accepted non-listed combo — parity violation. Keep scanning
+            # so multiple such combos are all surfaced in a single run.
             errors.append(
                 f"[dtype] {op_name}: _validate_dtypes accepts non-listed "
                 f"combo {candidate!r} (not in dtype_combos)"
             )
-            rejected_at_least_one = True
-            break
-        if checked_any and not rejected_at_least_one and warnings is not None:
+        if checked_any and not rejected_at_least_one and not errors \
+                and warnings is not None:
             warnings.append(
                 f"[dtype] {op_name}: could not find a non-listed combo to "
                 f"exercise rejection (dtype_combos exhausts the union)"

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import ast
 import importlib
 import inspect
+import itertools
 import re
 import sys
+import types
 import warnings as _warnings
 from pathlib import Path
 
@@ -854,6 +856,549 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# shape parity: _infer_output_shapes vs shape_rules (L2 extension)
+# ---------------------------------------------------------------------------
+
+# Default mock sizes for symbolic shape dimensions. Chosen small to keep
+# evaluation cheap; 2 avoids degenerate cases (e.g. shape[0]==1 matching
+# scalar broadcasts) while staying small.
+_MOCK_DIM_SIZE = 4
+
+
+class _MockShape(tuple):
+    """Tuple subclass representing a tensor shape, exposed via ``.shape``.
+
+    Used in the shape_rules evaluation context so expressions like
+    ``x.shape == (B, S, H, D)`` or ``x.ndim`` resolve correctly without
+    constructing real tensors.
+    """
+
+    @property
+    def shape(self) -> "tuple":  # type: ignore[override]
+        return tuple(self)
+
+    @property
+    def ndim(self) -> int:
+        return len(self)
+
+
+def _extract_shape_tuple_literals(rules: list) -> dict[str, int]:
+    """Parse ``<name>.shape == (<ids>...)`` rules for input-tensor rank hints.
+
+    Returns a mapping tensor-name → rank. Only handles the simple literal
+    form; other shape_rules patterns are skipped.
+    """
+    ranks: dict[str, int] = {}
+    shape_eq_re = re.compile(
+        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
+    )
+    for rule in rules:
+        if not isinstance(rule, str):
+            continue
+        m = shape_eq_re.match(rule)
+        if m is None:
+            continue
+        name, body = m.group(1), m.group(2)
+        parts = [p.strip() for p in body.split(",") if p.strip()]
+        # Require all parts to be bare identifiers so we can assign mock
+        # sizes by name; skip otherwise.
+        if all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts):
+            ranks[name] = len(parts)
+    return ranks
+
+
+def _mock_input_shapes(
+    sig: dict,
+) -> dict[str, _MockShape] | None:
+    """Derive concrete mock input shapes for every declared input.
+
+    Uses rank hints from ``shape_rules`` (literal ``tensor.shape == (...)``
+    forms). Falls back to a default 2D shape when the rank is unknown.
+    Returns None only if ``signature.inputs`` is malformed.
+    """
+    inputs = sig.get("inputs")
+    if not isinstance(inputs, dict) or not inputs:
+        return None
+    rules = sig.get("shape_rules") or []
+    ranks = _extract_shape_tuple_literals(rules)
+
+    shapes: dict[str, _MockShape] = {}
+    # Assign dim-name → size map shared across tensors for consistent rules.
+    dim_sizes: dict[str, int] = {}
+    shape_eq_re = re.compile(
+        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
+    )
+    for rule in rules:
+        if not isinstance(rule, str):
+            continue
+        m = shape_eq_re.match(rule)
+        if m is None:
+            continue
+        body = m.group(2)
+        parts = [p.strip() for p in body.split(",") if p.strip()]
+        for i, p in enumerate(parts):
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p):
+                # Give each distinct symbolic dim a unique mock size so
+                # equality checks across tensors are still meaningful.
+                dim_sizes.setdefault(p, _MOCK_DIM_SIZE + i)
+
+    for name in inputs:
+        if name in ranks:
+            parts = None
+            for rule in rules:
+                if not isinstance(rule, str):
+                    continue
+                m = shape_eq_re.match(rule)
+                if m is None or m.group(1) != name:
+                    continue
+                parts = [
+                    p.strip() for p in m.group(2).split(",") if p.strip()
+                ]
+                break
+            if parts is not None and all(
+                re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts
+            ):
+                shapes[name] = _MockShape(dim_sizes.get(p, _MOCK_DIM_SIZE)
+                                           for p in parts)
+                continue
+        # Fallback: 2D shape
+        shapes[name] = _MockShape(
+            (_MOCK_DIM_SIZE, _MOCK_DIM_SIZE)
+        )
+    return shapes
+
+
+def _param_defaults(params: dict) -> dict:
+    """Extract ``default`` values from a signature.params dict.
+
+    Parameters without a default are omitted.
+    """
+    out: dict = {}
+    if not isinstance(params, dict):
+        return out
+    for pname, pattrs in params.items():
+        if isinstance(pattrs, dict) and "default" in pattrs:
+            out[pname] = pattrs["default"]
+    return out
+
+
+def _class_overrides_method(cls: type, name: str) -> bool:
+    """Return True when *cls* (or a non-Op ancestor) defines *name*.
+
+    We walk the MRO skipping the root ``Op`` base class; the goal is to
+    detect user-authored overrides, not the base no-op.
+    """
+    from tileops.ops.op_base import Op as _OpBase  # local to avoid top-level import cost
+    for base in cls.__mro__:
+        if base is _OpBase or base is object:
+            continue
+        if name in base.__dict__:
+            return True
+    return False
+
+
+def _eval_shape_rule(
+    rule: str, ctx: dict,
+) -> tuple[bool, str | None]:
+    """Evaluate a single shape_rule in *ctx*.
+
+    Returns (ok, failure_reason). ``ok=False`` with reason=None means the
+    rule evaluated to a falsy non-exception value; a non-None reason
+    indicates the rule could not be evaluated (treated as skipped, not a
+    parity error).
+    """
+    try:
+        result = eval(rule, {"__builtins__": {}}, ctx)  # noqa: S307 — manifest-controlled
+    except Exception as exc:  # noqa: BLE001
+        return False, f"eval error: {exc.__class__.__name__}: {exc}"
+    try:
+        return bool(result), None
+    except Exception as exc:  # noqa: BLE001
+        return False, f"non-boolean result: {exc}"
+
+
+def check_l2_infer_parity(
+    op_name: str,
+    entry: dict,
+    cls: type | None,
+    *,
+    warnings: list[str] | None = None,
+) -> list[str]:
+    """L2 extension: ``_infer_output_shapes`` parity with ``shape_rules``.
+
+    Calls the Op class's ``_infer_output_shapes`` with concrete mock input
+    shapes (no tensor allocation, no kernel execution). Plugs the result
+    into a shape_rules evaluation context and verifies every rule holds.
+
+    Behaviour:
+      - Silently skips ops whose class does not override
+        ``_infer_output_shapes`` — this lets the validator coexist with
+        ops that have not yet been migrated to the codegen protocol.
+      - Skips ops whose ``_infer_output_shapes`` raises during the call
+        (e.g. method expects GPU-only state); emits a warning instead.
+      - Produces L2 errors only for concrete disagreement: the method
+        returns shapes that fail one or more ``shape_rules``.
+    """
+    errors: list[str] = []
+    if cls is None:
+        return errors
+
+    sig = entry.get("signature", {})
+    rules = sig.get("shape_rules") or []
+    if not isinstance(rules, list) or not rules:
+        return errors
+
+    if not _class_overrides_method(cls, "_infer_output_shapes"):
+        return errors
+
+    infer_fn = getattr(cls, "_infer_output_shapes", None)
+    if infer_fn is None:
+        return errors
+
+    mock_shapes = _mock_input_shapes(sig)
+    if mock_shapes is None:
+        return errors
+
+    params = sig.get("params") or {}
+    param_defaults = _param_defaults(params)
+
+    # Build a mock ``self`` carrying param attributes; no __init__ invoked.
+    mock_self = types.SimpleNamespace(**param_defaults)
+
+    shape_kwargs = {f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()}
+    try:
+        result = infer_fn(mock_self, **shape_kwargs)
+    except TypeError as exc:
+        # Signature mismatch between expected ``<input>_shape=`` kwargs and
+        # the op's ``_infer_output_shapes``; surface this as a parity error.
+        errors.append(
+            f"[shape] {op_name}: _infer_output_shapes signature does not match "
+            f"manifest inputs (expected kwargs {sorted(shape_kwargs)}): {exc}"
+        )
+        return errors
+    except Exception as exc:  # noqa: BLE001
+        if warnings is not None:
+            warnings.append(
+                f"[shape] {op_name}: _infer_output_shapes parity skipped — "
+                f"call raised {exc.__class__.__name__}: {exc}"
+            )
+        return errors
+
+    if not isinstance(result, dict):
+        errors.append(
+            f"[shape] {op_name}: _infer_output_shapes must return a dict "
+            f"(output_name -> shape), got {type(result).__name__}"
+        )
+        return errors
+
+    outputs = sig.get("outputs") or {}
+    for out_name in outputs:
+        if out_name not in result:
+            errors.append(
+                f"[shape] {op_name}: _infer_output_shapes missing output "
+                f"{out_name!r} (declared in manifest)"
+            )
+
+    # Assemble evaluation context: inputs + outputs + params.
+    ctx: dict = dict(param_defaults)
+    for name, shape in mock_shapes.items():
+        ctx[name] = _MockShape(shape)
+    for out_name, out_shape in result.items():
+        try:
+            ctx[out_name] = _MockShape(tuple(out_shape))
+        except TypeError:
+            errors.append(
+                f"[shape] {op_name}: _infer_output_shapes returned "
+                f"non-iterable shape for {out_name!r}: {out_shape!r}"
+            )
+
+    for i, rule in enumerate(rules):
+        if not isinstance(rule, str):
+            continue
+        ok, reason = _eval_shape_rule(rule, ctx)
+        if reason is not None:
+            # Could not evaluate this rule under the mock context; do not
+            # flag as parity mismatch.
+            if warnings is not None:
+                warnings.append(
+                    f"[shape] {op_name}: shape_rules[{i}] could not be "
+                    f"evaluated against mock inputs ({reason}); rule: {rule!r}"
+                )
+            continue
+        if not ok:
+            errors.append(
+                f"[shape] {op_name}: _infer_output_shapes output violates "
+                f"shape_rules[{i}] {rule!r} under mock inputs "
+                f"{shape_kwargs} -> {result}"
+            )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# dtype parity: _validate_dtypes vs dtype_combos / dtype unions (L3 extension)
+# ---------------------------------------------------------------------------
+
+
+def _dtype_options_for_tensor(
+    tname: str, dtype_str: str, resolved: dict[str, list[str]],
+) -> list[str] | None:
+    """Expand a dtype expression into concrete torch dtype names.
+
+    ``same_as(ref)`` resolves to whatever *ref* was resolved to (must
+    appear earlier). Returns None if the expression cannot be resolved.
+    """
+    tokens = _parse_dtype_expr(dtype_str)
+    # Pure same_as(ref): inherits ref's options.
+    if len(tokens) == 1:
+        m = _SAME_AS_RE.match(tokens[0])
+        if m:
+            ref = m.group(1)
+            return list(resolved.get(ref, []))
+    out: list[str] = []
+    for tok in tokens:
+        m = _SAME_AS_RE.match(tok)
+        if m:
+            ref = m.group(1)
+            out.extend(resolved.get(ref, []))
+        elif tok in _TORCH_DTYPES:
+            out.append(tok)
+        else:
+            return None
+    # De-dup preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for t in out:
+        if t not in seen:
+            seen.add(t)
+            uniq.append(t)
+    return uniq
+
+
+def _resolve_tensor_dtype_options(
+    sig: dict,
+) -> dict[str, list[str]] | None:
+    """Return dtype options for every declared tensor (inputs + outputs).
+
+    Resolves ``same_as`` references in declaration order; returns None if
+    any tensor's expression cannot be resolved.
+    """
+    resolved: dict[str, list[str]] = {}
+    for group in ("inputs", "outputs"):
+        tensors = sig.get(group) or {}
+        if not isinstance(tensors, dict):
+            continue
+        for tname, attrs in tensors.items():
+            if not isinstance(attrs, dict):
+                return None
+            opts = _dtype_options_for_tensor(
+                tname, attrs.get("dtype", ""), resolved,
+            )
+            if opts is None:
+                return None
+            resolved[tname] = opts
+    return resolved
+
+
+def _make_mock_tensor(dtype_name: str):
+    """Build a 0-sized torch tensor of the named dtype (CPU).
+
+    Uses 0 elements so allocation is cheap and no GPU is touched.
+    """
+    import torch
+    torch_dtype = getattr(torch, dtype_name, None)
+    if torch_dtype is None:
+        return None
+    try:
+        return torch.empty(0, dtype=torch_dtype, device="cpu")
+    except (RuntimeError, TypeError):
+        return None
+
+
+def _combo_accepted(
+    cls: type, forward_inputs: list[str], combo: dict[str, str],
+    param_defaults: dict,
+) -> tuple[bool, str | None]:
+    """Invoke ``cls._validate_dtypes`` on a mock-self with *combo*.
+
+    Returns (accepted, error_reason). ``accepted=False`` with
+    reason=None means the op raised during validation (rejected);
+    reason!=None indicates the call could not be performed (skip).
+    """
+    validate_fn = getattr(cls, "_validate_dtypes", None)
+    if validate_fn is None:
+        return False, "no _validate_dtypes"
+
+    tensors: dict = {}
+    for name in forward_inputs:
+        dtype_name = combo.get(name)
+        if dtype_name is None:
+            return False, f"combo missing input {name!r}"
+        t = _make_mock_tensor(dtype_name)
+        if t is None:
+            return False, f"cannot build mock tensor for dtype {dtype_name!r}"
+        tensors[name] = t
+
+    mock_self = types.SimpleNamespace(**param_defaults)
+    try:
+        validate_fn(mock_self, **tensors)
+    except (ValueError, TypeError) as exc:
+        # Expected rejection path.
+        return False, None if isinstance(exc, ValueError) else f"TypeError: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        return False, f"unexpected {exc.__class__.__name__}: {exc}"
+    return True, None
+
+
+def check_l3_validate_dtypes_parity(
+    op_name: str,
+    entry: dict,
+    cls: type | None,
+    *,
+    warnings: list[str] | None = None,
+) -> list[str]:
+    """L3 extension: ``_validate_dtypes`` parity with manifest dtypes.
+
+    With ``dtype_combos`` declared: iterate all combos and verify the
+    method accepts each listed combo and rejects at least one non-listed
+    combination drawn from the same input dtype universe.
+
+    Without ``dtype_combos``: verify every combination in the Cartesian
+    product of each input's declared dtype union is accepted.
+
+    Silently skips ops whose class does not override ``_validate_dtypes``
+    (bootstrap-friendly — ops not yet migrated are ignored).
+    """
+    errors: list[str] = []
+    if cls is None:
+        return errors
+
+    if not _class_overrides_method(cls, "_validate_dtypes"):
+        return errors
+
+    sig = entry.get("signature", {})
+    inputs = sig.get("inputs") or {}
+    if not isinstance(inputs, dict) or not inputs:
+        return errors
+
+    # Only pass tensors corresponding to manifest inputs (forward args).
+    forward_inputs = list(inputs.keys())
+    params = sig.get("params") or {}
+    param_defaults = _param_defaults(params)
+
+    dtype_options = _resolve_tensor_dtype_options(sig)
+    if dtype_options is None:
+        # L3 dtype check will already have reported unresolved tokens.
+        return errors
+
+    dtype_combos = sig.get("dtype_combos")
+    if isinstance(dtype_combos, list) and dtype_combos:
+        # Each listed combo should be accepted.
+        for i, combo in enumerate(dtype_combos):
+            if not isinstance(combo, dict):
+                continue
+            accepted, reason = _combo_accepted(
+                cls, forward_inputs, combo, param_defaults,
+            )
+            if reason and reason.startswith(("unexpected", "TypeError")):
+                if warnings is not None:
+                    warnings.append(
+                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
+                        f"for dtype_combos[{i}] — {reason}"
+                    )
+                continue
+            if not accepted:
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes rejects "
+                    f"dtype_combos[{i}] {combo!r} listed in manifest"
+                )
+
+        # A non-listed combo drawn from the inputs' union must be rejected.
+        # Build the union of each input independently and exclude listed combos.
+        input_options: list[list[str]] = [
+            dtype_options.get(name, []) for name in forward_inputs
+        ]
+        listed_combo_keys = {
+            tuple(combo.get(n) for n in forward_inputs)
+            for combo in dtype_combos if isinstance(combo, dict)
+        }
+        rejected_at_least_one = False
+        checked_any = False
+        for tup in itertools.product(*input_options):
+            if tup in listed_combo_keys:
+                continue
+            candidate = dict(zip(forward_inputs, tup, strict=True))
+            checked_any = True
+            accepted, reason = _combo_accepted(
+                cls, forward_inputs, candidate, param_defaults,
+            )
+            if reason and reason.startswith(("unexpected", "TypeError")):
+                continue
+            if not accepted:
+                rejected_at_least_one = True
+                break
+            # Accepted non-listed combo — parity violation.
+            errors.append(
+                f"[dtype] {op_name}: _validate_dtypes accepts non-listed "
+                f"combo {candidate!r} (not in dtype_combos)"
+            )
+            rejected_at_least_one = True
+            break
+        if checked_any and not rejected_at_least_one and warnings is not None:
+            warnings.append(
+                f"[dtype] {op_name}: could not find a non-listed combo to "
+                f"exercise rejection (dtype_combos exhausts the union)"
+            )
+    else:
+        # No dtype_combos — verify every Cartesian combination is accepted.
+        input_options = [
+            dtype_options.get(name, []) for name in forward_inputs
+        ]
+        if not all(input_options):
+            return errors
+        for tup in itertools.product(*input_options):
+            # Only keep combos that honour same_as identity constraints:
+            # when tensor T has dtype same_as(R), T and R must match.
+            candidate = dict(zip(forward_inputs, tup, strict=True))
+            if not _honours_same_as(sig, candidate):
+                continue
+            accepted, reason = _combo_accepted(
+                cls, forward_inputs, candidate, param_defaults,
+            )
+            if reason and reason.startswith(("unexpected", "TypeError")):
+                if warnings is not None:
+                    warnings.append(
+                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
+                        f"for combo {candidate!r} — {reason}"
+                    )
+                continue
+            if not accepted:
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes rejects valid "
+                    f"combo {candidate!r} drawn from manifest dtype unions"
+                )
+    return errors
+
+
+def _honours_same_as(sig: dict, candidate: dict[str, str]) -> bool:
+    """Return True when *candidate* satisfies same_as identity (R3)."""
+    inputs = sig.get("inputs") or {}
+    if not isinstance(inputs, dict):
+        return True
+    for tname, attrs in inputs.items():
+        if not isinstance(attrs, dict):
+            continue
+        dstr = attrs.get("dtype", "")
+        tokens = _parse_dtype_expr(dstr)
+        if len(tokens) == 1:
+            m = _SAME_AS_RE.match(tokens[0])
+            if m:
+                ref = m.group(1)
+                if ref in candidate and candidate.get(tname) != candidate[ref]:
+                    return False
+    return True
+
+
+# ---------------------------------------------------------------------------
 # bench: benchmark file uses manifest workloads
 # ---------------------------------------------------------------------------
 
@@ -1100,17 +1645,35 @@ def validate_manifest(
                 print(f"    {op_name}: spec-only, skipping signature/shape/dtype/bench")
             continue
 
+        # Resolve Op class once per entry so parity checks can reuse it.
+        # Resolution is lightweight (import + getattr); skipped silently
+        # when unnecessary.
+        source = entry.get("source", {})
+        op_file = source.get("op", "")
+        resolve_result = _resolve_op_class(op_file, op_name) if op_file else None
+        op_cls = resolve_result.cls if resolve_result is not None else None
+
         # signature: Op.forward() consistency
         if "signature" in levels:
             all_errors.extend(check_l1(op_name, entry, warnings=all_warnings))
 
-        # shape: shape_rules syntax
+        # shape: shape_rules syntax + _infer_output_shapes parity (L2 extension)
         if "shape" in levels:
             all_errors.extend(check_l2(op_name, entry))
+            all_errors.extend(
+                check_l2_infer_parity(
+                    op_name, entry, op_cls, warnings=all_warnings,
+                )
+            )
 
-        # dtype: dtype string conformance
+        # dtype: dtype string conformance + _validate_dtypes parity (L3 extension)
         if "dtype" in levels:
             all_errors.extend(check_l3(op_name, entry))
+            all_errors.extend(
+                check_l3_validate_dtypes_parity(
+                    op_name, entry, op_cls, warnings=all_warnings,
+                )
+            )
 
         # bench: benchmark uses manifest workloads
         if "bench" in levels:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -863,6 +863,103 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
     return errors
 
 
+def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
+    """Emit hard L3 errors describing why a signature failed to resolve.
+
+    Called when ``_resolve_tensor_dtype_options(sig)`` returns None inside
+    combo validation. Walks the pure ``same_as`` edges to distinguish:
+
+      * dangling references (``same_as(ref)`` where ``ref`` is not a
+        declared tensor) — per-tensor error;
+      * ``same_as`` cycles (``x -> y -> ... -> x``) — one error per cycle
+        naming every participating tensor;
+      * an unknown-token / ``same_as`` in a mixed expression that resolves
+        to nothing — generic fallback, so callers are never left guessing.
+    """
+    errors: list[str] = []
+    inputs = sig.get("inputs") or {}
+    outputs = sig.get("outputs") or {}
+    all_tensors: dict[str, dict] = {}
+    if isinstance(inputs, dict):
+        all_tensors.update(inputs)
+    if isinstance(outputs, dict):
+        all_tensors.update(outputs)
+
+    # Pure ``same_as(ref)`` edges only — mixed expressions (``float16 |
+    # same_as(x)``) are not part of the cycle graph; a cycle in pure edges
+    # is what makes fixpoint resolution stall.
+    edges: dict[str, str] = {}
+    for tname, attrs in all_tensors.items():
+        if not isinstance(attrs, dict):
+            continue
+        tokens = _parse_dtype_expr(attrs.get("dtype", ""))
+        if len(tokens) == 1:
+            m = _SAME_AS_RE.match(tokens[0])
+            if m:
+                edges[tname] = m.group(1)
+
+    # Dangling references: ``same_as(ref)`` where ``ref`` is not declared.
+    dangling: set[str] = set()
+    for tname, ref in edges.items():
+        if ref not in all_tensors:
+            errors.append(
+                f"[dtype] {op_name}: signature.inputs/outputs — tensor "
+                f"{tname!r} declares dtype same_as({ref}) but {ref!r} is "
+                f"not a declared tensor (dangling reference; combo "
+                f"validation cannot proceed)"
+            )
+            dangling.add(tname)
+
+    # Cycle detection via DFS over pure same_as edges. Only tensors that
+    # have not already been reported as dangling are considered (a chain
+    # ending in a dangling ref is not a cycle).
+    reported_cycles: set[frozenset[str]] = set()
+    visited: set[str] = set()
+    for start in edges:
+        if start in visited or start in dangling:
+            continue
+        path: list[str] = []
+        seen_in_path: dict[str, int] = {}
+        node: str | None = start
+        while node is not None and node not in visited:
+            if node in seen_in_path:
+                cycle_nodes = path[seen_in_path[node]:]
+                key = frozenset(cycle_nodes)
+                if key not in reported_cycles:
+                    reported_cycles.add(key)
+                    errors.append(
+                        f"[dtype] {op_name}: same_as cycle detected "
+                        f"among tensors "
+                        f"{sorted(cycle_nodes)} — dtype options cannot "
+                        f"be resolved (combo validation skipped)"
+                    )
+                break
+            seen_in_path[node] = len(path)
+            path.append(node)
+            nxt = edges.get(node)
+            if nxt is None or nxt in dangling:
+                break
+            if nxt not in edges:
+                # Chain terminates at a concrete-dtype tensor — not a
+                # cycle. Stop walking.
+                break
+            node = nxt
+        visited.update(path)
+
+    if not errors:
+        # Fixpoint failed but we cannot pinpoint a cycle or dangling edge
+        # (e.g. a mixed expression containing an unknown token that did
+        # not trip per-token validation). Emit a generic hard error so
+        # combo validation is never silently skipped.
+        errors.append(
+            f"[dtype] {op_name}: could not resolve signature.inputs/outputs "
+            f"dtype options — combo validation cannot proceed. Check "
+            f"signature.inputs/outputs dtype declarations for unresolved "
+            f"same_as references or malformed expressions."
+        )
+    return errors
+
+
 def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
     """Validate ``dtype_combos`` entries resolve to concrete torch dtypes.
 
@@ -882,7 +979,15 @@ def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
         return errors
     dtype_options = _resolve_tensor_dtype_options(sig)
     if dtype_options is None:
-        # Tensor-level dtype errors already reported in ``check_l3``.
+        # Unresolvable signature. Previously this branch returned silently
+        # under the assumption that ``check_l3`` had already flagged the
+        # culprit, but a pure ``same_as`` cycle (e.g. ``x: same_as(y)`` and
+        # ``y: same_as(x)``) satisfies per-token validation *and* the R3
+        # identity check, so combo validation would be silently skipped and
+        # invalid combo data would pass. Emit a hard L3 error with a
+        # specific diagnosis when possible (cycle / dangling reference),
+        # falling back to a generic unresolved-signature error otherwise.
+        errors.extend(_diagnose_unresolvable_signature(op_name, sig))
         return errors
     inputs = sig.get("inputs") or {}
     declared_input_names: list[str] = (
@@ -959,17 +1064,29 @@ _MOCK_DIM_SIZE = 4
 # sampling, so validation output stays reproducible.
 _MAX_DTYPE_COMBOS = 4096
 
-# Sentinel pool used to probe out-of-union dtype rejection in the
-# no-dtype_combos branch of ``check_l3_validate_dtypes_parity``. Chosen to
-# be common, cheap-to-allocate torch dtypes that are unlikely to appear
-# in every manifest declared union simultaneously — giving the probe at
-# least one out-of-union candidate per input on realistic specs. Probes
-# are bounded by ``_MAX_DTYPE_COMBOS`` so wide unions still stay within
-# CI budget.
+# Sentinel pool used only by the same_as-identity negative probe, where
+# the goal is a dtype *different from the ref's baseline* (union membership
+# is irrelevant). The out-of-union probes in both branches of
+# ``check_l3_validate_dtypes_parity`` derive their candidate pool from
+# ``sorted(_TORCH_DTYPES - declared)`` instead — that guarantees a
+# non-empty probe whenever declared does not cover the entire torch dtype
+# universe, closing a prior engulfment gap where a fixed 8-dtype pool
+# could be fully absorbed by a wide union and leave the probe vacuous.
 _DTYPE_SENTINELS: tuple[str, ...] = (
     "float16", "bfloat16", "float32", "float64",
     "int8", "int16", "int32", "int64",
 )
+
+
+def _out_of_union_candidates(declared: set[str]) -> list[str]:
+    """Return torch dtypes that are outside ``declared``.
+
+    Deterministic (sorted) so validator output is reproducible; bounded
+    because ``_TORCH_DTYPES`` is a fixed small set. Callers should still
+    cap the iteration length via ``_MAX_DTYPE_COMBOS`` when combining
+    with other enumeration.
+    """
+    return sorted(_TORCH_DTYPES - declared)
 
 
 class _MockShape(tuple):
@@ -1448,10 +1565,18 @@ def check_l2_infer_parity(
         for documented GPU-only cases where the method cannot be called
         outside a GPU context. Opt-out suppresses the missing-method
         warning entirely.
-      - Skips ops whose ``_infer_output_shapes`` raises during the call
-        (e.g. method expects GPU-only state); emits a warning instead.
-      - Produces L2 errors only for concrete disagreement: the method
-        returns shapes that fail one or more ``shape_rules``.
+      - An exception raised from the body of ``_infer_output_shapes``
+        (i.e. after argument binding succeeds) is a hard L2 error unless
+        the manifest entry declares ``parity_opt_out: [shape_parity]``
+        (or a bare ``parity_opt_out: true``). This is a policy change
+        from earlier revisions, which downgraded body exceptions to
+        warnings and let real bugs pass silently. Opt-out is reserved
+        for documented GPU-only methods that cannot be exercised outside
+        a GPU context; an introspection-level failure (signature binding
+        mismatch) is still reported separately as a signature error.
+      - Produces L2 errors for concrete disagreement: the method returns
+        shapes that fail one or more ``shape_rules`` or disagree with a
+        declared ``signature.outputs[*].shape``.
     """
     errors: list[str] = []
     if cls is None:
@@ -1723,8 +1848,26 @@ def check_l2_infer_parity(
     # an output-only symbol with only rank/consistency enforcement.
     static_expected: dict[str, int] = {
         name: int(val) for name, val in extra_attrs.items()
-        if isinstance(val, int)
+        if isinstance(val, int) and not isinstance(val, bool)
     }
+    # Params with a concrete integer ``default`` are also compile-time
+    # known and should pin declared-output-shape dims with the same
+    # authority as ``static_dims``. Without this, a declared output
+    # ``shape: "[k]"`` where ``k`` is a param default would be
+    # classified as an output-only symbol, and a bad
+    # ``_infer_output_shapes`` returning an arbitrary integer for that
+    # position would only trip rank/consistency checks rather than exact
+    # value comparison. Edge cases: params without a default (supplied
+    # at op construction, unknown to the validator) are skipped; params
+    # whose default is not a single ``int`` (e.g. ``list[int]``) are
+    # skipped so they cannot pin a scalar dim position.
+    for pname, pdefault in param_defaults.items():
+        if pname in static_expected:
+            continue  # static_dims wins — it is the declared source of truth.
+        if isinstance(pdefault, bool):
+            continue
+        if isinstance(pdefault, int):
+            static_expected[pname] = int(pdefault)
     output_only_seen: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         if out_name not in result:
@@ -2271,9 +2414,22 @@ def check_l3_validate_dtypes_parity(
                 if target in same_as_refs:
                     continue
                 declared = set(dtype_options.get(target, []))
-                out_of_union = [
-                    d for d in _DTYPE_SENTINELS if d not in declared
-                ]
+                out_of_union = _out_of_union_candidates(declared)
+                if not out_of_union:
+                    # Declared union covers the entire torch dtype
+                    # universe for this input — no candidate exists to
+                    # probe rejection. Emit a parity-skip warning naming
+                    # the op/input so the gap is visible rather than a
+                    # vacuous pass. Only possible when declared ==
+                    # _TORCH_DTYPES (wildly permissive spec).
+                    if warnings is not None:
+                        warnings.append(
+                            f"[dtype] {op_name}: out-of-union probe "
+                            f"skipped for input {target!r} — declared "
+                            f"dtype union covers the entire torch dtype "
+                            f"set; rejection side cannot be exercised"
+                        )
+                    continue
                 for bad_dtype in out_of_union:
                     if probed >= probe_budget:
                         break
@@ -2429,9 +2585,19 @@ def check_l3_validate_dtypes_parity(
                 if target in same_as_refs:
                     continue
                 declared = set(dtype_options.get(target, []))
-                out_of_union = [
-                    d for d in _DTYPE_SENTINELS if d not in declared
-                ]
+                out_of_union = _out_of_union_candidates(declared)
+                if not out_of_union:
+                    # Declared union covers every torch dtype — cannot
+                    # produce a rejection candidate. Skip with a warning
+                    # rather than vacuously pass.
+                    if warnings is not None:
+                        warnings.append(
+                            f"[dtype] {op_name}: out-of-union probe "
+                            f"skipped for input {target!r} — declared "
+                            f"dtype union covers the entire torch dtype "
+                            f"set; rejection side cannot be exercised"
+                        )
+                    continue
                 for bad_dtype in out_of_union:
                     if probed >= probe_budget:
                         break

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1143,6 +1143,12 @@ def check_l2_infer_parity(
     ctx: dict = dict(param_defaults)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
+    # Input-only context (no inferred outputs) is used to detect rules
+    # that already fail on the mock inputs themselves — such rules
+    # encode input-only preconditions (e.g. ``weight.shape ==
+    # (x.shape[dim],)``) that mock inputs may violate. A correct
+    # ``_infer_output_shapes`` must not be blamed in that case.
+    input_only_ctx: dict = dict(ctx)
     for out_name, out_shape in result.items():
         try:
             ctx[out_name] = _MockShape(tuple(out_shape))
@@ -1152,6 +1158,7 @@ def check_l2_infer_parity(
                 f"non-iterable shape for {out_name!r}: {out_shape!r}"
             )
 
+    output_names = set(result.keys()) | set(outputs.keys())
     for i, rule in enumerate(rules):
         if not isinstance(rule, str):
             continue
@@ -1166,6 +1173,27 @@ def check_l2_infer_parity(
                 )
             continue
         if not ok:
+            # Distinguish a genuine parity mismatch from a mock-input
+            # precondition violation: if the rule already fails with
+            # inputs only (and does not reference any declared output),
+            # the mock input shapes themselves violate the rule — skip
+            # with a warning instead of blaming _infer_output_shapes.
+            mentions_output = any(
+                re.search(rf"\b{re.escape(o)}\b", rule) for o in output_names
+            )
+            if not mentions_output:
+                ok_inputs, reason_inputs = _eval_shape_rule(
+                    rule, input_only_ctx,
+                )
+                if reason_inputs is None and not ok_inputs:
+                    if warnings is not None:
+                        warnings.append(
+                            f"[shape] {op_name}: shape_rules[{i}] "
+                            f"{rule!r} not satisfied by synthetic mock "
+                            f"inputs {shape_kwargs}; parity check "
+                            f"skipped (input-only precondition)"
+                        )
+                    continue
             errors.append(
                 f"[shape] {op_name}: _infer_output_shapes output violates "
                 f"shape_rules[{i}] {rule!r} under mock inputs "
@@ -1339,7 +1367,14 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, combo, param_defaults,
             )
-            if reason and reason.startswith(("unexpected", "TypeError")):
+            if reason and reason.startswith("TypeError"):
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes signature does "
+                    f"not match manifest inputs (expected kwargs "
+                    f"{sorted(forward_inputs)}): {reason}"
+                )
+                return errors
+            if reason and reason.startswith("unexpected"):
                 if warnings is not None:
                     warnings.append(
                         f"[dtype] {op_name}: _validate_dtypes parity skipped "
@@ -1406,7 +1441,17 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, candidate, param_defaults,
             )
-            if reason and reason.startswith(("unexpected", "TypeError")):
+            if reason and reason.startswith("TypeError"):
+                # Signature mismatch between manifest inputs and the op's
+                # _validate_dtypes — surface as a parity error (analogous
+                # to the L2 _infer_output_shapes signature check).
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes signature does "
+                    f"not match manifest inputs (expected kwargs "
+                    f"{sorted(forward_inputs)}): {reason}"
+                )
+                return errors
+            if reason and reason.startswith("unexpected"):
                 if warnings is not None:
                     warnings.append(
                         f"[dtype] {op_name}: _validate_dtypes parity skipped "

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -909,12 +909,16 @@ def _extract_shape_tuple_literals(rules: list) -> dict[str, int]:
 
 def _mock_input_shapes(
     sig: dict,
-) -> dict[str, _MockShape] | None:
+) -> tuple[dict[str, _MockShape], dict[str, int]] | None:
     """Derive concrete mock input shapes for every declared input.
 
     Uses rank hints from ``shape_rules`` (literal ``tensor.shape == (...)``
     forms). Falls back to a default 2D shape when the rank is unknown.
-    Returns None only if ``signature.inputs`` is malformed.
+    Returns (shapes, dim_sizes) where ``dim_sizes`` maps each symbolic
+    dimension name (e.g. ``B``, ``S``, ``H``, ``D``) to the integer size
+    used in the mock shapes, so callers can bind those names into a
+    shape_rules evaluation context. Returns None only if
+    ``signature.inputs`` is malformed.
     """
     inputs = sig.get("inputs")
     if not isinstance(inputs, dict) or not inputs:
@@ -965,7 +969,7 @@ def _mock_input_shapes(
         shapes[name] = _MockShape(
             (_MOCK_DIM_SIZE, _MOCK_DIM_SIZE)
         )
-    return shapes
+    return shapes, dim_sizes
 
 
 def _param_defaults(params: dict) -> dict:
@@ -980,6 +984,23 @@ def _param_defaults(params: dict) -> dict:
         if isinstance(pattrs, dict) and "default" in pattrs:
             out[pname] = pattrs["default"]
     return out
+
+
+def _parity_opted_out(entry: dict, check: str) -> bool:
+    """Return True when the manifest entry opts out of *check*.
+
+    Recognises two shapes for the ``parity_opt_out`` field:
+      - ``parity_opt_out: true`` — opt out of every parity check.
+      - ``parity_opt_out: [shape_parity, dtype_parity]`` — opt out of
+        specific checks only.
+
+    Used for documented GPU-only ops where the manifest-derived method
+    cannot be invoked from a CPU-only validator context.
+    """
+    opt = entry.get("parity_opt_out")
+    if opt is True:
+        return True
+    return bool(isinstance(opt, list) and check in opt)
 
 
 def _class_overrides_method(cls: type, name: str) -> bool:
@@ -1071,9 +1092,16 @@ def check_l2_infer_parity(
     into a shape_rules evaluation context and verifies every rule holds.
 
     Behaviour:
-      - Silently skips ops whose class does not override
-        ``_infer_output_shapes`` — this lets the validator coexist with
-        ops that have not yet been migrated to the codegen protocol.
+      - For implemented ops whose class does not override
+        ``_infer_output_shapes``, emits a warning reporting the missing
+        manifest-derived method. The parity check itself is skipped
+        because there is no concrete method to compare against, but the
+        gap is surfaced (no silent pass).
+      - Honors ``parity_opt_out: [shape_parity]`` (or a bare
+        ``parity_opt_out: true``) declared in the manifest entry — used
+        for documented GPU-only cases where the method cannot be called
+        outside a GPU context. Opt-out suppresses the missing-method
+        warning entirely.
       - Skips ops whose ``_infer_output_shapes`` raises during the call
         (e.g. method expects GPU-only state); emits a warning instead.
       - Produces L2 errors only for concrete disagreement: the method
@@ -1089,15 +1117,24 @@ def check_l2_infer_parity(
         return errors
 
     if not _class_overrides_method(cls, "_infer_output_shapes"):
+        if not _parity_opted_out(entry, "shape_parity") and warnings is not None:
+            warnings.append(
+                f"[shape] {op_name}: class does not override "
+                f"_infer_output_shapes — manifest-derived method not yet "
+                f"generated; parity check skipped. Declare "
+                f"'parity_opt_out: [shape_parity]' on the manifest entry "
+                f"to suppress this warning for documented GPU-only ops."
+            )
         return errors
 
     infer_fn = getattr(cls, "_infer_output_shapes", None)
     if infer_fn is None:
         return errors
 
-    mock_shapes = _mock_input_shapes(sig)
-    if mock_shapes is None:
+    mock = _mock_input_shapes(sig)
+    if mock is None:
         return errors
+    mock_shapes, dim_sizes = mock
 
     params = sig.get("params") or {}
     param_defaults = _param_defaults(params)
@@ -1139,8 +1176,14 @@ def check_l2_infer_parity(
                 f"{out_name!r} (declared in manifest)"
             )
 
-    # Assemble evaluation context: inputs + outputs + params.
-    ctx: dict = dict(param_defaults)
+    # Assemble evaluation context: symbolic dims + inputs + outputs +
+    # params. Symbolic dim names (e.g. B, S, H, D extracted from literal
+    # shape_rules like ``q.shape == (B, S, H, D)``) are bound first so
+    # param / tensor names later in the dict take precedence on any
+    # accidental collision.
+    ctx: dict = {}
+    ctx.update(dim_sizes)
+    ctx.update(param_defaults)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
     # Input-only context (no inferred outputs) is used to detect rules
@@ -1333,14 +1376,25 @@ def check_l3_validate_dtypes_parity(
     Without ``dtype_combos``: verify every combination in the Cartesian
     product of each input's declared dtype union is accepted.
 
-    Silently skips ops whose class does not override ``_validate_dtypes``
-    (bootstrap-friendly — ops not yet migrated are ignored).
+    For ops whose class does not override ``_validate_dtypes``, emits a
+    warning reporting the missing manifest-derived method (no silent
+    pass). Honors ``parity_opt_out: [dtype_parity]`` (or a bare
+    ``parity_opt_out: true``) declared in the manifest entry to suppress
+    the warning for documented GPU-only cases.
     """
     errors: list[str] = []
     if cls is None:
         return errors
 
     if not _class_overrides_method(cls, "_validate_dtypes"):
+        if not _parity_opted_out(entry, "dtype_parity") and warnings is not None:
+            warnings.append(
+                f"[dtype] {op_name}: class does not override "
+                f"_validate_dtypes — manifest-derived method not yet "
+                f"generated; parity check skipped. Declare "
+                f"'parity_opt_out: [dtype_parity]' on the manifest entry "
+                f"to suppress this warning for documented GPU-only ops."
+            )
         return errors
 
     sig = entry.get("signature", {})

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1177,17 +1177,35 @@ def check_l2_infer_parity(
     mock_self = types.SimpleNamespace(**param_defaults)
 
     shape_kwargs = {f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()}
+    # First, validate the callable signature independently of the body: a
+    # TypeError from inspect.signature().bind is a genuine signature mismatch
+    # between the expected ``<input>_shape=`` kwargs and _infer_output_shapes.
+    # TypeErrors raised inside the body (e.g. arithmetic on None) must not be
+    # misreported as signature mismatch.
     try:
-        result = infer_fn(mock_self, **shape_kwargs)
+        inspect.signature(infer_fn).bind(mock_self, **shape_kwargs)
     except TypeError as exc:
-        # Signature mismatch between expected ``<input>_shape=`` kwargs and
-        # the op's ``_infer_output_shapes``; surface this as a parity error.
         errors.append(
             f"[shape] {op_name}: _infer_output_shapes signature does not match "
             f"manifest inputs (expected kwargs {sorted(shape_kwargs)}): {exc}"
         )
         return errors
     except Exception as exc:  # noqa: BLE001
+        # signature() itself failed (e.g. builtin without introspection) —
+        # skip parity rather than fabricating a signature error.
+        if warnings is not None:
+            warnings.append(
+                f"[shape] {op_name}: _infer_output_shapes parity skipped — "
+                f"inspect.signature raised {exc.__class__.__name__}: {exc}"
+            )
+        return errors
+
+    try:
+        result = infer_fn(mock_self, **shape_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        # Signature is valid but the body raised. Treat as an
+        # implementation issue surfaced via warning (parity skipped) rather
+        # than a signature mismatch.
         if warnings is not None:
             warnings.append(
                 f"[shape] {op_name}: _infer_output_shapes parity skipped — "
@@ -1298,13 +1316,19 @@ def _dtype_options_for_tensor(
         m = _SAME_AS_RE.match(tokens[0])
         if m:
             ref = m.group(1)
-            return list(resolved.get(ref, []))
+            if ref not in resolved:
+                # Unresolved reference — propagate failure per docstring
+                # contract. Returning [] here would silently disable parity.
+                return None
+            return list(resolved[ref])
     out: list[str] = []
     for tok in tokens:
         m = _SAME_AS_RE.match(tok)
         if m:
             ref = m.group(1)
-            out.extend(resolved.get(ref, []))
+            if ref not in resolved:
+                return None
+            out.extend(resolved[ref])
         elif tok in _TORCH_DTYPES:
             out.append(tok)
         else:
@@ -1384,11 +1408,25 @@ def _combo_accepted(
         tensors[name] = t
 
     mock_self = types.SimpleNamespace(**param_defaults)
+    # Pre-bind the callable signature so only genuine signature mismatches
+    # surface as ``TypeError: ...``. TypeError raised from inside the body
+    # (e.g. comparing incompatible torch dtypes) is a legitimate rejection
+    # and must not be misreported as a signature mismatch.
+    try:
+        inspect.signature(validate_fn).bind(mock_self, **tensors)
+    except TypeError as exc:
+        return False, f"TypeError: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        # inspect.signature failed to introspect — treat as a skip.
+        return False, f"unexpected {exc.__class__.__name__}: {exc}"
+
     try:
         validate_fn(mock_self, **tensors)
-    except (ValueError, TypeError) as exc:
-        # Expected rejection path.
-        return False, None if isinstance(exc, ValueError) else f"TypeError: {exc}"
+    except (ValueError, TypeError):
+        # Body-level rejection: either an explicit ValueError or a
+        # TypeError arising from dtype comparisons. Both are legitimate
+        # rejections once the signature has been validated above.
+        return False, None
     except Exception as exc:  # noqa: BLE001
         return False, f"unexpected {exc.__class__.__name__}: {exc}"
     return True, None
@@ -1521,12 +1559,24 @@ def check_l3_validate_dtypes_parity(
                 f"[dtype] {op_name}: _validate_dtypes accepts non-listed "
                 f"combo {candidate!r} (not in dtype_combos)"
             )
-        if checked_any and not rejected_at_least_one and not errors \
-                and warnings is not None:
-            warnings.append(
-                f"[dtype] {op_name}: could not find a non-listed combo to "
-                f"exercise rejection (dtype_combos exhausts the union)"
-            )
+        if not errors and warnings is not None:
+            if not checked_any:
+                # No non-listed combo exists in the Cartesian product —
+                # dtype_combos already enumerates every reachable tuple.
+                warnings.append(
+                    f"[dtype] {op_name}: could not find a non-listed combo "
+                    f"to exercise rejection (dtype_combos exhausts the "
+                    f"union)"
+                )
+            elif not rejected_at_least_one:
+                # Non-listed combos were tried but none were rejected —
+                # either _validate_dtypes is too lax or every non-listed
+                # candidate was skipped (unexpected/TypeError).
+                warnings.append(
+                    f"[dtype] {op_name}: no non-listed dtype combo was "
+                    f"rejected by _validate_dtypes; parity coverage may be "
+                    f"incomplete"
+                )
     else:
         # No dtype_combos — verify every Cartesian combination is accepted.
         input_options = [

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1490,12 +1490,59 @@ def check_l2_infer_parity(
     ctx.update(param_defaults)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
-    # Input-only context (no inferred outputs) is used to detect rules
-    # that already fail on the mock inputs themselves — such rules
-    # encode input-only preconditions (e.g. ``weight.shape ==
-    # (x.shape[dim],)``) that mock inputs may violate. A correct
-    # ``_infer_output_shapes`` must not be blamed in that case.
-    input_only_ctx: dict = dict(ctx)
+    # Identify output-only symbols (symbols that appear only in declared
+    # output shapes, not in any input shape). Their concrete sizes are
+    # derived by ``_infer_output_shapes`` (possibly via a ``shape_rules``
+    # formula such as ``L_out == L_in - kW + 1``). For classification
+    # and rule evaluation, rebind these from the inferred ``result`` so
+    # a rule defining them is checked against the actual computed value
+    # rather than a synthetic mock size — otherwise a wrong
+    # _infer_output_shapes would silently pass, because the synthetic
+    # size pre-bound in ``dim_sizes`` would make the rule fail in both
+    # ctx and input_only_ctx and be misclassified as an input-only
+    # precondition to skip.
+    input_bound = _input_bound_symbols(sig)
+    output_only_symbols: set[str] = set()
+    # Rebind output-only symbols from the inferred ``result`` tuple
+    # positions. When the same symbol appears in multiple output
+    # positions that yield differing sizes, prefer the first and leave
+    # the consistency check below to flag the mismatch.
+    output_only_rebindings: dict[str, int] = {}
+    for out_name, decl_parts in declared_output_shapes.items():
+        for p in decl_parts:
+            if p not in input_bound:
+                output_only_symbols.add(p)
+        if out_name not in result:
+            continue
+        try:
+            inferred_tuple = tuple(result[out_name])
+        except TypeError:
+            continue
+        if len(inferred_tuple) != len(decl_parts):
+            continue
+        for p, got in zip(decl_parts, inferred_tuple, strict=True):
+            if p in input_bound:
+                continue
+            if not isinstance(got, int):
+                continue
+            if p not in output_only_rebindings:
+                output_only_rebindings[p] = got
+    # Apply output-only rebindings before rule evaluation. These replace
+    # the synthetic sizes that ``_mock_input_shapes`` seeded via the
+    # declared-output-shape pass in ``dim_sizes``.
+    for p, v in output_only_rebindings.items():
+        ctx[p] = v
+    # Input-only context (no inferred outputs, no output-only symbols)
+    # is used to detect rules that already fail on the mock inputs
+    # themselves — such rules encode input-only preconditions (e.g.
+    # ``weight.shape == (x.shape[dim],)``) that mock inputs may violate.
+    # A correct ``_infer_output_shapes`` must not be blamed in that
+    # case. Strip output-only symbols so a rule like
+    # ``L_out == L_in - kW + 1`` is never reachable via this path (it is
+    # output-dependent by construction).
+    input_only_ctx: dict = {
+        k: v for k, v in ctx.items() if k not in output_only_symbols
+    }
     for out_name, out_shape in result.items():
         try:
             ctx[out_name] = _MockShape(tuple(out_shape))
@@ -1522,11 +1569,15 @@ def check_l2_infer_parity(
         if not ok:
             # Distinguish a genuine parity mismatch from a mock-input
             # precondition violation: if the rule already fails with
-            # inputs only (and does not reference any declared output),
-            # the mock input shapes themselves violate the rule — skip
-            # with a warning instead of blaming _infer_output_shapes.
+            # inputs only (and does not reference any declared output
+            # tensor name *or* any output-only symbol), the mock input
+            # shapes themselves violate the rule — skip with a warning
+            # instead of blaming _infer_output_shapes.
             mentions_output = any(
                 re.search(rf"\b{re.escape(o)}\b", rule) for o in output_names
+            ) or any(
+                re.search(rf"\b{re.escape(s)}\b", rule)
+                for s in output_only_symbols
             )
             if not mentions_output:
                 ok_inputs, reason_inputs = _eval_shape_rule(
@@ -1564,7 +1615,8 @@ def check_l2_infer_parity(
     # For such symbols we enforce rank + per-symbol consistency instead
     # (same symbol must map to the same concrete size across every
     # position it appears in any declared output shape).
-    input_bound = _input_bound_symbols(sig)
+    # ``input_bound`` is already computed above (reused for the
+    # output-only rebinding pass before rule evaluation).
     output_only_seen: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         if out_name not in result:
@@ -1873,6 +1925,46 @@ def check_l3_validate_dtypes_parity(
 
     dtype_combos = sig.get("dtype_combos")
     if isinstance(dtype_combos, list) and dtype_combos:
+        # Upfront validation of dtype_combos values: every entry must be
+        # a concrete torch dtype (in ``_TORCH_DTYPES``) or a resolvable
+        # ``same_as(ref)`` expression that itself resolves to concrete
+        # torch dtypes. Invalid values are manifest data errors — surface
+        # as hard L3 errors rather than letting them fall through to a
+        # parity-skip warning (which would silently disable the check).
+        # The ``cannot build mock tensor`` warning path is reserved for
+        # valid dtype names that the local torch build cannot materialize
+        # (a validator-environment limitation, not a manifest defect).
+        combo_validation_errors: list[str] = []
+        for i, combo in enumerate(dtype_combos):
+            if not isinstance(combo, dict):
+                continue
+            for key, val in combo.items():
+                if not isinstance(val, str):
+                    combo_validation_errors.append(
+                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                        f"{val!r} is not a string"
+                    )
+                    continue
+                opts = _dtype_options_for_tensor(key, val, dtype_options)
+                if opts is None:
+                    combo_validation_errors.append(
+                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                        f"{val!r} is not a valid dtype (unresolved "
+                        f"same_as reference or not in torch dtype set)"
+                    )
+                elif not all(t in _TORCH_DTYPES for t in opts):
+                    bad = [t for t in opts if t not in _TORCH_DTYPES]
+                    combo_validation_errors.append(
+                        f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                        f"{val!r} resolves to unknown dtype(s) {bad!r}"
+                    )
+        if combo_validation_errors:
+            # Surface the data errors and stop before any parity probing:
+            # invalid combo entries would otherwise generate a cascade
+            # of misleading "rejects" / "skipped" diagnostics.
+            errors.extend(combo_validation_errors)
+            return errors
+
         # Each listed combo should be accepted.
         for i, combo in enumerate(dtype_combos):
             if not isinstance(combo, dict):

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -956,6 +956,55 @@ def _parse_shape_decl(shape_str: str) -> list[str] | None:
     return parts
 
 
+def _input_bound_symbols(sig: dict) -> set[str]:
+    """Return symbolic dim names bound by INPUT shapes only.
+
+    A symbol is input-bound when it appears in either:
+      - a ``<input>.shape == (...)`` literal in ``signature.shape_rules``
+      - a ``signature.inputs[*].shape`` declaration like ``"[N, C, L]"``
+
+    Symbols that appear only in output shape declarations (e.g. ``L_out``
+    in ``signature.outputs.y.shape = "[N, C, L_out]"`` where ``L_out`` is
+    derived by a ``shape_rules`` entry such as ``L_out = L_in - kW + 1``)
+    are **not** included. The L2 parity check uses this set to decide
+    whether a declared output-shape symbol carries a concrete mock size
+    (input-bound) versus a value derived by ``_infer_output_shapes``
+    (output-only): comparing the inferred output against an arbitrary
+    mock size for output-only symbols would misreport a correct
+    implementation as a parity mismatch.
+    """
+    bound: set[str] = set()
+    ident_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+    # shape_rules: <name>.shape == (<ids>...)
+    rules = sig.get("shape_rules") or []
+    shape_eq_re = re.compile(
+        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
+    )
+    inputs = sig.get("inputs") or {}
+    input_names = set(inputs.keys()) if isinstance(inputs, dict) else set()
+    for rule in rules:
+        if not isinstance(rule, str):
+            continue
+        m = shape_eq_re.match(rule)
+        if m is None:
+            continue
+        tname, body = m.group(1), m.group(2)
+        if tname not in input_names:
+            continue
+        for p in (q.strip() for q in body.split(",")):
+            if p and ident_re.fullmatch(p):
+                bound.add(p)
+    # Per-tensor shape decl on inputs
+    if isinstance(inputs, dict):
+        for attrs in inputs.values():
+            if not isinstance(attrs, dict):
+                continue
+            parts = _parse_shape_decl(attrs.get("shape", ""))
+            if parts is not None:
+                bound.update(parts)
+    return bound
+
+
 def _mock_input_shapes(
     sig: dict,
 ) -> tuple[dict[str, _MockShape], dict[str, int]] | None:
@@ -1082,6 +1131,54 @@ def _param_defaults(params: dict) -> dict:
     return out
 
 
+def _static_dim_values(
+    sig: dict,
+    mock_shapes: dict[str, _MockShape],
+    param_defaults: dict,
+) -> dict:
+    """Resolve ``signature.static_dims`` to concrete integer values.
+
+    Each entry is declared as ``<name>: "<tensor>.shape[<axis>]"`` where
+    ``<tensor>`` is an input and ``<axis>`` is either an integer literal
+    or a param name. Returns a mapping ``{static_dim_name: int}`` with
+    only successfully resolved entries (malformed / out-of-range entries
+    are silently skipped — validator's L0 schema check reports those).
+
+    Used by parity mock_self builders so methods that consult
+    ``self.<static_dim_name>`` attributes (e.g. ``_infer_output_shapes``
+    reading ``self.N``) see the concrete size carried by the synthetic
+    inputs, rather than raising ``AttributeError``.
+    """
+    out: dict = {}
+    sdims = sig.get("static_dims")
+    if not isinstance(sdims, dict):
+        return out
+    for dname, expr in sdims.items():
+        if not isinstance(expr, str):
+            continue
+        m = _STATIC_DIM_EXPR_RE.match(expr)
+        if m is None:
+            continue
+        tname, axis_ref = m.groups()
+        shape = mock_shapes.get(tname)
+        if shape is None:
+            continue
+        # Resolve axis: integer literal or param-name lookup.
+        if axis_ref.lstrip("-").isdigit():
+            axis = int(axis_ref)
+        elif axis_ref in param_defaults and isinstance(
+            param_defaults[axis_ref], int
+        ):
+            axis = param_defaults[axis_ref]
+        else:
+            continue
+        try:
+            out[dname] = int(shape[axis])
+        except (IndexError, TypeError, ValueError):
+            continue
+    return out
+
+
 def _parity_opted_out(entry: dict, check: str) -> bool:
     """Return True when the manifest entry opts out of *check*.
 
@@ -1197,7 +1294,11 @@ def _eval_shape_rule(
         return False, f"non-boolean result: {exc}"
 
 
-def _build_mock_self(cls: type, param_defaults: dict) -> object:
+def _build_mock_self(
+    cls: type,
+    param_defaults: dict,
+    extra_attrs: dict | None = None,
+) -> object:
     """Build a mock ``self`` instance without running ``__init__``.
 
     Uses ``cls.__new__(cls)`` so that methods bound to ``cls`` (and any
@@ -1209,19 +1310,29 @@ def _build_mock_self(cls: type, param_defaults: dict) -> object:
     ``param_defaults`` is the manifest-derived params map (from
     ``signature.params``). Each default is installed as an instance
     attribute so ``self.<param>`` lookups resolve without running any
-    initialization logic. Callers may install additional manifest-derived
-    attributes (e.g. ``dtype``) on the returned object before invoking
-    the target method.
+    initialization logic.
+
+    ``extra_attrs`` carries additional manifest-derived attributes to
+    install after the params — typically ``static_dims`` values resolved
+    from the synthetic mock inputs (so methods reading ``self.<N>``
+    where ``N`` is a static dim see a concrete size) and the dtype axis
+    (so ``self.dtype`` reflects the candidate combo instead of the
+    inherited ``Op.dtype = None`` base-class default). Entries in
+    ``extra_attrs`` override same-named entries in ``param_defaults``
+    because they are specific to the current parity probe context.
 
     Falls back to :class:`types.SimpleNamespace` if ``cls.__new__``
     raises (defensive; Python ``type`` subclasses can override ``__new__``
     with required positional arguments).
     """
+    merged: dict = dict(param_defaults)
+    if extra_attrs:
+        merged.update(extra_attrs)
     try:
         instance = cls.__new__(cls)
     except Exception:  # noqa: BLE001
-        return types.SimpleNamespace(**param_defaults)
-    for k, v in param_defaults.items():
+        return types.SimpleNamespace(**merged)
+    for k, v in merged.items():
         # __slots__ or read-only descriptors may reject setattr; ignore
         # — parity check will surface any resulting AttributeError as a
         # skip when the target method actually reads ``self.<k>``.
@@ -1308,7 +1419,14 @@ def check_l2_infer_parity(
     # manifest-derived params as instance attributes without running
     # __init__. A plain SimpleNamespace would raise AttributeError when
     # _infer_output_shapes consults an unrelated ``self.<attr>`` helper.
-    mock_self = _build_mock_self(cls, param_defaults)
+    #
+    # Generated ``_infer_output_shapes`` implementations commonly consult
+    # static_dims via ``self.<dim>`` (e.g. ``self.N`` for
+    # ``static_dims: {N: x.shape[-1]}``). Resolve them against the
+    # synthetic mock inputs so the parity call does not raise a spurious
+    # ``AttributeError`` and skip the check.
+    extra_attrs = _static_dim_values(sig, mock_shapes, param_defaults)
+    mock_self = _build_mock_self(cls, param_defaults, extra_attrs)
 
     shape_kwargs = {f"{name}_shape": tuple(shape) for name, shape in mock_shapes.items()}
     # First, validate the callable signature independently of the body: a
@@ -1432,9 +1550,22 @@ def check_l2_infer_parity(
     # Compare inferred outputs against per-tensor declared shapes in
     # signature.outputs[*].shape, independently of shape_rules. This
     # catches ops whose outputs are only specified via declared shape
-    # fields (no equivalent shape_rule). Expected dim sizes come from
-    # ``dim_sizes``, which was populated from all available symbolic
-    # names (rule literals + input/output shape declarations).
+    # fields (no equivalent shape_rule).
+    #
+    # Only symbols **bound by input shapes** (input shape_rules literals
+    # or signature.inputs[*].shape declarations) carry a concrete mock
+    # size that ``_infer_output_shapes`` is expected to echo back.
+    # Output-only symbols (e.g. ``L_out`` in a conv output shape that is
+    # derived by a ``shape_rules`` entry such as ``L_out = L_in - kW + 1``)
+    # cannot be meaningfully compared against an arbitrary
+    # ``dim_sizes`` entry — doing so would flag a correct
+    # implementation, since ``_infer_output_shapes`` computes the real
+    # post-conv length, not the synthetic size assigned to ``L_out``.
+    # For such symbols we enforce rank + per-symbol consistency instead
+    # (same symbol must map to the same concrete size across every
+    # position it appears in any declared output shape).
+    input_bound = _input_bound_symbols(sig)
+    output_only_seen: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         if out_name not in result:
             continue
@@ -1442,23 +1573,42 @@ def check_l2_infer_parity(
             inferred = tuple(result[out_name])
         except TypeError:
             continue  # already reported above
-        expected = tuple(
-            dim_sizes.get(p, _MOCK_DIM_SIZE) for p in decl_parts
-        )
-        if len(inferred) != len(expected):
+        if len(inferred) != len(decl_parts):
             errors.append(
                 f"[shape] {op_name}: _infer_output_shapes output "
                 f"{out_name!r} rank {len(inferred)} disagrees with "
-                f"declared shape {decl_parts} (rank {len(expected)}) "
+                f"declared shape {decl_parts} (rank {len(decl_parts)}) "
                 f"under mock inputs {shape_kwargs} -> {inferred}"
             )
             continue
-        if inferred != expected:
-            errors.append(
-                f"[shape] {op_name}: _infer_output_shapes output "
-                f"{out_name!r}={inferred} disagrees with declared shape "
-                f"{decl_parts}={expected} under mock inputs {shape_kwargs}"
-            )
+        for idx, (p, got) in enumerate(zip(decl_parts, inferred, strict=True)):
+            if p in input_bound:
+                # Input-bound symbol: concrete size is pinned by mock
+                # inputs and must match exactly.
+                expected = dim_sizes.get(p, _MOCK_DIM_SIZE)
+                if got != expected:
+                    errors.append(
+                        f"[shape] {op_name}: _infer_output_shapes output "
+                        f"{out_name!r} dim[{idx}]={got} disagrees with "
+                        f"declared {p}={expected} under mock inputs "
+                        f"{shape_kwargs} -> {inferred}"
+                    )
+            else:
+                # Output-only symbol: value is derived by
+                # _infer_output_shapes (and possibly a shape_rules
+                # formula). Only enforce consistency — the same symbol
+                # must resolve to the same concrete size everywhere it
+                # appears across all declared outputs.
+                prev = output_only_seen.get(p)
+                if prev is None:
+                    output_only_seen[p] = got
+                elif prev != got:
+                    errors.append(
+                        f"[shape] {op_name}: _infer_output_shapes output "
+                        f"{out_name!r} binds output-only symbol {p!r} to "
+                        f"{got} but earlier output bound it to {prev} "
+                        f"(inconsistent under mock inputs {shape_kwargs})"
+                    )
     return errors
 
 
@@ -1533,6 +1683,34 @@ def _resolve_tensor_dtype_options(
     return resolved
 
 
+def _primary_dtype_input(
+    sig: dict, forward_inputs: list[str],
+) -> str | None:
+    """Return the first input whose dtype is not bound by ``same_as(ref)``.
+
+    The returned input is used to stamp ``self.dtype`` on the mock self
+    for dtype parity. Same_as-bound inputs are skipped because their
+    dtype is derivative: their dtype follows ``ref``, and
+    manifest-derived ``_validate_dtypes`` implementations typically
+    compare the op's ``self.dtype`` against the unbound primary input.
+    """
+    inputs = sig.get("inputs") or {}
+    if not isinstance(inputs, dict):
+        return None
+    for name in forward_inputs:
+        attrs = inputs.get(name)
+        if not isinstance(attrs, dict):
+            continue
+        dstr = attrs.get("dtype", "")
+        tokens = _parse_dtype_expr(dstr)
+        if len(tokens) == 1 and _SAME_AS_RE.match(tokens[0]):
+            continue
+        return name
+    # Fallback: no fully-free input; use the first declared input even
+    # if it's same_as-bound, so ``self.dtype`` is at least non-None.
+    return forward_inputs[0] if forward_inputs else None
+
+
 def _make_mock_tensor(dtype_name: str):
     """Build a 0-sized torch tensor of the named dtype (CPU).
 
@@ -1550,13 +1728,30 @@ def _make_mock_tensor(dtype_name: str):
 
 def _combo_accepted(
     cls: type, forward_inputs: list[str], combo: dict[str, str],
-    param_defaults: dict,
+    param_defaults: dict, sig: dict | None = None,
+    self_dtype_name: str | None = None,
 ) -> tuple[bool, str | None]:
     """Invoke ``cls._validate_dtypes`` on a mock-self with *combo*.
 
     Returns (accepted, error_reason). ``accepted=False`` with
     reason=None means the op raised during validation (rejected);
     reason!=None indicates the call could not be performed (skip).
+
+    ``sig`` (optional) is the manifest signature; when provided, the
+    mock-self is enriched with static_dims values resolved against
+    synthetic mock input shapes and with ``self.dtype`` bound to the
+    candidate's dtype axis (see below). Both attributes are commonly
+    consulted by generated ``_validate_dtypes`` implementations (e.g.
+    ``if x.dtype != self.dtype: raise``); without them the parity
+    probe would spuriously reject listed combos.
+
+    ``self_dtype_name`` (optional) pins the dtype installed on
+    ``mock_self.dtype``. Used by out-of-union probes to keep the op's
+    configured dtype at a valid baseline while mutating the input
+    tensor's dtype — otherwise ``self.dtype`` would follow the bad
+    candidate and a ``x.dtype != self.dtype`` check would spuriously
+    pass. When omitted, defaults to the combo entry for the first
+    non-same_as-bound input (the listed-combo convention).
     """
     validate_fn = getattr(cls, "_validate_dtypes", None)
     if validate_fn is None:
@@ -1575,7 +1770,31 @@ def _combo_accepted(
     # Build mock self via ``cls.__new__(cls)`` so _validate_dtypes
     # methods that consult other class helpers or instance attributes
     # (beyond manifest params) do not falsely raise AttributeError.
-    mock_self = _build_mock_self(cls, param_defaults)
+    extra_attrs: dict = {}
+    if sig is not None:
+        mock = _mock_input_shapes(sig)
+        if mock is not None:
+            mock_shapes, _ = mock
+            extra_attrs.update(
+                _static_dim_values(sig, mock_shapes, param_defaults)
+            )
+        # Install self.dtype mirroring the manifest convention: the op's
+        # dtype attribute tracks the candidate's primary dtype (first
+        # non-same_as-bound input by default) unless an explicit
+        # ``self_dtype_name`` override is supplied (out-of-union probes
+        # pin the baseline valid dtype so only the input tensor's dtype
+        # deviates). A manifest-derived _validate_dtypes that compares
+        # ``x.dtype != self.dtype`` then sees a real torch.dtype instead
+        # of the base-class ``None``.
+        if self_dtype_name is not None:
+            override_t = _make_mock_tensor(self_dtype_name)
+            if override_t is not None:
+                extra_attrs["dtype"] = override_t.dtype
+        else:
+            primary = _primary_dtype_input(sig, forward_inputs)
+            if primary is not None and primary in tensors:
+                extra_attrs["dtype"] = tensors[primary].dtype
+    mock_self = _build_mock_self(cls, param_defaults, extra_attrs)
     # Pre-bind the callable signature so only genuine signature mismatches
     # surface as ``TypeError: ...``. TypeError raised from inside the body
     # (e.g. comparing incompatible torch dtypes) is a legitimate rejection
@@ -1659,7 +1878,7 @@ def check_l3_validate_dtypes_parity(
             if not isinstance(combo, dict):
                 continue
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, combo, param_defaults,
+                cls, forward_inputs, combo, param_defaults, sig=sig,
             )
             if reason and reason.startswith("TypeError"):
                 errors.append(
@@ -1731,7 +1950,7 @@ def check_l3_validate_dtypes_parity(
             candidate = dict(zip(forward_inputs, tup, strict=True))
             checked_any = True
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, candidate, param_defaults,
+                cls, forward_inputs, candidate, param_defaults, sig=sig,
             )
             if reason and reason.startswith(("unexpected", "TypeError")):
                 continue
@@ -1760,6 +1979,16 @@ def check_l3_validate_dtypes_parity(
                 break
         if baseline_combo is not None:
             same_as_refs = _same_as_refs(sig)
+            # Baseline's primary dtype pins ``self.dtype`` during the
+            # probe so only the input tensor's dtype deviates from the
+            # op's configured dtype (otherwise the ``x.dtype !=
+            # self.dtype`` check in a generated _validate_dtypes would
+            # spuriously pass, since both sides track the bad dtype).
+            baseline_primary = _primary_dtype_input(sig, forward_inputs)
+            baseline_self_dtype = (
+                baseline_combo.get(baseline_primary)
+                if baseline_primary is not None else None
+            )
             probe_budget = _MAX_DTYPE_COMBOS
             probed = 0
             for target in forward_inputs:
@@ -1783,6 +2012,7 @@ def check_l3_validate_dtypes_parity(
                             candidate[tname] = bad_dtype
                     accepted, reason = _combo_accepted(
                         cls, forward_inputs, candidate, param_defaults,
+                        sig=sig, self_dtype_name=baseline_self_dtype,
                     )
                     if reason and reason.startswith(
                         ("unexpected", "TypeError", "cannot build",
@@ -1844,7 +2074,7 @@ def check_l3_validate_dtypes_parity(
             if not _honours_same_as(sig, candidate):
                 continue
             accepted, reason = _combo_accepted(
-                cls, forward_inputs, candidate, param_defaults,
+                cls, forward_inputs, candidate, param_defaults, sig=sig,
             )
             if reason and reason.startswith("TypeError"):
                 # Signature mismatch between manifest inputs and the op's
@@ -1882,6 +2112,14 @@ def check_l3_validate_dtypes_parity(
                 break
         if baseline is not None:
             same_as_refs = _same_as_refs(sig)
+            # Keep ``self.dtype`` pinned to the baseline's primary valid
+            # dtype during out-of-union probes — see the dtype_combos
+            # branch above for rationale.
+            baseline_primary = _primary_dtype_input(sig, forward_inputs)
+            baseline_self_dtype = (
+                baseline.get(baseline_primary)
+                if baseline_primary is not None else None
+            )
             probe_budget = _MAX_DTYPE_COMBOS
             probed = 0
             for target in forward_inputs:
@@ -1908,6 +2146,7 @@ def check_l3_validate_dtypes_parity(
                             candidate[tname] = bad_dtype
                     accepted, reason = _combo_accepted(
                         cls, forward_inputs, candidate, param_defaults,
+                        sig=sig, self_dtype_name=baseline_self_dtype,
                     )
                     if reason and reason.startswith(
                         ("unexpected", "TypeError")
@@ -1951,7 +2190,7 @@ def check_l3_validate_dtypes_parity(
                     candidate = dict(baseline)
                     candidate[tname] = alt
                     accepted, reason = _combo_accepted(
-                        cls, forward_inputs, candidate, param_defaults,
+                        cls, forward_inputs, candidate, param_defaults, sig=sig,
                     )
                     if reason and reason.startswith(
                         ("unexpected", "TypeError")

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -884,14 +884,43 @@ def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
     if dtype_options is None:
         # Tensor-level dtype errors already reported in ``check_l3``.
         return errors
+    inputs = sig.get("inputs") or {}
+    declared_input_names: list[str] = (
+        list(inputs.keys()) if isinstance(inputs, dict) else []
+    )
     for i, combo in enumerate(dtype_combos):
         if not isinstance(combo, dict):
             continue
+        # Combo-row completeness: every declared signature.inputs tensor
+        # must be assigned a dtype in every combo row. Otherwise a combo
+        # row that silently omits an input would pass L3 when no
+        # ``_validate_dtypes`` override exists, since ``_combo_accepted``
+        # is never exercised for omitted inputs.
+        for input_name in declared_input_names:
+            if input_name not in combo:
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}] is missing "
+                    f"declared input {input_name!r} (every combo row "
+                    f"must cover every signature.inputs tensor)"
+                )
         for key, val in combo.items():
             if not isinstance(val, str):
                 errors.append(
                     f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
                     f"{val!r} is not a string"
+                )
+                continue
+            # Per manifest.md R4, each combo value must be a single
+            # concrete dtype token (or a ``same_as(ref)`` naming one
+            # sibling in the same combo row). Reject union expressions
+            # like ``"float16 | bfloat16"`` outright — a union in a
+            # combo row would let an implementation silently widen the
+            # accepted-dtype set beyond what the manifest authored.
+            if "|" in val:
+                errors.append(
+                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
+                    f"{val!r} — combo values must be a single concrete "
+                    f"dtype, not a union"
                 )
                 continue
             opts = _dtype_options_for_tensor(key, val, dtype_options)
@@ -1509,14 +1538,26 @@ def check_l2_infer_parity(
     try:
         result = infer_fn(mock_self, **shape_kwargs)
     except Exception as exc:  # noqa: BLE001
-        # Signature is valid but the body raised. Treat as an
-        # implementation issue surfaced via warning (parity skipped) rather
-        # than a signature mismatch.
-        if warnings is not None:
-            warnings.append(
-                f"[shape] {op_name}: _infer_output_shapes parity skipped — "
-                f"call raised {exc.__class__.__name__}: {exc}"
-            )
+        # Signature is valid but the body raised. This is a genuine
+        # implementation bug: a correct manifest-derived
+        # ``_infer_output_shapes`` must succeed on manifest-compatible
+        # mock inputs. Surface as a hard L2 parity error unless the
+        # entry explicitly opts out via ``parity_opt_out: [shape_parity]``
+        # (documented GPU-only cases). Previously downgraded to a
+        # warning — that let real bugs pass L2.
+        if _parity_opted_out(entry, "shape_parity"):
+            if warnings is not None:
+                warnings.append(
+                    f"[shape] {op_name}: _infer_output_shapes parity "
+                    f"skipped (opt-out) — call raised "
+                    f"{exc.__class__.__name__}: {exc}"
+                )
+            return errors
+        errors.append(
+            f"[shape] {op_name}: _infer_output_shapes raised "
+            f"{exc.__class__.__name__} under mock inputs "
+            f"{shape_kwargs}: {exc}"
+        )
         return errors
 
     if not isinstance(result, dict):
@@ -1671,6 +1712,19 @@ def check_l2_infer_parity(
     # position it appears in any declared output shape).
     # ``input_bound`` is already computed above (reused for the
     # output-only rebinding pass before rule evaluation).
+    #
+    # Static-dim resolution: symbols declared in ``signature.static_dims``
+    # (e.g. ``static_dims: {N: "x.shape[-1]"}``) are resolved to concrete
+    # integer sizes against the mock inputs via ``_static_dim_values``
+    # (already stored in ``extra_attrs`` above). Treat those as pinned
+    # expected sizes for the declared-output-shape comparison — a bad
+    # ``_infer_output_shapes`` returning arbitrary integers for a
+    # static-dim position must be caught, not mistakenly reclassified as
+    # an output-only symbol with only rank/consistency enforcement.
+    static_expected: dict[str, int] = {
+        name: int(val) for name, val in extra_attrs.items()
+        if isinstance(val, int)
+    }
     output_only_seen: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         if out_name not in result:
@@ -1688,10 +1742,14 @@ def check_l2_infer_parity(
             )
             continue
         for idx, (p, got) in enumerate(zip(decl_parts, inferred, strict=True)):
-            if p in input_bound:
-                # Input-bound symbol: concrete size is pinned by mock
-                # inputs and must match exactly.
-                expected = dim_sizes.get(p, _MOCK_DIM_SIZE)
+            if p in input_bound or p in static_expected:
+                # Input-bound or static-dim symbol: concrete size is
+                # pinned by mock inputs (or by the static_dims
+                # expression resolved against them) and must match
+                # exactly.
+                expected = static_expected.get(
+                    p, dim_sizes.get(p, _MOCK_DIM_SIZE)
+                )
                 if got != expected:
                     errors.append(
                         f"[shape] {op_name}: _infer_output_shapes output "
@@ -1728,8 +1786,14 @@ def _dtype_options_for_tensor(
 ) -> list[str] | None:
     """Expand a dtype expression into concrete torch dtype names.
 
-    ``same_as(ref)`` resolves to whatever *ref* was resolved to (must
-    appear earlier). Returns None if the expression cannot be resolved.
+    ``same_as(ref)`` resolves to whatever *ref* has already been resolved
+    to in the *resolved* map. Declaration order is irrelevant: callers
+    (``_resolve_tensor_dtype_options``) iterate to a fixpoint, retrying
+    tensors whose ``same_as(ref)`` targets unresolved refs until every
+    tensor resolves or no progress is made. Returns None when the
+    expression cannot be resolved in the current pass (caller decides
+    whether that is a temporary state inside the fixpoint loop or a
+    permanent failure).
     """
     tokens = _parse_dtype_expr(dtype_str)
     # Pure same_as(ref): inherits ref's options.
@@ -1931,8 +1995,11 @@ def _combo_accepted(
     except TypeError as exc:
         return False, f"TypeError: {exc}"
     except Exception as exc:  # noqa: BLE001
-        # inspect.signature failed to introspect — treat as a skip.
-        return False, f"unexpected {exc.__class__.__name__}: {exc}"
+        # inspect.signature itself failed to introspect — treat as a
+        # validator-side skip (not an op-side bug). Tagged distinctly
+        # from body-level unexpected exceptions so callers can enforce
+        # policy differences.
+        return False, f"introspect-failed {exc.__class__.__name__}: {exc}"
 
     try:
         validate_fn(mock_self, **tensors)
@@ -1942,6 +2009,12 @@ def _combo_accepted(
         # rejections once the signature has been validated above.
         return False, None
     except Exception as exc:  # noqa: BLE001
+        # Body raised a non-ValueError/TypeError exception. This is a
+        # genuine implementation bug (a correct manifest-derived
+        # ``_validate_dtypes`` must either accept or raise
+        # ValueError/TypeError, never e.g. RuntimeError). Callers
+        # enforce this as a hard L3 parity error unless the entry opts
+        # out via ``parity_opt_out: [dtype_parity]``.
         return False, f"unexpected {exc.__class__.__name__}: {exc}"
     return True, None
 
@@ -2051,12 +2124,35 @@ def check_l3_validate_dtypes_parity(
                     f"{sorted(forward_inputs)}): {reason}"
                 )
                 return errors
-            if reason and reason.startswith("unexpected"):
+            if reason and reason.startswith("introspect-failed"):
+                # Validator-side introspection failure (inspect.signature
+                # could not parse the method). Not an op-side bug —
+                # skip with warning.
                 if warnings is not None:
                     warnings.append(
                         f"[dtype] {op_name}: _validate_dtypes parity skipped "
                         f"for dtype_combos[{i}] — {reason}"
                     )
+                continue
+            if reason and reason.startswith("unexpected"):
+                # Body-level exception that is not ValueError / TypeError
+                # — a real implementation bug. Surface as a hard L3
+                # parity error unless the entry opts out. Previously
+                # downgraded to warning, which let broken implementations
+                # pass.
+                if _parity_opted_out(entry, "dtype_parity"):
+                    if warnings is not None:
+                        warnings.append(
+                            f"[dtype] {op_name}: _validate_dtypes parity "
+                            f"skipped (opt-out) for dtype_combos[{i}] — "
+                            f"{reason}"
+                        )
+                    continue
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes raised "
+                    f"unexpected exception on dtype_combos[{i}] "
+                    f"{combo!r} — {reason}"
+                )
                 continue
             if reason and reason.startswith("cannot build mock tensor"):
                 # Validator limitation (no torch dtype for this name) — emit
@@ -2116,7 +2212,20 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, candidate, param_defaults, sig=sig,
             )
-            if reason and reason.startswith(("unexpected", "TypeError")):
+            if reason and reason.startswith(
+                ("introspect-failed", "TypeError")
+            ):
+                continue
+            if reason and reason.startswith("unexpected"):
+                # Body-level unexpected exception — hard error unless
+                # opt-out (parity policy tightened).
+                if _parity_opted_out(entry, "dtype_parity"):
+                    continue
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes raised "
+                    f"unexpected exception on non-listed combo "
+                    f"{candidate!r} — {reason}"
+                )
                 continue
             if not accepted:
                 rejected_at_least_one = True
@@ -2179,9 +2288,18 @@ def check_l3_validate_dtypes_parity(
                         sig=sig, self_dtype_name=baseline_self_dtype,
                     )
                     if reason and reason.startswith(
-                        ("unexpected", "TypeError", "cannot build",
-                         "combo missing")
+                        ("introspect-failed", "TypeError",
+                         "cannot build", "combo missing")
                     ):
+                        continue
+                    if reason and reason.startswith("unexpected"):
+                        if _parity_opted_out(entry, "dtype_parity"):
+                            continue
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes raised "
+                            f"unexpected exception on out-of-union probe "
+                            f"{candidate!r} — {reason}"
+                        )
                         continue
                     if accepted:
                         errors.append(
@@ -2250,12 +2368,29 @@ def check_l3_validate_dtypes_parity(
                     f"{sorted(forward_inputs)}): {reason}"
                 )
                 return errors
-            if reason and reason.startswith("unexpected"):
+            if reason and reason.startswith("introspect-failed"):
                 if warnings is not None:
                     warnings.append(
                         f"[dtype] {op_name}: _validate_dtypes parity skipped "
                         f"for combo {candidate!r} — {reason}"
                     )
+                continue
+            if reason and reason.startswith("unexpected"):
+                # Body-level unexpected exception — hard error unless
+                # opt-out. See ``_combo_accepted`` docstring.
+                if _parity_opted_out(entry, "dtype_parity"):
+                    if warnings is not None:
+                        warnings.append(
+                            f"[dtype] {op_name}: _validate_dtypes parity "
+                            f"skipped (opt-out) for combo {candidate!r} — "
+                            f"{reason}"
+                        )
+                    continue
+                errors.append(
+                    f"[dtype] {op_name}: _validate_dtypes raised "
+                    f"unexpected exception on combo {candidate!r} — "
+                    f"{reason}"
+                )
                 continue
             if not accepted:
                 errors.append(
@@ -2313,8 +2448,17 @@ def check_l3_validate_dtypes_parity(
                         sig=sig, self_dtype_name=baseline_self_dtype,
                     )
                     if reason and reason.startswith(
-                        ("unexpected", "TypeError")
+                        ("introspect-failed", "TypeError")
                     ):
+                        continue
+                    if reason and reason.startswith("unexpected"):
+                        if _parity_opted_out(entry, "dtype_parity"):
+                            continue
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes raised "
+                            f"unexpected exception on out-of-union probe "
+                            f"{candidate!r} — {reason}"
+                        )
                         continue
                     if accepted:
                         errors.append(
@@ -2357,8 +2501,17 @@ def check_l3_validate_dtypes_parity(
                         cls, forward_inputs, candidate, param_defaults, sig=sig,
                     )
                     if reason and reason.startswith(
-                        ("unexpected", "TypeError")
+                        ("introspect-failed", "TypeError")
                     ):
+                        continue
+                    if reason and reason.startswith("unexpected"):
+                        if _parity_opted_out(entry, "dtype_parity"):
+                            continue
+                        errors.append(
+                            f"[dtype] {op_name}: _validate_dtypes raised "
+                            f"unexpected exception on same_as probe "
+                            f"{candidate!r} — {reason}"
+                        )
                         continue
                     if accepted:
                         errors.append(

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1019,6 +1019,52 @@ class TestInferShapeParity:
             for e in errors
         ), f"Expected ndim parity mismatch, got: {errors}"
 
+    def test_input_only_precondition_not_blamed_on_infer(self, validator):
+        """Mock-input precondition violations must not become parity errors.
+
+        When ``shape_rules`` encode an input-only precondition (e.g.
+        ``weight.shape == (x.shape[dim],)``) that the synthesised mock
+        inputs happen to violate, a correct ``_infer_output_shapes`` must
+        not be blamed. The rule must be reported as skipped via warning
+        rather than an error.
+        """
+        def infer(self, x_shape, weight_shape):
+            # Correct: y has the same shape as x.
+            return {"y": x_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16"},
+                    "weight": {"dtype": "float16"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "params": {"dim": {"default": -1}},
+                "shape_rules": [
+                    # Input-only precondition the mock (4,4) vs (4,4)
+                    # arrangement would naively satisfy; use a form that
+                    # the mock synthesis will not satisfy to trigger the
+                    # precondition-violation path.
+                    "weight.shape == (x.shape[dim] + 1,)",
+                    "y.shape == x.shape",
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        assert not any(
+            "_infer_output_shapes output violates" in e for e in errors
+        ), (
+            "Correct _infer_output_shapes should not be blamed for an "
+            f"input-only precondition violation on mock inputs: {errors}"
+        )
+        assert any(
+            "input-only precondition" in w for w in warnings
+        ), f"Expected precondition-skip warning, got: {warnings}"
+
 
 # ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
@@ -1213,6 +1259,64 @@ class TestValidateDtypesParity:
             for e in errors
         ), (
             f"Expected (bfloat16, float16) combo in errors, got: {errors}"
+        )
+
+    def test_signature_mismatch_union_fails(self, validator):
+        """AC-3 regression: _validate_dtypes with a wrong kwarg name must fail.
+
+        Previously TypeError from a signature mismatch was silently
+        downgraded to a warning, letting an unusable _validate_dtypes
+        satisfy parity. The validator must surface this as a hard error.
+        """
+        def validate(self, wrong_name):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "signature does not match manifest inputs" in e for e in errors
+        ), (
+            "Signature mismatch in _validate_dtypes must surface as a "
+            f"parity error, got errors={errors} warnings={warnings}"
+        )
+
+    def test_signature_mismatch_dtype_combos_fails(self, validator):
+        """Same signature-mismatch hard-fail on the dtype_combos branch."""
+        def validate(self, wrong_name, other_wrong):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                    {"x": "bfloat16", "w": "bfloat16"},
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "signature does not match manifest inputs" in e for e in errors
+        ), (
+            "Signature mismatch must surface on dtype_combos branch too, "
+            f"got errors={errors} warnings={warnings}"
         )
 
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -830,7 +830,12 @@ class TestInferShapeParity:
     """L2 extension: ``_infer_output_shapes`` output must satisfy shape_rules."""
 
     def test_no_override_skipped(self, validator):
-        """Ops without a ``_infer_output_shapes`` override produce no errors."""
+        """Ops without a ``_infer_output_shapes`` override produce no errors.
+
+        The check still surfaces the missing manifest-derived method as a
+        warning (see ``test_no_override_emits_missing_method_warning``);
+        this test pins the no-hard-error behaviour.
+        """
         from tileops.ops.op_base import Op
 
         class BareOp(Op):
@@ -849,6 +854,127 @@ class TestInferShapeParity:
             },
         }
         assert validator.check_l2_infer_parity("BareOp", entry, BareOp) == []
+
+    def test_no_override_emits_missing_method_warning(self, validator):
+        """F002 regression: missing override must not pass silently.
+
+        Implemented ops whose class does not yet define
+        ``_infer_output_shapes`` must surface a warning naming the gap.
+        Silently skipping every such op would make the parity check
+        vacuous on the current manifest (no op currently overrides this
+        method).
+        """
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "BareOp", entry, BareOp, warnings=warnings,
+        )
+        assert errors == []
+        assert any(
+            "does not override _infer_output_shapes" in w for w in warnings
+        ), (
+            f"Expected missing-method warning when implemented op lacks "
+            f"the codegen-derived method, got: {warnings}"
+        )
+
+    def test_no_override_opt_out_suppresses_warning(self, validator):
+        """F002: parity_opt_out: [shape_parity] suppresses the warning.
+
+        Documented GPU-only ops can opt out of shape parity via a
+        manifest flag.
+        """
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "parity_opt_out": ["shape_parity"],
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "BareOp", entry, BareOp, warnings=warnings,
+        )
+        assert errors == []
+        assert not any(
+            "does not override _infer_output_shapes" in w for w in warnings
+        ), warnings
+
+    def test_symbolic_dim_rule_detects_wrong_output(self, validator):
+        """F001 regression: rules like ``o.shape == (B, S, H, D)`` must fire.
+
+        The MultiHeadAttentionFwdOp-style manifest rule references
+        symbolic dimension names (B, S, H, D) declared only via literal
+        ``tensor.shape == (...)`` rules. Without binding those names into
+        the evaluation context, the rule raised NameError and the
+        validator silently downgraded it to a warning — meaning a
+        genuinely wrong ``_infer_output_shapes`` (e.g. returning a 1-D
+        shape instead of a 4-D shape) could pass parity.
+        """
+        def infer(self, q_shape, k_shape, v_shape):
+            # Wrong: returns a 1-D shape instead of a 4-D shape.
+            return {"o": (999,)}
+
+        cls = _make_op_cls_with_infer(infer, name="BadMHA")
+        entry = {
+            "signature": {
+                "inputs": {
+                    "q": {"dtype": "float16"},
+                    "k": {"dtype": "float16"},
+                    "v": {"dtype": "float16"},
+                },
+                "outputs": {"o": {"dtype": "float16"}},
+                "shape_rules": [
+                    "q.shape == (B, S, H, D)",
+                    "k.shape == (B, S, H, D)",
+                    "v.shape == (B, S, H, D)",
+                    "o.shape == (B, S, H, D)",
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "BadMHA", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "_infer_output_shapes output violates" in e and "o.shape" in e
+            for e in errors
+        ), (
+            f"Expected symbolic-dim rule to evaluate and flag mismatch, "
+            f"got errors={errors} warnings={warnings}"
+        )
+        assert not any(
+            "could not be evaluated" in w for w in warnings
+        ), (
+            f"Symbolic dim names must be bound into ctx, not reported as "
+            f"NameError: {warnings}"
+        )
 
     def test_no_cls_skipped(self, validator):
         entry = {"signature": {"shape_rules": ["y.shape == x.shape"]}}
@@ -1103,6 +1229,61 @@ class TestValidateDtypesParity:
             },
         }
         assert validator.check_l3_validate_dtypes_parity("Bare", entry, BareOp) == []
+
+    def test_no_override_emits_missing_method_warning(self, validator):
+        """F002 regression: missing override must not pass silently on L3."""
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "BareOp", entry, BareOp, warnings=warnings,
+        )
+        assert errors == []
+        assert any(
+            "does not override _validate_dtypes" in w for w in warnings
+        ), warnings
+
+    def test_no_override_opt_out_suppresses_warning(self, validator):
+        """F002: parity_opt_out: [dtype_parity] suppresses the warning."""
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "parity_opt_out": ["dtype_parity"],
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "BareOp", entry, BareOp, warnings=warnings,
+        )
+        assert errors == []
+        assert not any(
+            "does not override _validate_dtypes" in w for w in warnings
+        ), warnings
 
     def test_union_accept_all_passes(self, validator):
         import torch

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1191,6 +1191,49 @@ class TestInferShapeParity:
             "input-only precondition" in w for w in warnings
         ), f"Expected precondition-skip warning, got: {warnings}"
 
+    def test_mock_input_shapes_cross_tensor_dims_distinct(self, validator):
+        """Distinct symbolic dims across rules must get distinct mock sizes.
+
+        Regression for a latent correctness bug where a per-rule index
+        caused different symbolic dims to collide (e.g. ``A`` in rule
+        ``x.shape == (A, B)`` and ``C`` in rule ``y.shape == (C, D)``
+        both got assigned ``_MOCK_DIM_SIZE + 0``). A downstream rule
+        comparing ``x.shape[0]`` to ``y.shape[0]`` would then get a
+        spurious True / False depending on direction.
+        """
+        sig = {
+            "inputs": {"x": {}, "y": {}},
+            "shape_rules": [
+                "x.shape == (A, B)",
+                "y.shape == (C, D)",
+            ],
+        }
+        result = validator._mock_input_shapes(sig)
+        assert result is not None
+        shapes, dim_sizes = result
+        # Four distinct symbolic dims → four distinct mock sizes.
+        assert len({dim_sizes[k] for k in ("A", "B", "C", "D")}) == 4
+        # Corollary: the mock shapes of x and y disagree on the first
+        # dim, so a ``x.shape[0] == y.shape[0]`` rule would correctly
+        # evaluate False on mock inputs.
+        assert tuple(shapes["x"])[0] != tuple(shapes["y"])[0]
+
+    def test_eval_shape_rule_rejects_dunder_attr(self, validator):
+        """Shape-rule evaluator must reject dunder attribute access.
+
+        Defense-in-depth: manifest content is trusted (PR-gated), but
+        a classic sandbox-escape expression such as
+        ``().__class__.__mro__[1].__subclasses__()`` would bypass the
+        restricted builtins. The evaluator runs an AST filter that
+        rejects any attribute whose name starts or ends with ``__``.
+        """
+        ok, reason = validator._eval_shape_rule(
+            "().__class__ is None", {},
+        )
+        assert ok is False
+        assert reason is not None
+        assert "dunder attribute access not permitted" in reason
+
 
 # ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
@@ -1499,6 +1542,42 @@ class TestValidateDtypesParity:
             "Signature mismatch must surface on dtype_combos branch too, "
             f"got errors={errors} warnings={warnings}"
         )
+
+    def test_cartesian_product_over_bound_skipped_with_warning(
+        self, validator, monkeypatch,
+    ):
+        """Enumerating every combo must stay within a configurable bound.
+
+        Guards against future ops that declare many inputs × wide dtype
+        unions from exploding CI wall-time. When the product exceeds
+        ``_MAX_DTYPE_COMBOS`` the op is skipped deterministically with
+        a warning naming input count × option sizes.
+        """
+        monkeypatch.setattr(validator, "_MAX_DTYPE_COMBOS", 4)
+
+        def _accept_all(self, **kwargs):
+            return None
+
+        cls = _make_op_cls_with_validate(_accept_all, name="WideDtypeOp")
+        entry = {
+            "signature": {
+                "inputs": {
+                    "a": {"dtype": "float16 | bfloat16 | float32"},
+                    "b": {"dtype": "float16 | bfloat16 | float32"},
+                },
+                "outputs": {"y": {"dtype": "same_as(a)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "WideDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], (
+            f"Over-bound enumeration should skip, not error: {errors}"
+        )
+        assert any(
+            "exceeds _MAX_DTYPE_COMBOS" in w for w in warnings
+        ), f"Expected over-bound skip warning, got: {warnings}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -939,6 +939,38 @@ class TestInferShapeParity:
         assert validator.check_l2_infer_parity("FakeOp", entry, cls) == []
         assert seen_rank == [4], seen_rank
 
+    def test_r11_style_rule_uses_len_helper(self, validator):
+        """R11 / R11a rules that call ``len`` must be evaluable.
+
+        Regression: previously the eval context stripped ``__builtins__`` so
+        every rule using ``len`` / ``isinstance`` / ``set`` raised NameError
+        and was silently downgraded to a warning, causing real parity
+        mismatches to slip through.
+        """
+        # Wrong: reduction op declares dim=-1, keepdim=False so y should drop
+        # a rank, but _infer_output_shapes returns x_shape verbatim.
+        def infer(self, x_shape):
+            return {"y": x_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "params": {
+                    "dim": {"default": -1},
+                    "keepdim": {"default": False},
+                },
+                "shape_rules": [
+                    "y.ndim == x.ndim - len({dim % x.ndim})",
+                ],
+            },
+        }
+        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        assert any("_infer_output_shapes output violates" in e for e in errors), (
+            f"Expected R11-style rule to evaluate and flag mismatch, got: {errors}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
@@ -1087,6 +1119,53 @@ class TestValidateDtypesParity:
             "FakeDtypeOp", entry, cls,
         )
         assert any("accepts non-listed combo" in e for e in errors), errors
+
+    def test_dtype_combos_first_rejected_later_accepted_fails(self, validator):
+        """Regression: non-listed combos must all be checked, not just first.
+
+        Previously the loop broke on the first rejection, letting a later
+        accepted non-listed combo escape detection. Enumerate every
+        non-listed combination and report each acceptance.
+        """
+        import torch
+
+        def validate(self, x, w):
+            # Reject the first non-listed combo (fp16, bf16) but accept a
+            # later non-listed combo (bf16, fp16). Listed (fp16, fp16) is
+            # also accepted.
+            if x.dtype == torch.float16 and w.dtype == torch.bfloat16:
+                raise ValueError("rejected early non-listed combo")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "float16 | bfloat16"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                ],
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        )
+        # Must flag the later accepted non-listed combo (bf16, fp16) and
+        # may also flag (bf16, bf16). At minimum one 'accepts non-listed'
+        # error must be present.
+        assert any("accepts non-listed combo" in e for e in errors), (
+            f"Expected later non-listed acceptance to be flagged, got: {errors}"
+        )
+        # Stronger check: the (bfloat16, float16) combo specifically is
+        # surfaced — proves the loop did not stop at the first rejection.
+        assert any(
+            "'x': 'bfloat16'" in e and "'w': 'float16'" in e
+            for e in errors
+        ), (
+            f"Expected (bfloat16, float16) combo in errors, got: {errors}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1316,7 +1316,7 @@ class TestInferShapeParity:
             "FakeOp", entry, cls, warnings=warnings,
         )
         assert any(
-            "disagrees with declared shape" in e for e in errors
+            "disagrees with declared" in e for e in errors
         ), (
             "Wrong _infer_output_shapes against declared output shape "
             f"must surface as a parity error; errors={errors}"
@@ -1371,6 +1371,149 @@ class TestInferShapeParity:
             "self.<class_attr> lookup must not cause a parity skip; "
             f"warnings={warnings}"
         )
+
+    def test_infer_reads_static_dim_attr_populated(self, validator):
+        """``_infer_output_shapes`` reading ``self.<static_dim>`` must
+        exercise parity, not skip with AttributeError.
+
+        Regression (review thread 1): ``_build_mock_self`` previously
+        installed only ``signature.params`` defaults, so a generated
+        ``_infer_output_shapes`` that consults ``self.N`` (a
+        ``static_dims`` key) raised AttributeError and the check was
+        silently skipped. With static_dims now resolved against mock
+        inputs and installed on mock_self, the method runs and its
+        output is compared end-to-end.
+        """
+        from tileops.ops.op_base import Op
+
+        class StaticDimOp(Op):
+
+            def forward(self, x):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+            def _infer_output_shapes(self, x_shape):
+                # Reads a static_dims attribute: N = x.shape[-1]
+                return {"y": (self.N, self.N)}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16", "shape": "[B, N]"}},
+                "outputs": {"y": {"dtype": "float16", "shape": "[N, N]"}},
+                "static_dims": {"N": "x.shape[-1]"},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "StaticDimOp", entry, StaticDimOp, warnings=warnings,
+        )
+        assert errors == [], f"Expected no errors, got: {errors}"
+        assert not any(
+            "AttributeError" in w for w in warnings
+        ), f"static_dims lookup must not AttributeError-skip; warnings={warnings}"
+
+    def test_conv_like_output_only_symbol_not_blamed(self, validator):
+        """Conv-like op with output-only ``L_out`` derived by shape_rules
+        must pass parity when ``_infer_output_shapes`` is correct.
+
+        Regression (review thread 2): previously the declared
+        output-shape comparison pulled an arbitrary concrete size for
+        ``L_out`` from ``dim_sizes`` and flagged the correct
+        ``_infer_output_shapes`` as a mismatch. Output-only symbols must
+        only be checked for rank + per-symbol consistency across
+        outputs.
+        """
+        def infer(self, x_shape, w_shape):
+            # x: [N, C_in, L_in]; w: [C_out, C_in, kW]
+            # y: [N, C_out, L_in - kW + 1]
+            return {"y": (x_shape[0], w_shape[0], x_shape[2] - w_shape[2] + 1)}
+
+        cls = _make_op_cls_with_infer(infer, name="ConvLikeOp")
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
+                },
+                "outputs": {
+                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
+                },
+                "shape_rules": ["L_out == L_in - kW + 1"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "ConvLikeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], (
+            f"Correct conv-like infer must not be flagged for output-only "
+            f"symbol L_out; errors={errors}"
+        )
+
+    def test_conv_like_wrong_rank_still_caught(self, validator):
+        """Rank disagreement against declared output shape is still an
+        error, even for an op with an output-only ``L_out`` symbol.
+
+        Pins the positive side of the thread 2 fix: loosening the
+        output-only value check must not weaken the rank check.
+        """
+        def infer(self, x_shape, w_shape):
+            # Wrong rank: drops the spatial dim entirely.
+            return {"y": (x_shape[0], w_shape[0])}
+
+        cls = _make_op_cls_with_infer(infer, name="ConvLikeBadOp")
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
+                },
+                "outputs": {
+                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
+                },
+                "shape_rules": ["L_out == L_in - kW + 1"],
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "ConvLikeBadOp", entry, cls,
+        )
+        assert any(
+            "rank" in e and "disagrees" in e for e in errors
+        ), f"Expected rank error; got: {errors}"
+
+    def test_conv_like_output_only_inconsistent_across_outputs(self, validator):
+        """Output-only symbol reused across multiple outputs must be
+        consistent; otherwise the parity check flags the disagreement.
+        """
+        def infer(self, x_shape):
+            # Two outputs that both claim ``L_out`` but produce different
+            # concrete sizes — this is an internal inconsistency even
+            # though L_out is output-only.
+            return {
+                "y1": (x_shape[0], x_shape[1] - 1),
+                "y2": (x_shape[0], x_shape[1] - 2),
+            }
+
+        cls = _make_op_cls_with_infer(infer, name="InconsistentOutOnlyOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16", "shape": "[N, L_in]"}},
+                "outputs": {
+                    "y1": {"dtype": "float16", "shape": "[N, L_out]"},
+                    "y2": {"dtype": "float16", "shape": "[N, L_out]"},
+                },
+                "shape_rules": ["L_out == L_in - 1"],
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "InconsistentOutOnlyOp", entry, cls,
+        )
+        assert any(
+            "output-only symbol" in e and "L_out" in e for e in errors
+        ), f"Expected output-only consistency error; got: {errors}"
 
 
 class TestDtypeOptionsHelper:
@@ -2108,6 +2251,42 @@ class TestValidateDtypesParity:
         ), (
             "missing-input skip must not be reported as rejection; "
             f"errors={errors}"
+        )
+
+    def test_validate_dtypes_reads_self_dtype_attr(self, validator):
+        """``_validate_dtypes`` that compares ``x.dtype != self.dtype``
+        must accept every listed combo when mock_self.dtype is populated.
+
+        Regression (review thread 1): ``_build_mock_self`` previously
+        installed only ``signature.params`` defaults, so
+        ``self.dtype`` fell through to the base-class ``Op.dtype = None``
+        and the comparison always raised — causing the parity check to
+        mark every listed combo as rejected. With the dtype axis now
+        populated from the candidate combo, listed combos are accepted
+        end-to-end.
+        """
+        def validate(self, x):
+            # The generated pattern under test: compare the input dtype
+            # against ``self.dtype`` (set in __init__ via a dtype param).
+            if x.dtype != self.dtype:
+                raise ValueError(
+                    f"x.dtype {x.dtype} does not match self.dtype {self.dtype}"
+                )
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], (
+            "With self.dtype populated from the combo, listed combos "
+            f"must be accepted; errors={errors} warnings={warnings}"
         )
 
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1274,6 +1274,104 @@ class TestInferShapeParity:
             f"warnings={warnings}"
         )
 
+    def test_declared_output_shape_catches_wrong_infer(self, validator):
+        """Op with shape-declared-only outputs (no shape_rules) whose
+        ``_infer_output_shapes`` returns the wrong shape must produce a
+        parity error.
+
+        Regression: previously ``check_l2_infer_parity`` short-circuited
+        on empty ``shape_rules``, so a manifest that specified output
+        shape only via ``signature.outputs[*].shape`` (e.g. conv ops'
+        ``"[N, C_out, L_out]"``) could not catch a broken
+        ``_infer_output_shapes``. The validator now also compares
+        inferred outputs against declared output shape fields.
+        """
+        def infer(self, x_shape, w_shape):
+            # Wrong: returns x_shape verbatim instead of
+            # ``[N, C_out, L_out]`` implied by the declared output shape.
+            return {"y": tuple(x_shape)}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+                    "w": {
+                        "dtype": "float16",
+                        "shape": "[C_out, C_in, kW]",
+                    },
+                },
+                "outputs": {
+                    "y": {
+                        "dtype": "float16",
+                        "shape": "[N, C_out, L_out]",
+                    },
+                },
+                # No shape_rules; declared shape fields alone must drive
+                # the parity check.
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "disagrees with declared shape" in e for e in errors
+        ), (
+            "Wrong _infer_output_shapes against declared output shape "
+            f"must surface as a parity error; errors={errors}"
+        )
+
+    def test_infer_reads_self_attr_uses_cls_new(self, validator):
+        """``_infer_output_shapes`` that reads an instance attribute set
+        outside manifest params must not falsely skip.
+
+        Regression: when the mock ``self`` was a
+        :class:`types.SimpleNamespace`, the call raised AttributeError
+        and the parity check silently skipped. After switching to
+        ``cls.__new__(cls)`` + setattr for manifest params, the mock
+        ``self`` carries class-defined helpers (here a class attribute),
+        and the parity check proceeds end-to-end.
+        """
+        from tileops.ops.op_base import Op
+
+        class SelfAttrOp(Op):
+            # Class attribute accessible via ``self.some_attr`` even when
+            # ``__init__`` was not run.
+            some_attr = 7
+
+            def forward(self, x):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+            def _infer_output_shapes(self, x_shape):
+                # Read an attribute that must be reachable through self.
+                _ = self.some_attr
+                return {"y": tuple(x_shape)}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "SelfAttrOp", entry, SelfAttrOp, warnings=warnings,
+        )
+        assert errors == [], f"Expected no errors, got: {errors}"
+        assert not any(
+            "parity skipped" in w and "AttributeError" in w
+            for w in warnings
+        ), (
+            "self.<class_attr> lookup must not cause a parity skip; "
+            f"warnings={warnings}"
+        )
+
 
 class TestDtypeOptionsHelper:
     """Unit tests for ``_dtype_options_for_tensor`` unresolved-ref contract."""
@@ -1708,7 +1806,15 @@ class TestValidateDtypesParity:
         ``listed_combo_keys`` continue path and ``checked_any`` stays
         False.
         """
+        import torch
+
+        allowed = {torch.float16, torch.bfloat16}
+
         def validate(self, x, w):
+            # Reject dtypes outside the declared union so the new
+            # out-of-union probe does not produce parity errors.
+            if x.dtype not in allowed or w.dtype not in allowed:
+                raise ValueError("dtype out of union")
             return None
 
         cls = _make_op_cls_with_validate(validate)
@@ -1900,6 +2006,107 @@ class TestValidateDtypesParity:
         )
         assert errors == [], (
             "Conforming op must not emit a parity error; "
+            f"errors={errors}"
+        )
+
+    def test_combos_branch_out_of_union_probe(self, validator):
+        """Dtype_combos branch must fire the out-of-union probe.
+
+        Regression: previously the out-of-union negative probe only ran
+        in the no-dtype_combos branch, so a permissive ``_validate_dtypes``
+        that accepts every dtype could pass parity as long as every
+        listed combo was accepted. The probe now exercises the same
+        rejection invariant in the dtype_combos branch.
+        """
+        # Overly-permissive implementation: accepts any dtype combo.
+        def validate(self, x):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16"},
+                    {"x": "bfloat16"},
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "out-of-union" in e for e in errors
+        ), (
+            "Out-of-union probe must fire in the dtype_combos branch; "
+            f"errors={errors}"
+        )
+
+    def test_combo_skip_reasons_not_misattributed(self, validator):
+        """``_combo_accepted`` skip reasons ('combo missing input ...',
+        'cannot build mock tensor ...') must not be reported as plain
+        rejection parity failures.
+
+        Regression: the dtype_combos branch previously handled only
+        ``TypeError`` and ``unexpected`` reasons, so a combo lacking an
+        input entry or naming a dtype the validator cannot materialize
+        (no ``torch.<name>``) fell through to the rejection branch and
+        produced a misleading "rejects dtype_combos[i]" error that
+        blamed the op for a manifest gap or a validator limitation.
+        """
+        # Validator body must not matter; the skip path runs before it.
+        def validate(self, x, w):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        # dtype_combos[0] names a dtype with no torch equivalent →
+        # _combo_accepted returns reason="cannot build mock tensor ...".
+        # dtype_combos[1] omits 'w' entirely → reason="combo missing input 'w'".
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "not_a_real_dtype", "w": "not_a_real_dtype"},
+                    {"x": "float16"},  # missing 'w'
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        # Neither skip reason should surface as a rejection error.
+        assert not any(
+            "rejects dtype_combos[0]" in e for e in errors
+        ), (
+            "'cannot build mock tensor' must not be reported as a "
+            f"rejection parity failure; errors={errors}"
+        )
+        # The mock-tensor limitation should come through as a warning.
+        assert any(
+            "cannot build mock tensor" in w for w in warnings
+        ), (
+            "cannot-build-mock-tensor skip must surface as a parity-skip "
+            f"warning; warnings={warnings}"
+        )
+        # The missing-input combo is a manifest error — surface it, but
+        # not as a rejection.
+        assert any(
+            "combo missing input" in e for e in errors
+        ), (
+            "combo missing input must be reported as a manifest error; "
+            f"errors={errors}"
+        )
+        assert not any(
+            "rejects dtype_combos[1]" in e for e in errors
+        ), (
+            "missing-input skip must not be reported as rejection; "
             f"errors={errors}"
         )
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1739,6 +1739,170 @@ class TestValidateDtypesParity:
             f"Cartesian combo; warnings={warnings}"
         )
 
+    def test_no_combos_accepts_out_of_union_fails(self, validator):
+        """AC-3 rejection side: when the op has no ``dtype_combos`` and
+        ``_validate_dtypes`` accepts a dtype outside the declared union,
+        the no-combos branch must emit a parity error.
+
+        Regression for F010: previously the no-combos branch iterated
+        only the union's Cartesian product and so could not detect an
+        overly-permissive ``_validate_dtypes``.
+        """
+        # Overly-permissive implementation: accepts any dtype.
+        def validate(self, x):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "out-of-union" in e for e in errors
+        ), (
+            "Out-of-union dtype must surface as parity error when "
+            f"_validate_dtypes accepts it; errors={errors}"
+        )
+
+    def test_no_combos_rejects_out_of_union_pass(self, validator):
+        """Well-behaved op that rejects out-of-union dtypes produces no
+        parity error.
+        """
+        import torch
+
+        def validate(self, x):
+            if x.dtype not in (torch.float16, torch.bfloat16):
+                raise ValueError(f"unsupported dtype {x.dtype}")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], (
+            "Conforming op must not emit a parity error; "
+            f"errors={errors}"
+        )
+
+    def test_no_combos_out_of_union_probe_respects_max(
+        self, validator, monkeypatch,
+    ):
+        """Out-of-union probe must stay within ``_MAX_DTYPE_COMBOS``.
+
+        With the cap tightened to 2, at most 2 out-of-union probes fire
+        even though the sentinel pool contains 6 out-of-union dtypes
+        for a {float16, bfloat16} union.
+        """
+        # Product size for a single-input {float16, bfloat16} union is 2,
+        # so _MAX_DTYPE_COMBOS=2 keeps the Cartesian enumeration alive.
+        monkeypatch.setattr(validator, "_MAX_DTYPE_COMBOS", 2)
+
+        def validate(self, x):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        out_of_union_errs = [e for e in errors if "out-of-union" in e]
+        # Sentinel pool has 6 out-of-union entries but probe budget is 2.
+        assert len(out_of_union_errs) == 2, (
+            "Out-of-union probe must be bounded by _MAX_DTYPE_COMBOS; "
+            f"got {len(out_of_union_errs)} errors: {out_of_union_errs}"
+        )
+
+    def test_no_combos_accepts_same_as_violation_fails(self, validator):
+        """AC-3 / R3: when ``_validate_dtypes`` accepts a same_as
+        identity violation, the no-combos branch must surface it.
+
+        Regression for F011: the union-iteration loop skips every
+        same_as-violating candidate via ``_honours_same_as``, so a
+        permissive op that fails to enforce same_as would go unflagged
+        without a dedicated probe.
+        """
+        # Overly-permissive: does not check x.dtype == w.dtype.
+        def validate(self, x, w):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "same_as violation" in e for e in errors
+        ), (
+            "same_as identity violation must surface as parity error "
+            f"when _validate_dtypes accepts it; errors={errors}"
+        )
+
+    def test_no_combos_rejects_same_as_violation_pass(self, validator):
+        """Well-behaved op that enforces same_as produces no parity
+        error on the same_as probe.
+        """
+        import torch
+
+        allowed = (torch.float16, torch.bfloat16)
+
+        def validate(self, x, w):
+            if x.dtype not in allowed or w.dtype not in allowed:
+                raise ValueError(
+                    f"unsupported dtype: x.dtype={x.dtype} "
+                    f"w.dtype={w.dtype}"
+                )
+            if x.dtype != w.dtype:
+                raise ValueError(
+                    f"same_as violated: x.dtype={x.dtype} "
+                    f"w.dtype={w.dtype}"
+                )
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], (
+            "Conforming op must not emit a parity error; "
+            f"errors={errors}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Bench checks

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2717,6 +2717,230 @@ class TestUnexpectedValidateDtypesException:
         ), f"expected hard L3 error, got errors={errors} warnings={warnings}"
 
 
+class TestSameAsCycleHardError:
+    """PR #1005 follow-up: pure ``same_as`` cycles must surface a hard L3 error.
+
+    Previously, ``check_l3_dtype_combos_data`` returned silently when
+    ``_resolve_tensor_dtype_options`` returned None, relying on
+    ``check_l3`` to have flagged the culprit. But a pure cycle like
+    ``x: same_as(y)`` / ``y: same_as(x)`` satisfies per-token validation
+    and the R3 identity check, so combo validation would be silently
+    skipped and invalid combo data passes.
+    """
+
+    def test_pure_same_as_cycle_emits_hard_error(self, validator):
+        """A 2-cycle between two inputs must surface a diagnosed L3 error."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "same_as(y)"},
+                "y": {"dtype": "same_as(x)"},
+            },
+            "outputs": {"z": {"dtype": "same_as(x)"}},
+            "dtype_combos": [
+                {"x": "float16", "y": "float16"},
+            ],
+        }
+        errors = validator.check_l3_dtype_combos_data("CycleOp", sig)
+        assert any(
+            "same_as cycle" in e and "'x'" in e and "'y'" in e
+            for e in errors
+        ), f"expected cycle diagnosis naming x and y, got {errors}"
+
+    def test_dangling_same_as_emits_hard_error(self, validator):
+        """A ``same_as(missing)`` reference is reported as dangling.
+
+        The per-token ``_validate_dtype_token`` check already flags this
+        at L3, but combo validation must surface its own hard error so
+        callers never see a silent pass.
+        """
+        sig = {
+            "inputs": {
+                "x": {"dtype": "same_as(nope)"},
+            },
+            "outputs": {"z": {"dtype": "same_as(x)"}},
+            "dtype_combos": [
+                {"x": "float16"},
+            ],
+        }
+        errors = validator.check_l3_dtype_combos_data("DanglingOp", sig)
+        assert any(
+            "dangling reference" in e and "same_as(nope)" in e
+            for e in errors
+        ), f"expected dangling diagnosis, got {errors}"
+
+
+class TestParamDefaultOutputShapePin:
+    """PR #1005 follow-up: param defaults must pin declared output-shape dims.
+
+    A param with a concrete integer default (e.g. ``params.k.default = 4``)
+    is a compile-time-known value just like ``static_dims``. Declared
+    output ``shape: "[k]"`` must compare against the default, so a bad
+    ``_infer_output_shapes`` returning ``(999,)`` is caught by exact-value
+    comparison rather than only rank/consistency.
+    """
+
+    def test_param_default_pins_output_dim(self, validator):
+        """Bad infer returning ``(999,)`` for declared ``[k]`` with
+        ``params.k.default = 4`` must produce a hard L2 error."""
+        def bad_infer(self, x_shape):
+            return {"y": (999,)}
+
+        cls = _make_op_cls_with_infer(bad_infer, name="ParamDefaultBadOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16", "shape": "[M]"}},
+                "outputs": {
+                    "y": {"dtype": "same_as(x)", "shape": "[k]"},
+                },
+                "params": {"k": {"type": "int", "default": 4}},
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "ParamDefaultBadOp", entry, cls,
+        )
+        assert any(
+            "dim[0]=999" in e and "k=4" in e for e in errors
+        ), f"expected param-default parity error, got {errors}"
+
+    def test_param_default_pins_output_dim_pass(self, validator):
+        """Correct infer returning ``(4,)`` for declared ``[k]`` with
+        ``params.k.default = 4`` passes parity."""
+        def good_infer(self, x_shape):
+            return {"y": (4,)}
+
+        cls = _make_op_cls_with_infer(good_infer, name="ParamDefaultGoodOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16", "shape": "[M]"}},
+                "outputs": {
+                    "y": {"dtype": "same_as(x)", "shape": "[k]"},
+                },
+                "params": {"k": {"type": "int", "default": 4}},
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "ParamDefaultGoodOp", entry, cls,
+        )
+        assert errors == [], (
+            f"expected no parity errors on correct impl, got {errors}"
+        )
+
+
+class TestOutOfUnionProbeEngulfment:
+    """PR #1005 follow-up: out-of-union probe must not be engulfed by wide unions.
+
+    A prior implementation used a fixed 8-dtype ``_DTYPE_SENTINELS`` pool.
+    An op declaring exactly those 8 dtypes for an input left the probe
+    with no candidate, so an over-permissive ``_validate_dtypes``
+    accepting e.g. ``uint8`` would go undetected. The probe now derives
+    candidates from ``sorted(_TORCH_DTYPES - declared)``, guaranteeing a
+    non-empty pool whenever declared does not cover the entire torch
+    dtype universe.
+    """
+
+    _ALL_EIGHT = (
+        "float16 | bfloat16 | float32 | float64 | "
+        "int8 | int16 | int32 | int64"
+    )
+
+    def test_eight_sentinel_coverage_still_probes_out_of_union(self, validator):
+        """Declared union covers all 8 legacy sentinels but not uint8.
+
+        An over-permissive ``_validate_dtypes`` accepting ``uint8`` must
+        surface a hard L3 error because ``uint8 ∈ _TORCH_DTYPES -
+        declared``.
+        """
+        def accept_all(self, x):
+            return True  # over-permissive: accepts any dtype
+
+        cls = _make_op_cls_with_validate(accept_all, name="WideEightDtypeOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": self._ALL_EIGHT}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "WideEightDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "accepts out-of-union dtype" in e for e in errors
+        ), (
+            f"expected out-of-union rejection error despite 8-dtype "
+            f"union; errors={errors} warnings={warnings}"
+        )
+
+    def test_eight_sentinel_coverage_probes_in_combos_branch(self, validator):
+        """Same gap in the dtype_combos branch: declared combos cover all
+        8 legacy sentinels but permissive impl still accepts uint8."""
+        def accept_all(self, x):
+            return True
+
+        cls = _make_op_cls_with_validate(
+            accept_all, name="WideEightCombosOp",
+        )
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": self._ALL_EIGHT}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16"}, {"x": "bfloat16"},
+                    {"x": "float32"}, {"x": "float64"},
+                    {"x": "int8"}, {"x": "int16"},
+                    {"x": "int32"}, {"x": "int64"},
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "WideEightCombosOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "accepts out-of-union dtype" in e for e in errors
+        ), (
+            f"expected out-of-union rejection in dtype_combos branch; "
+            f"errors={errors} warnings={warnings}"
+        )
+
+    def test_full_torch_coverage_emits_skip_warning(self, validator):
+        """Declared union == full torch dtype set → warning, no vacuous pass.
+
+        The probe cannot produce a candidate so it skips with a warning
+        naming the op/input. No hard error is emitted because the
+        ``_validate_dtypes`` impl is free to accept anything in this
+        (wildly permissive) spec.
+        """
+        full_union = " | ".join(sorted(validator._TORCH_DTYPES))
+
+        def accept_all(self, x):
+            return True
+
+        cls = _make_op_cls_with_validate(
+            accept_all, name="FullCoverageOp",
+        )
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": full_union}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FullCoverageOp", entry, cls, warnings=warnings,
+        )
+        assert not any("accepts out-of-union dtype" in e for e in errors), (
+            f"full-coverage spec must not produce a probe error; "
+            f"errors={errors}"
+        )
+        assert any(
+            "out-of-union probe skipped" in w and "'x'" in w
+            for w in warnings
+        ), (
+            f"expected skip warning naming input 'x'; warnings={warnings}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Bench checks
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -805,9 +805,293 @@ class TestDtype:
 
 
 # ---------------------------------------------------------------------------
-# bench: benchmark uses manifest workloads
+# L2 extension: _infer_output_shapes parity with shape_rules
 # ---------------------------------------------------------------------------
 
+
+
+def _make_op_cls_with_infer(infer_fn, *, name="FakeOp"):
+    """Build a minimal Op subclass whose ``_infer_output_shapes`` is *infer_fn*.
+
+    Uses the real :class:`tileops.ops.op_base.Op` so ``_class_overrides_method``
+    correctly treats the method as an override.
+    """
+    from tileops.ops.op_base import Op
+
+    attrs = {
+        "_infer_output_shapes": infer_fn,
+        "forward": lambda self, *a, **kw: None,
+        "default_kernel_map": property(lambda self: {}),
+    }
+    return type(name, (Op,), attrs)
+
+
+class TestInferShapeParity:
+    """L2 extension: ``_infer_output_shapes`` output must satisfy shape_rules."""
+
+    def test_no_override_skipped(self, validator):
+        """Ops without a ``_infer_output_shapes`` override produce no errors."""
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):  # noqa: D401
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        assert validator.check_l2_infer_parity("BareOp", entry, BareOp) == []
+
+    def test_no_cls_skipped(self, validator):
+        entry = {"signature": {"shape_rules": ["y.shape == x.shape"]}}
+        assert validator.check_l2_infer_parity("Foo", entry, None) == []
+
+    def test_correct_infer_passes(self, validator):
+        def infer(self, x_shape):
+            return {"y": x_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        assert validator.check_l2_infer_parity("FakeOp", entry, cls) == []
+
+    def test_incorrect_infer_fails(self, validator):
+        """AC-2: parity error when _infer_output_shapes disagrees with shape_rules."""
+        def infer(self, x_shape):
+            # Wrong: drops a dim.
+            return {"y": x_shape[:-1]}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        assert any("_infer_output_shapes output violates" in e for e in errors), (
+            f"Expected parity error, got: {errors}"
+        )
+
+    def test_missing_output_fails(self, validator):
+        def infer(self, x_shape):
+            return {}  # missing y
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        assert any("missing output" in e for e in errors), errors
+
+    def test_signature_mismatch_reports(self, validator):
+        def infer(self, a_shape):
+            return {"y": a_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        assert any("signature does not match" in e for e in errors), errors
+
+    def test_tuple_literal_rule_rank(self, validator):
+        """tensor.shape == (A, B) rules inform the mock input rank."""
+        seen_rank: list[int] = []
+
+        def infer(self, x_shape):
+            seen_rank.append(len(x_shape))
+            return {"y": x_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": [
+                    "x.shape == (B, S, H, D)",
+                    "y.shape == x.shape",
+                ],
+            },
+        }
+        assert validator.check_l2_infer_parity("FakeOp", entry, cls) == []
+        assert seen_rank == [4], seen_rank
+
+
+# ---------------------------------------------------------------------------
+# L3 extension: _validate_dtypes parity with dtype_combos / unions
+# ---------------------------------------------------------------------------
+
+
+def _make_op_cls_with_validate(validate_fn, *, name="FakeDtypeOp"):
+    from tileops.ops.op_base import Op
+
+    attrs = {
+        "_validate_dtypes": validate_fn,
+        "forward": lambda self, *a, **kw: None,
+        "default_kernel_map": property(lambda self: {}),
+    }
+    return type(name, (Op,), attrs)
+
+
+class TestValidateDtypesParity:
+    """L3 extension: ``_validate_dtypes`` matches manifest dtype_combos/unions."""
+
+    def test_no_override_skipped(self, validator):
+        from tileops.ops.op_base import Op
+
+        class BareOp(Op):
+            def forward(self):
+                return None
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        assert validator.check_l3_validate_dtypes_parity("Bare", entry, BareOp) == []
+
+    def test_union_accept_all_passes(self, validator):
+        import torch
+
+        def validate(self, x):
+            if x.dtype not in (torch.float16, torch.bfloat16):
+                raise ValueError(f"bad dtype {x.dtype}")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        assert validator.check_l3_validate_dtypes_parity("FakeDtypeOp", entry, cls) == []
+
+    def test_union_reject_declared_fails(self, validator):
+        """AC-3: rejects a dtype in the declared union -> parity error."""
+        import torch
+
+        def validate(self, x):
+            if x.dtype != torch.float16:
+                raise ValueError("only fp16")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity("FakeDtypeOp", entry, cls)
+        assert any("rejects valid combo" in e for e in errors), errors
+
+    def test_dtype_combos_accept_listed_pass(self, validator):
+        import torch
+
+        def validate(self, x, w):
+            allowed = {(torch.float16, torch.float16), (torch.bfloat16, torch.bfloat16)}
+            if (x.dtype, w.dtype) not in allowed:
+                raise ValueError("unlisted")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                    {"x": "bfloat16", "w": "bfloat16"},
+                ],
+            },
+        }
+        assert validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        ) == []
+
+    def test_dtype_combos_rejects_listed_fails(self, validator):
+        import torch
+
+        def validate(self, x, w):
+            # Rejects the listed (bfloat16, bfloat16) combo.
+            if x.dtype != torch.float16:
+                raise ValueError("unlisted")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                    {"x": "bfloat16", "w": "bfloat16"},
+                ],
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        )
+        assert any("rejects dtype_combos" in e for e in errors), errors
+
+    def test_dtype_combos_accepts_unlisted_fails(self, validator):
+        """AC-3: accepts a non-listed combo -> parity error."""
+        def validate(self, x, w):
+            return None  # accepts everything
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "float16 | bfloat16"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                ],
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        )
+        assert any("accepts non-listed combo" in e for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# Bench checks
+# ---------------------------------------------------------------------------
 class TestBench:
     """bench checks that bench files use manifest workloads and op roofline."""
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1294,12 +1294,11 @@ class TestInferShapeParity:
         """TypeError raised inside _infer_output_shapes body must not be
         misreported as a signature mismatch.
 
-        Regression: previously any TypeError from infer_fn — including
-        those raised by a buggy body (e.g. arithmetic on None) — was
-        labeled as ``signature does not match manifest inputs``. After
-        pre-binding the signature via ``inspect.signature().bind``, a
-        TypeError from the body surfaces as a parity-skip warning
-        instead.
+        The signature is pre-bound via ``inspect.signature().bind`` so a
+        TypeError from the body is distinguished from a signature
+        mismatch. The body-raise is surfaced as a hard L2 parity error
+        (policy tightened in PR #1005: previously a warning, which let
+        genuine bugs silently pass).
         """
         def infer(self, x_shape):
             # Signature matches; the body itself raises TypeError.
@@ -1324,11 +1323,60 @@ class TestInferShapeParity:
             f"errors={errors}"
         )
         assert any(
-            "parity skipped" in w and "TypeError" in w for w in warnings
+            "raised TypeError" in e for e in errors
         ), (
-            "Body TypeError should surface as a parity-skip warning; "
-            f"warnings={warnings}"
+            "Body TypeError must surface as a hard L2 parity error; "
+            f"errors={errors}"
         )
+
+    def test_body_raise_opt_out_downgrades_to_warning(self, validator):
+        """``parity_opt_out: [shape_parity]`` downgrades a body-raise to
+        a warning for documented GPU-only ops.
+        """
+        def infer(self, x_shape):
+            raise RuntimeError("needs GPU-only state")
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+            "parity_opt_out": ["shape_parity"],
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == []
+        assert any(
+            "parity skipped (opt-out)" in w and "RuntimeError" in w
+            for w in warnings
+        )
+
+    def test_body_runtime_error_is_hard_l2_error(self, validator):
+        """Finding #2 regression: a body raising ``RuntimeError('not ready')``
+        must become a hard L2 parity error unless the entry opts out.
+        """
+        def infer(self, x_shape):
+            raise RuntimeError("not ready")
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "raised RuntimeError" in e and "not ready" in e for e in errors
+        ), f"expected hard L2 error, got errors={errors} warnings={warnings}"
 
     def test_declared_output_shape_catches_wrong_infer(self, validator):
         """Op with shape-declared-only outputs (no shape_rules) whose
@@ -2445,7 +2493,8 @@ class TestValidateDtypesParity:
             "FakeDtypeOp", entry, cls,
         )
         assert any(
-            "combo missing input" in e for e in errors
+            "is missing declared input" in e or "combo missing input" in e
+            for e in errors
         ), (
             "Combo missing an input entry must be reported as a "
             f"manifest error; errors={errors}"
@@ -2492,6 +2541,180 @@ class TestValidateDtypesParity:
             "With self.dtype populated from the combo, listed combos "
             f"must be accepted; errors={errors} warnings={warnings}"
         )
+
+
+class TestDtypeCombosDataHardening:
+    """Hardening regressions for ``check_l3_dtype_combos_data``.
+
+    Covers PR #1005 review findings #1 (combo-row completeness) and #5
+    (reject union dtype expressions in combo values).
+    """
+
+    def test_combo_missing_input_is_hard_error(self, validator):
+        """Finding #1: every combo row must cover every declared input.
+
+        Omitting a declared input from a combo row used to silently pass
+        when the op had no ``_validate_dtypes`` override — the parity
+        loop never ran, so the omission was invisible. The data-level
+        check must flag it independently.
+        """
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "w": {"dtype": "float16 | bfloat16"},
+            },
+            "outputs": {"y": {"dtype": "same_as(x)"}},
+            "dtype_combos": [
+                {"x": "float16", "w": "float16"},
+                {"x": "bfloat16"},  # missing 'w'
+            ],
+        }
+        errors = validator.check_l3_dtype_combos_data("FakeOp", sig)
+        assert any(
+            "dtype_combos[1]" in e and "missing declared input 'w'" in e
+            for e in errors
+        ), f"expected completeness error, got {errors}"
+
+    def test_combo_value_union_is_hard_error(self, validator):
+        """Finding #5: a union expression in a combo value is rejected.
+
+        Per manifest.md R4, ``dtype_combos[i].<key>`` must be a single
+        concrete dtype token (or a ``same_as(ref)`` resolving to one);
+        ``"float16 | bfloat16"`` is a union and must fail the data
+        check rather than silently expanding to multiple dtypes.
+        """
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+            },
+            "outputs": {"y": {"dtype": "same_as(x)"}},
+            "dtype_combos": [
+                {"x": "float16 | bfloat16"},
+            ],
+        }
+        errors = validator.check_l3_dtype_combos_data("FakeOp", sig)
+        assert any(
+            "combo values must be a single concrete dtype" in e for e in errors
+        ), f"expected union rejection, got {errors}"
+
+
+class TestStaticDimShapeParity:
+    """Finding #3 regression: static_dims values must pin expected output sizes."""
+
+    def test_static_dim_output_shape_catches_bad_infer(self, validator):
+        """A generated _infer_output_shapes returning arbitrary integers
+        for a static-dim-bound output position must fail parity.
+
+        Previously the declared-output-shape comparison only checked
+        input-bound symbols — ``static_dims`` keys were reclassified as
+        output-only, so only rank/consistency was enforced. A bad impl
+        returning e.g. ``(999, 999)`` for a declared ``[N, N]`` output
+        with ``static_dims: {N: "x.shape[-1]"}`` would pass.
+        """
+        def bad_infer(self, x_shape):
+            # Declared output shape is [N, N]; static_dims says N =
+            # x.shape[-1] (=4 under mock). A correct impl would return
+            # (4, 4); the bug returns (999, 999), which the old code
+            # failed to catch because N was treated as output-only.
+            return {"y": (999, 999)}
+
+        cls = _make_op_cls_with_infer(bad_infer, name="StaticDimBadOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16", "shape": "[M, N]"}},
+                "outputs": {
+                    "y": {"dtype": "same_as(x)", "shape": "[N, N]"},
+                },
+                "static_dims": {"N": "x.shape[-1]"},
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "StaticDimBadOp", entry, cls,
+        )
+        assert any(
+            "dim[0]=999" in e or "dim[1]=999" in e for e in errors
+        ), f"expected static-dim parity error, got {errors}"
+
+
+class TestUnexpectedValidateDtypesException:
+    """Finding #4 regression: body-level unexpected exceptions become hard L3 errors."""
+
+    def test_runtime_error_from_validate_body_is_hard_error(self, validator):
+        """_validate_dtypes raising RuntimeError for every valid combo
+        must produce a hard L3 parity error, not a warning.
+        """
+        def bad_validate(self, x):
+            raise RuntimeError("simulated bug")
+
+        cls = _make_op_cls_with_validate(bad_validate, name="BadValidateOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16"},
+                    {"x": "bfloat16"},
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "BadValidateOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "raised unexpected exception" in e and "RuntimeError" in e
+            for e in errors
+        ), f"expected hard L3 error, got errors={errors} warnings={warnings}"
+
+    def test_runtime_error_opt_out_downgrades_to_skip(self, validator):
+        """``parity_opt_out: [dtype_parity]`` downgrades the body-raise
+        to a silent skip for documented GPU-only cases.
+        """
+        def bad_validate(self, x):
+            raise RuntimeError("needs GPU state")
+
+        cls = _make_op_cls_with_validate(bad_validate, name="OptOutValidateOp")
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16"},
+                    {"x": "bfloat16"},
+                ],
+            },
+            "parity_opt_out": ["dtype_parity"],
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "OptOutValidateOp", entry, cls, warnings=warnings,
+        )
+        assert not any(
+            "raised unexpected exception" in e for e in errors
+        ), f"opt-out must suppress hard error; errors={errors}"
+
+    def test_runtime_error_no_combos_is_hard_error(self, validator):
+        """Same policy in the no-dtype_combos Cartesian branch."""
+        def bad_validate(self, x):
+            raise RuntimeError("simulated bug")
+
+        cls = _make_op_cls_with_validate(
+            bad_validate, name="BadValidateNoCombosOp",
+        )
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "BadValidateNoCombosOp", entry, cls, warnings=warnings,
+        )
+        assert any(
+            "raised unexpected exception" in e and "RuntimeError" in e
+            for e in errors
+        ), f"expected hard L3 error, got errors={errors} warnings={warnings}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -971,6 +971,54 @@ class TestInferShapeParity:
             f"Expected R11-style rule to evaluate and flag mismatch, got: {errors}"
         )
 
+    def test_r11a_comprehension_rule_evaluates(self, validator):
+        """R11a rules using generator / set comprehensions must be evaluable.
+
+        Regression: ``eval(rule, globals, locals)`` scopes comprehension
+        bodies against globals only, so passing ctx names only as locals
+        made every comprehension-shaped rule raise ``NameError`` and get
+        silently downgraded to a warning. An infer-shape mismatch could
+        pass because no rule ever evaluated to False.
+        """
+        # Wrong infer: keeps input rank even though dim reduction + keepdim=False
+        # must drop a rank.
+        def infer(self, x_shape):
+            return {"y": x_shape}
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "params": {
+                    "dim": {"default": [-1]},
+                    "keepdim": {"default": False},
+                },
+                "shape_rules": [
+                    # Generator expression inside all(...): comprehension scope.
+                    "all(d % x.ndim in range(x.ndim) for d in dim)",
+                    # Set comprehension: also its own scope.
+                    "len({d % x.ndim for d in dim}) == len(dim)",
+                    # Actual parity rule we expect to catch the mismatch:
+                    # y.ndim must shrink by len(dim) when keepdim is False.
+                    "y.ndim == x.ndim - len(dim)",
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        # No rule should be skipped with a NameError from a comprehension.
+        assert not any(
+            "could not be evaluated" in w for w in warnings
+        ), f"Comprehension rule skipped via warning: {warnings}"
+        # The parity mismatch on y.ndim must surface as an error.
+        assert any(
+            "_infer_output_shapes output violates" in e and "y.ndim" in e
+            for e in errors
+        ), f"Expected ndim parity mismatch, got: {errors}"
+
 
 # ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -803,6 +803,62 @@ class TestDtype:
             f"Expected partial-combo error, got: {errors}"
         )
 
+    def test_dtype_combos_invalid_value_is_hard_l3_error(self, validator):
+        """Un-migrated op with invalid dtype_combos value still produces
+        a hard L3 error in ``check_l3`` — does not depend on
+        ``_validate_dtypes`` override.
+        """
+        entry = {
+            "status": "implemented",
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "not_a_real_dtype"},
+                ],
+            },
+            "workloads": [{"dtypes": ["float16"]}],
+        }
+        errors = validator.check_l3("test_op", entry)
+        assert any(
+            "not_a_real_dtype" in e and "dtype_combos" in e for e in errors
+        ), f"Expected hard L3 error for invalid combo value, got: {errors}"
+
+    def test_resolve_dtype_options_forward_reference(self, validator):
+        """``_resolve_tensor_dtype_options`` resolves ``same_as(y)`` even
+        when ``y`` is declared later than ``x``. Declaration order must
+        not affect resolution (R3 is an identity constraint, not an
+        ordering rule).
+        """
+        sig = {
+            "inputs": {
+                "x": {"dtype": "same_as(y)"},
+                "y": {"dtype": "float16 | bfloat16"},
+            },
+            "outputs": {"z": {"dtype": "same_as(y)"}},
+        }
+        resolved = validator._resolve_tensor_dtype_options(sig)
+        assert resolved is not None, "Forward same_as reference must resolve"
+        assert resolved["x"] == ["float16", "bfloat16"]
+        assert resolved["y"] == ["float16", "bfloat16"]
+        assert resolved["z"] == ["float16", "bfloat16"]
+
+    def test_resolve_dtype_options_same_as_cycle_fails(self, validator):
+        """A pure ``same_as`` cycle (``x: same_as(y)``, ``y: same_as(x)``)
+        has no concrete dtype grounding — resolver returns None.
+        """
+        sig = {
+            "inputs": {
+                "x": {"dtype": "same_as(y)"},
+                "y": {"dtype": "same_as(x)"},
+            },
+            "outputs": {},
+        }
+        resolved = validator._resolve_tensor_dtype_options(sig)
+        assert resolved is None, (
+            "same_as cycle without concrete dtype must not resolve"
+        )
+
 
 # ---------------------------------------------------------------------------
 # L2 extension: _infer_output_shapes parity with shape_rules

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1453,6 +1453,48 @@ class TestInferShapeParity:
             f"symbol L_out; errors={errors}"
         )
 
+    def test_conv_like_wrong_output_only_value_reported(self, validator):
+        """Wrong output-only symbol value must be flagged as a parity
+        error via the shape_rules defining that symbol.
+
+        Regression: previously ``check_l2_infer_parity`` classified the
+        rule ``L_out == L_in - kW + 1`` as an input-only precondition
+        (the rule does not mention any output tensor name), so an
+        incorrect ``_infer_output_shapes`` that returned a bogus
+        ``L_out`` silently slipped past: the rule failed in both the
+        full and input-only contexts and was skipped. Output-only
+        symbols appearing in declared output shapes now trigger
+        mentions_output classification and are rebound from the
+        inferred result before rule evaluation.
+        """
+        def infer(self, x_shape, w_shape):
+            # Deliberately wrong output-only L_out value (999).
+            return {"y": (x_shape[0], w_shape[0], 999)}
+
+        cls = _make_op_cls_with_infer(infer, name="ConvLikeWrongOutOnlyOp")
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
+                },
+                "outputs": {
+                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
+                },
+                "shape_rules": ["L_out == L_in - kW + 1"],
+            },
+        }
+        errors = validator.check_l2_infer_parity(
+            "ConvLikeWrongOutOnlyOp", entry, cls,
+        )
+        assert any(
+            "L_out == L_in - kW + 1" in e and "violates shape_rules" in e
+            for e in errors
+        ), (
+            "Wrong L_out value must produce a shape_rules parity error; "
+            f"errors={errors}"
+        )
+
     def test_conv_like_wrong_rank_still_caught(self, validator):
         """Rank disagreement against declared output shape is still an
         error, even for an op with an output-only ``L_out`` symbol.
@@ -2187,26 +2229,21 @@ class TestValidateDtypesParity:
             f"errors={errors}"
         )
 
-    def test_combo_skip_reasons_not_misattributed(self, validator):
-        """``_combo_accepted`` skip reasons ('combo missing input ...',
-        'cannot build mock tensor ...') must not be reported as plain
-        rejection parity failures.
+    def test_invalid_dtype_combo_value_is_hard_error(self, validator):
+        """A ``dtype_combos`` entry naming a non-existent dtype must be
+        surfaced as a hard L3 error, not downgraded to a parity-skip
+        warning.
 
-        Regression: the dtype_combos branch previously handled only
-        ``TypeError`` and ``unexpected`` reasons, so a combo lacking an
-        input entry or naming a dtype the validator cannot materialize
-        (no ``torch.<name>``) fell through to the rejection branch and
-        produced a misleading "rejects dtype_combos[i]" error that
-        blamed the op for a manifest gap or a validator limitation.
+        Regression: previously an invalid dtype name reached the
+        ``cannot build mock tensor`` warning branch inside the parity
+        loop, which silently disabled the check and hid a manifest data
+        bug. The upfront validation pass now rejects entries that are
+        neither in ``_TORCH_DTYPES`` nor a resolvable ``same_as`` ref.
         """
-        # Validator body must not matter; the skip path runs before it.
         def validate(self, x, w):
             return None
 
         cls = _make_op_cls_with_validate(validate)
-        # dtype_combos[0] names a dtype with no torch equivalent →
-        # _combo_accepted returns reason="cannot build mock tensor ...".
-        # dtype_combos[1] omits 'w' entirely → reason="combo missing input 'w'".
         entry = {
             "signature": {
                 "inputs": {
@@ -2216,7 +2253,6 @@ class TestValidateDtypesParity:
                 "outputs": {"y": {"dtype": "same_as(x)"}},
                 "dtype_combos": [
                     {"x": "not_a_real_dtype", "w": "not_a_real_dtype"},
-                    {"x": "float16"},  # missing 'w'
                 ],
             },
         }
@@ -2224,30 +2260,142 @@ class TestValidateDtypesParity:
         errors = validator.check_l3_validate_dtypes_parity(
             "FakeDtypeOp", entry, cls, warnings=warnings,
         )
-        # Neither skip reason should surface as a rejection error.
-        assert not any(
-            "rejects dtype_combos[0]" in e for e in errors
+        assert any(
+            "not a valid dtype" in e and "not_a_real_dtype" in e
+            for e in errors
         ), (
-            "'cannot build mock tensor' must not be reported as a "
-            f"rejection parity failure; errors={errors}"
+            "Invalid dtype in dtype_combos must produce a hard error "
+            f"mentioning the invalid dtype name; errors={errors}"
         )
-        # The mock-tensor limitation should come through as a warning.
+        # Must not appear as a parity-skip warning either.
+        assert not any(
+            "cannot build mock tensor" in w for w in warnings
+        ), (
+            "Invalid dtype name must not be downgraded to "
+            f"'cannot build mock tensor' warning; warnings={warnings}"
+        )
+
+    def test_unresolved_same_as_in_dtype_combo_is_hard_error(self, validator):
+        """``dtype_combos`` entry with ``same_as(unknown_ref)`` must be
+        a hard L3 error.
+
+        Regression: previously unresolved ``same_as`` references inside
+        combo values silently skipped parity. The upfront validation now
+        routes them through ``_dtype_options_for_tensor`` — unresolved
+        references return None and become an error.
+        """
+        def validate(self, x, w):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "float16 | bfloat16"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "same_as(unknown_ref)"},
+                ],
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        )
+        assert any(
+            "not a valid dtype" in e and "unknown_ref" in e
+            for e in errors
+        ), (
+            "Unresolved same_as ref in dtype_combos must produce a hard "
+            f"error mentioning the ref name; errors={errors}"
+        )
+
+    def test_valid_dtype_combo_reaches_build_mock_tensor(
+        self, validator, monkeypatch,
+    ):
+        """Valid dtype names continue to reach the build-mock-tensor
+        branch; the ``cannot build mock tensor`` warning is still
+        reserved for valid names that the local torch build genuinely
+        cannot materialize.
+
+        Simulates a torch build lacking support for a declared dtype by
+        monkeypatching ``_make_mock_tensor`` to return None for
+        ``float8_e4m3fn`` while the combo itself is valid.
+        """
+        def validate(self, x):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | float8_e4m3fn"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float8_e4m3fn"},
+                ],
+            },
+        }
+        original = validator._make_mock_tensor
+
+        def fake(name):
+            if name == "float8_e4m3fn":
+                return None
+            return original(name)
+
+        monkeypatch.setattr(validator, "_make_mock_tensor", fake)
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        # Valid dtype that the local build can't materialize: no hard
+        # error, but the parity-skip warning path still fires.
+        assert not any(
+            "not a valid dtype" in e for e in errors
+        ), (
+            "Valid dtype name must not be flagged as invalid by the "
+            f"upfront validation pass; errors={errors}"
+        )
         assert any(
             "cannot build mock tensor" in w for w in warnings
         ), (
-            "cannot-build-mock-tensor skip must surface as a parity-skip "
-            f"warning; warnings={warnings}"
+            "Valid-name-but-unmaterializable dtype must still reach the "
+            f"'cannot build mock tensor' warning path; warnings={warnings}"
         )
-        # The missing-input combo is a manifest error — surface it, but
-        # not as a rejection.
+
+    def test_combo_missing_input_is_manifest_error(self, validator):
+        """A combo that omits an input entry remains a manifest error
+        surfaced via the parity loop (not a rejection, not a skip).
+        """
+        def validate(self, x, w):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16"},  # missing 'w'
+                ],
+            },
+        }
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls,
+        )
         assert any(
             "combo missing input" in e for e in errors
         ), (
-            "combo missing input must be reported as a manifest error; "
-            f"errors={errors}"
+            "Combo missing an input entry must be reported as a "
+            f"manifest error; errors={errors}"
         )
         assert not any(
-            "rejects dtype_combos[1]" in e for e in errors
+            "rejects dtype_combos[0]" in e for e in errors
         ), (
             "missing-input skip must not be reported as rejection; "
             f"errors={errors}"

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1234,6 +1234,80 @@ class TestInferShapeParity:
         assert reason is not None
         assert "dunder attribute access not permitted" in reason
 
+    def test_body_typeerror_not_reported_as_signature_mismatch(self, validator):
+        """TypeError raised inside _infer_output_shapes body must not be
+        misreported as a signature mismatch.
+
+        Regression: previously any TypeError from infer_fn — including
+        those raised by a buggy body (e.g. arithmetic on None) — was
+        labeled as ``signature does not match manifest inputs``. After
+        pre-binding the signature via ``inspect.signature().bind``, a
+        TypeError from the body surfaces as a parity-skip warning
+        instead.
+        """
+        def infer(self, x_shape):
+            # Signature matches; the body itself raises TypeError.
+            raise TypeError("simulated implementation bug")
+
+        cls = _make_op_cls_with_infer(infer)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "shape_rules": ["y.shape == x.shape"],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l2_infer_parity(
+            "FakeOp", entry, cls, warnings=warnings,
+        )
+        assert not any(
+            "signature does not match manifest inputs" in e for e in errors
+        ), (
+            "Body TypeError must not be misreported as signature mismatch; "
+            f"errors={errors}"
+        )
+        assert any(
+            "parity skipped" in w and "TypeError" in w for w in warnings
+        ), (
+            "Body TypeError should surface as a parity-skip warning; "
+            f"warnings={warnings}"
+        )
+
+
+class TestDtypeOptionsHelper:
+    """Unit tests for ``_dtype_options_for_tensor`` unresolved-ref contract."""
+
+    def test_pure_same_as_unresolved_returns_none(self, validator):
+        """same_as(ref) with ref missing from ``resolved`` returns None.
+
+        Regression: previously returned [] which silently disabled
+        downstream dtype parity (``_resolve_tensor_dtype_options`` only
+        bails on None, and an empty list yields an empty Cartesian
+        product).
+        """
+        out = validator._dtype_options_for_tensor(
+            "y", "same_as(x)", resolved={},
+        )
+        assert out is None, (
+            f"Pure same_as(unresolved) must return None, got {out!r}"
+        )
+
+    def test_mixed_token_unresolved_returns_none(self, validator):
+        """``same_as(ref) | float32`` with unresolved ref returns None."""
+        out = validator._dtype_options_for_tensor(
+            "y", "same_as(x) | float32", resolved={},
+        )
+        assert out is None, (
+            f"Mixed same_as(unresolved) must return None, got {out!r}"
+        )
+
+    def test_pure_same_as_resolved_inherits_options(self, validator):
+        out = validator._dtype_options_for_tensor(
+            "y", "same_as(x)", resolved={"x": ["float16", "bfloat16"]},
+        )
+        assert out == ["float16", "bfloat16"]
+
 
 # ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
@@ -1578,6 +1652,92 @@ class TestValidateDtypesParity:
         assert any(
             "exceeds _MAX_DTYPE_COMBOS" in w for w in warnings
         ), f"Expected over-bound skip warning, got: {warnings}"
+
+    def test_body_typeerror_is_rejection_not_signature_mismatch(self, validator):
+        """TypeError raised inside _validate_dtypes body is a legitimate
+        rejection, not a signature mismatch.
+
+        Regression: previously a bare ``except (ValueError, TypeError)``
+        could not distinguish between a kwarg-name mismatch (signature
+        error) and a TypeError raised inside the body (legitimate
+        rejection). The validator must pre-bind the signature and only
+        flag the former as a signature mismatch.
+        """
+        # Signature matches (``x`` kwarg), but the body raises TypeError
+        # on every call. This should be treated as a rejection of every
+        # combo drawn from the union, not a signature mismatch — which in
+        # turn means each Cartesian combo is reported as rejected.
+        def validate(self, x):
+            raise TypeError("dtype comparison not supported")
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        # No signature-mismatch error.
+        assert not any(
+            "signature does not match manifest inputs" in e for e in errors
+        ), (
+            "Body-level TypeError must not be misreported as signature "
+            f"mismatch; errors={errors}"
+        )
+        # The body rejects every combo drawn from the union, so the
+        # no-dtype_combos branch reports each as a parity violation.
+        assert any(
+            "rejects valid combo" in e for e in errors
+        ), (
+            "Body TypeError should surface as a rejection of declared "
+            f"union combos; errors={errors}"
+        )
+
+    def test_dtype_combos_exhausts_union_emits_warning(self, validator):
+        """When dtype_combos covers every Cartesian tuple, the validator
+        emits the 'exhausts the union' warning even though no non-listed
+        combo was checked.
+
+        Regression: previously the warning fired only when
+        ``checked_any and not rejected_at_least_one`` — which is
+        impossible in the exhaustive case because every tuple hits the
+        ``listed_combo_keys`` continue path and ``checked_any`` stays
+        False.
+        """
+        def validate(self, x, w):
+            return None
+
+        cls = _make_op_cls_with_validate(validate)
+        entry = {
+            "signature": {
+                "inputs": {
+                    "x": {"dtype": "float16 | bfloat16"},
+                    "w": {"dtype": "same_as(x)"},
+                },
+                "outputs": {"y": {"dtype": "same_as(x)"}},
+                "dtype_combos": [
+                    {"x": "float16", "w": "float16"},
+                    {"x": "float16", "w": "bfloat16"},
+                    {"x": "bfloat16", "w": "float16"},
+                    {"x": "bfloat16", "w": "bfloat16"},
+                ],
+            },
+        }
+        warnings: list[str] = []
+        errors = validator.check_l3_validate_dtypes_parity(
+            "FakeDtypeOp", entry, cls, warnings=warnings,
+        )
+        assert errors == [], f"Expected no errors, got: {errors}"
+        assert any(
+            "exhausts the union" in w for w in warnings
+        ), (
+            "Validator must warn when dtype_combos covers every "
+            f"Cartesian combo; warnings={warnings}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add validator checks that ensure a concrete op's `_infer_output_shapes` and `_validate_dtypes` agree with its manifest declaration. Introduces L2 infer-shape parity and L3 dtype parity checks in `scripts/validate_manifest.py`, plus documents the two new rows in the Consistency Enforcement table and the `parity_opt_out` entry field.

Closes #994

## What this PR does

- **L2 infer-shape parity**: for each `status: implemented` op, invokes `_infer_output_shapes` with concrete mock inputs and checks the returned shapes against `signature.outputs[*].shape` declarations, `signature.static_dims`, param defaults, and `shape_rules` (incl. R11a comprehensions). Symbolic dims (`B`, `S`, `H`, `D`, …) are bound from input shapes and also rebound from inferred outputs so output-only symbols like conv `L_out` can be checked against rule-derived values.
- **L3 dtype parity**: validates `_validate_dtypes` behaviour against `dtype_combos` (when present, exhaustive) or declared `dtype` unions (full Cartesian product), plus out-of-union negative probes and `same_as(ref)` identity probes on both branches.
- **Manifest-data validation (runs unconditionally in `check_l3`)**: combo completeness (every combo row must cover every declared input), invalid dtype tokens, unresolved / cyclic `same_as(ref)`, and union values in combo entries are hard L3 errors regardless of whether the class overrides `_validate_dtypes`.
- **`parity_opt_out`**: optional manifest entry field (`true` or subset of `[shape_parity, dtype_parity]`) to suppress parity checks for ops whose method genuinely needs GPU execution. Documented in `docs/manifest.md` (Entry Structure) and `docs/ops-design-reference.md` (Consistency Enforcement).
- **Security / bounds**: `eval()` for shape rules is restricted to a builtins allowlist, AST-filtered for dunder attrs, and protected from `ctx` overwriting `__builtins__`. Cartesian product iteration is bounded by `_MAX_DTYPE_COMBOS = 4096` with deterministic skip + warning on over-bound ops.
- **Policy (tightened over review rounds)**: unexpected body exceptions from `_infer_output_shapes` / `_validate_dtypes` are **hard parity errors by default**; reserve the soft-warning path for entries that explicitly opt out. Signature-bind failures (via `inspect.signature().bind`) remain a separate category.

## Test plan

- [x] **AC-1**: Modified files pass unit tests.
  - Evidence: `python -m pytest tests/test_validate_manifest.py -q` → 170 passed.
- [x] **AC-2**: Validator L2 reports error when `_infer_output_shapes` disagrees with `shape_rules` / declared shapes.
  - Evidence: `TestInferShapeParity` covers incorrect infer, symbolic dim mismatch, R11/R11a helper rules, input-only precondition separation, conv-like output-only symbols, declared-output-shape exact match, `self.attr` / `self.static_dim` mock populations, body-exception-as-hard-error (+ opt-out downgrade).
- [x] **AC-3**: Validator L3 reports error when `_validate_dtypes` accepts non-listed or rejects declared combos.
  - Evidence: `TestValidateDtypesParity` covers union accept/reject, `dtype_combos` accept/reject listed, first-rejected-later-accepted enumeration, out-of-union probes (both branches), `same_as` identity probes, signature-mismatch vs body-exception separation (body errors are hard unless opted out), Cartesian bound skip with warning, exhausts-the-union warning.
- [x] **AC-4**: Consistency Enforcement table adds two new rows.
  - Evidence: `docs/ops-design-reference.md` adds rows for `_infer_output_shapes` vs `shape_rules` (L2) and `_validate_dtypes` vs `dtype_combos` / unions (L3), plus a "Parity check coverage" paragraph documenting missing-override warning + `parity_opt_out`. `docs/manifest.md` Entry Structure documents the `parity_opt_out` field.

## Integration check

```
python scripts/validate_manifest.py → exit 0, 0 ERROR lines, 48 WARNING lines
  (expected: missing-override warnings for implemented ops awaiting codegen
   migration + pre-existing bench warnings). "All manifest checks passed."
```

No existing Op required `parity_opt_out` under the tightened body-exception policy.

## Test node-delta (testing-budget rule)

```
tests/test_validate_manifest.py     101     170      +69   (+68.3%)
```

Justification: the delta covers AC-1..AC-4 parity behaviour plus regression coverage from seven review rounds:

- signature-bind vs body-exception separation (body errors are hard L2/L3 by default, opted out via `parity_opt_out`)
- `same_as` fixpoint resolution (order-independent); pure-cycle and dangling-ref diagnosis produce hard L3 errors with all cycle participants named
- out-of-union negative probes on both branches (`dtype_combos` and Cartesian), sourced from `_TORCH_DTYPES − declared` so sentinel engulfment can't create a vacuous pass; full-coverage case emits a named warning
- `same_as(ref)` identity probes on both branches
- mock `self` via `cls.__new__(cls)` with `signature.params` defaults, `static_dims` resolved values, and primary `dtype` axis populated
- symbolic dim binding from `signature.*.shape`; output-only symbol rebinding from inferred outputs (conv-like `L_out` scenarios)
- `static_dims` and scalar-int param defaults both pin declared-output-shape positions to exact values (not just rank/consistency)
- combo completeness (every row covers every declared input), invalid dtype value rejection, union-in-combo-value rejection as hard L3 manifest errors — run unconditionally in `check_l3`, independent of `_validate_dtypes` override status
- Cartesian product bounded by `_MAX_DTYPE_COMBOS = 4096` with deterministic skip + warning
- `eval()` sandbox: restricted `__builtins__`, AST dunder-attr filter, `ctx` cannot overwrite `__builtins__`

Tests are validator regressions, not broad combinatorics.
