### PR TITLE
[Feat][Skills] add manifest-editing skills (add-manifest, fix-manifest)

### DIFF
--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -53,19 +53,15 @@ Locate from `op_path`:
 | test   | `tests/ops/test_<name>.py`                            |
 | bench  | `benchmarks/ops/bench_<name>.py`                      |
 
-Set `family` from kernel parent dir name with this mapping (manifest uses a closed family vocabulary, not raw dir names):
+Set `family` by **copying from the manifest itself**, not by inferring from kernel paths. Kernels live under both directories (`tileops/kernels/norm/`, `tileops/kernels/moe/`, `tileops/kernels/attention/`, …) and top-level files (`tileops/kernels/convolution.py`, `tileops/kernels/elementwise.py`, …), and the manifest uses a closed family vocabulary that does not match either layout 1:1 (e.g., kernel file `convolution.py` → family `convolution`; kernel dir `norm/` → family `normalization`).
 
-| Kernel dir                     | Manifest `family` |
-| ------------------------------ | ----------------- |
-| `tileops/kernels/norm/`        | `normalization`   |
-| `tileops/kernels/conv/`        | `convolution`     |
-| `tileops/kernels/reduction/`   | `reduction`       |
-| `tileops/kernels/scan/`        | `scan`            |
-| `tileops/kernels/moe/`         | `moe`             |
-| `tileops/kernels/elementwise/` | `elementwise`     |
-| `tileops/kernels/attention/`   | `attention`       |
+Procedure:
 
-If the dir is not in this table, scan `tileops/ops_manifest.yaml` for the convention used by an existing op under that dir. If still ambiguous, STOP.
+1. Find any existing entry in `tileops/ops_manifest.yaml` whose `source.kernel` equals the kernel path resolved above (or shares the parent dir / basename).
+1. Copy that entry's `family` value verbatim.
+1. If no neighbouring entry exists for that kernel, scan all `family` values currently used in the manifest and pick the one whose existing members most closely match the op's domain. If still ambiguous, STOP and ask the user.
+
+Never invent a new `family` value.
 
 Missing files: record absent, continue.
 

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -1,40 +1,36 @@
 ---
 name: add-manifest
-description: Generate spec-only manifest entries for legacy ops aligned to PyTorch API. Diagnose gaps via spec-audit, create draft PR with follow-up items.
+description: Generate a spec-only ops_manifest.yaml entry for a legacy op from its PyTorch docs URL. Validates, runs spec-audit, opens a draft PR linked to a follow-up issue.
 ---
 
 ## Arguments
 
-| Argument    | Required | Description                                                                                               |
-| ----------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)                                     |
-| `torch_api` | Yes      | PyTorch docs URL (e.g., `https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv1d.html`) |
+| Argument    | Required | Description                                                                       |
+| ----------- | -------- | --------------------------------------------------------------------------------- |
+| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)             |
+| `torch_api` | Yes      | PyTorch docs URL matching `https://docs.pytorch.org/docs/stable/generated/*.html` |
 
 ## Contract
 
-- **Input**: op file path + PyTorch docs URL
-- **Output**: `ops_manifest.yaml` entry + gap report + draft PR
-- **Termination**: draft PR created via `foundry:creating-pull-request`
-- **Boundary**: writes manifest only. Never modify op/kernel/test/bench code.
-
-## Input Validation
-
-`torch_api` must be a URL matching `https://docs.pytorch.org/docs/stable/generated/*.html`. If not, **terminate immediately** with an error message. Do not attempt to guess or resolve non-URL inputs.
+- **Output**: new entry in `ops_manifest.yaml` + follow-up issue + draft PR.
+- **MAY write**: `ops_manifest.yaml` (new entry only).
+- **MUST NOT write**: existing manifest entries, op / kernel / test / bench code.
+- **Termination**: draft PR created. BLOCKED on input or inference failure.
 
 ## Workflow
 
 ```mermaid
 stateDiagram-v2
     [*] --> VALIDATE_INPUT
-    VALIDATE_INPUT --> [*]: not a PyTorch docs URL → abort
-    VALIDATE_INPUT --> RESOLVE_SOURCES: URL valid
+    VALIDATE_INPUT --> [*]: URL malformed → abort
+    VALIDATE_INPUT --> RESOLVE_SOURCES
     RESOLVE_SOURCES --> READ_PYTORCH
-    READ_PYTORCH --> SPLIT_VARIANTS: Optional[Tensor] found
-    READ_PYTORCH --> DRAFT_ENTRY: no Optional[Tensor]
+    READ_PYTORCH --> SPLIT_VARIANTS: Optional Tensor present
+    READ_PYTORCH --> DRAFT_ENTRY
     SPLIT_VARIANTS --> DRAFT_ENTRY
     DRAFT_ENTRY --> VALIDATE
-    VALIDATE --> DRAFT_ENTRY: L0 fails → fix
-    VALIDATE --> RUN_AUDIT: L0 passes
+    VALIDATE --> DRAFT_ENTRY: L0 fail
+    VALIDATE --> RUN_AUDIT: L0 pass
     RUN_AUDIT --> CREATE_ISSUE
     CREATE_ISSUE --> CREATE_PR
     CREATE_PR --> [*]
@@ -42,89 +38,63 @@ stateDiagram-v2
 
 ## Steps
 
-### 1. VALIDATE INPUT
+### 1. VALIDATE_INPUT
 
-Check `torch_api` matches `https://docs.pytorch.org/docs/stable/generated/*.html`. Abort if not.
+`torch_api` must match `https://docs.pytorch.org/docs/stable/generated/*.html`. Else abort.
 
-### 2. RESOLVE SOURCES
+### 2. RESOLVE_SOURCES
 
-From `op_path`, locate four source files:
+Locate from `op_path`:
 
-| Source | Pattern                                       |
-| ------ | --------------------------------------------- |
-| kernel | `tileops/kernels/` — search for matching file |
-| op     | `op_path` itself                              |
-| test   | `tests/ops/test_<name>.py`                    |
-| bench  | `benchmarks/ops/bench_<name>.py`              |
+| Source | Path                                                  |
+| ------ | ----------------------------------------------------- |
+| kernel | search under `tileops/kernels/` for matching basename |
+| op     | `op_path`                                             |
+| test   | `tests/ops/test_<name>.py`                            |
+| bench  | `benchmarks/ops/bench_<name>.py`                      |
 
-Infer `family` from kernel subdirectory (e.g., `tileops/kernels/conv/` → `conv`).
+Set `family` = kernel parent dir name. Missing files: record absent, continue.
 
-Missing files: record as absent, continue. `spec-only` tolerates missing sources.
+### 3. READ_PYTORCH
 
-### 3. READ PYTORCH SIGNATURE
+`WebFetch` `torch_api`. The page is the **sole source of truth**. Extract:
 
-Fetch `torch_api` URL via WebFetch. The page is the **sole source of truth** for the manifest entry. Extract:
+| PyTorch param kind | Goes to                                     |
+| ------------------ | ------------------------------------------- |
+| Tensor             | `signature.inputs` (positional order)       |
+| Optional[Tensor]   | flag for SPLIT_VARIANTS                     |
+| non-Tensor         | `signature.params` (with `type`, `default`) |
+| return             | `signature.outputs`                         |
 
-- **Tensor params** → `inputs` (positional order preserved)
-- **Optional[Tensor] params** → flag for variant split
-- **Non-Tensor params** → `params` (with types and defaults)
-- **Return** → `outputs`
+Names must match PyTorch exactly. Include every PyTorch param even if the kernel ignores it. Exclude `float64`, `complex32/64/128` from dtypes.
 
-Rules:
+### 4. SPLIT_VARIANTS
 
-- Names match PyTorch exactly (R15)
-- Include all PyTorch params even if kernel ignores them (R2)
-- Exclude float64 and complex types (complex32, complex64, complex128) from dtypes — TileOPs GPU kernel library
+Skip if no `Optional[Tensor]` input. Otherwise emit two entries (manifest keys are PascalCase per `docs/ops-design-reference.md`):
 
-### 4. SPLIT VARIANTS (R16)
+| Entry   | Key                 | Inputs                | Extra                   |
+| ------- | ------------------- | --------------------- | ----------------------- |
+| primary | `<Op>FwdOp`         | required Tensors only | —                       |
+| variant | `<Op><Suffix>FwdOp` | required + optional   | `variant_of: <Op>FwdOp` |
 
-Skip if no Optional[Tensor] inputs.
+`<Suffix>` = PascalCase of the optional input name (e.g., `Bias`). Variants share `source.kernel` and `source.op`. Each gets its own `signature`, `workloads`, `roofline`.
 
-| Entry   | Name                | Contains                                            |
-| ------- | ------------------- | --------------------------------------------------- |
-| Primary | `<op>_fwd`          | Required tensors only                               |
-| Variant | `<op>_fwd_<suffix>` | Required + optional tensors, `variant_of: <op>_fwd` |
+Multiple `Optional[Tensor]`: follow decision tree in `docs/manifest.md`.
 
