### PR TITLE
[Maintain][Manifest] add kernel_map for normalization + reduction + scan + convolution; fix fix-manifest skill

### DIFF
--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -5,17 +5,17 @@ description: Generate a spec-only ops_manifest.yaml entry for a legacy op from i
 
 ## Arguments
 
-| Argument    | Required | Description                                                                                          |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)                                |
-| `torch_api` | Yes      | PyTorch docs URL matching the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` |
+| Argument    | Required | Description                                                                                 |
+| ----------- | -------- | ------------------------------------------------------------------------------------------- |
+| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`).                      |
+| `torch_api` | Yes      | PyTorch docs URL matching `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$`. |
 
 ## Contract
 
 - **Output**: new entry in `ops_manifest.yaml` + follow-up issue + draft PR.
 - **MAY write**: `ops_manifest.yaml` (new entry only).
-- **MUST NOT write**: existing manifest entries, op / kernel / test / bench code.
-- **Termination**: draft PR created. BLOCKED on input or inference failure.
+- **MUST NOT write**: existing manifest entries; op / kernel / test / bench code.
+- **Termination**: draft PR created, or BLOCKED on input or inference failure.
 
 ## Workflow
 
@@ -40,7 +40,7 @@ stateDiagram-v2
 
 ### 1. VALIDATE_INPUT
 
-`torch_api` must match the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` (both host forms are canonical PyTorch docs). Else abort.
+`torch_api` must match `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$`. Else abort.
 
 ### 2. RESOLVE_SOURCES
 
@@ -53,17 +53,15 @@ Locate from `op_path`:
 | test   | `tests/ops/test_<name>.py`                            |
 | bench  | `benchmarks/ops/bench_<name>.py`                      |
 
-Set `family` by **copying from the manifest itself**, not by inferring from kernel paths. Kernels live under both directories (`tileops/kernels/norm/`, `tileops/kernels/moe/`, `tileops/kernels/attention/`, …) and top-level files (`tileops/kernels/convolution.py`, `tileops/kernels/elementwise.py`, …), and the manifest uses a closed family vocabulary that does not match either layout 1:1 (e.g., kernel file `convolution.py` → family `convolution`; kernel dir `norm/` → family `normalization`).
+Missing files: record absent, continue.
 
-Procedure:
+**Set `family` by copying from the manifest, not by inferring from kernel paths.** The manifest uses a closed family vocabulary that does not match the kernel layout 1:1 (e.g., `tileops/kernels/convolution.py` → family `convolution`; `tileops/kernels/norm/` → family `normalization`). Procedure:
 
-1. Find any existing entry in `tileops/ops_manifest.yaml` whose `source.kernel` equals the kernel path resolved above (or shares the parent dir / basename).
+1. Find any existing entry in `tileops/ops_manifest.yaml` whose `source.kernel` matches (same path, parent dir, or basename).
 1. Copy that entry's `family` value verbatim.
-1. If no neighbouring entry exists for that kernel, scan all `family` values currently used in the manifest and pick the one whose existing members most closely match the op's domain. If still ambiguous, STOP and ask the user.
+1. If nothing matches, scan all `family` values used in the manifest and pick the closest by domain. Still ambiguous → STOP, ask user.
 
 Never invent a new `family` value.
-
-Missing files: record absent, continue.
 
 ### 3. READ_PYTORCH
 
@@ -76,11 +74,11 @@ Missing files: record absent, continue.
 | non-Tensor         | `signature.params` (with `type`, `default`) |
 | return             | `signature.outputs`                         |
 
-Names must match PyTorch exactly. Include every PyTorch param even if the kernel ignores it. Exclude `float64`, `complex32/64/128` from dtypes.
+Names must match PyTorch exactly. Include every PyTorch param even if the kernel ignores it. Exclude `float64` and complex types (`complex32/64/128`) from dtypes.
 
 ### 4. SPLIT_VARIANTS
 
-Skip if no `Optional[Tensor]` input. Otherwise emit two entries (manifest keys are PascalCase per `docs/ops-design-reference.md`):
+Skip if no `Optional[Tensor]` input. Otherwise emit two entries (PascalCase per `docs/ops-design-reference.md`):
 
 | Entry   | Key                 | Inputs                | Extra                   |
 | ------- | ------------------- | --------------------- | ----------------------- |
@@ -93,17 +91,17 @@ Multiple `Optional[Tensor]`: follow decision tree in `docs/manifest.md`.
 
 ### 5. DRAFT_ENTRY
 
-Per entry, fill these fields:
+Per entry:
 
 - `family`: from RESOLVE_SOURCES.
-- `status`: always `spec-only`. **Never** set `implemented` from this skill — that is `align-op@FLIP_STATUS`'s exclusive write.
-- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set (PyTorch dtypes minus `float64` and complex types `complex32/64/128`) joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
+- `status`: always `spec-only`. **Never** set `implemented` (that is `align-op@FLIP_STATUS`).
+- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set (PyTorch dtypes minus `float64` and `complex32/64/128`) joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
 - `signature.outputs`: same shape as inputs. Use `same_as(<ref>)` where applicable.
 - `signature.params`: ordered dict, each `{type, default}`.
 - `signature.shape_rules`: Python expressions for derived dims and inter-tensor constraints.
 - `signature.dtype_combos`: only if supported set ⊂ Cartesian product; else omit.
-- `workloads`: `[]` (empty list — schema requires a list; human fills shapes in a follow-up).
-- `roofline`: required by L0 schema (cannot be `null` or empty). For well-known ops (conv / pool / matmul / norm / reduction): emit standard formulas. Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping. **If the formula is not derivable from PyTorch docs alone, BLOCKED with `evidence_needed: roofline.flops|bytes for <op>`** — do not guess.
+- `workloads`: `[]` (schema requires a list; human fills shapes in a follow-up).
+- `roofline`: required by L0 (cannot be `null` or empty). For well-known ops (conv / pool / matmul / norm / reduction): emit standard formulas. Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping. If the formula is not derivable from PyTorch docs alone → BLOCKED `evidence_needed: roofline.flops|bytes for <op>`. **Never guess.**
 - `source`: paths from RESOLVE_SOURCES; `bench_manifest_driven: false`.
 
 ### 6. VALIDATE
@@ -112,7 +110,7 @@ Per entry, fill these fields:
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes. Higher-level (L1–L4) failures are surfaced as gap items in the follow-up issue, not blocking.
+L0 must pass. On fail: edit entry, rerun. Higher-level (L1–L4) failures are surfaced as gap items in the follow-up issue, not blocking.
 
 ### 7. RUN_AUDIT
 
@@ -138,13 +136,13 @@ Record the issue URL.
 
 ### 9. CREATE_PR
 
-Invoke `foundry:creating-pull-request` (draft).
+Invoke `foundry:creating-pull-request` (draft):
 
-| Element | Value                                                                                                             |
-| ------- | ----------------------------------------------------------------------------------------------------------------- |
-| title   | `[Maintain][Manifest] Add <Op> manifest entries`                                                                  |
-| branch  | `maintain/manifest/<op-slug>-entries` (slug: kebab-case of `<Op>`)                                                |
-| body    | manifest entries added (name, family, status); validator results (levels passed); `Related: #<issue from step 8>` |
+| Element | Value                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] Add <Op> manifest entries`                                                  |
+| branch  | `maintain/manifest/<op-slug>-entries` (slug: kebab-case of `<Op>`)                                |
+| body    | manifest entries added (name, family, status); validator results; `Related: #<issue from step 8>` |
 
 Title and branch must match `.claude/conventions/types.sh`.
 
