### PR TITLE
[Fix][CI] widen fork-PR gpu-smoke cache hits without widening write surface

### DIFF
--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -94,6 +94,16 @@ inputs:
       always run the full reclaim pass.
     required: false
     default: "false"
+  skip-atomic-age-trim:
+    description: >
+      When "true", skip the age-based atomic-trim pass on atomic cache roots.
+      Sentinel-repair on those roots still runs unconditionally (it self-heals
+      half-dead state and is cheap). Callers that run on every PR should opt
+      out of the destructive whole-subdir trim so it only runs via the daily
+      runner-maintenance.yml job; co-locating it on the per-PR path evicts
+      autotuner entries the next PR would otherwise reuse.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -113,6 +123,7 @@ runs:
         PRUNE_TOOL_CACHE: ${{ inputs.prune-tool-cache }}
         DF_PATHS: ${{ inputs.df-paths }}
         FORCE_RECLAIM: ${{ inputs.force-reclaim }}
+        SKIP_ATOMIC_AGE_TRIM: ${{ inputs.skip-atomic-age-trim }}
         TOOL_CACHE: ${{ runner.tool_cache }}
       run: |
         set -uo pipefail
@@ -288,7 +299,15 @@ runs:
           # Atomic roots are NEVER file-trimmed: doing so can strand a
           # subdir without its best_config.json sentinel and crash the
           # next consumer.
-          if [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
+          #
+          # Callers that run on every PR (gpu-smoke.yml) opt out via
+          # skip-atomic-age-trim so the destructive whole-subdir eviction
+          # only happens via the daily runner-maintenance.yml job;
+          # sentinel-repair above still ran unconditionally, so half-dead
+          # state is healed regardless of this opt-out.
+          if [[ "${SKIP_ATOMIC_AGE_TRIM}" == "true" ]]; then
+            echo "Skipping atomic age-trim (opted out)"
+          elif [[ -n "${ATOMIC_CACHE_DIRS}" ]]; then
             parse_list_into_array ATOMIC_TRIM_ARGS <<< "${ATOMIC_CACHE_DIRS}"
             if (( ${#ATOMIC_TRIM_ARGS[@]} > 0 )); then
               bash "${RECLAIM_SCRIPT}" atomic-trim "${CACHE_AGE_DAYS}" "${ATOMIC_TRIM_ARGS[@]}" || true

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -682,22 +682,56 @@ jobs:
         run: cat gpu_smoke_report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cache stats
-        if: ${{ always() && needs.security-policy.outputs.is_fork != 'true' }}
+        if: ${{ always() }}
+        env:
+          IS_FORK: ${{ needs.security-policy.outputs.is_fork }}
         run: |
-          set -euo pipefail
-          echo "=== Trusted cache stats ==="
+          # Cache stats is informational only. Do NOT use `set -e`: a transient
+          # failure in find/du/wc (e.g. a cache file vanishing mid-scan due to a
+          # concurrent cleanup) must not fail the gpu-smoke job, and must not
+          # skip the CACHE_SIGNAL logging below.
+          set -u
+          echo "=== Cache stats (is_fork=${IS_FORK}) ==="
+          echo "VENV_REUSED=${VENV_REUSED:-unknown}"
+          echo "FORK_CAN_COPY_TRUSTED_VENV=${FORK_CAN_COPY_TRUSTED_VENV:-unknown}"
+          echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH:-unknown}"
           for cache_dir in "${TILELANG_CACHE_DIR:-}" "${TRITON_CACHE_DIR:-}" "${WHEEL_DIR:-}"; do
             if [[ -z "${cache_dir}" ]]; then
               continue
             fi
             if [[ -d "${cache_dir}" ]]; then
-              file_count=$(find "${cache_dir}" -type f | wc -l)
-              cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1)
+              # Tolerate errors from find/du/wc; emit "unknown" when a scan
+              # fails rather than aborting the step. Enable pipefail inside
+              # the subshell so a find/du failure upstream of wc/cut
+              # propagates to the || fallback instead of being masked.
+              file_count=$(set -o pipefail; find "${cache_dir}" -type f 2>/dev/null | wc -l 2>/dev/null) || file_count="unknown"
+              cache_size=$(set -o pipefail; du -sh "${cache_dir}" 2>/dev/null | cut -f1 2>/dev/null) || cache_size="unknown"
+              if [[ -z "${file_count}" ]]; then file_count="unknown"; fi
+              if [[ -z "${cache_size}" ]]; then cache_size="unknown"; fi
               echo "${cache_dir}: ${file_count} files, ${cache_size}"
             else
               echo "${cache_dir}: does not exist"
             fi
           done
+
+          # Emit a concise cache hit/miss signal so future regressions surface
+          # in CI logs without needing to diff per-run durations manually.
+          # For fork PRs, "hit" means the trusted venv was copied (no cold pip
+          # install); for trusted runs, "hit" means the hash-matched venv was
+          # reused in place.
+          if [[ "${IS_FORK}" == "true" ]]; then
+            if [[ "${FORK_CAN_COPY_TRUSTED_VENV:-false}" == "true" ]]; then
+              echo "CACHE_SIGNAL: fork venv=hit"
+            else
+              echo "CACHE_SIGNAL: fork venv=miss (cold pip install path)"
+            fi
+          else
+            if [[ "${VENV_REUSED:-false}" == "true" ]]; then
+              echo "CACHE_SIGNAL: trusted venv=hit"
+            else
+              echo "CACHE_SIGNAL: trusted venv=miss (fresh venv created)"
+            fi
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -164,6 +164,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association || '' }}
         run: |
           set -euo pipefail
 
@@ -182,8 +183,26 @@ jobs:
           pytest_targets="tests"
           reason="GPU smoke will run."
 