-`<suffix>` = descriptive name of the optional input (e.g., `bias`).
+### 5. DRAFT_ENTRY
 
-Variants share `source.kernel` and `source.op` (R18). Each gets own `signature`, `workloads`, `roofline`.
+Per entry, fill these fields:
 
-Multiple Optional\[Tensor\]: follow decision tree in `docs/manifest.md`.
-
-### 5. DRAFT ENTRY
-
-Generate per entry:
-
-**`family`**: from step 2.
-
-**`status`**: default `spec-only`. Set to `implemented` only if `--check-op` passes L0–L4 in step 6.
-
-**`signature.inputs`**: ordered dict, PyTorch positional order.
-
-- `dtype`: PyTorch-supported dtypes minus float64, `|`-separated
-- `shape`: explicit named dimensions if fixed rank (R6); omit if arbitrary rank (R7)
-- `layout`: only if non-default (R19)
-- `constraints`: if applicable (R10)
-
-**`signature.outputs`**: same format. Use `same_as(ref)` where applicable (R8).
-
-**`signature.params`**: ordered dict with `type` and `default`.
-
-**`signature.shape_rules`**: Python expressions (R11) for:
-
-- Derived dimensions (e.g., `L_out` from stride/padding/kernel_size)
-- Inter-tensor constraints (e.g., `C_in_g == C_in // groups`)
-
-**`signature.dtype_combos`**: only if supported set ⊂ Cartesian product (R4). Otherwise omit.
-
-**`workloads`**: `null`. Human decision.
-
-**`roofline`**: fill for well-known ops (conv, pool, matmul) with standard FLOPs/bytes formulas. `null` if uncertain. Do not guess.
-
-- Fixed-rank: shape names auto-bind as variables (R14). Use `elem_bytes` for primary input byte size.
-- Arbitrary-rank: use `vars` mapping.
-
-**`source`**: paths from step 2. `bench_manifest_driven: false`.
+- `family`: from RESOLVE_SOURCES.
+- `status`: `spec-only`. Flip to `implemented` only if VALIDATE passes L0–L4.
+- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
+- `signature.outputs`: same shape as inputs. Use `same_as(<ref>)` where applicable.
+- `signature.params`: ordered dict, each `{type, default}`.
+- `signature.shape_rules`: Python expressions for derived dims and inter-tensor constraints.
+- `signature.dtype_combos`: only if supported set ⊂ Cartesian product; else omit.
+- `workloads`: `null` (human decision).
+- `roofline`: fill for well-known ops (conv / pool / matmul) with standard formulas; `null` otherwise. **Never guess.** Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping.
+- `source`: paths from RESOLVE_SOURCES; `bench_manifest_driven: false`.
 
 ### 6. VALIDATE
 
@@ -132,69 +102,49 @@ Generate per entry:
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-L0 must pass. If it fails: fix the entry, re-run. Do not proceed until L0 passes.
+L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes.
 
-If L0 passes, run full validation (`--check-op` without `--level`). If L1–L4 all pass: set `status: implemented`.
+After L0 passes, run again without `--level`. If L1–L4 all pass, set `status: implemented`.
 
-### 7. RUN SPEC-AUDIT
+### 7. RUN_AUDIT
 
-Invoke `spec-audit` for the op's family → `.foundry/migrations/<family>.json`.
+Invoke `spec-audit` for the op's family → writes `.foundry/migrations/<family>.json`.
 
-### 8. CREATE FOLLOW-UP ISSUE
+### 8. CREATE_ISSUE
 
-Invoke `foundry:creating-issue` to create a remediation issue.
+Invoke `foundry:creating-issue`. Issue body MUST contain, per `semantic_gap` op:
 
-The issue must go beyond surface-level diffs (validator already reports those). Focus on **semantic analysis** that a human or spec-pipeline agent needs to make decisions:
+- **Kernel feasibility**: cite specific kernel code; classify each missing param as `trivial` / `kernel-change` / `blocked`.
+- **Class structure impact**: does variant split fit the inheritance hierarchy?
+- **Effort per gap item**: same three-way classification.
+- **Family dependencies**: do changes cascade?
 
-**Required analysis per `semantic_gap` op:**
+Issue body MUST also list:
 
-- **Kernel feasibility**: read the kernel code. Can it support the missing params (e.g., `dilation`, `groups`) with config changes, or does it need architectural rework? Cite specific kernel code that proves the assessment.
-- **Class structure impact**: does the variant split (R16) fit the current inheritance hierarchy? Does a base class need to be introduced or modified?
-- **Effort classification per gap item**: `trivial` (rename, add passthrough default) vs `kernel-change` (new TileLang program logic) vs `blocked` (fundamental architecture mismatch)
-- **Dependencies**: do changes to this op cascade to other ops in the same family?
+- Outstanding human decisions: `workloads`, `roofline`.
+- Resolution path: which spec-pipeline steps apply.
 
-**Required sections in issue body:**
+MUST NOT duplicate validator-reported facts (missing params, wrong names) — the reader has the validator.
 
-- Semantic gap analysis (above)
-- Outstanding human decisions: `workloads`, `roofline` review
-- Resolution path: which spec-pipeline steps apply (`spec-test` → `spec-implement` → `spec-bench`)
+Record the issue URL.
 
-Do not list information that `validate_manifest.py` already reports (missing params, wrong names). The issue reader has access to the validator.
+### 9. CREATE_PR
 
-Record the issue URL for step 9.
+Invoke `foundry:creating-pull-request` (draft).
 
-### 9. CREATE DRAFT PR
+| Element | Value                                                                                                             |
+| ------- | ----------------------------------------------------------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] Add <Op> manifest entries`                                                                  |
+| branch  | `maintain/manifest/<op-slug>-entries` (slug: kebab-case of `<Op>`)                                                |
+| body    | manifest entries added (name, family, status); validator results (levels passed); `Related: #<issue from step 8>` |
 
-Invoke `foundry:creating-pull-request` to create a **draft** PR.
-
-**Title format**: must pass `validate-pr-title` CI. Use types from `.claude/conventions/types.sh`:
-
-- Pattern: `[Type][Scope] description` or `[Type] description`
-- Valid types: `Bench|BugFix|Chore|CI|Doc|Enhancement|Feat|Fix|Maintain|Perf|Refactor|Style|Test`
-- For manifest additions use: `[Maintain][Manifest] Add <op> manifest entries`
-
-**Branch naming**: must match `.claude/conventions/types.sh`:
-
-- Pattern: `<prefix>/<scope>/<slug>`
-- For manifest additions use: `maintain/manifest/<op>-entries`
-
-**PR body** must:
-
-- List manifest entries added (op names, family, status)
-- List validation results (which levels passed/failed)
-- **Link the follow-up issue** from step 8 (e.g., `Related: #N`)
+Title and branch must match `.claude/conventions/types.sh`.
 
 ## Guardrails
 
-- `torch_api` must be a `docs.pytorch.org` URL. Non-URL input → abort.
-- Never modify op/kernel/test/bench code.
-- Never invent parameters outside PyTorch API (R15).
-- Only set `status: implemented` when `--check-op` passes L0–L4. Default is `spec-only`.
-- Ambiguous PyTorch mapping → stop, ask user.
-- Mapping clearly wrong upon inspection → stop, explain.
-
-## Evolution
-
-- **Phase 1** (current): manifest generation for legacy ops.
-- **Phase 2** (future): spec legality checker for human-written specs.
-- Introspect after each run: capture surprising findings, missing rules, new checks.
+- Non-URL `torch_api` → abort.
+- Never edit op / kernel / test / bench files.
+- Never invent params outside PyTorch API.
+- `status: implemented` only when L0–L4 all pass. Otherwise `spec-only`.
+- Ambiguous PyTorch mapping → STOP, ask user.
+- Mapping clearly wrong → STOP, explain.

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: add-manifest
-description: Generate a spec-only ops_manifest.yaml entry for a legacy op from its PyTorch docs URL. Validates, runs spec-audit, opens a draft PR linked to a follow-up issue.
+description: Generate a spec-only ops_manifest.yaml entry for a legacy op from its PyTorch docs URL. Validates, runs audit-family, opens a draft PR linked to a follow-up issue.
 ---
 
 ## Arguments
 
