### PR TITLE
[Test][CI] Add smoke workflow for containerized nightly runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
     - tile-ops
     - venv
     - nightly
+    - nightly-containerized

--- a/.github/workflows/nightly-containerized-smoke.yml
+++ b/.github/workflows/nightly-containerized-smoke.yml
@@ -1,0 +1,64 @@
+name: Nightly Containerized Runner Smoke
+
+permissions: read-all
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    if: ${{ github.repository == 'tile-ai/TileOPs' }}
+    timeout-minutes: 30
+    runs-on: [self-hosted, tile-ops, nightly, nightly-containerized]
+    container:
+      image: tileops-runner:latest
+      volumes:
+        - /data/ci-cache/pip:/cache/pip
+        - /data/ci-cache/wheels:/cache/wheels
+        - /data/ci-cache/tilelang:/cache/tilelang
+        - /data/ci-cache/triton:/cache/triton
+      options: >-
+        --gpus device=1
+        --shm-size=16g
+      env:
+        TILELANG_CACHE_DIR: /cache/tilelang
+        TILELANG_TMP_DIR: /cache/tilelang/tmp
+        TRITON_CACHE_DIR: /cache/triton
+        PIP_CACHE_DIR: /cache/pip
+        WHEEL_DIR: /cache/wheels
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate containerized nightly runner path
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
+
+          echo "Runner: ${RUNNER_NAME:-unknown}"
+          echo "Workspace: ${GITHUB_WORKSPACE}"
+          pwd
+          ls -la
+
+          python -V
+          pip -V
+          nvidia-smi -L
+
+          touch "${PIP_CACHE_DIR}/.nightly-containerized-smoke"
+          touch "${WHEEL_DIR}/.nightly-containerized-smoke"
+          touch "${TILELANG_CACHE_DIR}/.nightly-containerized-smoke"
+          touch "${TRITON_CACHE_DIR}/.nightly-containerized-smoke"
+
+          ls -la "${PIP_CACHE_DIR}" "${WHEEL_DIR}" "${TILELANG_CACHE_DIR}" "${TRITON_CACHE_DIR}"
+
+          rm -f \
+            "${PIP_CACHE_DIR}/.nightly-containerized-smoke" \
+            "${WHEEL_DIR}/.nightly-containerized-smoke" \
+            "${TILELANG_CACHE_DIR}/.nightly-containerized-smoke" \
+            "${TRITON_CACHE_DIR}/.nightly-containerized-smoke"

--- a/.github/workflows/nightly-containerized-smoke.yml
+++ b/.github/workflows/nightly-containerized-smoke.yml
@@ -10,32 +10,22 @@ jobs:
     if: ${{ github.repository == 'tile-ai/TileOPs' }}
     timeout-minutes: 30
     runs-on: [self-hosted, tile-ops, nightly, nightly-containerized]
-    container:
-      image: tileops-runner:latest
-      volumes:
-        - /data/ci-cache/pip:/cache/pip
-        - /data/ci-cache/wheels:/cache/wheels
-        - /data/ci-cache/tilelang:/cache/tilelang
-        - /data/ci-cache/triton:/cache/triton
-      options: >-
-        --gpus device=1
-        --shm-size=16g
-      env:
-        TILELANG_CACHE_DIR: /cache/tilelang
-        TILELANG_TMP_DIR: /cache/tilelang/tmp
-        TRITON_CACHE_DIR: /cache/triton
-        PIP_CACHE_DIR: /cache/pip
-        WHEEL_DIR: /cache/wheels
     defaults:
       run:
         shell: bash
+    env:
+      TILELANG_CACHE_DIR: /home/ci-runner/.tilelang/cache
+      TILELANG_TMP_DIR: /home/ci-runner/.tilelang/cache/tmp
+      TRITON_CACHE_DIR: /home/ci-runner/.triton/cache
+      PIP_CACHE_DIR: /home/ci-runner/.cache/pip
+      WHEEL_DIR: /home/ci-runner/.wheel-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Validate containerized nightly runner path
+      - name: Validate direct-exec containerized nightly runner path
         run: |
           set -euo pipefail
 
@@ -49,6 +39,13 @@ jobs:
           python -V
           pip -V
           nvidia-smi -L
