### PR TITLE
[Refactor][OPS] align 13 norm/softmax-family ops with static_dims contract

### DIFF
--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -71,7 +71,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     bm = AdaLayerNormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AdaLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormFwdOp(N=n, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -90,7 +90,7 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     bm = AdaLayerNormZeroBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = AdaLayerNormZeroFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(N=n, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -27,7 +27,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_ARGMAX_OP, workload)
     inputs = workload.gen_inputs()
 
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=shape[-1], dtype=dtype)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
     # Broken invariant: benchmark must execute all manifest workload shapes
@@ -60,7 +60,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_ARGMIN_OP, workload)
     inputs = workload.gen_inputs()
 
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=shape[-1], dtype=dtype)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
     # Broken invariant: benchmark must execute all manifest workload shapes

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -157,7 +157,7 @@ def _manifest_bwd_params():
 def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     inputs = _make_inputs(N, C, spatial, dtype)
 
-    op = BatchNormFwdOp(N, C, *spatial, dtype=dtype, tune=tune)
+    op = BatchNormFwdOp(C=C, dtype=dtype, tune=tune)
 
     test = BatchNormFwdTest(N, C, spatial, dtype, training)
     bm = BatchNormFwdBenchmark(test, N, C, spatial)
@@ -174,7 +174,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
 def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     inputs = _make_bwd_inputs(N, C, spatial, dtype)
 
-    op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    op = BatchNormBwdOp(C=C, dtype=dtype)
 
     test = BatchNormBwdTest(N, C, spatial, dtype)
     bm = BatchNormBwdBenchmark(test, N, C, spatial)