-| Argument    | Required | Description                                                                       |
-| ----------- | -------- | --------------------------------------------------------------------------------- |
-| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)             |
-| `torch_api` | Yes      | PyTorch docs URL matching `https://docs.pytorch.org/docs/stable/generated/*.html` |
+| Argument    | Required | Description                                                                                          |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)                                |
+| `torch_api` | Yes      | PyTorch docs URL matching the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` |
 
 ## Contract
 
@@ -40,7 +40,7 @@ stateDiagram-v2
 
 ### 1. VALIDATE_INPUT
 
-`torch_api` must match `https://(docs\.)?pytorch\.org/docs/stable/generated/*.html` (both host forms are canonical PyTorch docs). Else abort.
+`torch_api` must match the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` (both host forms are canonical PyTorch docs). Else abort.
 
 ### 2. RESOLVE_SOURCES
 
@@ -120,7 +120,7 @@ L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes. Higher
 
 ### 7. RUN_AUDIT
 
-Invoke `spec-audit` for the op's family → writes `.foundry/migrations/<family>.json`.
+Invoke `audit-family` for the op's family → writes `.foundry/migrations/<family>.json`.
 
 ### 8. CREATE_ISSUE
 

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: add-manifest
+description: Generate spec-only manifest entries for legacy ops aligned to PyTorch API. Diagnose gaps via spec-audit, create draft PR with follow-up items.
+---
+
+## Arguments
+
+| Argument    | Required | Description                                                                                               |
+| ----------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)                                     |
+| `torch_api` | Yes      | PyTorch docs URL (e.g., `https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv1d.html`) |
+
+## Contract
+
+- **Input**: op file path + PyTorch docs URL
+- **Output**: `ops_manifest.yaml` entry + gap report + draft PR
+- **Termination**: draft PR created via `foundry:creating-pull-request`
+- **Boundary**: writes manifest only. Never modify op/kernel/test/bench code.
+
+## Input Validation
+
+`torch_api` must be a URL matching `https://docs.pytorch.org/docs/stable/generated/*.html`. If not, **terminate immediately** with an error message. Do not attempt to guess or resolve non-URL inputs.
+
+## Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> VALIDATE_INPUT
+    VALIDATE_INPUT --> [*]: not a PyTorch docs URL → abort
+    VALIDATE_INPUT --> RESOLVE_SOURCES: URL valid
+    RESOLVE_SOURCES --> READ_PYTORCH
+    READ_PYTORCH --> SPLIT_VARIANTS: Optional[Tensor] found
+    READ_PYTORCH --> DRAFT_ENTRY: no Optional[Tensor]
+    SPLIT_VARIANTS --> DRAFT_ENTRY
+    DRAFT_ENTRY --> VALIDATE
+    VALIDATE --> DRAFT_ENTRY: L0 fails → fix
+    VALIDATE --> RUN_AUDIT: L0 passes
+    RUN_AUDIT --> CREATE_ISSUE
+    CREATE_ISSUE --> CREATE_PR
+    CREATE_PR --> [*]
+```
+
+## Steps
+
+### 1. VALIDATE INPUT
+
+Check `torch_api` matches `https://docs.pytorch.org/docs/stable/generated/*.html`. Abort if not.
+
+### 2. RESOLVE SOURCES
+
+From `op_path`, locate four source files:
+
+| Source | Pattern                                       |
+| ------ | --------------------------------------------- |
+| kernel | `tileops/kernels/` — search for matching file |
+| op     | `op_path` itself                              |
+| test   | `tests/ops/test_<name>.py`                    |
+| bench  | `benchmarks/ops/bench_<name>.py`              |
+
+Infer `family` from kernel subdirectory (e.g., `tileops/kernels/conv/` → `conv`).
+
+Missing files: record as absent, continue. `spec-only` tolerates missing sources.
+
+### 3. READ PYTORCH SIGNATURE
+
+Fetch `torch_api` URL via WebFetch. The page is the **sole source of truth** for the manifest entry. Extract:
+
+- **Tensor params** → `inputs` (positional order preserved)
+- **Optional[Tensor] params** → flag for variant split
+- **Non-Tensor params** → `params` (with types and defaults)
+- **Return** → `outputs`
+
+Rules:
+
+- Names match PyTorch exactly (R15)
+- Include all PyTorch params even if kernel ignores them (R2)
+- Exclude float64 and complex types (complex32, complex64, complex128) from dtypes — TileOPs GPU kernel library
+
+### 4. SPLIT VARIANTS (R16)
+
+Skip if no Optional[Tensor] inputs.
+
+| Entry   | Name                | Contains                                            |
+| ------- | ------------------- | --------------------------------------------------- |
+| Primary | `<op>_fwd`          | Required tensors only                               |
+| Variant | `<op>_fwd_<suffix>` | Required + optional tensors, `variant_of: <op>_fwd` |
+
+`<suffix>` = descriptive name of the optional input (e.g., `bias`).
+
+Variants share `source.kernel` and `source.op` (R18). Each gets own `signature`, `workloads`, `roofline`.
+
+Multiple Optional\[Tensor\]: follow decision tree in `docs/manifest.md`.
+
+### 5. DRAFT ENTRY
+
+Generate per entry:
+
+**`family`**: from step 2.
+
+**`status`**: default `spec-only`. Set to `implemented` only if `--check-op` passes L0–L4 in step 6.
+
+**`signature.inputs`**: ordered dict, PyTorch positional order.
+
+- `dtype`: PyTorch-supported dtypes minus float64, `|`-separated
+- `shape`: explicit named dimensions if fixed rank (R6); omit if arbitrary rank (R7)
+- `layout`: only if non-default (R19)
+- `constraints`: if applicable (R10)
+
+**`signature.outputs`**: same format. Use `same_as(ref)` where applicable (R8).
+
+**`signature.params`**: ordered dict with `type` and `default`.
+
+**`signature.shape_rules`**: Python expressions (R11) for:
+
+- Derived dimensions (e.g., `L_out` from stride/padding/kernel_size)
+- Inter-tensor constraints (e.g., `C_in_g == C_in // groups`)
+
+**`signature.dtype_combos`**: only if supported set ⊂ Cartesian product (R4). Otherwise omit.
+
+**`workloads`**: `null`. Human decision.
+
+**`roofline`**: fill for well-known ops (conv, pool, matmul) with standard FLOPs/bytes formulas. `null` if uncertain. Do not guess.
+
+- Fixed-rank: shape names auto-bind as variables (R14). Use `elem_bytes` for primary input byte size.
+- Arbitrary-rank: use `vars` mapping.
+
+**`source`**: paths from step 2. `bench_manifest_driven: false`.
+
+### 6. VALIDATE
+
+```bash
+python scripts/validate_manifest.py --check-op <op_name>
+```
+
+L0 must pass. If it fails: fix the entry, re-run. Do not proceed until L0 passes.
+
+If L0 passes, run full validation (`--check-op` without `--level`). If L1–L4 all pass: set `status: implemented`.
+
+### 7. RUN SPEC-AUDIT
+
+Invoke `spec-audit` for the op's family → `.foundry/migrations/<family>.json`.
+
+### 8. CREATE FOLLOW-UP ISSUE
+
+Invoke `foundry:creating-issue` to create a remediation issue.
+
+The issue must go beyond surface-level diffs (validator already reports those). Focus on **semantic analysis** that a human or spec-pipeline agent needs to make decisions:
+
+**Required analysis per `semantic_gap` op:**
+
+- **Kernel feasibility**: read the kernel code. Can it support the missing params (e.g., `dilation`, `groups`) with config changes, or does it need architectural rework? Cite specific kernel code that proves the assessment.
+- **Class structure impact**: does the variant split (R16) fit the current inheritance hierarchy? Does a base class need to be introduced or modified?
+- **Effort classification per gap item**: `trivial` (rename, add passthrough default) vs `kernel-change` (new TileLang program logic) vs `blocked` (fundamental architecture mismatch)
+- **Dependencies**: do changes to this op cascade to other ops in the same family?
+
+**Required sections in issue body:**
+
+- Semantic gap analysis (above)
+- Outstanding human decisions: `workloads`, `roofline` review
+- Resolution path: which spec-pipeline steps apply (`spec-test` → `spec-implement` → `spec-bench`)
+
+Do not list information that `validate_manifest.py` already reports (missing params, wrong names). The issue reader has access to the validator.
+
+Record the issue URL for step 9.
+
+### 9. CREATE DRAFT PR
+
+Invoke `foundry:creating-pull-request` to create a **draft** PR.
+
+**Title format**: must pass `validate-pr-title` CI. Use types from `.claude/conventions/types.sh`:
+
+- Pattern: `[Type][Scope] description` or `[Type] description`
+- Valid types: `Bench|BugFix|Chore|CI|Doc|Enhancement|Feat|Fix|Maintain|Perf|Refactor|Style|Test`
+- For manifest additions use: `[Maintain][Manifest] Add <op> manifest entries`
+
+**Branch naming**: must match `.claude/conventions/types.sh`:
+
+- Pattern: `<prefix>/<scope>/<slug>`
+- For manifest additions use: `maintain/manifest/<op>-entries`
+
+**PR body** must:
+
+- List manifest entries added (op names, family, status)
+- List validation results (which levels passed/failed)
+- **Link the follow-up issue** from step 8 (e.g., `Related: #N`)
+
+## Guardrails
+
+- `torch_api` must be a `docs.pytorch.org` URL. Non-URL input → abort.
+- Never modify op/kernel/test/bench code.
+- Never invent parameters outside PyTorch API (R15).
+- Only set `status: implemented` when `--check-op` passes L0–L4. Default is `spec-only`.
+- Ambiguous PyTorch mapping → stop, ask user.
+- Mapping clearly wrong upon inspection → stop, explain.
+
+## Evolution
+
+- **Phase 1** (current): manifest generation for legacy ops.
+- **Phase 2** (future): spec legality checker for human-written specs.
+- Introspect after each run: capture surprising findings, missing rules, new checks.

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -40,7 +40,7 @@ stateDiagram-v2
 
 ### 1. VALIDATE_INPUT
 
