### PR TITLE
[Feat][OPS] add op-scaffold skill + fix _static_axes binding docs

### DIFF
--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -10,8 +10,8 @@ description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.y
 ## Contract
 
 - **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml).
-- **Output**: new file at `tileops/ops/{family}/{snake_case_name}.py` containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to `tileops/ops/{family}/__init__.py` with a matching `__all__` entry. Plus a side-artefact at `.foundry/plan/<op_name>/plan.json` carrying the DRY_RUN self-audit (not tracked in git).
-- **Termination (success)**: `python scripts/validate_manifest.py` reports **no new errors** attributable to this op. Warnings are allowed and passed through to the final summary.
+- **Output**: new file at the exact path declared by manifest `source.op` (e.g., `tileops/ops/reduction/cumsum.py`), containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to the package `__init__.py` at that path's parent directory (e.g., `tileops/ops/reduction/__init__.py`) with a matching `__all__` entry. Note: the filesystem package directory (parent of `source.op`) is not always the same as the manifest `family` field — for example, `CumsumFwdOp` has `family: scan` but lives under `tileops/ops/reduction/`. Always key paths off `source.op`, never off `family`. Plus a side-artefact at `.foundry/plan/<op_name>/plan.json` carrying the DRY_RUN self-audit (not tracked in git).
+- **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports **no errors** for this op. Warnings are allowed and passed through to the final summary.
 - **Termination (blocked)**: any validator error for `op_name` that the scaffold cannot fix by re-reading the playbook's slot rules. Do NOT commit; report with the failing rows from the validator.
 - **Constraints**:
   - MUST NOT emit family-specific protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, `_kernel_handles_padding`, `_op_name`, `kernel_cls`).
@@ -71,12 +71,12 @@ print(entry)
 
 Extract: `family`, `status`, `signature.inputs`, `signature.outputs`, `signature.params`, `signature.static_dims`, `signature.shape_rules`, `source.kernel_map`, `source.op`, `source.kernel`, `roofline.vars`, `roofline.flops`, `roofline.bytes`.
 
-Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum.py`). Family is `source.op`'s parent directory name. Module filename is `source.op`'s basename without `.py`.
+Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum.py`). The **filesystem package directory** is `source.op`'s parent (e.g. `tileops/ops/reduction/`). Do not use the manifest `family` field to compute paths — it is a semantic label, and some ops have `family` distinct from their filesystem parent (e.g., `CumsumFwdOp` has `family: scan` but lives under `reduction/`). Module filename is `source.op`'s basename without `.py`.
 
 ### 2. PRE_CHECK
 
 - `op_name` present in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
-- `status` is `spec-only` or absent → proceed; `status: implemented` → BLOCKED ("op already implemented; use spec-implement to migrate").
+- `status` field explicitly set to `spec-only` → proceed; `status: implemented` → BLOCKED ("op already implemented; use spec-implement to migrate"); missing `status` or any other value → BLOCKED ("manifest entry must declare a valid top-level `status`; the validator treats `status` as required").
 - Target file `source.op` does NOT exist → proceed; exists → BLOCKED ("target file already present; scaffold would overwrite").
 - Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path").
 
@@ -195,9 +195,9 @@ If a slot's rule is ambiguous for the given manifest entry (e.g. multi-kernel `k
 
 ### 5. REGISTER
 
-Append to `tileops/ops/{family}/__init__.py`:
+Append to the package `__init__.py` at the parent directory of `source.op` (e.g., `tileops/ops/reduction/__init__.py`):
 
-1. One `from .<module> import <ClassName>` line placed under the family's grouping comment (`# --- <KernelName> ops ---`). Create the comment block if the family doesn't have one yet.
+1. One `from .<module> import <ClassName>` line placed under the grouping comment for this op's kernel. The comment header form is `# --- <KernelClassName> ops ---`, where `<KernelClassName>` is the primary Kernel class name from `source.kernel_map` (the single value for single-kernel ops; for multi-kernel ops, the value shared with other ops already grouped in the file). If no existing block references the kernel, create a new `# --- <KernelClassName> ops ---` block at the natural position (keep groups in kernel-name alphabetical order, or follow any existing convention in the file).
 1. A matching `<ClassName>` entry added to the module-level `__all__` list, preserving grouping order if `__all__` is commented into sections.
 
 ### 6. VALIDATE
@@ -206,21 +206,20 @@ Two checks in order. The first catches skill-bugs; the second catches spec disag
 
 **(a) §1 post-check (plan vs emitted)** — mechanical diff between `plan.json.locked_facts` and the facts extracted from the emitted file:
 
-- Parse the new `tileops/ops/{family}/{name}.py` with `ast`.
+- Parse the new file at `source.op` with `ast`.
 - Extract class name, base class, import list, `__all__`, `__init__` kwarg names/defaults/types in order, `forward` parameter names, `default_kernel_map` dict, `_static_axes` class attribute.
 - For each field in `locked_facts`, compare. Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted file, or if the plan itself was wrong, revert and restart DRY_RUN.
 
