### PR TITLE
[Fix][Doc] add tileops-skills.md to docs/README.md index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,11 @@ Design-first, spec-driven documentation for TileOPs. [`ops_manifest.yaml`](../ti
 
 ## Process
 
-| Document                         | Scope                                                                                            |
-| -------------------------------- | ------------------------------------------------------------------------------------------------ |
-| [trust-model.md](trust-model.md) | Trust boundaries between manifest → test → implementation → benchmark; workloads layer contract. |
-| [testing.md](testing.md)         | Test and benchmark framework: core abstractions, tolerances, reporting rules.                    |
+| Document                               | Scope                                                                                                |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [trust-model.md](trust-model.md)       | Trust boundaries between manifest → test → implementation → benchmark; workloads layer contract.     |
+| [testing.md](testing.md)               | Test and benchmark framework: core abstractions, tolerances, reporting rules.                        |
+| [tileops-skills.md](tileops-skills.md) | Developer decision guide: which repo-provided skill to use for which task, with composition diagram. |
 
 ## Performance Guides
 


### PR DESCRIPTION
`docs/README.md` is the human-facing index for `docs/`. PR #1045 landed `docs/tileops-skills.md` and wired it into `CLAUDE.md` "Key References > Process" for agent discovery but missed adding it to `docs/README.md`. A human browsing `docs/` wouldn't find it.

## Change

Add one row to the Process table in `docs/README.md`:

```
| [tileops-skills.md](tileops-skills.md) | Developer decision guide: which repo-provided skill to use for which task, with composition diagram. |
```

Placed next to `trust-model.md` and `testing.md`, matching the categorisation in `CLAUDE.md`.

## Test plan

- [x] Pre-commit (mdformat, codespell, gitleaks) passes.
- [x] Single-file change, 5+/4- lines, mechanical.