-`torch_api` must match `https://docs.pytorch.org/docs/stable/generated/*.html`. Else abort.
+`torch_api` must match `https://(docs\.)?pytorch\.org/docs/stable/generated/*.html` (both host forms are canonical PyTorch docs). Else abort.
 
 ### 2. RESOLVE_SOURCES
 
@@ -53,7 +53,21 @@ Locate from `op_path`:
 | test   | `tests/ops/test_<name>.py`                            |
 | bench  | `benchmarks/ops/bench_<name>.py`                      |
 
-Set `family` = kernel parent dir name. Missing files: record absent, continue.
+Set `family` from kernel parent dir name with this mapping (manifest uses a closed family vocabulary, not raw dir names):
+
+| Kernel dir                     | Manifest `family` |
+| ------------------------------ | ----------------- |
+| `tileops/kernels/norm/`        | `normalization`   |
+| `tileops/kernels/conv/`        | `convolution`     |
+| `tileops/kernels/reduction/`   | `reduction`       |
+| `tileops/kernels/scan/`        | `scan`            |
+| `tileops/kernels/moe/`         | `moe`             |
+| `tileops/kernels/elementwise/` | `elementwise`     |
+| `tileops/kernels/attention/`   | `attention`       |
+
+If the dir is not in this table, scan `tileops/ops_manifest.yaml` for the convention used by an existing op under that dir. If still ambiguous, STOP.
+
+Missing files: record absent, continue.
 
 ### 3. READ_PYTORCH
 
@@ -86,14 +100,14 @@ Multiple `Optional[Tensor]`: follow decision tree in `docs/manifest.md`.
 Per entry, fill these fields:
 
 - `family`: from RESOLVE_SOURCES.
-- `status`: `spec-only`. Flip to `implemented` only if VALIDATE passes L0–L4.
-- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
+- `status`: always `spec-only`. **Never** set `implemented` from this skill — that is `align-op@FLIP_STATUS`'s exclusive write.
+- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set (PyTorch dtypes minus `float64` and complex types `complex32/64/128`) joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
 - `signature.outputs`: same shape as inputs. Use `same_as(<ref>)` where applicable.
 - `signature.params`: ordered dict, each `{type, default}`.
 - `signature.shape_rules`: Python expressions for derived dims and inter-tensor constraints.
 - `signature.dtype_combos`: only if supported set ⊂ Cartesian product; else omit.
-- `workloads`: `null` (human decision).
-- `roofline`: fill for well-known ops (conv / pool / matmul) with standard formulas; `null` otherwise. **Never guess.** Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping.
+- `workloads`: `[]` (empty list — schema requires a list; human fills shapes in a follow-up).
+- `roofline`: required by L0 schema (cannot be `null` or empty). For well-known ops (conv / pool / matmul / norm / reduction): emit standard formulas. Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping. **If the formula is not derivable from PyTorch docs alone, BLOCKED with `evidence_needed: roofline.flops|bytes for <op>`** — do not guess.
 - `source`: paths from RESOLVE_SOURCES; `bench_manifest_driven: false`.
 
 ### 6. VALIDATE
@@ -102,9 +116,7 @@ Per entry, fill these fields:
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes.
-
-After L0 passes, run again without `--level`. If L1–L4 all pass, set `status: implemented`.
+L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes. Higher-level (L1–L4) failures are surfaced as gap items in the follow-up issue, not blocking.
 
 ### 7. RUN_AUDIT
 
@@ -145,6 +157,6 @@ Title and branch must match `.claude/conventions/types.sh`.
 - Non-URL `torch_api` → abort.
 - Never edit op / kernel / test / bench files.
 - Never invent params outside PyTorch API.
-- `status: implemented` only when L0–L4 all pass. Otherwise `spec-only`.
+- `status` is always `spec-only`. Never set `implemented` (that is `align-op@FLIP_STATUS`).
 - Ambiguous PyTorch mapping → STOP, ask user.
 - Mapping clearly wrong → STOP, explain.

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -1,44 +1,41 @@
 ---
 name: fix-manifest
-description: Surgical patch of an existing ops_manifest.yaml entry. Adds missing structural fields (kernel_map, static_dims, shape_rules, roofline.vars) by inferring from op source and validator output. Does not touch signature, does not flip status, does not add new entries.
+description: Patch one missing structural field on an existing ops_manifest.yaml entry. Auto-detects the field via the validator or takes --field=. Refuses signature, status, and new entries.
 ---
 
 ## Arguments
 
-| Argument         | Required | Description                                                                                                                                    |
-| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `op_name`        | Yes      | Manifest key (e.g., `RMSNormFwdOp`)                                                                                                            |
-| `--field=<name>` | No       | Which field to patch. Omit to auto-detect from validator. Allowed: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos` |
-| `--dry-run`      | No       | Print the patch and the diff; do not write                                                                                                     |
+| Argument         | Required | Description                                                                                                             |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `op_name`        | Yes      | Manifest key (e.g., `RMSNormFwdOp`)                                                                                     |
+| `--field=<name>` | No       | One of `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`. Omit to auto-detect from validator. |
+| `--dry-run`      | No       | Print diff and exit; no write, no PR                                                                                    |
 
 ## Contract
 
-- **Input**: `op_name` must already exist in `tileops/ops_manifest.yaml`.
-- **Output**: single-field patch to that entry + manifest PR.
-- **Termination**: validator passes the level corresponding to the patched field, or BLOCKED with a structured reason.
-- **Boundary** (intentionally narrow):
-  - **MAY** patch: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`.
-  - **MUST NOT** modify: `signature.inputs`, `signature.outputs`, `signature.params`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops`, `roofline.bytes`, `roofline.func`, `source.*` (except `kernel_map`).
-  - **MUST NOT** create new entries — use `add-manifest` for greenfield.
-  - **MUST NOT** flip `status` — that is `align-op`'s `FLIP_STATUS` site.
-  - **MUST NOT** modify op / kernel / test / bench code.
-
-If the validator gap requires a forbidden change (e.g., `signature.params` is wrong), STOP and emit a structured BLOCKED report with the diagnosis. Do not silently widen scope.
+- **MAY write** in `ops_manifest.yaml`: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`.
+- **MUST NOT write**: `signature.*`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops|bytes|func`, `source.*` (except inserting `kernel_map` under `source`).
+- **MUST NOT** create new entries (use `add-manifest`).
+- **MUST NOT** flip `status` (that is `align-op@FLIP_STATUS`).
+- **MUST NOT** edit op / kernel / test / bench code.
+- **One field per invocation.** To fix two fields, run twice.
+- **Termination**: validator passes the level for the patched field, or BLOCKED.
 
 ## Workflow
 
 ```mermaid
 stateDiagram-v2
     [*] --> PRE_CHECK
-    PRE_CHECK --> [*]: op not in manifest → abort
-    PRE_CHECK --> DIAGNOSE: entry exists
-    DIAGNOSE --> INFER: target field decided
-    DIAGNOSE --> [*]: requires forbidden change → BLOCKED
-    INFER --> PATCH: patch payload built
-    INFER --> [*]: cannot infer → BLOCKED with evidence request
+    PRE_CHECK --> [*]: entry missing → BLOCKED
+    PRE_CHECK --> DIAGNOSE
+    DIAGNOSE --> INFER: target in allowed list
+    DIAGNOSE --> [*]: forbidden field → BLOCKED
+    DIAGNOSE --> [*]: nothing to fix
+    INFER --> PATCH
+    INFER --> [*]: cannot infer → BLOCKED
     PATCH --> VALIDATE