+          # `is_fork` gates the downstream runtime isolation: when true, the
+          # gpu-smoke job refuses to write persistent state under
+          # /home/ci-runner and instead runs from a disposable per-run dir.
+          # A repo member opening a PR from their personal fork technically
+          # satisfies head != base, but they already have push access to the
+          # base repo — treating their PR as untrusted forces them to
+          # round-trip through a fresh venv rebuild every run, for no real
+          # security gain. Keep external contributors on the isolated path;
+          # promote OWNER/MEMBER/COLLABORATOR authors back onto the trusted
+          # runtime layout.
           if [[ "$EVENT_NAME" == "pull_request" && "$HEAD_REPO" != "$BASE_REPO" ]]; then
-            is_fork="true"
+            case "$AUTHOR_ASSOC" in
+              OWNER|MEMBER|COLLABORATOR)
+                is_fork="false"
+                echo "Member-fork PR (author_association=${AUTHOR_ASSOC}); treating as trusted."
+                ;;
+              *)
+                is_fork="true"
+                ;;
+            esac
           fi
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
@@ -378,6 +397,11 @@ jobs:
         with:
           reclaim-below-gib: "10"
           cache-trim-cooldown-minutes: "120"
+          # Daily runner-maintenance.yml owns the destructive autotuner
+          # age-trim; per-PR runs only need sentinel-repair (still
+          # unconditional) so they don't evict tuning artefacts the next
+          # PR would otherwise reuse.
+          skip-atomic-age-trim: "true"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -390,11 +414,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Narrow the venv cache key to sections that actually drive the
+          # installed package set. Hashing the whole pyproject.toml means a
+          # tweak to [tool.pytest] or [tool.ruff] invalidates every warm
+          # fork-PR venv, defeating #996's fast path for no packaging
+          # reason. See scripts/ci_venv_hash.py for the parsed sections and
+          # the full-file fallback contract.
+          PYPROJECT_HASH=$(python scripts/ci_venv_hash.py pyproject.toml)
           HASH_INPUT="$(
             {
               echo "python=3.11"
               echo "install=PIP_NO_BUILD_ISOLATION=1 pip install -e '.[dev]'"
-              sha256sum pyproject.toml
+              echo "pyproject=${PYPROJECT_HASH}"
             } | sha256sum | cut -c1-16
           )"
           VENV_PREFIX="tileops_ci_venv"
@@ -412,51 +443,12 @@ jobs:
             PIP_CACHE_DIR="${RUNTIME_ROOT}/pip/cache"
             WHEEL_DIR="${RUNTIME_ROOT}/wheels"
             VENV_PATH="${RUNTIME_ROOT}/venv"
