### PR TITLE
[BugFix][Conv] Include output shared buffer in memory estimate

### DIFF
--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -31,7 +31,8 @@ def conv_shared_memory_bytes(
 ) -> int:
     dtype_bytes = torch.tensor([], dtype=dtype).element_size()
     per_stage_bytes = (block_m * block_k + block_k * block_n) * dtype_bytes
-    return per_stage_bytes * max(1, num_stages)
+    out_shared_bytes = block_m * block_n * dtype_bytes
+    return per_stage_bytes * max(1, num_stages) + out_shared_bytes
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #932

## Summary

- Include the convolution output shared buffer in `conv_shared_memory_bytes`.
- Keep kernel logic unchanged; only the autotune shared memory estimator changes.

## Test plan

- [x] pre-commit hooks passed during commit
- [ ] `scripts/validate.sh --pre` not run because `scripts/validate.sh` is not present in this checkout
- [ ] pytest not run; no related unit test was added per request

## Regression

- This tightens autotune filtering for convolution configs that would exceed shared memory once `out_shared` is included.