### PR TITLE
[CI] Fall back when data7 cache root is unavailable

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -449,8 +449,30 @@ jobs:
           VENV_PREFIX="tileops_ci_venv"
           VENV_DIR="${VENV_PREFIX}_${HASH_INPUT}"
           TRUSTED_VENV_PATH="${{ runner.tool_cache }}/${VENV_DIR}"
-          TRUSTED_CACHE_ROOT="/data7/shared/ci-cache"
+          TRUSTED_CACHE_ROOT_CANDIDATE="/data7/shared/ci-cache"
+          FALLBACK_TRUSTED_CACHE_ROOT="/home/ci-runner/.cache/tileops-ci"
           FORK_CAN_COPY_TRUSTED_VENV="false"
+
+          select_trusted_cache_root() {
+            local candidate="$1"
+            local fallback="$2"
+
+            if [[ -d "${candidate}" && -w "${candidate}" ]]; then
+              printf '%s\n' "${candidate}"
+              return
+            fi
+
+            if mkdir -p "${candidate}" 2>/dev/null && [[ -d "${candidate}" && -w "${candidate}" ]]; then
+              printf '%s\n' "${candidate}"
+              return
+            fi
+
+            echo "::warning::${candidate} is unavailable or not writable; using ${fallback} for this run." >&2
+            mkdir -p "${fallback}"
+            printf '%s\n' "${fallback}"
+          }
+
+          TRUSTED_CACHE_ROOT="$(select_trusted_cache_root "${TRUSTED_CACHE_ROOT_CANDIDATE}" "${FALLBACK_TRUSTED_CACHE_ROOT}")"
 
           if [[ "$IS_FORK" == "true" ]]; then
             RUNTIME_ROOT="${RUNNER_TEMP}/gpu-smoke-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/tests/test_gpu_smoke_policy.py
+++ b/tests/test_gpu_smoke_policy.py
@@ -153,6 +153,28 @@ def test_fork_divergent_pyproject_forces_fresh_install() -> None:
     )
 
 
+def test_data7_cache_root_has_local_fallback() -> None:
+    """The shared data7 cache is preferred, but some runner containers may
+    start without /data7 mounted or writable. Resolve runtime state must not
+    blindly mkdir /data7 as the unprivileged ci-runner user; it should probe
+    writability and fall back to a local cache root when data7 is unavailable.
+    """
+    wf = _load(GPU_SMOKE)
+    steps = wf["jobs"]["gpu-smoke"]["steps"]
+    resolve_step = next(
+        (s for s in steps if s.get("name") == "Resolve runtime state"), None
+    )
+    assert resolve_step is not None, "Resolve runtime state step must exist"
+    script = resolve_step["run"]
+
+    assert 'TRUSTED_CACHE_ROOT_CANDIDATE="/data7/shared/ci-cache"' in script
+    assert 'FALLBACK_TRUSTED_CACHE_ROOT="/home/ci-runner/.cache/tileops-ci"' in script
+    assert "select_trusted_cache_root()" in script
+    assert 'TRUSTED_CACHE_ROOT="$(select_trusted_cache_root' in script
+    assert 'echo "::warning::${candidate} is unavailable or not writable' in script
+    assert 'TRUSTED_CACHE_ROOT="/data7/shared/ci-cache"' not in script
+
+
 def test_reclaim_action_emits_opt_out_log_line() -> None:
     """When the opt-out is active, operators need a grep-able log line to
     confirm the destructive path was skipped. The AC explicitly names this


### PR DESCRIPTION
## Summary

- Keep `/data7/shared/ci-cache` as the preferred GPU smoke trusted cache root.
- Probe whether that root can actually be created/written before using it.
- Fall back to `/home/ci-runner/.cache/tileops-ci` when `/data7` is absent or not writable, so the job does not fail during `Resolve runtime state`.
- Add a structural test to keep the fallback guard in place.

Fixes #1057.
Follow-up to #1052 / #1053.

## Validation

```text
python -m pytest -q tests/test_gpu_smoke_policy.py tests/test_reclaim_action.py tests/test_ci_venv_hash.py
33 passed in 1.90s
```

```text
python - <<'PY'
from pathlib import Path
import yaml
for path in ['.github/workflows/gpu-smoke.yml', '.github/actions/reclaim-runner-disk/action.yml']:
    yaml.safe_load(Path(path).read_text())
    print('ok', path)
PY
```

```text
git diff --check
```
