### PR TITLE
[Refactor][CONV1D] Add dilation support to forward kernel

### DIFF
--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -19,6 +19,7 @@ class Conv1dBenchCase:
         kernel_size: int,
         stride: int,
         padding: int,
+        dilation: int,
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -28,6 +29,7 @@ class Conv1dBenchCase:
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -51,7 +53,7 @@ class Conv1dBenchCase:
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
 
@@ -60,12 +62,12 @@ class Conv1dBenchmark(BenchmarkBase[Conv1dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
-        out_l = (t.l_in + 2 * t.padding - t.kernel_size) // t.stride + 1
+        out_l = (t.l_in + 2 * t.padding - t.dilation * (t.kernel_size - 1) - 1) // t.stride + 1
         return 2.0 * t.n * t.c_out * out_l * t.c_in * t.kernel_size
 
     def calculate_memory(self) -> Optional[float]:
         t = self.workload
-        out_l = (t.l_in + 2 * t.padding - t.kernel_size) // t.stride + 1
+        out_l = (t.l_in + 2 * t.padding - t.dilation * (t.kernel_size - 1) - 1) // t.stride + 1
         bytes_ = (
             t.n * t.c_in * t.l_in
             + t.c_out * t.c_in * t.kernel_size
@@ -75,16 +77,17 @@ class Conv1dBenchmark(BenchmarkBase[Conv1dBenchCase]):
 
 
 _CONV1D_BENCH_PARAMS = [
-    pytest.param(4, 256, 32000, 512, 1, 1, 0, torch.float16, True, id="convtasnet-pointwise-k1-s1-fp16"),
-    pytest.param(4, 128, 4096, 256, 3, 1, 1, torch.float16, True, id="seanet-k3-s1-fp16"),
-    pytest.param(4, 64, 16000, 128, 5, 2, 2, torch.float16, True, id="audio-downsample-k5-s2-fp16"),
-    pytest.param(4, 128, 8192, 256, 7, 1, 3, torch.float16, True, id="seanet-stem-k7-s1-fp16"),
-    pytest.param(2, 128, 4096, 256, 3, 2, 1, torch.bfloat16, True, id="sequence-downsample-k3-s2-bf16"),
+    pytest.param(4, 256, 32000, 512, 1, 1, 0, 1, torch.float16, True, id="convtasnet-pointwise-k1-s1-fp16"),
+    pytest.param(4, 128, 4096, 256, 3, 1, 1, 1, torch.float16, True, id="seanet-k3-s1-fp16"),
+    pytest.param(4, 64, 16000, 128, 5, 2, 2, 1, torch.float16, True, id="audio-downsample-k5-s2-fp16"),
+    pytest.param(4, 128, 8192, 256, 7, 1, 3, 1, torch.float16, True, id="seanet-stem-k7-s1-fp16"),
+    pytest.param(2, 128, 4096, 256, 3, 2, 1, 1, torch.bfloat16, True, id="sequence-downsample-k3-s2-bf16"),
+    pytest.param(4, 128, 4096, 256, 3, 1, 2, 2, torch.float16, True, id="seanet-k3-s1-d2-fp16"),
 ]
 
 
 @pytest.mark.parametrize(
-    "n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune",
+    "n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype, tune",
     _CONV1D_BENCH_PARAMS,
 )
 def test_conv1d_bench(
@@ -95,10 +98,11 @@ def test_conv1d_bench(
     kernel_size: int,
     stride: int,
     padding: int,
+    dilation: int,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv1dBenchCase(n, c_in, l_in, c_out, kernel_size, stride, padding, dtype)
+    test = Conv1dBenchCase(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype)
     bm = Conv1dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
@@ -112,6 +116,7 @@ def test_conv1d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         bias=True,
         dtype=dtype,
         tune=tune,

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
+from tileops.ops import Conv1dBiasFwdOp, Conv2dOp, Conv3dOp
 
 
 class Conv1dBenchCase:
@@ -108,7 +108,7 @@ def test_conv1d_bench(
     x, weight, bias = inputs
     x_ncl = x.permute(0, 2, 1).contiguous()
 
-    op = Conv1dFwdOp(
+    op = Conv1dBiasFwdOp(
         n=n,
         c_in=c_in,
         l_in=l_in,
@@ -117,7 +117,6 @@ def test_conv1d_bench(
         stride=stride,
         padding=padding,
         dilation=dilation,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -191,8 +191,8 @@ def test_conv1d_bias_requires_bias_tensor() -> None:
 @pytest.mark.parametrize(
     "op_cls, dilation, use_bias",
     [
-        pytest.param(Conv1dFwdOp, (2,), False, marks=pytest.mark.smoke, id="no-bias-tuple"),
-        pytest.param(Conv1dBiasFwdOp, (2,), True, marks=pytest.mark.full, id="bias-tuple"),
+        pytest.param(Conv1dFwdOp, 2, False, marks=pytest.mark.smoke, id="no-bias"),
+        pytest.param(Conv1dBiasFwdOp, 2, True, marks=pytest.mark.full, id="bias"),
     ],
 )
 def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None:
@@ -227,39 +227,6 @@ def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None
     )
     ref = ref.permute(0, 2, 1).contiguous()
     torch.testing.assert_close(out, ref, atol=2e-3, rtol=3e-3)
-
-
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        pytest.param({"stride": [1]}, marks=pytest.mark.smoke, id="stride-list"),
-        pytest.param({"padding": [1]}, marks=pytest.mark.full, id="padding-list"),
-        pytest.param({"dilation": [2]}, marks=pytest.mark.full, id="dilation-list"),
-    ],
-)
-def test_conv1d_rejects_list_spatial_params(kwargs) -> None:
-    with pytest.raises(TypeError, match="tuple"):
-        Conv1dFwdOp(
-            n=1,
-            c_in=32,
-            l_in=128,
-            c_out=64,
-            kernel_size=3,
-            **kwargs,
-        )
-
-
-@pytest.mark.smoke
-def test_conv1d_rejects_unsupported_groups() -> None:
-    with pytest.raises(NotImplementedError, match="groups=1"):
-        Conv1dFwdOp(
-            n=1,
-            c_in=32,
-            l_in=128,
-            c_out=64,
-            kernel_size=3,
-            groups=2,
-        )
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -133,7 +133,7 @@ def test_conv1d(
     tune: bool,
 ) -> None:
     test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype)
-    op = Conv1dFwdOp(
+    op = Conv1dBiasFwdOp(
         n=n,
         c_in=c_in,
         l_in=l_in,
@@ -142,7 +142,6 @@ def test_conv1d(
         stride=stride,
         padding=padding,
         dilation=dilation,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )
@@ -151,7 +150,7 @@ def test_conv1d(
 
 
 @pytest.mark.smoke
-def test_conv1d_accepts_zero_bias() -> None:
+def test_conv1d_no_bias_matches_torch() -> None:
     op = Conv1dFwdOp(
         n=1,
         c_in=32,
@@ -160,7 +159,25 @@ def test_conv1d_accepts_zero_bias() -> None:
         kernel_size=5,
         stride=2,
         padding=2,
-        bias=True,
+    )
+    x = torch.randn(1, 256, 32, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 5, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    ref = F.conv1d(x.permute(0, 2, 1).contiguous(), weight, bias=None, stride=2, padding=2)
+    ref = ref.permute(0, 2, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv1d_bias_requires_bias_tensor() -> None:
+    op = Conv1dBiasFwdOp(
+        n=1,
+        c_in=32,
+        l_in=256,
+        c_out=64,
+        kernel_size=5,
+        stride=2,
+        padding=2,
     )
     x = torch.randn(1, 256, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 5, device="cuda", dtype=torch.float16).contiguous()
@@ -181,6 +198,7 @@ def test_conv1d_accepts_zero_bias() -> None:
 def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None:
     n, c_in, l_in, c_out, kernel_size = 1, 32, 128, 64, 3
     stride, padding = 1, 2
+    op_kwargs = {"bias": use_bias} if op_cls is Conv1dBiasFwdOp else {}
     op = op_cls(
         n=n,
         c_in=c_in,
@@ -190,7 +208,7 @@ def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None
         stride=stride,
         padding=padding,
         dilation=dilation,
-        bias=use_bias,
+        **op_kwargs,
     )
     x = torch.randn(n, l_in, c_in, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(c_out, c_in, kernel_size, device="cuda", dtype=torch.float16).contiguous()
@@ -198,7 +216,7 @@ def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None
         torch.randn(c_out, device="cuda", dtype=torch.float16).contiguous()
         if use_bias else None
     )
-    out = op(x, weight, bias)
+    out = op(x, weight, bias) if use_bias else op(x, weight)
     ref = F.conv1d(
         x.permute(0, 2, 1).contiguous(),
         weight,
@@ -254,7 +272,6 @@ def test_conv1d_dispatches_kernel() -> None:
         kernel_size=3,
         stride=1,
         padding=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv1dKernel)
 

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.convolution import Conv1dKernel, Conv2d1x1Kernel, Conv2dKernel, Conv3dKernel
-from tileops.ops import Conv1dFwdOp, Conv2dOp, Conv3dOp
+from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
 
 SKIPPED_CONV2D_CASES = {
     (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False),
@@ -23,41 +23,46 @@ SKIPPED_CONV3D_CASES = {
 
 class Conv1dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dtype, tune", [
+        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype, tune", [
             pytest.param(
-                2, 64, 512, 128, 3, 1, 1, torch.float16, False,
+                2, 64, 512, 128, 3, 1, 1, 1, torch.float16, False,
                 marks=[pytest.mark.smoke, pytest.mark.packaging],
                 id="smoke-tcn-k3-s1-fp16",
             ),
             pytest.param(
-                2, 64, 512, 128, 3, 1, 1, torch.bfloat16, False,
+                2, 64, 512, 128, 3, 1, 1, 1, torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-tcn-k3-s1-bf16",
             ),
             pytest.param(
-                4, 256, 32000, 512, 1, 1, 0, torch.float16, False,
+                4, 256, 32000, 512, 1, 1, 0, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-convtasnet-pointwise-k1-s1-fp16",
             ),
             pytest.param(
-                4, 128, 4096, 256, 3, 1, 1, torch.float16, False,
+                4, 128, 4096, 256, 3, 1, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-seanet-residual-k3-s1-fp16",
             ),
             pytest.param(
-                4, 64, 16000, 128, 5, 2, 2, torch.float16, False,
+                4, 64, 16000, 128, 5, 2, 2, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-audio-downsample-k5-s2-fp16",
             ),
             pytest.param(
-                1, 32, 256, 64, 7, 1, 3, torch.float16, False,
+                1, 32, 256, 64, 7, 1, 3, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-small-seanet-stem-k7-s1-fp16",
             ),
             pytest.param(
-                2, 128, 4096, 256, 3, 2, 1, torch.bfloat16, False,
+                2, 128, 4096, 256, 3, 2, 1, 1, torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-sequence-downsample-k3-s2-bf16",
+            ),
+            pytest.param(
+                1, 32, 512, 64, 3, 1, 2, 2, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-dilation-k3-d2-fp16",
             ),
         ]),
     ]
@@ -74,6 +79,7 @@ class Conv1dTest(TestBase):
         kernel_size: int,
         stride: int,
         padding: int,
+        dilation: int,
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -83,6 +89,7 @@ class Conv1dTest(TestBase):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -106,7 +113,7 @@ class Conv1dTest(TestBase):
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
         return out.permute(0, 2, 1).contiguous()
@@ -121,10 +128,11 @@ def test_conv1d(
     kernel_size: int,
     stride: int,
     padding: int,
+    dilation: int,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dtype)
+    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype)
     op = Conv1dFwdOp(
         n=n,
         c_in=c_in,
@@ -133,6 +141,7 @@ def test_conv1d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         bias=True,
         dtype=dtype,
         tune=tune,
@@ -160,6 +169,79 @@ def test_conv1d_accepts_zero_bias() -> None:
     ref = F.conv1d(x.permute(0, 2, 1).contiguous(), weight, bias=bias, stride=2, padding=2)
     ref = ref.permute(0, 2, 1).contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "op_cls, dilation, use_bias",
+    [
+        pytest.param(Conv1dFwdOp, (2,), False, marks=pytest.mark.smoke, id="no-bias-tuple"),
+        pytest.param(Conv1dBiasFwdOp, (2,), True, marks=pytest.mark.full, id="bias-tuple"),
+    ],
+)
+def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None:
+    n, c_in, l_in, c_out, kernel_size = 1, 32, 128, 64, 3
+    stride, padding = 1, 2
+    op = op_cls(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
+        c_out=c_out,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        bias=use_bias,
+    )
+    x = torch.randn(n, l_in, c_in, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(c_out, c_in, kernel_size, device="cuda", dtype=torch.float16).contiguous()
+    bias = (
+        torch.randn(c_out, device="cuda", dtype=torch.float16).contiguous()
+        if use_bias else None
+    )
+    out = op(x, weight, bias)
+    ref = F.conv1d(
+        x.permute(0, 2, 1).contiguous(),
+        weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        dilation=2,
+    )
+    ref = ref.permute(0, 2, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=2e-3, rtol=3e-3)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"stride": [1]}, marks=pytest.mark.smoke, id="stride-list"),
+        pytest.param({"padding": [1]}, marks=pytest.mark.full, id="padding-list"),
+        pytest.param({"dilation": [2]}, marks=pytest.mark.full, id="dilation-list"),
+    ],
+)
+def test_conv1d_rejects_list_spatial_params(kwargs) -> None:
+    with pytest.raises(TypeError, match="tuple"):
+        Conv1dFwdOp(
+            n=1,
+            c_in=32,
+            l_in=128,
+            c_out=64,
+            kernel_size=3,
+            **kwargs,
+        )
+
+
+@pytest.mark.smoke
+def test_conv1d_rejects_unsupported_groups() -> None:
+    with pytest.raises(NotImplementedError, match="groups=1"):
+        Conv1dFwdOp(
+            n=1,
+            c_in=32,
+            l_in=128,
+            c_out=64,
+            kernel_size=3,
+            groups=2,
+        )
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -48,11 +48,12 @@ def _conv1d_kernel(
     kernel_l: int,
     stride_l: int,
     pad_l: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     k_total = kernel_l * c_in
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
@@ -95,7 +96,7 @@ def _conv1d_kernel(
                         ci = k_idx % c_in
                         batch = m_idx // out_l
                         ol = m_idx % out_l
-                        il = ol * stride_l + kw - pad_l
+                        il = ol * stride_l + kw * dilation_l - pad_l
                         in_bound = (
                             (m_idx < n * out_l)
                             & (k_idx < k_total)
@@ -147,6 +148,7 @@ def _conv1d_wrapped_kernel(
     kernel_l: int,
     stride_l: int,
     pad_l: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -160,7 +162,7 @@ def _conv1d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, has_bias, dtype
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -173,6 +175,7 @@ def _(
     kernel_l: int,
     stride_l: int,
     pad_l: int,
+    dilation_l: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -183,7 +186,7 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, out_l, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
@@ -200,6 +203,7 @@ class Conv1dKernel(Kernel):
         stride_l: int,
         pad_l: int,
         dtype: torch.dtype,
+        dilation_l: int = 1,
         has_bias: bool = False,
         config: Optional[dict] = None,
         tune: bool = False,
@@ -212,9 +216,10 @@ class Conv1dKernel(Kernel):
         self.kernel_l = kernel_l
         self.stride_l = stride_l
         self.pad_l = pad_l
+        self.dilation_l = dilation_l
         self.dtype = dtype
         self.has_bias = has_bias
-        self.out_l = (l_in + 2 * pad_l - kernel_l) // stride_l + 1
+        self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
         self.k_total = c_in * kernel_l
 
@@ -226,6 +231,7 @@ class Conv1dKernel(Kernel):
             kernel_l,
             stride_l,
             pad_l,
+            dilation_l,
             has_bias,
             self.dtype_str,
         )
@@ -297,6 +303,7 @@ class Conv1dKernel(Kernel):
             self.kernel_l,
             self.stride_l,
             self.pad_l,
+            self.dilation_l,
             self.has_bias,
             self.dtype_str,
             self.config["block_m"],

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -34,20 +34,27 @@ def _conv_padding_to_tuple(
     stride: Tuple[int, ...],
     kernel_size: Tuple[int, ...],
     op_name: str,
+    dilation: Optional[Tuple[int, ...]] = None,
 ) -> Tuple[int, ...]:
     dims = len(kernel_size)
+    if dilation is None:
+        dilation = (1,) * dims
     if isinstance(padding, str):
         if padding == "valid":
             return (0,) * dims
         if padding == "same":
             if any(axis_stride != 1 for axis_stride in stride):
                 raise ValueError(f"{op_name} padding='same' requires stride == 1")
-            if any(axis_kernel % 2 == 0 for axis_kernel in kernel_size):
+            effective_kernel = tuple(
+                axis_dilation * (axis_kernel - 1) + 1
+                for axis_kernel, axis_dilation in zip(kernel_size, dilation, strict=True)
+            )
+            if any(axis_kernel % 2 == 0 for axis_kernel in effective_kernel):
                 raise ValueError(
-                    f"{op_name} padding='same' requires odd kernel_size values "
+                    f"{op_name} padding='same' requires odd effective kernel_size values "
                     "with the current symmetric padding kernel"
                 )
-            return tuple(axis_kernel // 2 for axis_kernel in kernel_size)
+            return tuple(axis_kernel // 2 for axis_kernel in effective_kernel)
         raise ValueError(
             f"{op_name} padding must be an int, {dims}-element tuple, 'valid', or 'same'"
         )
@@ -61,6 +68,14 @@ def _validate_positive_int(name: str, value: int, op_name: str) -> None:
         raise ValueError(f"{op_name} {name} must be greater than zero")
 
 
+def _validate_conv_groups(op_name: str, c_in: int, c_out: int, groups: int) -> None:
+    _validate_positive_int("groups", groups, op_name)
+    if c_in % groups != 0:
+        raise ValueError(f"{op_name} c_in must be divisible by groups")
+    if c_out % groups != 0:
+        raise ValueError(f"{op_name} c_out must be divisible by groups")
+
+
 def _validate_conv_params(
     *,
     op_name: str,
@@ -68,16 +83,27 @@ def _validate_conv_params(
     kernel_size: Tuple[int, ...],
     stride: Tuple[int, ...],
     padding: Tuple[int, ...],
+    dilation: Optional[Tuple[int, ...]] = None,
 ) -> None:
     ndim = len(input_size)
-    if len(kernel_size) != ndim or len(stride) != ndim or len(padding) != ndim:
-        raise ValueError(f"{op_name} kernel_size, stride, and padding must match dimensionality")
+    if dilation is None:
+        dilation = (1,) * ndim
+    if (
+        len(kernel_size) != ndim
+        or len(stride) != ndim
+        or len(padding) != ndim
+        or len(dilation) != ndim
+    ):
+        raise ValueError(
+            f"{op_name} kernel_size, stride, padding, and dilation must match dimensionality"
+        )
 
     for name, values in (
         ("input_size", input_size),
         ("kernel_size", kernel_size),
         ("stride", stride),
         ("padding", padding),
+        ("dilation", dilation),
     ):
         if not all(isinstance(v, int) and not isinstance(v, bool) for v in values):
             raise TypeError(f"{op_name} {name} must contain only ints")
@@ -90,11 +116,13 @@ def _validate_conv_params(
         raise ValueError(f"{op_name} stride must be greater than zero")
     if any(v < 0 for v in padding):
         raise ValueError(f"{op_name} padding must be non-negative")
+    if any(v <= 0 for v in dilation):
+        raise ValueError(f"{op_name} dilation must be greater than zero")
 
     output_size = tuple(
-        (input_dim + 2 * pad - kernel_dim) // stride_dim + 1
-        for input_dim, kernel_dim, stride_dim, pad in zip(
-            input_size, kernel_size, stride, padding, strict=True
+        (input_dim + 2 * pad - dilation_dim * (kernel_dim - 1) - 1) // stride_dim + 1
+        for input_dim, kernel_dim, stride_dim, pad, dilation_dim in zip(
+            input_size, kernel_size, stride, padding, dilation, strict=True
         )
     )
     if any(v <= 0 for v in output_size):
@@ -118,6 +146,8 @@ class Conv1dFwdOp(Op):
         kernel_size: int | Tuple[int],
         stride: int | Tuple[int] = 1,
         padding: int | Tuple[int] | str = 0,
+        dilation: int | Tuple[int] = 1,
+        groups: int = 1,
         bias: bool = False,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -127,23 +157,32 @@ class Conv1dFwdOp(Op):
         _validate_positive_int("c_in", c_in, "Conv1d")
         _validate_positive_int("l_in", l_in, "Conv1d")
         _validate_positive_int("c_out", c_out, "Conv1d")
+        _validate_conv_groups("Conv1d", c_in, c_out, groups)
+        if groups != 1:
+            raise NotImplementedError("Conv1d currently supports groups=1 only")
         self.n = n
         self.c_in = c_in
         self.l_in = l_in
         self.c_out = c_out
         kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
         stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
-        padding_tuple = _conv_padding_to_tuple(padding, stride_tuple, kernel_size_tuple, "Conv1d")
+        dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
+        padding_tuple = _conv_padding_to_tuple(
+            padding, stride_tuple, kernel_size_tuple, "Conv1d", dilation_tuple
+        )
         _validate_conv_params(
             op_name="Conv1d",
             input_size=(l_in,),
             kernel_size=kernel_size_tuple,
             stride=stride_tuple,
             padding=padding_tuple,
+            dilation=dilation_tuple,
         )
         self.kernel_size = kernel_size_tuple[0]
         self.stride = stride_tuple[0]
         self.padding = padding_tuple[0]
+        self.dilation = dilation_tuple[0]
+        self.groups = groups
         self.has_bias = bias
         self.dtype = dtype
 
@@ -158,6 +197,7 @@ class Conv1dFwdOp(Op):
             kernel_l=self.kernel_size,
             stride_l=self.stride,
             pad_l=self.padding,
+            dilation_l=self.dilation,
             dtype=dtype,
             has_bias=bias,
             tune=tune,
@@ -201,6 +241,8 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
         kernel_size: int | Tuple[int],
         stride: int | Tuple[int] = 1,
         padding: int | Tuple[int] | str = 0,
+        dilation: int | Tuple[int] = 1,
+        groups: int = 1,
         bias: bool = True,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -213,7 +255,8 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
             )
         super().__init__(
             n=n, c_in=c_in, l_in=l_in, c_out=c_out,
-            kernel_size=kernel_size, stride=stride, padding=padding,
+            kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation,
+            groups=groups,
             bias=bias, dtype=dtype, kernel_map=kernel_map, tune=tune,
         )
 

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -148,7 +148,6 @@ class Conv1dFwdOp(Op):
         padding: int | Tuple[int] | str = 0,
         dilation: int | Tuple[int] = 1,
         groups: int = 1,
-        bias: bool = False,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -183,7 +182,7 @@ class Conv1dFwdOp(Op):
         self.padding = padding_tuple[0]
         self.dilation = dilation_tuple[0]
         self.groups = groups
-        self.has_bias = bias
+        self.has_bias = False
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
@@ -199,7 +198,7 @@ class Conv1dFwdOp(Op):
             pad_l=self.padding,
             dilation_l=self.dilation,
             dtype=dtype,
-            has_bias=bias,
+            has_bias=False,
             tune=tune,
         )
 
@@ -211,7 +210,6 @@ class Conv1dFwdOp(Op):
         self,
         input: torch.Tensor,
         weight: torch.Tensor,
-        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         _validate_tensor_shape("Conv1d", "input", input, (self.n, self.l_in, self.c_in))
         _validate_tensor_shape(
@@ -220,9 +218,7 @@ class Conv1dFwdOp(Op):
             weight,
             (self.c_out, self.c_in, self.kernel_size),
         )
-        if bias is not None:
-            _validate_tensor_shape("Conv1d", "bias", bias, (self.c_out,))
-        return self.kernel(input, weight, bias)
+        return self.kernel(input, weight, None)
 
 
 class Conv1dBiasFwdOp(Conv1dFwdOp):
@@ -253,12 +249,71 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
                 "Conv1dBiasFwdOp requires bias=True. "
                 "Use Conv1dFwdOp for the no-bias variant."
             )
-        super().__init__(
-            n=n, c_in=c_in, l_in=l_in, c_out=c_out,
-            kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation,
-            groups=groups,
-            bias=bias, dtype=dtype, kernel_map=kernel_map, tune=tune,
+        _validate_positive_int("n", n, "Conv1d")
+        _validate_positive_int("c_in", c_in, "Conv1d")
+        _validate_positive_int("l_in", l_in, "Conv1d")
+        _validate_positive_int("c_out", c_out, "Conv1d")
+        _validate_conv_groups("Conv1d", c_in, c_out, groups)
+        if groups != 1:
+            raise NotImplementedError("Conv1d currently supports groups=1 only")
+        self.n = n
+        self.c_in = c_in
+        self.l_in = l_in
+        self.c_out = c_out
+        kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
+        stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
+        dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
+        padding_tuple = _conv_padding_to_tuple(
+            padding, stride_tuple, kernel_size_tuple, "Conv1d", dilation_tuple
         )
+        _validate_conv_params(
+            op_name="Conv1d",
+            input_size=(l_in,),
+            kernel_size=kernel_size_tuple,
+            stride=stride_tuple,
+            padding=padding_tuple,
+            dilation=dilation_tuple,
+        )
+        self.kernel_size = kernel_size_tuple[0]
+        self.stride = stride_tuple[0]
+        self.padding = padding_tuple[0]
+        self.dilation = dilation_tuple[0]
+        self.groups = groups
+        self.has_bias = True
+        self.dtype = dtype
+
+        self.dispatch_kernel(kernel_map)
+        if "conv1d_kernel" not in self.kernel_map:
+            raise NotImplementedError("Conv1dBiasFwdOp requires 'conv1d_kernel' in kernel_map")
+        self.kernel = self.kernel_map["conv1d_kernel"](
+            n=n,
+            c_in=c_in,
+            l_in=l_in,
+            c_out=c_out,
+            kernel_l=self.kernel_size,
+            stride_l=self.stride,
+            pad_l=self.padding,
+            dilation_l=self.dilation,
+            dtype=dtype,
+            has_bias=True,
+            tune=tune,
+        )
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        _validate_tensor_shape("Conv1d", "input", input, (self.n, self.l_in, self.c_in))
+        _validate_tensor_shape(
+            "Conv1d",
+            "weight",
+            weight,
+            (self.c_out, self.c_in, self.kernel_size),
+        )
+        _validate_tensor_shape("Conv1d", "bias", bias, (self.c_out,))
+        return self.kernel(input, weight, bias)
 
 
 def _pair(value: int | Tuple[int, int]) -> Tuple[int, int]:

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -151,6 +151,7 @@ class Conv1dFwdOp(Op):
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        _has_bias: bool = False,
     ) -> None:
         _validate_positive_int("n", n, "Conv1d")
         _validate_positive_int("c_in", c_in, "Conv1d")
@@ -182,7 +183,7 @@ class Conv1dFwdOp(Op):
         self.padding = padding_tuple[0]
         self.dilation = dilation_tuple[0]
         self.groups = groups
-        self.has_bias = False
+        self.has_bias = _has_bias
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
@@ -198,7 +199,7 @@ class Conv1dFwdOp(Op):
             pad_l=self.padding,
             dilation_l=self.dilation,
             dtype=dtype,
-            has_bias=False,
+            has_bias=_has_bias,
             tune=tune,
         )
 
@@ -249,54 +250,20 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
                 "Conv1dBiasFwdOp requires bias=True. "
                 "Use Conv1dFwdOp for the no-bias variant."
             )
-        _validate_positive_int("n", n, "Conv1d")
-        _validate_positive_int("c_in", c_in, "Conv1d")
-        _validate_positive_int("l_in", l_in, "Conv1d")
-        _validate_positive_int("c_out", c_out, "Conv1d")
-        _validate_conv_groups("Conv1d", c_in, c_out, groups)
-        if groups != 1:
-            raise NotImplementedError("Conv1d currently supports groups=1 only")
-        self.n = n
-        self.c_in = c_in
-        self.l_in = l_in
-        self.c_out = c_out
-        kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
-        stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
-        dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
-        padding_tuple = _conv_padding_to_tuple(
-            padding, stride_tuple, kernel_size_tuple, "Conv1d", dilation_tuple
-        )
-        _validate_conv_params(
-            op_name="Conv1d",
-            input_size=(l_in,),
-            kernel_size=kernel_size_tuple,
-            stride=stride_tuple,
-            padding=padding_tuple,
-            dilation=dilation_tuple,
-        )
-        self.kernel_size = kernel_size_tuple[0]
-        self.stride = stride_tuple[0]
-        self.padding = padding_tuple[0]
-        self.dilation = dilation_tuple[0]
-        self.groups = groups
-        self.has_bias = True
-        self.dtype = dtype
-
-        self.dispatch_kernel(kernel_map)
-        if "conv1d_kernel" not in self.kernel_map:
-            raise NotImplementedError("Conv1dBiasFwdOp requires 'conv1d_kernel' in kernel_map")
-        self.kernel = self.kernel_map["conv1d_kernel"](
+        super().__init__(
             n=n,
             c_in=c_in,
             l_in=l_in,
             c_out=c_out,
-            kernel_l=self.kernel_size,
-            stride_l=self.stride,
-            pad_l=self.padding,
-            dilation_l=self.dilation,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
             dtype=dtype,
-            has_bias=True,
+            kernel_map=kernel_map,
             tune=tune,
+            _has_bias=True,
         )
 
     def forward(


### PR DESCRIPTION
## Summary

Closes #1031.
Related #853.
Related #1037.

This PR adds PyTorch-compatible `dilation` support to the Conv1d forward kernel path and keeps the change scoped away from grouped convolution and manifest status promotion.

It also aligns the two Conv1d forward variants with their manifest semantics:
- `Conv1dFwdOp` is now the no-bias variant and exposes `forward(input, weight)`.
- `Conv1dBiasFwdOp` is now the bias-required variant and exposes `forward(input, weight, bias)`.

Implementation details:
- Adds `dilation` / `dilation_l` plumbing through `Conv1dFwdOp`, `Conv1dBiasFwdOp`, `Conv1dKernel`, `_conv1d_wrapped_kernel`, and `_conv1d_kernel`.
- Updates Conv1d output length to `(L_in + 2 * padding - dilation * (kW - 1) - 1) // stride + 1`.
- Updates kernel input indexing to `il = ol * stride_l + kw * dilation_l - pad_l`.
- Keeps `groups=1` as the only implemented path while validating the manifest-declared groups constraints and rejecting unsupported grouped Conv1d explicitly.
- Keeps Conv1d spatial params aligned with the manifest by accepting `int | tuple[int]`.

## Test plan

- `python -m py_compile tileops/ops/convolution.py tileops/kernels/convolution.py tests/ops/test_convolution.py benchmarks/ops/bench_convolution.py`
- `python -m ruff check tileops/ops/convolution.py tileops/kernels/convolution.py tests/ops/test_convolution.py benchmarks/ops/bench_convolution.py`
- `python -m pytest tests/ops/test_convolution.py --collect-only -q`
- `python -m pytest tests/ops/test_convolution.py -vvs -k conv1d`
- `python -m pytest benchmarks/ops/bench_convolution.py --collect-only -q -k conv1d_bench`
- `python -m pytest tests --collect-only -q`
- `python scripts/validate_manifest.py --check-op Conv1dFwdOp`
- `python scripts/validate_manifest.py --check-op Conv1dBiasFwdOp`

## Benchmark

Adds a focused Conv1d benchmark case with `dilation=2` while preserving existing `dilation=1` benchmark coverage. The benchmark still uses the existing hand-written benchmark harness; #1037 tracks making Conv1d benchmarks fully manifest-driven so manifest validation no longer emits L4 benchmark warnings.

## Regression

Existing Conv1d `dilation=1` behavior remains covered by the original Conv1d test and benchmark cases. New tests cover `dilation=2`, no-bias `Conv1dFwdOp`, and bias-required `Conv1dBiasFwdOp`.

## Additional context

`python scripts/validate_manifest.py --check-op Conv1dFwdOp` and `python scripts/validate_manifest.py --check-op Conv1dBiasFwdOp` now pass, but still report warnings for missing generated shape/dtype parity methods and the non-manifest-driven benchmark path. The benchmark warning is intentionally tracked separately in #1037.