@@ -153,6 +151,6 @@ Title and branch must match `.claude/conventions/types.sh`.
 - Non-URL `torch_api` → abort.
 - Never edit op / kernel / test / bench files.
 - Never invent params outside PyTorch API.
-- `status` is always `spec-only`. Never set `implemented` (that is `align-op@FLIP_STATUS`).
+- `status` is always `spec-only`. Never set `implemented`.
 - Ambiguous PyTorch mapping → STOP, ask user.
 - Mapping clearly wrong → STOP, explain.

--- a/.claude/skills/add-manifest/SKILL.md
+++ b/.claude/skills/add-manifest/SKILL.md
@@ -5,17 +5,17 @@ description: Generate a spec-only ops_manifest.yaml entry for a legacy op from i
 
 ## Arguments
 
-| Argument    | Required | Description                                                                                 |
-| ----------- | -------- | ------------------------------------------------------------------------------------------- |
-| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`).                      |
-| `torch_api` | Yes      | PyTorch docs URL matching `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$`. |
+| Argument    | Required | Description                                                                                          |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `op_path`   | Yes      | Op file path relative to project root (e.g., `tileops/ops/conv1d.py`)                                |
+| `torch_api` | Yes      | PyTorch docs URL matching the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` |
 
 ## Contract
 
 - **Output**: new entry in `ops_manifest.yaml` + follow-up issue + draft PR.
 - **MAY write**: `ops_manifest.yaml` (new entry only).
-- **MUST NOT write**: existing manifest entries; op / kernel / test / bench code.
-- **Termination**: draft PR created, or BLOCKED on input or inference failure.
+- **MUST NOT write**: existing manifest entries, op / kernel / test / bench code.
+- **Termination**: draft PR created. BLOCKED on input or inference failure.
 
 ## Workflow
 
@@ -40,7 +40,7 @@ stateDiagram-v2
 
 ### 1. VALIDATE_INPUT
 
-`torch_api` must match `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$`. Else abort.
+`torch_api` must match the regex `^https://(docs\.)?pytorch\.org/docs/stable/generated/.*\.html$` (both host forms are canonical PyTorch docs). Else abort.
 
 ### 2. RESOLVE_SOURCES
 
@@ -53,15 +53,17 @@ Locate from `op_path`:
 | test   | `tests/ops/test_<name>.py`                            |
 | bench  | `benchmarks/ops/bench_<name>.py`                      |
 
-Missing files: record absent, continue.
+Set `family` by **copying from the manifest itself**, not by inferring from kernel paths. Kernels live under both directories (`tileops/kernels/norm/`, `tileops/kernels/moe/`, `tileops/kernels/attention/`, …) and top-level files (`tileops/kernels/convolution.py`, `tileops/kernels/elementwise.py`, …), and the manifest uses a closed family vocabulary that does not match either layout 1:1 (e.g., kernel file `convolution.py` → family `convolution`; kernel dir `norm/` → family `normalization`).
 
-**Set `family` by copying from the manifest, not by inferring from kernel paths.** The manifest uses a closed family vocabulary that does not match the kernel layout 1:1 (e.g., `tileops/kernels/convolution.py` → family `convolution`; `tileops/kernels/norm/` → family `normalization`). Procedure:
+Procedure:
 
-1. Find any existing entry in `tileops/ops_manifest.yaml` whose `source.kernel` matches (same path, parent dir, or basename).
+1. Find any existing entry in `tileops/ops_manifest.yaml` whose `source.kernel` equals the kernel path resolved above (or shares the parent dir / basename).
 1. Copy that entry's `family` value verbatim.
-1. If nothing matches, scan all `family` values used in the manifest and pick the closest by domain. Still ambiguous → STOP, ask user.
+1. If no neighbouring entry exists for that kernel, scan all `family` values currently used in the manifest and pick the one whose existing members most closely match the op's domain. If still ambiguous, STOP and ask the user.
 
 Never invent a new `family` value.
+
+Missing files: record absent, continue.
 
 ### 3. READ_PYTORCH
 
@@ -74,11 +76,11 @@ Never invent a new `family` value.
 | non-Tensor         | `signature.params` (with `type`, `default`) |
 | return             | `signature.outputs`                         |
 
-Names must match PyTorch exactly. Include every PyTorch param even if the kernel ignores it. Exclude `float64` and complex types (`complex32/64/128`) from dtypes.
+Names must match PyTorch exactly. Include every PyTorch param even if the kernel ignores it. Exclude `float64`, `complex32/64/128` from dtypes.
 
 ### 4. SPLIT_VARIANTS
 
-Skip if no `Optional[Tensor]` input. Otherwise emit two entries (PascalCase per `docs/ops-design-reference.md`):
+Skip if no `Optional[Tensor]` input. Otherwise emit two entries (manifest keys are PascalCase per `docs/ops-design-reference.md`):
 
 | Entry   | Key                 | Inputs                | Extra                   |
 | ------- | ------------------- | --------------------- | ----------------------- |