-**(b) Manifest validator**:
+**(b) Manifest validator** — scoped to this op via `--check-op` so that L0-L4 checks run even on a freshly scaffolded `status: spec-only` entry (the default run skips L1-L4 for `spec-only`):
 
 ```bash
-python scripts/validate_manifest.py
+python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-Classify every line in the output that mentions `op_name`:
+Classify every line in the output:
 
-- **ERROR** attributable to `op_name` → BLOCKED. Do not commit. Copy the full error row into the report. If the error is a parity failure (L2 or L3 per PR #1005), re-check the emitted `_infer_output_shapes` or `_validate_dtypes` against the manifest's `shape_rules` / `dtype` / `dtype_combos` before classifying as BLOCKED — the scaffold may have mis-emitted.
-- **ERROR** not attributable to `op_name` (pre-existing, other ops) → ignore, not blocking.
-- **WARNING** attributable to `op_name` → pass through to the report unchanged.
+- **ERROR** → BLOCKED. Do not commit. Copy the full error row into the report. If the error is a parity failure (L2 or L3 per PR #1005), re-check the emitted `_infer_output_shapes` or `_validate_dtypes` against the manifest's `shape_rules` / `dtype` / `dtype_combos` before classifying as BLOCKED — the scaffold may have mis-emitted.
+- **WARNING** → pass through to the report unchanged.
 
 Do NOT edit the manifest to silence an error. Do NOT set `parity_opt_out` to silence a parity error. If the scaffold cannot produce a body that satisfies the manifest, BLOCKED is the correct outcome.
 
@@ -232,7 +231,7 @@ Print a concise summary in this format. The REPORT is the single surface where p
 Status: SUCCESS | BLOCKED
 Op: <op_name>
 File: <path> (<lines>)
-Package registration: tileops/ops/<family>/__init__.py (+1 import, +1 __all__)
+Package registration: <parent-of-source.op>/__init__.py (+1 import, +1 __all__)
 Plan: .foundry/plan/<op_name>/plan.json
 
 §1 drift: <none, or list of <field>: <plan value> vs <emitted value>>

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: op-scaffold
+description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.yaml` entry by following the 7-step playbook in docs/ops-design.md. Emits the 17 scaffold slots (S1-S7, S12-S21); leaves family-specific protocol variables, optional hooks, and kernel implementations to downstream skills.
+---
+
+## Arguments
+
+`op_name` (positional) — manifest key for the op to scaffold, equal to the target `cls.__name__` (e.g. `CumsumFwdOp`).
+
+## Contract
+
+- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml).
+- **Output**: new file at `tileops/ops/{family}/{snake_case_name}.py` containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to `tileops/ops/{family}/__init__.py` with a matching `__all__` entry.
+- **Termination (success)**: `python scripts/validate_manifest.py` reports **no new errors** attributable to this op. Warnings are allowed and passed through to the final summary.
+- **Termination (blocked)**: any validator error for `op_name` that the scaffold cannot fix by re-reading the playbook's slot rules. Do NOT commit; report with the failing rows from the validator.
+- **Constraints**:
+  - MUST NOT emit family-specific protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, `_kernel_handles_padding`, `_op_name`, `kernel_cls`).
+  - MUST NOT emit optional hooks (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`, `_cache_key` override).
+  - MUST NOT implement the kernel itself.
+  - MUST NOT modify `ops_manifest.yaml`, tests, benchmarks, or any existing op file.
+  - MUST NOT extend scope to a T1 (family-base) subclass — the scaffold is T2 only.
+
+## Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> READ
+    READ --> PRE_CHECK: manifest entry loaded
+    PRE_CHECK --> EMIT: preconditions satisfied
+    PRE_CHECK --> BLOCKED: precondition failed
+    EMIT --> REGISTER: file written
+    REGISTER --> VALIDATE: family __init__.py updated
+    VALIDATE --> REPORT: validator returns (errors + warnings classified)
+    VALIDATE --> BLOCKED: validator errors attributable to this op
+    REPORT --> [*]
+    BLOCKED --> [*]: return to caller with reason
+```
+
+## Scope boundary
+
+The scaffold emits **exactly** the 17 slots defined in [`docs/ops-design-reference.md` § Slot Rules](../../../docs/ops-design-reference.md#slot-rules): S1-S7 (file header, imports, class, docstring), S12-S13 (`__init__` signature and body), S14-S16 (`default_kernel_map`, `forward`), S17-S19 (`_infer_output_shapes`, `_validate_dtypes`, `eval_roofline`), S20 (package registration), S21 (`_static_axes`). S8-S11 are intentionally skipped (reserved from slot iteration for T1 thin-wrapper slots).
+
+Explicitly **out of scope** — leave empty, do not invent:
+
+- **Family-specific protocol variables** (e.g. `_op_kind` for reduction, `_op_name` for elementwise). Kernel-dispatch-convention-dependent; cannot be derived from the manifest. See [Family-Base Protocol (Appendix)](../../../docs/ops-design-reference.md#base-class-protocol).
+- **Optional hooks** (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`). Op-specific business logic; no manifest derivation.
+- **`_cache_key` override**. Required when `_static_axes` is empty, but the override logic depends on kernel math.
+- **Kernel implementations**. The scaffold only references the Kernel classes named in `source.kernel_map`; their implementation is out of scope.
+- **Tests and benchmarks**. Downstream skills (`spec-test`, `spec-bench`) own these.
+
+These gaps are expected and acceptable. The resulting scaffold will raise `NotImplementedError` or trigger validator warnings when invoked beyond the 17 slots' coverage; that is the intended hand-off to `spec-implement` and the family-refactoring skill.
+
+## Steps
+
+### 1. READ
+
+Load the manifest entry for `op_name`:
+
+```bash
+python -c "
+import yaml
+with open('tileops/ops_manifest.yaml') as f:
+    m = yaml.safe_load(f)
+entry = m['ops']['$op_name']
+print(entry)
+"
+```
+
+Extract: `family`, `status`, `signature.inputs`, `signature.outputs`, `signature.params`, `signature.static_dims`, `signature.shape_rules`, `source.kernel_map`, `source.op`, `source.kernel`, `roofline.vars`, `roofline.flops`, `roofline.bytes`.
+
+Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum.py`). Family is `source.op`'s parent directory name. Module filename is `source.op`'s basename without `.py`.
+
+### 2. PRE_CHECK
+
+- `op_name` present in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
+- `status` is `spec-only` or absent → proceed; `status: implemented` → BLOCKED ("op already implemented; use spec-implement to migrate").
+- Target file `source.op` does NOT exist → proceed; exists → BLOCKED ("target file already present; scaffold would overwrite").
+- Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path").
+
+BLOCKED terminations return without writing any file.
+
+### 3. EMIT
+
+Follow [`docs/ops-design.md` § Scaffolding an Op from a Manifest Entry](../../../docs/ops-design.md#scaffolding-an-op-from-a-manifest-entry) Steps 1-7 in order. For each scaffold slot, read the authoritative rule at `docs/ops-design-reference.md#slot-sN` before emitting.
+
+Key slot pointers (follow the reference, do not re-derive):
+
+| Playbook step | Slots          | Reference anchor                                                                                                                                                    |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Step 1        | S1, S2, S3, S4 | [S1](../../../docs/ops-design-reference.md#slot-s1)-[S4](../../../docs/ops-design-reference.md#slot-s4)                                                             |
+| Step 2        | S5, S6, S7     | [S5](../../../docs/ops-design-reference.md#slot-s5)-[S7](../../../docs/ops-design-reference.md#slot-s7)                                                             |
+| Step 3        | S21, S12, S13  | [S21](../../../docs/ops-design-reference.md#slot-s21), [S12](../../../docs/ops-design-reference.md#slot-s12), [S13](../../../docs/ops-design-reference.md#slot-s13) |
+| Step 4        | S14, S15, S16  | [S14](../../../docs/ops-design-reference.md#slot-s14)-[S16](../../../docs/ops-design-reference.md#slot-s16)                                                         |
+| Step 5        | S17, S18       | [S17](../../../docs/ops-design-reference.md#slot-s17), [S18](../../../docs/ops-design-reference.md#slot-s18)                                                        |
+| Step 6        | S19            | [S19](../../../docs/ops-design-reference.md#slot-s19)                                                                                                               |
+| Step 7        | S20            | [S20](../../../docs/ops-design-reference.md#slot-s20)                                                                                                               |
+
+If a slot's rule is ambiguous for the given manifest entry (e.g. multi-kernel `kernel_map`, multiple independent dtype axes, fixed-rank vs arbitrary-rank branching), STOP and surface the ambiguity in the final report instead of guessing. Do not expand scope.
+
+### 4. REGISTER
+
+Append to `tileops/ops/{family}/__init__.py`:
+
+1. One `from .<module> import <ClassName>` line placed under the family's grouping comment (`# --- <KernelName> ops ---`). Create the comment block if the family doesn't have one yet.
+1. A matching `<ClassName>` entry added to the module-level `__all__` list, preserving grouping order if `__all__` is commented into sections.
+
+### 5. VALIDATE
+
+Run the manifest validator on the full manifest (the validator filters by op internally):
+
+```bash
+python scripts/validate_manifest.py
+```
+
+Classify every line in the output that mentions `op_name`:
+
+- **ERROR** attributable to `op_name` → BLOCKED. Do not commit. Copy the full error row into the report. If the error is a parity failure (L2 or L3 per PR #1005), re-check the emitted `_infer_output_shapes` or `_validate_dtypes` against the manifest's `shape_rules` / `dtype` / `dtype_combos` before classifying as BLOCKED — the scaffold may have mis-emitted.
+- **ERROR** not attributable to `op_name` (pre-existing, other ops) → ignore, not blocking.
+- **WARNING** attributable to `op_name` → pass through to the report unchanged.
+
+Do NOT edit the manifest to silence an error. Do NOT set `parity_opt_out` to silence a parity error. If the scaffold cannot produce a body that satisfies the manifest, BLOCKED is the correct outcome.
+
+### 6. REPORT
+
+Print a concise summary in this format:
+
+```
+Status: SUCCESS | BLOCKED
+Op: <op_name>
+File: <path> (<lines>)
+Package registration: tileops/ops/<family>/__init__.py (+1 import, +1 __all__)
+
+Validator: <N errors, M warnings>
+<if BLOCKED, list each blocking error row verbatim>
+
+Warnings (not blocking):
+  - <warning 1>
+  - <warning 2>
+
+Not filled (out of scope; hand-off to downstream):
+  - Kernel implementation: <source.kernel>
+  - Optional hooks: <list hook names if the family-base appendix documents any for this family>
+  - Family protocol variables: <list if this family uses any, e.g. reduction's _op_kind>
+  - _cache_key override: required if _static_axes is empty
+```
+
+On SUCCESS, commit the new file + `__init__.py` update with message `[Feat][OPS] scaffold <op_name>`. On BLOCKED, leave the working tree dirty and return without committing — caller inspects and decides.
+
+## Calibration against the playbook
+
+The scaffold's behaviour must stay in sync with `docs/ops-design.md` and `docs/ops-design-reference.md`. If you discover during EMIT or VALIDATE that a slot rule is internally inconsistent or cannot be mechanically followed, file a follow-up documentation issue and BLOCK; do NOT paper over by inventing slot behaviour.
+
+## Non-goals
+
+- Not a codegen engine. This skill is an agent-executable procedure. A future real codegen script can replace the EMIT step; the skill's input/output contract is designed to be codegen-compatible.
+- Not a migration driver. If `op_name` already exists with `status: implemented`, use `spec-implement` (or `spec-pipeline`) instead.
+- Not a kernel scaffold. Kernel-side scaffolding is a separate concern.

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -9,7 +9,7 @@ description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.y
 
 ## Contract
 
-- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml).
+- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map`. `source.kernel_map` is manifest-level source of truth for Op→Kernel dispatch and cannot be derived by the scaffold (dispatch keys are kernel-internal conventions); adding it for a spec-only entry is a prerequisite manifest PR.
 - **Output**: new file at the exact path declared by manifest `source.op` (e.g., `tileops/ops/reduction/cumsum.py`), containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to the package `__init__.py` at that path's parent directory (e.g., `tileops/ops/reduction/__init__.py`) with a matching `__all__` entry. Note: the filesystem package directory (parent of `source.op`) is not always the same as the manifest `family` field — for example, `CumsumFwdOp` has `family: scan` but lives under `tileops/ops/reduction/`. Always key paths off `source.op`, never off `family`. Plus a side-artefact at `.foundry/plan/<op_name>/plan.json` carrying the DRY_RUN self-audit (not tracked in git).
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports **no errors** for this op. Warnings are allowed and passed through to the final summary.
 - **Termination (blocked)**: any validator error for `op_name` that the scaffold cannot fix by re-reading the playbook's slot rules. Do NOT commit; report with the failing rows from the validator.
@@ -77,8 +77,9 @@ Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum
 
 - `op_name` present in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
 - `status` field explicitly set to `spec-only` → proceed; `status: implemented` → BLOCKED ("op already implemented; use spec-implement to migrate"); missing `status` or any other value → BLOCKED ("manifest entry must declare a valid top-level `status`; the validator treats `status` as required").
-- Target file `source.op` does NOT exist → proceed; exists → BLOCKED ("target file already present; scaffold would overwrite").
+- `source.kernel_map` declared and non-empty → proceed; missing or empty → BLOCKED ("manifest entry needs `source.kernel_map` before scaffolding — add the dispatch map in a separate manifest PR per the trust model; the scaffold cannot invent dispatch keys because they are kernel-internal conventions"). Note: per `docs/manifest.md`, `source.kernel_map` is only required when `status: implemented`, so many existing `spec-only` entries lack it — these are the cases that need the manifest-PR prerequisite before scaffolding can run.
 - Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path").
+- Target file `source.op` does NOT exist → proceed; exists → BLOCKED ("target file already present; scaffold would overwrite").
 
 BLOCKED terminations return without writing any file.
 

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -47,7 +47,7 @@ Explicitly **out of scope** — leave empty, do not invent:
 
 - **Family-specific protocol variables** (e.g. `_op_kind` for reduction, `_op_name` for elementwise). Kernel-dispatch-convention-dependent; cannot be derived from the manifest. See [Family-Base Protocol (Appendix)](../../../docs/ops-design-reference.md#base-class-protocol).
 - **Optional hooks** (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`). Op-specific business logic; no manifest derivation.
-- **`_cache_key` override**. Required when `_static_axes` is empty, but the override logic depends on kernel math.
+- **`_cache_key` override**. Recommended for cache efficiency under dynamic shapes when `_static_axes` is empty — the `Op._cache_key` default is correctness-preserving (it keys by all non-static axis sizes) but may over-fragment under dynamic shapes and emits a once-per-type `UserWarning` to surface the missing override. The override logic depends on kernel math and is out of scope for scaffolding.
 - **Kernel implementations**. The scaffold only references the Kernel classes named in `source.kernel_map`; their implementation is out of scope.
 - **Tests and benchmarks**. Downstream skills (`spec-test`, `spec-bench`) own these.
 
@@ -59,14 +59,19 @@ These gaps are expected and acceptable. The resulting scaffold will raise `NotIm
 
 Load the manifest entry for `op_name`:
 
+Before running the snippet, substitute `<op_name>` with the requested manifest key (the skill's positional argument — agent literal substitution, not shell interpolation):
+
 ```bash
-python -c "
+python - "<op_name>" <<'PY'
+import sys
 import yaml
+
+op_name = sys.argv[1]
 with open('tileops/ops_manifest.yaml') as f:
     m = yaml.safe_load(f)
-entry = m['ops']['$op_name']
+entry = m['ops'][op_name]
 print(entry)
-"
+PY
 ```
 
 Extract: `family`, `status`, `signature.inputs`, `signature.outputs`, `signature.params`, `signature.static_dims`, `signature.shape_rules`, `source.kernel_map`, `source.op`, `source.kernel`, `roofline.vars`, `roofline.flops`, `roofline.bytes`.
@@ -198,8 +203,10 @@ If a slot's rule is ambiguous for the given manifest entry (e.g. multi-kernel `k
 
 Append to the package `__init__.py` at the parent directory of `source.op` (e.g., `tileops/ops/reduction/__init__.py`):
 
-1. One `from .<module> import <ClassName>` line placed under the grouping comment for this op's kernel. The comment header form is `# --- <KernelClassName> ops ---`, where `<KernelClassName>` is the primary Kernel class name from `source.kernel_map` (the single value for single-kernel ops; for multi-kernel ops, the value shared with other ops already grouped in the file). If no existing block references the kernel, create a new `# --- <KernelClassName> ops ---` block at the natural position (keep groups in kernel-name alphabetical order, or follow any existing convention in the file).
-1. A matching `<ClassName>` entry added to the module-level `__all__` list, preserving grouping order if `__all__` is commented into sections.
+1. One `from .<module> import <ClassName>` line, matching the file's existing style. Inspect the current `__init__.py` first:
+   - **File uses grouping comments `# --- <KernelClassName> ops ---`** (e.g., `tileops/ops/reduction/__init__.py`): place the import under the matching kernel block, where `<KernelClassName>` is the primary Kernel class name from `source.kernel_map` (the single value for single-kernel ops; for multi-kernel ops, the value shared with already-grouped siblings). If no existing block references the kernel, create a new `# --- <KernelClassName> ops ---` block at the natural position (keep groups in kernel-name alphabetical order, or follow any existing convention in the file).
+   - **File uses flat imports with no grouping comments** (e.g., `tileops/ops/norm/__init__.py`, `tileops/ops/attention/__init__.py`): append the import alongside the existing package imports following the current ordering convention (alphabetical by filename is common). Do NOT introduce new block comments — match the file's existing style.
+1. A matching `<ClassName>` entry added to the module-level `__all__` list. If `__all__` is commented into sections, preserve grouping order. If `__all__` is a flat list, update it flat — do not introduce new commented sections or other grouping scaffolding.
 
 ### 6. VALIDATE
 
@@ -207,11 +214,13 @@ Two checks in order. The first catches skill-bugs; the second catches spec disag
 
 **(a) §1 post-check (plan vs emitted)** — mechanical diff between `plan.json.locked_facts` and the facts extracted from the emitted file:
 
-Mechanical diff across **both** emitted artefacts (the new op file and the updated package `__init__.py`):
+Mechanical diff across **both** emitted artefacts (the new op file and the updated package `__init__.py`), using syntax-aware and text-aware checks as appropriate:
 
 - Parse the new file at `source.op` with `ast`. Extract class name, base class, import list, `__all__`, `__init__` kwarg names / defaults / types in order, `forward` parameter names, `default_kernel_map` dict, `_static_axes` class attribute.
-- Parse the updated `dirname(source.op)/__init__.py` with `ast`. Verify the exact `from .<module> import <ClassName>` line exists under the correct `# --- <KernelClassName> ops ---` block (or in a newly created, correctly-ordered block), and that `__all__` contains a matching `<ClassName>` entry in the right grouping / order when `__all__` is sectioned.
-- For each field in `locked_facts`, compare against the applicable artefact (op file for class-level facts; `__init__.py` for registration facts). Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted op file or `__init__.py`, or if the plan itself was wrong, revert and restart DRY_RUN.
+- For `dirname(source.op)/__init__.py`: use **both** `ast` and raw-source text.
+  - `ast`: verify the exact `from .<module> import <ClassName>` import exists and that `__all__` contains a matching `<ClassName>` entry.
+  - Raw source text / token-level inspection: verify the import sits under the correct `# --- <KernelClassName> ops ---` block when the file uses grouping comments, or that a newly created block was inserted in the correct order; verify `__all__` section placement when `__all__` is sectioned. Comment-delimited placement cannot be asserted from `ast` alone because comments are not preserved in the AST. When the file is flat-style (no grouping comments), skip the block-placement check — only presence + ordering matter.
+- For each field in `locked_facts`, compare against the applicable artefact using the appropriate extraction method (op-file facts from the `source.op` AST; `__init__.py` registration facts from AST plus raw-source / token inspection for comment-delimited placement). Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted op file or `__init__.py`, or if the plan itself was wrong, revert and restart DRY_RUN.
 
 **(b) Manifest validator** — scoped to this op via `--check-op` so that L0-L4 checks run even on a freshly scaffolded `status: spec-only` entry (the default run skips L1-L4 for `spec-only`):
 
@@ -257,7 +266,7 @@ Not filled (out of scope; hand-off to downstream):
   - Kernel implementation: <source.kernel>
   - Optional hooks: <list hook names if the family-base appendix documents any for this family>
   - Family protocol variables: <list if this family uses any, e.g. reduction's _op_kind>
-  - _cache_key override: required if _static_axes is empty
+  - _cache_key override: recommended for cache efficiency under dynamic shapes / empty _static_axes; the default is correctness-preserving but may over-fragment
 ```
 
 On SUCCESS, commit the new file + `__init__.py` update with message `[Feat][OPS] scaffold <op_name>`. On BLOCKED, leave the working tree dirty and return without committing — caller inspects and decides. In both cases, `plan.json` remains under `.foundry/plan/<op_name>/` for post-mortem / follow-up action.

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -30,7 +30,7 @@ stateDiagram-v2
     PRE_CHECK --> BLOCKED: precondition failed
     DRY_RUN --> EMIT: plan.json written
     EMIT --> REGISTER: file written per plan §1 facts
-    REGISTER --> VALIDATE: family __init__.py updated
+    REGISTER --> VALIDATE: package __init__.py (parent of source.op) updated
     VALIDATE --> REPORT: validator + §1 post-check classified
     VALIDATE --> BLOCKED: validator errors attributable to this op, or §1 drift
     REPORT --> [*]
@@ -207,9 +207,11 @@ Two checks in order. The first catches skill-bugs; the second catches spec disag
 
 **(a) §1 post-check (plan vs emitted)** — mechanical diff between `plan.json.locked_facts` and the facts extracted from the emitted file:
 
-- Parse the new file at `source.op` with `ast`.
-- Extract class name, base class, import list, `__all__`, `__init__` kwarg names/defaults/types in order, `forward` parameter names, `default_kernel_map` dict, `_static_axes` class attribute.
-- For each field in `locked_facts`, compare. Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted file, or if the plan itself was wrong, revert and restart DRY_RUN.
+Mechanical diff across **both** emitted artefacts (the new op file and the updated package `__init__.py`):
+
+- Parse the new file at `source.op` with `ast`. Extract class name, base class, import list, `__all__`, `__init__` kwarg names / defaults / types in order, `forward` parameter names, `default_kernel_map` dict, `_static_axes` class attribute.
+- Parse the updated `dirname(source.op)/__init__.py` with `ast`. Verify the exact `from .<module> import <ClassName>` line exists under the correct `# --- <KernelClassName> ops ---` block (or in a newly created, correctly-ordered block), and that `__all__` contains a matching `<ClassName>` entry in the right grouping / order when `__all__` is sectioned.
+- For each field in `locked_facts`, compare against the applicable artefact (op file for class-level facts; `__init__.py` for registration facts). Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted op file or `__init__.py`, or if the plan itself was wrong, revert and restart DRY_RUN.
 
 **(b) Manifest validator** — scoped to this op via `--check-op` so that L0-L4 checks run even on a freshly scaffolded `status: spec-only` entry (the default run skips L1-L4 for `spec-only`):
 

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -10,7 +10,7 @@ description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.y
 ## Contract
 
 - **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml).
-- **Output**: new file at `tileops/ops/{family}/{snake_case_name}.py` containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to `tileops/ops/{family}/__init__.py` with a matching `__all__` entry.
+- **Output**: new file at `tileops/ops/{family}/{snake_case_name}.py` containing the 17 scaffold slots; one-line `from .<module> import <ClassName>` added to `tileops/ops/{family}/__init__.py` with a matching `__all__` entry. Plus a side-artefact at `.foundry/plan/<op_name>/plan.json` carrying the DRY_RUN self-audit (not tracked in git).
 - **Termination (success)**: `python scripts/validate_manifest.py` reports **no new errors** attributable to this op. Warnings are allowed and passed through to the final summary.
 - **Termination (blocked)**: any validator error for `op_name` that the scaffold cannot fix by re-reading the playbook's slot rules. Do NOT commit; report with the failing rows from the validator.
 - **Constraints**:
@@ -26,15 +26,18 @@ description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.y
 stateDiagram-v2
     [*] --> READ
     READ --> PRE_CHECK: manifest entry loaded
-    PRE_CHECK --> EMIT: preconditions satisfied
+    PRE_CHECK --> DRY_RUN: preconditions satisfied
     PRE_CHECK --> BLOCKED: precondition failed
-    EMIT --> REGISTER: file written
+    DRY_RUN --> EMIT: plan.json written
+    EMIT --> REGISTER: file written per plan §1 facts
     REGISTER --> VALIDATE: family __init__.py updated
-    VALIDATE --> REPORT: validator returns (errors + warnings classified)
-    VALIDATE --> BLOCKED: validator errors attributable to this op
+    VALIDATE --> REPORT: validator + §1 post-check classified
+    VALIDATE --> BLOCKED: validator errors attributable to this op, or §1 drift
     REPORT --> [*]
     BLOCKED --> [*]: return to caller with reason
 ```
+
+`DRY_RUN` is the skill's self-audit before codegen: agent freezes manifest-sourced facts as a JSON contract (`plan.json` §1), records its own judgement calls (§2), and tags open questions (§3). `VALIDATE` re-parses the emitted file and diffs it against §1 — any drift means the skill (agent) deviated from its own frozen contract, not that the manifest or docs are wrong.
 
 ## Scope boundary
 
@@ -79,7 +82,100 @@ Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum
 
 BLOCKED terminations return without writing any file.
 
-### 3. EMIT
+### 3. DRY_RUN
+
+Before any code is emitted, produce a self-audit plan at `.foundry/plan/<op_name>/plan.json`. This is the skill's own contract — it freezes manifest-sourced facts so that later EMIT cannot silently drift, and it lets the agent record its own judgement calls and observations.
+
+The file has three top-level keys: `locked_facts`, `agent_notes`, `open_questions`.
+
+**`locked_facts` (§1) — non-negotiable, machine-diffed at VALIDATE**
+
+Verbatim extraction from the manifest entry. If the emitted file disagrees with any field here, VALIDATE raises a hard error (skill bug, not a manifest or doc issue).
+
+```json
+{
+  "locked_facts": {
+    "op_name": "CumsumFwdOp",
+    "class_name": "CumsumFwdOp",
+    "family": "reduction",
+    "module_path": "tileops/ops/reduction/cumsum.py",
+    "parent_class": "Op",
+    "kernel_imports": [
+      {"module": "tileops.kernels.reduction.cumulative", "symbol": "CumulativeKernel"}
+    ],
+    "kernel_map": {"cumulative_fwd": "CumulativeKernel"},
+    "init_kwargs": [
+      {"name": "N", "source": "static_dims", "type": "int", "default": null},
+      {"name": "dtype", "source": "dtype", "type": "torch.dtype", "default": null},
+      {"name": "dim", "source": "signature.params.dim", "type": "int", "default": -1}
+    ],
+    "forward_inputs": ["x"],
+    "forward_outputs": ["y"],
+    "dtype_unions": {"x": ["float32", "float16", "bfloat16"]},
+    "dtype_combos": null,
+    "shape_rules": ["-x.ndim <= dim < x.ndim", "y.shape == x.shape"],
+    "static_dims": {"N": "x.shape[dim]"},
+    "roofline": {
+      "vars": {
+        "M": "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])",
+        "N": "x.shape[dim % x.ndim]"
+      },
+      "flops": "M * N",
+      "bytes": "2 * M * N * elem_bytes"
+    }
+  }
+}
+```
+
+**`agent_notes` (§2) — agent discretion, NOT diffed at VALIDATE**
+
+Judgement calls and codebase observations that inform EMIT without being locked. Record them so the reasoning is auditable but not brittle.
+
+```json
+{
+  "agent_notes": {
+    "docstring_summary": "Cumulative sum operator: y = cumsum(x, dim=-1).",
+    "kernel_ctor_signature_observed": "CumulativeKernel(M, N, op_kind, dtype, tune=False)",
+    "helper_state_on_self": ["N_padded = align_up(N, DEFAULT_ALIGNMENT)", "_kernel_cache = {}"],
+    "forward_reshape_strategy": "movedim(dim, -1) + reshape to (M, N); restore via movedim(-1, dim)",
+    "codebase_references_consulted": [
+      "tileops/ops/reduction/cumsum.py (for helper-var names like N_padded)",
+      "tileops/kernels/reduction/cumulative.py (kernel ctor signature)"
+    ]
+  }
+}
+```
+
+**`open_questions` (§3) — tagged observations for post-run iteration, NOT blocking**
+
+Ambiguities the agent had to judgement-call through, plus anything that smells like it needs human or doc attention. This section does NOT block DRY_RUN or EMIT — the skill proceeds with the agent's best judgement. These items are surfaced in the final REPORT for follow-up.
+
+Each item carries a tag driving the follow-up action:
+
+- `needs_doc_fix` — design docs (`ops-design.md`, `ops-design-reference.md`, `roofline.md`, `manifest.md`) don't cover the case encountered. Follow-up: file a doc issue.
+- `needs_manifest_fix` — the op's manifest entry is missing or ambiguous (not a general-doc gap, this specific entry). Follow-up: file a manifest-PR.
+- `needs_human_decision` — a legitimate design call that's neither doc nor manifest's fault; this op needs a human to look at it. Follow-up: route to reviewer.
+
+```json
+{
+  "open_questions": [
+    {
+      "tag": "needs_human_decision",
+      "topic": "multi-kernel dispatch selection",
+      "detail": "kernel_map has 3 entries; chose 'mha_bwd' as primary. Confirm?"
+    },
+    {
+      "tag": "needs_doc_fix",
+      "topic": "fixed-rank vs arbitrary-rank in Step 3",
+      "detail": "playbook Step 3 Example is arbitrary-rank; fixed-rank branching is not spelled out in ops-design-reference.md"
+    }
+  ]
+}
+```
+
+DRY_RUN terminates by writing `plan.json` and proceeding to EMIT unconditionally. Empty `open_questions` is fine. Non-empty is fine. Only the validator and §1-drift checks in VALIDATE can BLOCK.
+
+### 4. EMIT
 
 Follow [`docs/ops-design.md` § Scaffolding an Op from a Manifest Entry](../../../docs/ops-design.md#scaffolding-an-op-from-a-manifest-entry) Steps 1-7 in order. For each scaffold slot, read the authoritative rule at `docs/ops-design-reference.md#slot-sN` before emitting.
 
@@ -97,16 +193,24 @@ Key slot pointers (follow the reference, do not re-derive):
 
 If a slot's rule is ambiguous for the given manifest entry (e.g. multi-kernel `kernel_map`, multiple independent dtype axes, fixed-rank vs arbitrary-rank branching), STOP and surface the ambiguity in the final report instead of guessing. Do not expand scope.
 
-### 4. REGISTER
+### 5. REGISTER
 
 Append to `tileops/ops/{family}/__init__.py`:
 
 1. One `from .<module> import <ClassName>` line placed under the family's grouping comment (`# --- <KernelName> ops ---`). Create the comment block if the family doesn't have one yet.
 1. A matching `<ClassName>` entry added to the module-level `__all__` list, preserving grouping order if `__all__` is commented into sections.
 
-### 5. VALIDATE
+### 6. VALIDATE
 
-Run the manifest validator on the full manifest (the validator filters by op internally):
+Two checks in order. The first catches skill-bugs; the second catches spec disagreements.
+
+**(a) §1 post-check (plan vs emitted)** — mechanical diff between `plan.json.locked_facts` and the facts extracted from the emitted file:
+
+- Parse the new `tileops/ops/{family}/{name}.py` with `ast`.
+- Extract class name, base class, import list, `__all__`, `__init__` kwarg names/defaults/types in order, `forward` parameter names, `default_kernel_map` dict, `_static_axes` class attribute.
+- For each field in `locked_facts`, compare. Any mismatch is a skill bug — BLOCKED with a `§1 drift: <field>` row. The agent deviated from its own frozen contract during EMIT. Do NOT rationalize; do NOT edit the plan to match. Fix the emitted file, or if the plan itself was wrong, revert and restart DRY_RUN.
+
+**(b) Manifest validator**:
 
 ```bash
 python scripts/validate_manifest.py
@@ -120,22 +224,32 @@ Classify every line in the output that mentions `op_name`:
 
 Do NOT edit the manifest to silence an error. Do NOT set `parity_opt_out` to silence a parity error. If the scaffold cannot produce a body that satisfies the manifest, BLOCKED is the correct outcome.
 
-### 6. REPORT
+### 7. REPORT
 
-Print a concise summary in this format:
+Print a concise summary in this format. The REPORT is the single surface where post-run iteration feedback leaves the skill — it is the only channel for `open_questions` to reach the caller.
 
 ```
 Status: SUCCESS | BLOCKED
 Op: <op_name>
 File: <path> (<lines>)
 Package registration: tileops/ops/<family>/__init__.py (+1 import, +1 __all__)
+Plan: .foundry/plan/<op_name>/plan.json
 
+§1 drift: <none, or list of <field>: <plan value> vs <emitted value>>
 Validator: <N errors, M warnings>
 <if BLOCKED, list each blocking error row verbatim>
 
 Warnings (not blocking):
   - <warning 1>
   - <warning 2>
+
+Open questions (post-run iteration; from plan.json §3):
+  needs_doc_fix:
+    - <topic>: <detail>
+  needs_manifest_fix:
+    - <topic>: <detail>
+  needs_human_decision:
+    - <topic>: <detail>
 
 Not filled (out of scope; hand-off to downstream):
   - Kernel implementation: <source.kernel>
@@ -144,7 +258,7 @@ Not filled (out of scope; hand-off to downstream):
   - _cache_key override: required if _static_axes is empty
 ```
 
-On SUCCESS, commit the new file + `__init__.py` update with message `[Feat][OPS] scaffold <op_name>`. On BLOCKED, leave the working tree dirty and return without committing — caller inspects and decides.
+On SUCCESS, commit the new file + `__init__.py` update with message `[Feat][OPS] scaffold <op_name>`. On BLOCKED, leave the working tree dirty and return without committing — caller inspects and decides. In both cases, `plan.json` remains under `.foundry/plan/<op_name>/` for post-mortem / follow-up action.
 
 ## Calibration against the playbook
 

--- a/.claude/skills/op-scaffold/SKILL.md
+++ b/.claude/skills/op-scaffold/SKILL.md
@@ -98,7 +98,7 @@ Verbatim extraction from the manifest entry. If the emitted file disagrees with 
   "locked_facts": {
     "op_name": "CumsumFwdOp",
     "class_name": "CumsumFwdOp",
-    "family": "reduction",
+    "family": "scan",
     "module_path": "tileops/ops/reduction/cumsum.py",
     "parent_class": "Op",
     "kernel_imports": [

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ docs/plans/
 .humanize*
 .foundry/runs/
 .foundry/migrations/
+.foundry/plan/
 .foundry/config.local.json
 
 CLAUDE.local.md

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -217,17 +217,18 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 ### Slot S21: <a id="slot-s21"></a> `_static_axes` class attribute
 
-- **Rule.** Each concrete op declares `_static_axes: frozenset[tuple[int, int]]` of `(input_index, axis)` pairs committed at constructor time. `input_index` is the positional index in `signature.inputs`; `axis` is a non-negative integer within that input's shape. Empty frozenset is legal (means "no axes committed at ctor"). When the manifest expresses the axis via a ctor param (e.g., `static_dims: N: "x.shape[dim]"` where `dim` is a param), the axis is not known at class-definition time — the scaffold emits an empty class-level default and the concrete op binds `self._static_axes` inside `__init__` after resolving the param.
-- **Derivation.** Manifest `static_dims`; for each entry `<kwarg>: <tensor>.shape[<axis>]`: if `<axis>` is an integer literal, emit a class-level pair `(input_index_of_<tensor>, <axis>)`; if `<axis>` is a ctor param name, emit `_static_axes = frozenset()` at class level and `self._static_axes = frozenset({(i, <param> % ndim_at_forward)})` inside `__init__`. PyTorch-aligned reductions with `dim=None` → empty frozenset (see [manifest.md § Empty static_dims](manifest.md#empty-static_dims)).
+- **Rule.** Each concrete op declares `_static_axes: frozenset[tuple[int, int]]` of `(input_index, axis)` pairs committed at constructor time. `input_index` is the positional index in `signature.inputs`; `axis` is a non-negative integer within that input's shape. Empty frozenset is legal (means "no axes committed at ctor"). When the manifest expresses the axis via a ctor param (e.g., `static_dims: N: "x.shape[dim]"` where `dim` is a param and may be negative), the concrete `(input_index, axis)` pair cannot be resolved at `__init__` — `x.ndim` is unknown until a tensor is passed. The scaffold emits an empty class-level default; the concrete op binds `self._static_axes` inside `forward()` after normalizing the axis via `dim % x.ndim` (or equivalently inside a `_cache_key` override that projects the shape inline).
+- **Derivation.** Manifest `static_dims`; for each entry `<kwarg>: <tensor>.shape[<axis>]`: if `<axis>` is an integer literal, emit a class-level pair `(input_index_of_<tensor>, <axis>)`; if `<axis>` is a ctor param name, emit `_static_axes = frozenset()` at class level and assign `self._static_axes = frozenset({(i, <param> % x.ndim)})` inside `forward()` (after the `static_dims` commitment check), or override `_cache_key` to compute the same projection inline. PyTorch-aligned reductions with `dim=None` → empty frozenset (see [manifest.md § Empty static_dims](manifest.md#empty-static_dims)).
 - **Example.**
   ```python
   class CumsumFwdOp(Op):
-      # static_dims: N: "x.shape[dim]" — axis is parameter-dependent,
-      # so the class-level default is empty; bind in __init__ once `dim`
-      # is resolved against a concrete input rank.
+      # static_dims: N: "x.shape[dim]" — axis is parameter-dependent
+      # (and dim may be negative), so the concrete (input_index, axis)
+      # pair is resolved at forward() time after dim % x.ndim
+      # normalization. Class-level default is empty.
       _static_axes: frozenset[tuple[int, int]] = frozenset()
   ```
-- **Common mistakes.** Omitting `_static_axes` entirely when `static_dims` is non-empty (relies on `Op`'s empty default, silently disables static-axis projection in `_cache_key`); emitting a literal `(input_index, axis)` pair when `axis` is actually a ctor param (produces a wrong axis under arbitrary rank); negative axis indices (must be non-negative per [`op_base.py`](../tileops/ops/op_base.py)); empty `_static_axes` without overriding `_cache_key` (emits a once-per-type `UserWarning` — see [Optional Hooks (Appendix)](#optional-hooks-appendix)).
+- **Common mistakes.** Omitting `_static_axes` entirely when `static_dims` is non-empty (relies on `Op`'s empty default, silently disables static-axis projection in `_cache_key`); emitting a literal `(input_index, axis)` pair when `axis` is actually a ctor param (produces a wrong axis under arbitrary rank); binding `self._static_axes` inside `__init__` when the axis comes from a param — `x.ndim` is not known yet, so a negative `dim` cannot be normalized (bind at `forward()` instead); storing a negative axis (must be non-negative per [`op_base.py`](../tileops/ops/op_base.py)); empty `_static_axes` without overriding `_cache_key` (emits a once-per-type `UserWarning` — see [Optional Hooks (Appendix)](#optional-hooks-appendix)).
 
 ## Family-Base Protocol (Appendix) <a id="base-class-protocol"></a>
 

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -112,7 +112,7 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 ### Slot S13: <a id="slot-s13"></a> `__init__` body
 
 - **Rule.** Body sequence: (a) `self.<name> = <name>` per kwarg; (b) `self.dispatch_kernel(kernel_map)`; then branch by op shape:
-  - **Fully-static op** (all non-static axes committed at ctor): (c-static) `self.kernel = self.kernel_map[<key>](...)` — kernel built once at init; (d-static) `self._output_shapes = self._infer_output_shapes(<input>_shape=(...))` — output shapes resolved at init.
+  - **Fully-static op** (all non-static axes committed at ctor): (c-static) `self.kernel = self.kernel_map[<key>](...)` — kernel built once at init; (d-static) optionally precompute `self._infer_output_shapes(<input>_shape=(...))` eagerly if a caller needs the output shapes before `forward()`. The `Op` base class does not currently consume an `_output_shapes` attribute — do not introduce one unless a concrete consumer requires it.
   - **Arbitrary-rank op** (at least one axis unknown until forward): (c-dyn) initialise `self._kernel_cache: Dict[tuple, Kernel] = {}` and defer kernel construction to `forward()` keyed by `_cache_key(*input_shapes)`; (d-dyn) defer `_infer_output_shapes` to `forward()` per unique input shape.
 - **Derivation.** Each `self.*` assignment mirrors one S12 kwarg. Kernel-build positional args follow the kernel class's ctor (kernel author's API). "Fully-static" iff every `signature.inputs` shape axis is either a manifest `shape` dim name or a `static_dims` key resolvable at ctor; otherwise arbitrary-rank and the deferred branch applies.
 - **Example (arbitrary-rank; `CumsumFwdOp`).**
@@ -171,7 +171,9 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
   self._static_axes = frozenset({(0, dim)})
   M = math.prod(s for i, s in enumerate(x.shape) if i != dim)
   self.M = M
-  key = (M,)
+  # default _cache_key projects non-static axes; override for coarser
+  # keying when kernel math permits (see Optional Hooks appendix).
+  key = self._cache_key(x.shape)
   if key not in self._kernel_cache:
       self._kernel_cache[key] = self.kernel_map["cumulative_fwd"](
           M, self.N, "sum", self.dtype, tune=self.tune

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -113,7 +113,7 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 - **Rule.** Body sequence: (a) `self.<name> = <name>` per kwarg; (b) `self.dispatch_kernel(kernel_map)`; then branch by op shape:
   - **Fully-static op** (all non-static axes committed at ctor): (c-static) `self.kernel = self.kernel_map[<key>](...)` — kernel built once at init; (d-static) optionally precompute `self._infer_output_shapes(<input>_shape=(...))` eagerly if a caller needs the output shapes before `forward()`. The `Op` base class does not currently consume an `_output_shapes` attribute — do not introduce one unless a concrete consumer requires it.
-  - **Arbitrary-rank op** (at least one axis unknown until forward): (c-dyn) initialise `self._kernel_cache: Dict[tuple, Kernel] = {}` and defer kernel construction to `forward()` keyed by `_cache_key(*input_shapes)`; (d-dyn) defer `_infer_output_shapes` to `forward()` per unique input shape.
+  - **Arbitrary-rank op** (at least one axis unknown until forward): (c-dyn) initialise `self._kernel_cache: Dict[Hashable, Kernel] = {}` (the cache key follows `Op._cache_key`'s `Hashable` return type — often a tuple, but overrides may return `int` or other hashables) and defer kernel construction to `forward()` keyed by `self._cache_key(*input_shapes)`; (d-dyn) defer `_infer_output_shapes` to `forward()` per unique input shape.
 - **Derivation.** Each `self.*` assignment mirrors one S12 kwarg. Kernel-build positional args follow the kernel class's ctor (kernel author's API). "Fully-static" iff every `signature.inputs` shape axis is either a manifest `shape` dim name or a `static_dims` key resolvable at ctor; otherwise arbitrary-rank and the deferred branch applies.
 - **Example (arbitrary-rank; `CumsumFwdOp`).**
   ```python
@@ -125,7 +125,7 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
   self.dispatch_kernel(kernel_map)
   # M unknown at init (only N committed via static_dims); kernel
   # is built lazily in forward() once M is derived.
-  self._kernel_cache: Dict[tuple, Kernel] = {}
+  self._kernel_cache: Dict[Hashable, Kernel] = {}
   ```
 - **Common mistakes.** `_infer_output_shapes` called before `dispatch_kernel`; hard-coding the kernel class instead of routing through `self.kernel_map`; building the kernel in `__init__` for an arbitrary-rank op (fails when a non-static axis value is required by the kernel ctor); omitting `self._kernel_cache` initialisation for the deferred branch (first forward-time cache lookup raises `AttributeError`).
 

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -111,18 +111,23 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 ### Slot S13: <a id="slot-s13"></a> `__init__` body
 
-- **Rule.** Body sequence: (a) `self.<name> = <name>` per kwarg; (b) `self.dispatch_kernel(kernel_map)`; (c) `self.kernel = self.kernel_map[<key>](...)`; (d) `self._infer_output_shapes(...)` when shapes are fully known at init.
-- **Derivation.** Each `self.*` assignment mirrors one S12 kwarg. Kernel-build positional args follow the kernel class's ctor (kernel author's API).
-- **Example.**
+- **Rule.** Body sequence: (a) `self.<name> = <name>` per kwarg; (b) `self.dispatch_kernel(kernel_map)`; then branch by op shape:
+  - **Fully-static op** (all non-static axes committed at ctor): (c-static) `self.kernel = self.kernel_map[<key>](...)` — kernel built once at init; (d-static) `self._output_shapes = self._infer_output_shapes(<input>_shape=(...))` — output shapes resolved at init.
+  - **Arbitrary-rank op** (at least one axis unknown until forward): (c-dyn) initialise `self._kernel_cache: Dict[tuple, Kernel] = {}` and defer kernel construction to `forward()` keyed by `_cache_key(*input_shapes)`; (d-dyn) defer `_infer_output_shapes` to `forward()` per unique input shape.
+- **Derivation.** Each `self.*` assignment mirrors one S12 kwarg. Kernel-build positional args follow the kernel class's ctor (kernel author's API). "Fully-static" iff every `signature.inputs` shape axis is either a manifest `shape` dim name or a `static_dims` key resolvable at ctor; otherwise arbitrary-rank and the deferred branch applies.
+- **Example (arbitrary-rank; `CumsumFwdOp`).**
   ```python
-  self.M = M
   self.N = N
   self.dtype = dtype
+  self.dim = dim
+  self.tune = tune
   self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
   self.dispatch_kernel(kernel_map)
-  self.kernel = self.kernel_map["cumulative_fwd"](M, N, "sum", dtype, tune=tune)
+  # M unknown at init (only N committed via static_dims); kernel
+  # is built lazily in forward() once M is derived.
+  self._kernel_cache: Dict[tuple, Kernel] = {}
   ```
-- **Common mistakes.** `_infer_output_shapes` called before `dispatch_kernel`; hard-coding the kernel class instead of routing through `self.kernel_map`.
+- **Common mistakes.** `_infer_output_shapes` called before `dispatch_kernel`; hard-coding the kernel class instead of routing through `self.kernel_map`; building the kernel in `__init__` for an arbitrary-rank op (fails when a non-static axis value is required by the kernel ctor); omitting `self._kernel_cache` initialisation for the deferred branch (first forward-time cache lookup raises `AttributeError`).
 
 ### Slot S14: <a id="slot-s14"></a> `default_kernel_map` property
 
@@ -148,25 +153,39 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 ### Slot S16: <a id="slot-s16"></a> `forward` body
 
-- **Rule.** Body sequence: (a) `self._validate_dtypes(...)`; (b) `.contiguous()` + reshape to the kernel layout; (c) validate each `static_dims` commitment and any ctor-committed non-`static_dims` size (e.g. `M` when kept in ctor for legacy layouts) against the actual tensor shape; (d) call the kernel; (e) trim alignment padding (if any) and restore the original shape.
-- **Derivation.** Validation expressions come from each `static_dims` entry's `<tensor>.shape[<axis>]` RHS; padding trim applies when the kernel operates on `align_up(N, DEFAULT_ALIGNMENT)` (compare `self.N_padded` vs `self.N`).
-- **Example.**
+- **Rule.** Body sequence: (a) `self._validate_dtypes(...)`; (b) validate `shape_rules` (e.g. `-x.ndim <= dim < x.ndim`) and normalise parameter-dependent axes via modulo (e.g. `dim = self.dim % x.ndim`); (c) validate each `static_dims` commitment (`x.shape[<resolved_axis>] == self.<kwarg>`); (d) for arbitrary-rank ops, bind `self._static_axes = frozenset({(input_index, resolved_axis)})` and look up / lazily build the kernel in `self._kernel_cache` keyed by `self._cache_key(*input_shapes)`; (e) `.contiguous()` + reshape to the kernel's expected 2D layout; (f) call the kernel; (g) trim alignment padding (if any) and restore the original shape. Fully-static ops skip the cache-lookup part of (d) since `self.kernel` was built at init.
+- **Derivation.** Validation expressions come from each `static_dims` entry's `<tensor>.shape[<axis>]` RHS; axis normalisation mirrors the param evaluation in `static_dims` + `shape_rules`; kernel cache key is whatever `_cache_key` projects (default: tuple of non-static-axis sizes). Padding trim applies when the kernel operates on `align_up(N, DEFAULT_ALIGNMENT)` (`self.N_padded != self.N`).
+- **Example (arbitrary-rank; `CumsumFwdOp`).**
   ```python
   self._validate_dtypes(x)
   if not x.is_cuda:
       raise ValueError("x must be a CUDA tensor")
-  if x.shape[-1] != self.N:
-      raise ValueError(f"Expected last dim {self.N}, got {x.shape[-1]}")
+  if not -x.ndim <= self.dim < x.ndim:
+      raise ValueError(f"dim {self.dim} out of range for x.ndim={x.ndim}")
+  dim = self.dim % x.ndim
+  if x.shape[dim] != self.N:
+      raise ValueError(
+          f"static_dim mismatch: expected x.shape[{dim}] == {self.N}, "
+          f"got {x.shape[dim]}"
+      )
+  self._static_axes = frozenset({(0, dim)})
+  M = math.prod(s for i, s in enumerate(x.shape) if i != dim)
+  self.M = M
+  key = (M,)
+  if key not in self._kernel_cache:
+      self._kernel_cache[key] = self.kernel_map["cumulative_fwd"](
+          M, self.N, "sum", self.dtype, tune=self.tune
+      )
+  kernel = self._kernel_cache[key]
   orig_shape = x.shape
-  x = x.contiguous().reshape(-1, self.N)
-  if x.shape[0] != self.M:
-      raise ValueError(f"Expected M={self.M}, got {x.shape[0]}")
-  y = self.kernel(x)
+  x2 = x.movedim(dim, -1).contiguous().reshape(M, self.N)
+  y2 = kernel(x2)
   if self.N_padded != self.N:
-      y = y[:, : self.N]
-  return y.reshape(orig_shape)
+      y2 = y2[:, : self.N]
+  y = y2.reshape(*orig_shape[:dim], *orig_shape[dim + 1 :], self.N)
+  return y.movedim(-1, dim)
   ```
-- **Common mistakes.** Skipping `_validate_dtypes`; reshape before `.contiguous()`; forgetting the padding trim when `self.N_padded != self.N` (causes `reshape(orig_shape)` to raise on size mismatch); not restoring the original shape.
+- **Common mistakes.** Skipping `_validate_dtypes`; reshape before `.contiguous()`; hard-coding `x.shape[-1]` instead of the normalised `x.shape[self.dim % x.ndim]`; binding `self._static_axes` before the axis is non-negative (violates `Op._static_axes` contract); forgetting the kernel cache lookup so every forward rebuilds the kernel; forgetting the padding trim when `self.N_padded != self.N` (causes `reshape(orig_shape)` to raise on size mismatch); not restoring the original shape.
 
 ### Slot S17: <a id="slot-s17"></a> `_infer_output_shapes` method body
 
@@ -217,9 +236,22 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 ### Slot S21: <a id="slot-s21"></a> `_static_axes` class attribute
 
-- **Rule.** Each concrete op declares `_static_axes: frozenset[tuple[int, int]]` of `(input_index, axis)` pairs committed at constructor time. `input_index` is the positional index in `signature.inputs`; `axis` is a non-negative integer within that input's shape. Empty frozenset is legal (means "no axes committed at ctor"). When the manifest expresses the axis via a ctor param (e.g., `static_dims: N: "x.shape[dim]"` where `dim` is a param and may be negative), the concrete `(input_index, axis)` pair cannot be resolved at `__init__` — `x.ndim` is unknown until a tensor is passed. The scaffold emits an empty class-level default; the concrete op binds `self._static_axes` inside `forward()` after normalizing the axis via `dim % x.ndim` (or equivalently inside a `_cache_key` override that projects the shape inline).
-- **Derivation.** Manifest `static_dims`; for each entry `<kwarg>: <tensor>.shape[<axis>]`: if `<axis>` is an integer literal, emit a class-level pair `(input_index_of_<tensor>, <axis>)`; if `<axis>` is a ctor param name, emit `_static_axes = frozenset()` at class level and assign `self._static_axes = frozenset({(i, <param> % x.ndim)})` inside `forward()` (after the `static_dims` commitment check), or override `_cache_key` to compute the same projection inline. PyTorch-aligned reductions with `dim=None` → empty frozenset (see [manifest.md § Empty static_dims](manifest.md#empty-static_dims)).
+- **Rule.** Each concrete op declares `_static_axes: frozenset[tuple[int, int]]` of `(input_index, axis)` pairs, where `input_index` is the positional index in `signature.inputs` and `axis` is a **non-negative** integer within that input's shape. The commitment happens at one of two points:
+
+  - **Ctor time**, as a class-level literal, when every axis can be resolved to a non-negative integer without knowing runtime rank (e.g., manifest declares `static_dims: M: "x.shape[0]"`).
+  - **`forward()` time**, with an empty class-level default, when at least one axis depends on runtime rank — most commonly a ctor param that may be negative (e.g., `static_dims: N: "x.shape[dim]"` with `dim` defaulting to `-1`). At forward, the concrete op normalises the axis (`dim % x.ndim`), then assigns `self._static_axes = frozenset({(i, <resolved_axis>)})`. Equivalently the op may override `_cache_key` and project the shape inline without ever populating `_static_axes`.
+
+  Empty frozenset is legal as the class-level default (means "no axes committed yet"). Negative axes MUST NOT be stored in `_static_axes` without prior normalisation — the `Op` base class relies on non-negative indexing into `*input_shapes`.
+
+- **Derivation.** Manifest `static_dims`; for each entry `<kwarg>: <tensor>.shape[<axis>]`:
+
+  - If `<axis>` is resolvable to a non-negative integer literal at class-definition time → emit class-level `_static_axes = frozenset({(input_index_of_<tensor>, <axis>)})`.
+  - If `<axis>` is a ctor param name, or is written as a negative literal whose normalised value depends on runtime rank → emit `_static_axes = frozenset()` at class level and assign `self._static_axes = frozenset({(i, <param> % x.ndim)})` inside `forward()` after the `static_dims` commitment check, or override `_cache_key` to project inline.
+
+  PyTorch-aligned reductions with `dim=None` → empty frozenset (see [manifest.md § Empty static_dims](manifest.md#empty-static_dims)).
+
 - **Example.**
+
   ```python
   class CumsumFwdOp(Op):
       # static_dims: N: "x.shape[dim]" — axis is parameter-dependent
@@ -228,6 +260,7 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
       # normalization. Class-level default is empty.
       _static_axes: frozenset[tuple[int, int]] = frozenset()
   ```
+
 - **Common mistakes.** Omitting `_static_axes` entirely when `static_dims` is non-empty (relies on `Op`'s empty default, silently disables static-axis projection in `_cache_key`); emitting a literal `(input_index, axis)` pair when `axis` is actually a ctor param (produces a wrong axis under arbitrary rank); binding `self._static_axes` inside `__init__` when the axis comes from a param — `x.ndim` is not known yet, so a negative `dim` cannot be normalized (bind at `forward()` instead); storing a negative axis (must be non-negative per [`op_base.py`](../tileops/ops/op_base.py)); empty `_static_axes` without overriding `_cache_key` (emits a once-per-type `UserWarning` — see [Optional Hooks (Appendix)](#optional-hooks-appendix)).
 
 ## Family-Base Protocol (Appendix) <a id="base-class-protocol"></a>

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -93,7 +93,7 @@ class CumsumFwdOp(Op):
 
 ### Step 3: `_static_axes` + `__init__` signature and body
 
-**Input.** `static_dims` (literal-axis → class-level `_static_axes` frozenset; param-axis → empty default, bind in `__init__`); `signature.params`; `dtype`.
+**Input.** `static_dims` (literal-axis → class-level `_static_axes` frozenset; param-axis → empty class-level default, bind at `forward()` after `dim % x.ndim` normalization); `signature.params`; `dtype`.
 
 **Output.**
 


### PR DESCRIPTION
## Summary

Add `.claude/skills/op-scaffold/SKILL.md` — an agent-executable procedure that scaffolds a new T2 (L1-direct) Op file from a single `ops_manifest.yaml` entry by following the 7-step playbook in `docs/ops-design.md`. The skill emits exactly the 17 scaffold slots (S1-S7, S12-S21) defined in `docs/ops-design-reference.md § Slot Rules`; it explicitly does NOT emit family-specific protocol variables, optional hooks, or kernel implementations — those are downstream-skill responsibility.

Also bundles documentation calibration work that emerged during review:

- Slot S13 / S16 rules broadened to cover arbitrary-rank ops (deferred kernel build + cache lookup), which the original rules only covered for the fully-static case.
- Slot S21 rewritten to document both ctor-time and forward-time `_static_axes` binding per the `Op._static_axes` non-negative-axis contract.
- `docs/ops-design.md` Step 3 **Input** line updated to match the forward-time binding used in its Output code block.

## Structure (final, post-review)

The skill is **agent-executable procedure**, not a codegen engine. The agent follows the procedure using the playbook + reference slot rules as authoritative source.

Workflow: `READ → PRE_CHECK → DRY_RUN → EMIT → REGISTER → VALIDATE → REPORT`.

### DRY_RUN (self-audit before codegen)

Produces `.foundry/plan/<op_name>/plan.json` with three sections:

- **§1 locked_facts** — verbatim extraction from the manifest entry (op_name, class_name, filesystem module_path, parent_class, kernel_imports, kernel_map, init_kwargs with source tags, forward_inputs/outputs, dtype_unions, dtype_combos, shape_rules, static_dims, roofline vars/flops/bytes). Machine-diffed at VALIDATE across both the new op file **and** the updated package `__init__.py` (registration side-effects). Any drift = skill bug, hard BLOCKED.
- **§2 agent_notes** — discretion area (docstring wording, helper state on `self`, reshape strategy, which codebase files the agent consulted). Recorded but not diffed.
- **§3 open_questions** — tagged observations (`needs_doc_fix` / `needs_manifest_fix` / `needs_human_decision`). Do NOT block; surfaced in REPORT as post-run iteration feedback.

`.foundry/plan/` is gitignored — per-run intermediate artefact.

### Prerequisites (PRE_CHECK rules)

- `op_name` in `ops_manifest.yaml`
- `status: spec-only` (explicit; missing / other values → BLOCKED, validator treats `status` as required)
- `source.kernel_map` non-empty (dispatch keys are kernel-internal conventions; scaffold cannot invent them — the manifest PR that adds `kernel_map` is a prerequisite to running the scaffold)
- Every `source.kernel_map` value importable
- Target `source.op` does not exist

### VALIDATE (two-step gate)

1. Parse emitted op file AND updated package `__init__.py` with `ast`. Field-by-field diff against `plan.json.locked_facts`. Mismatch on either → `§1 drift` BLOCKED. Covers both class-level facts (class name, bases, imports, kwargs, ...) and registration side-effects (import line under correct block, `__all__` entry in right section).
2. `python scripts/validate_manifest.py --check-op <op_name>` — scoped so L0-L4 run on the fresh spec-only entry (default run skips L1-L4 for `spec-only`).

### Path derivation (critical contract)

Filesystem paths key off **`source.op`**, not manifest `family` — these can differ (e.g. `CumsumFwdOp` has `family: scan` but lives in `tileops/ops/reduction/`). Contract Output line, READ step, REGISTER step, and the workflow state diagram all document this.

## Scope boundary

The scaffold emits **only** the 17 slots. Explicitly **not** emitted:

- Family-specific protocol variables (`_op_kind`, `_kernel_key`, etc. — kernel-dispatch-convention-dependent)
- Optional hooks (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`, `_cache_key` override)
- Kernel implementations
- Tests / benchmarks / manifest modifications

## Bundled doc fixes (from review)

- `docs/ops-design-reference.md § Slot S13` Rule: fully-static vs arbitrary-rank branch. Arbitrary-rank defers kernel to forward + initialises `self._kernel_cache`. Example uses CumsumFwdOp's deferred pattern. Common mistakes updated. (Also dropped the stray `self._output_shapes` assignment — `Op` base does not consume that attribute.)
- `docs/ops-design-reference.md § Slot S16` Rule: full arbitrary-rank forward pipeline (shape_rules validation + axis normalisation + `_static_axes` binding + `_cache_key` lookup + lazy kernel build + padding trim). Example uses `self._cache_key(x.shape)` per the cache-key contract rather than a hard-coded tuple.
- `docs/ops-design-reference.md § Slot S21` Rule + Derivation: two commitment points (ctor time vs forward time) documented; explicit prohibition on storing negative axes without normalisation.
- `docs/ops-design.md § Step 3 Input`: "bind in `__init__`" → "bind at `forward()` after `dim % x.ndim` normalisation", matching the Output code block's already-corrected comment.

## Test plan

- [x] SKILL file exists at `.claude/skills/op-scaffold/SKILL.md`.
- [x] All `#slot-sN` anchors in the skill resolve against `docs/ops-design-reference.md`.
- [x] Path derivation uses `source.op` everywhere — no `{family}` templates remain, including in the workflow state diagram labels.
- [x] PRE_CHECK rejects missing `status`, missing `source.kernel_map`, and importability failures with clear BLOCKED messages.
- [x] VALIDATE uses `--check-op <op_name>` so L1-L4 run on spec-only entries.
- [x] DRY_RUN `plan.json` schema covers all 17 slots' fact extraction; §1 post-check covers both the op file and the package `__init__.py` registration.
- [x] Pre-commit hooks (mdformat, gitleaks, codespell) pass across all 5 commits.
- [ ] Exercise the skill against a real op — deferred to the first scaffold run; plan artefacts under `.foundry/plan/<op_name>/` will drive any follow-up tightening.