### PR TITLE
[Refactor][Norm] migrate RowNormOp + RMSNormFwdOp to canonical static_dims pattern

### DIFF
--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -59,7 +59,7 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = _RMSNormTestBaseline(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = RMSNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = RMSNormFwdOp(N=n, dtype=dtype, tune=tune)
     bm = RMSNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -38,7 +38,7 @@ class RMSNormFixture(FixtureBase):
 @RMSNormFixture
 def test_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = RMSNormTest(m, n, dtype)
-    op = RMSNormFwdOp(M=m, N=n, dtype=dtype)
+    op = RMSNormFwdOp(N=n, dtype=dtype)
     atol = 1e-2 if dtype == torch.float16 else 1.6e-2
     rtol = atol
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
@@ -60,7 +60,7 @@ def test_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     x = x_full[:, :n]  # non-contiguous slice
     weight = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = RMSNormFwdOp(M=m, N=n, dtype=dtype)
+    op = RMSNormFwdOp(N=n, dtype=dtype)
 
     # Reference on contiguous copy
     eps = 1e-6
@@ -90,8 +90,7 @@ def test_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> N
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = RMSNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = RMSNormFwdOp(N=hidden, dtype=dtype)
 
     # Reference
     eps = 1e-6

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -104,5 +104,42 @@ def test_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> N
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
 
 
+class RMSNormDimAxis1Fixture(FixtureBase):
+    PARAMS = [
+        ("batch, hidden, seq, dtype", [
+            pytest.param(2, 4096, 512, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(2, 4096, 512, torch.bfloat16, marks=pytest.mark.smoke),
+        ]),
+    ]
+
+
+@RMSNormDimAxis1Fixture
+def test_rms_norm_dim_axis1(
+    batch: int, hidden: int, seq: int, dtype: torch.dtype
+) -> None:
+    """Test reducing along dim=1 (not -1) with a 3D tensor.
+
+    Exercises the movedim choreography in RowNormOp._flatten_to_2d /
+    _trim_and_unflatten — the new code path enabled by this PR. Without
+    this test, the dim != -1 branch could regress while the suite passes.
+    """
+    x = torch.randn(batch, hidden, seq, dtype=dtype, device="cuda")
+    weight = torch.randn(hidden, dtype=dtype, device="cuda")
+
+    op = RMSNormFwdOp(N=hidden, dtype=dtype, dim=1)
+
+    eps = 1e-6
+    x_f32 = x.float()
+    rms = torch.sqrt(x_f32.pow(2).mean(dim=1, keepdim=True) + eps)
+    # Apply 1-D weight to dim=1 via reshape for broadcasting.
+    weight_b = weight.float().view(1, hidden, 1)
+    y_ref = ((x_f32 / rms) * weight_b).to(dtype)
+
+    y = op(x, weight)
+    atol = 1e-2 if dtype == torch.float16 else 1.6e-2
+    assert torch.allclose(y, y_ref, atol=atol, rtol=atol), \
+        f"dim=1 test failed, max err: {(y - y_ref).abs().max()}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tileops/ops/norm/norm_base.py
+++ b/tileops/ops/norm/norm_base.py
@@ -1,13 +1,18 @@
 """RowNormOp base class for row-wise normalization operators.
 
-Encapsulates the shared validate -> reshape -> pad -> kernel -> trim -> reshape
-pattern used by RMSNormFwdOp, LayerNormFwdOp, and similar dim=-1 normalization ops.
+Implements the canonical static_dims pattern from docs/ops-design.md: ctor
+binds only what the manifest declares as `static_dims` (`N`) plus
+signature.params (`dim`, `eps`); `M` (the leading-dims product) is derived
+at forward time and used to lazily build / cache kernels keyed by `M`.
 
-BatchNorm uses spatial reduction (not dim=-1), so it does NOT inherit from this.
+Forward pipeline: validate -> movedim(dim → -1) -> reshape (M, N) -> pad ->
+kernel -> trim -> reshape -> movedim(-1 → dim).
+
+BatchNorm uses spatial reduction (not a single axis), so it does NOT inherit
+from this.
 """
 
-from abc import abstractmethod
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -22,22 +27,19 @@ ALIGNMENT = 256
 
 
 class RowNormOp(Op):
-    """Abstract base class for row-wise (dim=-1) normalization operators.
-
-    Handles shared constructor logic (M, N, dtype, eps, alignment, kernel
-    dispatch) and provides helpers for the validate/reshape/pad/trim/reshape
-    pipeline.  Subclasses implement ``forward()`` themselves (preserving their
-    own positional-arg signatures) and call the helpers.
+    """Abstract base class for row-wise normalization operators with a
+    user-selectable reduction axis.
 
     Subclasses must override:
-    - ``_kernel_key`` (class attribute or property): kernel-map key string.
-    - ``_kernel_cls`` (class attribute or property): kernel class.
-    - ``forward()``: the user-facing call.
+    - ``_kernel_key`` (class attribute): kernel-map key string.
+    - ``_kernel_cls`` (class attribute): kernel class.
+    - ``forward()``: the user-facing call (use the helpers below).
 
     Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
+        N: Hidden / reduction dimension size (statically committed at ctor).
         dtype: Data type (float16 or bfloat16).
+        dim: Reduction axis (default -1). Negative values are normalized at
+            forward time (``dim % x.ndim``).
         eps: Epsilon for numerical stability.
         kernel_map: Optional kernel override dict.
         tune: If True, autotune tile configs.
@@ -46,24 +48,30 @@ class RowNormOp(Op):
     _kernel_key: str
     _kernel_cls: type
 
+    # `static_dims.N = x.shape[dim]` is param-dependent (depends on `dim`),
+    # so the static-axis frozenset is bound at forward time after dim
+    # normalization, not at the class level (per docs/ops-design.md § Step 3).
+    _static_axes: frozenset = frozenset()
+
     def __init__(
         self,
-        M: int,
+        *,
         N: int,
         dtype: torch.dtype,
+        dim: int = -1,
         eps: float = 1e-6,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.M = M
         self.N = N
         self.dtype = dtype
+        self.dim = dim
         self.eps = eps
+        self.tune = tune
         self.N_padded = self._align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._kernel_key](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[int, Kernel] = {}
+        self._last_roofline_mn: Optional[Tuple[int, int]] = None
 
     @staticmethod
     def _align_up(n: int, alignment: int) -> int:
@@ -74,50 +82,73 @@ class RowNormOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {self._kernel_key: self._kernel_cls}
 
-    def eval_roofline(self) -> tuple[int, int]:
+    def eval_roofline(self) -> Tuple[int, int]:
+        if self._last_roofline_mn is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind dynamic input shape (M)"
+            )
+        M, N = self._last_roofline_mn
         elem_bytes = self.dtype.itemsize
-        return (
-            4 * self.M * self.N,
-            (2 * self.M * self.N + self.N) * elem_bytes,
-        )
+        return (4 * M * N, (2 * M * N + N) * elem_bytes)
 
-    # -- Validation helpers --------------------------------------------------
+    @property
+    def _needs_pad(self) -> bool:
+        return self.N_padded != self.N
 
-    def _validate_cuda_dtype(self, name: str, t: torch.Tensor) -> None:
-        """Raise ValueError if *t* is not on CUDA or has wrong dtype."""
-        if not t.is_cuda:
-            raise ValueError(f"{name} must be a CUDA tensor")
-        if t.dtype != self.dtype:
-            raise ValueError(
-                f"Expected {name}.dtype {self.dtype}, got {t.dtype}"
+    def _get_kernel(self, M: int) -> Kernel:
+        """Return a kernel built for (M, self.N), caching by M."""
+        if M not in self._kernel_cache:
+            self._kernel_cache[M] = self.kernel_map[self._kernel_key](
+                M, self.N, self.eps, self.dtype, tune=self.tune,
             )
+        return self._kernel_cache[M]
 
-    def _validate_1d(self, name: str, t: torch.Tensor) -> None:
-        """Raise ValueError if *t* is not 1-D with size N."""
-        if t.ndim != 1:
-            raise ValueError(f"Expected {name} to be 1D, got {t.ndim}D")
-        if t.shape[0] != self.N:
+    # -- Forward pipeline helpers --------------------------------------------
+
+    def _validate_and_normalize_dim(
+        self, x: torch.Tensor, weight: torch.Tensor
+    ) -> int:
+        """Validate input/weight, return the non-negative reduction axis."""
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.dtype != self.dtype:
+            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        if not weight.is_cuda or weight.dtype != self.dtype:
             raise ValueError(
-                f"Expected {name} dim {self.N}, got {t.shape[0]}"
+                f"weight must be a CUDA tensor of dtype {self.dtype}"
             )
-
-    def _validate_hidden_dim(self, x: torch.Tensor) -> None:
-        """Raise ValueError if x's last dim != N."""
-        if x.shape[-1] != self.N:
+        if weight.ndim != 1 or weight.shape[0] != self.N:
             raise ValueError(
-                f"Expected hidden dim {self.N}, got {x.shape[-1]}"
+                f"weight must be 1-D with shape ({self.N},), "
+                f"got {tuple(weight.shape)}"
             )
+        ndim = x.ndim
+        dim_norm = self.dim if self.dim >= 0 else self.dim + ndim
+        if not (0 <= dim_norm < ndim):
+            raise ValueError(
+                f"dim={self.dim} out of range for {ndim}-D input"
+            )
+        if x.shape[dim_norm] != self.N:
+            raise ValueError(
+                f"Expected x.shape[{self.dim}]={self.N}, "
+                f"got {x.shape[dim_norm]}"
+            )
+        return dim_norm
 
-    # -- Reshape / pad helpers -----------------------------------------------
+    def _flatten_to_2d(
+        self, x: torch.Tensor, dim_norm: int
+    ) -> Tuple[torch.Tensor, Tuple[int, ...]]:
+        """Move target axis to last, flatten leading dims to (M, N).
 
-    def _flatten_and_check_M(self, x: torch.Tensor) -> torch.Tensor:
-        """Flatten leading dims to (M, N), validate M, return contiguous 2-D."""
+        Returns (2-D x, shape after movedim) so the caller can restore
+        leading dims after the kernel.
+        """
+        if dim_norm != x.ndim - 1:
+            x = x.movedim(dim_norm, -1)
+        post_move_shape = tuple(x.shape)
         x = x.contiguous().reshape(-1, self.N)
-        if x.shape[0] != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {x.shape[0]}"
-            )
-        return x
+        return x, post_move_shape
 
     def _pad_row(self, t: torch.Tensor) -> torch.Tensor:
         """Pad a 2-D row tensor along dim=-1 to N_padded."""
@@ -127,18 +158,20 @@ class RowNormOp(Op):
         """Pad a 1-D vector to N_padded."""
         return F.pad(t, (0, self.N_padded - self.N))
 
-    @property
-    def _needs_pad(self) -> bool:
-        return self.N_padded != self.N
-
-    def _trim_and_reshape(
-        self, y: torch.Tensor, orig_shape: tuple
+    def _trim_and_unflatten(
+        self,
+        y: torch.Tensor,
+        post_move_shape: Tuple[int, ...],
+        dim_norm: int,
+        ndim: int,
     ) -> torch.Tensor:
-        """Trim padding from dim=-1 and restore *orig_shape*."""
+        """Inverse of `_flatten_to_2d`: trim padding, restore shape, move axis back."""
         if self._needs_pad:
             y = y[:, : self.N]
-        return y.reshape(orig_shape)
+        y = y.reshape(post_move_shape)
+        if dim_norm != ndim - 1:
+            y = y.movedim(-1, dim_norm)
+        return y
 
-    @abstractmethod
-    def forward(self, *args: object, **kwargs: object) -> object:
-        """Subclasses must implement their own forward with concrete args."""
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError("Subclasses must implement forward()")

--- a/tileops/ops/norm/norm_base.py
+++ b/tileops/ops/norm/norm_base.py
@@ -12,7 +12,8 @@ BatchNorm uses spatial reduction (not a single axis), so it does NOT inherit
 from this.
 """
 
-from typing import Dict, Optional, Tuple
+from abc import abstractmethod
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -124,16 +125,19 @@ class RowNormOp(Op):
                 f"got {tuple(weight.shape)}"
             )
         ndim = x.ndim
-        dim_norm = self.dim if self.dim >= 0 else self.dim + ndim
-        if not (0 <= dim_norm < ndim):
+        if not (-ndim <= self.dim < ndim):
             raise ValueError(
                 f"dim={self.dim} out of range for {ndim}-D input"
             )
+        dim_norm = self.dim % ndim
         if x.shape[dim_norm] != self.N:
             raise ValueError(
                 f"Expected x.shape[{self.dim}]={self.N}, "
                 f"got {x.shape[dim_norm]}"
             )
+        # Bind the dynamic static-axis (param-dependent N axis) so
+        # Op-layer cache-key/introspection consumers see the committed axis.
+        self._static_axes = frozenset({(0, dim_norm)})
         return dim_norm
 
     def _flatten_to_2d(
@@ -173,5 +177,9 @@ class RowNormOp(Op):
             y = y.movedim(-1, dim_norm)
         return y
 
-    def forward(self, *args, **kwargs):
+    @abstractmethod
+    def forward(
+        self, *args: object, **kwargs: object
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:
+        """Subclasses must implement their own forward with concrete args."""
         raise NotImplementedError("Subclasses must implement forward()")

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -10,20 +10,20 @@ __all__ = ["RMSNormFwdOp"]
 class RMSNormFwdOp(RowNormOp):
     """Standalone RMS Norm operator.
 
-    y = x * rsqrt(mean(x^2, dim=-1) + eps) * weight
+    y = x * rsqrt(mean(x^2, dim) + eps) * weight
     """
 
     _kernel_key = "rms_norm"
     _kernel_cls = RMSNormKernel
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        self._validate_cuda_dtype("x", x)
-        self._validate_hidden_dim(x)
-        self._validate_cuda_dtype("weight", weight)
-        self._validate_1d("weight", weight)
-        orig_shape = x.shape
-        x = self._flatten_and_check_M(x)
+        ndim = x.ndim
+        dim_norm = self._validate_and_normalize_dim(x, weight)
+        x, post_move_shape = self._flatten_to_2d(x, dim_norm)
+        M = x.shape[0]
         if self._needs_pad:
             x = self._pad_row(x)
             weight = self._pad_vec(weight)
-        return self._trim_and_reshape(self.kernel(x, weight), orig_shape)
+        y = self._get_kernel(M)(x, weight)
+        self._last_roofline_mn = (M, self.N)
+        return self._trim_and_unflatten(y, post_move_shape, dim_norm, ndim)


### PR DESCRIPTION
## Summary

First op-layer migration to the canonical pattern in `docs/ops-design.md` § Step 3: ctor binds only `static_dims` (`N`) + `signature.params` (`dim`, `eps`); `M` is derived at forward time; kernels are built lazily and cached by `M`.

| File | Change |
|---|---|
| `tileops/ops/norm/norm_base.py` | Rewrite `RowNormOp`. Kw-only ctor `(*, N, dtype, dim=-1, eps=1e-6, kernel_map=None, tune=False)`. Lazy kernel cache keyed by `M`. Helpers honor `self.dim` via `movedim`. `eval_roofline` reads `_last_roofline_mn` (set by forward). `_static_axes` bound at forward after dim normalization. |
| `tileops/ops/norm/rms_norm.py` | `RMSNormFwdOp.forward` becomes a 5-line orchestration of base helpers. |
| `tests/ops/test_rms_norm.py` | Update 3 existing call-sites to the new kw-only API. Add `test_rms_norm_dim_axis1` covering the `dim != -1` movedim path. |
| `benchmarks/ops/bench_rms_norm.py` | Same call-site update. |

`RowNormOp` has only one subclass — no dual-path needed.

## Out of scope

- `status` flip — stays `spec-only`. Per the trust model only `align-op@FLIP_STATUS` flips status.
- `LayerNormFwdOp` / `AdaLayerNormFwdOp` / etc. — extend `Op` directly, not `RowNormOp`. Independent migrations.

## Validation

- [x] `pre-commit` passes.
- [x] `python scripts/validate_manifest.py --check-op RMSNormFwdOp` passes (only pre-existing `FIXME(staged-rollout)` parity warnings remain).
- [x] 8/8 smoke tests pass on H200 (1024×4096 fp16/bf16, non-contig slice, 3D batch×seq×hidden, dim=1 over hidden axis).