### PR TITLE
[Fix][OPS] align-op mermaid workflow fails to render on GitHub

### DIFF
--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -60,15 +60,15 @@ stateDiagram-v2
     REDESIGN_PATH --> KERNEL_CHECK: rescaffold + port done
     KERNEL_CHECK --> TEST: kernel-check.json written
     MINOR_PATH --> TEST: implement-op succeeded (minor-case main stage ran here)
-    TEST --> IMPLEMENT: tests fail on current code (expected; gap to close)
-    TEST --> BENCH: tests already pass (DONE_SKIP) — typically minor path where implement-op already ran
+    TEST --> IMPLEMENT: tests fail on current code (expected gap to close)
+    TEST --> BENCH: tests already pass (DONE_SKIP), usually minor path
     IMPLEMENT --> BENCH: implementation closes the gap, tests pass
-    IMPLEMENT --> BLOCKED: gap beyond op-layer (e.g., kernel rewrite required)
+    IMPLEMENT --> BLOCKED: gap beyond op-layer (e.g. kernel rewrite required)
     BENCH --> REVALIDATE: benchmark produces numbers
-    REVALIDATE --> FLIP_STATUS: --check-op + pytest pass
+    REVALIDATE --> FLIP_STATUS: check-op and pytest both pass
     REVALIDATE --> BLOCKED: regression
     FLIP_STATUS --> CLEANUP: manifest status flipped
-    CLEANUP --> REPORT: pre-rewrite/ dropped (redesign only); mode/plan/kernel-check kept
+    CLEANUP --> REPORT: pre-rewrite dropped on redesign, plan artefacts kept
     REPORT --> [*]
     CLASSIFY_ONLY_EXIT --> [*]
     GREEN_PATH --> BLOCKED: scaffold failed (§1 drift or validator error)


### PR DESCRIPTION
GitHub reports `Parse error on line 22` when rendering the align-op `SKILL.md` Workflow diagram. Root cause: the `CLEANUP → REPORT` transition label contains a semicolon (mermaid treats `;` as a statement terminator in state diagrams) and forward slashes. Two earlier lines had similar risky chars but did not trigger the first error only because the parser stopped at line 22.

## Fix

All changes are inside the mermaid block; labels only, diagram structure unchanged.

| Line | Before | After |
| --- | --- | --- |
| 14 | `tests fail on current code (expected; gap to close)` | `tests fail on current code (expected gap to close)` |
| 15 | `tests already pass (DONE_SKIP) — typically minor path where implement-op already ran` | `tests already pass (DONE_SKIP), usually minor path` |
| 17 | `gap beyond op-layer (e.g., kernel rewrite required)` | `gap beyond op-layer (e.g. kernel rewrite required)` |
| 19 | `--check-op + pytest pass` | `check-op and pytest both pass` |
| 22 | `pre-rewrite/ dropped (redesign only); mode/plan/kernel-check kept` | `pre-rewrite dropped on redesign, plan artefacts kept` |

All labels now free of `;`, `/`, em-dash, and leading `--` — the characters most likely to break mermaid's state-diagram label parsing.

Diagram semantics identical. The CLEANUP step text in the Steps section still describes the precise artefact-retention policy; the label is just a short summary.

## Test plan

- [x] `sed -n '/^\`\`\`mermaid/,/^\`\`\`/p' .claude/skills/align-op/SKILL.md | grep -nE ';|—|/' ` returns no matches inside labels.
- [x] Pre-commit hooks (mdformat, codespell, gitleaks) pass.
- [ ] Render check: will visually verify on the PR diff after push.