### PR TITLE
[Doc][OPS] refresh align-op Interaction section after #1046 landed

### DIFF
--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -310,7 +310,7 @@ On BLOCKED, replace "Status flipped" line with the blocking error and list remai
 
 ## Interaction with `align-family`
 
-`align-family` is the family-scoped orchestrator and delegates every per-op stage to `align-op`. Its workflow is `AUDIT → GROUP_BY_BASE → ROUTE → (per op: ALIGN_OP) → CLEANUP_GATE → CLEANUP → CREATE_PR`; the family orchestrator never invokes the atomic per-op skills (test-op / implement-op / bench-op) directly — every per-op stage runs inside `align-op`'s contract.
+`align-family` is the family-scoped orchestrator and delegates every per-op stage to `align-op`. Its workflow is `AUDIT → GROUP_BY_BASE → ROUTE → (per op: ALIGN_OP) → CLEANUP_GATE → CLEANUP → CREATE_PR`; the family orchestrator never invokes the atomic per-op skills (`scaffold-op` / `test-op` / `implement-op` / `bench-op`) directly — every per-op stage runs inside `align-op`'s contract.
 
 - Use `align-op <op>` for per-op work (green field, redesign, or minor delta).
 - Use `align-family <family>` for family-scoped historical migration of many ops at once.

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -310,14 +310,12 @@ On BLOCKED, replace "Status flipped" line with the blocking error and list remai
 
 ## Interaction with `align-family`
 
-`align-family` remains the family-scoped orchestrator. Its per-op inner loop (`TEST → IMPLEMENT → BENCH → REVALIDATE → FLIP_STATUS`) can be refactored to call `align-op` instead of managing the per-op stages itself. That refactor is out of scope for this PR — current align-family stays functional; a follow-up can consolidate.
+`align-family` is the family-scoped orchestrator and delegates every per-op stage to `align-op`. Its workflow is `AUDIT → GROUP_BY_BASE → ROUTE → (per op: ALIGN_OP) → CLEANUP_GATE → CLEANUP → CREATE_PR`; the family orchestrator never invokes the atomic per-op skills (test-op / implement-op / bench-op) directly — every per-op stage runs inside `align-op`'s contract.
 
-Until consolidated:
-
-- Use `align-op <op>` for per-op work (redesign or minor delta, or green field when a manifest PR added a new entry).
+- Use `align-op <op>` for per-op work (green field, redesign, or minor delta).
 - Use `align-family <family>` for family-scoped historical migration of many ops at once.
 
-They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s.
+They do not conflict. `align-op` never manages cross-op cleanup gates; that remains `align-family`'s. `align-op`'s `FLIP_STATUS` is the sole manifest-write site, observed by `align-family` via `align-op`'s SUCCESS return.
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

- Refresh `## Interaction with align-family` in `.claude/skills/align-op/SKILL.md` to match the consolidated contract that shipped in #1049 (issue #1046).
- Drop the stale "out of scope / until consolidated / follow-up" framing — the consolidation is now on main.
- State the trust invariant explicitly: `align-op`'s `FLIP_STATUS` is the sole manifest-write site, observed by `align-family` via `align-op`'s `SUCCESS` return.

Single-file, docs-only.

## Test plan

- [x] AC-2: section no longer contains `out of scope`, `until consolidated`, or follow-up-consolidation phrasing.
- [x] AC-3: first paragraph names the align-family workflow stages (`AUDIT`, `GROUP_BY_BASE`, `ROUTE`, `ALIGN_OP`, `CLEANUP_GATE`, `CLEANUP`, `CREATE_PR`).
- [x] AC-4: usage guidance bullets retained (per-op vs per-family entry).
- [x] AC-5: trust-invariant line about FLIP_STATUS present.
- [x] AC-6: `grep -nE 'future consolidation|until consolidated|out of scope.*align-family|follow-up.*consolidat' .claude/skills/align-op/SKILL.md` returns no matches.
- [x] AC-7: only `.claude/skills/align-op/SKILL.md` modified.
- [x] AC-8: pre-commit (mdformat, codespell, gitleaks) passes.

Closes #1050.