### PR TITLE
[Refactor][Skills] delegate align-family per-op loop to align-op

### DIFF
--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -89,11 +89,11 @@ Track group completion: a group is complete when all its ops are `promoted` or `
 
 Read the gap report from AUDIT. For each op in the current group, route by `classification` (the field `audit-family` populates):
 
-| Gap-report `classification` | Action                                                 | Why                                                                                                                                          |
-| --------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ready`                     | → ALIGN_OP with `--mode=minor`                         | Existing code already conforms; align-op's minor path runs the spec tests (DONE_SKIP since they pass), then the shared downstream + flip.    |
-| `semantic_gap`              | → ALIGN_OP with `--mode=redesign`                      | Legacy code structurally diverges from the spec; align-op archives it, rescaffolds, and ports — full per-op pipeline.                        |
-| `blocked`                   | → REPORT_BLOCKED with audit's `reason`. Skip align-op. | Audit determined the op cannot be migrated autonomously (no `pytorch_equivalent`, kernel-layer change required, etc.). No per-op work to do. |
+| Gap-report `classification` | Action                                                 | Why                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ready`                     | → ALIGN_OP with `--mode=minor`                         | Existing code already conforms; align-op's minor path runs the spec tests (DONE_SKIP since they pass), then the shared downstream + flip.                                                                                                                                                                                                                                                     |
+| `semantic_gap`              | → ALIGN_OP with `--mode=redesign`                      | Family-scoped historical migration treats every `semantic_gap` op as a structural redesign by default — legacy code is being replaced wholesale. For per-op `semantic_gap` cases that are actually minor manifest deltas, use single-op `align-op <op> --mode=minor` directly instead of `align-family`. A future `recommended_mode` gap-report field could refine the routing automatically. |
+| `blocked`                   | → REPORT_BLOCKED with audit's `reason`. Skip align-op. | Audit determined the op cannot be migrated autonomously (no `pytorch_equivalent`, kernel-layer change required, etc.). No per-op work to do.                                                                                                                                                                                                                                                  |
 
 The mapping is deterministic — `align-family` MUST pass `--mode=` explicitly so `align-op` never falls into its interactive prompt branch in a batch family migration.
 
@@ -116,7 +116,7 @@ Per-op outcome:
 
 ### 5. CLEANUP_GATE
 
-After each `align-op` invocation returns (SUCCESS or BLOCKED), check group completion:
+After each per-op outcome — whether `align-op` returned SUCCESS / BLOCKED or ROUTE recorded an audit-classified `blocked` op directly to `REPORT_BLOCKED` — check group completion:
 
 - All siblings in the current base-class group are `promoted` or `blocked`? → trigger CLEANUP
 - Otherwise → continue to next op (ROUTE → ALIGN_OP)

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: align-family
-description: Drive the full migration for an op family — audit, delegate per-op alignment to align-op, run cross-op cleanup, create PR.
+description: Drive the full migration for an op family — audit, delegate per-op alignment to align-op, run cross-op cleanup. Two terminal outcomes: SUCCESS opens a PR; CLEANUP_REGRESSION exits blocked without a PR when post-cleanup tests fail.
 ---
 
 ## Arguments
@@ -13,7 +13,7 @@ Family name from `ops_manifest.yaml` (e.g., `reduction`, `norm`, `attention`).
 - **Output** (two terminal outcomes):
   - **SUCCESS**: PR URL + final report — all ops processed via `align-op` (promoted or blocked), cleanup succeeds, PR opens.
   - **BLOCKED**: blocked report (no PR) — reached when CLEANUP detects a regression in a promoted op's tests after dual-path removal; see `CLEANUP_REGRESSION` terminal in the state diagram. Distinct from the non-terminal per-op `REPORT_BLOCKED` state.
-- **Termination**: all ops processed (promoted or blocked via `align-op`) and either (a) CLEANUP + CREATE_PR succeed, or (b) CLEANUP fails and the run exits via `CLEANUP_REGRESSION` with the regression recorded. (`REPORT_BLOCKED` is the non-terminal per-op blocked state and never terminates the run.)
+- **Termination**: all ops processed (promoted or blocked via `align-op`) and either (a) CLEANUP + CREATE_PR succeed, or (b) a promoted op's tests fail after CLEANUP's dual-path removal, causing the run to exit via `CLEANUP_REGRESSION` with the regression recorded. (`REPORT_BLOCKED` is the non-terminal per-op blocked state and never terminates the run.)
 
 ## Trust Model
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -41,6 +41,8 @@ stateDiagram-v2
     CLEANUP_GATE --> CLEANUP: all siblings promoted or blocked
     CLEANUP --> ROUTE: legacy path removed, next group
     ROUTE --> CREATE_PR: all ops processed
+    CLEANUP --> REPORT_BLOCKED: cleanup regression (promoted op test fails)
+    REPORT_BLOCKED --> [*]: terminal blocked (cleanup regression, no PR)
     CREATE_PR --> [*]
 ```
 
