### PR TITLE
[Feat][OPS] add align-op per-op orchestrator skill + rename skill set to verb-noun

### DIFF
--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: spec-pipeline
+name: align-family
 description: Drive the full migration for an op family — audit, test, implement, bench, flip status, create PR.
 ---
 
@@ -15,9 +15,9 @@ Family name from `ops_manifest.yaml` (e.g., `reduction`, `norm`, `attention`).
 
 ## Trust Model
 
-- spec-test agent ≠ spec-implement agent (separate invocations)
+- test-op agent ≠ implement-op agent (separate invocations)
 - Only the orchestrator modifies `ops_manifest.yaml` status
-- spec-implement must not modify tests; spec-bench must not modify Op code
+- implement-op must not modify tests; bench-op must not modify Op code
 
 ## Workflow
 
@@ -59,7 +59,7 @@ This catches tracked changes, staged changes, AND untracked files. If not clean:
 
 ### Dual-path is acceptable during migration
 
-When spec-implement rewrites a base class, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
+When implement-op rewrites a base class, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
 
 **Dual-path definition**: a class `__init__` with runtime branching to support two incompatible construction interfaces, and `forward` dispatching to two execution paths. Not polymorphism — same semantics, temporary interface coexistence.
 
@@ -68,7 +68,7 @@ When spec-implement rewrites a base class, it may create a dual-path `__init__` 
 ### 1. AUDIT
 
 ```
-/spec-audit <family>
+/audit-family <family>
 ```
 
 Gap report written to `.foundry/migrations/<family>.json`.
@@ -77,7 +77,7 @@ Gap report written to `.foundry/migrations/<family>.json`.
 
 Group ops by `base_class` from the gap report. Each group is a set of sibling ops sharing a base class. Process groups in order; within each group, process ops in order (first op likely fixes the base class, subsequent ops validate).
 
-`base_class` is a required field in the gap report. spec-audit must populate it for every op entry. If an op inherits `Op` directly (no intermediate base class), its `base_class` is `"Op"` — these ops form a single group but are independent (no shared base class to rewrite, so cleanup gate is a no-op for this group).
+`base_class` is a required field in the gap report. audit-family must populate it for every op entry. If an op inherits `Op` directly (no intermediate base class), its `base_class` is `"Op"` — these ops form a single group but are independent (no shared base class to rewrite, so cleanup gate is a no-op for this group).
 
 Track group completion: a group is complete when all its ops are `promoted` or `blocked`.
 
@@ -93,28 +93,28 @@ Read gap report. For each op, extract params from the entry and dispatch:
 
 ### 4. TEST (per op)
 
-Invoke spec-test as a **separate agent** (trust model):
+Invoke test-op as a **separate agent** (trust model):
 
 ```
-spec-test(op_name, manifest_signature, pytorch_equivalent, source_test)
+test-op(op_name, manifest_signature, pytorch_equivalent, source_test)
 ```
 
 ### 5. IMPLEMENT (per op)
 
-Invoke spec-implement as a **separate agent** (trust model):
+Invoke implement-op as a **separate agent** (trust model):
 
 ```
-spec-implement(op_name, manifest_signature, source_op, source_test)
+implement-op(op_name, manifest_signature, source_op, source_test)
 ```
 
 Collect `observations` from return.
 
 ### 6. BENCH (per op)
 
-Invoke spec-bench:
+Invoke bench-op:
 
 ```
-spec-bench(op_name, source_bench, source_op)
+bench-op(op_name, source_bench, source_op)
 ```
 
 Requires local GPU.
@@ -165,7 +165,7 @@ If any promoted op's test fails after cleanup → REPORT_BLOCKED (cleanup regres
 
 After all ops processed:
 