--- a/benchmarks/ops/bench_fused_add_layer_norm.py
+++ b/benchmarks/ops/bench_fused_add_layer_norm.py
@@ -49,7 +49,7 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
     bm = FusedAddLayerNormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FusedAddLayerNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = FusedAddLayerNormFwdOp(N=n, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_fused_add_rms_norm.py
+++ b/benchmarks/ops/bench_fused_add_rms_norm.py
@@ -56,7 +56,7 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
     bm = FusedAddRMSNormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = FusedAddRMSNormFwdOp(N=n, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -54,7 +54,7 @@ def test_instance_norm_bench(n: int, c: int, spatial: tuple,
     bm = InstanceNormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype, tune=tune)
+    op = InstanceNormFwdOp(C=c, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -49,7 +49,7 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
     bm = LayerNormBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = LayerNormFwdOp(N=n, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -38,7 +38,7 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_SOFTMAX_OP, test)
     inputs = test.gen_inputs()
 
-    op = SoftmaxFwdOp(dtype=dtype, dim=-1, tune=True)
+    op = SoftmaxFwdOp(N=shape[-1], dtype=dtype, dim=-1, tune=True)
     try:
         result = bm.profile(op, *inputs)
     except ValueError as exc:
@@ -65,7 +65,7 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_LOG_SOFTMAX_OP, test)
     inputs = test.gen_inputs()
 
-    op = LogSoftmaxFwdOp(dtype=dtype, dim=-1, tune=True)
+    op = LogSoftmaxFwdOp(N=shape[-1], dtype=dtype, dim=-1, tune=True)
     try:
         result = bm.profile(op, *inputs)
     except ValueError as exc:

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -56,7 +56,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @AdaLayerNormFixture
 def test_ada_layer_norm_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormTest(m, n, dtype)
-    op = AdaLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormFwdOp(N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -78,8 +78,7 @@ def test_ada_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype
     scale = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     shift = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = AdaLayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = AdaLayerNormFwdOp(N=hidden, dtype=dtype)
 
     # Reference: scale * LayerNorm(x) + shift
     eps = 1e-5

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -58,7 +58,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @AdaLayerNormZeroFixture
 def test_ada_layer_norm_zero_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroTest(m, n, dtype)
-    op = AdaLayerNormZeroFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -81,8 +81,7 @@ def test_ada_layer_norm_zero_3d(batch: int, seq: int, hidden: int, dtype: torch.
     shift = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     gate = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = AdaLayerNormZeroFwdOp(M=M, N=hidden, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(N=hidden, dtype=dtype)
 
     # Reference: gate * (scale * LayerNorm(x) + shift)
     eps = 1e-5

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -449,8 +449,10 @@ def test_argreduce_rejects_multidim(op_cls_path: str, dim) -> None:
     mod = importlib.import_module(module_path)
     op_cls = getattr(mod, cls_name)
 
-    with pytest.raises((TypeError, ValueError)):
-        op_cls(dtype=torch.float16, dim=dim)
+    # Supply the required N kwarg so the test exercises the multidim/None
+    # dim-rejection path rather than the missing-required-argument path.
+    with pytest.raises(ValueError):
+        op_cls(N=8, dtype=torch.float16, dim=dim)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -173,7 +173,7 @@ def test_argmax_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     test = ArgreduceTest(m, n, dtype, "argmax")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=n, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -183,7 +183,7 @@ def test_argmax_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=n, dtype=dtype)
     ref = x.contiguous().argmax(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -195,7 +195,7 @@ def test_argmax_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=hidden, dtype=dtype)
     ref = x.argmax(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -207,7 +207,7 @@ def test_argmax_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=n, dtype=dtype)
     ref = x.argmax(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -219,7 +219,7 @@ def test_argmax_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(N=n, dtype=dtype)
     ref = x.argmax(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -232,7 +232,7 @@ def test_argmax_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=0)
+    op = ArgmaxFwdOp(N=batch, dtype=dtype, dim=0)
     ref = x.argmax(dim=0)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -246,7 +246,7 @@ def test_argmax_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
+    op = ArgmaxFwdOp(N=batch, dtype=dtype, dim=0, keepdim=True)
     ref = x.argmax(dim=0, keepdim=True)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -260,7 +260,7 @@ def test_argmax_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=0)
+    op = ArgmaxFwdOp(N=b0, dtype=dtype, dim=0)
     ref = x.argmax(dim=0)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -274,7 +274,7 @@ def test_argmax_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
+    op = ArgmaxFwdOp(N=b0, dtype=dtype, dim=0, keepdim=True)
     ref = x.argmax(dim=0, keepdim=True)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -288,7 +288,7 @@ def test_argmax_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
+    op = ArgmaxFwdOp(N=shape[dim], dtype=dtype, dim=dim, keepdim=keepdim)
     ref = x.argmax(dim=dim, keepdim=keepdim)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -306,7 +306,7 @@ def test_argmin_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     test = ArgreduceTest(m, n, dtype, "argmin")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=n, dtype=dtype)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -316,7 +316,7 @@ def test_argmin_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=n, dtype=dtype)
     ref = x.contiguous().argmin(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -328,7 +328,7 @@ def test_argmin_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=hidden, dtype=dtype)
     ref = x.argmin(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -340,7 +340,7 @@ def test_argmin_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=n, dtype=dtype)
     ref = x.argmin(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -352,7 +352,7 @@ def test_argmin_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(N=n, dtype=dtype)
     ref = x.argmin(dim=-1)
     y = op(x)
     assert y.dtype == torch.int64
@@ -365,7 +365,7 @@ def test_argmin_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=0)
+    op = ArgminFwdOp(N=batch, dtype=dtype, dim=0)
     ref = x.argmin(dim=0)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -379,7 +379,7 @@ def test_argmin_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
+    op = ArgminFwdOp(N=batch, dtype=dtype, dim=0, keepdim=True)
     ref = x.argmin(dim=0, keepdim=True)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -393,7 +393,7 @@ def test_argmin_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=0)
+    op = ArgminFwdOp(N=b0, dtype=dtype, dim=0)
     ref = x.argmin(dim=0)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -407,7 +407,7 @@ def test_argmin_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
+    op = ArgminFwdOp(N=b0, dtype=dtype, dim=0, keepdim=True)
     ref = x.argmin(dim=0, keepdim=True)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
@@ -421,7 +421,7 @@ def test_argmin_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
+    op = ArgminFwdOp(N=shape[dim], dtype=dtype, dim=dim, keepdim=keepdim)
     ref = x.argmin(dim=dim, keepdim=keepdim)
     y = op(x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -161,5 +161,92 @@ def test_batch_norm_bwd(N, C, spatial, dtype):
     print("test_batch_norm_bwd passed: grad_x/weight/bias all match")
 
 
+@pytest.mark.smoke
+def test_batch_norm_bwd_input_validation():
+    """BatchNormBwdOp rejects inconsistent backward inputs in both the
+    user-facing ``forward`` path and the eager path used by the custom op
+    (``_eager_forward``)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    device = torch.device("cuda")
+    C = 4
+    dtype = torch.float16
+    op = BatchNormBwdOp(C=C, dtype=dtype)
+
+    def _good():
+        grad_out = torch.randn(2, C, 3, device=device, dtype=dtype)
+        x = torch.randn(2, C, 3, device=device, dtype=dtype)
+        weight = torch.randn(C, device=device, dtype=torch.float32)
+        mean = torch.randn(C, device=device, dtype=torch.float32)
+        rstd = torch.ones(C, device=device, dtype=torch.float32)
+        return grad_out, x, weight, mean, rstd
+
+    # Baseline: valid inputs must pass _validate_inputs (no raise).
+    op._validate_inputs(*_good())
+
+    # Case 1: x.shape != grad_out.shape — the exact bug from the finding.
+    grad_out, x, weight, mean, rstd = _good()
+    x_bad = torch.randn(1, C, 3, device=device, dtype=dtype)
+    with pytest.raises(ValueError, match="x.shape == grad_out.shape"):
+        op._validate_inputs(grad_out, x_bad, weight, mean, rstd)
+    with pytest.raises(ValueError, match="x.shape == grad_out.shape"):
+        op.forward(grad_out, x_bad, weight, mean, rstd)
+    # Eager path used by the custom op must validate consistently.
+    with pytest.raises(ValueError, match="x.shape == grad_out.shape"):
+        op._eager_forward(grad_out, x_bad, weight, mean, rstd)
+
+    # Case 2: grad_out not CUDA.
+    grad_out, x, weight, mean, rstd = _good()
+    with pytest.raises(ValueError, match="grad_out must be a CUDA tensor"):
+        op._validate_inputs(grad_out.cpu(), x, weight, mean, rstd)
+
+    # Case 3: grad_out dtype mismatch.
+    grad_out, x, weight, mean, rstd = _good()
+    grad_out_bad = grad_out.to(torch.float32)
+    with pytest.raises(ValueError, match="grad_out.dtype"):
+        op._validate_inputs(grad_out_bad, x, weight, mean, rstd)
+
+    # Case 4: grad_out.ndim < 2.
+    grad_out_1d = torch.randn(C, device=device, dtype=dtype)
+    x_1d = torch.randn(C, device=device, dtype=dtype)
+    _, _, weight, mean, rstd = _good()
+    with pytest.raises(ValueError, match="ndim >= 2"):
+        op._validate_inputs(grad_out_1d, x_1d, weight, mean, rstd)
+
+    # Case 5: channel dim mismatch.
+    grad_out_badc = torch.randn(2, C + 1, 3, device=device, dtype=dtype)
+    x_badc = torch.randn(2, C + 1, 3, device=device, dtype=dtype)
+    _, _, weight, mean, rstd = _good()
+    with pytest.raises(ValueError, match=f"Expected channel dim {C}"):
+        op._validate_inputs(grad_out_badc, x_badc, weight, mean, rstd)
+
+    # Case 6: x dtype mismatch.
+    grad_out, x, weight, mean, rstd = _good()
+    x_bad_dtype = x.to(torch.float32)
+    with pytest.raises(ValueError, match="x.dtype"):
+        op._validate_inputs(grad_out, x_bad_dtype, weight, mean, rstd)
+
+    # Case 7: weight wrong shape.
+    grad_out, x, weight, mean, rstd = _good()
+    weight_bad = torch.randn(C + 1, device=device, dtype=torch.float32)
+    with pytest.raises(ValueError, match=r"weight\.shape"):
+        op._validate_inputs(grad_out, x, weight_bad, mean, rstd)
+
+    # Case 8: mean wrong dtype (must be float32).
+    grad_out, x, weight, mean, rstd = _good()
+    mean_bad = mean.to(torch.float16)
+    with pytest.raises(ValueError, match=r"mean\.dtype"):
+        op._validate_inputs(grad_out, x, weight, mean_bad, rstd)
+
+    # Case 9: rstd wrong shape.
+    grad_out, x, weight, mean, rstd = _good()
+    rstd_bad = torch.ones(C + 2, device=device, dtype=torch.float32)
+    with pytest.raises(ValueError, match=r"rstd\.shape"):
+        op._validate_inputs(grad_out, x, weight, mean, rstd_bad)
+
+    print("test_batch_norm_bwd_input_validation passed")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -115,7 +115,7 @@ def test_batch_norm_fwd(N, C, spatial, dtype, training):
     running_mean_ref = running_mean.clone()
     running_var_ref = running_var.clone()
 
-    op = BatchNormFwdOp(N, C, *spatial, dtype=dtype)
+    op = BatchNormFwdOp(C=C, dtype=dtype)
     y, mean, rstd = op(x, weight, bias, running_mean, running_var, training=training)
 
     ref_y, ref_rm, ref_rv = _ref_fwd(x, weight, bias, running_mean_ref, running_var_ref,
@@ -143,7 +143,7 @@ def test_batch_norm_bwd(N, C, spatial, dtype):
     test = BatchNormBwdTest(N, C, spatial, dtype)
     grad_out, x, weight, mean, rstd = test.gen_inputs()
 
-    op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    op = BatchNormBwdOp(C=C, dtype=dtype)
     grad_x, grad_weight, grad_bias = op(grad_out, x, weight, mean, rstd)
 
     ref_gx, ref_gw, ref_gb = test.ref_program(grad_out, x, weight, mean, rstd)

--- a/tests/ops/test_fused_add_layer_norm.py
+++ b/tests/ops/test_fused_add_layer_norm.py
@@ -63,7 +63,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @FusedAddLayerNormFixture
 def test_fused_add_layer_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddLayerNormTest(m, n, dtype)
-    op = FusedAddLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddLayerNormFwdOp(N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -88,7 +88,7 @@ def test_fused_add_layer_norm_non_contiguous(m: int, n: int, dtype: torch.dtype)
     weight = torch.randn(n, dtype=dtype, device="cuda")
     bias = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = FusedAddLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddLayerNormFwdOp(N=n, dtype=dtype)
 
     # Reference on contiguous copies
     test = FusedAddLayerNormTest(m, n, dtype)
@@ -121,7 +121,7 @@ def test_fused_add_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch
     bias = torch.randn(hidden, dtype=dtype, device="cuda")
 
     M = batch * seq
-    op = FusedAddLayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = FusedAddLayerNormFwdOp(N=hidden, dtype=dtype)
 
     test = FusedAddLayerNormTest(M, hidden, dtype)
     y_ref, add_ref = test.ref_program(x, residual, weight, bias)

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -51,7 +51,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @FusedAddRMSNormFixture
 def test_fused_add_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddRMSNormTest(m, n, dtype)
-    op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddRMSNormFwdOp(N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -74,7 +74,7 @@ def test_fused_add_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -
     residual = r_full[:, :n]
     weight = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddRMSNormFwdOp(N=n, dtype=dtype)
 
     # Reference on contiguous copies
     test = FusedAddRMSNormTest(m, n, dtype)
@@ -105,7 +105,7 @@ def test_fused_add_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.d
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
 
     M = batch * seq
-    op = FusedAddRMSNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = FusedAddRMSNormFwdOp(N=hidden, dtype=dtype)
 
     test = FusedAddRMSNormTest(M, hidden, dtype)
     y_ref, add_ref = test.ref_program(x, residual, weight)

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -51,7 +51,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 def test_instance_norm_op(n: int, c: int, spatial: tuple,
                           dtype: torch.dtype, tune: bool) -> None:
     test = InstanceNormTest(n, c, spatial, dtype)
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp(C=c, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -75,7 +75,7 @@ def test_instance_norm_non_contiguous(n: int, c: int, spatial: tuple,
     weight = torch.randn(c, dtype=dtype, device="cuda")
     bias = torch.randn(c, dtype=dtype, device="cuda")
 
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp(C=c, dtype=dtype)
 
     y_ref = F.instance_norm(
         x.contiguous().float(),

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -60,7 +60,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @LayerNormFixture
 def test_layer_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = LayerNormTest(m, n, dtype)
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(N=n, dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -83,7 +83,7 @@ def test_layer_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     weight = torch.randn(n, dtype=dtype, device="cuda")
     bias = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(N=n, dtype=dtype)
 
     # Reference using torch.nn.functional.layer_norm
     x_ref = x.contiguous()
@@ -115,8 +115,7 @@ def test_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) ->
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
     bias = torch.randn(hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = LayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = LayerNormFwdOp(N=hidden, dtype=dtype)
 
     # Reference using torch.nn.functional.layer_norm
     y_ref = F.layer_norm(
@@ -159,7 +158,7 @@ def test_layer_norm_large_offset(m: int, n: int, dtype: torch.dtype) -> None:
     weight = torch.ones(n, dtype=dtype, device="cuda")
     bias = torch.zeros(n, dtype=dtype, device="cuda")
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(N=n, dtype=dtype)
 
     y_ref = F.layer_norm(
         x.float(), (n,),

--- a/tests/ops/test_norm_ops.py
+++ b/tests/ops/test_norm_ops.py
@@ -19,7 +19,7 @@ class TestBatchNormFwdValidation:
 
     def _make_op(self):
         from tileops.ops.norm.batch_norm import BatchNormFwdOp
-        return BatchNormFwdOp(4, 8, 4, 4, dtype=torch.float16)
+        return BatchNormFwdOp(C=8, dtype=torch.float16)
 
     def _make_inputs(self, device="cuda", dtype=torch.float16):
         x = torch.randn(4, 8, 4, 4, device=device, dtype=dtype)
@@ -62,7 +62,7 @@ class TestBatchNormCustomOp:
 
     def test_fwd_torch_compile_smoke(self):
         from tileops.ops.norm.batch_norm import BatchNormFwdOp
-        op = BatchNormFwdOp(4, 8, 4, 4, dtype=torch.float16)
+        op = BatchNormFwdOp(C=8, dtype=torch.float16)
         x = torch.randn(4, 8, 4, 4, device="cuda", dtype=torch.float16)
         weight = torch.randn(8, device="cuda", dtype=torch.float32)
         bias = torch.randn(8, device="cuda", dtype=torch.float32)
@@ -76,7 +76,7 @@ class TestBatchNormCustomOp:
     def test_bwd_torch_compile_smoke(self):
         from tileops.ops.norm.batch_norm import BatchNormBwdOp
         N, C, H, W = 4, 8, 4, 4
-        op = BatchNormBwdOp(N, C, H, W, dtype=torch.float16)
+        op = BatchNormBwdOp(C=C, dtype=torch.float16)
         grad_out = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
         x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
         weight = torch.randn(C, device="cuda", dtype=torch.float32)

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -8,8 +8,8 @@ Smoke tests (1 per function, first param) use small data for quick CI.
 Full tests use small data for config breadth + large data for stress.
 
 All operators use the spec-conformant interface:
-  SoftmaxFwdOp(dtype=dtype, dim=dim)
-  LogSoftmaxFwdOp(dtype=dtype, dim=dim)
+  SoftmaxFwdOp(N=N, dtype=dtype, dim=dim)
+  LogSoftmaxFwdOp(N=N, dtype=dtype, dim=dim)
   LogSumExpFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
 """
 
@@ -105,7 +105,7 @@ class SoftmaxTest(_SoftmaxTestWorkload, TestBase):
 @SoftmaxFixture
 def test_softmax_op(shape: tuple, dim: int, dtype: torch.dtype, tune: bool) -> None:
     test = SoftmaxTest(shape, dtype, dim=dim)
-    op = SoftmaxFwdOp(dtype=dtype, dim=dim, tune=tune)
+    op = SoftmaxFwdOp(N=shape[dim], dtype=dtype, dim=dim, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -138,7 +138,7 @@ def test_softmax_non_contiguous(shape: tuple, dtype: torch.dtype) -> None:
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]  # non-contiguous slice
 
-    op = SoftmaxFwdOp(dtype=dtype, dim=-1)
+    op = SoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
 
     y_ref = F.softmax(x.float().contiguous(), dim=-1).to(dtype)
     y = op(x)
@@ -173,7 +173,7 @@ class Softmax1DFixture(FixtureBase):
 def test_softmax_1d(n: int, dtype: torch.dtype) -> None:
     """Test softmax with 1D input (single row)."""
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = SoftmaxFwdOp(dtype=dtype, dim=-1)
+    op = SoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
 
     y_ref = F.softmax(x.float(), dim=-1).to(dtype)
     y = op(x)
@@ -249,7 +249,7 @@ class LogSoftmaxTest(_LogSoftmaxTestWorkload, TestBase):
 @LogSoftmaxFixture
 def test_log_softmax_op(shape: tuple, dim: int, dtype: torch.dtype, tune: bool) -> None:
     test = LogSoftmaxTest(shape, dtype, dim=dim)
-    op = LogSoftmaxFwdOp(dtype=dtype, dim=dim, tune=tune)
+    op = LogSoftmaxFwdOp(N=shape[dim], dtype=dtype, dim=dim, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -392,7 +392,7 @@ def test_log_softmax_non_contiguous(shape: tuple, dtype: torch.dtype) -> None:
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
 
-    op = LogSoftmaxFwdOp(dtype=dtype, dim=-1)
+    op = LogSoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
 
     y_ref = F.log_softmax(x.float().contiguous(), dim=-1).to(dtype)
     y = op(x)
@@ -460,7 +460,7 @@ class LogSoftmax1DFixture(FixtureBase):
 def test_log_softmax_1d(n: int, dtype: torch.dtype) -> None:
     """Test log_softmax with 1D input."""
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = LogSoftmaxFwdOp(dtype=dtype, dim=-1)
+    op = LogSoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
 
     y_ref = F.log_softmax(x.float(), dim=-1).to(dtype)
     y = op(x)
@@ -511,7 +511,7 @@ def test_logsumexp_1d(n: int, dtype: torch.dtype) -> None:
 def test_softmax_rejects_multidim_before_kernel() -> None:
     """SoftmaxFwdOp must raise ValueError for list dim before touching the kernel."""
     x = torch.randn(4, 8, device="cuda", dtype=torch.float32)
-    op = SoftmaxFwdOp(dtype=torch.float32, dim=[-1, 0])
+    op = SoftmaxFwdOp(N=8, dtype=torch.float32, dim=[-1, 0])
     with pytest.raises(ValueError, match="does not support multi-dim"):
         op(x)
     # Verify no kernel was built (cache must remain empty).
@@ -522,7 +522,7 @@ def test_softmax_rejects_multidim_before_kernel() -> None:
 def test_log_softmax_rejects_multidim_before_kernel() -> None:
     """LogSoftmaxFwdOp must raise ValueError for list dim before touching the kernel."""
     x = torch.randn(4, 8, device="cuda", dtype=torch.float32)
-    op = LogSoftmaxFwdOp(dtype=torch.float32, dim=[-1, 0])
+    op = LogSoftmaxFwdOp(N=8, dtype=torch.float32, dim=[-1, 0])
     with pytest.raises(ValueError, match="does not support multi-dim"):
         op(x)
     assert len(op._kernel_cache) == 0

--- a/tileops/ops/norm/ada_layer_norm.py
+++ b/tileops/ops/norm/ada_layer_norm.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -28,7 +28,7 @@ class AdaLayerNormFwdOp(Op):
             + \\epsilon}} + d
 
     where *s* (scale) and *d* (shift) are per-token tensors of shape
-    ``(M, N)``, pre-computed by the caller from a conditioning signal.
+    ``(*leading, N)``, pre-computed by the caller from a conditioning signal.
     Linear projection from the conditioning input to scale/shift is the
     caller's responsibility.
 
@@ -41,8 +41,8 @@ class AdaLayerNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        N: Hidden dimension (last dim). Committed at construction per
+            manifest ``static_dims``; forward validates ``x.shape[-1] == N``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -52,26 +52,42 @@ class AdaLayerNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.M = M
         self.N = N
         self.dtype = dtype
         self.eps = eps
+        self._tune = tune
         self.N_padded = _align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ada_layer_norm"](
-            M, N, eps, dtype, has_gate=False, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ada_layer_norm": AdaLayerNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: the (M,) product of leading dims of ``x``."""
+        x_shape = input_shapes[0]
+        M = 1
+        for s in x_shape[:-1]:
+            M *= s
+        return (M,)
+
+    def _get_or_create_kernel(self, M: int) -> Kernel:
+        key = (M,)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["ada_layer_norm"](
+                M, self.N, self.eps, self.dtype, has_gate=False, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(
         self, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor,
@@ -108,6 +124,7 @@ class AdaLayerNormFwdOp(Op):
             raise ValueError(
                 f"Expected shift.dtype {self.dtype}, got {shift.dtype}"
             )
+        # static_dims validation: x.shape[-1] == N (committed at ctor).
         if x.shape[-1] != self.N:
             raise ValueError(
                 f"Expected hidden dim {self.N}, got {x.shape[-1]}"
@@ -117,11 +134,8 @@ class AdaLayerNormFwdOp(Op):
         x = x.contiguous().reshape(-1, self.N)
         scale = scale.contiguous().reshape(-1, self.N)
         shift = shift.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
-            )
+        M = x.shape[0]
+        kernel = self._get_or_create_kernel(M)
 
         # Pad hidden dim to 256-element alignment if needed
         if self.N_padded != self.N:
@@ -129,7 +143,7 @@ class AdaLayerNormFwdOp(Op):
             scale = F.pad(scale, (0, self.N_padded - self.N))
             shift = F.pad(shift, (0, self.N_padded - self.N))
 
-        y = self.kernel(x, scale, shift)
+        y = kernel(x, scale, shift)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/ada_layer_norm.py
+++ b/tileops/ops/norm/ada_layer_norm.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -74,9 +75,7 @@ class AdaLayerNormFwdOp(Op):
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Kernel cache key: the (M,) product of leading dims of ``x``."""
         x_shape = input_shapes[0]
-        M = 1
-        for s in x_shape[:-1]:
-            M *= s
+        M = prod(x_shape[:-1])
         return (M,)
 
     def _get_or_create_kernel(self, M: int) -> Kernel:

--- a/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/tileops/ops/norm/ada_layer_norm_zero.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -75,9 +76,7 @@ class AdaLayerNormZeroFwdOp(Op):
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Kernel cache key: the (M,) product of leading dims of ``x``."""
         x_shape = input_shapes[0]
-        M = 1
-        for s in x_shape[:-1]:
-            M *= s
+        M = prod(x_shape[:-1])
         return (M,)
 
     def _get_or_create_kernel(self, M: int) -> Kernel:

--- a/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/tileops/ops/norm/ada_layer_norm_zero.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -29,9 +29,9 @@ class AdaLayerNormZeroFwdOp(Op):
             {\\sqrt{\\mathrm{Var}[x] + \\epsilon}} + d \\right)
 
     where *s* (scale), *d* (shift), and *g* (gate) are per-token tensors of
-    shape ``(M, N)``, pre-computed by the caller from a conditioning signal.
-    Linear projection from the conditioning input to scale/shift/gate is the
-    caller's responsibility.
+    shape ``(*leading, N)``, pre-computed by the caller from a conditioning
+    signal.  Linear projection from the conditioning input to scale/shift/gate
+    is the caller's responsibility.
 
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
@@ -42,8 +42,8 @@ class AdaLayerNormZeroFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        N: Hidden dimension (last dim). Committed at construction per
+            manifest ``static_dims``; forward validates ``x.shape[-1] == N``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -53,26 +53,42 @@ class AdaLayerNormZeroFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.M = M
         self.N = N
         self.dtype = dtype
         self.eps = eps
+        self._tune = tune
         self.N_padded = _align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ada_layer_norm"](
-            M, N, eps, dtype, has_gate=True, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ada_layer_norm": AdaLayerNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: the (M,) product of leading dims of ``x``."""
+        x_shape = input_shapes[0]
+        M = 1
+        for s in x_shape[:-1]:
+            M *= s
+        return (M,)
+
+    def _get_or_create_kernel(self, M: int) -> Kernel:
+        key = (M,)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["ada_layer_norm"](
+                M, self.N, self.eps, self.dtype, has_gate=True, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(
         self,
@@ -120,6 +136,7 @@ class AdaLayerNormZeroFwdOp(Op):
             raise ValueError(
                 f"Expected gate.dtype {self.dtype}, got {gate.dtype}"
             )
+        # static_dims validation: x.shape[-1] == N (committed at ctor).
         if x.shape[-1] != self.N:
             raise ValueError(
                 f"Expected hidden dim {self.N}, got {x.shape[-1]}"
@@ -130,11 +147,8 @@ class AdaLayerNormZeroFwdOp(Op):
         scale = scale.contiguous().reshape(-1, self.N)
         shift = shift.contiguous().reshape(-1, self.N)
         gate = gate.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
-            )
+        M = x.shape[0]
+        kernel = self._get_or_create_kernel(M)
 
         # Pad hidden dim to 256-element alignment if needed
         if self.N_padded != self.N:
@@ -143,7 +157,7 @@ class AdaLayerNormZeroFwdOp(Op):
             shift = F.pad(shift, (0, self.N_padded - self.N))
             gate = F.pad(gate, (0, self.N_padded - self.N))
 
-        y = self.kernel(x, scale, shift, gate)
+        y = kernel(x, scale, shift, gate)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -5,9 +5,10 @@ in a standard TileOPs Op interface.
 
 User-facing API mirrors torch.nn.functional.batch_norm:
 
-    fwd_op = BatchNormFwdOp(C=channels, dtype=dtype, momentum=0.1, eps=1e-5)
-    y, mean, rstd = fwd_op(x, weight, bias, running_mean, running_var,
-                           training=True)
+    fwd_op = BatchNormFwdOp(C=channels, dtype=dtype, training=True,
+                            eps=1e-5, momentum=0.1)
+    y, mean, rstd = fwd_op(x, weight, bias, running_mean, running_var)
+    # forward() also accepts an optional `training` override per call.
 
     bwd_op = BatchNormBwdOp(C=channels, dtype=dtype)
     grad_x, grad_weight, grad_bias = bwd_op(grad_out, x, weight, mean, rstd)
@@ -81,6 +82,10 @@ class BatchNormFwdOp(Op):
         C: Number of channels (committed at construction per manifest
             ``static_dims``; forward validates ``x.shape[1] == C``).
         dtype: Input/output data type.
+        training: Default training-mode flag. Stored as ``self.training`` and
+            used when ``forward()`` is called without an explicit ``training``
+            override. Order matches manifest ``params`` block (training, eps,
+            momentum) per codegen contract.
         eps: Epsilon for numerical stability.
         momentum: Running-stat update momentum (used in training mode).
         kernel_map: Optional kernel override dictionary.
@@ -95,6 +100,7 @@ class BatchNormFwdOp(Op):
         *,
         C: int,
         dtype: torch.dtype,
+        training: bool = True,
         eps: float = 1e-5,
         momentum: float = 0.1,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -102,6 +108,7 @@ class BatchNormFwdOp(Op):
     ) -> None:
         self.C = C
         self.dtype = dtype
+        self.training = training
         self.eps = eps
         self.momentum = momentum
         self._tune = tune
@@ -176,7 +183,7 @@ class BatchNormFwdOp(Op):
         bias: torch.Tensor,
         running_mean: torch.Tensor,
         running_var: torch.Tensor,
-        training: bool = True,
+        training: Optional[bool] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
         """Run batch normalization forward pass.
 
@@ -192,8 +199,8 @@ class BatchNormFwdOp(Op):
             running_var: Running variance of shape ``(C,)`` on the same CUDA
                 device as ``x``, with dtype ``torch.float32``. Updated
                 in-place during training.
-            training: If ``True``, compute batch statistics and update
-                running stats; otherwise use running stats directly.
+            training: Optional per-call override. When ``None`` (default), the
+                instance's ``self.training`` (set at ``__init__``) is used.
 
         Returns:
             Tuple of ``(y, mean, rstd)`` where *y* is the normalized output
@@ -205,6 +212,8 @@ class BatchNormFwdOp(Op):
         x_cl, orig_shape = self._prepare(x)
         L = x_cl.shape[1]
 
+        if training is None:
+            training = self.training
         if training:
             kernel = self._get_train_kernel(L)
             y_cl, mean, rstd = kernel(
@@ -408,12 +417,14 @@ def _batchnorm_fwd_eager_forward(
     bias: torch.Tensor,
     running_mean: torch.Tensor,
     running_var: torch.Tensor,
-    training: bool = True,
+    training: Optional[bool] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """Direct kernel call (no torch.compile wrapping)."""
     self._validate_inputs(x)
     x_cl, orig_shape = self._prepare(x)
     L = x_cl.shape[1]
+    if training is None:
+        training = self.training
     if training:
         kernel = self._get_train_kernel(L)
         y_cl, mean, rstd = kernel(
@@ -441,7 +452,9 @@ def _patched_fwd_init(self, *args, **kwargs):
 BatchNormFwdOp.__init__ = _patched_fwd_init
 
 
-def _patched_fwd_forward(self, x, weight, bias, running_mean, running_var, training=True):
+def _patched_fwd_forward(self, x, weight, bias, running_mean, running_var, training=None):
+    if training is None:
+        training = self.training
     y, mean, rstd = _batch_norm_fwd_wrapped(
         x, weight, bias, running_mean, running_var, training, self._instance_key)
     if mean.numel() == 0:

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -5,22 +5,21 @@ in a standard TileOPs Op interface.
 
 User-facing API mirrors torch.nn.functional.batch_norm:
 
-    fwd_op = BatchNormFwdOp(N, C, *spatial, dtype=dtype, momentum=0.1, eps=1e-5)
+    fwd_op = BatchNormFwdOp(C=channels, dtype=dtype, momentum=0.1, eps=1e-5)
     y, mean, rstd = fwd_op(x, weight, bias, running_mean, running_var,
                            training=True)
 
-    bwd_op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    bwd_op = BatchNormBwdOp(C=channels, dtype=dtype)
     grad_x, grad_weight, grad_bias = bwd_op(grad_out, x, weight, mean, rstd)
 
-Input tensors accept any shape (N, C, *spatial); the op reshapes to (C, L)
-internally.  L = N * prod(spatial) must be divisible by the kernel's block_l
-(chosen automatically by the kernel's default_config).
+Input tensors accept any shape ``(N, C, *spatial)``; the op reshapes to
+``(C, L)`` internally where ``L = N * prod(spatial)``.  Kernels are built
+lazily per-``L`` and cached.
 """
 
 import functools
-import math
 import weakref
-from typing import Dict, Optional, Tuple
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 
@@ -74,12 +73,13 @@ class BatchNormFwdOp(Op):
 
     Note:
         Input tensors accept any shape ``(N, C, *spatial)``; the op reshapes
-        to ``(C, L)`` internally where ``L = N * prod(spatial)``.
+        to ``(C, L)`` internally where ``L = N * prod(spatial)``.  ``N`` and
+        ``*spatial`` are derived from the input tensor at forward time;
+        kernels are cached by ``L``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        *spatial: Spatial dimensions (H, W, ...).
+        C: Number of channels (committed at construction per manifest
+            ``static_dims``; forward validates ``x.shape[1] == C``).
         dtype: Input/output data type.
         eps: Epsilon for numerical stability.
         momentum: Running-stat update momentum (used in training mode).
@@ -87,31 +87,28 @@ class BatchNormFwdOp(Op):
         tune: If ``True``, autotune tile configurations.
     """
 
+    # Channel axis (1 of input 0) is static.
+    _static_axes = frozenset({(0, 1)})
+
     def __init__(
         self,
-        N: int,
+        *,
         C: int,
-        *spatial: int,
-        dtype: torch.dtype = torch.float16,
+        dtype: torch.dtype,
         eps: float = 1e-5,
         momentum: float = 0.1,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.N = N
         self.C = C
-        self.spatial = spatial
-        self.L = N * math.prod(spatial) if spatial else N
         self.dtype = dtype
         self.eps = eps
         self.momentum = momentum
+        self._tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        self.train_kernel: BatchNormFwdTrainKernel = self.kernel_map["fwd_train_kernel"](
-            C, self.L, dtype, eps, momentum, tune=tune)
-        self.infer_kernel: BatchNormFwdInferKernel = self.kernel_map["fwd_infer_kernel"](
-            C, self.L, dtype, eps, tune=tune)
+        self._train_cache: Dict[Hashable, BatchNormFwdTrainKernel] = {}
+        self._infer_cache: Dict[Hashable, BatchNormFwdInferKernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -119,6 +116,36 @@ class BatchNormFwdOp(Op):
             "fwd_train_kernel": BatchNormFwdTrainKernel,
             "fwd_infer_kernel": BatchNormFwdInferKernel,
         }
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: (L,) where L = N * prod(spatial) for input x."""
+        x_shape = input_shapes[0]
+        # L = all non-static (non-C) axes multiplied
+        L = 1
+        for i, s in enumerate(x_shape):
+            if i != 1:
+                L *= s
+        return (L,)
+
+    def _get_train_kernel(self, L: int) -> BatchNormFwdTrainKernel:
+        key = (L,)
+        kernel = self._train_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["fwd_train_kernel"](
+                self.C, L, self.dtype, self.eps, self.momentum, tune=self._tune,
+            )
+            self._train_cache[key] = kernel
+        return kernel
+
+    def _get_infer_kernel(self, L: int) -> BatchNormFwdInferKernel:
+        key = (L,)
+        kernel = self._infer_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["fwd_infer_kernel"](
+                self.C, L, self.dtype, self.eps, tune=self._tune,
+            )
+            self._infer_cache[key] = kernel
+        return kernel
 
     def _prepare(self, x: torch.Tensor) -> Tuple[torch.Tensor, Tuple]:
         """Reshape x to (C, L)."""
@@ -132,10 +159,14 @@ class BatchNormFwdOp(Op):
             raise ValueError(
                 f"Expected x.dtype {self.dtype}, got {x.dtype}"
             )
-        expected_shape = (self.N, self.C, *self.spatial)
-        if x.shape != expected_shape:
+        if x.ndim < 2:
             raise ValueError(
-                f"Expected input shape {expected_shape}, got {x.shape}"
+                f"Expected x.ndim >= 2 (N, C, *spatial), got {x.ndim}"
+            )
+        # static_dims validation: x.shape[1] == C (committed at ctor).
+        if x.shape[1] != self.C:
+            raise ValueError(
+                f"Expected channel dim {self.C}, got {x.shape[1]}"
             )
 
     def forward(
@@ -172,15 +203,18 @@ class BatchNormFwdOp(Op):
         """
         self._validate_inputs(x)
         x_cl, orig_shape = self._prepare(x)
+        L = x_cl.shape[1]
 
         if training:
-            y_cl, mean, rstd = self.train_kernel(
+            kernel = self._get_train_kernel(L)
+            y_cl, mean, rstd = kernel(
                 x_cl, weight.float(), bias.float(),
                 running_mean, running_var)
             y = _restore_shape(y_cl, orig_shape)
             return y, mean, rstd
         else:
-            y_cl = self.infer_kernel(
+            kernel = self._get_infer_kernel(L)
+            y_cl = kernel(
                 x_cl, weight.float(), bias.float(),
                 running_mean, running_var)
             y = _restore_shape(y_cl, orig_shape)
@@ -204,40 +238,57 @@ class BatchNormBwdOp(Op):
 
     Note:
         Input tensors accept any shape ``(N, C, *spatial)``; the op reshapes
-        to ``(C, L)`` internally where ``L = N * prod(spatial)``.
+        to ``(C, L)`` internally where ``L = N * prod(spatial)``.  ``N`` and
+        ``*spatial`` are derived from the input tensor at forward time;
+        kernels are cached by ``L``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        *spatial: Spatial dimensions (H, W, ...).
+        C: Number of channels (committed at construction per manifest
+            ``static_dims``; forward validates ``grad_out.shape[1] == C``).
         dtype: Data type of ``grad_out``, ``x``, and ``grad_x``.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
     """
 
+    _static_axes = frozenset({(0, 1)})
+
     def __init__(
         self,
-        N: int,
+        *,
         C: int,
-        *spatial: int,
-        dtype: torch.dtype = torch.float16,
+        dtype: torch.dtype,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.N = N
         self.C = C
-        self.spatial = spatial
-        self.L = N * math.prod(spatial) if spatial else N
         self.dtype = dtype
+        self._tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        self.bwd_kernel: BatchNormBwdKernel = self.kernel_map["bwd_kernel"](
-            C, self.L, dtype, tune=tune)
+        self._bwd_cache: Dict[Hashable, BatchNormBwdKernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"bwd_kernel": BatchNormBwdKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: (L,) where L = N * prod(spatial) for grad_out."""
+        grad_out_shape = input_shapes[0]
+        L = 1
+        for i, s in enumerate(grad_out_shape):
+            if i != 1:
+                L *= s
+        return (L,)
+
+    def _get_bwd_kernel(self, L: int) -> BatchNormBwdKernel:
+        key = (L,)
+        kernel = self._bwd_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["bwd_kernel"](
+                self.C, L, self.dtype, tune=self._tune,
+            )
+            self._bwd_cache[key] = kernel
+        return kernel
 
     def _prepare(self, t: torch.Tensor) -> torch.Tensor:
         t_cl, _ = _reshape_to_CL(t)
@@ -273,11 +324,18 @@ class BatchNormBwdOp(Op):
             has the same shape as *x*, *grad_weight* has shape ``(C,)``,
             and *grad_bias* has shape ``(C,)``.
         """
+        # static_dims validation: grad_out.shape[1] == C (committed at ctor).
+        if grad_out.shape[1] != self.C:
+            raise ValueError(
+                f"Expected channel dim {self.C}, got {grad_out.shape[1]}"
+            )
         orig_shape = grad_out.shape
         go_cl = self._prepare(grad_out)
         x_cl = self._prepare(x)
+        L = go_cl.shape[1]
+        kernel = self._get_bwd_kernel(L)
 
-        grad_x_cl, grad_weight, grad_bias = self.bwd_kernel(
+        grad_x_cl, grad_weight, grad_bias = kernel(
             go_cl, x_cl, weight.float(), mean, rstd)
 
         grad_x = _restore_shape(grad_x_cl, orig_shape)
@@ -355,12 +413,15 @@ def _batchnorm_fwd_eager_forward(
     """Direct kernel call (no torch.compile wrapping)."""
     self._validate_inputs(x)
     x_cl, orig_shape = self._prepare(x)
+    L = x_cl.shape[1]
     if training:
-        y_cl, mean, rstd = self.train_kernel(
+        kernel = self._get_train_kernel(L)
+        y_cl, mean, rstd = kernel(
             x_cl, weight.float(), bias.float(), running_mean, running_var)
         return _restore_shape(y_cl, orig_shape), mean, rstd
     else:
-        y_cl = self.infer_kernel(
+        kernel = self._get_infer_kernel(L)
+        y_cl = kernel(
             x_cl, weight.float(), bias.float(), running_mean, running_var)
         return _restore_shape(y_cl, orig_shape), None, None
 
@@ -437,10 +498,16 @@ def _batchnorm_bwd_eager_forward(
     rstd: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Direct kernel call (no torch.compile wrapping)."""
+    if grad_out.shape[1] != self.C:
+        raise ValueError(
+            f"Expected channel dim {self.C}, got {grad_out.shape[1]}"
+        )
     orig_shape = grad_out.shape
     go_cl = self._prepare(grad_out)
     x_cl = self._prepare(x)
-    grad_x_cl, grad_weight, grad_bias = self.bwd_kernel(
+    L = go_cl.shape[1]
+    kernel = self._get_bwd_kernel(L)
+    grad_x_cl, grad_weight, grad_bias = kernel(
         go_cl, x_cl, weight.float(), mean, rstd)
     grad_x = _restore_shape(grad_x_cl, orig_shape)
     return grad_x, grad_weight, grad_bias

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -20,6 +20,7 @@ lazily per-``L`` and cached.
 
 import functools
 import weakref
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -128,10 +129,7 @@ class BatchNormFwdOp(Op):
         """Kernel cache key: (L,) where L = N * prod(spatial) for input x."""
         x_shape = input_shapes[0]
         # L = all non-static (non-C) axes multiplied
-        L = 1
-        for i, s in enumerate(x_shape):
-            if i != 1:
-                L *= s
+        L = prod(s for i, s in enumerate(x_shape) if i != 1)
         return (L,)
 
     def _get_train_kernel(self, L: int) -> BatchNormFwdTrainKernel:
@@ -283,10 +281,7 @@ class BatchNormBwdOp(Op):
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Kernel cache key: (L,) where L = N * prod(spatial) for grad_out."""
         grad_out_shape = input_shapes[0]
-        L = 1
-        for i, s in enumerate(grad_out_shape):
-            if i != 1:
-                L *= s
+        L = prod(s for i, s in enumerate(grad_out_shape) if i != 1)
         return (L,)
 
     def _get_bwd_kernel(self, L: int) -> BatchNormBwdKernel:

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -303,6 +303,80 @@ class BatchNormBwdOp(Op):
         t_cl, _ = _reshape_to_CL(t)
         return t_cl
 
+    def _validate_inputs(
+        self,
+        grad_out: torch.Tensor,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        mean: torch.Tensor,
+        rstd: torch.Tensor,
+    ) -> None:
+        """Validate device, dtype, ndim, and shape of all backward inputs.
+
+        Checks:
+          * ``grad_out`` is CUDA, dtype ``self.dtype``, ndim >= 2, and
+            ``grad_out.shape[1] == self.C`` (static_dims contract).
+          * ``x`` has the same shape and dtype as ``grad_out`` and resides
+            on the same CUDA device.
+          * ``weight``, ``mean``, ``rstd`` each have shape ``(self.C,)``
+            and reside on the same CUDA device as ``grad_out``.
+          * ``weight``, ``mean``, and ``rstd`` are ``torch.float32``
+            (``mean``/``rstd`` are produced by the forward training kernel;
+            ``weight`` is upcast to float32 before the backward kernel).
+        """
+        if not grad_out.is_cuda:
+            raise ValueError("grad_out must be a CUDA tensor")
+        if grad_out.dtype != self.dtype:
+            raise ValueError(
+                f"Expected grad_out.dtype {self.dtype}, got {grad_out.dtype}"
+            )
+        if grad_out.ndim < 2:
+            raise ValueError(
+                "Expected grad_out.ndim >= 2 (N, C, *spatial), got "
+                f"{grad_out.ndim}"
+            )
+        # static_dims validation: grad_out.shape[1] == C (committed at ctor).
+        if grad_out.shape[1] != self.C:
+            raise ValueError(
+                f"Expected channel dim {self.C}, got {grad_out.shape[1]}"
+            )
+
+        if not x.is_cuda or x.device != grad_out.device:
+            raise ValueError(
+                "x must be a CUDA tensor on the same device as grad_out"
+            )
+        if x.dtype != self.dtype:
+            raise ValueError(
+                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+            )
+        if tuple(x.shape) != tuple(grad_out.shape):
+            raise ValueError(
+                "Expected x.shape == grad_out.shape, got "
+                f"x.shape={tuple(x.shape)} vs "
+                f"grad_out.shape={tuple(grad_out.shape)}"
+            )
+
+        expected_c_shape = (self.C,)
+        for name, t, expected_dtype in (
+                ("weight", weight, torch.float32),
+                ("mean", mean, torch.float32),
+                ("rstd", rstd, torch.float32),
+        ):
+            if not t.is_cuda or t.device != grad_out.device:
+                raise ValueError(
+                    f"{name} must be a CUDA tensor on the same device as "
+                    "grad_out"
+                )
+            if tuple(t.shape) != expected_c_shape:
+                raise ValueError(
+                    f"Expected {name}.shape {expected_c_shape}, got "
+                    f"{tuple(t.shape)}"
+                )
+            if t.dtype != expected_dtype:
+                raise ValueError(
+                    f"Expected {name}.dtype {expected_dtype}, got {t.dtype}"
+                )
+
     def forward(
         self,
         grad_out: torch.Tensor,
@@ -333,11 +407,7 @@ class BatchNormBwdOp(Op):
             has the same shape as *x*, *grad_weight* has shape ``(C,)``,
             and *grad_bias* has shape ``(C,)``.
         """
-        # static_dims validation: grad_out.shape[1] == C (committed at ctor).
-        if grad_out.shape[1] != self.C:
-            raise ValueError(
-                f"Expected channel dim {self.C}, got {grad_out.shape[1]}"
-            )
+        self._validate_inputs(grad_out, x, weight, mean, rstd)
         orig_shape = grad_out.shape
         go_cl = self._prepare(grad_out)
         x_cl = self._prepare(x)
@@ -511,10 +581,7 @@ def _batchnorm_bwd_eager_forward(
     rstd: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Direct kernel call (no torch.compile wrapping)."""
-    if grad_out.shape[1] != self.C:
-        raise ValueError(
-            f"Expected channel dim {self.C}, got {grad_out.shape[1]}"
-        )
+    self._validate_inputs(grad_out, x, weight, mean, rstd)
     orig_shape = grad_out.shape
     go_cl = self._prepare(grad_out)
     x_cl = self._prepare(x)

--- a/tileops/ops/norm/fused_add_layer_norm.py
+++ b/tileops/ops/norm/fused_add_layer_norm.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -76,9 +77,7 @@ class FusedAddLayerNormFwdOp(Op):
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Kernel cache key: the (M,) product of leading dims of ``x``."""
         x_shape = input_shapes[0]
-        M = 1
-        for s in x_shape[:-1]:
-            M *= s
+        M = prod(x_shape[:-1])
         return (M,)
 
     def _get_or_create_kernel(self, M: int) -> Kernel:

--- a/tileops/ops/norm/fused_add_layer_norm.py
+++ b/tileops/ops/norm/fused_add_layer_norm.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -43,8 +43,8 @@ class FusedAddLayerNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        N: Hidden dimension (last dim). Committed at construction per
+            manifest ``static_dims``; forward validates ``x.shape[-1] == N``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -54,26 +54,42 @@ class FusedAddLayerNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.M = M
         self.N = N
         self.dtype = dtype
         self.eps = eps
+        self._tune = tune
         self.N_padded = _align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fused_add_layer_norm"](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fused_add_layer_norm": FusedAddLayerNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: the (M,) product of leading dims of ``x``."""
+        x_shape = input_shapes[0]
+        M = 1
+        for s in x_shape[:-1]:
+            M *= s
+        return (M,)
+
+    def _get_or_create_kernel(self, M: int) -> Kernel:
+        key = (M,)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["fused_add_layer_norm"](
+                M, self.N, self.eps, self.dtype, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(
         self,
@@ -114,6 +130,7 @@ class FusedAddLayerNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias to be 1D, got {bias.ndim}D"
             )
+        # static_dims validation: x.shape[-1] == N (committed at ctor).
         if x.shape[-1] != self.N:
             raise ValueError(
                 f"Expected hidden dim {self.N}, got {x.shape[-1]}"
@@ -134,11 +151,8 @@ class FusedAddLayerNormFwdOp(Op):
         orig_shape = x.shape
         x = x.contiguous().reshape(-1, self.N)
         residual = residual.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
-            )
+        M = x.shape[0]
+        kernel = self._get_or_create_kernel(M)
 
         # Pad hidden dim to 256-element alignment if needed
         if self.N_padded != self.N:
@@ -147,7 +161,7 @@ class FusedAddLayerNormFwdOp(Op):
             weight = F.pad(weight, (0, self.N_padded - self.N))
             bias = F.pad(bias, (0, self.N_padded - self.N))
 
-        y, residual_out = self.kernel(x, residual, weight, bias)
+        y, residual_out = kernel(x, residual, weight, bias)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -74,9 +75,7 @@ class FusedAddRMSNormFwdOp(Op):
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Kernel cache key: the (M,) product of leading dims of ``x``."""
         x_shape = input_shapes[0]
-        M = 1
-        for s in x_shape[:-1]:
-            M *= s
+        M = prod(x_shape[:-1])
         return (M,)
 
     def _get_or_create_kernel(self, M: int) -> Kernel:

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -42,8 +42,8 @@ class FusedAddRMSNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        N: Hidden dimension (last dim). Committed at construction per
+            manifest ``static_dims``; forward validates ``x.shape[-1] == N``.
         dtype: Data type (``torch.float16`` or ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
         kernel_map: Optional kernel override dictionary.
@@ -52,26 +52,42 @@ class FusedAddRMSNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
         eps: float = 1e-6,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.M = M
         self.N = N
         self.dtype = dtype
         self.eps = eps
+        self._tune = tune
         self.N_padded = _align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fused_add_rms_norm"](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fused_add_rms_norm": FusedAddRMSNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: the (M,) product of leading dims of ``x``."""
+        x_shape = input_shapes[0]
+        M = 1
+        for s in x_shape[:-1]:
+            M *= s
+        return (M,)
+
+    def _get_or_create_kernel(self, M: int) -> Kernel:
+        key = (M,)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["fused_add_rms_norm"](
+                M, self.N, self.eps, self.dtype, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(
         self,
@@ -106,6 +122,7 @@ class FusedAddRMSNormFwdOp(Op):
             raise ValueError(
                 f"Expected weight to be 1D, got {weight.ndim}D"
             )
+        # static_dims validation: x.shape[-1] == N (committed at ctor).
         if x.shape[-1] != self.N:
             raise ValueError(
                 f"Expected hidden dim {self.N}, got {x.shape[-1]}"
@@ -122,11 +139,8 @@ class FusedAddRMSNormFwdOp(Op):
         orig_shape = x.shape
         x = x.contiguous().reshape(-1, self.N)
         residual = residual.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
-            )
+        M = x.shape[0]
+        kernel = self._get_or_create_kernel(M)
 
         # Pad hidden dim to 256-element alignment if needed
         if self.N_padded != self.N:
@@ -134,7 +148,7 @@ class FusedAddRMSNormFwdOp(Op):
             residual = F.pad(residual, (0, self.N_padded - self.N))
             weight = F.pad(weight, (0, self.N_padded - self.N))
 
-        y, residual_out = self.kernel(x, residual, weight)
+        y, residual_out = kernel(x, residual, weight)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -88,9 +88,19 @@ class InstanceNormFwdOp(Op):
         return {"group_norm": GroupNormKernel}
 
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
-        """Kernel cache key: (N, *spatial) — everything except the channel axis."""
+        """Kernel cache key: (M, D) with M = N * C and D = prod(spatial).
+
+        Matches the kernel construction projection in ``forward``: kernels are
+        keyed by the same ``(M, D)`` tuple used at ``_get_or_create_kernel``,
+        so input shapes that differ only in how spatial dims split (e.g.
+        ``(N, C, H, W)`` vs ``(N, C, H*W)``) share one cached kernel.
+        """
         x_shape = input_shapes[0]
-        return tuple(s for i, s in enumerate(x_shape) if i != 1)
+        N = x_shape[0]
+        spatial = x_shape[2:]
+        D = prod(spatial) if spatial else 1
+        M = N * self.C
+        return (M, D)
 
     def _get_or_create_kernel(self, M: int, D: int) -> Kernel:
         key = (M, D)

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -5,14 +5,16 @@ is its own group). This operator delegates to GroupNormKernel with G=C.
 
 User-facing API mirrors torch.nn.functional.instance_norm:
 
-    op = InstanceNormFwdOp(N=batch, C=channels, spatial=(H, W), dtype=dtype)
+    op = InstanceNormFwdOp(C=channels, dtype=dtype)
     y = op(x, weight, bias)
 
-Input tensors accept shape (N, C, *spatial).
+Input tensors accept shape ``(N, C, *spatial)``.  ``N`` and ``*spatial``
+are derived at forward time; kernels are cached by
+``(M=N*C, D=prod(spatial))``.
 """
 
-import math
-from typing import Dict, Optional
+from math import prod
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -54,9 +56,8 @@ class InstanceNormFwdOp(Op):
         Hidden dimension is padded to 256-element alignment internally.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        spatial: Spatial dimensions tuple ``(H, W, ...)``.
+        C: Number of channels (committed at construction per manifest
+            ``static_dims``; forward validates ``x.shape[1] == C``).
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -64,35 +65,42 @@ class InstanceNormFwdOp(Op):
         tune: If ``True``, autotune tile configurations.
     """
 
+    _static_axes = frozenset({(0, 1)})
+
     def __init__(
         self,
-        N: int,
+        *,
         C: int,
-        spatial: tuple,
         dtype: torch.dtype,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.N = N
         self.C = C
-        self.spatial = spatial
-        self.G = C  # InstanceNorm: each channel is its own group
         self.dtype = dtype
         self.eps = eps
-        self.spatial_size = math.prod(spatial)
-        # For InstanceNorm (G=C): D = (C/C) * spatial_size = spatial_size
-        self.D = self.spatial_size
-        self.M = N * C  # number of rows = N * G = N * C
-        self.D_padded = _align_up(self.D, ALIGNMENT)
+        self._tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["group_norm"](
-            self.M, self.D, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"group_norm": GroupNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: (N, *spatial) — everything except the channel axis."""
+        x_shape = input_shapes[0]
+        return tuple(s for i, s in enumerate(x_shape) if i != 1)
+
+    def _get_or_create_kernel(self, M: int, D: int) -> Kernel:
+        key = (M, D)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["group_norm"](
+                M, D, self.eps, self.dtype, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         """Apply instance normalization.
@@ -127,6 +135,15 @@ class InstanceNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
             )
+        if x.ndim < 3:
+            raise ValueError(
+                f"Expected x.ndim >= 3 (N, C, *spatial), got {x.ndim}"
+            )
+        # static_dims validation: x.shape[1] == C (committed at ctor).
+        if x.shape[1] != self.C:
+            raise ValueError(
+                f"Expected channel dim {self.C}, got {x.shape[1]}"
+            )
         if weight.ndim != 1 or weight.shape[0] != self.C:
             raise ValueError(
                 f"Expected weight shape ({self.C},), got {weight.shape}"
@@ -137,31 +154,40 @@ class InstanceNormFwdOp(Op):
             )
 
         orig_shape = x.shape
+        N = orig_shape[0]
+        spatial = orig_shape[2:]
+        spatial_size = prod(spatial) if spatial else 1
+        # For InstanceNorm (G=C): D = spatial_size, M = N * C
+        D = spatial_size
+        M = N * self.C
+        D_padded = _align_up(D, ALIGNMENT)
+        kernel = self._get_or_create_kernel(M, D)
+
         x = x.contiguous()
 
         # Reshape: (N, C, *spatial) -> (N*C, spatial_size)
-        x_2d = x.reshape(self.M, self.D)
+        x_2d = x.reshape(M, D)
 
         # Unit weight and zero bias for the kernel (affine applied after)
-        unit_weight = torch.ones(self.D_padded, dtype=self.dtype, device=x.device)
-        zero_bias = torch.zeros(self.D_padded, dtype=self.dtype, device=x.device)
+        unit_weight = torch.ones(D_padded, dtype=self.dtype, device=x.device)
+        zero_bias = torch.zeros(D_padded, dtype=self.dtype, device=x.device)
 
         # Pad to alignment
-        if self.D_padded != self.D:
-            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+        if D_padded != D:
+            x_2d = F.pad(x_2d, (0, D_padded - D))
 
         # Run kernel: produces (x - mean) / sqrt(var + eps)
-        y_2d = self.kernel(x_2d, unit_weight, zero_bias)
+        y_2d = kernel(x_2d, unit_weight, zero_bias)
 
         # Trim padding
-        if self.D_padded != self.D:
-            y_2d = y_2d[:, :self.D]
+        if D_padded != D:
+            y_2d = y_2d[:, :D]
 
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)
 
         # Apply per-channel affine: y = y * weight + bias
-        affine_shape = [1, self.C] + [1] * len(self.spatial)
+        affine_shape = [1, self.C] + [1] * len(spatial)
         y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
 
         return y

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -38,8 +38,8 @@ class LayerNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        N: Hidden dimension (last dim). Committed at construction per
+            manifest ``static_dims``; forward validates ``x.shape[-1] == N``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -47,28 +47,52 @@ class LayerNormFwdOp(Op):
         tune: If ``True``, autotune tile configurations.
     """
 
+    # The committed static axis (last of x) is not a fixed non-negative
+    # index; `_cache_key` is overridden below, so `_static_axes` remains
+    # empty (the default path is unused).
+
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.M = M
         self.N = N
         self.dtype = dtype
         self.eps = eps
+        self._tune = tune
         self.N_padded = _align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["layer_norm"](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"layer_norm": LayerNormKernel}
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key: the (M,) product of leading dims of ``x``.
+
+        The kernel math depends only on ``(M, N)`` and ``N`` is committed
+        at construction, so keying by ``M`` alone is sufficient.
+        """
+        x_shape = input_shapes[0]
+        M = 1
+        for s in x_shape[:-1]:
+            M *= s
+        return (M,)
+
+    def _get_or_create_kernel(self, M: int) -> Kernel:
+        key = (M,)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["layer_norm"](
+                M, self.N, self.eps, self.dtype, tune=self._tune,
+            )
+            self._kernel_cache[key] = kernel
+        return kernel
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         """Apply layer normalization.
@@ -111,6 +135,7 @@ class LayerNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias to be 1D, got {bias.ndim}D"
             )
+        # static_dims validation: x.shape[-1] == N (committed at ctor).
         if x.shape[-1] != self.N:
             raise ValueError(
                 f"Expected hidden dim {self.N}, got {x.shape[-1]}"
@@ -126,11 +151,8 @@ class LayerNormFwdOp(Op):
 
         orig_shape = x.shape
         x = x.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
-            )
+        M = x.shape[0]
+        kernel = self._get_or_create_kernel(M)
 
         # Pad hidden dim to 256-element alignment if needed
         if self.N_padded != self.N:
@@ -138,7 +160,7 @@ class LayerNormFwdOp(Op):
             weight = F.pad(weight, (0, self.N_padded - self.N))
             bias = F.pad(bias, (0, self.N_padded - self.N))
 
-        y = self.kernel(x, weight, bias)
+        y = kernel(x, weight, bias)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Dict, Hashable, Optional, Tuple
 
 import torch
@@ -79,9 +80,7 @@ class LayerNormFwdOp(Op):
         at construction, so keying by ``M`` alone is sufficient.
         """
         x_shape = input_shapes[0]
-        M = 1
-        for s in x_shape[:-1]:
-            M *= s
+        M = prod(x_shape[:-1])
         return (M,)
 
     def _get_or_create_kernel(self, M: int) -> Kernel:

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -10,7 +10,7 @@ from the input tensor at forward time, and kernels are cached by
 """
 
 from math import prod
-from typing import Dict, List, Optional, Union
+from typing import Dict, Hashable, List, Optional, Tuple, Union
 
 import torch
 
@@ -42,14 +42,28 @@ class _SoftmaxBaseOp(Op):
     _kernel_class: type  # set by subclass
     _supports_multidim: bool = False  # override to True in reduced-dim ops (e.g. LogSumExpFwdOp)
 
+    # The manifest commits ``N = x.shape[dim]`` as a static axis for
+    # softmax/log_softmax; but ``dim`` is configurable at ctor, so the static
+    # axis position cannot be expressed as a compile-time (input_index, axis)
+    # pair.  ``_cache_key`` is overridden below to project directly onto ``(M,)``
+    # for same-shape ops (softmax/log_softmax) or ``(M, N)`` for LogSumExp
+    # (no static_dims, so N is dynamic).  ``_static_axes`` remains empty.
+    _static_axes = frozenset()
+
     def __init__(
         self,
         *,
+        N: Optional[int] = None,
         dtype: torch.dtype,
         dim: Union[int, List[int]] = -1,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        # ``N`` captures the manifest ``static_dims`` commitment for
+        # subclasses whose reduction extent is known at construction
+        # (softmax, log_softmax, argmax, argmin). LogSumExp has no
+        # static_dims; it leaves ``N`` as ``None``.
+        self.N = N
         self.dtype = dtype
         self.dim = dim
         self.keepdim = False
@@ -116,6 +130,14 @@ class _SoftmaxBaseOp(Op):
             )
         dim = self.dim % x.ndim
 
+        # static_dims validation: when N is committed at ctor, the reduction
+        # extent along ``dim`` must match.
+        if self.N is not None and x.shape[dim] != self.N:
+            raise ValueError(
+                f"static_dim mismatch: expected x.shape[{dim}] == {self.N}, "
+                f"got {x.shape[dim]}"
+            )
+
         # N = size along reduction dim, M = product of all other dims.
         N = x.shape[dim]
         M = prod(s for i, s in enumerate(x.shape) if i != dim)
@@ -139,6 +161,28 @@ class _SoftmaxBaseOp(Op):
             y = y[:, :N] if y.ndim == 2 else y
 
         return self._reshape_output(y, orig_shape, dim, needs_transpose)
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key projection.
+
+        When ``N`` is committed at ctor (softmax/log_softmax), the kernel
+        depends only on ``M`` (product of non-reduction dims); otherwise
+        (LogSumExp), both ``M`` and ``N`` drive kernel selection.
+        """
+        x_shape = input_shapes[0]
+        # Resolve reduction dim once — ``self.dim`` is an int here; multidim
+        # (LogSumExp) bypasses this code path via ``_kernel_cache`` keyed
+        # directly in ``_get_or_create_kernel``.
+        if isinstance(self.dim, int):
+            d = self.dim % len(x_shape)
+            M = prod(s for i, s in enumerate(x_shape) if i != d)
+            N = x_shape[d]
+        else:
+            # Multidim dim (tuple/list): fall back to full shape.
+            return tuple(x_shape)
+        if self.N is not None:
+            return (M,)
+        return (M, N)
 
     def _get_or_create_kernel(self, M: int, N: int, device_index: int | None = None) -> object:
         """Return a cached kernel for (M, N, device_index), creating one if needed."""

--- a/tileops/ops/reduction/argmax.py
+++ b/tileops/ops/reduction/argmax.py
@@ -51,8 +51,9 @@ class ArgmaxFwdOp(_ReduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        self.N = N
         super().__init__(
-            N=N, dtype=dtype, dim=dim, keepdim=keepdim,
+            dtype=dtype, dim=dim, keepdim=keepdim,
             kernel_map=kernel_map, tune=tune,
         )
 

--- a/tileops/ops/reduction/argmax.py
+++ b/tileops/ops/reduction/argmax.py
@@ -2,7 +2,9 @@
 
 The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment,
 calls the kernel, and reshapes the output back. Output dtype is always int64.
-Kernels are cached by ``(M, N)`` so the same op instance handles varying shapes.
+Kernels are cached by ``(M, N)`` so the same op instance handles varying
+leading dims.  ``N`` is committed at construction per manifest
+``static_dims``; forward validates ``x.shape[dim] == N``.
 """
 
 from typing import Dict, Optional
@@ -20,11 +22,14 @@ __all__ = ["ArgmaxFwdOp"]
 class ArgmaxFwdOp(_ReduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgmaxFwdOp(dtype=..., dim=-1, keepdim=False)``.  M and N are
-    derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``ArgmaxFwdOp(N=..., dtype=..., dim=-1, keepdim=False)``.
+    The reduction extent ``N`` is committed at construction per manifest
+    ``static_dims``; forward validates ``x.shape[dim] == N``.  Non-static
+    leading dimensions are derived from the input at forward time, and
+    kernels are cached by ``(M, N)`` to avoid rebuilds.
 
     Args:
+        N: Reduction-dim extent (``x.shape[dim]``).
         dtype: Input data type.
         dim: Reduction dimension (default -1).
         keepdim: Whether to retain the reduced dimension as size 1.
@@ -39,6 +44,7 @@ class ArgmaxFwdOp(_ReduceOpBase):
     def __init__(
         self,
         *,
+        N: int,
         dtype: torch.dtype,
         dim: int = -1,
         keepdim: bool = False,
@@ -46,7 +52,7 @@ class ArgmaxFwdOp(_ReduceOpBase):
         tune: bool = False,
     ):
         super().__init__(
-            dtype=dtype, dim=dim, keepdim=keepdim,
+            N=N, dtype=dtype, dim=dim, keepdim=keepdim,
             kernel_map=kernel_map, tune=tune,
         )
 

--- a/tileops/ops/reduction/argmin.py
+++ b/tileops/ops/reduction/argmin.py
@@ -2,7 +2,9 @@
 
 The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment,
 calls the kernel, and reshapes the output back. Output dtype is always int64.
-Kernels are cached by ``(M, N)`` so the same op instance handles varying shapes.
+Kernels are cached by ``(M, N)`` so the same op instance handles varying
+leading dims.  ``N`` is committed at construction per manifest
+``static_dims``; forward validates ``x.shape[dim] == N``.
 """
 
 from typing import Dict, Optional
@@ -20,11 +22,14 @@ __all__ = ["ArgminFwdOp"]
 class ArgminFwdOp(_ReduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgminFwdOp(dtype=..., dim=-1, keepdim=False)``.  M and N are
-    derived from the input tensor at forward time, and kernels are cached
-    by ``(M, N)`` to avoid rebuilds.
+    Construction: ``ArgminFwdOp(N=..., dtype=..., dim=-1, keepdim=False)``.
+    The reduction extent ``N`` is committed at construction per manifest
+    ``static_dims``; forward validates ``x.shape[dim] == N``.  Non-static
+    leading dimensions are derived from the input at forward time, and
+    kernels are cached by ``(M, N)`` to avoid rebuilds.
 
     Args:
+        N: Reduction-dim extent (``x.shape[dim]``).
         dtype: Input data type.
         dim: Reduction dimension (default -1).
         keepdim: Whether to retain the reduced dimension as size 1.
@@ -39,6 +44,7 @@ class ArgminFwdOp(_ReduceOpBase):
     def __init__(
         self,
         *,
+        N: int,
         dtype: torch.dtype,
         dim: int = -1,
         keepdim: bool = False,
@@ -46,7 +52,7 @@ class ArgminFwdOp(_ReduceOpBase):
         tune: bool = False,
     ):
         super().__init__(
-            dtype=dtype, dim=dim, keepdim=keepdim,
+            N=N, dtype=dtype, dim=dim, keepdim=keepdim,
             kernel_map=kernel_map, tune=tune,
         )
 

--- a/tileops/ops/reduction/argmin.py
+++ b/tileops/ops/reduction/argmin.py
@@ -51,8 +51,9 @@ class ArgminFwdOp(_ReduceOpBase):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        self.N = N
         super().__init__(
-            N=N, dtype=dtype, dim=dim, keepdim=keepdim,
+            dtype=dtype, dim=dim, keepdim=keepdim,
             kernel_map=kernel_map, tune=tune,
         )
 

--- a/tileops/ops/reduction/log_softmax.py
+++ b/tileops/ops/reduction/log_softmax.py
@@ -4,11 +4,16 @@ Provides:
   - LogSoftmaxFwdOp: y = log_softmax(x, dim)
 
 Example:
-    >>> op = LogSoftmaxFwdOp(dtype=torch.float16, dim=-1)
+    >>> op = LogSoftmaxFwdOp(N=4096, dtype=torch.float16, dim=-1)
     >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
     >>> y = op(x)  # shape: (1024, 4096)
 """
 
+from typing import Dict, Optional
+
+import torch
+
+from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 
 from ._softmax_base import _SoftmaxBaseOp
@@ -22,6 +27,8 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
     Output has the same shape and dtype as input.
 
     Args:
+        N: Reduction-dim extent (committed at construction per manifest
+            ``static_dims``: ``N = x.shape[dim]``; forward validates).
         dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default -1).
         kernel_map: Optional override for kernel dispatch.
@@ -31,3 +38,14 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
     _op_kind = "log_softmax"
     _kernel_key = "softmax_fwd"
     _kernel_class = SoftmaxKernel
+
+    def __init__(
+        self,
+        *,
+        N: int,
+        dtype: torch.dtype,
+        dim: int = -1,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        super().__init__(N=N, dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune)

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -13,7 +13,7 @@ varying shapes.
 """
 
 from math import prod
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Hashable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -70,15 +70,28 @@ class _ReduceOpBase(Op):
     _kernel_cls: type = ReduceKernel  # overridden by subclasses for different kernel classes
     _kernel_handles_padding: bool = False  # True when kernel accepts (M, N) with masked loads
 
+    # ``dim`` is a ctor parameter, so the static reduction axis cannot be
+    # encoded as a compile-time (input_index, axis) pair.  ``_cache_key`` is
+    # overridden below to project onto ``(M,)`` when ``N`` is committed at
+    # ctor (argmax/argmin) and ``(M, N)`` otherwise (simple/Welford reduce
+    # ops with ``static_dims: None``).
+    _static_axes = frozenset()
+
     def __init__(
         self,
         *,
+        N: Optional[int] = None,
         dtype: torch.dtype,
         dim: Union[int, List[int], None] = -1,
         keepdim: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        # ``N`` captures the manifest ``static_dims`` commitment for
+        # subclasses whose reduction extent is known at construction
+        # (argmax, argmin). Simple/Welford reduce ops with
+        # ``static_dims: None`` leave ``N`` as ``None``.
+        self.N = N
         self.dtype = dtype
         self.dim = dim
         self.keepdim = keepdim
@@ -172,6 +185,23 @@ class _ReduceOpBase(Op):
     # Kernel cache
     # ------------------------------------------------------------------
 
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Kernel cache key projection.
+
+        When ``N`` is committed at ctor (argmax/argmin), the kernel depends
+        only on ``M``; otherwise simple/Welford reduce ops key by both.
+        Multi-dim reduction falls back to the full shape.
+        """
+        x_shape = input_shapes[0]
+        if isinstance(self.dim, int):
+            d = self.dim % len(x_shape)
+            M = prod(s for i, s in enumerate(x_shape) if i != d)
+            N = x_shape[d]
+            if self.N is not None:
+                return (M,)
+            return (M, N)
+        return tuple(x_shape)
+
     def _get_or_create_kernel(self, M: int, N: int) -> object:
         """Return a cached kernel for (M, N), creating one if needed."""
         key = (M, N)
@@ -233,6 +263,14 @@ class _ReduceOpBase(Op):
                 f"[{-x.ndim}, {x.ndim - 1}], but got {self.dim})"
             )
         dim = self.dim % x.ndim
+
+        # static_dims validation: when N is committed at ctor, the reduction
+        # extent along ``dim`` must match.
+        if self.N is not None and x.shape[dim] != self.N:
+            raise ValueError(
+                f"static_dim mismatch: expected x.shape[{dim}] == {self.N}, "
+                f"got {x.shape[dim]}"
+            )
 
         N = x.shape[dim]
         M = prod(s for i, s in enumerate(x.shape) if i != dim)

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -80,18 +80,21 @@ class _ReduceOpBase(Op):
     def __init__(
         self,
         *,
-        N: Optional[int] = None,
         dtype: torch.dtype,
         dim: Union[int, List[int], None] = -1,
         keepdim: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        # ``N`` captures the manifest ``static_dims`` commitment for
+        # ``self.N`` captures the manifest ``static_dims`` commitment for
         # subclasses whose reduction extent is known at construction
         # (argmax, argmin). Simple/Welford reduce ops with
-        # ``static_dims: None`` leave ``N`` as ``None``.
-        self.N = N
+        # ``static_dims: None`` leave ``self.N`` as ``None``.  Argreduce
+        # subclasses set ``self.N`` before calling ``super().__init__()`` so
+        # that ``N`` stays out of the simple/Welford op public signatures
+        # (AC-4: codegen-style constructors from manifest).
+        if not hasattr(self, "N"):
+            self.N = None
         self.dtype = dtype
         self.dim = dim
         self.keepdim = keepdim

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -4,11 +4,16 @@ Provides:
   - SoftmaxFwdOp: y = softmax(x, dim)
 
 Example:
-    >>> op = SoftmaxFwdOp(dtype=torch.float16, dim=-1)
+    >>> op = SoftmaxFwdOp(N=4096, dtype=torch.float16, dim=-1)
     >>> x = torch.randn(2, 32, 4096, dtype=torch.float16, device="cuda")
     >>> y = op(x)  # shape: (2, 32, 4096)
 """
 
+from typing import Dict, Optional
+
+import torch
+
+from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 
 from ._softmax_base import _SoftmaxBaseOp
@@ -22,6 +27,8 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
     Output has the same shape and dtype as input.
 
     Args:
+        N: Reduction-dim extent (committed at construction per manifest
+            ``static_dims``: ``N = x.shape[dim]``; forward validates).
         dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default -1).
         kernel_map: Optional override for kernel dispatch.
@@ -31,3 +38,14 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
     _op_kind = "softmax"
     _kernel_key = "softmax_fwd"
     _kernel_class = SoftmaxKernel
+
+    def __init__(
+        self,
+        *,
+        N: int,
+        dtype: torch.dtype,
+        dim: int = -1,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        super().__init__(N=N, dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune)

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -335,7 +335,7 @@ ops:
   BatchNormFwdOp:
     ref_api: "torch.nn.functional.batch_norm"
     family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -393,7 +393,7 @@ ops:
   BatchNormBwdOp:
     ref_api: "torch.nn.functional.batch_norm"
     family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -492,7 +492,7 @@ ops:
   InstanceNormFwdOp:
     ref_api: "torch.nn.functional.instance_norm"
     family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -89,7 +89,7 @@ ops:
   LayerNormFwdOp:
     ref_api: "torch.nn.functional.layer_norm"
     family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -138,7 +138,7 @@ ops:
   AdaLayerNormFwdOp:
     ref_api: "none"
     family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -183,7 +183,7 @@ ops:
   AdaLayerNormZeroFwdOp:
     ref_api: "none"
     family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -230,7 +230,7 @@ ops:
   FusedAddLayerNormFwdOp:
     ref_api: "none"
     family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -280,7 +280,7 @@ ops:
   FusedAddRMSNormFwdOp:
     ref_api: "none"
     family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1424,7 +1424,7 @@ ops:
   SoftmaxFwdOp:
     ref_api: "torch.nn.functional.softmax"
     family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -1467,7 +1467,7 @@ ops:
   LogSoftmaxFwdOp:
     ref_api: "torch.nn.functional.log_softmax"
     family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -1510,7 +1510,7 @@ ops:
   LogSumExpFwdOp:
     ref_api: "torch.logsumexp"
     family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -1903,7 +1903,7 @@ ops:
   ArgmaxFwdOp:
     ref_api: "torch.argmax"
     family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:
@@ -1946,7 +1946,7 @@ ops:
   ArgminFwdOp:
     ref_api: "torch.argmin"
     family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+    status: implemented
 
     signature:
       inputs:


### PR DESCRIPTION
## Summary

Bring all 13 norm/softmax-family ops back to `status: implemented` by aligning their `__init__` / `forward` / `_static_axes` / `_cache_key` with the manifest's `static_dims` contract. Delivered as three family-scoped commits plus a cleanup:

- Row-norm family (LayerNorm, AdaLayerNorm, AdaLayerNormZero, FusedAddLayerNorm, FusedAddRMSNorm) — 5 ops
- Batch/instance-norm family (BatchNormFwd, BatchNormBwd, InstanceNorm) — 3 ops
- Softmax-like family (Softmax, LogSoftmax, LogSumExp, Argmax, Argmin) — 5 ops
- Fix: move BatchNorm `training` into `__init__`; unmask `argreduce` multidim test

Closes #993

## Test plan

- [x] AC-1: Modified files pass unit tests — `pytest -q tests/ops/test_ada_layer_norm.py tests/ops/test_ada_layer_norm_zero.py tests/ops/test_argreduce.py tests/ops/test_batch_norm.py tests/ops/test_fused_add_layer_norm.py tests/ops/test_fused_add_rms_norm.py tests/ops/test_instance_norm.py tests/ops/test_layer_norm.py tests/ops/test_norm_ops.py tests/ops/test_softmax.py` → **315 passed, 0 failed in 24.94s**
- [x] AC-2: `grep -n "align with static_dims in follow-up PR" tileops/ops_manifest.yaml` returns no hits
- [x] AC-3: `python scripts/validate_manifest.py` reports "All manifest checks passed" — no spec/impl L1 signature errors for the 13 ops (26 unrelated benchmark warnings only)
- [x] AC-4: `inspect.signature` matches manifest-derived codegen order (`static_dims -> dtype -> params`, all kw-only) for all 13 ops:
  - LayerNorm / AdaLayerNorm / AdaLayerNormZero / FusedAddLayerNorm / FusedAddRMSNorm — `(N, dtype, eps)`
  - BatchNormFwd — `(C, dtype, training, eps, momentum)`; BatchNormBwd — `(C, dtype)`
  - InstanceNorm — `(C, dtype, eps)`
  - Softmax / LogSoftmax — `(N, dtype, dim)`; LogSumExp — `(dtype, dim, keepdim)`
  - Argmax / Argmin — `(N, dtype, dim, keepdim)`

**Totals:** 315/315 tests pass across the 10 affected test files. No manifest edits beyond flipping `status` and removing the mismatch comment, per the trust-model constraint.
