### PR TITLE
[Fix][Skills] address align-op + implement-op bugs found during RMSNormFwdOp migration

### DIFF
--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -102,6 +102,8 @@ Decide which case applies. Machine-decidable input: does `source.op` exist?
 - `source.op` **missing** → only `green` is valid. `--mode=minor` → BLOCKED ("`source.op` is missing; cannot edit a non-existent op file; use `--mode=green` or omit `--mode`"). `--mode=redesign` → BLOCKED ("`source.op` is missing; no archive source to rewrite; use `--mode=green` or omit `--mode`").
 - `source.op` **exists** → `--mode=green` → BLOCKED ("`source.op` already exists; green-field scaffold would silently overwrite; use `--mode=redesign` for rewrite+port or `--mode=minor` for in-place edit").
 
+**First-op bias.** If no op in the same `family` has `status: implemented` and follows the canonical static_dims pattern (`docs/ops-design.md` § Step 3), set `auto-case = redesign` (skip the prompt). mode.json: `decided_by: "auto"`, `reason: "no canonical-pattern precedent in family <name>"`. User may override with `--mode=minor`.
+
 Write `.foundry/plan/<op_name>/mode.json`:
 
 ```json

--- a/.claude/skills/align-op/SKILL.md
+++ b/.claude/skills/align-op/SKILL.md
@@ -102,7 +102,7 @@ Decide which case applies. Machine-decidable input: does `source.op` exist?
 - `source.op` **missing** → only `green` is valid. `--mode=minor` → BLOCKED ("`source.op` is missing; cannot edit a non-existent op file; use `--mode=green` or omit `--mode`"). `--mode=redesign` → BLOCKED ("`source.op` is missing; no archive source to rewrite; use `--mode=green` or omit `--mode`").
 - `source.op` **exists** → `--mode=green` → BLOCKED ("`source.op` already exists; green-field scaffold would silently overwrite; use `--mode=redesign` for rewrite+port or `--mode=minor` for in-place edit").
 
-**First-op bias.** If no op in the same `family` has `status: implemented` and follows the canonical static_dims pattern (`docs/ops-design.md` § Step 3), set `auto-case = redesign` (skip the prompt). mode.json: `decided_by: "auto"`, `reason: "no canonical-pattern precedent in family <name>"`. User may override with `--mode=minor`.
+**First-op bias.** If no op in the same `family` has `status: implemented` and follows the canonical pattern (`docs/ops-design.md` § Step 3), set `auto-case = redesign` (skip the prompt). mode.json: `decided_by: "auto"`, `reason: "no canonical-pattern precedent in family <name>"`. User may override with `--mode=minor`.
 
 Write `.foundry/plan/<op_name>/mode.json`:
 
@@ -323,5 +323,5 @@ They do not conflict. `align-op` never manages cross-op cleanup gates; that rema
 
 - **Kernel scaffolding / kernel-layer edits.** align-op surfaces kernel work as a follow-up via `kernel-check.json`; a separate (future) `kernel-scaffold` / `kernel-align` skill will own that layer.
 - **Family-level cleanup.** Cross-op dual-path removal lives in `align-family` and is not a concern of per-op alignment.
-- **Auto-detecting "redesign vs minor."** The distinction is a design judgement; align-op prompts or accepts `--mode`.
+- **General auto-detection of "redesign vs minor."** The distinction is a design judgement; align-op prompts or accepts `--mode`. The one exception is the **first-op bias** in CLASSIFY (no canonical-pattern precedent in the family → auto `redesign`). Beyond that one case, no auto-detection.
 - **Manifest changes (other than FLIP_STATUS).** Per the trust model, manifest changes live in separate manifest PRs.

--- a/.claude/skills/implement-op/SKILL.md
+++ b/.claude/skills/implement-op/SKILL.md
@@ -38,7 +38,7 @@ stateDiagram-v2
 Before refactoring a base class, count its subclasses:
 
 ```bash
-grep -lE "class [A-Z][A-Za-z0-9]*\(<BaseName>\)" tileops/ops/
+grep -rlE "class\s+[A-Z][A-Za-z0-9]*\s*\(\s*<BaseName>\s*\)" tileops/ops/
 ```
 
 - **One subclass** (the op being migrated): refactor the base in place. No dual-path.

--- a/.claude/skills/implement-op/SKILL.md
+++ b/.claude/skills/implement-op/SKILL.md
@@ -13,7 +13,7 @@ description: Modify op code to match the manifest-declared interface, making spe
 - **Output**: modified op code + commit + `observations` list (returned to orchestrator)
 - **Termination (success)**: `python scripts/validate_manifest.py --check-op <name>` all levels pass + new tests pass.
 - **Termination (blocked)**: fix requires changes beyond Op layer. Return `blocked` with reason.
-- **Constraint**: must NOT modify `ops_manifest.yaml` (orchestrator's responsibility). Must NOT modify tests from test-op.
+- **Constraint**: must NOT modify `ops_manifest.yaml`. Must NOT modify tests written by `test-op` in this align-op run (spec contract). MAY update pre-existing tests in `<source_test>` whose call-sites use the legacy API.
 - **Behavioral compatibility**: default param values (from manifest) must produce identical results to the old implementation. The old API shape (e.g., `__init__(M, N)`) is NOT preserved — the manifest defines the target interface.
 
 ## Workflow
@@ -35,9 +35,16 @@ stateDiagram-v2
 
 ## Dual-path policy
 
-When rewriting a base class shared by sibling ops, it is acceptable to create a dual-path `__init__` — a runtime branch supporting both the legacy `(M, N)` interface and the new spec `(dim)` interface. This keeps unmigrated siblings' tests passing.
+Before refactoring a base class, count its subclasses:
 
-Dual-path is temporary debt. The orchestrator's cleanup gate removes it after all siblings are promoted or blocked. The implementer should NOT try to avoid dual-path by preemptively migrating siblings — that violates per-op scope.
+```bash
+grep -lE "class [A-Z][A-Za-z0-9]*\(<BaseName>\)" tileops/ops/
+```
+
+- **One subclass** (the op being migrated): refactor the base in place. No dual-path.
+- **Multiple subclasses**: keep the legacy `__init__` path alongside the new one so unmigrated siblings still pass. Cleanup gate removes the legacy path after all siblings migrate.
+
+Do NOT preemptively migrate siblings to avoid dual-path — that violates per-op scope.
 
 ## Steps
 


### PR DESCRIPTION
## What this PR does

Three contract fixes to manifest-skill specs:

| # | Skill | Change |
|---|---|---|
| 1 | `align-op` CLASSIFY | Add first-op bias: when no same-family op has `status: implemented` following the canonical pattern (`docs/ops-design.md` § Step 3), auto-select `redesign`. Non-goals updated to carve out this exception. User may override with `--mode=minor`. |
| 2 | `implement-op` constraint | Pre-existing tests in `<source_test>` whose call-sites use the legacy API MAY be updated. Tests written by `test-op` in the same run remain sacred. |
| 3 | `implement-op` dual-path | Subclass-count gate: `grep -rlE "class\s+[A-Z][A-Za-z0-9]*\s*\(\s*<BaseName>\s*\)" tileops/ops/`. One subclass → refactor in place. Multiple subclasses → keep legacy `__init__` until cleanup gate. |

Docs-only, +12/-3 lines.