-    VALIDATE --> PATCH: validator regressed → revert and BLOCK
-    VALIDATE --> CREATE_PR: clean
+    VALIDATE --> [*]: regression → revert and BLOCK
+    VALIDATE --> CREATE_PR
     CREATE_PR --> [*]
 ```
 
@@ -46,43 +43,42 @@ stateDiagram-v2
 
 ### 1. PRE_CHECK
 
-- Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED ("op not in manifest; use `add-manifest` for greenfield").
-- Read the current entry verbatim (preserve key order; we will round-trip it).
+Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED with message `op not in manifest; use add-manifest for greenfield`.
 
 ### 2. DIAGNOSE
 
-Decide which field to patch:
+Decide the target field:
 
-- If `--field=` was passed: that field. Validate it is in the allowed list.
-- Otherwise: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse the first error.
-  - Error names a field in the allowed list → patch that field.
-  - Error names a forbidden field (e.g., `signature.params.dim` is missing) → BLOCKED. Report: which field, why it is forbidden, and what skill / workflow owns it (`add-manifest` for new entries, an issue + manifest review for signature changes).
-  - No errors at the requested level → no-op; print "nothing to fix" and exit cleanly.
+- `--field=` provided → must be in the allowed list above; else BLOCKED.
+- Else: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse first error.
+  - Field in allowed list → that field.
+  - Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.*`).
+  - No errors → no-op; print `nothing to fix` and exit 0.
 
-Write `.foundry/plan/<op_name>/fix-diagnosis.json` with: target field, validator output excerpt, decided action.
+Write `.foundry/plan/<op_name>/fix-diagnosis.json`: `{op_name, target_field, validator_excerpt, action}`.
 
 ### 3. INFER
 
-Derive the patch payload from authoritative evidence on disk:
+Build the patch payload from on-disk evidence. Source per field:
 
-| Field           | Inference source                                                                                                                                                                                                                                                                       |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kernel_map`    | `source.op` file. Read the op class. The mapping `<key>: <fully-qualified Kernel class>` is reconstructed from `_kernel_key` (or kernel-dispatch dict) + `_kernel_cls` (or callable used in `kernel_map`). For T1 thin wrappers: read the family base class to find the dispatch dict. |
-| `static_dims`   | `signature.inputs` shape names + the op's `forward` body (which dim is the row / hidden / channel). Cross-check against `roofline.vars` if present (often the same names).                                                                                                             |
-| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (via `ref_api`) are the tiebreaker.                                                                                                                                                                                       |
-| `roofline.vars` | `static_dims` keys + any extra dims used in `roofline.flops` / `roofline.bytes` expressions.                                                                                                                                                                                           |
-| `dtype_combos`  | Existing tests (`source.test`) — if tests parametrize over dtypes, those are the supported combos.                                                                                                                                                                                     |
+| Field           | Inference source                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kernel_map`    | The op's runtime kernel dispatch. T2 (L1-direct): `default_kernel_map()` returns the dict verbatim. T1 (thin wrapper, see `docs/ops-design.md` §"Family-specific protocol variables"): combine the op's `_kernel_key` / `_kernel_cls` (or equivalent class-level protocol vars) with the family base's kernel-dispatch logic. Output: `{<key>: <fully-qualified Kernel class>}`. |
+| `static_dims`   | `signature.inputs` shape names that the op binds at construction time (each entry in the op's `__init__` kwarg block, excluding `dtype` / `kernel_map` / `tune` / `signature.params` entries — see `docs/ops-design.md` §"Step 3"). Cross-check with `roofline.vars` if present.                                                                                                 |
+| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (`ref_api`) is tiebreaker.                                                                                                                                                                                                                                                                                          |
+| `roofline.vars` | `static_dims` keys + any extra dims referenced in `roofline.flops` / `roofline.bytes`.                                                                                                                                                                                                                                                                                           |
+| `dtype_combos`  | `source.test`: dtypes the tests parametrize over.                                                                                                                                                                                                                                                                                                                                |
 
-If inference is impossible from on-disk evidence, BLOCKED with a structured "evidence needed" report listing what the human must decide. Do not guess.
+If inference impossible, BLOCKED with an `evidence_needed` report listing what the human must decide. **Do not guess.**
 
 ### 4. PATCH
 
-Apply the inferred payload to the entry. Preserve YAML formatting:
+Apply the payload to the entry. Required formatting rules:
 
 - Insert `kernel_map` directly under `source.kernel`.
-- Insert `static_dims` directly under `signature.params` (or `signature.outputs` if no `params`).
-- Other fields per their canonical position in [`docs/manifest.md`](../../../docs/manifest.md).
-- Preserve comments adjacent to the target section.
+- Insert `static_dims` directly under `signature.params` (or under `signature.outputs` if no `params`).
+- Other fields: per `docs/manifest.md` canonical order.
+- Preserve adjacent comments.
 - Do not reorder unrelated keys.
 
 ### 5. VALIDATE
@@ -91,40 +87,32 @@ Apply the inferred payload to the entry. Preserve YAML formatting:
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-Must pass at least the level the patch targets:
+Required passing level:
 
-| Patched field   | Required passing level |
-| --------------- | ---------------------- |
-| `kernel_map`    | L0 (structural)        |
-| `static_dims`   | L1                     |
-| `shape_rules`   | L2                     |
-| `roofline.vars` | L3                     |
-| `dtype_combos`  | L1                     |
+| Patched field   | Level |
+| --------------- | ----- |
+| `kernel_map`    | L0    |
+| `static_dims`   | L1    |
+| `shape_rules`   | L2    |
+| `roofline.vars` | L3    |
+| `dtype_combos`  | L1    |
 
-If the validator now reports a *new* error not present before the patch, revert and BLOCKED. The patch must monotonically improve.
+If validator emits any error not present before the patch, revert the patch and BLOCKED. Patch must be monotonic.
 
 ### 6. CREATE_PR
 
-Invoke `foundry:creating-pull-request` with:
+If `--dry-run`, print the diff and exit 0. Otherwise invoke `foundry:creating-pull-request`:
 
-- **Title**: `[Maintain][Manifest] fix <field> for <op_name>` (or `[Fix][Manifest] …` if patching an entry that the validator was actively rejecting).
-- **Branch**: `maintain/manifest/fix-<op-slug>-<field>`.
-- **Body**:
-  - Single-field patch summary (which field, why missing, evidence used to infer).
-  - Validator output before vs. after.
-  - Explicit **scope guard**: list what was NOT touched (signature, status, sources).
-  - If `--dry-run` was passed: no PR; print the diff and exit.
+| Element | Value                                                                                                         |
+| ------- | ------------------------------------------------------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] fix <field> for <op_name>` (use `[Fix][Manifest]` if validator was actively rejecting)  |
+| branch  | `maintain/manifest/fix-<op-slug>-<field>`                                                                     |
+| body    | which field, evidence used to infer; validator output before vs. after; explicit list of what was NOT touched |
 
 ## Guardrails
 
-- Never bundle two field fixes in one invocation. Run twice.
-- Never edit op / kernel / test / bench files.
-- Never invent values that have no source on disk. Inference must trace back to a file in the repo or to `ref_api` PyTorch docs.
-- Never flip `status`. If the entry currently says `spec-only` and the patch makes it conformant, leave the status alone — `align-op` flips it after code is aligned.
-- If the validator output is ambiguous (multiple possible fixes), STOP and ask.
-
-## Relation to other skills
-
-- **`add-manifest`** — greenfield: op exists, manifest entry does not. `fix-manifest` refuses on missing entries and points the user there.
-- **`align-op`** — code-side alignment. `align-op` PRE_CHECK requires `kernel_map`; `fix-manifest --field=kernel_map` is the standard prerequisite when PRE_CHECK BLOCKS for that reason.
-- **Trust model** — `fix-manifest` is the second authorized writer of `ops_manifest.yaml` after `align-op`'s `FLIP_STATUS`. Their write scopes do not overlap: `align-op` writes only the `status` field; `fix-manifest` writes everything in the allowed list except `status`. `add-manifest` adds whole new entries.
+- One field per invocation.
+- Never widen scope to cover a forbidden field — emit BLOCKED instead.
+- Never invent values. All payload data must trace to a file or to `ref_api`.
+- Never flip `status`.
+- Validator output ambiguous → STOP, ask user.

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-manifest
-description: Patch one missing structural field (kernel_map, static_dims, shape_rules, roofline.vars, dtype_combos) on an existing ops_manifest.yaml entry. Auto-detects the field via the validator or takes --field=. Refuses signature.{inputs,outputs,params}, status, and new entries.
+description: Patch one missing structural field (kernel_map, static_dims, shape_rules, roofline.vars, dtype_combos) on an existing ops_manifest.yaml entry. Auto-detects the field via the validator or takes `--field=<name>`. Refuses signature.{inputs,outputs,params}, status, and new entries.
 ---
 
 ## Arguments
@@ -49,11 +49,15 @@ Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED with messa
 
 Decide the target field. The validator does NOT flag every missing allowed field for spec-only entries (e.g., `source.kernel_map` is only warned when `status == implemented`). Therefore DIAGNOSE runs **two checks** when `--field=` is omitted:
 
-1. **Explicit presence checks** for each allowed field. Order:
+1. **Explicit presence check** for `kernel_map` only. The validator only warns on missing `kernel_map` when `status == implemented`, so a `spec-only` entry can be missing it without an error:
+
    - `source.kernel_map` missing or empty → target = `kernel_map`.
-   - `signature.static_dims` missing → target = `static_dims`.
    - else fall through to validator.
+
+   Do NOT presence-check `static_dims`, `shape_rules`, `dtype_combos`, or `roofline.vars` — `docs/manifest.md` (R7, R20) explicitly allows `static_dims` to be absent on fixed-rank ops, and the other fields are conditionally required. Patching them based on absence alone would manufacture changes for valid entries (e.g., reduction-style ops). Target these fields only when the validator emits an error or the user passes `--field=`.
+
 1. **Validator output**: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse first error.
+
    - Field in allowed list → that field.
    - Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
    - No errors and no missing presence → no-op; print `nothing to fix` and exit 0.

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-manifest
-description: Patch one missing structural field on an existing ops_manifest.yaml entry. Auto-detects the field via the validator or takes --field=. Refuses signature, status, and new entries.
+description: Patch one missing structural field (kernel_map, static_dims, shape_rules, roofline.vars, dtype_combos) on an existing ops_manifest.yaml entry. Auto-detects the field via the validator or takes --field=. Refuses signature.{inputs,outputs,params}, status, and new entries.
 ---
 
 ## Arguments
@@ -14,7 +14,7 @@ description: Patch one missing structural field on an existing ops_manifest.yaml
 ## Contract
 
 - **MAY write** in `ops_manifest.yaml`: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`.