+
+          echo "Cache layout:"
+          printf '  TILELANG_CACHE_DIR=%s\n' "${TILELANG_CACHE_DIR}"
+          printf '  TILELANG_TMP_DIR=%s\n' "${TILELANG_TMP_DIR}"
+          printf '  TRITON_CACHE_DIR=%s\n' "${TRITON_CACHE_DIR}"
+          printf '  PIP_CACHE_DIR=%s\n' "${PIP_CACHE_DIR}"
+          printf '  WHEEL_DIR=%s\n' "${WHEEL_DIR}"
 
           touch "${PIP_CACHE_DIR}/.nightly-containerized-smoke"
           touch "${WHEEL_DIR}/.nightly-containerized-smoke"


### PR DESCRIPTION
Refs #987.

## Summary
- add a manual smoke workflow for the proposed containerized `nightly` runner deployment model
- target a temporary runner label set `self-hosted,tile-ops,nightly,nightly-containerized`
- validate the safer direct-exec model where nightly workload runs inside the containerized runner environment itself

## Relationship to PR #1004

This PR and #1004 are **mutually exclusive implementation directions** for nightly runner/container orchestration and should **not** both be merged.

- `#1010` is the validation path for a containerized-runner deployment model where nightly commands execute directly inside the long-lived runner container
- `#1004` is the host-runner alternative that keeps the runner on the host and migrates nightly directly to GitHub-native `container:` jobs

If we choose the containerized-runner direct-exec model, keep this PR as the first validation step and do not merge #1004 as-is.
If we choose the host-runner model, merge #1004 and close this PR as an alternative path.

## What this direction optimizes for

Compared with #1004, this PR primarily optimizes for:

- a more unified runner deployment model, closer to the existing `venv` PR-gate runner path
- lower system complexity by avoiding nested job containers
- removal of `docker.sock` from the nightly validation path
- fewer orchestration layers to reason about during debugging and operations

In short, `#1010` optimizes the **runner deployment model**.
`#1004` optimizes the **nightly workload execution model**.

## Why
We have been discussing a follow-up deployment model where the `nightly` runner itself would run inside a long-lived runner container.

This PR now validates the simpler and safer variant of that idea:

- GitHub dispatches to a containerized nightly runner
- the workload executes directly in the runner container environment
- the runner uses mounted cache directories and direct GPU access
- the model does **not** rely on `docker.sock`
- the model does **not** require nested job containers

Before touching the host deployment, we want a minimal workflow that can validate that path:

- GitHub can dispatch to the new runner label
- the runner container environment already contains the expected Python/tooling stack
- the runner container can access GPU directly
- the runner container can access and write the mounted cache directories

## Proposed nightly flow under this model

The intended long-term execution path for this model is:

`GitHub -> containerized nightly runner -> direct nightly execution inside runner environment`

More concretely:

1. GitHub dispatches the nightly workflow to a self-hosted runner labeled `self-hosted,tile-ops,nightly`.
2. That runner process is no longer a bare host process. Instead, it lives inside a long-lived runner container.
3. The runner container is provisioned with the required GPU visibility and mounted cache directories.
4. Nightly jobs run directly inside that runner container environment, similar to the existing PR gate `venv` runner model.
5. Benchmark/test/package commands consume GPU and cache paths directly from the runner container environment.
6. The runner container stays alive across workflows, while the job steps themselves remain ordinary GitHub Actions steps rather than nested Docker containers.

So this model containerizes the **runner process** and executes nightly workload directly inside that environment, instead of containerizing each nightly job again.

## What this PR adds
- `.github/workflows/nightly-containerized-smoke.yml`

The workflow is intentionally small and manual-only:
- `workflow_dispatch` only
- runs on `[self-hosted, tile-ops, nightly, nightly-containerized]`
- executes directly in the runner environment instead of using `container:`
- validates Python, pip, GPU visibility, and cache write access
- validates the expected cache layout under `/home/ci-runner/...`

## Non-goals
- this PR does not containerize the runner by itself
- this PR does not modify the existing nightly workflow
- this PR does not introduce Docker-in-Docker
- this PR does not use `docker.sock`
- this PR does not change cache layout for the existing host-based nightly path

## Validation
Local static validation performed:
- YAML parse check passed for `.github/workflows/nightly-containerized-smoke.yml`
- confirmed the workflow contains no step-level `docker run`
- confirmed the workflow does not use GitHub job-level `container:`

Remote validation will happen after a containerized nightly runner is stood up with the temporary `nightly-containerized` label and the expected cache mounts.