@@ -116,7 +118,12 @@ Actions:
 1. Run tests and `--check-op` for **promoted ops only** (blocked ops' tests may legitimately fail)
 1. Commit cleanup changes
 
-If any promoted op's test fails after cleanup → record as a cleanup regression in the final report. Do not proceed with broken state.
+If any promoted op's test fails after cleanup → transition to `REPORT_BLOCKED` as a terminal outcome: record the regression, skip `CREATE_PR`, and exit with `blocked` status. Do not proceed with a broken state.
+
+**`REPORT_BLOCKED` has two distinct uses:**
+
+- **Per-op blocked** (ALIGN_OP BLOCKED): records the blocked reason, returns to `CLEANUP_GATE`, continues processing other siblings. Non-terminal.
+- **Cleanup regression** (CLEANUP fails): terminal — the family migration exits without opening a PR. The blocked report becomes the run's final artefact.
 
 **Timeout policy for blocked ops**: if a group has blocked ops that prevent the cleanup gate from firing for an extended period, the orchestrator may force cleanup — remove legacy path and mark blocked ops' tests as `xfail`. This is a human decision, not automatic.
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -88,7 +88,7 @@ For each op in the current group, invoke `align-op` as a **separate sub-agent**:
 align-op <op_name>
 ```
 
-`align-op` owns the entire per-op pipeline internally: PRE_CHECK → CLASSIFY → DISPATCH (green / redesign / minor) → TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS → CLEANUP → REPORT. `align-family` does not manage these stages and does not run `test-op` / `implement-op` / `bench-op` itself.
+`align-op` owns the entire per-op pipeline internally: PRE_CHECK → CLASSIFY → DISPATCH (green / redesign / minor) → TEST → [IMPLEMENT] → BENCH → REVALIDATE → FLIP_STATUS → CLEANUP → REPORT. IMPLEMENT is conditional — skipped when TEST returns DONE_SKIP (tests already pass), and skipped on the minor path because `implement-op` already ran as the main stage in DISPATCH. `align-family` does not manage these stages and does not run `test-op` / `implement-op` / `bench-op` itself.
 
 Per-op outcome:
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: align-family
-description: Drive the full migration for an op family — audit, test, implement, bench, flip status, create PR.
+description: Drive the full migration for an op family — audit, delegate per-op alignment to align-op, run cross-op cleanup, create PR.
 ---
 
 ## Arguments
@@ -11,13 +11,20 @@ Family name from `ops_manifest.yaml` (e.g., `reduction`, `norm`, `attention`).
 
 - **Input**: `family` name
 - **Output**: PR URL + final report
-- **Termination**: all ops promoted or blocked, PR created
+- **Termination**: all ops promoted or blocked (via `align-op`), PR created
 
 ## Trust Model
 
-- test-op agent ≠ implement-op agent (separate invocations)
-- Only the orchestrator modifies `ops_manifest.yaml` status
-- implement-op must not modify tests; bench-op must not modify Op code
+- `align-family` delegates every per-op stage to `align-op`, invoked as a **separate sub-agent** per op. The family orchestrator never runs `test-op`, `implement-op`, or `bench-op` directly — those are inside `align-op`'s contract.
+
+- `align-family` does **not** write `ops_manifest.yaml`. After the refactor, `align-op` is the sole manifest writer (at its own FLIP_STATUS step); `align-family` observes status transitions via `align-op`'s SUCCESS return. No `align-family` stage edits, modifies, or flips the manifest.
+
+- Directly-invoked sub-skills of `align-family` are exactly two: `audit-family` (in AUDIT) and `align-op` (per op).
+
+  | Stage    | Sub-skill      |
+  | -------- | -------------- |
+  | AUDIT    | `audit-family` |
+  | ALIGN_OP | `align-op`     |
 
 ## Workflow
 
@@ -26,18 +33,10 @@ stateDiagram-v2
     [*] --> AUDIT
     AUDIT --> GROUP_BY_BASE: gap report generated
     GROUP_BY_BASE --> ROUTE: ops grouped by base class
-    ROUTE --> TEST: semantic_gap op
-    ROUTE --> FLIP_STATUS: ready op
-    ROUTE --> REPORT_BLOCKED: blocked op
-    TEST --> IMPLEMENT: tests written
-    IMPLEMENT --> BENCH: implementation done, collect observations
-    IMPLEMENT --> REPORT_BLOCKED: blocked
-    BENCH --> REVALIDATE: benchmark passes
-    BENCH --> REPORT_BLOCKED: benchmark blocked
-    REVALIDATE --> FLIP_STATUS: --check-op + tests pass
-    REVALIDATE --> REPORT_BLOCKED: regression detected
-    FLIP_STATUS --> CLEANUP_GATE: check group completion
-    REPORT_BLOCKED --> CLEANUP_GATE: check group completion
+    ROUTE --> ALIGN_OP: next op in current group
+    ALIGN_OP --> CLEANUP_GATE: align-op SUCCESS
+    ALIGN_OP --> REPORT_BLOCKED: align-op BLOCKED
+    REPORT_BLOCKED --> CLEANUP_GATE: record blocked reason
     CLEANUP_GATE --> ROUTE: group incomplete, next op
     CLEANUP_GATE --> CLEANUP: all siblings promoted or blocked
     CLEANUP --> ROUTE: legacy path removed, next group
@@ -59,7 +58,7 @@ This catches tracked changes, staged changes, AND untracked files. If not clean:
 
 ### Dual-path is acceptable during migration
 
-When implement-op rewrites a base class, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
+When `align-op` (via its internal `implement-op` stage) rewrites a base class, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
 
 **Dual-path definition**: a class `__init__` with runtime branching to support two incompatible construction interfaces, and `forward` dispatching to two execution paths. Not polymorphism — same semantics, temporary interface coexistence.
 
@@ -81,73 +80,33 @@ Group ops by `base_class` from the gap report. Each group is a set of sibling op
 
 Track group completion: a group is complete when all its ops are `promoted` or `blocked`.
 
-### 3. ROUTE
+### 3. ALIGN_OP (per op)
 
-Read gap report. For each op, extract params from the entry and dispatch:
-
-| Classification | Action                                                |
-| -------------- | ----------------------------------------------------- |
-| `ready`        | → FLIP_STATUS                                         |
-| `semantic_gap` | → TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS |
-| `blocked`      | → REPORT_BLOCKED                                      |
-
-### 4. TEST (per op)
-
-Invoke test-op as a **separate agent** (trust model):
+For each op in the current group, invoke `align-op` as a **separate sub-agent**:
 
 ```
-test-op(op_name, manifest_signature, pytorch_equivalent, source_test)
+align-op <op_name>
 ```
 
-### 5. IMPLEMENT (per op)
+`align-op` owns the entire per-op pipeline internally: PRE_CHECK → CLASSIFY → DISPATCH (green / redesign / minor) → TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS → CLEANUP → REPORT. `align-family` does not manage these stages and does not run `test-op` / `implement-op` / `bench-op` itself.
 
-Invoke implement-op as a **separate agent** (trust model):
+Per-op outcome:
 
-```
-implement-op(op_name, manifest_signature, source_op, source_test)
-```
+- `align-op` returns SUCCESS → op is `promoted` (manifest status already flipped by `align-op`'s FLIP_STATUS). Record the returned report. Proceed to CLEANUP_GATE.
+- `align-op` returns BLOCKED → op is `blocked`. Capture `align-op`'s BLOCKED reason verbatim as the per-op result. Proceed to CLEANUP_GATE.
 
-Collect `observations` from return.
+`align-family` MUST NOT re-flip manifest status or re-run per-op validation on its own; `align-op`'s SUCCESS return is the single source of truth that the manifest was flipped.
 
-### 6. BENCH (per op)
+### 4. CLEANUP_GATE
 
-Invoke bench-op:
-
-```
-bench-op(op_name, source_bench, source_op)
-```
-
-Requires local GPU.
-
-### 7. REVALIDATE (per op)
-
-Final gate after benchmark edits. Re-run validation to confirm no regressions:
-
-```bash
-python scripts/validate_manifest.py --check-op <op_name>
-python -m pytest <source_test> -v
-```
-
-Both must pass. If not → REPORT_BLOCKED (benchmark change introduced regression).
-
-### 8. FLIP_STATUS
-
-Orchestrator (not a sub-skill) changes manifest:
-
-- `status: spec-only` → `status: implemented`
-- Commit the manifest change
-- Update gap report: add `promoted_at` timestamp (keep `classification` unchanged)
-
-### 9. CLEANUP_GATE
-
-After each terminal per-op outcome (FLIP_STATUS or REPORT_BLOCKED), check group completion:
+After each `align-op` invocation returns (SUCCESS or BLOCKED), check group completion:
 
 - All siblings in the current base-class group are `promoted` or `blocked`? → trigger CLEANUP
-- Otherwise → continue to next op (ROUTE)
+- Otherwise → continue to next op (ROUTE → ALIGN_OP)
 
-### 10. CLEANUP
+### 5. CLEANUP
 
-Remove dual-path legacy code from the base class. This step fires once per base-class group, after all siblings are done.
+Remove dual-path legacy code from the base class. This step fires once per base-class group, after all siblings have gone through `align-op` (SUCCESS or BLOCKED).
 
 Actions:
 
@@ -157,17 +116,17 @@ Actions:
 1. Run tests and `--check-op` for **promoted ops only** (blocked ops' tests may legitimately fail)
 1. Commit cleanup changes
 
-If any promoted op's test fails after cleanup → REPORT_BLOCKED (cleanup regression). Do not proceed with broken state.
+If any promoted op's test fails after cleanup → record as a cleanup regression in the final report. Do not proceed with broken state.
 
-**Timeout policy for blocked ops**: if a group has blocked ops that prevent cleanup gate from firing for an extended period, the orchestrator may force cleanup — remove legacy path and mark blocked ops' tests as `xfail`. This is a human decision, not automatic.
+**Timeout policy for blocked ops**: if a group has blocked ops that prevent the cleanup gate from firing for an extended period, the orchestrator may force cleanup — remove legacy path and mark blocked ops' tests as `xfail`. This is a human decision, not automatic.
 
-### 11. CREATE_PR
+### 6. CREATE_PR
 
 After all ops processed:
 
-- Collect all observations from implement-op calls
+- Collect all per-op reports returned by `align-op`
 - Create PR with:
   - Migration summary (promoted / blocked counts)
-  - Per-op change table
-  - Observations for human doc review
-  - Blocked ops with reasons
+  - Per-op change table (derived from `align-op` reports)
+  - Observations surfaced by `align-op` (e.g., `needs_kernel_work`, `needs_human_decision`) for human doc review
+  - Blocked ops with `align-op`'s BLOCKED reasons

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -10,12 +10,14 @@ Family name from `ops_manifest.yaml` (e.g., `reduction`, `norm`, `attention`).
 ## Contract
 
 - **Input**: `family` name
-- **Output**: PR URL + final report
-- **Termination**: all ops promoted or blocked (via `align-op`), PR created
+- **Output** (two terminal outcomes):
+  - **SUCCESS**: PR URL + final report — all ops processed via `align-op` (promoted or blocked), cleanup succeeds, PR opens.
+  - **BLOCKED**: blocked report (no PR) — reached when CLEANUP detects a regression in a promoted op's tests after dual-path removal; see `REPORT_BLOCKED` terminal in the state diagram.
+- **Termination**: all ops processed (promoted or blocked via `align-op`) and either (a) CLEANUP + CREATE_PR succeed, or (b) CLEANUP fails and the run exits via `REPORT_BLOCKED` with the regression recorded.
 
 ## Trust Model
 
-- `align-family` delegates every per-op stage to `align-op`, invoked as a **separate sub-agent** per op. The family orchestrator never runs `test-op`, `implement-op`, or `bench-op` directly — those are inside `align-op`'s contract.
+- `align-family` delegates every per-op stage to `align-op`, invoked as a **separate sub-agent** per op. The family orchestrator never runs any atomic per-op skill directly — those live inside `align-op`'s contract.
 
 - `align-family` does **not** write `ops_manifest.yaml`. After the refactor, `align-op` is the sole manifest writer (at its own FLIP_STATUS step); `align-family` observes status transitions via `align-op`'s SUCCESS return. No `align-family` stage edits, modifies, or flips the manifest.
 
@@ -60,7 +62,7 @@ This catches tracked changes, staged changes, AND untracked files. If not clean:
 
 ### Dual-path is acceptable during migration
 
-When `align-op` (via its internal `implement-op` stage) rewrites a base class, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
+When `align-op` rewrites a base class during its per-op pipeline, it may create a dual-path `__init__` (legacy + spec) to keep unmigrated sibling tests passing. This is correct temporary debt — the cleanup gate removes it.
 
 **Dual-path definition**: a class `__init__` with runtime branching to support two incompatible construction interfaces, and `forward` dispatching to two execution paths. Not polymorphism — same semantics, temporary interface coexistence.
 
@@ -90,7 +92,7 @@ For each op in the current group, invoke `align-op` as a **separate sub-agent**:
 align-op <op_name>
 ```
 
-`align-op` owns the entire per-op pipeline internally: PRE_CHECK → CLASSIFY → DISPATCH (green / redesign / minor) → TEST → [IMPLEMENT] → BENCH → REVALIDATE → FLIP_STATUS → CLEANUP → REPORT. IMPLEMENT is conditional — skipped when TEST returns DONE_SKIP (tests already pass), and skipped on the minor path because `implement-op` already ran as the main stage in DISPATCH. `align-family` does not manage these stages and does not run `test-op` / `implement-op` / `bench-op` itself.
+`align-op` owns the entire per-op pipeline internally — its internal stages (classify, dispatch on case, test / implement / bench, revalidate, flip status, cleanup, report) are `align-op`'s contract, not `align-family`'s. See [`align-op/SKILL.md`](../align-op/SKILL.md) for the authoritative stage list and the conditional-IMPLEMENT rule. `align-family` does not manage or observe `align-op`'s internal stages; the only interface between them is `align-op`'s SUCCESS / BLOCKED return.
 
 Per-op outcome:
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -43,8 +43,8 @@ stateDiagram-v2
     CLEANUP_GATE --> CLEANUP: all siblings promoted or blocked
     CLEANUP --> ROUTE: legacy path removed, next group
     ROUTE --> CREATE_PR: all ops processed
-    CLEANUP --> REPORT_BLOCKED: cleanup regression (promoted op test fails)
-    REPORT_BLOCKED --> [*]: terminal blocked (cleanup regression, no PR)
+    CLEANUP --> CLEANUP_REGRESSION: promoted op test fails after cleanup
+    CLEANUP_REGRESSION --> [*]: terminal blocked, no PR
     CREATE_PR --> [*]
 ```
 
@@ -120,12 +120,12 @@ Actions:
 1. Run tests and `--check-op` for **promoted ops only** (blocked ops' tests may legitimately fail)
 1. Commit cleanup changes
 
-If any promoted op's test fails after cleanup → transition to `REPORT_BLOCKED` as a terminal outcome: record the regression, skip `CREATE_PR`, and exit with `blocked` status. Do not proceed with a broken state.
+If any promoted op's test fails after cleanup → transition to `CLEANUP_REGRESSION` (terminal): record the regression, skip `CREATE_PR`, exit with `blocked` status. Do not proceed with a broken state.
 
-**`REPORT_BLOCKED` has two distinct uses:**
+**Two distinct blocked states**, split so the diagram has one meaning per state:
 
-- **Per-op blocked** (ALIGN_OP BLOCKED): records the blocked reason, returns to `CLEANUP_GATE`, continues processing other siblings. Non-terminal.
-- **Cleanup regression** (CLEANUP fails): terminal — the family migration exits without opening a PR. The blocked report becomes the run's final artefact.
+- **`REPORT_BLOCKED`** — per-op `align-op` returned BLOCKED. Records the reason, returns to `CLEANUP_GATE`, continues with sibling ops. Non-terminal.
+- **`CLEANUP_REGRESSION`** — a promoted op's tests fail after CLEANUP's dual-path removal. Terminal: the family migration exits without opening a PR. The blocked report becomes the run's final artefact.
 
 **Timeout policy for blocked ops**: if a group has blocked ops that prevent the cleanup gate from firing for an extended period, the orchestrator may force cleanup — remove legacy path and mark blocked ops' tests as `xfail`. This is a human decision, not automatic.
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -35,7 +35,8 @@ stateDiagram-v2
     [*] --> AUDIT
     AUDIT --> GROUP_BY_BASE: gap report generated
     GROUP_BY_BASE --> ROUTE: ops grouped by base class
-    ROUTE --> ALIGN_OP: next op in current group
+    ROUTE --> ALIGN_OP: ready (mode=minor) or semantic_gap (mode=redesign)
+    ROUTE --> REPORT_BLOCKED: classification=blocked (audit-family)
     ALIGN_OP --> CLEANUP_GATE: align-op SUCCESS
     ALIGN_OP --> REPORT_BLOCKED: align-op BLOCKED
     REPORT_BLOCKED --> CLEANUP_GATE: record blocked reason
@@ -84,12 +85,24 @@ Group ops by `base_class` from the gap report. Each group is a set of sibling op
 
 Track group completion: a group is complete when all its ops are `promoted` or `blocked`.
 
-### 3. ALIGN_OP (per op)
+### 3. ROUTE
 
-For each op in the current group, invoke `align-op` as a **separate sub-agent**:
+Read the gap report from AUDIT. For each op in the current group, route by `classification` (the field `audit-family` populates):
+
+| Gap-report `classification` | Action                                                 | Why                                                                                                                                          |
+| --------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ready`                     | → ALIGN_OP with `--mode=minor`                         | Existing code already conforms; align-op's minor path runs the spec tests (DONE_SKIP since they pass), then the shared downstream + flip.    |
+| `semantic_gap`              | → ALIGN_OP with `--mode=redesign`                      | Legacy code structurally diverges from the spec; align-op archives it, rescaffolds, and ports — full per-op pipeline.                        |
+| `blocked`                   | → REPORT_BLOCKED with audit's `reason`. Skip align-op. | Audit determined the op cannot be migrated autonomously (no `pytorch_equivalent`, kernel-layer change required, etc.). No per-op work to do. |
+
+The mapping is deterministic — `align-family` MUST pass `--mode=` explicitly so `align-op` never falls into its interactive prompt branch in a batch family migration.
+
+### 4. ALIGN_OP (per op)
+
+For each op routed here, invoke `align-op` as a **separate sub-agent** with the mode determined in Step 3:
 
 ```
-align-op <op_name>
+align-op <op_name> --mode=<minor|redesign>
 ```
 
 `align-op` owns the entire per-op pipeline internally — its internal stages (classify, dispatch on case, test / implement / bench, revalidate, flip status, cleanup, report) are `align-op`'s contract, not `align-family`'s. See [`align-op/SKILL.md`](../align-op/SKILL.md) for the authoritative stage list and the conditional-IMPLEMENT rule. `align-family` does not manage or observe `align-op`'s internal stages; the only interface between them is `align-op`'s SUCCESS / BLOCKED return.
@@ -101,14 +114,14 @@ Per-op outcome:
 
 `align-family` MUST NOT re-flip manifest status or re-run per-op validation on its own; `align-op`'s SUCCESS return is the single source of truth that the manifest was flipped.
 
-### 4. CLEANUP_GATE
+### 5. CLEANUP_GATE
 
 After each `align-op` invocation returns (SUCCESS or BLOCKED), check group completion:
 
 - All siblings in the current base-class group are `promoted` or `blocked`? → trigger CLEANUP
 - Otherwise → continue to next op (ROUTE → ALIGN_OP)
 
-### 5. CLEANUP
+### 6. CLEANUP
 
 Remove dual-path legacy code from the base class. This step fires once per base-class group, after all siblings have gone through `align-op` (SUCCESS or BLOCKED).
 
@@ -129,7 +142,7 @@ If any promoted op's test fails after cleanup → transition to `CLEANUP_REGRESS
 
 **Timeout policy for blocked ops**: if a group has blocked ops that prevent the cleanup gate from firing for an extended period, the orchestrator may force cleanup — remove legacy path and mark blocked ops' tests as `xfail`. This is a human decision, not automatic.
 
-### 6. CREATE_PR
+### 7. CREATE_PR
 
 After all ops processed:
 

--- a/.claude/skills/align-family/SKILL.md
+++ b/.claude/skills/align-family/SKILL.md
@@ -12,8 +12,8 @@ Family name from `ops_manifest.yaml` (e.g., `reduction`, `norm`, `attention`).
 - **Input**: `family` name
 - **Output** (two terminal outcomes):
   - **SUCCESS**: PR URL + final report — all ops processed via `align-op` (promoted or blocked), cleanup succeeds, PR opens.
-  - **BLOCKED**: blocked report (no PR) — reached when CLEANUP detects a regression in a promoted op's tests after dual-path removal; see `REPORT_BLOCKED` terminal in the state diagram.
-- **Termination**: all ops processed (promoted or blocked via `align-op`) and either (a) CLEANUP + CREATE_PR succeed, or (b) CLEANUP fails and the run exits via `REPORT_BLOCKED` with the regression recorded.
+  - **BLOCKED**: blocked report (no PR) — reached when CLEANUP detects a regression in a promoted op's tests after dual-path removal; see `CLEANUP_REGRESSION` terminal in the state diagram. Distinct from the non-terminal per-op `REPORT_BLOCKED` state.
+- **Termination**: all ops processed (promoted or blocked via `align-op`) and either (a) CLEANUP + CREATE_PR succeed, or (b) CLEANUP fails and the run exits via `CLEANUP_REGRESSION` with the regression recorded. (`REPORT_BLOCKED` is the non-terminal per-op blocked state and never terminates the run.)
 
 ## Trust Model
 

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -310,12 +310,14 @@ On BLOCKED, replace "Status flipped" line with the blocking error and list remai
 
 ## Interaction with `align-family`
 
-`align-family` is the family-scoped orchestrator and delegates every per-op stage to `align-op` — its workflow is `AUDIT → GROUP_BY_BASE → (per op: align-op) → CLEANUP_GATE → CLEANUP → CREATE_PR`. The family orchestrator never calls atomic per-op skills directly; everything per-op runs inside `align-op`'s contract.
+`align-family` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `align-op` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current align-family stays functional; a follow-up can consolidate.
 
-- Use `align-op <op>` for per-op work (green field, redesign, or minor delta).
+Until consolidated:
+
+- Use `align-op <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
 - Use `align-family <family>` for family-scoped historical migration of many ops at once.
 
-They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s. `align-op`'s `FLIP_STATUS` is the sole manifest-write site, observed by `align-family` via `align-op`'s SUCCESS return.
+They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s.
 
 ## Non-goals
 

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -310,14 +310,12 @@ On BLOCKED, replace "Status flipped" line with the blocking error and list remai
 
 ## Interaction with `align-family`
 
-`align-family` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `align-op` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current align-family stays functional; a follow-up can consolidate.
+`align-family` is the family-scoped orchestrator and delegates every per-op stage to `align-op` — its workflow is `AUDIT → GROUP_BY_BASE → (per op: align-op) → CLEANUP_GATE → CLEANUP → CREATE_PR`. The family orchestrator never calls atomic per-op skills directly; everything per-op runs inside `align-op`'s contract.
 
-Until consolidated:
-
-- Use `align-op <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
+- Use `align-op <op>` for per-op work (green field, redesign, or minor delta).
 - Use `align-family <family>` for family-scoped historical migration of many ops at once.
 
-They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s.
+They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s. `align-op`'s `FLIP_STATUS` is the sole manifest-write site, observed by `align-family` via `align-op`'s SUCCESS return.
 
 ## Non-goals
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -102,6 +102,7 @@ align-op <op_name>                       ← per-op orchestrator
 │   └─ minor:    implement-op
 └─ shared downstream:
     ├─ test-op
+    ├─ implement-op                      ← conditional: green/redesign only; skipped on minor (already ran in DISPATCH) and on TEST DONE_SKIP
     ├─ bench-op
     ├─ [orchestrator] REVALIDATE
     ├─ [orchestrator] FLIP_STATUS        ← only manifest writer

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -39,7 +39,7 @@ Brings a single op into alignment with its manifest entry. Classifies into one o
 
 ### `align-family`  ·  per-family orchestrator
 
-Drives the historical migration of an entire op family. Audits, then pipelines every spec-only op through test → implement → bench → flip status; handles cross-op cleanup (dual-path removal); creates the PR.
+Drives the historical migration of an entire op family. Audits, delegates each per-op alignment to `align-op`, then handles family-scoped concerns: cross-op cleanup (dual-path removal) and PR creation. The family orchestrator never calls `test-op` / `implement-op` / `bench-op` directly and never writes `ops_manifest.yaml`.
 
 - **Use when.** You have a whole family of spec-only ops to migrate.
 - **Don't use when.** Only one op needs attention — use `align-op`.
@@ -110,7 +110,7 @@ align-op <op_name>                       ← per-op orchestrator
 
 | Resource                          | Writer                                                                                                                                                             |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ops_manifest.yaml`               | Only `align-op` / `align-family` at `FLIP_STATUS`. No atomic skill writes the manifest.                                                                            |
+| `ops_manifest.yaml`               | Only `align-op` at `FLIP_STATUS`. No atomic skill writes the manifest; `align-family` delegates to `align-op` and never writes it directly.                        |
 | `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                       |
 | `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work. |
 | `tests/ops/**`                    | `test-op`.                                                                                                                                                         |

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -94,14 +94,19 @@ align-family <family>                    ← per-family orchestrator
 └─ [orchestrator] CLEANUP_GATE + CLEANUP + CREATE_PR
 
 align-op <op_name>                       ← per-op orchestrator
+├─ [orchestrator] PRE_CHECK
 ├─ [orchestrator] CLASSIFY
-├─ green:     scaffold-op
-├─ redesign:  [orchestrator] ARCHIVE + CLEAR → scaffold-op → PORT → KERNEL_CHECK
-├─ minor:     implement-op
+├─ [orchestrator] DISPATCH
+│   ├─ green:    scaffold-op
+│   ├─ redesign: [orchestrator] ARCHIVE + CLEAR → scaffold-op → PORT → KERNEL_CHECK
+│   └─ minor:    implement-op
 └─ shared downstream:
     ├─ test-op
     ├─ bench-op
-    └─ [orchestrator] FLIP_STATUS        ← only manifest writer
+    ├─ [orchestrator] REVALIDATE
+    ├─ [orchestrator] FLIP_STATUS        ← only manifest writer
+    ├─ [orchestrator] CLEANUP
+    └─ [orchestrator] REPORT
 ```
 
 `align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest; `align-op`'s FLIP_STATUS is the sole manifest-write site.

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -85,7 +85,7 @@ Compares each op's code signature against its manifest spec, classifies gaps (`r
 
 ## Composition
 
-How orchestrators delegate to atomic skills.
+How orchestrators delegate. Note that orchestrators may delegate to other orchestrators (e.g., `align-family` → `align-op`) as well as to atomic skills.
 
 ```text
 align-family <family>                    ← per-family orchestrator

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -90,12 +90,8 @@ How orchestrators delegate to atomic skills.
 ```text
 align-family <family>                    ← per-family orchestrator
 ├─ audit-family
-├─ per op:
-│   ├─ test-op
-│   ├─ implement-op
-│   ├─ bench-op
-│   └─ [orchestrator] FLIP_STATUS
-└─ [orchestrator] CLEANUP + CREATE_PR
+├─ per op: align-op <op_name>            ← full per-op pipeline delegated
+└─ [orchestrator] CLEANUP_GATE + CLEANUP + CREATE_PR
 
 align-op <op_name>                       ← per-op orchestrator
 ├─ [orchestrator] CLASSIFY
@@ -108,7 +104,7 @@ align-op <op_name>                       ← per-op orchestrator
     └─ [orchestrator] FLIP_STATUS        ← only manifest writer
 ```
 
-A follow-up may refactor `align-family`'s per-op loop to delegate to `align-op`, removing duplication.
+`align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest; `align-op`'s FLIP_STATUS is the sole manifest-write site.
 
 ## Trust model  ·  who may write what
 


### PR DESCRIPTION
## Summary

Docs-only refactor of `.claude/skills/align-family/SKILL.md` and `docs/tileops-skills.md`. `align-family` now delegates the entire per-op pipeline to `align-op` (a single sub-agent invocation per op) instead of running `test-op` / `implement-op` / `bench-op` itself. Family-scoped concerns (`AUDIT`, `GROUP_BY_BASE`, `CLEANUP_GATE`, `CLEANUP`, `CREATE_PR`) are preserved. Trust-model invariant restored: `align-op`'s `FLIP_STATUS` is the sole manifest-write site; `align-family` never writes `ops_manifest.yaml`.

Closes #1046.

## Test plan

- [x] **AC-1** Docs-only scope confirmed — `git diff --name-only main...HEAD` lists only the two target files.
- [x] **AC-2** Workflow mermaid replaces per-op substates (`TEST` / `IMPLEMENT` / `BENCH` / `REVALIDATE` / `FLIP_STATUS`) with a single `ALIGN_OP` substate calling `align-op <op_name>`.
- [x] **AC-3** Steps collapse: old Steps 3-8 become a single `ALIGN_OP` step; `AUDIT` / `GROUP_BY_BASE` / `CLEANUP_GATE` / `CLEANUP` / `CREATE_PR` remain as their own steps.
- [x] **AC-4** Trust-model section names exactly two direct sub-skills: `audit-family` and `align-op`. No references to `test-op` / `implement-op` / `bench-op` as direct sub-skills.
- [x] **AC-5** Manifest-write grep returns only (a) the trust-model statement explicitly denying `align-family` writes the manifest, or (b) non-prescriptive references to `align-op`'s `FLIP_STATUS`. No line prescribes `align-family` writing the manifest.
- [x] **AC-6** `docs/tileops-skills.md` § Composition updated: `align-family → align-op` delegation is shown; "future consolidation" note removed.
- [x] **AC-7** Pre-commit hooks pass (mdformat, codespell, gitleaks, ruff, and the full set — 16 passed, 2 skipped, 0 failed).
- [x] **AC-8** Only `.claude/skills/align-family/SKILL.md` and `docs/tileops-skills.md` are modified.
