### PR TITLE
[CI] skip validate-manifest and benchmark-contract-tests when paths unchanged

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -101,10 +101,12 @@ jobs:
                 ;;
             esac
             # `benchmark-contract-tests` runs `pytest benchmarks/tests`, which
-            # imports `workloads.workload_base` and `tileops.manifest`. Any of
-            # those layers can break the contract tests, so include them all.
+            # imports `workloads.workload_base`, `tileops.manifest`, and reads
+            # `tileops/ops_manifest.yaml` via `load_workloads()` /
+            # `workloads_to_params()`. Any of those layers can break the
+            # contract tests, so include them all.
             case "$f" in
-              benchmarks/*|workloads/*|tileops/manifest.py|"$WORKFLOW_PATH")
+              benchmarks/*|workloads/*|tileops/manifest.py|tileops/ops_manifest.yaml|"$WORKFLOW_PATH")
                 benchmark=true
                 ;;
             esac

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -73,7 +73,21 @@ jobs:
             exit 0
           fi
 
-          FILES=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          # Fail-open: if the API call errors out or returns nothing, run
+          # everything. The optimization must never reduce CI reliability.
+          if ! FILES=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>&1); then
+            echo "::warning::gh api failed; defaulting to run all gated jobs"
+            echo "$FILES"
+            echo "manifest=true" >> "$GITHUB_OUTPUT"
+            echo "benchmark=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ -z "$FILES" ]]; then
+            echo "::warning::no files returned; defaulting to run all gated jobs"
+            echo "manifest=true" >> "$GITHUB_OUTPUT"
+            echo "benchmark=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "Changed files in PR #$PR_NUMBER:"
           echo "$FILES"
 
@@ -86,8 +100,11 @@ jobs:
                 manifest=true
                 ;;
             esac
+            # `benchmark-contract-tests` runs `pytest benchmarks/tests`, which
+            # imports `workloads.workload_base` and `tileops.manifest`. Any of
+            # those layers can break the contract tests, so include them all.
             case "$f" in
-              benchmarks/*|"$WORKFLOW_PATH")
+              benchmarks/*|workloads/*|tileops/manifest.py|"$WORKFLOW_PATH")
                 benchmark=true
                 ;;
             esac
@@ -130,6 +147,10 @@ jobs:
             exit 0
           fi
 
+          # `benchmark-contract-tests` is intentionally skipped on PRs that
+          # don't touch its inputs (see detect-changes), so accept `skipped`
+          # as well as `success` here — only genuine failures should block
+          # the ready_for_review short-circuit.
           CHECKS=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" --jq '
             [
               .check_runs
@@ -139,9 +160,9 @@ jobs:
               | .conclusion
             ]
           ')
-          ALL_SUCCESS=$(echo "$CHECKS" | jq 'all(. == "success")')
+          ALL_OK=$(echo "$CHECKS" | jq 'all(. == "success" or . == "skipped")')
           COUNT=$(echo "$CHECKS" | jq 'length')
-          if [[ "$ALL_SUCCESS" == "true" && "$COUNT" -ge 4 ]]; then
+          if [[ "$ALL_OK" == "true" && "$COUNT" -ge 4 ]]; then
             echo "CI already passed for SHA $HEAD_SHA; skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -220,8 +220,8 @@ jobs:
         run: gitleaks dir . --redact --no-banner
 
   validate-manifest:
-    needs: [validate-pr-title, detect-changes]
-    if: ${{ github.repository == 'tile-ai/TileOPs' && needs.detect-changes.outputs.manifest == 'true' }}
+    needs: [validate-pr-title, ci-gate, detect-changes]
+    if: ${{ github.repository == 'tile-ai/TileOPs' && needs.ci-gate.outputs.skip != 'true' && needs.detect-changes.outputs.manifest == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -3,6 +3,7 @@ name: Preflight Checks
 permissions:
   contents: read
   checks: read
+  pull-requests: read
 
 on:
   push:
@@ -46,6 +47,56 @@ jobs:
             exit 1
           fi
           echo "PR title is valid: $PR_TITLE"
+
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      manifest: ${{ steps.filter.outputs.manifest }}
+      benchmark: ${{ steps.filter.outputs.benchmark }}
+    steps:
+      - name: Detect relevant changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_PATH: .github/workflows/preflight.yml
+        run: |
+          set -euo pipefail
+
+          # Non-PR events (push to main, tags, manual dispatch) always run
+          # both gated jobs — no base ref to diff against.
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "manifest=true" >> "$GITHUB_OUTPUT"
+            echo "benchmark=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FILES=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          echo "Changed files in PR #$PR_NUMBER:"
+          echo "$FILES"
+
+          manifest=false
+          benchmark=false
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            case "$f" in
+              tileops/ops_manifest.yaml|scripts/validate_manifest.py|"$WORKFLOW_PATH")
+                manifest=true
+                ;;
+            esac
+            case "$f" in
+              benchmarks/*|"$WORKFLOW_PATH")
+                benchmark=true
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "manifest=$manifest"
+          echo "benchmark=$benchmark"
+          echo "manifest=$manifest" >> "$GITHUB_OUTPUT"
+          echo "benchmark=$benchmark" >> "$GITHUB_OUTPUT"
 
   ci-gate:
     runs-on: ubuntu-latest
@@ -146,8 +197,8 @@ jobs:
         run: gitleaks dir . --redact --no-banner
 
   validate-manifest:
-    needs: [validate-pr-title]
-    if: ${{ github.repository == 'tile-ai/TileOPs' }}
+    needs: [validate-pr-title, detect-changes]
+    if: ${{ github.repository == 'tile-ai/TileOPs' && needs.detect-changes.outputs.manifest == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -195,8 +246,8 @@ jobs:
     # CPU-only contract tests for benchmark workload protocols.
     # Scoped to `benchmarks/tests/` so the GPU-bound `benchmarks/ops/`
     # suites (nightly-only) are NOT collected on PR CI.
-    needs: [validate-pr-title, ci-gate]
-    if: ${{ github.repository == 'tile-ai/TileOPs' && needs.ci-gate.outputs.skip != 'true' }}
+    needs: [validate-pr-title, ci-gate, detect-changes]
+    if: ${{ github.repository == 'tile-ai/TileOPs' && needs.ci-gate.outputs.skip != 'true' && needs.detect-changes.outputs.benchmark == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Add `detect-changes` job to `preflight.yml` that lists PR files via `gh api pulls/<n>/files` and emits two outputs: `manifest` and `benchmark`. Fails open if the API errors out or returns no files.
- Gate `validate-manifest` and `benchmark-contract-tests` on the matching output so unrelated PRs don't pay the ~2-minute cost per job.
- Non-PR events (push to `main`, tags, manual dispatch) default both outputs to `true`.
- Add `pull-requests: read` to workflow permissions for the `gh api` call.
- Also gate `validate-manifest` on `ci-gate.outputs.skip` for consistency with the other jobs (allows `ready_for_review` rerun suppression).

## Watch sets

`manifest=true` when any of:
- `tileops/ops_manifest.yaml`
- `scripts/validate_manifest.py`
- `.github/workflows/preflight.yml`

`benchmark=true` when any of:
- `benchmarks/**`
- `workloads/**` (imported by `benchmarks/tests/test_roofline_workload_protocol.py`)
- `tileops/manifest.py` (imported by `benchmarks/benchmark_base.py`)
- `tileops/ops_manifest.yaml` (read transitively by `workloads_to_params()` → `load_workloads()`)
- `.github/workflows/preflight.yml`

## ci-gate update

`ci-gate`'s `ready_for_review` short-circuit previously required `benchmark-contract-tests` to conclude `success`. With this PR that job will often be intentionally `skipped`, so the predicate now accepts `success` or `skipped` — only genuine failures block the rerun-suppression path.

Motivation: PR #1051 was a single-file docs change that still triggered both `validate-manifest` (1m48s) and `benchmark-contract-tests` (1m55s).

## Branch protection note

The `main` ruleset (id 8507572) requires only `validate-pr-title` and `gpu-smoke`, so neither newly gated job is required. GitHub rulesets also treat `skipped` conclusions as satisfying required checks, so this change is safe even if these jobs are later added to the required list.

## Test plan

- [x] `detect-changes` fails open on API error / empty result.
- [ ] After merge, open a docs-only follow-up PR and confirm `validate-manifest` and `benchmark-contract-tests` show `skipped`.
- [ ] Confirm a manifest-only PR runs `validate-manifest` AND `benchmark-contract-tests` (manifest is in both watch sets).
- [ ] Confirm a `workloads/**`-only PR runs `benchmark-contract-tests` but skips `validate-manifest`.