@@ -91,17 +93,17 @@ Multiple `Optional[Tensor]`: follow decision tree in `docs/manifest.md`.
 
 ### 5. DRAFT_ENTRY
 
-Per entry:
+Per entry, fill these fields:
 
 - `family`: from RESOLVE_SOURCES.
-- `status`: always `spec-only`. **Never** set `implemented` (that is `align-op@FLIP_STATUS`).
-- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set (PyTorch dtypes minus `float64` and `complex32/64/128`) joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
+- `status`: always `spec-only`. **Never** set `implemented` from this skill — that is `align-op@FLIP_STATUS`'s exclusive write.
+- `signature.inputs`: ordered dict, PyTorch positional order. Per input: `dtype` is the supported set (PyTorch dtypes minus `float64` and complex types `complex32/64/128`) joined with `|`; `shape` only if fixed rank; `layout` only if non-default; `constraints` if applicable.
 - `signature.outputs`: same shape as inputs. Use `same_as(<ref>)` where applicable.
 - `signature.params`: ordered dict, each `{type, default}`.
 - `signature.shape_rules`: Python expressions for derived dims and inter-tensor constraints.
 - `signature.dtype_combos`: only if supported set ⊂ Cartesian product; else omit.
-- `workloads`: `[]` (schema requires a list; human fills shapes in a follow-up).
-- `roofline`: required by L0 (cannot be `null` or empty). For well-known ops (conv / pool / matmul / norm / reduction): emit standard formulas. Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping. If the formula is not derivable from PyTorch docs alone → BLOCKED `evidence_needed: roofline.flops|bytes for <op>`. **Never guess.**
+- `workloads`: `[]` (empty list — schema requires a list; human fills shapes in a follow-up).
+- `roofline`: required by L0 schema (cannot be `null` or empty). For well-known ops (conv / pool / matmul / norm / reduction): emit standard formulas. Fixed-rank: shape names auto-bind, use `elem_bytes`. Arbitrary-rank: use `vars` mapping. **If the formula is not derivable from PyTorch docs alone, BLOCKED with `evidence_needed: roofline.flops|bytes for <op>`** — do not guess.
 - `source`: paths from RESOLVE_SOURCES; `bench_manifest_driven: false`.
 
 ### 6. VALIDATE
@@ -110,7 +112,7 @@ Per entry:
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-L0 must pass. On fail: edit entry, rerun. Higher-level (L1–L4) failures are surfaced as gap items in the follow-up issue, not blocking.
+L0 must pass. On fail: edit entry, rerun. Do not advance until L0 passes. Higher-level (L1–L4) failures are surfaced as gap items in the follow-up issue, not blocking.
 
 ### 7. RUN_AUDIT
 
@@ -136,13 +138,13 @@ Record the issue URL.
 
 ### 9. CREATE_PR
 
-Invoke `foundry:creating-pull-request` (draft):
+Invoke `foundry:creating-pull-request` (draft).
 
-| Element | Value                                                                                             |
-| ------- | ------------------------------------------------------------------------------------------------- |
-| title   | `[Maintain][Manifest] Add <Op> manifest entries`                                                  |
-| branch  | `maintain/manifest/<op-slug>-entries` (slug: kebab-case of `<Op>`)                                |
-| body    | manifest entries added (name, family, status); validator results; `Related: #<issue from step 8>` |
+| Element | Value                                                                                                             |
+| ------- | ----------------------------------------------------------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] Add <Op> manifest entries`                                                                  |
+| branch  | `maintain/manifest/<op-slug>-entries` (slug: kebab-case of `<Op>`)                                                |
+| body    | manifest entries added (name, family, status); validator results (levels passed); `Related: #<issue from step 8>` |
 
 Title and branch must match `.claude/conventions/types.sh`.
 
@@ -151,6 +153,6 @@ Title and branch must match `.claude/conventions/types.sh`.
 - Non-URL `torch_api` → abort.
 - Never edit op / kernel / test / bench files.
 - Never invent params outside PyTorch API.
-- `status` is always `spec-only`. Never set `implemented`.
+- `status` is always `spec-only`. Never set `implemented` (that is `align-op@FLIP_STATUS`).
 - Ambiguous PyTorch mapping → STOP, ask user.
 - Mapping clearly wrong → STOP, explain.

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -85,15 +85,15 @@ Build the patch payload from on-disk evidence. **Never guess** — if inference 
 
 ### 4. PATCH
 
-Before writing, capture the **before** validator baseline (used in step 5):
+First capture the validator baseline — **before any file mutation**:
 
 ```bash
 python scripts/validate_manifest.py --check-op <op_name> > /tmp/fix-manifest-<op>-before.txt
 ```
 
-Do NOT use `git stash` to derive the baseline — it is unsafe on a dirty working tree (would stash unrelated user changes and make the comparison ambiguous). Capture before mutating any file.
+Do NOT use `git stash` for this — unsafe on a dirty tree (pulls in unrelated user changes).
 
-Then insert each new key as a **sibling** of the existing keys in its parent block, at this exact position (verifiable from any sibling entry):
+Then insert each new key as a **sibling** of existing keys in its parent block, at this exact position (verifiable from any sibling entry):
 
 | Field           | YAML path                | Position                                                                                              |
 | --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
@@ -107,14 +107,14 @@ Preserve adjacent comments. Do not reorder unrelated keys. If the existing entry
 
 ### 5. VALIDATE
 
-Capture the **after** baseline and compare to the **before** baseline saved in PATCH:
+Capture after-baseline and diff:
 
 ```bash
 python scripts/validate_manifest.py --check-op <op_name> > /tmp/fix-manifest-<op>-after.txt
 diff /tmp/fix-manifest-<op>-before.txt /tmp/fix-manifest-<op>-after.txt
 ```
 