-
-            # Diagnostic: log the trusted venv probe so FORK_CAN_COPY_TRUSTED_VENV
-            # decisions are traceable in CI logs. This surfaces permission issues
-            # (runner tool_cache owned by a different user), missing paths, or
-            # partial venvs where bin/python exists but is not executable.
-            echo "=== Trusted venv probe ==="
-            echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH}"
-            if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
-              echo "Trusted venv directory exists:"
-              # find + -printf keeps shellcheck SC2012 clean vs `ls -la`.
-              find "${TRUSTED_VENV_PATH}" -maxdepth 1 -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null || true
-              if [[ -d "${TRUSTED_VENV_PATH}/bin" ]]; then
-                echo "Trusted venv bin/ contents (up to 20 entries):"
-                find "${TRUSTED_VENV_PATH}/bin" -maxdepth 1 -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null | head -20 || true
-              else
-                echo "Trusted venv bin/ does not exist"
-              fi
-            else
-              echo "Trusted venv directory does not exist"
-              echo "Sibling venvs under ${{ runner.tool_cache }}:"
-              # Use find + -printf (not `ls | grep`) so actionlint+shellcheck
-              # (SC2010/SC2012) stays clean while listing hash-suffixed venvs.
-              sibling_list=$(find "${{ runner.tool_cache }}" -maxdepth 1 -name "tileops_ci_venv_*" -printf '  %M %u %g %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null || true)
-              if [[ -n "${sibling_list}" ]]; then
-                printf '%s\n' "${sibling_list}"
-              else
-                echo "  (none)"
-              fi
-            fi
-            python_bin="${TRUSTED_VENV_PATH}/bin/python"
-            if [[ -e "${python_bin}" ]]; then
-              echo "python_bin exists=true executable=$([[ -x "${python_bin}" ]] && echo true || echo false) readable=$([[ -r "${python_bin}" ]] && echo true || echo false)"
-              stat "${python_bin}" || true
-            else
-              echo "python_bin exists=false"
-            fi
-            echo "=========================="
-
             if [[ -x "${TRUSTED_VENV_PATH}/bin/python" ]]; then
               FORK_CAN_COPY_TRUSTED_VENV="true"
               VENV_REUSED="true"
             else
               VENV_REUSED="false"
             fi
-            echo "FORK_CAN_COPY_TRUSTED_VENV decision: ${FORK_CAN_COPY_TRUSTED_VENV} (path=${TRUSTED_VENV_PATH})"
             mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
             # Copy trusted compile caches into the isolated per-run dir.
@@ -601,22 +593,18 @@ jobs:
             # TileLang cache keys include the library's mtime (kernel_cache.py); a fresh
             # pip install produces a new mtime, causing all rsync'd cache entries to miss.
             # See: https://github.com/tile-ai/TileOPs/issues/594
-            #
-            # Use TRUSTED_VENV_PATH (the hash-matched venv) directly. Picking an
-            # arbitrary venv via `find ... | sort | head -1` can select a stale
-            # venv built against a different pyproject.toml, whose libtilelang.so
-            # mtime does not match any rsync'd cache entry.
-            if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
-              TRUSTED_LIB=$(find "${TRUSTED_VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
+            TRUSTED_VENV=$(find "${{ runner.tool_cache }}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -exec test -x '{}/bin/python' \; -print 2>/dev/null | sort -t_ -k5 -r | head -1 || true)
+            if [[ -n "$TRUSTED_VENV" ]]; then
+              TRUSTED_LIB=$(find "$TRUSTED_VENV" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               FORK_LIB=$(find "${VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               if [[ -n "$TRUSTED_LIB" && -n "$FORK_LIB" ]]; then
                 touch -r "$TRUSTED_LIB" "$FORK_LIB"
-                echo "Synced libtilelang.so mtime from ${TRUSTED_LIB} to ${FORK_LIB}"
+                echo "Synced libtilelang.so mtime for cache key compatibility"
               else
-                echo "Warning: could not locate libtilelang.so for mtime sync (trusted=${TRUSTED_LIB:-<none>}, fork=${FORK_LIB:-<none>})"
+                echo "Warning: could not locate libtilelang.so for mtime sync"
               fi
             else
-              echo "Warning: hash-matched trusted venv ${TRUSTED_VENV_PATH} does not exist; skipping mtime sync"
+              echo "Warning: no trusted venv found for mtime sync"
             fi
           else
             PIP_NO_BUILD_ISOLATION=1 PIP_NO_CACHE_DIR=1 pip install -e '.[dev]'
@@ -680,56 +668,22 @@ jobs:
         run: cat gpu_smoke_report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cache stats
-        if: ${{ always() }}
-        env:
-          IS_FORK: ${{ needs.security-policy.outputs.is_fork }}
+        if: ${{ always() && needs.security-policy.outputs.is_fork != 'true' }}
         run: |
-          # Cache stats is informational only. Do NOT use `set -e`: a transient
-          # failure in find/du/wc (e.g. a cache file vanishing mid-scan due to a
-          # concurrent cleanup) must not fail the gpu-smoke job, and must not
-          # skip the CACHE_SIGNAL logging below.
-          set -u
-          echo "=== Cache stats (is_fork=${IS_FORK}) ==="
-          echo "VENV_REUSED=${VENV_REUSED:-unknown}"
-          echo "FORK_CAN_COPY_TRUSTED_VENV=${FORK_CAN_COPY_TRUSTED_VENV:-unknown}"
-          echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH:-unknown}"
+          set -euo pipefail
+          echo "=== Trusted cache stats ==="
           for cache_dir in "${TILELANG_CACHE_DIR:-}" "${TRITON_CACHE_DIR:-}" "${WHEEL_DIR:-}"; do
             if [[ -z "${cache_dir}" ]]; then
               continue
             fi
             if [[ -d "${cache_dir}" ]]; then
-              # Tolerate errors from find/du/wc; emit "unknown" when a scan
-              # fails rather than aborting the step. Enable pipefail inside
-              # the subshell so a find/du failure upstream of wc/cut
-              # propagates to the || fallback instead of being masked.
-              file_count=$(set -o pipefail; find "${cache_dir}" -type f 2>/dev/null | wc -l 2>/dev/null) || file_count="unknown"
-              cache_size=$(set -o pipefail; du -sh "${cache_dir}" 2>/dev/null | cut -f1 2>/dev/null) || cache_size="unknown"
-              if [[ -z "${file_count}" ]]; then file_count="unknown"; fi
-              if [[ -z "${cache_size}" ]]; then cache_size="unknown"; fi
+              file_count=$(find "${cache_dir}" -type f | wc -l)
+              cache_size=$(du -sh "${cache_dir}" 2>/dev/null | cut -f1)
               echo "${cache_dir}: ${file_count} files, ${cache_size}"
             else
               echo "${cache_dir}: does not exist"
             fi
           done
-
-          # Emit a concise cache hit/miss signal so future regressions surface
-          # in CI logs without needing to diff per-run durations manually.
-          # For fork PRs, "hit" means the trusted venv was copied (no cold pip
-          # install); for trusted runs, "hit" means the hash-matched venv was
-          # reused in place.
-          if [[ "${IS_FORK}" == "true" ]]; then
-            if [[ "${FORK_CAN_COPY_TRUSTED_VENV:-false}" == "true" ]]; then
-              echo "CACHE_SIGNAL: fork venv=hit"
-            else
-              echo "CACHE_SIGNAL: fork venv=miss (cold pip install path)"
-            fi
-          else
-            if [[ "${VENV_REUSED:-false}" == "true" ]]; then
-              echo "CACHE_SIGNAL: trusted venv=hit"
-            else
-              echo "CACHE_SIGNAL: trusted venv=miss (fresh venv created)"
-            fi
-          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -453,10 +453,25 @@ jobs:
             PIP_CACHE_DIR="${RUNTIME_ROOT}/pip/cache"
             WHEEL_DIR="${RUNTIME_ROOT}/wheels"
             VENV_PATH="${RUNTIME_ROOT}/venv"
-            if [[ -x "${TRUSTED_VENV_PATH}/bin/python" ]]; then
+            # Divergence guard: TRUSTED_VENV_PATH was derived from the trusted
+            # base-repo pyproject.toml hash. A fork PR may have edited its own
+            # workspace pyproject.toml (added/removed dependencies) without
+            # that touching the base-repo file. If we copy the trusted venv
+            # for such a fork, the installed package set silently disagrees
+            # with `.[dev]` in the fork's workspace. Re-run the (trusted) hash
+            # script against the fork's workspace pyproject.toml and only
+            # fast-path when both hashes match; otherwise fall through to a
+            # fresh isolated pip install below.
+            WORKSPACE_PYPROJECT_HASH=$(python .trusted/scripts/ci_venv_hash.py ./pyproject.toml)
+            echo "WORKSPACE_PYPROJECT_HASH=${WORKSPACE_PYPROJECT_HASH}"
+            echo "TRUSTED_PYPROJECT_HASH=${PYPROJECT_HASH}"
+            if [[ -x "${TRUSTED_VENV_PATH}/bin/python" && "${WORKSPACE_PYPROJECT_HASH}" == "${PYPROJECT_HASH}" ]]; then
               FORK_CAN_COPY_TRUSTED_VENV="true"
               VENV_REUSED="true"
             else
+              if [[ -x "${TRUSTED_VENV_PATH}/bin/python" ]]; then
+                echo "Fork pyproject diverges from trusted base; forcing fresh isolated venv install"
+              fi
               VENV_REUSED="false"
             fi
             mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -391,6 +391,8 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             .github/actions
+            scripts/ci_venv_hash.py
+            pyproject.toml
 
       - name: Reclaim runner disk
         uses: ./.trusted/.github/actions/reclaim-runner-disk
@@ -420,7 +422,15 @@ jobs:
           # fork-PR venv, defeating #996's fast path for no packaging
           # reason. See scripts/ci_venv_hash.py for the parsed sections and
           # the full-file fallback contract.
-          PYPROJECT_HASH=$(python scripts/ci_venv_hash.py pyproject.toml)
+          #
+          # Trust note: always run the hash script from `.trusted/` (the
+          # sparse-checked-out base/head ref selected above). This prevents
+          # external fork PRs from executing attacker-controlled Python on
+          # the self-hosted runner before the IS_FORK runtime isolation
+          # branches. We also hash the `.trusted/` pyproject.toml so the
+          # computed key identifies the trusted venv that was actually
+          # installed from that same pyproject, not the fork's edits.
+          PYPROJECT_HASH=$(python .trusted/scripts/ci_venv_hash.py .trusted/pyproject.toml)
           HASH_INPUT="$(
             {
               echo "python=3.11"
@@ -593,9 +603,13 @@ jobs:
             # TileLang cache keys include the library's mtime (kernel_cache.py); a fresh
             # pip install produces a new mtime, causing all rsync'd cache entries to miss.
             # See: https://github.com/tile-ai/TileOPs/issues/594
-            TRUSTED_VENV=$(find "${{ runner.tool_cache }}" -maxdepth 1 -type d -name "tileops_ci_venv_*" -exec test -x '{}/bin/python' \; -print 2>/dev/null | sort -t_ -k5 -r | head -1 || true)
-            if [[ -n "$TRUSTED_VENV" ]]; then
-              TRUSTED_LIB=$(find "$TRUSTED_VENV" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
+            #
+            # Use the hash-matched TRUSTED_VENV_PATH directly. A `find`-then-`sort`
+            # sweep over `runner.tool_cache` can select a stale `tileops_ci_venv_*`
+            # with a different libtilelang.so mtime, which would poison the rsync'd
+            # cache entries keyed off the correct trusted venv's mtime.
+            if [[ -d "${TRUSTED_VENV_PATH}" ]]; then
+              TRUSTED_LIB=$(find "${TRUSTED_VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               FORK_LIB=$(find "${VENV_PATH}" -name "libtilelang.so" -type f 2>/dev/null | head -1 || true)
               if [[ -n "$TRUSTED_LIB" && -n "$FORK_LIB" ]]; then
                 touch -r "$TRUSTED_LIB" "$FORK_LIB"
@@ -604,7 +618,7 @@ jobs:
                 echo "Warning: could not locate libtilelang.so for mtime sync"
               fi
             else
-              echo "Warning: no trusted venv found for mtime sync"
+              echo "Warning: hash-matched trusted venv not found at ${TRUSTED_VENV_PATH}; skipping mtime sync"
             fi
           else
             PIP_NO_BUILD_ISOLATION=1 PIP_NO_CACHE_DIR=1 pip install -e '.[dev]'

--- a/scripts/ci_venv_hash.py
+++ b/scripts/ci_venv_hash.py
@@ -8,11 +8,16 @@ would differ. Hashing the full pyproject.toml is too coarse — every tweak to
 invalidates the cache and forces every fork PR to rebuild the venv from
 scratch, even though the resolved wheel set is identical.
 
-Narrow the hash to the sections that actually drive dependency resolution:
+Narrow the hash to the fields that actually drive dependency resolution:
 
-* ``[project]`` — dependencies, requires-python, name/version.
-* ``[project.optional-dependencies]`` — the ``[dev]`` extras we install in CI.
+* ``[project].dependencies`` — runtime deps.
+* ``[project].optional-dependencies`` — the ``[dev]`` extras we install in CI.
+* ``[project].requires-python`` — interpreter constraint affects wheel picks.
 * ``[build-system]`` — build backend and its pinned requires.
+
+Project metadata that does not change the installed wheel set (``name``,
+``version``, ``description``, ``authors``, ``classifiers``, ``readme``, …)
+is deliberately excluded so routine metadata edits keep the cache warm.
 
 Fall back to hashing the full file if tomllib parsing fails, so a syntax
 error never silently collapses all venvs to the same key. The fallback
@@ -30,18 +35,36 @@ import json
 import pathlib
 import sys
 
-import tomllib
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - exercised on 3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:
+        # Last-resort: no TOML parser available (e.g. a stripped-down 3.10
+        # interpreter without ``tomli``). ``compute`` will fall through to
+        # the full-file hash path, which still produces a valid 16-hex key.
+        tomllib = None  # type: ignore[assignment]
 
 HASH_LEN = 16
+
+# Fields under ``[project]`` that actually change the installed dependency set.
+# Metadata-only edits (description, authors, classifiers, version, readme, …)
+# must NOT bust the venv cache, otherwise every routine metadata bump forces
+# fork PRs to rebuild the whole venv from scratch.
+_PROJECT_DEP_FIELDS = (
+    "dependencies",
+    "optional-dependencies",
+    "requires-python",
+)
 
 
 def _narrow_hash(data: dict) -> str:
     """Hash only the dependency-relevant sections of a parsed pyproject."""
+    project = data.get("project", {}) or {}
+    project_deps = {k: project[k] for k in _PROJECT_DEP_FIELDS if k in project}
     relevant = {
-        "project": data.get("project", {}),
-        "project.optional-dependencies": data.get("project", {}).get(
-            "optional-dependencies", {}
-        ),
+        "project": project_deps,
         "build-system": data.get("build-system", {}),
     }
     payload = json.dumps(relevant, sort_keys=True).encode("utf-8")
@@ -55,6 +78,16 @@ def _full_file_hash(raw: bytes) -> str:
 
 def compute(path: pathlib.Path) -> str:
     raw = path.read_bytes()
+    if tomllib is None:
+        # No TOML parser available on this interpreter. Fall back to a
+        # full-file hash so the venv path still has the correct 16-hex
+        # format. This path is coarser (tweaking ``[tool.ruff]`` will bust
+        # the cache) but never breaks CI.
+        print(
+            "ci_venv_hash: no tomllib/tomli available; falling back to full-file hash",
+            file=sys.stderr,
+        )
+        return _full_file_hash(raw)
     try:
         data = tomllib.loads(raw.decode("utf-8"))
     except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:

--- a/scripts/ci_venv_hash.py
+++ b/scripts/ci_venv_hash.py
@@ -59,6 +59,29 @@ _PROJECT_DEP_FIELDS = (
 )
 
 
+def _canonicalize(value):
+    """Recursively sort dependency-like string lists so pure reordering of
+    entries (e.g. swapping two items in ``[project].dependencies``) does not
+    change the hash. Order-sensitive structures (dicts, non-string lists) are
+    preserved as-is apart from descending into their children.
+
+    Rationale: ``pip install`` is order-insensitive for a requirements list,
+    so two pyproject files that differ only by list order install the same
+    wheels and must share a venv cache key.
+    """
+    if isinstance(value, list):
+        canon = [_canonicalize(v) for v in value]
+        # Only sort when every element is a string — this covers the
+        # dependency-list shape (``["torch>=2.1", "tilelang==0.1.8", ...]``)
+        # without reordering structured lists where position may matter.
+        if all(isinstance(v, str) for v in canon):
+            return sorted(canon)
+        return canon
+    if isinstance(value, dict):
+        return {k: _canonicalize(v) for k, v in value.items()}
+    return value
+
+
 def _narrow_hash(data: dict) -> str:
     """Hash only the dependency-relevant sections of a parsed pyproject."""
     project = data.get("project", {}) or {}
@@ -67,7 +90,8 @@ def _narrow_hash(data: dict) -> str:
         "project": project_deps,
         "build-system": data.get("build-system", {}),
     }
-    payload = json.dumps(relevant, sort_keys=True).encode("utf-8")
+    canonical = _canonicalize(relevant)
+    payload = json.dumps(canonical, sort_keys=True).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()[:HASH_LEN]
 
 

--- a/scripts/ci_venv_hash.py
+++ b/scripts/ci_venv_hash.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Compute a stable 16-char venv cache key for the CI trusted-venv scheme.
+
+The CI workflow caches the installed virtualenv under a path derived from
+this hash, so the hash must change **only** when the installed package set
+would differ. Hashing the full pyproject.toml is too coarse — every tweak to
+``[tool.pytest]``, ``[tool.ruff]``, or similar style/tooling sections
+invalidates the cache and forces every fork PR to rebuild the venv from
+scratch, even though the resolved wheel set is identical.
+
+Narrow the hash to the sections that actually drive dependency resolution:
+
+* ``[project]`` — dependencies, requires-python, name/version.
+* ``[project.optional-dependencies]`` — the ``[dev]`` extras we install in CI.
+* ``[build-system]`` — build backend and its pinned requires.
+
+Fall back to hashing the full file if tomllib parsing fails, so a syntax
+error never silently collapses all venvs to the same key. The fallback
+still produces a 16-char hex digest, preserving the ``tileops_ci_venv_*``
+path format downstream.
+
+Usage:
+    python scripts/ci_venv_hash.py [path/to/pyproject.toml]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import sys
+
+import tomllib
+
+HASH_LEN = 16
+
+
+def _narrow_hash(data: dict) -> str:
+    """Hash only the dependency-relevant sections of a parsed pyproject."""
+    relevant = {
+        "project": data.get("project", {}),
+        "project.optional-dependencies": data.get("project", {}).get(
+            "optional-dependencies", {}
+        ),
+        "build-system": data.get("build-system", {}),
+    }
+    payload = json.dumps(relevant, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:HASH_LEN]
+
+
+def _full_file_hash(raw: bytes) -> str:
+    """Fallback: hash the entire pyproject.toml as bytes."""
+    return hashlib.sha256(raw).hexdigest()[:HASH_LEN]
+
+
+def compute(path: pathlib.Path) -> str:
+    raw = path.read_bytes()
+    try:
+        data = tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        # Fail open: any parse error collapses to a full-file hash so the
+        # venv path still has the correct 16-hex format. Emit a warning to
+        # stderr so operators can spot the degraded path in CI logs.
+        print(
+            f"ci_venv_hash: tomllib parse failed ({exc}); falling back to full-file hash",
+            file=sys.stderr,
+        )
+        return _full_file_hash(raw)
+    return _narrow_hash(data)
+
+
+def main(argv: list[str]) -> int:
+    path = pathlib.Path(argv[1]) if len(argv) > 1 else pathlib.Path("pyproject.toml")
+    if not path.exists():
+        print(f"ci_venv_hash: {path} does not exist", file=sys.stderr)
+        return 1
+    print(compute(path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_ci_venv_hash.py
+++ b/tests/test_ci_venv_hash.py
@@ -139,8 +139,27 @@ def test_fallback_matches_full_file_hash_shape(tmp_path: Path) -> None:
     """The fallback path is a pure function of the file bytes, so identical
     malformed files must hash identically."""
     malformed = "nope = = =\nstill bad\n"
-    a = CI_VENV_HASH.compute(_write(tmp_path / "a", malformed) if False else _write(tmp_path, malformed))
+    a = CI_VENV_HASH.compute(_write(tmp_path, malformed))
     p2 = tmp_path / "other.toml"
     p2.write_text(malformed)
     b = CI_VENV_HASH.compute(p2)
     assert a == b
+
+
+def test_hash_stable_when_project_version_changes(tmp_path: Path) -> None:
+    """Metadata-only edits to ``[project].version`` must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace('version = "0.0.1"', 'version = "0.0.2"')
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new == base, "version-only bump must not invalidate the venv"
+
+
+def test_hash_stable_when_project_description_changes(tmp_path: Path) -> None:
+    """Adding/changing ``[project].description`` must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace(
+        'version = "0.0.1"',
+        'version = "0.0.1"\ndescription = "A different blurb"',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new == base, "description-only edit must not invalidate the venv"

--- a/tests/test_ci_venv_hash.py
+++ b/tests/test_ci_venv_hash.py
@@ -1,0 +1,146 @@
+"""Unit tests for ``scripts/ci_venv_hash.py``.
+
+The CI trusted-venv cache key must:
+
+* stay stable across changes to tooling/style sections (``[tool.pytest]``,
+  ``[tool.ruff]``, ``[tool.codespell]``) so fork PRs can reuse a warm venv
+  even when someone tightens a lint rule;
+* change when the actual dependency surface changes
+  (``[project.dependencies]``, ``[project.optional-dependencies]``,
+  ``[build-system].requires``);
+* preserve the 16-char hex format required by the ``tileops_ci_venv_*``
+  path convention, even on the parse-error fallback path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci_venv_hash.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ci_venv_hash", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CI_VENV_HASH = _load_module()
+HEX16 = re.compile(r"^[0-9a-f]{16}$")
+
+
+BASE_PYPROJECT = """\
+[project]
+name = "tileops"
+version = "0.0.1"
+dependencies = [
+    "torch>=2.1.0",
+    "tilelang==0.1.8",
+]
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "ruff==0.14.13"]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = ["smoke", "full"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.codespell]
+ignore-words-list = "nd, te"
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(text)
+    return p
+
+
+def test_hash_is_16_char_hex(tmp_path: Path) -> None:
+    h = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    assert HEX16.match(h), h
+
+
+def test_hash_stable_when_tool_pytest_changes(tmp_path: Path) -> None:
+    """AC-1: mutating ``[tool.pytest]`` must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace(
+        'markers = ["smoke", "full"]',
+        'markers = ["smoke", "full", "nightly"]\naddopts = "-q"',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new == base, "pytest-only config change must not invalidate the venv"
+
+
+def test_hash_stable_when_tool_ruff_changes(tmp_path: Path) -> None:
+    """AC-1: mutating ``[tool.ruff]`` must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace("line-length = 100", "line-length = 120")
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new == base, "ruff-only config change must not invalidate the venv"
+
+
+def test_hash_changes_when_project_dependencies_change(tmp_path: Path) -> None:
+    """AC-2: adding a runtime dep MUST change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace(
+        '"tilelang==0.1.8",',
+        '"tilelang==0.1.8",\n    "einops",',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new != base
+
+
+def test_hash_changes_when_build_system_requires_change(tmp_path: Path) -> None:
+    """AC-2: bumping ``[build-system].requires`` MUST change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace(
+        'requires = ["setuptools>=68", "wheel"]',
+        'requires = ["setuptools>=70", "wheel"]',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new != base
+
+
+def test_hash_changes_when_optional_dependencies_change(tmp_path: Path) -> None:
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    mutated = BASE_PYPROJECT.replace(
+        'dev = ["pytest>=8.0", "ruff==0.14.13"]',
+        'dev = ["pytest>=8.0", "ruff==0.14.13", "pytest-xdist"]',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, mutated))
+    assert new != base
+
+
+def test_fallback_on_parse_error_still_emits_16_hex(tmp_path: Path) -> None:
+    """Fallback contract: malformed TOML still produces a 16-char hex hash."""
+    p = _write(tmp_path, "this is [not valid == toml\n")
+    h = CI_VENV_HASH.compute(p)
+    assert HEX16.match(h), h
+
+
+def test_fallback_matches_full_file_hash_shape(tmp_path: Path) -> None:
+    """The fallback path is a pure function of the file bytes, so identical
+    malformed files must hash identically."""
+    malformed = "nope = = =\nstill bad\n"
+    a = CI_VENV_HASH.compute(_write(tmp_path / "a", malformed) if False else _write(tmp_path, malformed))
+    p2 = tmp_path / "other.toml"
+    p2.write_text(malformed)
+    b = CI_VENV_HASH.compute(p2)
+    assert a == b

--- a/tests/test_ci_venv_hash.py
+++ b/tests/test_ci_venv_hash.py
@@ -146,6 +146,44 @@ def test_fallback_matches_full_file_hash_shape(tmp_path: Path) -> None:
     assert a == b
 
 
+def test_hash_stable_when_dependencies_reordered(tmp_path: Path) -> None:
+    """Pure reordering of ``[project].dependencies`` must NOT change the hash.
+
+    ``pip install`` is order-insensitive, so swapping two dep entries installs
+    the same wheels and must share a venv cache key.
+    """
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    reordered = BASE_PYPROJECT.replace(
+        '    "torch>=2.1.0",\n    "tilelang==0.1.8",',
+        '    "tilelang==0.1.8",\n    "torch>=2.1.0",',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, reordered))
+    assert new == base, "reordering runtime deps must not invalidate the venv"
+
+
+def test_hash_stable_when_optional_dependencies_reordered(tmp_path: Path) -> None:
+    """Pure reordering inside a ``[project.optional-dependencies]`` extra
+    list must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    reordered = BASE_PYPROJECT.replace(
+        'dev = ["pytest>=8.0", "ruff==0.14.13"]',
+        'dev = ["ruff==0.14.13", "pytest>=8.0"]',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, reordered))
+    assert new == base, "reordering dev extras must not invalidate the venv"
+
+
+def test_hash_stable_when_build_system_requires_reordered(tmp_path: Path) -> None:
+    """Pure reordering of ``[build-system].requires`` must NOT change the hash."""
+    base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))
+    reordered = BASE_PYPROJECT.replace(
+        'requires = ["setuptools>=68", "wheel"]',
+        'requires = ["wheel", "setuptools>=68"]',
+    )
+    new = CI_VENV_HASH.compute(_write(tmp_path, reordered))
+    assert new == base, "reordering build requires must not invalidate the venv"
+
+
 def test_hash_stable_when_project_version_changes(tmp_path: Path) -> None:
     """Metadata-only edits to ``[project].version`` must NOT change the hash."""
     base = CI_VENV_HASH.compute(_write(tmp_path, BASE_PYPROJECT))

--- a/tests/test_gpu_smoke_policy.py
+++ b/tests/test_gpu_smoke_policy.py
@@ -1,0 +1,129 @@
+"""Structural tests for the gpu-smoke / runner-maintenance CI wiring.
+
+These tests do NOT spin up a self-hosted runner — they parse the workflow
+YAML and assert the contract documented in the acceptance criteria:
+
+* AC-3: the ``security-policy`` job downgrades ``is_fork`` to ``false`` for
+  OWNER/MEMBER/COLLABORATOR authors on head != base PRs.
+* AC-4: the ``gpu-smoke`` job passes ``skip-atomic-age-trim: "true"`` when
+  invoking the ``reclaim-runner-disk`` composite action.
+* AC-5: the daily ``runner-maintenance.yml`` job does NOT pass
+  ``skip-atomic-age-trim``, so the full destructive trim still runs there.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.smoke
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GPU_SMOKE = REPO_ROOT / ".github" / "workflows" / "gpu-smoke.yml"
+RUNNER_MAINT = REPO_ROOT / ".github" / "workflows" / "runner-maintenance.yml"
+RECLAIM_ACTION = REPO_ROOT / ".github" / "actions" / "reclaim-runner-disk" / "action.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _find_step(steps: list[dict], *, uses_contains: str) -> dict:
+    for step in steps:
+        if uses_contains in (step.get("uses") or ""):
+            return step
+    raise AssertionError(f"no step with uses containing {uses_contains!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-3: member-fork demotion
+# ---------------------------------------------------------------------------
+
+
+def test_security_policy_handles_member_fork_as_trusted() -> None:
+    """AC-3: PRs from OWNER/MEMBER/COLLABORATOR authors on a fork repo
+    must be treated as trusted (is_fork=false) by the security-policy
+    step so the gpu-smoke job uses the /home/ci-runner trusted runtime
+    layout."""
+    wf = _load(GPU_SMOKE)
+    policy_job = wf["jobs"]["security-policy"]
+    run_steps = [s for s in policy_job["steps"] if "run" in s and s.get("id") == "policy"]
+    assert run_steps, "expected a 'policy' step in security-policy job"
+    script = run_steps[0]["run"]
+
+    # The promotion logic must name all three trusted author_association
+    # values, and must key off AUTHOR_ASSOC in the head != base branch.
+    assert "AUTHOR_ASSOC" in script, "AUTHOR_ASSOC env must be referenced"
+    for assoc in ("OWNER", "MEMBER", "COLLABORATOR"):
+        assert assoc in script, f"author_association {assoc!r} must be handled"
+    # Must actually set is_fork=false in the trusted branch.
+    assert 'is_fork="false"' in script
+    # And AUTHOR_ASSOC must be sourced from github.event.pull_request.author_association.
+    env = run_steps[0]["env"]
+    assert "AUTHOR_ASSOC" in env, "AUTHOR_ASSOC must be plumbed via env:"
+    assert "author_association" in env["AUTHOR_ASSOC"]
+
+
+# ---------------------------------------------------------------------------
+# AC-4: gpu-smoke opts out of atomic age-trim
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_smoke_invokes_reclaim_with_skip_atomic_age_trim() -> None:
+    wf = _load(GPU_SMOKE)
+    steps = wf["jobs"]["gpu-smoke"]["steps"]
+    reclaim_step = _find_step(steps, uses_contains="reclaim-runner-disk")
+    with_ = reclaim_step.get("with") or {}
+    assert str(with_.get("skip-atomic-age-trim")).lower() == "true", (
+        "AC-4: gpu-smoke must pass skip-atomic-age-trim: true so the daily "
+        "maintenance job is the only place autotuner subdirs get evicted."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: daily maintenance preserves full-trim behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_runner_maintenance_still_runs_full_atomic_trim() -> None:
+    wf = _load(RUNNER_MAINT)
+    steps = wf["jobs"]["reclaim-disk"]["steps"]
+    reclaim_step = _find_step(steps, uses_contains="reclaim-runner-disk")
+    with_ = reclaim_step.get("with") or {}
+    # Absent OR explicitly "false". Presence of "true" would regress AC-5.
+    value = with_.get("skip-atomic-age-trim", "false")
+    assert str(value).lower() == "false", (
+        "AC-5: runner-maintenance.yml must not opt out of the atomic age-trim "
+        "pass — that daily job is what ultimately reclaims stale autotuner "
+        "entries."
+    )
+    # And force-reclaim must still be on so it actually runs every day.
+    assert str(with_.get("force-reclaim")).lower() == "true"
+
+
+# ---------------------------------------------------------------------------
+# Composite action: surface + semantics
+# ---------------------------------------------------------------------------
+
+
+def test_reclaim_action_declares_skip_atomic_age_trim_input() -> None:
+    action = _load(RECLAIM_ACTION)
+    inputs = action["inputs"]
+    assert "skip-atomic-age-trim" in inputs, (
+        "The skip-atomic-age-trim input must exist on the composite action "
+        "so callers can opt out of the destructive trim."
+    )
+    assert str(inputs["skip-atomic-age-trim"]["default"]).lower() == "false", (
+        "Default must be false so existing callers (runner-maintenance.yml) "
+        "keep their full-trim behaviour without changes."
+    )
+
+
+def test_reclaim_action_emits_opt_out_log_line() -> None:
+    """When the opt-out is active, operators need a grep-able log line to
+    confirm the destructive path was skipped. The AC explicitly names this
+    string ('Skipping atomic age-trim (opted out)')."""
+    text = RECLAIM_ACTION.read_text()
+    assert "Skipping atomic age-trim (opted out)" in text

--- a/tests/test_gpu_smoke_policy.py
+++ b/tests/test_gpu_smoke_policy.py
@@ -121,6 +121,38 @@ def test_reclaim_action_declares_skip_atomic_age_trim_input() -> None:
     )
 
 
+def test_fork_divergent_pyproject_forces_fresh_install() -> None:
+    """Fork PRs must not reuse the trusted venv when the fork's workspace
+    pyproject.toml diverges from the trusted base-repo pyproject.toml.
+
+    The trusted venv is keyed by the base-repo pyproject hash. If a fork
+    edits `[project].dependencies` (or any other hashed section) in its own
+    workspace pyproject, copying the trusted venv would install a package
+    set that silently disagrees with the fork's `.[dev]`. The Resolve
+    runtime state step must re-run the (trusted) hash script against the
+    fork's workspace pyproject and gate FORK_CAN_COPY_TRUSTED_VENV on the
+    two hashes being equal.
+    """
+    wf = _load(GPU_SMOKE)
+    steps = wf["jobs"]["gpu-smoke"]["steps"]
+    resolve_step = next(
+        (s for s in steps if s.get("name") == "Resolve runtime state"), None
+    )
+    assert resolve_step is not None, "Resolve runtime state step must exist"
+    script = resolve_step["run"]
+
+    # Must run the trusted hash script against the workspace pyproject.
+    assert "python .trusted/scripts/ci_venv_hash.py ./pyproject.toml" in script, (
+        "Workspace pyproject must be hashed via the trusted script so the "
+        "fork cannot substitute its own ci_venv_hash.py."
+    )
+    # Must gate the copy fast-path on hashes matching.
+    assert "WORKSPACE_PYPROJECT_HASH" in script
+    assert 'WORKSPACE_PYPROJECT_HASH}" == "${PYPROJECT_HASH}' in script, (
+        "FORK_CAN_COPY_TRUSTED_VENV must require workspace hash == trusted hash."
+    )
+
+
 def test_reclaim_action_emits_opt_out_log_line() -> None:
     """When the opt-out is active, operators need a grep-able log line to
     confirm the destructive path was skipped. The AC explicitly names this


### PR DESCRIPTION
## Summary

Maximize cache hit rate for fork-PR `gpu-smoke` runs without widening the write-path attack surface.

Three narrowly-scoped fixes:

1. **Narrow venv HASH** (`scripts/ci_venv_hash.py`): parse `pyproject.toml` with `tomllib` and hash only `[project]` + `[build-system]` + `[project.optional-dependencies]`. Edits to `[tool.pytest]` / `[tool.ruff]` no longer bust the venv cache. Falls back to full-file hash on parse failure, preserving the 16-char hex format.
2. **Member-fork → trusted runtime path** (`.github/workflows/gpu-smoke.yml` policy): when head repo differs from base but `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`, set `is_fork=false` so the PR traverses the trusted runtime path (`RUNTIME_ROOT=/home/ci-runner`). External contributors still go the isolated path.
3. **Skip in-line atomic age-trim** (`.github/actions/reclaim-runner-disk/action.yml`): add `skip-atomic-age-trim` input (default `false`); `gpu-smoke.yml` passes `true` so the destructive autotuner age-trim only runs via `runner-maintenance.yml` (daily). Sentinel-repair remains always on.

Closes #1007

## Test plan

- **AC-1**: Changing `[tool.pytest]` / `[tool.ruff]` sections of `pyproject.toml` does NOT change the computed venv HASH — pass. `python -m pytest -q tests/test_ci_venv_hash.py tests/test_gpu_smoke_policy.py tests/test_reclaim_action.py`: 26 passed in 1.20s. Direct hash probe: base=`c2c5efe07bd7e601`, tool-section mutation=`c2c5efe07bd7e601`, stable=True.
- **AC-2**: Changing `[project.dependencies]` or `[build-system].requires` DOES change the computed HASH — pass. Dependency mutation `d435cbfc2b7aca79` changed=True; build-system requires mutation `93760788d3b9ecd3` changed=True.
- **AC-3**: Member-fork PRs produce `is_fork=false` and traverse the trusted runtime path — pass. Policy probe with `HEAD_REPO!=BASE_REPO` and `AUTHOR_ASSOC=MEMBER` produced `is_fork=false`; Resolve-runtime probe with `IS_FORK=false` exported `RUNTIME_ROOT=/home/ci-runner`. Negative probe with `AUTHOR_ASSOC=CONTRIBUTOR` produced `is_fork=true` and isolated `RUNNER_TEMP` runtime.
- **AC-4**: `gpu-smoke` in-line `reclaim-runner-disk` does NOT invoke atomic age-trim — pass. Composite-action run with `SKIP_ATOMIC_AGE_TRIM=true` emitted `Skipping atomic age-trim (opted out)`, still ran sentinel-repair on half-dead atomic subdir, and preserved the complete atomic subdir.
- **AC-5**: `runner-maintenance.yml` daily job still performs full atomic trim — pass. YAML probe confirmed reclaim step has `force-reclaim=true` and `skip-atomic-age-trim` absent/false. `git diff main...HEAD` does not modify `runner-maintenance.yml`.
- **AC-6**: Unit tests for `reclaim_cache.sh` still pass — pass. `tests/test_reclaim_action.py` Base 13 nodes, HEAD 13 nodes, Delta 0; all 13 sentinel-repair tests pass.
