### PR TITLE
[CI] Move GPU CI caches to data7 shared cache

### DIFF
--- a/.github/actions/reclaim-runner-disk/action.yml
+++ b/.github/actions/reclaim-runner-disk/action.yml
@@ -49,17 +49,16 @@ inputs:
     description: >
       Newline-separated list of cache directory roots whose files older than
       cache-age-days should be trimmed at file granularity. Defaults target
-      the `venv`-label runner layout. Nightly's `nightly`-label runner stores
-      caches under /data/ci-cache/* — pass that layout explicitly.
+      the shared /data7-backed runner cache layout.
       Do NOT include atomic cache roots here (see atomic-cache-dirs); file-
       level trim on an atomic root can produce a half-dead "directory exists
       but sentinel missing" state that crashes downstream consumers.
     required: false
     default: |
-      /home/ci-runner/.triton/cache
-      /home/ci-runner/.cache/pip
-      /home/ci-runner/.wheel-cache
-      /home/ci-runner/.tilelang/cache/tmp
+      /data7/shared/ci-cache/triton
+      /data7/shared/ci-cache/pip
+      /data7/shared/ci-cache/wheels
+      /data7/shared/ci-cache/tilelang/tmp
   atomic-cache-dirs:
     description: >
       Newline-separated list of cache directory roots whose first-level
@@ -76,7 +75,7 @@ inputs:
       tuning artefacts alongside a best_config.json sentinel.
     required: false
     default: |
-      /home/ci-runner/.tilelang/cache/autotuner
+      /data7/shared/ci-cache/tilelang/autotuner
   prune-tool-cache:
     description: >
       Whether to prune old tileops_ci_venv_* directories under runner.tool_cache.

--- a/.github/actions/reclaim-runner-disk/reclaim_cache.sh
+++ b/.github/actions/reclaim-runner-disk/reclaim_cache.sh
@@ -11,7 +11,7 @@
 # validate behaviour against a tmp_path fixture.
 #
 # The core safety invariant this script enforces is that some cache
-# roots (notably /home/ci-runner/.tilelang/cache/autotuner) store
+# roots (notably /data7/shared/ci-cache/tilelang/autotuner) store
 # *atomic* first-level subdirectories: consumers assume "directory
 # exists => contents complete" and the directory is only valid if the
 # sentinel file (best_config.json) is present. File-level `-mtime`
@@ -37,8 +37,8 @@
 #   trim-files <age-days> <root> [<root>...]
 #       File-level `-mtime +N -delete` trim for non-atomic cache
 #       roots, followed by empty-directory cleanup. This is the legacy
-#       behaviour used for /home/ci-runner/.triton/cache,
-#       /home/ci-runner/.cache/pip, /home/ci-runner/.wheel-cache, etc.
+#       behaviour used for /data7/shared/ci-cache/triton,
+#       /data7/shared/ci-cache/pip, /data7/shared/ci-cache/wheels, etc.
 #
 # All subcommands are idempotent, tolerate missing roots (skipped
 # silently), and never exit non-zero for per-directory errors so a

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -399,6 +399,14 @@ jobs:
         with:
           reclaim-below-gib: "10"
           cache-trim-cooldown-minutes: "120"
+          cache-dirs: |
+            /data7/shared/ci-cache/triton
+            /data7/shared/ci-cache/pip
+            /data7/shared/ci-cache/wheels
+            /data7/shared/ci-cache/tilelang/tmp
+          atomic-cache-dirs: |
+            /data7/shared/ci-cache/tilelang/autotuner
+          df-paths: "/data7 /data7/shared/ci-cache"
           # Daily runner-maintenance.yml owns the destructive autotuner
           # age-trim; per-PR runs only need sentinel-repair (still
           # unconditional) so they don't evict tuning artefacts the next
@@ -441,6 +449,7 @@ jobs:
           VENV_PREFIX="tileops_ci_venv"
           VENV_DIR="${VENV_PREFIX}_${HASH_INPUT}"
           TRUSTED_VENV_PATH="${{ runner.tool_cache }}/${VENV_DIR}"
+          TRUSTED_CACHE_ROOT="/data7/shared/ci-cache"
           FORK_CAN_COPY_TRUSTED_VENV="false"
 
           if [[ "$IS_FORK" == "true" ]]; then
@@ -478,19 +487,19 @@ jobs:
 
             # Copy trusted compile caches into the isolated per-run dir.
             # rsync is fast for warm caches (<5s); fork state is fully disposable.
-            TRUSTED_WHEEL_DIR="/home/ci-runner/.wheel-cache"
+            TRUSTED_WHEEL_DIR="${TRUSTED_CACHE_ROOT}/wheels"
             copy_start=$SECONDS
             if command -v rsync >/dev/null 2>&1; then
-              rsync -a /home/ci-runner/.tilelang/cache/ "${TILELANG_CACHE_DIR}/" 2>/dev/null || true
-              rsync -a /home/ci-runner/.triton/cache/ "${TRITON_CACHE_DIR}/" 2>/dev/null || true
-              rsync -a /home/ci-runner/.cache/pip/ "${PIP_CACHE_DIR}/" 2>/dev/null || true
+              rsync -a "${TRUSTED_CACHE_ROOT}/tilelang/" "${TILELANG_CACHE_DIR}/" 2>/dev/null || true
+              rsync -a "${TRUSTED_CACHE_ROOT}/triton/" "${TRITON_CACHE_DIR}/" 2>/dev/null || true
+              rsync -a "${TRUSTED_CACHE_ROOT}/pip/" "${PIP_CACHE_DIR}/" 2>/dev/null || true
               if [[ -d "${TRUSTED_WHEEL_DIR}" ]]; then
                 rsync -a "${TRUSTED_WHEEL_DIR}/" "${WHEEL_DIR}/" 2>/dev/null || true
               fi
             else
-              cp -a /home/ci-runner/.tilelang/cache/. "${TILELANG_CACHE_DIR}/" 2>/dev/null || true
-              cp -a /home/ci-runner/.triton/cache/. "${TRITON_CACHE_DIR}/" 2>/dev/null || true
-              cp -a /home/ci-runner/.cache/pip/. "${PIP_CACHE_DIR}/" 2>/dev/null || true
+              cp -a "${TRUSTED_CACHE_ROOT}/tilelang/." "${TILELANG_CACHE_DIR}/" 2>/dev/null || true
+              cp -a "${TRUSTED_CACHE_ROOT}/triton/." "${TRITON_CACHE_DIR}/" 2>/dev/null || true
+              cp -a "${TRUSTED_CACHE_ROOT}/pip/." "${PIP_CACHE_DIR}/" 2>/dev/null || true
               if [[ -d "${TRUSTED_WHEEL_DIR}" ]]; then
                 cp -a "${TRUSTED_WHEEL_DIR}/." "${WHEEL_DIR}/" 2>/dev/null || true
               fi
@@ -499,13 +508,13 @@ jobs:
             echo "Cache copy completed in ${copy_elapsed}s"
           else
             RUNTIME_ROOT="/home/ci-runner"
-            TILELANG_CACHE_DIR="/home/ci-runner/.tilelang/cache"
+            TILELANG_CACHE_DIR="${TRUSTED_CACHE_ROOT}/tilelang"
             TILELANG_TMP_DIR="${TILELANG_CACHE_DIR}/tmp"
-            TRITON_CACHE_DIR="/home/ci-runner/.triton/cache"
-            PIP_CACHE_DIR=""
-            WHEEL_DIR="/home/ci-runner/.wheel-cache"
+            TRITON_CACHE_DIR="${TRUSTED_CACHE_ROOT}/triton"
+            PIP_CACHE_DIR="${TRUSTED_CACHE_ROOT}/pip"
+            WHEEL_DIR="${TRUSTED_CACHE_ROOT}/wheels"
 
-            mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${WHEEL_DIR}"
+            mkdir -p "${TILELANG_CACHE_DIR}" "${TILELANG_TMP_DIR}" "${TRITON_CACHE_DIR}" "${PIP_CACHE_DIR}" "${WHEEL_DIR}"
 
             VENV_PATH="${TRUSTED_VENV_PATH}"
             if [[ -x "${VENV_PATH}/bin/python" ]]; then
@@ -524,6 +533,7 @@ jobs:
             echo "WHEEL_DIR=${WHEEL_DIR}"
             echo "VENV_PATH=${VENV_PATH}"
             echo "TRUSTED_VENV_PATH=${TRUSTED_VENV_PATH}"
+            echo "TRUSTED_CACHE_ROOT=${TRUSTED_CACHE_ROOT}"
             echo "FORK_CAN_COPY_TRUSTED_VENV=${FORK_CAN_COPY_TRUSTED_VENV}"
             echo "VENV_REUSED=${VENV_REUSED}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,11 +18,11 @@ concurrency:
 # ---------------------------------------------------------------------------
 
 env:
-  TILELANG_CACHE_DIR: /cache/tilelang
-  TILELANG_TMP_DIR: /cache/tilelang/tmp
-  TRITON_CACHE_DIR: /cache/triton
-  PIP_CACHE_DIR: /cache/pip
-  WHEEL_DIR: /cache/wheels
+  TILELANG_CACHE_DIR: /data7/shared/ci-cache/tilelang
+  TILELANG_TMP_DIR: /data7/shared/ci-cache/tilelang/tmp
+  TRITON_CACHE_DIR: /data7/shared/ci-cache/triton
+  PIP_CACHE_DIR: /data7/shared/ci-cache/pip
+  WHEEL_DIR: /data7/shared/ci-cache/wheels
   MAX_JOBS: "64"
 
 jobs:

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -7,11 +7,8 @@ name: Runner Maintenance
 # cooldown; this scheduled job forces the full cleanup pass on days with
 # little PR traffic.
 #
-# FIXME: The `nightly`-label runner has its own cache tree under
-# `/data/ci-cache/*` and is not wired up here. This PR intentionally defers
-# that work until #987 lands, which collapses nightly's cache layout into
-# `/home/ci-runner/.*/cache`; once that is merged, add a second job (or a
-# matrix entry) targeting the `nightly` runner with its own `cache-dirs`.
+# GPU smoke and nightly share the persistent cache tree under
+# `/data7/shared/ci-cache/*`.
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- move trusted GPU smoke caches to `/data7/shared/ci-cache/{tilelang,triton,pip,wheels}`
- point nightly at the same `/data7/shared/ci-cache/*` layout
- update reclaim-runner-disk defaults/comments and runner maintenance notes for the data7 cache root

Closes #1052.

## Notes

This does not change PR gate or security-policy behavior. The TL0.1.9 smoke hang skip was already merged in #1043; this PR carries the follow-up cache placement cleanup from the same investigation.

## Validation

- `python - <<'PY' ... yaml.safe_load(...) ... PY` for `gpu-smoke.yml`, `nightly.yml`, `runner-maintenance.yml`, and `reclaim-runner-disk/action.yml`
- `bash -n .github/actions/reclaim-runner-disk/reclaim_cache.sh`
- `python -m pytest -q tests/test_reclaim_action.py tests/test_gpu_smoke_policy.py tests/test_ci_venv_hash.py` -> `32 passed`
