### PR TITLE
[Refactor][OpBase] Align L1 Op base with docs/ops-design.md

### DIFF
--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -1,11 +1,23 @@
-"""Tests for tileops.ops.op_base Op._cache_key default + runtime warnings."""
+"""Tests for tileops.ops.op_base.
+
+Covers:
+- ``Op._cache_key`` default behavior and runtime warnings for missing
+  subclass overrides when ``_static_axes`` is empty.
+- ``Op.eval_roofline`` and the module-level whitelist AST evaluator
+  ``_safe_eval`` introduced to align the L1 base class with
+  docs/ops-design.md §``eval_roofline``.
+- Base-class stubs for ``_infer_output_shapes`` / ``_validate_dtypes`` that
+  raise :class:`NotImplementedError` pointing at the design doc.
+"""
 
 import warnings
+from typing import Dict
 
 import pytest
+import torch
 
 from tileops.ops import op_base
-from tileops.ops.op_base import Op
+from tileops.ops.op_base import Op, _safe_eval
 
 pytestmark = pytest.mark.smoke
 
@@ -119,3 +131,109 @@ class TestCacheKeyWarning:
 
         user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
         assert len(user_warnings) == 2
+
+
+# ---------------------------------------------------------------------------
+# L1 codegen contract: eval_roofline, _safe_eval, NotImplementedError stubs
+# ---------------------------------------------------------------------------
+
+
+class _MinimalOp(Op):
+    """Smallest Op subclass that can be instantiated.
+
+    Implements only the strictly-abstract members so tests can exercise
+    base-class behavior without pulling any kernel code.
+    """
+
+    def __init__(self, *, dtype=None):
+        self.dtype = dtype
+
+    @property
+    def default_kernel_map(self) -> Dict[str, object]:  # pragma: no cover - unused
+        return {}
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - unused
+        return None
+
+
+class _RooflineOp(_MinimalOp):
+    """Op subclass that declares real roofline slots."""
+
+    _roofline_vars = ["M", "N"]
+    _flops_expr = "4 * M * N"
+    _bytes_expr = "(2 * M * N + N) * elem_bytes"
+
+    def __init__(self, *, M: int, N: int, dtype: torch.dtype):
+        super().__init__(dtype=dtype)
+        self.M = M
+        self.N = N
+
+
+class TestEvalRoofline:
+    def test_defaults_return_zero(self):
+        """Class-level slots at defaults -> eval_roofline returns (0, 0)."""
+        op = _MinimalOp(dtype=torch.float16)
+        assert op.eval_roofline() == (0, 0)
+
+    def test_real_expression(self):
+        """``4*M*N`` and ``(2*M*N + N)*elem_bytes`` with M=128, N=256, fp16."""
+        op = _RooflineOp(M=128, N=256, dtype=torch.float16)
+        flops, nbytes = op.eval_roofline()
+        # 4 * 128 * 256 = 131072
+        assert flops == 4 * 128 * 256
+        assert flops == 131072
+        # elem_bytes = 2 (fp16); (2*128*256 + 256) * 2 = 131584
+        elem_bytes = torch.tensor([], dtype=torch.float16).element_size()
+        assert elem_bytes == 2
+        assert nbytes == (2 * 128 * 256 + 256) * 2
+        assert nbytes == 131584
+
+    def test_returns_int_tuple(self):
+        op = _RooflineOp(M=4, N=8, dtype=torch.float32)
+        flops, nbytes = op.eval_roofline()
+        assert isinstance(flops, int)
+        assert isinstance(nbytes, int)
+
+
+class TestSafeEval:
+    def test_rejects_call(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("f(1)", {})
+        assert "Call" in str(excinfo.value)
+
+    def test_rejects_attribute(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("x.y", {"x": 1})
+        assert "Attribute" in str(excinfo.value)
+
+    def test_rejects_subscript(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("x[0]", {"x": 1})
+        assert "Subscript" in str(excinfo.value)
+
+    def test_rejects_undefined_name(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("missing + 1", {})
+        assert "missing" in str(excinfo.value)
+
+    def test_accepts_basic_arithmetic(self):
+        assert _safe_eval("2 + 3 * 4", {}) == 14
+        assert _safe_eval("-a + b", {"a": 5, "b": 7}) == 2
+        assert _safe_eval("2 ** 10", {}) == 1024
+
+
+class TestBaseClassStubs:
+    def test_infer_output_shapes_raises_not_implemented(self):
+        op = _MinimalOp()
+        with pytest.raises(NotImplementedError) as excinfo:
+            op._infer_output_shapes()
+        assert "docs/ops-design.md" in str(excinfo.value)
+        assert "_infer_output_shapes" in str(excinfo.value)
+
+    def test_validate_dtypes_raises_not_implemented(self):
+        op = _MinimalOp()
+        x = torch.empty(1)
+        with pytest.raises(NotImplementedError) as excinfo:
+            op._validate_dtypes(x)
+        assert "docs/ops-design.md" in str(excinfo.value)
+        assert "_validate_dtypes" in str(excinfo.value)

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -3,14 +3,13 @@
 Covers:
 - ``Op._cache_key`` default behavior and runtime warnings for missing
   subclass overrides when ``_static_axes`` is empty.
-- ``Op.eval_roofline`` and the module-level whitelist AST evaluator
-  ``_safe_eval`` introduced to align the L1 base class with
-  docs/ops-design.md §``eval_roofline``.
-- Base-class stubs for ``_infer_output_shapes`` / ``_validate_dtypes`` that
-  raise :class:`NotImplementedError` pointing at the design doc.
+- L1 stubs for ``_infer_output_shapes`` / ``_validate_dtypes`` /
+  ``eval_roofline`` that raise :class:`NotImplementedError` pointing at the
+  design docs. Per docs/roofline.md §4.4.6, the L1 base deliberately does
+  not provide a generic roofline evaluator — each op's ``eval_roofline``
+  body is emitted by codegen as plain Python.
 """
 
-import math
 import warnings
 from typing import Dict
 
@@ -18,7 +17,7 @@ import pytest
 import torch
 
 from tileops.ops import op_base
-from tileops.ops.op_base import Op, _safe_eval
+from tileops.ops.op_base import Op
 
 pytestmark = pytest.mark.smoke
 
@@ -157,234 +156,6 @@ class _MinimalOp(Op):
         return None
 
 
-class _RooflineOp(_MinimalOp):
-    """Op subclass that declares real roofline slots."""
-
-    _roofline_vars = ["M", "N"]
-    _flops_expr = "4 * M * N"
-    _bytes_expr = "(2 * M * N + N) * elem_bytes"
-
-    def __init__(self, *, M: int, N: int, dtype: torch.dtype):
-        super().__init__(dtype=dtype)
-        self.M = M
-        self.N = N
-
-
-class TestEvalRoofline:
-    def test_defaults_return_zero(self):
-        """Class-level slots at defaults -> eval_roofline returns (0, 0)."""
-        op = _MinimalOp(dtype=torch.float16)
-        assert op.eval_roofline() == (0, 0)
-
-    def test_real_expression(self):
-        """``4*M*N`` and ``(2*M*N + N)*elem_bytes`` with M=128, N=256, fp16."""
-        op = _RooflineOp(M=128, N=256, dtype=torch.float16)
-        flops, nbytes = op.eval_roofline()
-        # 4 * 128 * 256 = 131072
-        assert flops == 4 * 128 * 256
-        assert flops == 131072
-        # elem_bytes = 2 (fp16); (2*128*256 + 256) * 2 = 131584
-        elem_bytes = torch.tensor([], dtype=torch.float16).element_size()
-        assert elem_bytes == 2
-        assert nbytes == (2 * 128 * 256 + 256) * 2
-        assert nbytes == 131584
-
-    def test_returns_int_tuple(self):
-        op = _RooflineOp(M=4, N=8, dtype=torch.float32)
-        flops, nbytes = op.eval_roofline()
-        assert isinstance(flops, int)
-        assert isinstance(nbytes, int)
-
-    def test_rejects_non_integral_flops(self):
-        """A fractional result from ``/`` must raise rather than be silently
-        truncated by ``int()``."""
-
-        class _FractionalFlopsOp(_MinimalOp):
-            _flops_expr = "3 / 2"
-            _bytes_expr = "0"
-
-        op = _FractionalFlopsOp(dtype=torch.float16)
-        with pytest.raises(ValueError) as excinfo:
-            op.eval_roofline()
-        assert "non-integral" in str(excinfo.value)
-        assert "flops" in str(excinfo.value)
-
-    def test_rejects_non_integral_bytes(self):
-        class _FractionalBytesOp(_MinimalOp):
-            _flops_expr = "0"
-            _bytes_expr = "5 / 2"
-
-        op = _FractionalBytesOp(dtype=torch.float16)
-        with pytest.raises(ValueError) as excinfo:
-            op.eval_roofline()
-        assert "non-integral" in str(excinfo.value)
-        assert "bytes" in str(excinfo.value)
-
-    def test_accepts_integral_true_division(self):
-        """``/`` is permitted as long as the result is integer-valued."""
-
-        class _IntegralDivOp(_MinimalOp):
-            _flops_expr = "6 / 2"  # -> 3.0, coerced to 3
-            _bytes_expr = "0"
-
-        op = _IntegralDivOp(dtype=torch.float16)
-        flops, nbytes = op.eval_roofline()
-        assert flops == 3
-        assert isinstance(flops, int)
-        assert nbytes == 0
-
-    def test_rejects_negative_result(self):
-        class _NegativeOp(_MinimalOp):
-            _flops_expr = "-1"
-            _bytes_expr = "0"
-
-        op = _NegativeOp(dtype=torch.float16)
-        with pytest.raises(ValueError) as excinfo:
-            op.eval_roofline()
-        assert "negative" in str(excinfo.value)
-
-    def test_elem_bytes_uses_dtype_itemsize_no_tensor_alloc(self, monkeypatch):
-        """``eval_roofline`` derives ``elem_bytes`` from ``dtype.itemsize``
-        and must not allocate a tensor each call."""
-        calls: list[object] = []
-        real_tensor = torch.tensor
-
-        def _spy_tensor(*args, **kwargs):
-            calls.append((args, kwargs))
-            return real_tensor(*args, **kwargs)
-
-        monkeypatch.setattr(torch, "tensor", _spy_tensor)
-        op = _RooflineOp(M=128, N=256, dtype=torch.float16)
-        op.eval_roofline()
-        assert calls == []
-
-
-class TestSafeEval:
-    def test_rejects_non_whitelisted_call(self):
-        """Direct calls to names outside ``_ROOFLINE_SAFE_FUNCTIONS`` are
-        rejected even though ``ast.Call`` is now permitted for
-        ``ceil``/``floor``/``log2``."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("f(1)", {})
-        msg = str(excinfo.value)
-        assert "f" in msg and "forbidden call" in msg
-
-    def test_rejects_attribute_call(self):
-        """``math.ceil(x)`` is rejected because the call target is an
-        attribute access, not a bare name."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("math.ceil(1)", {})
-        assert "call target" in str(excinfo.value)
-
-    def test_rejects_keyword_argument_call(self):
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("ceil(x=1)", {})
-        assert "keyword arguments" in str(excinfo.value)
-
-    def test_accepts_ceil_floor_log2(self):
-        """Whitelisted numeric helpers mirror
-        ``tileops.manifest._safe_eval`` so manifest-side roofline expressions
-        can be spliced into ``_flops_expr`` / ``_bytes_expr`` without
-        translation."""
-        assert _safe_eval("ceil(10 / 3)", {}) == 4
-        assert _safe_eval("floor(10 / 3)", {}) == 3
-        assert _safe_eval("log2(N)", {"N": 8}) == 3.0
-
-    def test_accepts_moe_permute_align_style_expression(self):
-        """Regression test using the shape of
-        ``MoePermuteAlignFwdOp``'s manifest ``roofline.bytes`` expression,
-        which mixes ``ceil(...)``, ``/``, ``+``, and ``*``."""
-        ctx = {
-            "total_tokens": 16,
-            "top_k": 2,
-            "num_experts": 4,
-            "block_size": 8,
-        }
-        # total_tokens*top_k*4 + (total_tokens*top_k + (num_experts+1)*(block_size-1))*4 +
-        # ceil((total_tokens*top_k + (num_experts+1)*(block_size-1)) / block_size)*4 + 4
-        expr = (
-            "total_tokens * top_k * 4 + "
-            "(total_tokens * top_k + (num_experts + 1) * (block_size - 1)) * 4 + "
-            "ceil((total_tokens * top_k + (num_experts + 1) * (block_size - 1))"
-            " / block_size) * 4 + 4")
-        inner = ctx["total_tokens"] * ctx["top_k"] + (ctx["num_experts"] + 1) * (
-            ctx["block_size"] - 1)
-        expected = (ctx["total_tokens"] * ctx["top_k"] * 4 + inner * 4 +
-                    math.ceil(inner / ctx["block_size"]) * 4 + 4)
-        assert _safe_eval(expr, ctx) == expected
-
-    def test_rejects_attribute(self):
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("x.y", {"x": 1})
-        assert "Attribute" in str(excinfo.value)
-
-    def test_rejects_subscript(self):
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("x[0]", {"x": 1})
-        assert "Subscript" in str(excinfo.value)
-
-    def test_rejects_undefined_name(self):
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("missing + 1", {})
-        assert "missing" in str(excinfo.value)
-
-    def test_accepts_basic_arithmetic(self):
-        assert _safe_eval("2 + 3 * 4", {}) == 14
-        assert _safe_eval("-a + b", {"a": 5, "b": 7}) == 2
-        # Integer floor-division and modulus are permitted; true division
-        # stays in the whitelist so eval_roofline can surface non-integral
-        # results as a ValueError (see TestEvalRoofline).
-        assert _safe_eval("10 // 3", {}) == 3
-        assert _safe_eval("10 % 3", {}) == 1
-
-    def test_accepts_pow(self):
-        """``**`` is admitted to match the manifest evaluator. Pathological
-        inputs (fractional / complex / non-finite results) are rejected in
-        depth by ``_coerce_roofline_result`` at the roofline layer; see
-        :class:`TestEvalRoofline`. The raw evaluator just returns a number."""
-        assert _safe_eval("2 ** 10", {}) == 1024
-        assert _safe_eval("N ** 2", {"N": 5}) == 25
-
-    def test_rejects_bool_literal_true(self):
-        """``bool`` subclasses ``int`` in Python; ensure a bare ``True``
-        literal is rejected rather than silently treated as ``1``."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("True", {})
-        assert "bool" in str(excinfo.value)
-
-    def test_rejects_bool_in_binop_left(self):
-        """``False + 1`` must not evaluate to ``1``."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("False + 1", {})
-        assert "bool" in str(excinfo.value)
-
-    def test_rejects_bool_in_binop_right(self):
-        """``1 + True`` must not evaluate to ``2``."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("1 + True", {})
-        assert "bool" in str(excinfo.value)
-
-    def test_rejects_bool_name_binding(self):
-        """Name lookup must reject a ``bool`` ctx binding (subclass of int)."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("x", {"x": True})
-        assert "bool" in str(excinfo.value)
-        assert "'x'" in str(excinfo.value)
-
-    def test_rejects_bool_name_binding_in_binop(self):
-        """``x + 1`` with ``x=True`` must not evaluate to ``2``."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("x + 1", {"x": True})
-        assert "bool" in str(excinfo.value)
-
-    def test_rejects_str_name_binding(self):
-        """Name lookup must reject a non-numeric (e.g. ``str``) binding."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("x", {"x": "3"})
-        assert "str" in str(excinfo.value)
-        assert "'x'" in str(excinfo.value)
-
-
 class TestBaseClassStubs:
     def test_infer_output_shapes_raises_not_implemented(self):
         op = _MinimalOp()
@@ -400,3 +171,14 @@ class TestBaseClassStubs:
             op._validate_dtypes(x)
         assert "docs/ops-design.md" in str(excinfo.value)
         assert "_validate_dtypes" in str(excinfo.value)
+
+    def test_eval_roofline_raises_not_implemented(self):
+        """L1 eval_roofline is a stub; per docs/roofline.md §4.4.6 each
+        concrete op's body is emitted by codegen, not fed through a
+        generic L1 evaluator."""
+        op = _MinimalOp()
+        with pytest.raises(NotImplementedError) as excinfo:
+            op.eval_roofline()
+        msg = str(excinfo.value)
+        assert "docs/roofline.md" in msg
+        assert "eval_roofline" in msg

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -240,6 +240,26 @@ class TestSafeEval:
             _safe_eval("1 + True", {})
         assert "bool" in str(excinfo.value)
 
+    def test_rejects_bool_name_binding(self):
+        """Name lookup must reject a ``bool`` ctx binding (subclass of int)."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("x", {"x": True})
+        assert "bool" in str(excinfo.value)
+        assert "'x'" in str(excinfo.value)
+
+    def test_rejects_bool_name_binding_in_binop(self):
+        """``x + 1`` with ``x=True`` must not evaluate to ``2``."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("x + 1", {"x": True})
+        assert "bool" in str(excinfo.value)
+
+    def test_rejects_str_name_binding(self):
+        """Name lookup must reject a non-numeric (e.g. ``str``) binding."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("x", {"x": "3"})
+        assert "str" in str(excinfo.value)
+        assert "'x'" in str(excinfo.value)
+
 
 class TestBaseClassStubs:
     def test_infer_output_shapes_raises_not_implemented(self):

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -1,20 +1,12 @@
 """Tests for tileops.ops.op_base.
 
-Covers:
-- ``Op._cache_key`` default behavior and runtime warnings for missing
-  subclass overrides when ``_static_axes`` is empty.
-- L1 stubs for ``_infer_output_shapes`` / ``_validate_dtypes`` /
-  ``eval_roofline`` that raise :class:`NotImplementedError` pointing at the
-  design docs. Per docs/roofline.md §4.4.6, the L1 base deliberately does
-  not provide a generic roofline evaluator — each op's ``eval_roofline``
-  body is emitted by codegen as plain Python.
+Covers ``Op._cache_key`` default behavior and the runtime warning fired when
+a subclass with empty ``_static_axes`` does not override ``_cache_key``.
 """
 
 import warnings
-from typing import Dict
 
 import pytest
-import torch
 
 from tileops.ops import op_base
 from tileops.ops.op_base import Op
@@ -131,54 +123,3 @@ class TestCacheKeyWarning:
 
         user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
         assert len(user_warnings) == 2
-
-
-# ---------------------------------------------------------------------------
-# L1 codegen contract: eval_roofline, _safe_eval, NotImplementedError stubs
-# ---------------------------------------------------------------------------
-
-
-class _MinimalOp(Op):
-    """Smallest Op subclass that can be instantiated.
-
-    Implements only the strictly-abstract members so tests can exercise
-    base-class behavior without pulling any kernel code.
-    """
-
-    def __init__(self, *, dtype=None):
-        self.dtype = dtype
-
-    @property
-    def default_kernel_map(self) -> Dict[str, object]:  # pragma: no cover - unused
-        return {}
-
-    def forward(self, *args, **kwargs):  # pragma: no cover - unused
-        return None
-
-
-class TestBaseClassStubs:
-    def test_infer_output_shapes_raises_not_implemented(self):
-        op = _MinimalOp()
-        with pytest.raises(NotImplementedError) as excinfo:
-            op._infer_output_shapes()
-        assert "docs/ops-design.md" in str(excinfo.value)
-        assert "_infer_output_shapes" in str(excinfo.value)
-
-    def test_validate_dtypes_raises_not_implemented(self):
-        op = _MinimalOp()
-        x = torch.empty(1)
-        with pytest.raises(NotImplementedError) as excinfo:
-            op._validate_dtypes(x)
-        assert "docs/ops-design.md" in str(excinfo.value)
-        assert "_validate_dtypes" in str(excinfo.value)
-
-    def test_eval_roofline_raises_not_implemented(self):
-        """L1 eval_roofline is a stub; per docs/roofline.md §4.4.6 each
-        concrete op's body is emitted by codegen, not fed through a
-        generic L1 evaluator."""
-        op = _MinimalOp()
-        with pytest.raises(NotImplementedError) as excinfo:
-            op.eval_roofline()
-        msg = str(excinfo.value)
-        assert "docs/roofline.md" in msg
-        assert "eval_roofline" in msg

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -194,6 +194,69 @@ class TestEvalRoofline:
         assert isinstance(flops, int)
         assert isinstance(nbytes, int)
 
+    def test_rejects_non_integral_flops(self):
+        """A fractional result from ``/`` must raise rather than be silently
+        truncated by ``int()``."""
+
+        class _FractionalFlopsOp(_MinimalOp):
+            _flops_expr = "3 / 2"
+            _bytes_expr = "0"
+
+        op = _FractionalFlopsOp(dtype=torch.float16)
+        with pytest.raises(ValueError) as excinfo:
+            op.eval_roofline()
+        assert "non-integral" in str(excinfo.value)
+        assert "flops" in str(excinfo.value)
+
+    def test_rejects_non_integral_bytes(self):
+        class _FractionalBytesOp(_MinimalOp):
+            _flops_expr = "0"
+            _bytes_expr = "5 / 2"
+
+        op = _FractionalBytesOp(dtype=torch.float16)
+        with pytest.raises(ValueError) as excinfo:
+            op.eval_roofline()
+        assert "non-integral" in str(excinfo.value)
+        assert "bytes" in str(excinfo.value)
+
+    def test_accepts_integral_true_division(self):
+        """``/`` is permitted as long as the result is integer-valued."""
+
+        class _IntegralDivOp(_MinimalOp):
+            _flops_expr = "6 / 2"  # -> 3.0, coerced to 3
+            _bytes_expr = "0"
+
+        op = _IntegralDivOp(dtype=torch.float16)
+        flops, nbytes = op.eval_roofline()
+        assert flops == 3
+        assert isinstance(flops, int)
+        assert nbytes == 0
+
+    def test_rejects_negative_result(self):
+        class _NegativeOp(_MinimalOp):
+            _flops_expr = "-1"
+            _bytes_expr = "0"
+
+        op = _NegativeOp(dtype=torch.float16)
+        with pytest.raises(ValueError) as excinfo:
+            op.eval_roofline()
+        assert "negative" in str(excinfo.value)
+
+    def test_elem_bytes_uses_dtype_itemsize_no_tensor_alloc(self, monkeypatch):
+        """``eval_roofline`` derives ``elem_bytes`` from ``dtype.itemsize``
+        and must not allocate a tensor each call."""
+        calls: list[object] = []
+        real_tensor = torch.tensor
+
+        def _spy_tensor(*args, **kwargs):
+            calls.append((args, kwargs))
+            return real_tensor(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "tensor", _spy_tensor)
+        op = _RooflineOp(M=128, N=256, dtype=torch.float16)
+        op.eval_roofline()
+        assert calls == []
+
 
 class TestSafeEval:
     def test_rejects_call(self):
@@ -219,7 +282,24 @@ class TestSafeEval:
     def test_accepts_basic_arithmetic(self):
         assert _safe_eval("2 + 3 * 4", {}) == 14
         assert _safe_eval("-a + b", {"a": 5, "b": 7}) == 2
-        assert _safe_eval("2 ** 10", {}) == 1024
+        # Integer floor-division and modulus are permitted; true division
+        # stays in the whitelist so eval_roofline can surface non-integral
+        # results as a ValueError (see TestEvalRoofline).
+        assert _safe_eval("10 // 3", {}) == 3
+        assert _safe_eval("10 % 3", {}) == 1
+
+    def test_rejects_pow(self):
+        """``**`` is excluded from the whitelist: it permits unbounded
+        allocation (``10 ** 10 ** N``) and complex results
+        (``(-1) ** 0.5``) in what is advertised as a *safe* evaluator."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("2 ** 10", {})
+        assert "Pow" in str(excinfo.value)
+
+    def test_rejects_pow_even_with_name(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("(-1) ** 0.5", {})
+        assert "Pow" in str(excinfo.value)
 
     def test_rejects_bool_literal_true(self):
         """``bool`` subclasses ``int`` in Python; ensure a bare ``True``

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -10,6 +10,7 @@ Covers:
   raise :class:`NotImplementedError` pointing at the design doc.
 """
 
+import math
 import warnings
 from typing import Dict
 
@@ -259,10 +260,58 @@ class TestEvalRoofline:
 
 
 class TestSafeEval:
-    def test_rejects_call(self):
+    def test_rejects_non_whitelisted_call(self):
+        """Direct calls to names outside ``_ROOFLINE_SAFE_FUNCTIONS`` are
+        rejected even though ``ast.Call`` is now permitted for
+        ``ceil``/``floor``/``log2``."""
         with pytest.raises(ValueError) as excinfo:
             _safe_eval("f(1)", {})
-        assert "Call" in str(excinfo.value)
+        msg = str(excinfo.value)
+        assert "f" in msg and "forbidden call" in msg
+
+    def test_rejects_attribute_call(self):
+        """``math.ceil(x)`` is rejected because the call target is an
+        attribute access, not a bare name."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("math.ceil(1)", {})
+        assert "call target" in str(excinfo.value)
+
+    def test_rejects_keyword_argument_call(self):
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("ceil(x=1)", {})
+        assert "keyword arguments" in str(excinfo.value)
+
+    def test_accepts_ceil_floor_log2(self):
+        """Whitelisted numeric helpers mirror
+        ``tileops.manifest._safe_eval`` so manifest-side roofline expressions
+        can be spliced into ``_flops_expr`` / ``_bytes_expr`` without
+        translation."""
+        assert _safe_eval("ceil(10 / 3)", {}) == 4
+        assert _safe_eval("floor(10 / 3)", {}) == 3
+        assert _safe_eval("log2(N)", {"N": 8}) == 3.0
+
+    def test_accepts_moe_permute_align_style_expression(self):
+        """Regression test using the shape of
+        ``MoePermuteAlignFwdOp``'s manifest ``roofline.bytes`` expression,
+        which mixes ``ceil(...)``, ``/``, ``+``, and ``*``."""
+        ctx = {
+            "total_tokens": 16,
+            "top_k": 2,
+            "num_experts": 4,
+            "block_size": 8,
+        }
+        # total_tokens*top_k*4 + (total_tokens*top_k + (num_experts+1)*(block_size-1))*4 +
+        # ceil((total_tokens*top_k + (num_experts+1)*(block_size-1)) / block_size)*4 + 4
+        expr = (
+            "total_tokens * top_k * 4 + "
+            "(total_tokens * top_k + (num_experts + 1) * (block_size - 1)) * 4 + "
+            "ceil((total_tokens * top_k + (num_experts + 1) * (block_size - 1))"
+            " / block_size) * 4 + 4")
+        inner = ctx["total_tokens"] * ctx["top_k"] + (ctx["num_experts"] + 1) * (
+            ctx["block_size"] - 1)
+        expected = (ctx["total_tokens"] * ctx["top_k"] * 4 + inner * 4 +
+                    math.ceil(inner / ctx["block_size"]) * 4 + 4)
+        assert _safe_eval(expr, ctx) == expected
 
     def test_rejects_attribute(self):
         with pytest.raises(ValueError) as excinfo:
@@ -288,18 +337,13 @@ class TestSafeEval:
         assert _safe_eval("10 // 3", {}) == 3
         assert _safe_eval("10 % 3", {}) == 1
 
-    def test_rejects_pow(self):
-        """``**`` is excluded from the whitelist: it permits unbounded
-        allocation (``10 ** 10 ** N``) and complex results
-        (``(-1) ** 0.5``) in what is advertised as a *safe* evaluator."""
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("2 ** 10", {})
-        assert "Pow" in str(excinfo.value)
-
-    def test_rejects_pow_even_with_name(self):
-        with pytest.raises(ValueError) as excinfo:
-            _safe_eval("(-1) ** 0.5", {})
-        assert "Pow" in str(excinfo.value)
+    def test_accepts_pow(self):
+        """``**`` is admitted to match the manifest evaluator. Pathological
+        inputs (fractional / complex / non-finite results) are rejected in
+        depth by ``_coerce_roofline_result`` at the roofline layer; see
+        :class:`TestEvalRoofline`. The raw evaluator just returns a number."""
+        assert _safe_eval("2 ** 10", {}) == 1024
+        assert _safe_eval("N ** 2", {"N": 5}) == 25
 
     def test_rejects_bool_literal_true(self):
         """``bool`` subclasses ``int`` in Python; ensure a bare ``True``

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -221,6 +221,25 @@ class TestSafeEval:
         assert _safe_eval("-a + b", {"a": 5, "b": 7}) == 2
         assert _safe_eval("2 ** 10", {}) == 1024
 
+    def test_rejects_bool_literal_true(self):
+        """``bool`` subclasses ``int`` in Python; ensure a bare ``True``
+        literal is rejected rather than silently treated as ``1``."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("True", {})
+        assert "bool" in str(excinfo.value)
+
+    def test_rejects_bool_in_binop_left(self):
+        """``False + 1`` must not evaluate to ``1``."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("False + 1", {})
+        assert "bool" in str(excinfo.value)
+
+    def test_rejects_bool_in_binop_right(self):
+        """``1 + True`` must not evaluate to ``2``."""
+        with pytest.raises(ValueError) as excinfo:
+            _safe_eval("1 + True", {})
+        assert "bool" in str(excinfo.value)
+
 
 class TestBaseClassStubs:
     def test_infer_output_shapes_raises_not_implemented(self):

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -2,7 +2,7 @@ import ast
 import math
 import warnings
 from abc import ABC, abstractmethod
-from typing import Hashable, Optional, Union
+from typing import Callable, Hashable, Optional, Union
 
 import torch
 
@@ -12,8 +12,11 @@ from tileops.utils import get_sm_version
 # Module-level dedup for empty-static_dims warnings; keyed by Op subclass.
 _EMPTY_STATIC_DIMS_WARNED: set = set()
 
-# Whitelist of AST nodes permitted in roofline expressions.
-# Explicitly excludes Call, Attribute, Subscript, Lambda, Comprehension, etc.
+# Whitelist of AST nodes permitted in roofline expressions. This mirrors the
+# manifest-level evaluator in ``tileops.manifest._safe_eval`` so that any
+# expression accepted by the manifest schema (and therefore any expression
+# codegen may splice into ``_flops_expr`` / ``_bytes_expr``) is also accepted
+# here. Explicitly excludes Attribute, Subscript, Lambda, Comprehension, etc.
 #
 # ``ast.Num`` is a deprecated alias of ``ast.Constant`` on every supported
 # Python (3.8+) — AC-4's back-compat requirement for ``ast.Num`` is satisfied
@@ -22,26 +25,37 @@ _EMPTY_STATIC_DIMS_WARNED: set = set()
 # to avoid the Python 3.12+ DeprecationWarning that would fire at isinstance()
 # time; the whitelist is evaluated on the recursive AST walk hot path.
 #
-# ``ast.Pow`` is intentionally excluded: roofline formulas are integer
-# polynomials in the static dimensions, so exponentiation is never needed,
-# and permitting it exposes the safe evaluator to unbounded CPU/memory (e.g.
-# ``10 ** 10 ** N``) and to complex results (e.g. ``(-1) ** 0.5``). If a
-# future op genuinely needs a power, it should compute it in Python and
-# pass the result in via ``_roofline_vars`` rather than encoded in the
-# expression string.
+# ``ast.Call`` is accepted but constrained to a narrow whitelist of numeric
+# helpers (see ``_ROOFLINE_SAFE_FUNCTIONS``); attribute-call syntax
+# (``math.ceil(x)``) and keyword/star arguments are rejected in the Call
+# branch of ``_walk`` below.
+#
+# ``ast.Pow`` is accepted to match the manifest evaluator, which admits it for
+# the rare formula that needs an exponent. Unbounded inputs (``10 ** 10 ** N``)
+# and fractional/complex results (``(-1) ** 0.5``) are defended in depth by
+# ``_coerce_roofline_result`` which rejects non-finite / non-integral /
+# negative final outputs.
+_ROOFLINE_SAFE_FUNCTIONS: dict[str, Callable[..., Union[int, float]]] = {
+    "log2": math.log2,
+    "ceil": math.ceil,
+    "floor": math.floor,
+}
+
 _SAFE_AST_NODES: tuple[type, ...] = (
     ast.Expression,
     ast.BinOp,
     ast.UnaryOp,
     ast.Constant,  # covers legacy ast.Num (alias on Python 3.8+)
     ast.Name,
-    # Arithmetic operators (Pow deliberately omitted; see comment above).
+    ast.Call,  # restricted to _ROOFLINE_SAFE_FUNCTIONS in _walk
+    # Arithmetic operators
     ast.Add,
     ast.Sub,
     ast.Mult,
     ast.Div,
     ast.FloorDiv,
     ast.Mod,
+    ast.Pow,
     # Unary operators
     ast.UAdd,
     ast.USub,
@@ -128,9 +142,31 @@ def _safe_eval(expr: str, ctx: dict[str, Union[int, float]]) -> Union[int, float
                 return left // right
             if isinstance(op, ast.Mod):
                 return left % right
+            if isinstance(op, ast.Pow):
+                return left**right
             raise ValueError(
                 f"forbidden binary operator {type(op).__name__} in "
                 f"roofline expression {expr!r}")
+        if isinstance(node, ast.Call):
+            # Only allow direct calls to whitelisted name callables, mirroring
+            # ``tileops.manifest._safe_eval``. Reject attribute-call syntax
+            # (``math.ceil(x)``) and any keyword / star arguments.
+            if not isinstance(node.func, ast.Name):
+                raise ValueError(
+                    f"forbidden call target in roofline expression {expr!r}; "
+                    f"only direct calls to whitelisted functions are permitted")
+            func_name = node.func.id
+            if func_name not in _ROOFLINE_SAFE_FUNCTIONS:
+                raise ValueError(
+                    f"forbidden call to {func_name!r} in roofline expression "
+                    f"{expr!r}; allowed functions: "
+                    f"{sorted(_ROOFLINE_SAFE_FUNCTIONS)}")
+            if node.keywords:
+                raise ValueError(
+                    f"keyword arguments are not permitted in roofline "
+                    f"expression {expr!r}")
+            args = [_walk(a) for a in node.args]
+            return _ROOFLINE_SAFE_FUNCTIONS[func_name](*args)
         # Unreachable: _SAFE_AST_NODES gate above covers every handled type.
         raise ValueError(  # pragma: no cover - defensive
             f"unhandled AST node {type(node).__name__} in roofline expression {expr!r}")
@@ -304,10 +340,16 @@ class Op(ABC):
             ctx["elem_bytes"] = self.dtype.itemsize
         else:
             ctx["elem_bytes"] = 0
-        flops = _coerce_roofline_result("flops", self._flops_expr,
-                                        _safe_eval(self._flops_expr, ctx))
-        nbytes = _coerce_roofline_result("bytes", self._bytes_expr,
-                                         _safe_eval(self._bytes_expr, ctx))
+        flops = _coerce_roofline_result(
+            "flops",
+            self._flops_expr,
+            _safe_eval(self._flops_expr, ctx),
+        )
+        nbytes = _coerce_roofline_result(
+            "bytes",
+            self._bytes_expr,
+            _safe_eval(self._bytes_expr, ctx),
+        )
         return flops, nbytes
 
     def dispatch_kernel(self, kernel_map: Optional[dict[str, Kernel]] = None) -> None:

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -1,7 +1,8 @@
 import ast
+import math
 import warnings
 from abc import ABC, abstractmethod
-from typing import Dict, FrozenSet, Hashable, List, Optional, Tuple, Union
+from typing import Hashable, Optional, Union
 
 import torch
 
@@ -20,27 +21,34 @@ _EMPTY_STATIC_DIMS_WARNED: set = set()
 # also an ``ast.Constant``. We intentionally omit ``ast.Num`` from the tuple
 # to avoid the Python 3.12+ DeprecationWarning that firing at isinstance()
 # time; the whitelist is evaluated on the recursive AST walk hot path.
-_SAFE_AST_NODES: Tuple[type, ...] = (
+#
+# ``ast.Pow`` is intentionally excluded: roofline formulas are integer
+# polynomials in the static dimensions, so exponentiation is never needed,
+# and permitting it exposes the safe evaluator to unbounded CPU/memory (e.g.
+# ``10 ** 10 ** N``) and to complex results (e.g. ``(-1) ** 0.5``). If a
+# future op genuinely needs a power, it should compute it in Python and
+# pass the result in via ``_roofline_vars`` rather than encoded in the
+# expression string.
+_SAFE_AST_NODES: tuple[type, ...] = (
     ast.Expression,
     ast.BinOp,
     ast.UnaryOp,
     ast.Constant,  # covers legacy ast.Num (alias on Python 3.8+)
     ast.Name,
-    # Arithmetic operators
+    # Arithmetic operators (Pow deliberately omitted; see comment above).
     ast.Add,
     ast.Sub,
     ast.Mult,
     ast.Div,
     ast.FloorDiv,
     ast.Mod,
-    ast.Pow,
     # Unary operators
     ast.UAdd,
     ast.USub,
 )
 
 
-def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float]:
+def _safe_eval(expr: str, ctx: dict[str, Union[int, float]]) -> Union[int, float]:
     """Evaluate an arithmetic expression against ``ctx`` using a whitelist AST walker.
 
     Only binary/unary arithmetic on numeric constants and names resolved from
@@ -120,8 +128,6 @@ def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float
                 return left // right
             if isinstance(op, ast.Mod):
                 return left % right
-            if isinstance(op, ast.Pow):
-                return left**right
             raise ValueError(
                 f"forbidden binary operator {type(op).__name__} in "
                 f"roofline expression {expr!r}")
@@ -130,6 +136,40 @@ def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float
             f"unhandled AST node {type(node).__name__} in roofline expression {expr!r}")
 
     return _walk(tree)
+
+
+def _coerce_roofline_result(kind: str, expr: str, value: Union[int, float]) -> int:
+    """Validate that a roofline expression result is a finite, non-negative integer.
+
+    ``_safe_eval`` returns ``int`` or ``float`` depending on the operators used
+    in the expression (``/`` promotes to ``float``). FLOPs and bytes counts
+    are inherently non-negative integers, so we refuse to silently truncate
+    fractional values or accept ``inf``/``nan`` via ``int()``. A mismatch
+    typically indicates a bug in the expression (e.g. ``3 * M / 2`` where
+    ``M`` is odd).
+    """
+    if isinstance(value, bool):  # defense in depth; _safe_eval already rejects
+        raise ValueError(
+            f"roofline {kind} expression {expr!r} evaluated to a bool, expected int")
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(
+                f"roofline {kind} expression {expr!r} evaluated to non-finite "
+                f"{value!r}, expected a finite integer")
+        if not value.is_integer():
+            raise ValueError(
+                f"roofline {kind} expression {expr!r} evaluated to non-integral "
+                f"{value!r}; use // or integer-valued subexpressions instead of /")
+        value = int(value)
+    if not isinstance(value, int):  # pragma: no cover - defensive
+        raise ValueError(
+            f"roofline {kind} expression {expr!r} evaluated to unexpected type "
+            f"{type(value).__name__}")
+    if value < 0:
+        raise ValueError(
+            f"roofline {kind} expression {expr!r} evaluated to negative value "
+            f"{value!r}; flops and bytes counts must be non-negative")
+    return value
 
 
 class Op(ABC):
@@ -163,7 +203,7 @@ class Op(ABC):
     """
 
     kernel: Kernel
-    kernel_map: Optional[Dict[str, Kernel]] = None
+    kernel_map: Optional[dict[str, Kernel]] = None
     dtype: Optional[torch.dtype] = None
     device: Optional[Union[torch.device, str]] = 'cuda'
     input_shapes: Optional[list[tuple]] = None
@@ -172,22 +212,22 @@ class Op(ABC):
     # `input_index` is the position in *input_shapes; `axis` is a non-negative
     # axis index within that shape. Subclasses set this to reflect their
     # manifest `static_dims`. Default empty = no committed axes.
-    _static_axes: FrozenSet[Tuple[int, int]] = frozenset()
+    _static_axes: frozenset[tuple[int, int]] = frozenset()
 
     # Roofline evaluation slots (see docs/ops-design.md §`eval_roofline`).
     # Concrete ops override these as class-level declarations; `eval_roofline`
     # reads them and evaluates the expressions via `_safe_eval`. Defaults
     # produce `(0, 0)` — a transitional escape hatch for ops not yet migrated.
-    _roofline_vars: List[str] = []
+    _roofline_vars: list[str] = []
     _flops_expr: str = "0"
     _bytes_expr: str = "0"
 
     @property
     @abstractmethod
-    def default_kernel_map(self) -> Dict[str, Kernel]:
+    def default_kernel_map(self) -> dict[str, Kernel]:
         raise NotImplementedError("Op must implement default_kernel_map")
 
-    def _infer_output_shapes(self, **shape_kwargs: Tuple[int, ...]) -> Dict[str, tuple]:
+    def _infer_output_shapes(self, **shape_kwargs: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
         """Infer output tensor shapes from input shapes.
 
         Concrete ops override this with a signature matching the named input
@@ -237,7 +277,7 @@ class Op(ABC):
             "_validate_dtypes must be implemented by the concrete Op subclass; "
             "see docs/ops-design.md §`_validate_dtypes` (codegen)")
 
-    def eval_roofline(self) -> Tuple[int, int]:
+    def eval_roofline(self) -> tuple[int, int]:
         """Evaluate (flops, bytes) from class-level roofline slots.
 
         Reads ``_roofline_vars`` (list of attribute names on ``self``) plus a
@@ -245,22 +285,32 @@ class Op(ABC):
         ``_flops_expr`` and ``_bytes_expr`` via the whitelist AST evaluator
         :func:`_safe_eval`. Returns integer ``(flops, bytes)``.
 
+        Results must be finite, non-negative, and integer-valued; a non-
+        integral or non-finite value (e.g. from a stray ``/`` that does not
+        divide evenly) raises :class:`ValueError` instead of being silently
+        truncated by ``int()``.
+
         When the class-level slots are at defaults, returns ``(0, 0)`` — a
         transitional default for ops not yet migrated. See
         docs/ops-design.md §``eval_roofline``.
         """
-        ctx: Dict[str, Union[int, float]] = {}
+        ctx: dict[str, Union[int, float]] = {}
         for name in self._roofline_vars:
             ctx[name] = getattr(self, name)
         if self.dtype is not None:
-            ctx["elem_bytes"] = torch.tensor([], dtype=self.dtype).element_size()
+            # ``torch.dtype.itemsize`` is the byte width of a scalar element
+            # and matches ``torch.tensor([], dtype=self.dtype).element_size()``
+            # without allocating an empty tensor on every eval_roofline call.
+            ctx["elem_bytes"] = self.dtype.itemsize
         else:
             ctx["elem_bytes"] = 0
-        flops = _safe_eval(self._flops_expr, ctx)
-        nbytes = _safe_eval(self._bytes_expr, ctx)
-        return int(flops), int(nbytes)
+        flops = _coerce_roofline_result("flops", self._flops_expr,
+                                        _safe_eval(self._flops_expr, ctx))
+        nbytes = _coerce_roofline_result("bytes", self._bytes_expr,
+                                         _safe_eval(self._bytes_expr, ctx))
+        return flops, nbytes
 
-    def dispatch_kernel(self, kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
+    def dispatch_kernel(self, kernel_map: Optional[dict[str, Kernel]] = None) -> None:
         if self.default_kernel_map is None or len(self.default_kernel_map) == 0:
             raise ValueError("default_kernel_map must be non-empty")
         self.kernel_map = {}
@@ -283,14 +333,14 @@ class Op(ABC):
                 attr.autotune()
 
     @abstractmethod
-    def forward(self, *args: object, **kwargs: object) -> Union[torch.Tensor, Tuple]:
+    def forward(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:
         raise NotImplementedError("forward method is not implemented")
 
-    def __call__(self, *args: object, **kwargs: object) -> Union[torch.Tensor, Tuple]:
+    def __call__(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:
         """Make the op callable - delegates to forward()"""
         return self.forward(*args, **kwargs)
 
-    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+    def _cache_key(self, *input_shapes: tuple[int, ...]) -> Hashable:
         """Return a cache key for kernel dispatch given forward-time input shapes.
 
         Default implementation returns the tuple of non-static-axis sizes across

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -19,7 +19,7 @@ _EMPTY_STATIC_DIMS_WARNED: set = set()
 # Python (3.8+) — AC-4's back-compat requirement for ``ast.Num`` is satisfied
 # by accepting ``ast.Constant``, since any legacy ``ast.Num`` node instance is
 # also an ``ast.Constant``. We intentionally omit ``ast.Num`` from the tuple
-# to avoid the Python 3.12+ DeprecationWarning that firing at isinstance()
+# to avoid the Python 3.12+ DeprecationWarning that would fire at isinstance()
 # time; the whitelist is evaluated on the recursive AST walk hot path.
 #
 # ``ast.Pow`` is intentionally excluded: roofline formulas are integer

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -1,6 +1,7 @@
+import ast
 import warnings
 from abc import ABC, abstractmethod
-from typing import Dict, FrozenSet, Hashable, Optional, Tuple, Union
+from typing import Dict, FrozenSet, Hashable, List, Optional, Tuple, Union
 
 import torch
 
@@ -9,6 +10,121 @@ from tileops.utils import get_sm_version
 
 # Module-level dedup for empty-static_dims warnings; keyed by Op subclass.
 _EMPTY_STATIC_DIMS_WARNED: set = set()
+
+# ``ast.Num`` is a deprecated alias (Python 3.8+) that becomes ``ast.Constant``
+# under the hood; AC-4 requires the roofline evaluator to accept legacy
+# ``Num`` nodes for back-compat. Resolve it here without triggering the
+# Python 3.12+ DeprecationWarning, and omit it from the whitelist tuple when
+# ``ast.Constant`` already covers it (which is true on every supported Python).
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    _AST_NUM: type = getattr(ast, "Num", ast.Constant)
+
+# Whitelist of AST nodes permitted in roofline expressions.
+# Explicitly excludes Call, Attribute, Subscript, Lambda, Comprehension, etc.
+# ``ast.Num`` nodes (legacy) are instances of ``ast.Constant`` on Python 3.8+,
+# so they pass the Constant gate without needing a separate whitelist entry.
+_SAFE_AST_NODES: Tuple[type, ...] = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Constant,
+    _AST_NUM,  # ast.Num (back-compat); subclass of Constant on Python 3.8+
+    ast.Name,
+    ast.Load,
+    # Arithmetic operators
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+    # Unary operators
+    ast.UAdd,
+    ast.USub,
+)
+
+
+def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float]:
+    """Evaluate an arithmetic expression against ``ctx`` using a whitelist AST walker.
+
+    Only binary/unary arithmetic on numeric constants and names resolved from
+    ``ctx`` is permitted. Function calls, attribute access, subscripts, lambdas,
+    comprehensions, and any other node type raise :class:`ValueError` naming
+    the forbidden node.
+
+    This is the roofline evaluator referenced by :meth:`Op.eval_roofline`; it
+    intentionally avoids :func:`eval` / :func:`exec` and any third-party
+    expression evaluator.
+    """
+    try:
+        tree = ast.parse(expr, mode='eval')
+    except SyntaxError as e:
+        raise ValueError(f"invalid roofline expression {expr!r}: {e}") from e
+
+    def _walk(node: ast.AST) -> Union[int, float]:
+        # Suppress the Python 3.12+ DeprecationWarning triggered by ast.Num
+        # appearing inside the isinstance tuple. The ast.Num entry is a legacy
+        # alias of ast.Constant on all supported Pythons; keeping it in the
+        # whitelist matches AC-4 and the design doc without changing behavior.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            permitted = isinstance(node, _SAFE_AST_NODES)
+        if not permitted:
+            raise ValueError(
+                f"forbidden AST node {type(node).__name__} in roofline expression "
+                f"{expr!r}; only arithmetic over Name/Constant is permitted")
+        if isinstance(node, ast.Expression):
+            return _walk(node.body)
+        if isinstance(node, ast.Constant):
+            if not isinstance(node.value, (int, float)):
+                raise ValueError(
+                    f"forbidden constant type {type(node.value).__name__} in "
+                    f"roofline expression {expr!r}")
+            return node.value
+        # Note: on Python 3.8+, ``ast.Num`` nodes are instances of
+        # ``ast.Constant`` and are handled by the Constant branch above.
+        if isinstance(node, ast.Name):
+            if node.id not in ctx:
+                raise ValueError(
+                    f"undefined name {node.id!r} in roofline expression {expr!r}")
+            return ctx[node.id]
+        if isinstance(node, ast.UnaryOp):
+            operand = _walk(node.operand)
+            if isinstance(node.op, ast.UAdd):
+                return +operand
+            if isinstance(node.op, ast.USub):
+                return -operand
+            raise ValueError(
+                f"forbidden unary operator {type(node.op).__name__} in "
+                f"roofline expression {expr!r}")
+        if isinstance(node, ast.BinOp):
+            left = _walk(node.left)
+            right = _walk(node.right)
+            op = node.op
+            if isinstance(op, ast.Add):
+                return left + right
+            if isinstance(op, ast.Sub):
+                return left - right
+            if isinstance(op, ast.Mult):
+                return left * right
+            if isinstance(op, ast.Div):
+                return left / right
+            if isinstance(op, ast.FloorDiv):
+                return left // right
+            if isinstance(op, ast.Mod):
+                return left % right
+            if isinstance(op, ast.Pow):
+                return left**right
+            raise ValueError(
+                f"forbidden binary operator {type(op).__name__} in "
+                f"roofline expression {expr!r}")
+        # Unreachable: _SAFE_AST_NODES gate above covers every handled type.
+        raise ValueError(  # pragma: no cover - defensive
+            f"unhandled AST node {type(node).__name__} in roofline expression {expr!r}")
+
+    return _walk(tree)
 
 
 class Op(ABC):
@@ -53,10 +169,91 @@ class Op(ABC):
     # manifest `static_dims`. Default empty = no committed axes.
     _static_axes: FrozenSet[Tuple[int, int]] = frozenset()
 
+    # Roofline evaluation slots (see docs/ops-design.md §`eval_roofline`).
+    # Concrete ops override these as class-level declarations; `eval_roofline`
+    # reads them and evaluates the expressions via `_safe_eval`. Defaults
+    # produce `(0, 0)` — a transitional escape hatch for ops not yet migrated.
+    _roofline_vars: List[str] = []
+    _flops_expr: str = "0"
+    _bytes_expr: str = "0"
+
     @property
     @abstractmethod
     def default_kernel_map(self) -> Dict[str, Kernel]:
         raise NotImplementedError("Op must implement default_kernel_map")
+
+    def _infer_output_shapes(self, **shape_kwargs: Tuple[int, ...]) -> Dict[str, tuple]:
+        """Infer output tensor shapes from input shapes.
+
+        Concrete ops override this with a signature matching the named input
+        shapes declared in their manifest ``shape_rules`` section (e.g.
+        ``_infer_output_shapes(self, x_shape, weight_shape)``). The uniform
+        ``**shape_kwargs`` base signature exists only to make the L1 contract
+        grepable and discoverable; see docs/ops-design.md §``_infer_output_shapes``.
+        """
+        # FIXME(staged-rollout): L1 Op does not yet strictly enforce _infer_output_shapes
+        # via @abstractmethod; base raises NotImplementedError instead.
+        #
+        # Broken invariant: L1 base does not strictly enforce implementation
+        #     of _infer_output_shapes on every concrete Op subclass.
+        # Why: Introducing @abstractmethod now would break all existing concrete
+        #     ops under tileops/ops/ that have not yet been migrated to the spec
+        #     in docs/ops-design.md; the trust model requires a separate
+        #     per-op migration PR.
+        # Cleanup: once all concrete ops under tileops/ops/ implement both
+        #     _infer_output_shapes and _validate_dtypes, convert this stub
+        #     (and _validate_dtypes below) to `@abstractmethod` and remove the
+        #     default class-level _roofline_vars/_flops_expr/_bytes_expr
+        #     transitional defaults.
+        raise NotImplementedError(
+            "_infer_output_shapes must be implemented by the concrete Op subclass; "
+            "see docs/ops-design.md §`_infer_output_shapes` (codegen)")
+
+    def _validate_dtypes(self, *args: torch.Tensor) -> None:
+        """Validate dtypes of input tensors passed to ``forward``.
+
+        Concrete ops override this with a signature matching their manifest
+        ``signature.inputs`` (e.g. ``_validate_dtypes(self, x, weight)``).
+        See docs/ops-design.md §``_validate_dtypes``.
+        """
+        # FIXME(staged-rollout): L1 Op does not yet strictly enforce _validate_dtypes
+        # via @abstractmethod; base raises NotImplementedError instead.
+        #
+        # Broken invariant: L1 base does not strictly enforce implementation
+        #     of _validate_dtypes on every concrete Op subclass.
+        # Why: Introducing @abstractmethod now would break all existing concrete
+        #     ops under tileops/ops/ that have not yet been migrated to the spec
+        #     in docs/ops-design.md; the trust model requires a separate
+        #     per-op migration PR.
+        # Cleanup: once all concrete ops under tileops/ops/ implement both
+        #     _infer_output_shapes and _validate_dtypes, convert this stub
+        #     (and _infer_output_shapes above) to `@abstractmethod`.
+        raise NotImplementedError(
+            "_validate_dtypes must be implemented by the concrete Op subclass; "
+            "see docs/ops-design.md §`_validate_dtypes` (codegen)")
+
+    def eval_roofline(self) -> Tuple[int, int]:
+        """Evaluate (flops, bytes) from class-level roofline slots.
+
+        Reads ``_roofline_vars`` (list of attribute names on ``self``) plus a
+        derived ``elem_bytes`` from ``self.dtype``, then evaluates
+        ``_flops_expr`` and ``_bytes_expr`` via the whitelist AST evaluator
+        :func:`_safe_eval`. Returns integer ``(flops, bytes)``.
+
+        When the class-level slots are at defaults, returns ``(0, 0)`` — a
+        transitional default for ops not yet migrated. See
+        docs/ops-design.md §``eval_roofline``.
+        """
+        ctx: Dict[str, Union[int, float]] = {}
+        for name in self._roofline_vars:
+            ctx[name] = getattr(self, name)
+        if self.dtype is not None:
+            ctx["elem_bytes"] = torch.tensor([], dtype=self.dtype).element_size()
+        else:
+            ctx["elem_bytes"] = 0
+        flops = _safe_eval(self._flops_expr, ctx)
+        nbytes = _safe_eval(self._bytes_expr, ctx)
+        return int(flops), int(nbytes)
 
     def dispatch_kernel(self, kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
         if self.default_kernel_map is None or len(self.default_kernel_map) == 0:

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -84,7 +84,17 @@ def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float
             if node.id not in ctx:
                 raise ValueError(
                     f"undefined name {node.id!r} in roofline expression {expr!r}")
-            return ctx[node.id]
+            value = ctx[node.id]
+            # Mirror the Constant branch: ``bool`` is a subclass of ``int``,
+            # so explicitly reject it, then require int/float. This prevents
+            # non-numeric ctx bindings from bypassing the numeric-only
+            # contract via Name lookup.
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(
+                    f"forbidden binding type {type(value).__name__} for name "
+                    f"{node.id!r} in roofline expression {expr!r}; "
+                    f"only int/float bindings are permitted")
+            return value
         if isinstance(node, ast.UnaryOp):
             operand = _walk(node.operand)
             if isinstance(node.op, ast.UAdd):

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -78,7 +78,11 @@ def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float
         if isinstance(node, ast.Expression):
             return _walk(node.body)
         if isinstance(node, ast.Constant):
-            if not isinstance(node.value, (int, float)):
+            # ``bool`` is a subclass of ``int`` in Python, so the int/float check
+            # below would accept ``True``/``False`` as numeric constants. Reject
+            # bool literals explicitly so boolean expressions (e.g. ``True``,
+            # ``False + 1``) cannot masquerade as valid roofline arithmetic.
+            if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
                 raise ValueError(
                     f"forbidden constant type {type(node.value).__name__} in "
                     f"roofline expression {expr!r}")

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -11,27 +11,21 @@ from tileops.utils import get_sm_version
 # Module-level dedup for empty-static_dims warnings; keyed by Op subclass.
 _EMPTY_STATIC_DIMS_WARNED: set = set()
 
-# ``ast.Num`` is a deprecated alias (Python 3.8+) that becomes ``ast.Constant``
-# under the hood; AC-4 requires the roofline evaluator to accept legacy
-# ``Num`` nodes for back-compat. Resolve it here without triggering the
-# Python 3.12+ DeprecationWarning, and omit it from the whitelist tuple when
-# ``ast.Constant`` already covers it (which is true on every supported Python).
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", DeprecationWarning)
-    _AST_NUM: type = getattr(ast, "Num", ast.Constant)
-
 # Whitelist of AST nodes permitted in roofline expressions.
 # Explicitly excludes Call, Attribute, Subscript, Lambda, Comprehension, etc.
-# ``ast.Num`` nodes (legacy) are instances of ``ast.Constant`` on Python 3.8+,
-# so they pass the Constant gate without needing a separate whitelist entry.
+#
+# ``ast.Num`` is a deprecated alias of ``ast.Constant`` on every supported
+# Python (3.8+) — AC-4's back-compat requirement for ``ast.Num`` is satisfied
+# by accepting ``ast.Constant``, since any legacy ``ast.Num`` node instance is
+# also an ``ast.Constant``. We intentionally omit ``ast.Num`` from the tuple
+# to avoid the Python 3.12+ DeprecationWarning that firing at isinstance()
+# time; the whitelist is evaluated on the recursive AST walk hot path.
 _SAFE_AST_NODES: Tuple[type, ...] = (
     ast.Expression,
     ast.BinOp,
     ast.UnaryOp,
-    ast.Constant,
-    _AST_NUM,  # ast.Num (back-compat); subclass of Constant on Python 3.8+
+    ast.Constant,  # covers legacy ast.Num (alias on Python 3.8+)
     ast.Name,
-    ast.Load,
     # Arithmetic operators
     ast.Add,
     ast.Sub,
@@ -64,14 +58,11 @@ def _safe_eval(expr: str, ctx: Dict[str, Union[int, float]]) -> Union[int, float
         raise ValueError(f"invalid roofline expression {expr!r}: {e}") from e
 
     def _walk(node: ast.AST) -> Union[int, float]:
-        # Suppress the Python 3.12+ DeprecationWarning triggered by ast.Num
-        # appearing inside the isinstance tuple. The ast.Num entry is a legacy
-        # alias of ast.Constant on all supported Pythons; keeping it in the
-        # whitelist matches AC-4 and the design doc without changing behavior.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            permitted = isinstance(node, _SAFE_AST_NODES)
-        if not permitted:
+        # The whitelist is built once at module load (see _SAFE_AST_NODES).
+        # On supported Pythons, ast.Num is already an alias of ast.Constant,
+        # so the isinstance check here does not trigger a DeprecationWarning
+        # and needs no per-node suppression.
+        if not isinstance(node, _SAFE_AST_NODES):
             raise ValueError(
                 f"forbidden AST node {type(node).__name__} in roofline expression "
                 f"{expr!r}; only arithmetic over Name/Constant is permitted")

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -1,8 +1,6 @@
-import ast
-import math
 import warnings
 from abc import ABC, abstractmethod
-from typing import Callable, Hashable, Optional, Union
+from typing import Hashable, Optional, Union
 
 import torch
 
@@ -11,202 +9,6 @@ from tileops.utils import get_sm_version
 
 # Module-level dedup for empty-static_dims warnings; keyed by Op subclass.
 _EMPTY_STATIC_DIMS_WARNED: set = set()
-
-# Whitelist of AST nodes permitted in roofline expressions. This mirrors the
-# manifest-level evaluator in ``tileops.manifest._safe_eval`` so that any
-# expression accepted by the manifest schema (and therefore any expression
-# codegen may splice into ``_flops_expr`` / ``_bytes_expr``) is also accepted
-# here. Explicitly excludes Attribute, Subscript, Lambda, Comprehension, etc.
-#
-# ``ast.Num`` is a deprecated alias of ``ast.Constant`` on every supported
-# Python (3.8+) — AC-4's back-compat requirement for ``ast.Num`` is satisfied
-# by accepting ``ast.Constant``, since any legacy ``ast.Num`` node instance is
-# also an ``ast.Constant``. We intentionally omit ``ast.Num`` from the tuple
-# to avoid the Python 3.12+ DeprecationWarning that would fire at isinstance()
-# time; the whitelist is evaluated on the recursive AST walk hot path.
-#
-# ``ast.Call`` is accepted but constrained to a narrow whitelist of numeric
-# helpers (see ``_ROOFLINE_SAFE_FUNCTIONS``); attribute-call syntax
-# (``math.ceil(x)``) and keyword/star arguments are rejected in the Call
-# branch of ``_walk`` below.
-#
-# ``ast.Pow`` is accepted to match the manifest evaluator, which admits it for
-# the rare formula that needs an exponent. Unbounded inputs (``10 ** 10 ** N``)
-# and fractional/complex results (``(-1) ** 0.5``) are defended in depth by
-# ``_coerce_roofline_result`` which rejects non-finite / non-integral /
-# negative final outputs.
-_ROOFLINE_SAFE_FUNCTIONS: dict[str, Callable[..., Union[int, float]]] = {
-    "log2": math.log2,
-    "ceil": math.ceil,
-    "floor": math.floor,
-}
-
-_SAFE_AST_NODES: tuple[type, ...] = (
-    ast.Expression,
-    ast.BinOp,
-    ast.UnaryOp,
-    ast.Constant,  # covers legacy ast.Num (alias on Python 3.8+)
-    ast.Name,
-    ast.Call,  # restricted to _ROOFLINE_SAFE_FUNCTIONS in _walk
-    # Arithmetic operators
-    ast.Add,
-    ast.Sub,
-    ast.Mult,
-    ast.Div,
-    ast.FloorDiv,
-    ast.Mod,
-    ast.Pow,
-    # Unary operators
-    ast.UAdd,
-    ast.USub,
-)
-
-
-def _safe_eval(expr: str, ctx: dict[str, Union[int, float]]) -> Union[int, float]:
-    """Evaluate an arithmetic expression against ``ctx`` using a whitelist AST walker.
-
-    Only binary/unary arithmetic on numeric constants and names resolved from
-    ``ctx`` is permitted. Function calls, attribute access, subscripts, lambdas,
-    comprehensions, and any other node type raise :class:`ValueError` naming
-    the forbidden node.
-
-    This is the roofline evaluator referenced by :meth:`Op.eval_roofline`; it
-    intentionally avoids :func:`eval` / :func:`exec` and any third-party
-    expression evaluator.
-    """
-    try:
-        tree = ast.parse(expr, mode='eval')
-    except SyntaxError as e:
-        raise ValueError(f"invalid roofline expression {expr!r}: {e}") from e
-
-    def _walk(node: ast.AST) -> Union[int, float]:
-        # The whitelist is built once at module load (see _SAFE_AST_NODES).
-        # On supported Pythons, ast.Num is already an alias of ast.Constant,
-        # so the isinstance check here does not trigger a DeprecationWarning
-        # and needs no per-node suppression.
-        if not isinstance(node, _SAFE_AST_NODES):
-            raise ValueError(
-                f"forbidden AST node {type(node).__name__} in roofline expression "
-                f"{expr!r}; only arithmetic over Name/Constant is permitted")
-        if isinstance(node, ast.Expression):
-            return _walk(node.body)
-        if isinstance(node, ast.Constant):
-            # ``bool`` is a subclass of ``int`` in Python, so the int/float check
-            # below would accept ``True``/``False`` as numeric constants. Reject
-            # bool literals explicitly so boolean expressions (e.g. ``True``,
-            # ``False + 1``) cannot masquerade as valid roofline arithmetic.
-            if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
-                raise ValueError(
-                    f"forbidden constant type {type(node.value).__name__} in "
-                    f"roofline expression {expr!r}")
-            return node.value
-        # Note: on Python 3.8+, ``ast.Num`` nodes are instances of
-        # ``ast.Constant`` and are handled by the Constant branch above.
-        if isinstance(node, ast.Name):
-            if node.id not in ctx:
-                raise ValueError(
-                    f"undefined name {node.id!r} in roofline expression {expr!r}")
-            value = ctx[node.id]
-            # Mirror the Constant branch: ``bool`` is a subclass of ``int``,
-            # so explicitly reject it, then require int/float. This prevents
-            # non-numeric ctx bindings from bypassing the numeric-only
-            # contract via Name lookup.
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(
-                    f"forbidden binding type {type(value).__name__} for name "
-                    f"{node.id!r} in roofline expression {expr!r}; "
-                    f"only int/float bindings are permitted")
-            return value
-        if isinstance(node, ast.UnaryOp):
-            operand = _walk(node.operand)
-            if isinstance(node.op, ast.UAdd):
-                return +operand
-            if isinstance(node.op, ast.USub):
-                return -operand
-            raise ValueError(
-                f"forbidden unary operator {type(node.op).__name__} in "
-                f"roofline expression {expr!r}")
-        if isinstance(node, ast.BinOp):
-            left = _walk(node.left)
-            right = _walk(node.right)
-            op = node.op
-            if isinstance(op, ast.Add):
-                return left + right
-            if isinstance(op, ast.Sub):
-                return left - right
-            if isinstance(op, ast.Mult):
-                return left * right
-            if isinstance(op, ast.Div):
-                return left / right
-            if isinstance(op, ast.FloorDiv):
-                return left // right
-            if isinstance(op, ast.Mod):
-                return left % right
-            if isinstance(op, ast.Pow):
-                return left**right
-            raise ValueError(
-                f"forbidden binary operator {type(op).__name__} in "
-                f"roofline expression {expr!r}")
-        if isinstance(node, ast.Call):
-            # Only allow direct calls to whitelisted name callables, mirroring
-            # ``tileops.manifest._safe_eval``. Reject attribute-call syntax
-            # (``math.ceil(x)``) and any keyword / star arguments.
-            if not isinstance(node.func, ast.Name):
-                raise ValueError(
-                    f"forbidden call target in roofline expression {expr!r}; "
-                    f"only direct calls to whitelisted functions are permitted")
-            func_name = node.func.id
-            if func_name not in _ROOFLINE_SAFE_FUNCTIONS:
-                raise ValueError(
-                    f"forbidden call to {func_name!r} in roofline expression "
-                    f"{expr!r}; allowed functions: "
-                    f"{sorted(_ROOFLINE_SAFE_FUNCTIONS)}")
-            if node.keywords:
-                raise ValueError(
-                    f"keyword arguments are not permitted in roofline "
-                    f"expression {expr!r}")
-            args = [_walk(a) for a in node.args]
-            return _ROOFLINE_SAFE_FUNCTIONS[func_name](*args)
-        # Unreachable: _SAFE_AST_NODES gate above covers every handled type.
-        raise ValueError(  # pragma: no cover - defensive
-            f"unhandled AST node {type(node).__name__} in roofline expression {expr!r}")
-
-    return _walk(tree)
-
-
-def _coerce_roofline_result(kind: str, expr: str, value: Union[int, float]) -> int:
-    """Validate that a roofline expression result is a finite, non-negative integer.
-
-    ``_safe_eval`` returns ``int`` or ``float`` depending on the operators used
-    in the expression (``/`` promotes to ``float``). FLOPs and bytes counts
-    are inherently non-negative integers, so we refuse to silently truncate
-    fractional values or accept ``inf``/``nan`` via ``int()``. A mismatch
-    typically indicates a bug in the expression (e.g. ``3 * M / 2`` where
-    ``M`` is odd).
-    """
-    if isinstance(value, bool):  # defense in depth; _safe_eval already rejects
-        raise ValueError(
-            f"roofline {kind} expression {expr!r} evaluated to a bool, expected int")
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(
-                f"roofline {kind} expression {expr!r} evaluated to non-finite "
-                f"{value!r}, expected a finite integer")
-        if not value.is_integer():
-            raise ValueError(
-                f"roofline {kind} expression {expr!r} evaluated to non-integral "
-                f"{value!r}; use // or integer-valued subexpressions instead of /")
-        value = int(value)
-    if not isinstance(value, int):  # pragma: no cover - defensive
-        raise ValueError(
-            f"roofline {kind} expression {expr!r} evaluated to unexpected type "
-            f"{type(value).__name__}")
-    if value < 0:
-        raise ValueError(
-            f"roofline {kind} expression {expr!r} evaluated to negative value "
-            f"{value!r}; flops and bytes counts must be non-negative")
-    return value
-
 
 class Op(ABC):
     """Base class for TileOPs operations.
@@ -250,14 +52,6 @@ class Op(ABC):
     # manifest `static_dims`. Default empty = no committed axes.
     _static_axes: frozenset[tuple[int, int]] = frozenset()
 
-    # Roofline evaluation slots (see docs/ops-design.md §`eval_roofline`).
-    # Concrete ops override these as class-level declarations; `eval_roofline`
-    # reads them and evaluates the expressions via `_safe_eval`. Defaults
-    # produce `(0, 0)` — a transitional escape hatch for ops not yet migrated.
-    _roofline_vars: list[str] = []
-    _flops_expr: str = "0"
-    _bytes_expr: str = "0"
-
     @property
     @abstractmethod
     def default_kernel_map(self) -> dict[str, Kernel]:
@@ -281,11 +75,9 @@ class Op(ABC):
         #     ops under tileops/ops/ that have not yet been migrated to the spec
         #     in docs/ops-design.md; the trust model requires a separate
         #     per-op migration PR.
-        # Cleanup: once all concrete ops under tileops/ops/ implement both
-        #     _infer_output_shapes and _validate_dtypes, convert this stub
-        #     (and _validate_dtypes below) to `@abstractmethod` and remove the
-        #     default class-level _roofline_vars/_flops_expr/_bytes_expr
-        #     transitional defaults.
+        # Cleanup: once all concrete ops under tileops/ops/ implement
+        #     _infer_output_shapes, _validate_dtypes, and eval_roofline,
+        #     convert this stub (and the two below) to `@abstractmethod`.
         raise NotImplementedError(
             "_infer_output_shapes must be implemented by the concrete Op subclass; "
             "see docs/ops-design.md §`_infer_output_shapes` (codegen)")
@@ -306,51 +98,42 @@ class Op(ABC):
         #     ops under tileops/ops/ that have not yet been migrated to the spec
         #     in docs/ops-design.md; the trust model requires a separate
         #     per-op migration PR.
-        # Cleanup: once all concrete ops under tileops/ops/ implement both
-        #     _infer_output_shapes and _validate_dtypes, convert this stub
-        #     (and _infer_output_shapes above) to `@abstractmethod`.
+        # Cleanup: once all concrete ops under tileops/ops/ implement
+        #     _infer_output_shapes, _validate_dtypes, and eval_roofline,
+        #     convert this stub (and the others) to `@abstractmethod`.
         raise NotImplementedError(
             "_validate_dtypes must be implemented by the concrete Op subclass; "
             "see docs/ops-design.md §`_validate_dtypes` (codegen)")
 
     def eval_roofline(self) -> tuple[int, int]:
-        """Evaluate (flops, bytes) from class-level roofline slots.
+        """Return ``(flops, bytes)`` for this op instance.
 
-        Reads ``_roofline_vars`` (list of attribute names on ``self``) plus a
-        derived ``elem_bytes`` from ``self.dtype``, then evaluates
-        ``_flops_expr`` and ``_bytes_expr`` via the whitelist AST evaluator
-        :func:`_safe_eval`. Returns integer ``(flops, bytes)``.
-
-        Results must be finite, non-negative, and integer-valued; a non-
-        integral or non-finite value (e.g. from a stray ``/`` that does not
-        divide evenly) raises :class:`ValueError` instead of being silently
-        truncated by ``int()``.
-
-        When the class-level slots are at defaults, returns ``(0, 0)`` — a
-        transitional default for ops not yet migrated. See
-        docs/ops-design.md §``eval_roofline``.
+        Per docs/roofline.md §4.4 and §4.4.6, each concrete op's
+        ``eval_roofline`` body is emitted by codegen as plain Python directly
+        over ``self.*`` attributes — there is no shared roofline expression
+        evaluator at L1, by design (§4.4.6 rejects "Op-local AST evaluator").
+        The L1 base only declares the contract; concrete ops supply the body.
         """
-        ctx: dict[str, Union[int, float]] = {}
-        for name in self._roofline_vars:
-            ctx[name] = getattr(self, name)
-        if self.dtype is not None:
-            # ``torch.dtype.itemsize`` is the byte width of a scalar element
-            # and matches ``torch.tensor([], dtype=self.dtype).element_size()``
-            # without allocating an empty tensor on every eval_roofline call.
-            ctx["elem_bytes"] = self.dtype.itemsize
-        else:
-            ctx["elem_bytes"] = 0
-        flops = _coerce_roofline_result(
-            "flops",
-            self._flops_expr,
-            _safe_eval(self._flops_expr, ctx),
-        )
-        nbytes = _coerce_roofline_result(
-            "bytes",
-            self._bytes_expr,
-            _safe_eval(self._bytes_expr, ctx),
-        )
-        return flops, nbytes
+        # FIXME(staged-rollout): L1 Op does not yet strictly enforce eval_roofline
+        # via @abstractmethod; base raises NotImplementedError instead.
+        #
+        # Broken invariant: L1 base does not strictly enforce implementation
+        #     of eval_roofline on every concrete Op subclass.
+        # Why: Introducing @abstractmethod now would break every existing
+        #     concrete op under tileops/ops/ (none of them ship an
+        #     eval_roofline yet). The op-scaffold codegen work that will
+        #     generate these bodies per docs/roofline.md §4.4 is pre-
+        #     requisite; the trust model requires a separate per-op migration
+        #     PR to flip any given op from stub to generated body.
+        # Cleanup: once all concrete ops under tileops/ops/ implement
+        #     eval_roofline (via codegen emission per docs/roofline.md §4.4),
+        #     convert this stub and the two stubs above (_infer_output_shapes,
+        #     _validate_dtypes) to `@abstractmethod`.
+        raise NotImplementedError(
+            "eval_roofline must be implemented by the concrete Op subclass, "
+            "emitted per docs/roofline.md §4.4 (codegen); the L1 base "
+            "intentionally does not provide a generic evaluator — see "
+            "docs/roofline.md §4.4.6 (Evaluator Surface Boundary)")
 
     def dispatch_kernel(self, kernel_map: Optional[dict[str, Kernel]] = None) -> None:
         if self.default_kernel_map is None or len(self.default_kernel_map) == 0:


### PR DESCRIPTION
## Summary

Declare three L1 codegen contracts on `Op` as `NotImplementedError` stubs with `FIXME(staged-rollout)` markers:

- `_infer_output_shapes(**shape_kwargs)` → cites `docs/ops-design.md §_infer_output_shapes`
- `_validate_dtypes(*args)` → cites `docs/ops-design.md §_validate_dtypes`
- `eval_roofline(self) -> tuple[int, int]` → cites `docs/roofline.md §4.4` and `§4.4.6`

No runtime evaluator at L1. `docs/roofline.md §4.4.6` rejects an "Op-local AST evaluator"; each op's `eval_roofline` body is emitted by codegen as plain Python. `docs/ops-design.md:199-204`: "Do not define an Op-local roofline expression parser in `Op` or family bases." Cleanup trigger for all three FIXMEs: once every concrete op implements the method (via codegen per `docs/roofline.md §4.4`), flip the stubs to `@abstractmethod`.

No concrete op, doc, or manifest file is modified. No `eval()` / `exec()` / third-party evaluator introduced.

Closes #1011. Prerequisite for the `op-scaffold` codegen skill.

## Test plan

- [x] `pytest tests/test_op_base.py` passes (7 tests, existing `_cache_key` coverage).
- [x] `pytest tests/ops/test_reduce.py -m smoke` passes (77 tests; no regression).
- [x] `pre-commit run --files tileops/ops/op_base.py tests/test_op_base.py` clean.
- [x] `grep -rn 'FIXME(staged-rollout)' tileops/ops/op_base.py` → 3 markers with Broken invariant + Why + Cleanup.
- [x] No `eval()` / `exec()` / third-party evaluator in `tileops/ops/op_base.py`.

## Test node-delta

- `tests/test_op_base.py`: 7 → 7. Earlier iterations added runtime-evaluator tests; they were removed with the evaluator they covered.

## Design references

- [`docs/roofline.md §4.4`](docs/roofline.md) — codegen emits `eval_roofline` body as plain Python
- [`docs/roofline.md §4.4.6`](docs/roofline.md) — Evaluator Surface Boundary (Op-local AST evaluator: REJECTED)
- [`docs/ops-design.md §eval_roofline`](docs/ops-design.md)