-- **MUST NOT write**: `signature.*`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops|bytes|func`, `source.*` (except inserting `kernel_map` under `source`).
+- **MUST NOT write**: `signature.{inputs,outputs,params}`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops|bytes|func`, `source.{kernel,op,test,bench,bench_manifest_driven}`. (Note: `signature.static_dims`, `signature.shape_rules`, `signature.dtype_combos`, and `source.kernel_map` ARE in the allowed write set above.)
 - **MUST NOT** create new entries (use `add-manifest`).
 - **MUST NOT** flip `status` (that is `align-op@FLIP_STATUS`).
 - **MUST NOT** edit op / kernel / test / bench code.
@@ -47,13 +47,18 @@ Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED with messa
 
 ### 2. DIAGNOSE
 
-Decide the target field:
+Decide the target field. The validator does NOT flag every missing allowed field for spec-only entries (e.g., `source.kernel_map` is only warned when `status == implemented`). Therefore DIAGNOSE runs **two checks** when `--field=` is omitted:
 
-- `--field=` provided → must be in the allowed list above; else BLOCKED.
-- Else: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse first error.
-  - Field in allowed list → that field.
-  - Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.*`).
-  - No errors → no-op; print `nothing to fix` and exit 0.
+1. **Explicit presence checks** for each allowed field. Order:
+   - `source.kernel_map` missing or empty → target = `kernel_map`.
+   - `signature.static_dims` missing → target = `static_dims`.
+   - else fall through to validator.
+1. **Validator output**: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse first error.
+   - Field in allowed list → that field.
+   - Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
+   - No errors and no missing presence → no-op; print `nothing to fix` and exit 0.
+
+`--field=` provided → must be in the allowed list; else BLOCKED. Skip the presence/validator dance.
 
 Write `.foundry/plan/<op_name>/fix-diagnosis.json`: `{op_name, target_field, validator_excerpt, action}`.
 
@@ -73,11 +78,20 @@ If inference impossible, BLOCKED with an `evidence_needed` report listing what t
 
 ### 4. PATCH
 
-Apply the payload to the entry. Required formatting rules:
+Apply the payload to the entry. The target keys live at these exact YAML paths (see `docs/manifest.md`):
 
-- Insert `kernel_map` directly under `source.kernel`.
-- Insert `static_dims` directly under `signature.params` (or under `signature.outputs` if no `params`).
-- Other fields: per `docs/manifest.md` canonical order.
+| Field           | YAML path                                                |
+| --------------- | -------------------------------------------------------- |
+| `kernel_map`    | `source.kernel_map` (sibling of `source.kernel`)         |
+| `static_dims`   | `signature.static_dims` (sibling of `signature.params`)  |
+| `shape_rules`   | `signature.shape_rules` (sibling of `signature.params`)  |
+| `dtype_combos`  | `signature.dtype_combos` (sibling of `signature.params`) |
+| `roofline.vars` | `roofline.vars` (sibling of `roofline.flops`)            |
+
+Insertion rules:
+
+- Insert each new key as a **sibling** of the existing keys in its parent block (NOT nested under another sibling).
+- Order within parent block: per `docs/manifest.md` canonical order. When unsure, place the new key just before the first existing key (top of block).
 - Preserve adjacent comments.
 - Do not reorder unrelated keys.
 
@@ -94,8 +108,8 @@ Required passing level:
 | `kernel_map`    | L0    |
 | `static_dims`   | L1    |
 | `shape_rules`   | L2    |
-| `roofline.vars` | L3    |
-| `dtype_combos`  | L1    |
+| `roofline.vars` | L0    |
+| `dtype_combos`  | L3    |
 
 If validator emits any error not present before the patch, revert the patch and BLOCKED. Patch must be monotonic.
 

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -47,22 +47,19 @@ Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED with messa
 
 ### 2. DIAGNOSE
 
-Decide the target field. The validator does NOT flag every missing allowed field for spec-only entries (e.g., `source.kernel_map` is only warned when `status == implemented`). Therefore DIAGNOSE runs **two checks** when `--field=` is omitted:
+Decide the target field. The validator does NOT flag every missing allowed field for spec-only entries (e.g., `source.kernel_map` is only warned when `status == implemented`). When `--field=` is omitted, run two checks in strict order — Check A first; only fall through to Check B if A finds nothing.
 
-1. **Explicit presence check** for `kernel_map` only. The validator only warns on missing `kernel_map` when `status == implemented`, so a `spec-only` entry can be missing it without an error:
+**Check A — `kernel_map` presence (single field only).** If `source.kernel_map` is missing or empty → target = `kernel_map`, jump to INFER. Otherwise fall through to Check B.
 
-   - `source.kernel_map` missing or empty → target = `kernel_map`.
-   - else fall through to validator.
+Do NOT extend Check A to `static_dims`, `shape_rules`, `dtype_combos`, or `roofline.vars`. `docs/manifest.md` R7 and R20 explicitly allow `static_dims` to be absent on fixed-rank ops; the other three fields are conditionally required. Patching them on absence alone would manufacture changes for valid entries (e.g., reduction-style ops).
 
-   Do NOT presence-check `static_dims`, `shape_rules`, `dtype_combos`, or `roofline.vars` — `docs/manifest.md` (R7, R20) explicitly allows `static_dims` to be absent on fixed-rank ops, and the other fields are conditionally required. Patching them based on absence alone would manufacture changes for valid entries (e.g., reduction-style ops). Target these fields only when the validator emits an error or the user passes `--field=`.
+**Check B — validator output.** Run `python scripts/validate_manifest.py --check-op <op_name>`. Parse the first error:
 
-1. **Validator output**: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse first error.
+- Field in the allowed list above → target = that field, jump to INFER.
+- Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
+- No errors and Check A also empty → no-op; print `nothing to fix` and exit 0.
 
-   - Field in allowed list → that field.
-   - Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
-   - No errors and no missing presence → no-op; print `nothing to fix` and exit 0.
-
-`--field=` provided → must be in the allowed list; else BLOCKED. Skip the presence/validator dance.
+When `--field=` IS provided: must be in the allowed list; else BLOCKED. Skip both checks.
 
 Write `.foundry/plan/<op_name>/fix-diagnosis.json`: `{op_name, target_field, validator_excerpt, action}`.
 

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: fix-manifest
+description: Surgical patch of an existing ops_manifest.yaml entry. Adds missing structural fields (kernel_map, static_dims, shape_rules, roofline.vars) by inferring from op source and validator output. Does not touch signature, does not flip status, does not add new entries.
+---
+
+## Arguments
+
+| Argument         | Required | Description                                                                                                                                    |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `op_name`        | Yes      | Manifest key (e.g., `RMSNormFwdOp`)                                                                                                            |
+| `--field=<name>` | No       | Which field to patch. Omit to auto-detect from validator. Allowed: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos` |
+| `--dry-run`      | No       | Print the patch and the diff; do not write                                                                                                     |
+
+## Contract
+
+- **Input**: `op_name` must already exist in `tileops/ops_manifest.yaml`.
+- **Output**: single-field patch to that entry + manifest PR.
+- **Termination**: validator passes the level corresponding to the patched field, or BLOCKED with a structured reason.
+- **Boundary** (intentionally narrow):
+  - **MAY** patch: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`.
+  - **MUST NOT** modify: `signature.inputs`, `signature.outputs`, `signature.params`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops`, `roofline.bytes`, `roofline.func`, `source.*` (except `kernel_map`).
+  - **MUST NOT** create new entries — use `add-manifest` for greenfield.
+  - **MUST NOT** flip `status` — that is `align-op`'s `FLIP_STATUS` site.
+  - **MUST NOT** modify op / kernel / test / bench code.
+
+If the validator gap requires a forbidden change (e.g., `signature.params` is wrong), STOP and emit a structured BLOCKED report with the diagnosis. Do not silently widen scope.
+
+## Workflow
+
+```mermaid
+stateDiagram-v2
+    [*] --> PRE_CHECK
+    PRE_CHECK --> [*]: op not in manifest → abort
+    PRE_CHECK --> DIAGNOSE: entry exists
+    DIAGNOSE --> INFER: target field decided
+    DIAGNOSE --> [*]: requires forbidden change → BLOCKED
+    INFER --> PATCH: patch payload built
+    INFER --> [*]: cannot infer → BLOCKED with evidence request
+    PATCH --> VALIDATE
+    VALIDATE --> PATCH: validator regressed → revert and BLOCK
+    VALIDATE --> CREATE_PR: clean
+    CREATE_PR --> [*]
+```
+
+## Steps
+
+### 1. PRE_CHECK
+
+- Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED ("op not in manifest; use `add-manifest` for greenfield").
+- Read the current entry verbatim (preserve key order; we will round-trip it).
+
+### 2. DIAGNOSE
+
+Decide which field to patch:
+
+- If `--field=` was passed: that field. Validate it is in the allowed list.
+- Otherwise: run `python scripts/validate_manifest.py --check-op <op_name>`. Parse the first error.
+  - Error names a field in the allowed list → patch that field.
+  - Error names a forbidden field (e.g., `signature.params.dim` is missing) → BLOCKED. Report: which field, why it is forbidden, and what skill / workflow owns it (`add-manifest` for new entries, an issue + manifest review for signature changes).
+  - No errors at the requested level → no-op; print "nothing to fix" and exit cleanly.
+
+Write `.foundry/plan/<op_name>/fix-diagnosis.json` with: target field, validator output excerpt, decided action.
+
+### 3. INFER
+
+Derive the patch payload from authoritative evidence on disk:
+
+| Field           | Inference source                                                                                                                                                                                                                                                                       |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kernel_map`    | `source.op` file. Read the op class. The mapping `<key>: <fully-qualified Kernel class>` is reconstructed from `_kernel_key` (or kernel-dispatch dict) + `_kernel_cls` (or callable used in `kernel_map`). For T1 thin wrappers: read the family base class to find the dispatch dict. |
+| `static_dims`   | `signature.inputs` shape names + the op's `forward` body (which dim is the row / hidden / channel). Cross-check against `roofline.vars` if present (often the same names).                                                                                                             |
+| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (via `ref_api`) are the tiebreaker.                                                                                                                                                                                       |
+| `roofline.vars` | `static_dims` keys + any extra dims used in `roofline.flops` / `roofline.bytes` expressions.                                                                                                                                                                                           |
+| `dtype_combos`  | Existing tests (`source.test`) — if tests parametrize over dtypes, those are the supported combos.                                                                                                                                                                                     |
+
+If inference is impossible from on-disk evidence, BLOCKED with a structured "evidence needed" report listing what the human must decide. Do not guess.
+
+### 4. PATCH
+
+Apply the inferred payload to the entry. Preserve YAML formatting:
+
+- Insert `kernel_map` directly under `source.kernel`.
+- Insert `static_dims` directly under `signature.params` (or `signature.outputs` if no `params`).
+- Other fields per their canonical position in [`docs/manifest.md`](../../../docs/manifest.md).
+- Preserve comments adjacent to the target section.
+- Do not reorder unrelated keys.
+
+### 5. VALIDATE
+
+```bash
+python scripts/validate_manifest.py --check-op <op_name>
+```
+
+Must pass at least the level the patch targets:
+
+| Patched field   | Required passing level |
+| --------------- | ---------------------- |
+| `kernel_map`    | L0 (structural)        |
+| `static_dims`   | L1                     |
+| `shape_rules`   | L2                     |
+| `roofline.vars` | L3                     |
+| `dtype_combos`  | L1                     |
+
+If the validator now reports a *new* error not present before the patch, revert and BLOCKED. The patch must monotonically improve.
+
+### 6. CREATE_PR
+
+Invoke `foundry:creating-pull-request` with:
+
+- **Title**: `[Maintain][Manifest] fix <field> for <op_name>` (or `[Fix][Manifest] …` if patching an entry that the validator was actively rejecting).
+- **Branch**: `maintain/manifest/fix-<op-slug>-<field>`.
+- **Body**:
+  - Single-field patch summary (which field, why missing, evidence used to infer).
+  - Validator output before vs. after.
+  - Explicit **scope guard**: list what was NOT touched (signature, status, sources).
+  - If `--dry-run` was passed: no PR; print the diff and exit.
+
+## Guardrails
+
+- Never bundle two field fixes in one invocation. Run twice.
+- Never edit op / kernel / test / bench files.
+- Never invent values that have no source on disk. Inference must trace back to a file in the repo or to `ref_api` PyTorch docs.
+- Never flip `status`. If the entry currently says `spec-only` and the patch makes it conformant, leave the status alone — `align-op` flips it after code is aligned.
+- If the validator output is ambiguous (multiple possible fixes), STOP and ask.
+
+## Relation to other skills
+
+- **`add-manifest`** — greenfield: op exists, manifest entry does not. `fix-manifest` refuses on missing entries and points the user there.
+- **`align-op`** — code-side alignment. `align-op` PRE_CHECK requires `kernel_map`; `fix-manifest --field=kernel_map` is the standard prerequisite when PRE_CHECK BLOCKS for that reason.
+- **Trust model** — `fix-manifest` is the second authorized writer of `ops_manifest.yaml` after `align-op`'s `FLIP_STATUS`. Their write scopes do not overlap: `align-op` writes only the `status` field; `fix-manifest` writes everything in the allowed list except `status`. `add-manifest` adds whole new entries.

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -22,7 +22,7 @@ Orchestrators are the day-to-day entry points. Atomics are their sub-skills — 
 | Find out which case an op is in, without touching anything        | `/align-op <op_name> --classify-only`      |
 | Migrate every spec-only op in a whole family (historical backlog) | `/align-family <family>`                   |
 | Read-only audit of a family's spec gaps                           | `/audit-family <family>`                   |
-| Add a new manifest entry from a PyTorch docs URL                  | `/add-manifest <op_path> <torch_url>`      |
+| Add a new manifest entry from a PyTorch docs URL                  | `/add-manifest <op_path> <torch_api>`      |
 | Patch a single missing field in an existing manifest entry        | `/fix-manifest <op_name>`                  |
 | Scaffold a fresh op file, bypassing the orchestrator              | `/scaffold-op <op_name>`                   |
 | Debug one atomic phase by hand                                    | `/test-op` · `/implement-op` · `/bench-op` |

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -10,8 +10,9 @@ Naming is **verb-noun**. The verb is the action; the noun (`op` or `family`) is 
 | -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **per op**     | [`align-op`](../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../.claude/skills/test-op/SKILL.md) · [`implement-op`](../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../.claude/skills/bench-op/SKILL.md) |
 | **per family** | [`align-family`](../.claude/skills/align-family/SKILL.md) | [`audit-family`](../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                 |
+| **manifest**   | —                                                         | [`add-manifest`](../.claude/skills/add-manifest/SKILL.md) · [`fix-manifest`](../.claude/skills/fix-manifest/SKILL.md)                                                                                                     |
 
-Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging.
+Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging. Manifest skills are standalone editors of `ops_manifest.yaml` and have no orchestrator: they precede op-layer work, not contain it.
 
 ## What do I want to do?
 
@@ -21,6 +22,8 @@ Orchestrators are the day-to-day entry points. Atomics are their sub-skills — 
 | Find out which case an op is in, without touching anything        | `/align-op <op_name> --classify-only`      |
 | Migrate every spec-only op in a whole family (historical backlog) | `/align-family <family>`                   |
 | Read-only audit of a family's spec gaps                           | `/audit-family <family>`                   |
+| Add a new manifest entry from a PyTorch docs URL                  | `/add-manifest <op_path> <torch_url>`      |
+| Patch a single missing field in an existing manifest entry        | `/fix-manifest <op_name>`                  |
 | Scaffold a fresh op file, bypassing the orchestrator              | `/scaffold-op <op_name>`                   |
 | Debug one atomic phase by hand                                    | `/test-op` · `/implement-op` · `/bench-op` |
 
@@ -83,6 +86,23 @@ Compares each op's code signature against its manifest spec, classifies gaps (`r
 - **Use when.** You want read-only inspection of a family's current conformance. Also called internally by `align-family`.
 - **Contract:** [SKILL.md](../.claude/skills/audit-family/SKILL.md)
 