-Acceptable iff the set of error messages **after** is a subset of the set **before** (monotonic). New error → revert that op's patch and BLOCKED.
+Acceptable iff after's errors are a subset of before's (monotonic). Any new error → revert that op's patch and BLOCKED.
 
 For multi-op runs: per-op independent. One op's regression reverts only that op's patch; siblings proceed.
 

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -7,9 +7,11 @@ description: Patch one missing structural field (kernel_map, static_dims, shape_
 
 | Argument         | Required | Description                                                                                                             |
 | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `op_name`        | Yes      | Manifest key (e.g., `RMSNormFwdOp`)                                                                                     |
+| `op_name`        | Yes      | One manifest key, or a comma-separated list (e.g., `RMSNormFwdOp` or `SumFwdOp,MeanFwdOp,VarFwdOp`).                    |
 | `--field=<name>` | No       | One of `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`. Omit to auto-detect from validator. |
 | `--dry-run`      | No       | Print diff and exit; no write, no PR                                                                                    |
+
+When `op_name` is a list, the same `--field=<name>` is applied to every op (DIAGNOSE / INFER / PATCH / VALIDATE run per op). Mixing fields requires separate invocations. Use this when N sibling ops share the same gap (e.g., a family migration adding `kernel_map` to every spec-only entry); the resulting commit groups them together for a single review.
 
 ## Contract
 
@@ -18,8 +20,8 @@ description: Patch one missing structural field (kernel_map, static_dims, shape_
 - **MUST NOT** create new entries (use `add-manifest`).
 - **MUST NOT** flip `status` (that is `align-op@FLIP_STATUS`).
 - **MUST NOT** edit op / kernel / test / bench code.
-- **One field per invocation.** To fix two fields, run twice.
-- **Termination**: validator passes the level for the patched field, or BLOCKED.
+- **One field per invocation.** Multi-op is allowed (same field across many ops); multi-field is not.
+- **Termination**: every patched op's validator output is **monotonic** — no error category is added by the patch — or BLOCKED. Pre-existing errors on `spec-only` entries (the common case) are not blockers; that is precisely why those entries are `spec-only`.
 
 ## Workflow
 
@@ -67,62 +69,58 @@ Write `.foundry/plan/<op_name>/fix-diagnosis.json`: `{op_name, target_field, val
 
 Build the patch payload from on-disk evidence. Source per field:
 
-| Field           | Inference source                                                                                                                                                                                                                                                                                                                                                                 |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kernel_map`    | The op's runtime kernel dispatch. T2 (L1-direct): `default_kernel_map()` returns the dict verbatim. T1 (thin wrapper, see `docs/ops-design.md` §"Family-specific protocol variables"): combine the op's `_kernel_key` / `_kernel_cls` (or equivalent class-level protocol vars) with the family base's kernel-dispatch logic. Output: `{<key>: <fully-qualified Kernel class>}`. |
-| `static_dims`   | `signature.inputs` shape names that the op binds at construction time (each entry in the op's `__init__` kwarg block, excluding `dtype` / `kernel_map` / `tune` / `signature.params` entries — see `docs/ops-design.md` §"Step 3"). Cross-check with `roofline.vars` if present.                                                                                                 |
-| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (`ref_api`) is tiebreaker.                                                                                                                                                                                                                                                                                          |
-| `roofline.vars` | `static_dims` keys + any extra dims referenced in `roofline.flops` / `roofline.bytes`.                                                                                                                                                                                                                                                                                           |
-| `dtype_combos`  | `source.test`: dtypes the tests parametrize over.                                                                                                                                                                                                                                                                                                                                |
+| Field           | Inference source                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kernel_map`    | The op's runtime kernel dispatch, read directly from the op file. **T2 (L1-direct)**: read `default_kernel_map()` and copy its return dict verbatim. **T1 (thin wrapper, see `docs/ops-design.md` §"Family-specific protocol variables")**: T1 family bases (e.g., `RowNormOp`, `_ReduceOpBase`) typically expose `default_kernel_map()` returning `{self._kernel_key: self._kernel_cls}` — read the family base's `default_kernel_map()` and substitute the subclass's `_kernel_key` / `_kernel_cls`. Output format per `docs/manifest.md` § kernel_map: `{<dispatch_key>: <BareKernelClassName>}` — bare class name, NOT fully-qualified. |
+| `static_dims`   | `signature.inputs` shape names that the op binds at construction time (each entry in the op's `__init__` kwarg block, excluding `dtype` / `kernel_map` / `tune` / `signature.params` entries — see `docs/ops-design.md` §"Step 3"). Cross-check with `roofline.vars` if present.                                                                                                                                                                                                                                                                                                                                                            |
+| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (`ref_api`) is tiebreaker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `roofline.vars` | `static_dims` keys + any extra dims referenced in `roofline.flops` / `roofline.bytes`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `dtype_combos`  | `source.test`: dtypes the tests parametrize over.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
 If inference impossible, BLOCKED with an `evidence_needed` report listing what the human must decide. **Do not guess.**
 
 ### 4. PATCH
 
-Apply the payload to the entry. The target keys live at these exact YAML paths (see `docs/manifest.md`):
+Apply the payload to the entry. The target keys live at these exact YAML paths and exact relative positions (verifiable by inspecting any existing entry in `tileops/ops_manifest.yaml`):
 
-| Field           | YAML path                                                |
-| --------------- | -------------------------------------------------------- |
-| `kernel_map`    | `source.kernel_map` (sibling of `source.kernel`)         |
-| `static_dims`   | `signature.static_dims` (sibling of `signature.params`)  |
-| `shape_rules`   | `signature.shape_rules` (sibling of `signature.params`)  |
-| `dtype_combos`  | `signature.dtype_combos` (sibling of `signature.params`) |
-| `roofline.vars` | `roofline.vars` (sibling of `roofline.flops`)            |
+| Field           | YAML path                | Insert location                                                                                                                  |
+| --------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `kernel_map`    | `source.kernel_map`      | Between `source.kernel` and `source.op` (sibling of both)                                                                        |
+| `static_dims`   | `signature.static_dims`  | Between `signature.params` and `signature.shape_rules` (sibling of both); if `params` is absent, place after `signature.outputs` |
+| `shape_rules`   | `signature.shape_rules`  | After `signature.static_dims` (or after `signature.params` if no `static_dims`)                                                  |
+| `dtype_combos`  | `signature.dtype_combos` | After `signature.shape_rules`                                                                                                    |
+| `roofline.vars` | `roofline.vars`          | First key inside `roofline:` (before `flops` / `bytes` / `func`)                                                                 |
 
 Insertion rules:
 
 - Insert each new key as a **sibling** of the existing keys in its parent block (NOT nested under another sibling).
-- Order within parent block: per `docs/manifest.md` canonical order. When unsure, place the new key just before the first existing key (top of block).
+- Use the canonical relative position above. If the existing entry is unusually formatted, fall back to the order documented in `docs/manifest.md`.
 - Preserve adjacent comments.
 - Do not reorder unrelated keys.
 
 ### 5. VALIDATE
 
+For each patched op, capture validator output **before** the patch (from `git stash`) and **after** the patch:
+
 ```bash
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-Required passing level:
+The patch is acceptable iff the set of error messages **after** is a (non-strict) subset of the set **before** — i.e., the patch is **monotonic**. If any new error category appears, revert the patch for that op and BLOCKED.
 
-| Patched field   | Level |
-| --------------- | ----- |
-| `kernel_map`    | L0    |
-| `static_dims`   | L1    |
-| `shape_rules`   | L2    |
-| `roofline.vars` | L0    |
-| `dtype_combos`  | L3    |
+Why monotonic-only, not "validator clean": `spec-only` entries typically already have unrelated errors (the reason they are `spec-only` — e.g., `[signature]` mismatches between manifest and code). Those are out of scope for `fix-manifest`; `align-op` will close them later. Requiring a clean validator run would block this skill on every spec-only op, which is exactly the case it most often runs against.
 
-If validator emits any error not present before the patch, revert the patch and BLOCKED. Patch must be monotonic.
+For multi-op invocations: run the monotonic check per op independently. A single op's regression must not block patches on its siblings — revert that op's patch only.
 
 ### 6. CREATE_PR
 
 If `--dry-run`, print the diff and exit 0. Otherwise invoke `foundry:creating-pull-request`:
 
-| Element | Value                                                                                                         |
-| ------- | ------------------------------------------------------------------------------------------------------------- |
-| title   | `[Maintain][Manifest] fix <field> for <op_name>` (use `[Fix][Manifest]` if validator was actively rejecting)  |
-| branch  | `maintain/manifest/fix-<op-slug>-<field>`                                                                     |
-| body    | which field, evidence used to infer; validator output before vs. after; explicit list of what was NOT touched |
+| Element | Single-op value                                                                                               | Multi-op value                                                             |
+| ------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] fix <field> for <op_name>` (use `[Fix][Manifest]` if validator was actively rejecting)  | `[Maintain][Manifest] add <field> for <family> spec-only ops`              |
+| branch  | `maintain/manifest/fix-<op-slug>-<field>`                                                                     | `maintain/manifest/fix-<family>-<field>`                                   |
+| body    | which field, evidence used to infer; validator output before vs. after; explicit list of what was NOT touched | per-op evidence table; per-op monotonic-check result; explicit scope guard |
 
 ## Guardrails
 

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -85,7 +85,15 @@ Build the patch payload from on-disk evidence. **Never guess** — if inference 
 
 ### 4. PATCH
 
-Insert each new key as a **sibling** of the existing keys in its parent block, at this exact position (verifiable from any sibling entry):
+Before writing, capture the **before** validator baseline (used in step 5):
+
+```bash
+python scripts/validate_manifest.py --check-op <op_name> > /tmp/fix-manifest-<op>-before.txt
+```
+
+Do NOT use `git stash` to derive the baseline — it is unsafe on a dirty working tree (would stash unrelated user changes and make the comparison ambiguous). Capture before mutating any file.
+
+Then insert each new key as a **sibling** of the existing keys in its parent block, at this exact position (verifiable from any sibling entry):
 
 | Field           | YAML path                | Position                                                                                              |
 | --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
@@ -99,10 +107,11 @@ Preserve adjacent comments. Do not reorder unrelated keys. If the existing entry
 
 ### 5. VALIDATE
 
-For each patched op, capture validator output **before** (from `git stash`) and **after**:
+Capture the **after** baseline and compare to the **before** baseline saved in PATCH:
 
 ```bash
-python scripts/validate_manifest.py --check-op <op_name>
+python scripts/validate_manifest.py --check-op <op_name> > /tmp/fix-manifest-<op>-after.txt
+diff /tmp/fix-manifest-<op>-before.txt /tmp/fix-manifest-<op>-after.txt
 ```
 
 Acceptable iff the set of error messages **after** is a subset of the set **before** (monotonic). New error → revert that op's patch and BLOCKED.

--- a/.claude/skills/fix-manifest/SKILL.md
+++ b/.claude/skills/fix-manifest/SKILL.md
@@ -5,23 +5,23 @@ description: Patch one missing structural field (kernel_map, static_dims, shape_
 
 ## Arguments
 
-| Argument         | Required | Description                                                                                                             |
-| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `op_name`        | Yes      | One manifest key, or a comma-separated list (e.g., `RMSNormFwdOp` or `SumFwdOp,MeanFwdOp,VarFwdOp`).                    |
-| `--field=<name>` | No       | One of `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`. Omit to auto-detect from validator. |
-| `--dry-run`      | No       | Print diff and exit; no write, no PR                                                                                    |
+| Argument         | Required | Description                                                                                              |
+| ---------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `op_name`        | Yes      | One manifest key, or comma-separated list (e.g., `RMSNormFwdOp` or `SumFwdOp,MeanFwdOp,VarFwdOp`).       |
+| `--field=<name>` | No       | One of `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`. Omit to auto-detect. |
+| `--dry-run`      | No       | Print diff and exit; no write, no PR.                                                                    |
 
-When `op_name` is a list, the same `--field=<name>` is applied to every op (DIAGNOSE / INFER / PATCH / VALIDATE run per op). Mixing fields requires separate invocations. Use this when N sibling ops share the same gap (e.g., a family migration adding `kernel_map` to every spec-only entry); the resulting commit groups them together for a single review.
+Multi-op: same `--field` applied to every op in the list. Multi-field is not supported — run again.
 
 ## Contract
 
 - **MAY write** in `ops_manifest.yaml`: `kernel_map`, `static_dims`, `shape_rules`, `roofline.vars`, `dtype_combos`.
-- **MUST NOT write**: `signature.{inputs,outputs,params}`, `status`, `family`, `ref_api`, `workloads`, `roofline.flops|bytes|func`, `source.{kernel,op,test,bench,bench_manifest_driven}`. (Note: `signature.static_dims`, `signature.shape_rules`, `signature.dtype_combos`, and `source.kernel_map` ARE in the allowed write set above.)
+- **MUST NOT write**: `signature.{inputs,outputs,params}`, `status`, `family`, `ref_api`, `workloads`, `roofline.{flops,bytes,func}`, `source.{kernel,op,test,bench,bench_manifest_driven}`. (`signature.static_dims`, `signature.shape_rules`, `signature.dtype_combos`, `source.kernel_map` ARE allowed — they are the patch targets above.)
 - **MUST NOT** create new entries (use `add-manifest`).
 - **MUST NOT** flip `status` (that is `align-op@FLIP_STATUS`).
 - **MUST NOT** edit op / kernel / test / bench code.
-- **One field per invocation.** Multi-op is allowed (same field across many ops); multi-field is not.
-- **Termination**: every patched op's validator output is **monotonic** — no error category is added by the patch — or BLOCKED. Pre-existing errors on `spec-only` entries (the common case) are not blockers; that is precisely why those entries are `spec-only`.
+- **One field per invocation.**
+- **Termination**: every patched op's validator output is **monotonic** (no new error category vs. before the patch), or BLOCKED.
 
 ## Workflow
 
@@ -45,87 +45,86 @@ stateDiagram-v2
 
 ### 1. PRE_CHECK
 
-Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED with message `op not in manifest; use add-manifest for greenfield`.
+Resolve `op_name` in `tileops/ops_manifest.yaml`. Missing → BLOCKED: `op not in manifest; use add-manifest for greenfield`.
 
 ### 2. DIAGNOSE
 
-Decide the target field. The validator does NOT flag every missing allowed field for spec-only entries (e.g., `source.kernel_map` is only warned when `status == implemented`). When `--field=` is omitted, run two checks in strict order — Check A first; only fall through to Check B if A finds nothing.
+When `--field=` is provided: must be in the allowed list; else BLOCKED. Skip both checks below.
 
-**Check A — `kernel_map` presence (single field only).** If `source.kernel_map` is missing or empty → target = `kernel_map`, jump to INFER. Otherwise fall through to Check B.
+When `--field=` is omitted, run two checks in strict order:
 
-Do NOT extend Check A to `static_dims`, `shape_rules`, `dtype_combos`, or `roofline.vars`. `docs/manifest.md` R7 and R20 explicitly allow `static_dims` to be absent on fixed-rank ops; the other three fields are conditionally required. Patching them on absence alone would manufacture changes for valid entries (e.g., reduction-style ops).
+**Check A — `kernel_map` presence.** If `source.kernel_map` is missing or empty → target = `kernel_map`, jump to INFER.
+
+The validator only warns on missing `kernel_map` when `status == implemented`, so spec-only entries need this explicit check. Do NOT extend it to other fields — `static_dims` is legitimately optional on fixed-rank ops (`docs/manifest.md` R7, R20), and the rest are conditionally required; absence-only patching would manufacture changes for valid entries.
 
 **Check B — validator output.** Run `python scripts/validate_manifest.py --check-op <op_name>`. Parse the first error:
 
-- Field in the allowed list above → target = that field, jump to INFER.
-- Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Message must name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
+- Field in allowed list → target = that field, jump to INFER.
+- Field forbidden (e.g., `signature.params.dim`) → BLOCKED. Name the field, why it is out of scope, and the owning workflow (`add-manifest` for new entries; manifest-review issue for `signature.{inputs,outputs,params}`).
 - No errors and Check A also empty → no-op; print `nothing to fix` and exit 0.
-
-When `--field=` IS provided: must be in the allowed list; else BLOCKED. Skip both checks.
 
 Write `.foundry/plan/<op_name>/fix-diagnosis.json`: `{op_name, target_field, validator_excerpt, action}`.
 
 ### 3. INFER
 
-Build the patch payload from on-disk evidence. Source per field:
+Build the patch payload from on-disk evidence. **Never guess** — if inference is impossible, BLOCKED with `evidence_needed: <what>`.
 
-| Field           | Inference source                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kernel_map`    | The op's runtime kernel dispatch, read directly from the op file. **T2 (L1-direct)**: read `default_kernel_map()` and copy its return dict verbatim. **T1 (thin wrapper, see `docs/ops-design.md` §"Family-specific protocol variables")**: T1 family bases (e.g., `RowNormOp`, `_ReduceOpBase`) typically expose `default_kernel_map()` returning `{self._kernel_key: self._kernel_cls}` — read the family base's `default_kernel_map()` and substitute the subclass's `_kernel_key` / `_kernel_cls`. Output format per `docs/manifest.md` § kernel_map: `{<dispatch_key>: <BareKernelClassName>}` — bare class name, NOT fully-qualified. |
-| `static_dims`   | `signature.inputs` shape names that the op binds at construction time (each entry in the op's `__init__` kwarg block, excluding `dtype` / `kernel_map` / `tune` / `signature.params` entries — see `docs/ops-design.md` §"Step 3"). Cross-check with `roofline.vars` if present.                                                                                                                                                                                                                                                                                                                                                            |
-| `shape_rules`   | `signature.inputs/outputs` shape relationships. PyTorch docs (`ref_api`) is tiebreaker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `roofline.vars` | `static_dims` keys + any extra dims referenced in `roofline.flops` / `roofline.bytes`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `dtype_combos`  | `source.test`: dtypes the tests parametrize over.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+**`kernel_map`** — read the op file:
 
-If inference impossible, BLOCKED with an `evidence_needed` report listing what the human must decide. **Do not guess.**
+- T2 (L1-direct): copy `default_kernel_map()`'s return dict verbatim.
+- T1 (thin wrapper, see `docs/ops-design.md` § "Family-specific protocol variables"): family bases (`RowNormOp`, `_ReduceOpBase`, …) expose `default_kernel_map()` returning `{self._kernel_key: self._kernel_cls}`. Read it; substitute the subclass's `_kernel_key` / `_kernel_cls`.
+- Output format per `docs/manifest.md` § kernel_map: `{<dispatch_key>: <BareKernelClassName>}` — bare class name, NOT fully-qualified.
+
+**`static_dims`** — `signature.inputs` shape names that the op binds at construction time (each entry in the op's `__init__` kwarg block, excluding `dtype` / `kernel_map` / `tune` / `signature.params` entries — see `docs/ops-design.md` § "Step 3"). Cross-check with `roofline.vars` if present.
+
+**`shape_rules`** — `signature.inputs/outputs` shape relationships. PyTorch docs (`ref_api`) is tiebreaker.
+
+**`roofline.vars`** — `static_dims` keys + any extra dims referenced in `roofline.flops` / `roofline.bytes`.
+
+**`dtype_combos`** — dtypes the tests in `source.test` parametrize over.
 
 ### 4. PATCH
 
-Apply the payload to the entry. The target keys live at these exact YAML paths and exact relative positions (verifiable by inspecting any existing entry in `tileops/ops_manifest.yaml`):
+Insert each new key as a **sibling** of the existing keys in its parent block, at this exact position (verifiable from any sibling entry):
 
-| Field           | YAML path                | Insert location                                                                                                                  |
-| --------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `kernel_map`    | `source.kernel_map`      | Between `source.kernel` and `source.op` (sibling of both)                                                                        |
-| `static_dims`   | `signature.static_dims`  | Between `signature.params` and `signature.shape_rules` (sibling of both); if `params` is absent, place after `signature.outputs` |
-| `shape_rules`   | `signature.shape_rules`  | After `signature.static_dims` (or after `signature.params` if no `static_dims`)                                                  |
-| `dtype_combos`  | `signature.dtype_combos` | After `signature.shape_rules`                                                                                                    |
-| `roofline.vars` | `roofline.vars`          | First key inside `roofline:` (before `flops` / `bytes` / `func`)                                                                 |
+| Field           | YAML path                | Position                                                                                              |
+| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `kernel_map`    | `source.kernel_map`      | between `source.kernel` and `source.op`                                                               |
+| `static_dims`   | `signature.static_dims`  | between `signature.params` and `signature.shape_rules`; if `params` absent, after `signature.outputs` |
+| `shape_rules`   | `signature.shape_rules`  | after `signature.static_dims` (or after `signature.params` if no `static_dims`)                       |
+| `dtype_combos`  | `signature.dtype_combos` | after `signature.shape_rules`                                                                         |
+| `roofline.vars` | `roofline.vars`          | first key inside `roofline:` (before `flops`/`bytes`/`func`)                                          |
 
-Insertion rules:
-
-- Insert each new key as a **sibling** of the existing keys in its parent block (NOT nested under another sibling).
-- Use the canonical relative position above. If the existing entry is unusually formatted, fall back to the order documented in `docs/manifest.md`.
-- Preserve adjacent comments.
-- Do not reorder unrelated keys.
+Preserve adjacent comments. Do not reorder unrelated keys. If the existing entry deviates from the canonical layout, fall back to the order in `docs/manifest.md`.
 
 ### 5. VALIDATE
 
-For each patched op, capture validator output **before** the patch (from `git stash`) and **after** the patch:
+For each patched op, capture validator output **before** (from `git stash`) and **after**:
 
 ```bash
 python scripts/validate_manifest.py --check-op <op_name>
 ```
 
-The patch is acceptable iff the set of error messages **after** is a (non-strict) subset of the set **before** — i.e., the patch is **monotonic**. If any new error category appears, revert the patch for that op and BLOCKED.
+Acceptable iff the set of error messages **after** is a subset of the set **before** (monotonic). New error → revert that op's patch and BLOCKED.
 
-Why monotonic-only, not "validator clean": `spec-only` entries typically already have unrelated errors (the reason they are `spec-only` — e.g., `[signature]` mismatches between manifest and code). Those are out of scope for `fix-manifest`; `align-op` will close them later. Requiring a clean validator run would block this skill on every spec-only op, which is exactly the case it most often runs against.
+For multi-op runs: per-op independent. One op's regression reverts only that op's patch; siblings proceed.
 
-For multi-op invocations: run the monotonic check per op independently. A single op's regression must not block patches on its siblings — revert that op's patch only.
+Spec-only entries usually carry pre-existing errors (the reason they are spec-only — typically `[signature]` mismatches). Those are out of scope here — `align-op` closes them later.
 
 ### 6. CREATE_PR
 
-If `--dry-run`, print the diff and exit 0. Otherwise invoke `foundry:creating-pull-request`:
+If `--dry-run`, print diff and exit 0. Otherwise invoke `foundry:creating-pull-request`:
 
-| Element | Single-op value                                                                                               | Multi-op value                                                             |
-| ------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| title   | `[Maintain][Manifest] fix <field> for <op_name>` (use `[Fix][Manifest]` if validator was actively rejecting)  | `[Maintain][Manifest] add <field> for <family> spec-only ops`              |
-| branch  | `maintain/manifest/fix-<op-slug>-<field>`                                                                     | `maintain/manifest/fix-<family>-<field>`                                   |
-| body    | which field, evidence used to infer; validator output before vs. after; explicit list of what was NOT touched | per-op evidence table; per-op monotonic-check result; explicit scope guard |
+| Element | Single-op                                                                                                    | Multi-op                                                          |
+| ------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| title   | `[Maintain][Manifest] fix <field> for <op_name>` (use `[Fix][Manifest]` if validator was actively rejecting) | `[Maintain][Manifest] add <field> for <family> spec-only ops`     |
+| branch  | `maintain/manifest/fix-<op-slug>-<field>`                                                                    | `maintain/manifest/fix-<family>-<field>`                          |
+| body    | which field, evidence, validator before/after, scope guard                                                   | per-op evidence table; per-op monotonic-check result; scope guard |
 
 ## Guardrails
 
 - One field per invocation.
-- Never widen scope to cover a forbidden field — emit BLOCKED instead.
-- Never invent values. All payload data must trace to a file or to `ref_api`.
+- Never widen scope to a forbidden field — emit BLOCKED.
+- Never invent values; payload must trace to a file or to `ref_api`.
 - Never flip `status`.
 - Validator output ambiguous → STOP, ask user.

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2308,6 +2308,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/cumulative.py
+      kernel_map:
+        cumulative_fwd: CumulativeKernel
       op: tileops/ops/reduction/cumsum.py
       test: tests/ops/test_cumulative.py
       bench: benchmarks/ops/bench_cumulative.py
@@ -2347,6 +2349,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/cumulative.py
+      kernel_map:
+        cumulative_fwd: CumulativeKernel
       op: tileops/ops/reduction/cumprod.py
       test: tests/ops/test_cumulative.py
       bench: benchmarks/ops/bench_cumulative.py
@@ -2410,6 +2414,8 @@ ops:
 
     source:
       kernel: tileops/kernels/convolution.py
+      kernel_map:
+        conv1d_kernel: Conv1dKernel
       op: tileops/ops/convolution.py
       test: tests/ops/test_convolution.py
       bench: benchmarks/ops/bench_convolution.py
@@ -2459,6 +2465,8 @@ ops:
 
     source:
       kernel: tileops/kernels/convolution.py
+      kernel_map:
+        conv1d_kernel: Conv1dKernel
       op: tileops/ops/convolution.py
       test: tests/ops/test_convolution.py
       bench: benchmarks/ops/bench_convolution.py

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -487,6 +487,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/group_norm.py
+      kernel_map:
+        group_norm: GroupNormKernel
       op: tileops/ops/norm/group_norm.py
       test: tests/ops/test_group_norm.py
       bench: benchmarks/ops/bench_group_norm.py
@@ -1598,6 +1600,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1639,6 +1643,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1680,6 +1686,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1721,6 +1729,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1760,6 +1770,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1806,6 +1818,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1848,6 +1862,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -1893,6 +1909,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/reduce.py
+      kernel_map:
+        reduce: ReduceKernel
       op: tileops/ops/reduction/reduce.py
       test: tests/ops/test_reduce.py
       bench: benchmarks/ops/bench_reduce.py
@@ -2027,6 +2045,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/logical_reduce.py
+      kernel_map:
+        logical_reduce: LogicalReduceKernel
       op: tileops/ops/reduction/all_op.py
       test: tests/ops/test_logical_reduce.py
       bench: benchmarks/ops/bench_logical_reduce.py
@@ -2067,6 +2087,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/logical_reduce.py
+      kernel_map:
+        logical_reduce: LogicalReduceKernel
       op: tileops/ops/reduction/any_op.py
       test: tests/ops/test_logical_reduce.py
       bench: benchmarks/ops/bench_logical_reduce.py
@@ -2107,6 +2129,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/logical_reduce.py
+      kernel_map:
+        logical_reduce: LogicalReduceKernel
       op: tileops/ops/reduction/count_nonzero.py
       test: tests/ops/test_logical_reduce.py
       bench: benchmarks/ops/bench_logical_reduce.py
@@ -2152,6 +2176,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/vector_norm.py
+      kernel_map:
+        vector_norm: VectorNormKernel
       op: tileops/ops/reduction/l1_norm.py
       test: tests/ops/test_vector_norm.py
       bench: benchmarks/ops/bench_vector_norm.py
@@ -2193,6 +2219,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/vector_norm.py
+      kernel_map:
+        vector_norm: VectorNormKernel
       op: tileops/ops/reduction/l2_norm.py
       test: tests/ops/test_vector_norm.py
       bench: benchmarks/ops/bench_vector_norm.py
@@ -2234,6 +2262,8 @@ ops:
 
     source:
       kernel: tileops/kernels/reduction/vector_norm.py
+      kernel_map:
+        vector_norm: VectorNormKernel
       op: tileops/ops/reduction/inf_norm.py
       test: tests/ops/test_vector_norm.py
       bench: benchmarks/ops/bench_vector_norm.py

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -82,6 +82,8 @@ ops:
 
     source:
       kernel: tileops/kernels/norm/rms_norm.py
+      kernel_map:
+        rms_norm: RMSNormKernel
       op: tileops/ops/norm/rms_norm.py
       test: tests/ops/test_rms_norm.py
       bench: benchmarks/ops/bench_rms_norm.py


### PR DESCRIPTION
## What this PR does

1. **Manifest data** — adds `source.kernel_map` to **20 spec-only ops** in 4 families (`normalization`, `reduction`, `scan`, `convolution`). Format: bare kernel class names per `docs/manifest.md` § kernel_map; inserted between `source.kernel` and `source.op`.
2. **`fix-manifest` skill fixes** — 5 contract bugs corrected; VALIDATE/PATCH baseline capture switched to redirected output files (no `git stash`).
3. **`fix-manifest` + `add-manifest` editorial pass** — prose tightened for agent-execution clarity. Rules unchanged.

## Manifest patches

| Family | Ops | kernel_map |
|---|---|---|
| normalization | `RMSNormFwdOp` | `{rms_norm: RMSNormKernel}` |
| normalization | `GroupNormFwdOp` | `{group_norm: GroupNormKernel}` |
| reduction | `SumFwdOp`, `MeanFwdOp`, `AmaxFwdOp`, `AminFwdOp`, `ProdFwdOp`, `VarFwdOp`, `StdFwdOp`, `VarMeanFwdOp` | `{reduce: ReduceKernel}` |
| reduction | `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp` | `{logical_reduce: LogicalReduceKernel}` |
| reduction | `L1NormFwdOp`, `L2NormFwdOp`, `InfNormFwdOp` | `{vector_norm: VectorNormKernel}` |
| scan | `CumsumFwdOp`, `CumprodFwdOp` | `{cumulative_fwd: CumulativeKernel}` |
| convolution | `Conv1dFwdOp`, `Conv1dBiasFwdOp` | `{conv1d_kernel: Conv1dKernel}` |

## `fix-manifest` skill — bug fixes

1. INFER `kernel_map`: bare class name (was "fully-qualified").
2. PATCH placement: exact relative position per field (was "top of block").
3. VALIDATE: monotonic-only (was "Required passing level" + "monotonic" tension).
4. INFER T1 path: read family base's `default_kernel_map()` directly.
5. New batch mode: `op_name` accepts comma-separated list.
6. VALIDATE/PATCH: capture baseline via `>` redirect, not `git stash`.

## Scope guard

Untouched: `signature.{inputs, outputs, params}`, `status`, `family`, `ref_api`, `workloads`, `roofline.*`, `source.{kernel, op, test, bench}`, op / kernel / test / bench code. `moe` family deferred.

## Test plan

- [x] `pre-commit` passes.
- [x] Validator output is monotonic on each of the 20 patched ops.
- [x] CI green.