-- Collect all observations from spec-implement calls
+- Collect all observations from implement-op calls
 - Create PR with:
   - Migration summary (promoted / blocked counts)
   - Per-op change table

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -12,11 +12,13 @@ description: Per-op orchestrator that brings a single op into alignment with its
 ## Contract
 
 - **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as scaffold-op; see [PRE_CHECK](#pre_check)).
-- **Path bindings used throughout this skill** (resolved by the orchestrator once at `READ`):
-  - `<source_op>` — the op's manifest `source.op` path.
-  - `<source_test>` — the op's manifest `source.test` path.
-  - `<source_bench>` — the op's manifest `source.bench` path.
-  - `<source_kernel>` — the op's manifest `source.kernel` path.
+- **Path and data bindings used throughout this skill** (resolved by the orchestrator once at `READ`, then passed into every sub-skill invocation):
+  - `<source_op>` — manifest `source.op` path (e.g., `tileops/ops/reduction/cumsum.py`).
+  - `<source_test>` — manifest `source.test` path (e.g., `tests/ops/test_cumulative.py`).
+  - `<source_bench>` — manifest `source.bench` path.
+  - `<source_kernel>` — manifest `source.kernel` path (the primary kernel implementation file).
+  - `<manifest_signature>` — the `signature` sub-tree from the op's manifest entry, passed verbatim to test-op / implement-op.
+  - `<pytorch_equivalent>` — manifest `ref_api` value (e.g., `"torch.cumsum"`) or `null` if the op has no PyTorch reference. Required by test-op.
 - **Output** (SUCCESS path): op file at `source.op` aligned with the manifest; test file `source.test` aligned; `__init__.py` registrations consistent; `status` flipped `spec-only → implemented` (single commit). Side-artefacts in `.foundry/plan/<op_name>/`: `mode.json` (classification), `plan.json` (scaffold-op's §1/§2/§3 when that skill ran), `kernel-check.json` (redesign case only), `pre-rewrite/source.py` (redesign case, removed at CLEANUP on SUCCESS).
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports no errors + `python -m pytest <source_test> -v` passes + benchmark produces numbers + manifest status flipped.
 - **Termination (blocked)**: any sub-skill (scaffold-op / test-op / implement-op / bench-op) returns blocked; or scaffold-op §1 drift; or REVALIDATE fails. Kernel-layer mismatches surfaced by `KERNEL_CHECK` are **informational only** and never cause BLOCKED by themselves — BLOCKED is reached only if a kernel drift propagates into a downstream sub-skill failure (e.g., bench-op runtime error, REVALIDATE regression). Archives are kept for post-mortem.
@@ -148,7 +150,12 @@ Sequence:
 #### 3c. MINOR path (`case = minor`)
 
 ```
-implement-op <op_name>
+implement-op(
+  op_name=<op_name>,
+  manifest_signature=<manifest_signature>,
+  source_op=<source_op>,
+  source_test=<source_test>
+)
 ```
 
 Sub-skill does ANALYZE → DIAGNOSE → IMPLEMENT → VALIDATE → MARK_DONE → COMMIT. Op-align waits for SUCCESS or BLOCKED.
@@ -197,7 +204,12 @@ Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. Op-al
 ### 6. TEST
 
 ```
-test-op <op_name>
+test-op(
+  op_name=<op_name>,
+  manifest_signature=<manifest_signature>,
+  pytorch_equivalent=<pytorch_equivalent>,
+  source_test=<source_test>
+)
 ```
 
 Sub-skill writes tests against the new spec. Termination:
@@ -208,7 +220,12 @@ Sub-skill writes tests against the new spec. Termination:
 ### 7. IMPLEMENT
 
 ```
-implement-op <op_name>
+implement-op(
+  op_name=<op_name>,
+  manifest_signature=<manifest_signature>,
+  source_op=<source_op>,
+  source_test=<source_test>
+)
 ```
 
 Closes the gap between the emitted op file and the tests from Step 6. Applies to:
@@ -222,7 +239,11 @@ BLOCKED if the gap requires kernel-layer changes (op-align is op-layer only; ker
 ### 8. BENCH
 
 ```
-bench-op <op_name>
+bench-op(
+  op_name=<op_name>,
+  source_bench=<source_bench>,
+  source_op=<source_op>
+)
 ```
 
 Produces numbers. Sub-skill unchanged. If BLOCKED and reason is not kernel-related, propagate blocked.

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -66,7 +66,7 @@ stateDiagram-v2
     REVALIDATE --> FLIP_STATUS: --check-op + pytest pass
     REVALIDATE --> BLOCKED: regression
     FLIP_STATUS --> CLEANUP: manifest status flipped
-    CLEANUP --> REPORT: archives dropped
+    CLEANUP --> REPORT: pre-rewrite/ dropped (redesign only); mode/plan/kernel-check kept
     REPORT --> [*]
     CLASSIFY_ONLY_EXIT --> [*]
     GREEN_PATH --> BLOCKED: scaffold failed (§1 drift or validator error)

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: op-align
-description: Per-op orchestrator that brings a single op into alignment with its manifest entry. Classifies the op into one of three cases (green field / interface redesign / minor delta), dispatches to the right path (op-scaffold for new, archive+rescaffold+port for redesign, spec-implement for minor), then runs the shared downstream (test → bench → validate → flip status → report). Complements the family-scoped `spec-pipeline`; per-op entry when you know the op you want to touch.
+name: align-op
+description: Per-op orchestrator that brings a single op into alignment with its manifest entry. Classifies the op into one of three cases (green field / interface redesign / minor delta), dispatches to the right path (scaffold-op for new, archive+rescaffold+port for redesign, implement-op for minor), then runs the shared downstream (test → bench → validate → flip status → report). Complements the family-scoped `align-family`; per-op entry when you know the op you want to touch.
 ---
 
 ## Arguments
@@ -11,30 +11,30 @@ description: Per-op orchestrator that brings a single op into alignment with its
 
 ## Contract
 
-- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as op-scaffold; see [PRE_CHECK](#pre_check)).
-- **Output** (SUCCESS path): op file at `source.op` aligned with the manifest; test file `source.test` aligned; `__init__.py` registrations consistent; `status` flipped `spec-only → implemented` (single commit). Side-artefacts in `.foundry/plan/<op_name>/`: `mode.json` (classification), `plan.json` (op-scaffold's §1/§2/§3 when that skill ran), `kernel-check.json` (redesign case only), `pre-rewrite/source.py` (redesign case, removed at CLEANUP on SUCCESS).
+- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as scaffold-op; see [PRE_CHECK](#pre_check)).
+- **Output** (SUCCESS path): op file at `source.op` aligned with the manifest; test file `source.test` aligned; `__init__.py` registrations consistent; `status` flipped `spec-only → implemented` (single commit). Side-artefacts in `.foundry/plan/<op_name>/`: `mode.json` (classification), `plan.json` (scaffold-op's §1/§2/§3 when that skill ran), `kernel-check.json` (redesign case only), `pre-rewrite/source.py` (redesign case, removed at CLEANUP on SUCCESS).
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports no errors + `python -m pytest <source_test> -v` passes + benchmark produces numbers + manifest status flipped.
-- **Termination (blocked)**: any sub-skill returns blocked, or §1 drift in op-scaffold, or kernel mismatch discovered in redesign path that op-align cannot resolve at the op layer. Report with concrete reason. Archives are kept for post-mortem.
+- **Termination (blocked)**: any sub-skill returns blocked, or §1 drift in scaffold-op, or kernel mismatch discovered in redesign path that align-op cannot resolve at the op layer. Report with concrete reason. Archives are kept for post-mortem.
 - **Constraints**:
-  - Only op-align (and only at FLIP_STATUS) may modify `ops_manifest.yaml`. Sub-skills never touch the manifest.
+  - Only align-op (and only at FLIP_STATUS) may modify `ops_manifest.yaml`. Sub-skills never touch the manifest.
   - MUST NOT modify kernel code. Kernel-layer work, if needed, is surfaced via `kernel-check.json` as a separate follow-up.
-  - MUST NOT expand to multi-op scope; that is `spec-pipeline`'s role.
+  - MUST NOT expand to multi-op scope; that is `align-family`'s role.
 
 ## Trust model
 
-- `CLASSIFY`, `DISPATCH`, `FLIP_STATUS`, `CLEANUP`, `REPORT` are orchestrator stages (op-align itself). Every other stage delegates to an atomic skill as a **separate sub-agent invocation**:
+- `CLASSIFY`, `DISPATCH`, `FLIP_STATUS`, `CLEANUP`, `REPORT` are orchestrator stages (align-op itself). Every other stage delegates to an atomic skill as a **separate sub-agent invocation**:
 
   | Stage         | Sub-skill                             |
   | ------------- | ------------------------------------- |
-  | GREEN path    | `op-scaffold`                         |
-  | REDESIGN path | `op-scaffold` (after ARCHIVE + CLEAR) |
-  | MINOR path    | `spec-implement`                      |
-  | TEST          | `spec-test`                           |
-  | BENCH         | `spec-bench`                          |
+  | GREEN path    | `scaffold-op`                         |
+  | REDESIGN path | `scaffold-op` (after ARCHIVE + CLEAR) |
+  | MINOR path    | `implement-op`                        |
+  | TEST          | `test-op`                             |
+  | BENCH         | `bench-op`                            |
 
-  Separate invocations preserve the per-skill contracts (e.g., op-scaffold's §1 fact-freeze; spec-implement's no-test-modification rule).
+  Separate invocations preserve the per-skill contracts (e.g., scaffold-op's §1 fact-freeze; implement-op's no-test-modification rule).
 
-- After each sub-skill returns, op-align verifies `git status --porcelain` is empty before dispatching the next. If a sub-skill left an uncommitted change, op-align commits on its behalf with `Sub-skill [name]: [summary]` before proceeding.
+- After each sub-skill returns, align-op verifies `git status --porcelain` is empty before dispatching the next. If a sub-skill left an uncommitted change, align-op commits on its behalf with `Sub-skill [name]: [summary]` before proceeding.
 
 ## Workflow
 
@@ -48,10 +48,10 @@ stateDiagram-v2
     DISPATCH --> GREEN_PATH: case = green
     DISPATCH --> REDESIGN_PATH: case = redesign
     DISPATCH --> MINOR_PATH: case = minor
-    GREEN_PATH --> TEST: op-scaffold succeeded
+    GREEN_PATH --> TEST: scaffold-op succeeded
     REDESIGN_PATH --> KERNEL_CHECK: rescaffold + port done
     KERNEL_CHECK --> TEST: kernel-check.json written
-    MINOR_PATH --> TEST: spec-implement succeeded
+    MINOR_PATH --> TEST: implement-op succeeded
     TEST --> BENCH: tests written, failing as expected (or DONE_SKIP)
     BENCH --> REVALIDATE: benchmark produces numbers
     REVALIDATE --> FLIP_STATUS: --check-op + pytest pass
@@ -62,7 +62,7 @@ stateDiagram-v2
     CLASSIFY_ONLY_EXIT --> [*]
     GREEN_PATH --> BLOCKED: scaffold failed (§1 drift or validator error)
     REDESIGN_PATH --> BLOCKED: scaffold or port failed
-    MINOR_PATH --> BLOCKED: spec-implement failed
+    MINOR_PATH --> BLOCKED: implement-op failed
     BLOCKED --> [*]: return to caller with reason
 ```
 
@@ -70,11 +70,11 @@ stateDiagram-v2
 
 ### <a id="pre_check"></a>1. PRE_CHECK
 
-Preconditions identical to `op-scaffold`'s — orchestrator enforces them up front so sub-skills never see ill-formed input:
+Preconditions identical to `scaffold-op`'s — orchestrator enforces them up front so sub-skills never see ill-formed input:
 
 - `op_name` in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
 - `status: spec-only` → proceed; `implemented` → BLOCKED ("already aligned; flip status to spec-only in a manifest PR first if you intend to re-align"); missing/other → BLOCKED.
-- `source.kernel_map` declared and non-empty → proceed; missing → BLOCKED with the same guidance op-scaffold uses (add in a prerequisite manifest PR).
+- `source.kernel_map` declared and non-empty → proceed; missing → BLOCKED with the same guidance scaffold-op uses (add in a prerequisite manifest PR).
 - Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path" — kernel must exist for op layer to align, regardless of case).
 
 ### 2. CLASSIFY
@@ -113,30 +113,30 @@ Each path produces the aligned op file under `source.op` plus whatever artefacts
 #### 3a. GREEN path (`case = green`)
 
 ```
-op-scaffold <op_name>
+scaffold-op <op_name>
 ```
 
-Sub-skill does PRE_CHECK → DRY_RUN (plan.json) → EMIT → REGISTER → VALIDATE → REPORT. op-align waits for SUCCESS or BLOCKED; on BLOCKED, surface the row and terminate.
+Sub-skill does PRE_CHECK → DRY_RUN (plan.json) → EMIT → REGISTER → VALIDATE → REPORT. align-op waits for SUCCESS or BLOCKED; on BLOCKED, surface the row and terminate.
 
 #### 3b. REDESIGN path (`case = redesign`)
 
 Sequence:
 
 1. **ARCHIVE** — `mkdir -p .foundry/plan/<op_name>/pre-rewrite/`, copy `source.op` there as `source.py` (rename: strip family path, keep basename). The archive is the source of truth for manual porting. It persists until CLEANUP.
-1. **CLEAR** — remove `source.op` from the tree; remove the op's `from .<module> import <ClassName>` line and its `__all__` entry from the package `__init__.py`. Commit as `[Chore] op-align: archive <op_name> before rescaffold`.
-1. **SCAFFOLD** — `op-scaffold <op_name>`. Target now absent, PRE_CHECK passes, emits the 17 mechanical slots.
+1. **CLEAR** — remove `source.op` from the tree; remove the op's `from .<module> import <ClassName>` line and its `__all__` entry from the package `__init__.py`. Commit as `[Chore] align-op: archive <op_name> before rescaffold`.
+1. **SCAFFOLD** — `scaffold-op <op_name>`. Target now absent, PRE_CHECK passes, emits the 17 mechanical slots.
 1. **PORT** — read `pre-rewrite/source.py` and port op-specific content that the scaffold cannot produce:
    - Optional hooks (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`, `_cache_key` override).
    - Family-specific protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, etc.) if the op was a T1 thin wrapper.
    - Any `forward` body specifics beyond the universal pattern (kernel-specific reshape/movedim choreography).
    - Any class-level non-slot attributes the old file had that still make sense under the new spec.
-     Commit as `[Feat] op-align: port business logic for <op_name> from pre-rewrite`. If the agent is uncertain whether a specific override should be ported, record an `open_questions` item in plan.json §3 (`needs_human_decision`) and port conservatively.
+     Commit as `[Feat] align-op: port business logic for <op_name> from pre-rewrite`. If the agent is uncertain whether a specific override should be ported, record an `open_questions` item in plan.json §3 (`needs_human_decision`) and port conservatively.
 1. **KERNEL_CHECK** — see §5 below.
 
 #### 3c. MINOR path (`case = minor`)
 
 ```
-spec-implement <op_name>
+implement-op <op_name>
 ```
 
 Sub-skill does ANALYZE → DIAGNOSE → IMPLEMENT → VALIDATE → MARK_DONE → COMMIT. Op-align waits for SUCCESS or BLOCKED.
@@ -150,7 +150,7 @@ Determine whether the kernel layer also needs work. Op-align does **not** modify
 For each Kernel class referenced in `source.kernel_map`:
 
 1. Inspect the kernel's `__init__` / `forward` / `_build_program` signatures (wherever applicable) in its source file.
-1. Compare against the new op's kernel-build call emitted by op-scaffold (`self.kernel_map[<key>](<args>)`). Specifically check:
+1. Compare against the new op's kernel-build call emitted by scaffold-op (`self.kernel_map[<key>](<args>)`). Specifically check:
    - Argument names and positional order.
    - Argument types.
    - Any layout / dtype expectations the kernel documents.
@@ -185,15 +185,15 @@ Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. Op-al
 ### 6. TEST
 
 ```
-spec-test <op_name>
+test-op <op_name>
 ```
 
-Sub-skill writes tests against the new spec, confirms they fail (or DONE_SKIP if base class fix from a sibling already handles them). Reuses existing spec-test contract unchanged.
+Sub-skill writes tests against the new spec, confirms they fail (or DONE_SKIP if base class fix from a sibling already handles them). Reuses existing test-op contract unchanged.
 
 ### 7. BENCH
 
 ```
-spec-bench <op_name>
+bench-op <op_name>
 ```
 
 Produces numbers. Sub-skill unchanged. If BLOCKED and reason is not kernel-related, propagate blocked.
@@ -237,14 +237,14 @@ Mode decided by: auto | user_prompt | flag_override
 File: <source.op> (<lines>)
 
 Sub-skills run:
-  - op-scaffold: <SUCCESS|BLOCKED|skipped>
-  - spec-implement: <...>
-  - spec-test: <...>
-  - spec-bench: <...>
+  - scaffold-op: <SUCCESS|BLOCKED|skipped>
+  - implement-op: <...>
+  - test-op: <...>
+  - bench-op: <...>
 
 Plan artefacts (.foundry/plan/<op_name>/):
   - mode.json
-  - plan.json (if op-scaffold ran)
+  - plan.json (if scaffold-op ran)
   - kernel-check.json (if redesign path)
   - pre-rewrite/ (redesign path, cleaned on SUCCESS)
 
@@ -258,20 +258,20 @@ Follow-ups:
 
 On BLOCKED, replace "Status flipped" line with the blocking error and list remaining follow-ups.
 
-## Interaction with `spec-pipeline`
+## Interaction with `align-family`
 
-`spec-pipeline` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `op-align` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current spec-pipeline stays functional; a follow-up can consolidate.
+`align-family` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `align-op` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current align-family stays functional; a follow-up can consolidate.
 
 Until consolidated:
 
-- Use `op-align <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
-- Use `spec-pipeline <family>` for family-scoped historical migration of many ops at once.
+- Use `align-op <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
+- Use `align-family <family>` for family-scoped historical migration of many ops at once.
 
-They do not conflict. `op-align` never manages cross-op cleanup gates; that remains `spec-pipeline`'s.
+They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s.
 
 ## Non-goals
 
 - **Kernel scaffolding / kernel-layer edits.** Op-align surfaces kernel work as a follow-up via `kernel-check.json`; a separate (future) `kernel-scaffold` / `kernel-align` skill will own that layer.
-- **Family-level cleanup.** Cross-op dual-path removal lives in `spec-pipeline` and is not a concern of per-op alignment.
-- **Auto-detecting "redesign vs minor."** The distinction is a design judgement; op-align prompts or accepts `--mode`.
+- **Family-level cleanup.** Cross-op dual-path removal lives in `align-family` and is not a concern of per-op alignment.
+- **Auto-detecting "redesign vs minor."** The distinction is a design judgement; align-op prompts or accepts `--mode`.
 - **Manifest changes (other than FLIP_STATUS).** Per the trust model, manifest changes live in separate manifest PRs.

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -12,7 +12,7 @@ description: Per-op orchestrator that brings a single op into alignment with its
 ## Contract
 
 - **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as scaffold-op; see [PRE_CHECK](#pre_check)).
-- **Path and data bindings used throughout this skill** (resolved by the orchestrator once at `READ`, then passed into every sub-skill invocation):
+- **Path and data bindings used throughout this skill** (resolved by the orchestrator once at `PRE_CHECK` when the manifest entry is first loaded, then passed into every sub-skill invocation):
   - `<source_op>` — manifest `source.op` path (e.g., `tileops/ops/reduction/cumsum.py`).
   - `<source_test>` — manifest `source.test` path (e.g., `tests/ops/test_cumulative.py`).
   - `<source_bench>` — manifest `source.bench` path.
@@ -158,13 +158,13 @@ implement-op(
 )
 ```
 
-Sub-skill does ANALYZE → DIAGNOSE → IMPLEMENT → VALIDATE → MARK_DONE → COMMIT. Op-align waits for SUCCESS or BLOCKED.
+Sub-skill does ANALYZE → DIAGNOSE → IMPLEMENT → VALIDATE → MARK_DONE → COMMIT. align-op waits for SUCCESS or BLOCKED.
 
 ### 4. Skipped anchor (reserved)
 
 ### <a id="kernel_check"></a>5. KERNEL_CHECK (redesign path only)
 
-Determine whether the kernel layer also needs work. Op-align does **not** modify kernel code; it surfaces the question.
+Determine whether the kernel layer also needs work. align-op does **not** modify kernel code; it surfaces the question.
 
 For each Kernel class referenced in `source.kernel_map`:
 
@@ -199,7 +199,7 @@ Write `.foundry/plan/<op_name>/kernel-check.json`:
 }
 ```
 
-Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. Op-align itself continues to TEST — the downstream path may still pass if the kernel drift only affects performance (not correctness), or fail fast if the kernel mismatch causes runtime errors, which REVALIDATE will catch.
+Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. align-op itself continues to TEST — the downstream path may still pass if the kernel drift only affects performance (not correctness), or fail fast if the kernel mismatch causes runtime errors, which REVALIDATE will catch.
 
 ### 6. TEST
 
@@ -234,7 +234,7 @@ Closes the gap between the emitted op file and the tests from Step 6. Applies to
 - **Redesign path**: the `PORT` sub-step in Step 3b did a first pass; `implement-op` closes residual gaps surfaced by the tests.
 - **Minor path**: **skipped** — `implement-op` already ran as the minor-case main stage in Step 3c. If TEST didn't DONE_SKIP here, that signals spec-drift beyond the minor-case scope and becomes BLOCKED.
 
-BLOCKED if the gap requires kernel-layer changes (op-align is op-layer only; kernel work surfaces via `kernel-check.json` from KERNEL_CHECK or as a `blocked` return from `implement-op`).
+BLOCKED if the gap requires kernel-layer changes (align-op is op-layer only; kernel work surfaces via `kernel-check.json` from KERNEL_CHECK or as a `blocked` return from `implement-op`).
 
 ### 8. BENCH
 
@@ -321,7 +321,7 @@ They do not conflict. `align-op` never manages cross-op cleanup gates; that rema
 
 ## Non-goals
 
-- **Kernel scaffolding / kernel-layer edits.** Op-align surfaces kernel work as a follow-up via `kernel-check.json`; a separate (future) `kernel-scaffold` / `kernel-align` skill will own that layer.
+- **Kernel scaffolding / kernel-layer edits.** align-op surfaces kernel work as a follow-up via `kernel-check.json`; a separate (future) `kernel-scaffold` / `kernel-align` skill will own that layer.
 - **Family-level cleanup.** Cross-op dual-path removal lives in `align-family` and is not a concern of per-op alignment.
 - **Auto-detecting "redesign vs minor."** The distinction is a design judgement; align-op prompts or accepts `--mode`.
 - **Manifest changes (other than FLIP_STATUS).** Per the trust model, manifest changes live in separate manifest PRs.

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -12,9 +12,14 @@ description: Per-op orchestrator that brings a single op into alignment with its
 ## Contract
 
 - **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as scaffold-op; see [PRE_CHECK](#pre_check)).
+- **Path bindings used throughout this skill** (resolved by the orchestrator once at `READ`):
+  - `<source_op>` — the op's manifest `source.op` path.
+  - `<source_test>` — the op's manifest `source.test` path.
+  - `<source_bench>` — the op's manifest `source.bench` path.
+  - `<source_kernel>` — the op's manifest `source.kernel` path.
 - **Output** (SUCCESS path): op file at `source.op` aligned with the manifest; test file `source.test` aligned; `__init__.py` registrations consistent; `status` flipped `spec-only → implemented` (single commit). Side-artefacts in `.foundry/plan/<op_name>/`: `mode.json` (classification), `plan.json` (scaffold-op's §1/§2/§3 when that skill ran), `kernel-check.json` (redesign case only), `pre-rewrite/source.py` (redesign case, removed at CLEANUP on SUCCESS).
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports no errors + `python -m pytest <source_test> -v` passes + benchmark produces numbers + manifest status flipped.
-- **Termination (blocked)**: any sub-skill returns blocked, or §1 drift in scaffold-op, or kernel mismatch discovered in redesign path that align-op cannot resolve at the op layer. Report with concrete reason. Archives are kept for post-mortem.
+- **Termination (blocked)**: any sub-skill (scaffold-op / test-op / implement-op / bench-op) returns blocked; or scaffold-op §1 drift; or REVALIDATE fails. Kernel-layer mismatches surfaced by `KERNEL_CHECK` are **informational only** and never cause BLOCKED by themselves — BLOCKED is reached only if a kernel drift propagates into a downstream sub-skill failure (e.g., bench-op runtime error, REVALIDATE regression). Archives are kept for post-mortem.
 - **Constraints**:
   - Only align-op (and only at FLIP_STATUS) may modify `ops_manifest.yaml`. Sub-skills never touch the manifest.
   - MUST NOT modify kernel code. Kernel-layer work, if needed, is surfaced via `kernel-check.json` as a separate follow-up.
@@ -24,13 +29,14 @@ description: Per-op orchestrator that brings a single op into alignment with its
 
 - `CLASSIFY`, `DISPATCH`, `FLIP_STATUS`, `CLEANUP`, `REPORT` are orchestrator stages (align-op itself). Every other stage delegates to an atomic skill as a **separate sub-agent invocation**:
 
-  | Stage         | Sub-skill                             |
-  | ------------- | ------------------------------------- |
-  | GREEN path    | `scaffold-op`                         |
-  | REDESIGN path | `scaffold-op` (after ARCHIVE + CLEAR) |
-  | MINOR path    | `implement-op`                        |
-  | TEST          | `test-op`                             |
-  | BENCH         | `bench-op`                            |
+  | Stage         | Sub-skill                                                    |
+  | ------------- | ------------------------------------------------------------ |
+  | GREEN path    | `scaffold-op`                                                |
+  | REDESIGN path | `scaffold-op` (after ARCHIVE + CLEAR)                        |
+  | MINOR path    | `implement-op`                                               |
+  | TEST          | `test-op`                                                    |
+  | IMPLEMENT     | `implement-op` (green / redesign only; minor already did it) |
+  | BENCH         | `bench-op`                                                   |
 
   Separate invocations preserve the per-skill contracts (e.g., scaffold-op's §1 fact-freeze; implement-op's no-test-modification rule).
 
@@ -51,8 +57,11 @@ stateDiagram-v2
     GREEN_PATH --> TEST: scaffold-op succeeded
     REDESIGN_PATH --> KERNEL_CHECK: rescaffold + port done
     KERNEL_CHECK --> TEST: kernel-check.json written
-    MINOR_PATH --> TEST: implement-op succeeded
-    TEST --> BENCH: tests written, failing as expected (or DONE_SKIP)
+    MINOR_PATH --> TEST: implement-op succeeded (minor-case main stage ran here)
+    TEST --> IMPLEMENT: tests fail on current code (expected; gap to close)
+    TEST --> BENCH: tests already pass (DONE_SKIP) — typically minor path where implement-op already ran
+    IMPLEMENT --> BENCH: implementation closes the gap, tests pass
+    IMPLEMENT --> BLOCKED: gap beyond op-layer (e.g., kernel rewrite required)
     BENCH --> REVALIDATE: benchmark produces numbers
     REVALIDATE --> FLIP_STATUS: --check-op + pytest pass
     REVALIDATE --> BLOCKED: regression
@@ -86,7 +95,10 @@ Decide which case applies. Machine-decidable input: does `source.op` exist?
 | `source.op` does not exist | `green`   | no                                                          |
 | `source.op` exists         | (unknown) | yes — "redesign (rewrite + port) or minor (in-place edit)?" |
 
-`--mode=<case>` overrides prompting. `--mode=green` is rejected if `source.op` exists (would silently delete existing code); use `--mode=redesign` instead.
+`--mode=<case>` overrides prompting only when consistent with file presence. The orchestrator validates this during CLASSIFY and BLOCKs immediately on invalid combinations so sub-skills never see contradictory input:
+
+- `source.op` **missing** → only `green` is valid. `--mode=minor` → BLOCKED ("`source.op` is missing; cannot edit a non-existent op file; use `--mode=green` or omit `--mode`"). `--mode=redesign` → BLOCKED ("`source.op` is missing; no archive source to rewrite; use `--mode=green` or omit `--mode`").
+- `source.op` **exists** → `--mode=green` → BLOCKED ("`source.op` already exists; green-field scaffold would silently overwrite; use `--mode=redesign` for rewrite+port or `--mode=minor` for in-place edit").
 
 Write `.foundry/plan/<op_name>/mode.json`:
 
@@ -98,7 +110,7 @@ Write `.foundry/plan/<op_name>/mode.json`:
   "kernel_class_importable": true,
   "decided_by": "user_prompt",
   "reason": "User declared: manifest _static_axes shape rewritten; structural redesign.",
-  "classified_at": "2026-04-24T..."
+  "classified_at": "YYYY-MM-DDTHH:MM:SSZ"
 }
 ```
 
@@ -165,7 +177,7 @@ Write `.foundry/plan/<op_name>/kernel-check.json`:
 ```json
 {
   "op_name": "CumsumFwdOp",
-  "checked_at": "2026-04-24T...",
+  "checked_at": "YYYY-MM-DDTHH:MM:SSZ",
   "kernels": [
     {
       "dispatch_key": "cumulative_fwd",
@@ -188,9 +200,26 @@ Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. Op-al
 test-op <op_name>
 ```
 
-Sub-skill writes tests against the new spec, confirms they fail (or DONE_SKIP if base class fix from a sibling already handles them). Reuses existing test-op contract unchanged.
+Sub-skill writes tests against the new spec. Termination:
 
-### 7. BENCH
+- **tests fail on current code** (expected TDD seed) → proceed to IMPLEMENT.
+- **DONE_SKIP** (tests already pass, e.g. a sibling migration fixed the base class, or minor-path `implement-op` already closed the gap in Step 3c) → skip IMPLEMENT, proceed to BENCH.
+
+### 7. IMPLEMENT
+
+```
+implement-op <op_name>
+```
+
+Closes the gap between the emitted op file and the tests from Step 6. Applies to:
+
+- **Green path**: `scaffold-op` produced the 17 mechanical slots, but not optional hooks or family protocol vars; `implement-op` fills any that are required for the tests to pass.
+- **Redesign path**: the `PORT` sub-step in Step 3b did a first pass; `implement-op` closes residual gaps surfaced by the tests.
+- **Minor path**: **skipped** — `implement-op` already ran as the minor-case main stage in Step 3c. If TEST didn't DONE_SKIP here, that signals spec-drift beyond the minor-case scope and becomes BLOCKED.
+
+BLOCKED if the gap requires kernel-layer changes (op-align is op-layer only; kernel work surfaces via `kernel-check.json` from KERNEL_CHECK or as a `blocked` return from `implement-op`).
+
+### 8. BENCH
 
 ```
 bench-op <op_name>
@@ -198,7 +227,7 @@ bench-op <op_name>
 
 Produces numbers. Sub-skill unchanged. If BLOCKED and reason is not kernel-related, propagate blocked.
 
-### 8. REVALIDATE
+### 9. REVALIDATE
 
 ```bash
 python scripts/validate_manifest.py --check-op <op_name>
@@ -207,7 +236,7 @@ python -m pytest <source_test> -v
 
 Both must pass. Regression after benchmark changes → BLOCKED.
 
-### 9. FLIP_STATUS
+### 10. FLIP_STATUS
 
 Orchestrator (not a sub-skill) edits the manifest:
 
@@ -216,7 +245,7 @@ Orchestrator (not a sub-skill) edits the manifest:
 
 This is the only manifest write in the entire workflow.
 
-### 10. CLEANUP
+### 11. CLEANUP
 
 On SUCCESS path:
 
@@ -225,7 +254,7 @@ On SUCCESS path:
 
 On BLOCKED path: keep all artefacts for post-mortem.
 
-### 11. REPORT
+### 12. REPORT
 
 Single-page summary printed to stdout. Always includes:
 

--- a/.claude/skills/audit-family/SKILL.md
+++ b/.claude/skills/audit-family/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: spec-audit
+name: audit-family
 description: Compare each op's code signature against its manifest spec, classify gaps, produce a structured report.
 ---
 
@@ -42,7 +42,7 @@ Key gate: `pytorch_equivalent` determines autonomous vs human-required migration
 | Classification | Condition                                                          | Downstream                          |
 | -------------- | ------------------------------------------------------------------ | ----------------------------------- |
 | `ready`        | `--check-op` passes, no signature difference                       | Orchestrator flips status directly  |
-| `semantic_gap` | Manifest-code difference + `pytorch_equivalent` exists             | spec-test → spec-implement          |
+| `semantic_gap` | Manifest-code difference + `pytorch_equivalent` exists             | test-op → implement-op              |
 | `blocked`      | Difference but no PyTorch reference; or kernel-level change needed | Terminate. `reason` field explains. |
 
 ## Gap Report Format

--- a/.claude/skills/bench-op/SKILL.md
+++ b/.claude/skills/bench-op/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: spec-bench
+name: bench-op
 description: Fix benchmark file to work with the new Op interface. Run benchmark, fix errors, repeat until it produces numbers.
 ---
 
 ## Arguments
 
-`op_name`, `source_bench`, `source_op` — passed by spec-pipeline orchestrator.
+`op_name`, `source_bench`, `source_op` — passed by align-family orchestrator.
 
 ## Contract
 

--- a/.claude/skills/implement-op/SKILL.md
+++ b/.claude/skills/implement-op/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: spec-implement
+name: implement-op
 description: Modify op code to match the manifest-declared interface, making spec tests pass.
 ---
 
 ## Arguments
 
-`op_name`, `manifest_signature`, `source_op`, `source_test` — passed by spec-pipeline orchestrator.
+`op_name`, `manifest_signature`, `source_op`, `source_test` — passed by align-family orchestrator.
 
 ## Contract
 
@@ -13,7 +13,7 @@ description: Modify op code to match the manifest-declared interface, making spe
 - **Output**: modified op code + commit + `observations` list (returned to orchestrator)
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <name>` all levels pass + new tests pass.
 - **Termination (blocked)**: fix requires changes beyond Op layer. Return `blocked` with reason.
-- **Constraint**: must NOT modify `ops_manifest.yaml` (orchestrator's responsibility). Must NOT modify tests from spec-test.
+- **Constraint**: must NOT modify `ops_manifest.yaml` (orchestrator's responsibility). Must NOT modify tests from test-op.
 - **Behavioral compatibility**: default param values (from manifest) must produce identical results to the old implementation. The old API shape (e.g., `__init__(M, N)`) is NOT preserved — the manifest defines the target interface.
 
 ## Workflow

--- a/.claude/skills/op-align/SKILL.md
+++ b/.claude/skills/op-align/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: op-align
+description: Per-op orchestrator that brings a single op into alignment with its manifest entry. Classifies the op into one of three cases (green field / interface redesign / minor delta), dispatches to the right path (op-scaffold for new, archive+rescaffold+port for redesign, spec-implement for minor), then runs the shared downstream (test → bench → validate → flip status → report). Complements the family-scoped `spec-pipeline`; per-op entry when you know the op you want to touch.
+---
+
+## Arguments
+
+- `op_name` (positional) — manifest key, e.g. `CumsumFwdOp`.
+- `--mode=green|redesign|minor` (optional) — override the automatic classification. When omitted, `CLASSIFY` decides (auto if unambiguous, otherwise prompt).
+- `--classify-only` (optional) — stop after `CLASSIFY`; write `mode.json` and return without executing any case path. Use to ask "which case is this op in?" without side effects.
+
+## Contract
+
+- **Input**: `op_name` must be present in [`tileops/ops_manifest.yaml`](../../../tileops/ops_manifest.yaml) with `status: spec-only` and a non-empty `source.kernel_map` (same preconditions as op-scaffold; see [PRE_CHECK](#pre_check)).
+- **Output** (SUCCESS path): op file at `source.op` aligned with the manifest; test file `source.test` aligned; `__init__.py` registrations consistent; `status` flipped `spec-only → implemented` (single commit). Side-artefacts in `.foundry/plan/<op_name>/`: `mode.json` (classification), `plan.json` (op-scaffold's §1/§2/§3 when that skill ran), `kernel-check.json` (redesign case only), `pre-rewrite/source.py` (redesign case, removed at CLEANUP on SUCCESS).
+- **Termination (success)**: `python scripts/validate_manifest.py --check-op <op_name>` reports no errors + `python -m pytest <source_test> -v` passes + benchmark produces numbers + manifest status flipped.
+- **Termination (blocked)**: any sub-skill returns blocked, or §1 drift in op-scaffold, or kernel mismatch discovered in redesign path that op-align cannot resolve at the op layer. Report with concrete reason. Archives are kept for post-mortem.
+- **Constraints**:
+  - Only op-align (and only at FLIP_STATUS) may modify `ops_manifest.yaml`. Sub-skills never touch the manifest.
+  - MUST NOT modify kernel code. Kernel-layer work, if needed, is surfaced via `kernel-check.json` as a separate follow-up.
+  - MUST NOT expand to multi-op scope; that is `spec-pipeline`'s role.
+
+## Trust model
+
+- `CLASSIFY`, `DISPATCH`, `FLIP_STATUS`, `CLEANUP`, `REPORT` are orchestrator stages (op-align itself). Every other stage delegates to an atomic skill as a **separate sub-agent invocation**:
+
+  | Stage         | Sub-skill                             |
+  | ------------- | ------------------------------------- |
+  | GREEN path    | `op-scaffold`                         |
+  | REDESIGN path | `op-scaffold` (after ARCHIVE + CLEAR) |
+  | MINOR path    | `spec-implement`                      |
+  | TEST          | `spec-test`                           |
+  | BENCH         | `spec-bench`                          |
+
+  Separate invocations preserve the per-skill contracts (e.g., op-scaffold's §1 fact-freeze; spec-implement's no-test-modification rule).
+
+- After each sub-skill returns, op-align verifies `git status --porcelain` is empty before dispatching the next. If a sub-skill left an uncommitted change, op-align commits on its behalf with `Sub-skill [name]: [summary]` before proceeding.
+
+## Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> PRE_CHECK
+    PRE_CHECK --> CLASSIFY: manifest preconditions pass
+    PRE_CHECK --> BLOCKED: prereq missing
+    CLASSIFY --> CLASSIFY_ONLY_EXIT: --classify-only flag
+    CLASSIFY --> DISPATCH: mode decided (auto or --mode or user-declared)
+    DISPATCH --> GREEN_PATH: case = green
+    DISPATCH --> REDESIGN_PATH: case = redesign
+    DISPATCH --> MINOR_PATH: case = minor
+    GREEN_PATH --> TEST: op-scaffold succeeded
+    REDESIGN_PATH --> KERNEL_CHECK: rescaffold + port done
+    KERNEL_CHECK --> TEST: kernel-check.json written
+    MINOR_PATH --> TEST: spec-implement succeeded
+    TEST --> BENCH: tests written, failing as expected (or DONE_SKIP)
+    BENCH --> REVALIDATE: benchmark produces numbers
+    REVALIDATE --> FLIP_STATUS: --check-op + pytest pass
+    REVALIDATE --> BLOCKED: regression
+    FLIP_STATUS --> CLEANUP: manifest status flipped
+    CLEANUP --> REPORT: archives dropped
+    REPORT --> [*]
+    CLASSIFY_ONLY_EXIT --> [*]
+    GREEN_PATH --> BLOCKED: scaffold failed (§1 drift or validator error)
+    REDESIGN_PATH --> BLOCKED: scaffold or port failed
+    MINOR_PATH --> BLOCKED: spec-implement failed
+    BLOCKED --> [*]: return to caller with reason
+```
+
+## Steps
+
+### <a id="pre_check"></a>1. PRE_CHECK
+
+Preconditions identical to `op-scaffold`'s — orchestrator enforces them up front so sub-skills never see ill-formed input:
+
+- `op_name` in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
+- `status: spec-only` → proceed; `implemented` → BLOCKED ("already aligned; flip status to spec-only in a manifest PR first if you intend to re-align"); missing/other → BLOCKED.
+- `source.kernel_map` declared and non-empty → proceed; missing → BLOCKED with the same guidance op-scaffold uses (add in a prerequisite manifest PR).
+- Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path" — kernel must exist for op layer to align, regardless of case).
+
+### 2. CLASSIFY
+
+Decide which case applies. Machine-decidable input: does `source.op` exist?
+
+| Input                      | Auto case | User prompt?                                                |
+| -------------------------- | --------- | ----------------------------------------------------------- |
+| `source.op` does not exist | `green`   | no                                                          |
+| `source.op` exists         | (unknown) | yes — "redesign (rewrite + port) or minor (in-place edit)?" |
+
+`--mode=<case>` overrides prompting. `--mode=green` is rejected if `source.op` exists (would silently delete existing code); use `--mode=redesign` instead.
+
+Write `.foundry/plan/<op_name>/mode.json`:
+
+```json
+{
+  "op_name": "CumsumFwdOp",
+  "case": "redesign",
+  "file_present": true,
+  "kernel_class_importable": true,
+  "decided_by": "user_prompt",
+  "reason": "User declared: manifest _static_axes shape rewritten; structural redesign.",
+  "classified_at": "2026-04-24T..."
+}
+```
+
+`decided_by` is one of `auto` / `user_prompt` / `flag_override`. `reason` is free-form text.
+
+If `--classify-only` was passed, terminate here and print the mode.json content. No other side effects.
+
+### 3. DISPATCH — case-specific main stage
+
+Each path produces the aligned op file under `source.op` plus whatever artefacts the sub-skill creates under `.foundry/plan/<op_name>/`.
+
+#### 3a. GREEN path (`case = green`)
+
+```
+op-scaffold <op_name>
+```
+
+Sub-skill does PRE_CHECK → DRY_RUN (plan.json) → EMIT → REGISTER → VALIDATE → REPORT. op-align waits for SUCCESS or BLOCKED; on BLOCKED, surface the row and terminate.
+
+#### 3b. REDESIGN path (`case = redesign`)
+
+Sequence:
+
+1. **ARCHIVE** — `mkdir -p .foundry/plan/<op_name>/pre-rewrite/`, copy `source.op` there as `source.py` (rename: strip family path, keep basename). The archive is the source of truth for manual porting. It persists until CLEANUP.
+1. **CLEAR** — remove `source.op` from the tree; remove the op's `from .<module> import <ClassName>` line and its `__all__` entry from the package `__init__.py`. Commit as `[Chore] op-align: archive <op_name> before rescaffold`.
+1. **SCAFFOLD** — `op-scaffold <op_name>`. Target now absent, PRE_CHECK passes, emits the 17 mechanical slots.
+1. **PORT** — read `pre-rewrite/source.py` and port op-specific content that the scaffold cannot produce:
+   - Optional hooks (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`, `_cache_key` override).
+   - Family-specific protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, etc.) if the op was a T1 thin wrapper.
+   - Any `forward` body specifics beyond the universal pattern (kernel-specific reshape/movedim choreography).
+   - Any class-level non-slot attributes the old file had that still make sense under the new spec.
+     Commit as `[Feat] op-align: port business logic for <op_name> from pre-rewrite`. If the agent is uncertain whether a specific override should be ported, record an `open_questions` item in plan.json §3 (`needs_human_decision`) and port conservatively.
+1. **KERNEL_CHECK** — see §5 below.
+
+#### 3c. MINOR path (`case = minor`)
+
+```
+spec-implement <op_name>
+```
+
+Sub-skill does ANALYZE → DIAGNOSE → IMPLEMENT → VALIDATE → MARK_DONE → COMMIT. Op-align waits for SUCCESS or BLOCKED.
+
+### 4. Skipped anchor (reserved)
+
+### <a id="kernel_check"></a>5. KERNEL_CHECK (redesign path only)
+
+Determine whether the kernel layer also needs work. Op-align does **not** modify kernel code; it surfaces the question.
+
+For each Kernel class referenced in `source.kernel_map`:
+
+1. Inspect the kernel's `__init__` / `forward` / `_build_program` signatures (wherever applicable) in its source file.
+1. Compare against the new op's kernel-build call emitted by op-scaffold (`self.kernel_map[<key>](<args>)`). Specifically check:
+   - Argument names and positional order.
+   - Argument types.
+   - Any layout / dtype expectations the kernel documents.
+1. Classify per kernel:
+   - `aligned` — new op's kernel invocation matches the kernel's ctor; no kernel work.
+   - `signature_drift` — arg names or order differ; kernel ctor must be adjusted.
+   - `semantic_drift` — the kernel expects a different data layout / dtype than the new op provides (e.g. op now passes `(M, N)` where kernel expects `(N, M)`).
+   - `unknown` — cannot determine from static inspection.
+
+Write `.foundry/plan/<op_name>/kernel-check.json`:
+
+```json
+{
+  "op_name": "CumsumFwdOp",
+  "checked_at": "2026-04-24T...",
+  "kernels": [
+    {
+      "dispatch_key": "cumulative_fwd",
+      "kernel_class": "CumulativeKernel",
+      "kernel_source": "tileops/kernels/reduction/cumulative.py",
+      "classification": "aligned",
+      "op_call": "self.kernel_map['cumulative_fwd'](M, N, 'sum', self.dtype, tune=self.tune)",
+      "kernel_ctor": "__init__(self, M, N, op_kind, dtype, *, tune=False)",
+      "notes": "Positional and named args match; no kernel work required."
+    }
+  ]
+}
+```
+
+Non-`aligned` entries surface in REPORT as `needs_kernel_work` follow-ups. Op-align itself continues to TEST — the downstream path may still pass if the kernel drift only affects performance (not correctness), or fail fast if the kernel mismatch causes runtime errors, which REVALIDATE will catch.
+
+### 6. TEST
+
+```
+spec-test <op_name>
+```
+
+Sub-skill writes tests against the new spec, confirms they fail (or DONE_SKIP if base class fix from a sibling already handles them). Reuses existing spec-test contract unchanged.
+
+### 7. BENCH
+
+```
+spec-bench <op_name>
+```
+
+Produces numbers. Sub-skill unchanged. If BLOCKED and reason is not kernel-related, propagate blocked.
+
+### 8. REVALIDATE
+
+```bash
+python scripts/validate_manifest.py --check-op <op_name>
+python -m pytest <source_test> -v
+```
+
+Both must pass. Regression after benchmark changes → BLOCKED.
+
+### 9. FLIP_STATUS
+
+Orchestrator (not a sub-skill) edits the manifest:
+
+- `ops.<op_name>.status: spec-only` → `status: implemented`
+- Commit as `[Refactor][Manifest] promote <op_name> to implemented`.
+
+This is the only manifest write in the entire workflow.
+
+### 10. CLEANUP
+
+On SUCCESS path:
+
+- Delete `.foundry/plan/<op_name>/pre-rewrite/` (redesign case only; archive purpose is served).
+- Keep `mode.json`, `plan.json`, `kernel-check.json` as audit trail — they are under `.foundry/plan/` which is gitignored but persists in the local worktree.
+
+On BLOCKED path: keep all artefacts for post-mortem.
+
+### 11. REPORT
+
+Single-page summary printed to stdout. Always includes:
+
+```
+Status: SUCCESS | BLOCKED
+Op: <op_name>
+Case: green | redesign | minor
+Mode decided by: auto | user_prompt | flag_override
+File: <source.op> (<lines>)
+
+Sub-skills run:
+  - op-scaffold: <SUCCESS|BLOCKED|skipped>
+  - spec-implement: <...>
+  - spec-test: <...>
+  - spec-bench: <...>
+
+Plan artefacts (.foundry/plan/<op_name>/):
+  - mode.json
+  - plan.json (if op-scaffold ran)
+  - kernel-check.json (if redesign path)
+  - pre-rewrite/ (redesign path, cleaned on SUCCESS)
+
+Status flipped: spec-only → implemented (commit <sha>)
+
+Follow-ups:
+  - <needs_kernel_work for kernel X> (from kernel-check.json non-aligned entries)
+  - <needs_doc_fix for slot S21> (from plan.json §3)
+  - <needs_human_decision about port of _pad_value> (from port observations)
+```
+
+On BLOCKED, replace "Status flipped" line with the blocking error and list remaining follow-ups.
+
+## Interaction with `spec-pipeline`
+
+`spec-pipeline` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `op-align` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current spec-pipeline stays functional; a follow-up can consolidate.
+
+Until consolidated:
+
+- Use `op-align <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
+- Use `spec-pipeline <family>` for family-scoped historical migration of many ops at once.
+
+They do not conflict. `op-align` never manages cross-op cleanup gates; that remains `spec-pipeline`'s.
+
+## Non-goals
+
+- **Kernel scaffolding / kernel-layer edits.** Op-align surfaces kernel work as a follow-up via `kernel-check.json`; a separate (future) `kernel-scaffold` / `kernel-align` skill will own that layer.
+- **Family-level cleanup.** Cross-op dual-path removal lives in `spec-pipeline` and is not a concern of per-op alignment.
+- **Auto-detecting "redesign vs minor."** The distinction is a design judgement; op-align prompts or accepts `--mode`.
+- **Manifest changes (other than FLIP_STATUS).** Per the trust model, manifest changes live in separate manifest PRs.

--- a/.claude/skills/scaffold-op/SKILL.md
+++ b/.claude/skills/scaffold-op/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: op-scaffold
+name: scaffold-op
 description: Scaffold a new T2 (L1-direct) Op file from a single `ops_manifest.yaml` entry by following the 7-step playbook in docs/ops-design.md. Emits the 17 scaffold slots (S1-S7, S12-S21); leaves family-specific protocol variables, optional hooks, and kernel implementations to downstream skills.
 ---
 
@@ -49,9 +49,9 @@ Explicitly **out of scope** — leave empty, do not invent:
 - **Optional hooks** (`_pad_value`, `_validate_dim`, `_pre_kernel`, `_post_kernel`). Op-specific business logic; no manifest derivation.
 - **`_cache_key` override**. Recommended for cache efficiency under dynamic shapes when `_static_axes` is empty — the `Op._cache_key` default is correctness-preserving (it keys by all non-static axis sizes) but may over-fragment under dynamic shapes and emits a once-per-type `UserWarning` to surface the missing override. The override logic depends on kernel math and is out of scope for scaffolding.
 - **Kernel implementations**. The scaffold only references the Kernel classes named in `source.kernel_map`; their implementation is out of scope.
-- **Tests and benchmarks**. Downstream skills (`spec-test`, `spec-bench`) own these.
+- **Tests and benchmarks**. Downstream skills (`test-op`, `bench-op`) own these.
 
-These gaps are expected and acceptable. The resulting scaffold will raise `NotImplementedError` or trigger validator warnings when invoked beyond the 17 slots' coverage; that is the intended hand-off to `spec-implement` and the family-refactoring skill.
+These gaps are expected and acceptable. The resulting scaffold will raise `NotImplementedError` or trigger validator warnings when invoked beyond the 17 slots' coverage; that is the intended hand-off to `implement-op` and the family-refactoring skill.
 
 ## Steps
 
@@ -81,7 +81,7 @@ Derive the target file path from `source.op` (e.g. `tileops/ops/reduction/cumsum
 ### 2. PRE_CHECK
 
 - `op_name` present in `ops_manifest.yaml` → proceed; otherwise BLOCKED ("op not in manifest").
-- `status` field explicitly set to `spec-only` → proceed; `status: implemented` → BLOCKED ("op already implemented; use spec-implement to migrate"); missing `status` or any other value → BLOCKED ("manifest entry must declare a valid top-level `status`; the validator treats `status` as required").
+- `status` field explicitly set to `spec-only` → proceed; `status: implemented` → BLOCKED ("op already implemented; use implement-op to migrate"); missing `status` or any other value → BLOCKED ("manifest entry must declare a valid top-level `status`; the validator treats `status` as required").
 - `source.kernel_map` declared and non-empty → proceed; missing or empty → BLOCKED ("manifest entry needs `source.kernel_map` before scaffolding — add the dispatch map in a separate manifest PR per the trust model; the scaffold cannot invent dispatch keys because they are kernel-internal conventions"). Note: per `docs/manifest.md`, `source.kernel_map` is only required when `status: implemented`, so many existing `spec-only` entries lack it — these are the cases that need the manifest-PR prerequisite before scaffolding can run.
 - Every value in `source.kernel_map` resolves to an importable symbol → proceed; otherwise BLOCKED ("kernel class not found at expected path").
 - Target file `source.op` does NOT exist → proceed; exists → BLOCKED ("target file already present; scaffold would overwrite").
@@ -278,5 +278,5 @@ The scaffold's behaviour must stay in sync with `docs/ops-design.md` and `docs/o
 ## Non-goals
 
 - Not a codegen engine. This skill is an agent-executable procedure. A future real codegen script can replace the EMIT step; the skill's input/output contract is designed to be codegen-compatible.
-- Not a migration driver. If `op_name` already exists with `status: implemented`, use `spec-implement` (or `spec-pipeline`) instead.
+- Not a migration driver. If `op_name` already exists with `status: implemented`, use `implement-op` (or `align-family`) instead.
 - Not a kernel scaffold. Kernel-side scaffolding is a separate concern.

--- a/.claude/skills/test-op/SKILL.md
+++ b/.claude/skills/test-op/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: spec-test
+name: test-op
 description: Write tests for the target spec using PyTorch as ground truth, verify they fail on current code.
 ---
 
 ## Arguments
 
-`op_name`, `manifest_signature`, `pytorch_equivalent`, `source_test` — passed by spec-pipeline orchestrator.
+`op_name`, `manifest_signature`, `pytorch_equivalent`, `source_test` — passed by align-family orchestrator.
 
 ## Contract
 
 - **Input**: `op_name`, `manifest_signature`, `pytorch_equivalent`, `source_test`
 - **Output**: updated test file + commit
 - **Constraint**: must NOT modify op implementation. Test-only.
-- **Trust model**: this agent must be a different invocation from spec-implement.
+- **Trust model**: this agent must be a different invocation from implement-op.
 
 ## Workflow
 
@@ -71,4 +71,4 @@ python -m pytest <source_test> -v
 
 New tests must **fail** on current code. Construction-time error counts (e.g., current `__init__` doesn't accept `dim`).
 
-**DONE_SKIP**: if tests already pass (base class fixed by a previous op's migration), this is valid. Proceed to spec-implement.
+**DONE_SKIP**: if tests already pass (base class fixed by a previous op's migration), this is valid. Proceed to implement-op.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ This project follows **design-first, spec-driven** development: design docs and 
 
 - [trust-model.md](docs/trust-model.md) — trust boundaries (manifest → test → implementation → benchmark), workloads layer contract
 - [testing.md](docs/testing.md) — test/benchmark framework, core abstractions, tolerances, reporting rules
+- [tileops-skills.md](docs/tileops-skills.md) — developer decision guide: which repo-provided skill to use for which task
 
 ### External
 

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -1,6 +1,6 @@
 # Op Interface Design — Reference
 
-Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) and the `op-scaffold` skill. Each `### Slot S{N}` entry states the authoritative **Rule**, its manifest **Derivation**, a concrete **Example** modelled on [`tileops/ops/reduction/cumsum.py`](../tileops/ops/reduction/cumsum.py), and **Common mistakes**. Non-slot content lives in the appendices. Slot IDs S8–S11 are intentionally absent (reserved during iteration for T1 thin-wrapper slots later declared out of scope).
+Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) and the `scaffold-op` skill. Each `### Slot S{N}` entry states the authoritative **Rule**, its manifest **Derivation**, a concrete **Example** modelled on [`tileops/ops/reduction/cumsum.py`](../tileops/ops/reduction/cumsum.py), and **Common mistakes**. Non-slot content lives in the appendices. Slot IDs S8–S11 are intentionally absent (reserved during iteration for T1 thin-wrapper slots later declared out of scope).
 
 ## Slot Rules
 
@@ -278,7 +278,7 @@ Per-family protocol variables, declared by L2 bases and overridden by L3 ops.
 | `_op_name`                | elementwise     | `torch.library.custom_op` registration key                |
 | `kernel_cls`              | elementwise     | Kernel class reference                                    |
 
-**The `op-scaffold` skill does NOT emit these variables** — kernel-dispatch-convention-dependent (e.g., `VectorNormKernel` uses `{"l1", "l2", "inf"}`, `ReduceKernel` uses `{"sum", "mean", ...}`); filled in during family-specific refactoring (future skill). Adding a new protocol variable requires updating the L2 base, all concrete ops, and the manifest schema if applicable.
+**The `scaffold-op` skill does NOT emit these variables** — kernel-dispatch-convention-dependent (e.g., `VectorNormKernel` uses `{"l1", "l2", "inf"}`, `ReduceKernel` uses `{"sum", "mean", ...}`); filled in during family-specific refactoring (future skill). Adding a new protocol variable requires updating the L2 base, all concrete ops, and the manifest schema if applicable.
 
 ### `Op` base class attributes ([`tileops/ops/op_base.py`](../tileops/ops/op_base.py))
 
@@ -307,7 +307,7 @@ Abstract interface: `forward()`. Key methods: `init_config(config, tune)`, `auto
 
 ## Optional Hooks (Appendix)
 
-Hooks family bases expose for op-specific semantics. The `op-scaffold` skill does NOT emit these.
+Hooks family bases expose for op-specific semantics. The `scaffold-op` skill does NOT emit these.
 
 | Hook              | Family    | Default                     | Override example                                                       |
 | ----------------- | --------- | --------------------------- | ---------------------------------------------------------------------- |

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -263,7 +263,7 @@ This playbook emits exactly the 17 slots above. The following are **not** produc
 
 ## Implementing a Kernel
 
-Brief reference surface for the device-side class that a scaffolded Op depends on. Kernel implementation is not covered by the op-scaffold skill.
+Brief reference surface for the device-side class that a scaffolded Op depends on. Kernel implementation is not covered by the scaffold-op skill.
 
 | Interface             | Required | Description                                                   |
 | --------------------- | -------- | ------------------------------------------------------------- |
@@ -278,7 +278,7 @@ See [Kernel base class attributes](ops-design-reference.md#base-class-protocol) 
 
 ## Family-Base Refactoring (Future Work)
 
-The scaffold emits T2 (L1-direct) ops only. Once a family accumulates 2-3 ops sharing an identical `forward()` flow, extract an L2 family base via refactoring; concrete ops then become T1 thin wrappers declaring family protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, …). This transformation is driven by a separate family-specific skill, not the op-scaffold. See [Development Path](ops-design-reference.md#development-path) for when to extract an L2 base and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the step-by-step process.
+The scaffold emits T2 (L1-direct) ops only. Once a family accumulates 2-3 ops sharing an identical `forward()` flow, extract an L2 family base via refactoring; concrete ops then become T1 thin wrappers declaring family protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, …). This transformation is driven by a separate family-specific skill, not the scaffold-op. See [Development Path](ops-design-reference.md#development-path) for when to extract an L2 base and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the step-by-step process.
 
 ## Further Reference
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -1,136 +1,128 @@
 # TileOPs Skills — Developer Decision Guide
 
-Skills this repo provides for TileOPs op development, plus when to use each and when not to. For the authoritative per-skill contract (arguments, workflow, termination conditions), open the linked `SKILL.md`.
+Skills this repo provides for TileOPs op development: what each does, when to use it, when not to. Authoritative per-skill contracts live in each `SKILL.md`; this page is the human-facing map.
 
-Naming convention: **verb-noun**. The noun (`op` or `family`) tells you the scope; the verb tells you the action. Orchestrator skills compose atomic skills — see [Composition](#composition) below.
+Naming is **verb-noun**. The verb is the action; the noun (`op` or `family`) is the scope.
 
-## Which skill should I use?
+## At a glance
 
-"I want to…"
+|                | Orchestrator                                              | Atomic                                                                                                                                                                                                                    |
+| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **per op**     | [`align-op`](../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../.claude/skills/test-op/SKILL.md) · [`implement-op`](../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../.claude/skills/bench-op/SKILL.md) |
+| **per family** | [`align-family`](../.claude/skills/align-family/SKILL.md) | [`audit-family`](../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                 |
 
-### … align or add a single op to its manifest entry
+Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging.
 
-→ **[`/align-op <op_name>`](../.claude/skills/align-op/SKILL.md)**
+## What do I want to do?
 
-This is the per-op entry for almost every day-to-day workflow. The skill internally classifies into three cases and dispatches:
+| Intent                                                            | Run                                        |
+| ----------------------------------------------------------------- | ------------------------------------------ |
+| Align / add a single op to its manifest entry (the common case)   | `/align-op <op_name>`                      |
+| Find out which case an op is in, without touching anything        | `/align-op <op_name> --classify-only`      |
+| Migrate every spec-only op in a whole family (historical backlog) | `/align-family <family>`                   |
+| Read-only audit of a family's spec gaps                           | `/audit-family <family>`                   |
+| Scaffold a fresh op file, bypassing the orchestrator              | `/scaffold-op <op_name>`                   |
+| Debug one atomic phase by hand                                    | `/test-op` · `/implement-op` · `/bench-op` |
 
-- **green** — no op code yet (scaffolds from the manifest)
-- **redesign** — op exists but the interface was restructured (archives old file → rescaffolds → ports business logic)
-- **minor** — small manifest delta (in-place edit)
+## Skills in detail
 
-Omit `--mode` to auto-classify (green is auto-detected; redesign vs minor is prompted). Pass `--mode=green|redesign|minor` to force.
+Each block names the skill, its one-line purpose, clear **use when** / **don't use when** guidance, and a link to the authoritative `SKILL.md`.
 
-### … ask "which case is this op in?" without running anything
+### `align-op`  ·  per-op orchestrator
 
-→ **`/align-op <op_name> --classify-only`**
+Brings a single op into alignment with its manifest entry. Classifies into one of three cases and dispatches internally; runs the shared downstream (test → bench → validate → flip status → report).
 
-Writes `.foundry/plan/<op_name>/mode.json` and exits. Zero side effects. Useful for triage before you commit to a workflow.
+- **Cases.** `green` (no code yet → calls `scaffold-op`), `redesign` (archive + rescaffold + port), `minor` (in-place edit via `implement-op`).
+- **Use when.** You want to add or re-align a single op after a manifest or design-doc change.
+- **Don't use when.** You need to batch-migrate a whole family — use `align-family` instead.
+- **Contract:** [SKILL.md](../.claude/skills/align-op/SKILL.md)
 
-### … migrate a whole op family (historical backlog)
+### `align-family`  ·  per-family orchestrator
 
-→ **[`/align-family <family>`](../.claude/skills/align-family/SKILL.md)**
+Drives the historical migration of an entire op family. Audits, then pipelines every spec-only op through test → implement → bench → flip status; handles cross-op cleanup (dual-path removal); creates the PR.
 
-Family-scoped orchestrator. Audits the family, pipelines every `spec-only` op through test → implement → bench → flip_status, handles cross-op cleanup (dual-path removal), creates the PR.
+- **Use when.** You have a whole family of spec-only ops to migrate.
+- **Don't use when.** Only one op needs attention — use `align-op`.
+- **Contract:** [SKILL.md](../.claude/skills/align-family/SKILL.md)
 
-### … audit a family's spec-conformance gap without migrating anything
+### `scaffold-op`  ·  per-op atomic
 
-→ **[`/audit-family <family>`](../.claude/skills/audit-family/SKILL.md)**
+Writes a new T2 (L1-direct) op file from one manifest entry by following the 7-step playbook in `docs/ops-design.md`. Emits the 17 mechanical slots.
 
-Writes `.foundry/migrations/<family>.json` classifying every op as `ready` / `semantic_gap` / `blocked`. Read-only inspection.
+- **Use when.** Called by `align-op` on the green path; rarely needed standalone.
+- **Don't use when.** `source.op` already exists — PRE_CHECK refuses. Use `align-op --mode=redesign`, which archives the old file first.
+- **Don't expect.** Family protocol variables (`_op_kind`, `_kernel_key`, …) or optional hooks (`_pad_value`, `_validate_dim`, …). Those are op-specific business logic, outside the 17 mechanical slots.
+- **Contract:** [SKILL.md](../.claude/skills/scaffold-op/SKILL.md)
 
-### … run a single atomic phase by hand (debugging an orchestrator)
+### `implement-op`  ·  per-op atomic
 
-→ **[`/test-op`](../.claude/skills/test-op/SKILL.md)**, **[`/implement-op`](../.claude/skills/implement-op/SKILL.md)**, **[`/bench-op`](../.claude/skills/bench-op/SKILL.md)**
+Edits an existing op file to match the manifest-declared interface, making spec tests pass.
 
-Normally these are invoked as sub-skills by `align-op` or `align-family`. Direct invocation is for debugging the orchestrator — rarely the right entry point.
+- **Use when.** Called by orchestrators.
+- **Don't use when.** The change is a structural rewrite — `align-op --mode=redesign` archives the old file and regenerates cleanly before implementing.
+- **Contract:** [SKILL.md](../.claude/skills/implement-op/SKILL.md)
 
-### … scaffold a fresh op file directly (bypassing the orchestrator)
+### `test-op`  ·  per-op atomic
 
-→ **[`/scaffold-op <op_name>`](../.claude/skills/scaffold-op/SKILL.md)**
+Writes tests for the target spec using PyTorch as ground truth; verifies they fail on current code (the TDD seed before `implement-op`).
 
-`align-op` already calls this internally for the green path. Prefer `align-op` unless you are scripting around the orchestrator or debugging scaffold emission itself.
+- **Use when.** Called by orchestrators.
+- **Contract:** [SKILL.md](../.claude/skills/test-op/SKILL.md)
 
-## When NOT to use a particular skill
+### `bench-op`  ·  per-op atomic
 
-### `scaffold-op` (atomic)
+Fixes the benchmark file to compile against the new op interface. Runs it, fixes errors, repeats until it produces numbers.
 
-- **Don't** invoke directly when `source.op` already exists — PRE_CHECK refuses to overwrite. Use `align-op --mode=redesign`; the orchestrator archives the old file before rescaffolding.
-- **Don't** expect it to emit family protocol variables (`_op_kind`, `_kernel_key`, …) or optional hooks (`_pad_value`, `_validate_dim`, …). Those are op-specific business logic that must be hand-ported — `align-op`'s redesign path owns that step.
+- **Use when.** Called by orchestrators.
+- **Contract:** [SKILL.md](../.claude/skills/bench-op/SKILL.md)
 
-### `align-family` (orchestrator)
+### `audit-family`  ·  per-family atomic
 
-- **Don't** use for single-op work — `align-op` is the per-op entry. `align-family` is the right choice only when you want to batch-migrate every `spec-only` op in a family.
-- **Don't** use if the family has no `spec-only` ops — run `audit-family` first, or just check `ops_manifest.yaml`.
+Compares each op's code signature against its manifest spec, classifies gaps (`ready` / `semantic_gap` / `blocked`), writes `.foundry/migrations/<family>.json`.
 
-### `implement-op` / `test-op` / `bench-op` (atomic)
-
-- **Don't** invoke standalone unless debugging — they are normally sub-skills inside `align-op` or `align-family`.
-- **Don't** use `implement-op` for full rewrites — prefer `align-op --mode=redesign`, which archives the old file before regenerating.
-
-### `audit-family` (atomic)
-
-- Fine to invoke standalone for a read-only inspection. If you find yourself running audit + manually doing the per-op migration, just use `align-family` — it does the audit internally.
-
-## Skill catalog
-
-The purpose line comes from each skill's `SKILL.md` frontmatter `description` field — edit that and update this row to match.
-
-| Skill                                                     | Scope      | Tier         | Purpose                                                                                                                                                                                                       |
-| --------------------------------------------------------- | ---------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`align-op`](../.claude/skills/align-op/SKILL.md)         | per op     | orchestrator | Brings a single op into alignment with its manifest entry. Classifies into green / redesign / minor, dispatches, runs the shared downstream (test → bench → validate → flip status → report).                 |
-| [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md)   | per op     | atomic       | Scaffolds a new T2 (L1-direct) Op file from one manifest entry by following the 7-step playbook in `docs/ops-design.md`. Emits the 17 mechanical slots; leaves hooks/protocol-vars/kernel impl to downstream. |
-| [`test-op`](../.claude/skills/test-op/SKILL.md)           | per op     | atomic       | Writes tests for the target spec using PyTorch as ground truth; verifies they fail on current code.                                                                                                           |
-| [`implement-op`](../.claude/skills/implement-op/SKILL.md) | per op     | atomic       | Modifies op code to match the manifest-declared interface, making spec tests pass.                                                                                                                            |
-| [`bench-op`](../.claude/skills/bench-op/SKILL.md)         | per op     | atomic       | Fixes the benchmark file to work with the new Op interface. Runs benchmark, fixes errors, repeats until it produces numbers.                                                                                  |
-| [`align-family`](../.claude/skills/align-family/SKILL.md) | per family | orchestrator | Drives the full migration for an op family — audit, test, implement, bench, flip status, create PR.                                                                                                           |
-| [`audit-family`](../.claude/skills/audit-family/SKILL.md) | per family | atomic       | Compares each op's code signature against its manifest spec, classifies gaps, produces a structured report.                                                                                                   |
+- **Use when.** You want read-only inspection of a family's current conformance. Also called internally by `align-family`.
+- **Contract:** [SKILL.md](../.claude/skills/audit-family/SKILL.md)
 
 ## Composition
 
 How orchestrators delegate to atomic skills.
 
-```
-align-family <family>           ← family-scoped orchestrator
-  ├─ audit-family               (internal call)
-  ├─ per op:
-  │   ├─ test-op
-  │   ├─ implement-op
-  │   ├─ bench-op
-  │   └─ (orchestrator flips manifest status)
-  └─ CLEANUP + CREATE_PR        (orchestrator)
+```text
+align-family <family>                    ← per-family orchestrator
+├─ audit-family
+├─ per op:
+│   ├─ test-op
+│   ├─ implement-op
+│   ├─ bench-op
+│   └─ [orchestrator] FLIP_STATUS
+└─ [orchestrator] CLEANUP + CREATE_PR
 
-align-op <op_name>              ← per-op orchestrator
-  ├─ CLASSIFY                   (internal)
-  ├─ GREEN path:
-  │   └─ scaffold-op
-  ├─ REDESIGN path:
-  │   ├─ ARCHIVE + CLEAR        (internal, prepares clean target)
-  │   ├─ scaffold-op
-  │   ├─ PORT                   (internal, agent reads archive)
-  │   └─ KERNEL_CHECK           (internal, writes kernel-check.json)
-  ├─ MINOR path:
-  │   └─ implement-op
-  └─ shared downstream:
-      ├─ test-op
-      ├─ bench-op
-      └─ FLIP_STATUS            (orchestrator; only manifest writer)
+align-op <op_name>                       ← per-op orchestrator
+├─ [orchestrator] CLASSIFY
+├─ green:     scaffold-op
+├─ redesign:  [orchestrator] ARCHIVE + CLEAR → scaffold-op → PORT → KERNEL_CHECK
+├─ minor:     implement-op
+└─ shared downstream:
+    ├─ test-op
+    ├─ bench-op
+    └─ [orchestrator] FLIP_STATUS        ← only manifest writer
 ```
 
-Future consolidation: `align-family`'s per-op inner loop may delegate to `align-op` to remove duplication. Tracked as follow-up.
+A follow-up may refactor `align-family`'s per-op loop to delegate to `align-op`, removing duplication.
 
-## Trust model (who can write what)
+## Trust model  ·  who may write what
 
-| Concern                             | Owner                                                                                                                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ops_manifest.yaml` writes          | Only `align-op` (at FLIP_STATUS) or `align-family` (at its FLIP_STATUS step); no atomic skill may touch the manifest.                                               |
-| `tileops/ops/**` op files           | `scaffold-op` creates; `implement-op` edits; `align-op` / `align-family` orchestrate.                                                                               |
-| `tileops/kernels/**` kernel files   | No TileOPs skill modifies kernel files today. `align-op --mode=redesign` surfaces kernel mismatches as `kernel-check.json` entries for a future kernel-layer skill. |
-| `tests/ops/**` test files           | Only `test-op`.                                                                                                                                                     |
-| `benchmarks/ops/**` benchmark files | Only `bench-op`.                                                                                                                                                    |
+| Resource                          | Writer                                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ops_manifest.yaml`               | Only `align-op` / `align-family` at `FLIP_STATUS`. No atomic skill writes the manifest.                                                                            |
+| `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                       |
+| `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work. |
+| `tests/ops/**`                    | `test-op`.                                                                                                                                                         |
+| `benchmarks/ops/**`               | `bench-op`.                                                                                                                                                        |
 
 ## Maintenance
 
-- **Purpose lines** in the Catalog table are the `description` YAML frontmatter in each skill's `SKILL.md`. Edit there first; update this table to match.
-- **Decision tree, NOT-use rules, composition diagram** are hand-maintained. Add an entry when a new skill lands; remove when one is retired.
-- **Source of skill list**: `ls .claude/skills/` is authoritative. Every directory there should appear in the Catalog.
-- **No lint automation** at current scale (7 skills). Add a `scripts/lint_skill_index.py` only if drift becomes observable or the skill count grows past ~15.
+- **Per-skill blocks above** mirror each skill's `description` frontmatter. Edit the frontmatter first; update the matching block here to stay consistent.
+- **At-a-glance matrix, intent table, use/don't-use rules, composition diagram, trust-model table**: hand-maintained. Add entries when a new skill lands; remove when one is retired.
+- **Authoritative skill list**: `ls .claude/skills/` is the source of truth. Every directory there should appear in the at-a-glance matrix and have a block in "Skills in detail".
+- **Lint automation**: none at 7-skill scale. Revisit if drift becomes observable or the count passes ~15.

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -1,0 +1,136 @@
+# TileOPs Skills — Developer Decision Guide
+
+Skills this repo provides for TileOPs op development, plus when to use each and when not to. For the authoritative per-skill contract (arguments, workflow, termination conditions), open the linked `SKILL.md`.
+
+Naming convention: **verb-noun**. The noun (`op` or `family`) tells you the scope; the verb tells you the action. Orchestrator skills compose atomic skills — see [Composition](#composition) below.
+
+## Which skill should I use?
+
+"I want to…"
+
+### … align or add a single op to its manifest entry
+
+→ **[`/align-op <op_name>`](../.claude/skills/align-op/SKILL.md)**
+
+This is the per-op entry for almost every day-to-day workflow. The skill internally classifies into three cases and dispatches:
+
+- **green** — no op code yet (scaffolds from the manifest)
+- **redesign** — op exists but the interface was restructured (archives old file → rescaffolds → ports business logic)
+- **minor** — small manifest delta (in-place edit)
+
+Omit `--mode` to auto-classify (green is auto-detected; redesign vs minor is prompted). Pass `--mode=green|redesign|minor` to force.
+
+### … ask "which case is this op in?" without running anything
+
+→ **`/align-op <op_name> --classify-only`**
+
+Writes `.foundry/plan/<op_name>/mode.json` and exits. Zero side effects. Useful for triage before you commit to a workflow.
+
+### … migrate a whole op family (historical backlog)
+
+→ **[`/align-family <family>`](../.claude/skills/align-family/SKILL.md)**
+
+Family-scoped orchestrator. Audits the family, pipelines every `spec-only` op through test → implement → bench → flip_status, handles cross-op cleanup (dual-path removal), creates the PR.
+
+### … audit a family's spec-conformance gap without migrating anything
+
+→ **[`/audit-family <family>`](../.claude/skills/audit-family/SKILL.md)**
+
+Writes `.foundry/migrations/<family>.json` classifying every op as `ready` / `semantic_gap` / `blocked`. Read-only inspection.
+
+### … run a single atomic phase by hand (debugging an orchestrator)
+
+→ **[`/test-op`](../.claude/skills/test-op/SKILL.md)**, **[`/implement-op`](../.claude/skills/implement-op/SKILL.md)**, **[`/bench-op`](../.claude/skills/bench-op/SKILL.md)**
+
+Normally these are invoked as sub-skills by `align-op` or `align-family`. Direct invocation is for debugging the orchestrator — rarely the right entry point.
+
+### … scaffold a fresh op file directly (bypassing the orchestrator)
+
+→ **[`/scaffold-op <op_name>`](../.claude/skills/scaffold-op/SKILL.md)**
+
+`align-op` already calls this internally for the green path. Prefer `align-op` unless you are scripting around the orchestrator or debugging scaffold emission itself.
+
+## When NOT to use a particular skill
+
+### `scaffold-op` (atomic)
+
+- **Don't** invoke directly when `source.op` already exists — PRE_CHECK refuses to overwrite. Use `align-op --mode=redesign`; the orchestrator archives the old file before rescaffolding.
+- **Don't** expect it to emit family protocol variables (`_op_kind`, `_kernel_key`, …) or optional hooks (`_pad_value`, `_validate_dim`, …). Those are op-specific business logic that must be hand-ported — `align-op`'s redesign path owns that step.
+
+### `align-family` (orchestrator)
+
+- **Don't** use for single-op work — `align-op` is the per-op entry. `align-family` is the right choice only when you want to batch-migrate every `spec-only` op in a family.
+- **Don't** use if the family has no `spec-only` ops — run `audit-family` first, or just check `ops_manifest.yaml`.
+
+### `implement-op` / `test-op` / `bench-op` (atomic)
+
+- **Don't** invoke standalone unless debugging — they are normally sub-skills inside `align-op` or `align-family`.
+- **Don't** use `implement-op` for full rewrites — prefer `align-op --mode=redesign`, which archives the old file before regenerating.
+
+### `audit-family` (atomic)
+
+- Fine to invoke standalone for a read-only inspection. If you find yourself running audit + manually doing the per-op migration, just use `align-family` — it does the audit internally.
+
+## Skill catalog
+
+The purpose line comes from each skill's `SKILL.md` frontmatter `description` field — edit that and update this row to match.
+
+| Skill                                                     | Scope      | Tier         | Purpose                                                                                                                                                                                                       |
+| --------------------------------------------------------- | ---------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`align-op`](../.claude/skills/align-op/SKILL.md)         | per op     | orchestrator | Brings a single op into alignment with its manifest entry. Classifies into green / redesign / minor, dispatches, runs the shared downstream (test → bench → validate → flip status → report).                 |
+| [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md)   | per op     | atomic       | Scaffolds a new T2 (L1-direct) Op file from one manifest entry by following the 7-step playbook in `docs/ops-design.md`. Emits the 17 mechanical slots; leaves hooks/protocol-vars/kernel impl to downstream. |
+| [`test-op`](../.claude/skills/test-op/SKILL.md)           | per op     | atomic       | Writes tests for the target spec using PyTorch as ground truth; verifies they fail on current code.                                                                                                           |
+| [`implement-op`](../.claude/skills/implement-op/SKILL.md) | per op     | atomic       | Modifies op code to match the manifest-declared interface, making spec tests pass.                                                                                                                            |
+| [`bench-op`](../.claude/skills/bench-op/SKILL.md)         | per op     | atomic       | Fixes the benchmark file to work with the new Op interface. Runs benchmark, fixes errors, repeats until it produces numbers.                                                                                  |
+| [`align-family`](../.claude/skills/align-family/SKILL.md) | per family | orchestrator | Drives the full migration for an op family — audit, test, implement, bench, flip status, create PR.                                                                                                           |
+| [`audit-family`](../.claude/skills/audit-family/SKILL.md) | per family | atomic       | Compares each op's code signature against its manifest spec, classifies gaps, produces a structured report.                                                                                                   |
+
+## Composition
+
+How orchestrators delegate to atomic skills.
+
+```
+align-family <family>           ← family-scoped orchestrator
+  ├─ audit-family               (internal call)
+  ├─ per op:
+  │   ├─ test-op
+  │   ├─ implement-op
+  │   ├─ bench-op
+  │   └─ (orchestrator flips manifest status)
+  └─ CLEANUP + CREATE_PR        (orchestrator)
+
+align-op <op_name>              ← per-op orchestrator
+  ├─ CLASSIFY                   (internal)
+  ├─ GREEN path:
+  │   └─ scaffold-op
+  ├─ REDESIGN path:
+  │   ├─ ARCHIVE + CLEAR        (internal, prepares clean target)
+  │   ├─ scaffold-op
+  │   ├─ PORT                   (internal, agent reads archive)
+  │   └─ KERNEL_CHECK           (internal, writes kernel-check.json)
+  ├─ MINOR path:
+  │   └─ implement-op
+  └─ shared downstream:
+      ├─ test-op
+      ├─ bench-op
+      └─ FLIP_STATUS            (orchestrator; only manifest writer)
+```
+
+Future consolidation: `align-family`'s per-op inner loop may delegate to `align-op` to remove duplication. Tracked as follow-up.
+
+## Trust model (who can write what)
+
+| Concern                             | Owner                                                                                                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ops_manifest.yaml` writes          | Only `align-op` (at FLIP_STATUS) or `align-family` (at its FLIP_STATUS step); no atomic skill may touch the manifest.                                               |
+| `tileops/ops/**` op files           | `scaffold-op` creates; `implement-op` edits; `align-op` / `align-family` orchestrate.                                                                               |
+| `tileops/kernels/**` kernel files   | No TileOPs skill modifies kernel files today. `align-op --mode=redesign` surfaces kernel mismatches as `kernel-check.json` entries for a future kernel-layer skill. |
+| `tests/ops/**` test files           | Only `test-op`.                                                                                                                                                     |
+| `benchmarks/ops/**` benchmark files | Only `bench-op`.                                                                                                                                                    |
+
+## Maintenance
+
+- **Purpose lines** in the Catalog table are the `description` YAML frontmatter in each skill's `SKILL.md`. Edit there first; update this table to match.
+- **Decision tree, NOT-use rules, composition diagram** are hand-maintained. Add an entry when a new skill lands; remove when one is retired.
+- **Source of skill list**: `ls .claude/skills/` is authoritative. Every directory there should appear in the Catalog.
+- **No lint automation** at current scale (7 skills). Add a `scripts/lint_skill_index.py` only if drift becomes observable or the skill count grows past ~15.

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -121,7 +121,7 @@ class Op(ABC):
         #     of eval_roofline on every concrete Op subclass.
         # Why: Introducing @abstractmethod now would break every existing
         #     concrete op under tileops/ops/ (none of them ship an
-        #     eval_roofline yet). The op-scaffold codegen work that will
+        #     eval_roofline yet). The scaffold-op codegen work that will
         #     generate these bodies per docs/roofline.md §4.4 is pre-
         #     requisite; the trust model requires a separate per-op migration
         #     PR to flip any given op from stub to generated body.


### PR DESCRIPTION
Closes #1044.

## Three things

**1. New skill `align-op`** (per-op orchestrator, `.claude/skills/align-op/SKILL.md`)

Classifies an op into one of three cases and dispatches:

| Case         | Trigger                                      | Main stage                                            |
| ------------ | -------------------------------------------- | ----------------------------------------------------- |
| **green**    | `source.op` missing                          | `scaffold-op`                                         |
| **redesign** | `source.op` exists + structural spec change  | `ARCHIVE → CLEAR → scaffold-op → PORT → KERNEL_CHECK` |
| **minor**    | `source.op` exists + small manifest delta    | `implement-op`                                        |

Shared downstream: `test-op → [implement-op] → bench-op → revalidate → flip status → cleanup → report`. `--classify-only` queries the case without side effects. Kernel work never happens here — `kernel-check.json` surfaces it for a future skill.

**2. Skill set renamed to verb-noun**

| Old              | New              |
| ---------------- | ---------------- |
| `op-scaffold`    | `scaffold-op`    |
| `spec-test`      | `test-op`        |
| `spec-implement` | `implement-op`   |
| `spec-bench`     | `bench-op`       |
| `spec-audit`     | `audit-family`   |
| `spec-pipeline`  | `align-family`   |
| (new)            | `align-op`       |

Verb-noun makes action + scope readable. `align-op` ↔ `align-family` is the orchestrator pair. Old `spec-` prefix dropped (didn't discriminate tier). Cross-refs updated in all 7 SKILL.md + `docs/ops-design.md` / `docs/ops-design-reference.md` + one comment in `tileops/ops/op_base.py`.

**3. Developer decision guide** (`docs/tileops-skills.md`)

At-a-glance Scope×Tier matrix, intent→command table, per-skill use/don't-use blocks, composition diagram, trust-model table. `CLAUDE.md` "Key References" picks up a one-line pointer.

## Invariants

- `align-op` is the **only** `ops_manifest.yaml` writer (at FLIP_STATUS). All atomic skills preserve their no-manifest-write contract.
- `scaffold-op`'s strict PRE_CHECK stays intact. Overwrite discipline lives in `align-op`'s ARCHIVE + CLEAR; scaffold always sees a clean target.
- No kernel code is modified. `kernel-check.json` classifies drift as `aligned` / `signature_drift` / `semantic_drift` / `unknown` — informational only.

## Test plan

- [x] All 7 skills renamed; frontmatter names match dirs; no leftover old names across the tree.
- [x] `tileops-skills.md` covers all 7 skills; `CLAUDE.md` updated.
- [x] Pre-commit (mdformat, codespell, gitleaks) passes on every commit.
- [ ] End-to-end `align-op` run deferred to first real use; plan artefacts (`mode.json` / `plan.json` / `kernel-check.json`) designed to drive iteration from that run.

## Follow-up

- #1046 — refactor `align-family`'s per-op inner loop to delegate to `align-op` (duplication removal; scope-separated from this PR for diff-size + review-independence).