+### `add-manifest` · manifest atomic
+
+Generates a fresh `ops_manifest.yaml` entry for a legacy op from its PyTorch reference. Reads the PyTorch docs URL as the sole source of truth, drafts `signature` / `shape_rules` / `roofline`, validates, and opens a draft PR with a follow-up issue capturing semantic-gap analysis.
+
+- **Use when.** A code-side op exists but has no manifest entry yet. Greenfield path.
+- **Don't use when.** The entry already exists — use `fix-manifest` for surgical patches, or open a manifest-review issue if the change touches `signature`.
+- **Contract:** [SKILL.md](../.claude/skills/add-manifest/SKILL.md)
+
+### `fix-manifest` · manifest atomic
+
+Surgical patch of an existing manifest entry. Diagnoses one missing structural field via the validator, infers the patch from on-disk evidence (op source, kernel class, PyTorch reference), writes a single-field change, and opens a manifest PR.
+
+- **Allowed fields.** `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`. Everything else (signature, status, sources) is out of scope by design.
+- **Use when.** The validator rejects an existing entry for a missing structural field — most commonly `kernel_map`, which `align-op`'s PRE_CHECK requires.
+- **Don't use when.** The entry doesn't exist (`add-manifest`), the gap is in `signature.*` (open a manifest-review issue), or you want to flip `status: spec-only → implemented` (that is `align-op`'s `FLIP_STATUS`).
+- **Contract:** [SKILL.md](../.claude/skills/fix-manifest/SKILL.md)
+
 ## Composition
 
 How orchestrators delegate. Note that orchestrators may delegate to other orchestrators (e.g., `align-family` → `align-op`) as well as to atomic skills.
@@ -114,13 +134,13 @@ align-op <op_name>                       ← per-op orchestrator
 
 ## Trust model  ·  who may write what
 
-| Resource                          | Writer                                                                                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ops_manifest.yaml`               | Only `align-op` at `FLIP_STATUS`. No atomic skill writes the manifest; `align-family` delegates to `align-op` and never writes it directly.                        |
-| `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                       |
-| `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work. |
-| `tests/ops/**`                    | `test-op`.                                                                                                                                                         |
-| `benchmarks/ops/**`               | `bench-op`.                                                                                                                                                        |
+| Resource                          | Writer                                                                                                                                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ops_manifest.yaml`               | Three writers, disjoint slices: `add-manifest` (new entries), `fix-manifest` (one structural field on an existing entry, never `signature.*` or `status`), `align-op` at `FLIP_STATUS` (the `status` field only). No op-layer or family skill writes the manifest. |
+| `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                                                                                                                       |
+| `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work.                                                                                                 |
+| `tests/ops/**`                    | `test-op`.                                                                                                                                                                                                                                                         |
+| `benchmarks/ops/**`               | `bench-op`.                                                                                                                                                                                                                                                        |
 
 ## Maintenance
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -2,7 +2,7 @@
 
 Skills this repo provides for TileOPs op development: what each does, when to use it, when not to. Authoritative per-skill contracts live in each `SKILL.md`; this page is the human-facing map.
 
-Naming is **verb-noun**. The verb is the action; the noun (`op` or `family`) is the scope.
+Naming is **verb-noun**. The verb is the action; the noun is the scope (`op`, `family`, or `manifest`).
 
 ## At a glance
 
@@ -125,22 +125,22 @@ align-op <op_name>                       ← per-op orchestrator
     ├─ implement-op                      ← conditional: green/redesign only; skipped on minor (already ran in DISPATCH) and on TEST DONE_SKIP
     ├─ bench-op
     ├─ [orchestrator] REVALIDATE
-    ├─ [orchestrator] FLIP_STATUS        ← only manifest writer
+    ├─ [orchestrator] FLIP_STATUS        ← writes status field only (one of three manifest writers)
     ├─ [orchestrator] CLEANUP
     └─ [orchestrator] REPORT
 ```
 
-`align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest; `align-op`'s FLIP_STATUS is the sole manifest-write site.
+`align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest. Among the op- and family-scoped skills, `align-op`'s `FLIP_STATUS` is the only manifest writer (and writes only the `status` field). Manifest-scoped skills (`add-manifest`, `fix-manifest`) write disjoint slices — see the trust-model table below.
 
 ## Trust model  ·  who may write what
 
-| Resource                          | Writer                                                                                                                                                                                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ops_manifest.yaml`               | Three writers, disjoint slices: `add-manifest` (new entries), `fix-manifest` (one structural field on an existing entry, never `signature.*` or `status`), `align-op` at `FLIP_STATUS` (the `status` field only). No op-layer or family skill writes the manifest. |
-| `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                                                                                                                       |
-| `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work.                                                                                                 |
-| `tests/ops/**`                    | `test-op`.                                                                                                                                                                                                                                                         |
-| `benchmarks/ops/**`               | `bench-op`.                                                                                                                                                                                                                                                        |
+| Resource                          | Writer                                                                                                                                                                                                                                                                                                                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ops_manifest.yaml`               | Three writers, disjoint slices: `add-manifest` creates new entries; `fix-manifest` patches one structural field on an existing entry (allowed: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`; never `signature.{inputs,outputs,params}` or `status`); `align-op` at `FLIP_STATUS` writes only the `status` field. No other skill writes the manifest. |
+| `tileops/ops/**` op files         | `scaffold-op` creates; `implement-op` edits.                                                                                                                                                                                                                                                                                                                                        |
+| `tileops/kernels/**` kernel files | No TileOPs skill writes kernels. `align-op --mode=redesign` surfaces mismatches via `kernel-check.json`; a future `kernel-align` skill will own kernel-layer work.                                                                                                                                                                                                                  |
+| `tests/ops/**`                    | `test-op`.                                                                                                                                                                                                                                                                                                                                                                          |
+| `benchmarks/ops/**`               | `bench-op`.                                                                                                                                                                                                                                                                                                                                                                         |
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary

- Introduce a **manifest** scope alongside per-op and per-family. Two
disjoint paths for common manifest operations:
- **`add-manifest`** — greenfield entry from a PyTorch docs URL
(relocated from local user skills as-is, no logic changes).
- **`fix-manifest`** — surgical patch of **one** structural field on an
existing entry (`kernel_map`, `static_dims`, `shape_rules`,
`roofline.vars`, `dtype_combos`). Refuses to touch `signature`,
`status`, or new entries.
- Refines the trust model: `ops_manifest.yaml` now has **three writers
with disjoint slices**:
  - `add-manifest` → new entries
- `fix-manifest` → one structural field, never `signature.*` or `status`
  - `align-op` at `FLIP_STATUS` → `status` field only
- `docs/tileops-skills.md`: new manifest row in the at-a-glance matrix,
two new intent rows, two detail blocks, refined trust-model table.

## Motivation

While dry-running `align-op RMSNormFwdOp` to smoke-test the per-op
orchestrator, PRE_CHECK BLOCKED on missing `source.kernel_map`. An audit
shows **27 of 40 spec-only ops** in `ops_manifest.yaml` lack
`kernel_map` (across `normalization`, `moe`, `reduction`, `scan`,
`convolution` families). The repo had no in-tree skill to remediate this
surgically — `align-op` is forbidden from manifest writes outside
`FLIP_STATUS`, and `add-manifest` overshoots (it generates entries from
scratch).

`fix-manifest` closes the gap with the narrowest possible scope.
`add-manifest` ships in the same PR because the two skills are designed
as complementary paths and share the same trust-model row.

## Test plan

- [x] `pre-commit run --files .claude/skills/add-manifest/SKILL.md
.claude/skills/fix-manifest/SKILL.md docs/tileops-skills.md` passes
(mdformat, codespell, gitleaks).
- [x] Both `SKILL.md` files have valid frontmatter (`name`,
`description`).
- [x] `docs/tileops-skills.md` cross-links resolve
(`../.claude/skills/<name>/SKILL.md`).
- [ ] First end-to-end run of `fix-manifest RMSNormFwdOp
--field=kernel_map` will land in a follow-up PR (the smoke test that
motivated this work).

## Notes for reviewers

- `add-manifest` is moved verbatim from
`~/.claude/skills/add-manifest/SKILL.md`; no behavior change. Open to
renaming if the convention prefers a different verb.
- `fix-manifest`'s allowed-field list is intentionally narrow. Any
expansion (e.g., letting it touch `signature.*`) should be a separate
design decision — not a quiet broadening.
- The `manifest` row in the at-a-glance matrix has `—` under
Orchestrator on purpose: these are standalone editors that *precede*
op-layer work, not contain it.

---------

Co-authored-by: Ibuki 🍃 — a wind born from Claude Opus <Ibuki-wind@users.noreply.github.com>
