### PR TITLE
[BugFix][Conv] thread has_bias through conv2d 1x1 wrapper

### DIFF
--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -524,6 +524,7 @@ def _conv2d_1x1_wrapped_kernel(
     h: int,
     w: int,
     c_out: int,
+    has_bias: bool,
     dtype: str,
     block_m: int,
     block_n: int,
@@ -536,7 +537,7 @@ def _conv2d_1x1_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv2d_1x1_kernel(
-        n, c_in, h, w, c_out, 1, 1, 0, 0, True, dtype
+        n, c_in, h, w, c_out, 1, 1, 0, 0, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -547,6 +548,7 @@ def _(
     h: int,
     w: int,
     c_out: int,
+    has_bias: bool,
     dtype: str,
     block_m: int,
     block_n: int,
@@ -886,6 +888,7 @@ class Conv2d1x1Kernel(Kernel):
             self.h,
             self.w,
             self.c_out,
+            self.has_bias,
             self.dtype_str,
             self.config["block_m"],
             self.config["block_n"],


### PR DESCRIPTION
Closes #933

## Summary

- Thread `has_bias` through the Conv2d 1x1 torch custom op wrapper and fake registration.
- Pass `self.has_bias` from `Conv2d1x1Kernel.forward` so the compiled kernel can skip the bias branch when disabled.

## Test plan

- [x] `python -m pytest tests/ops/test_convolution.py` (24 passed, 8 skipped)
- [x] pre-commit hooks passed during commit

## Benchmark

- Not run. This only fixes wrapper plumbing so the existing no-bias kernel path is reachable under `torch.compile`.

## Regression

- Verified existing convolution op tests still pass.
- `scripts/validate.sh --pre` was unavailable in this checkout (`No such file or directory`), so title and branch patterns were checked directly against `.claude/conventions/types.sh`.
