### PR TITLE
[Refactor][Manifest] promote RMSNormFwdOp to implemented

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -44,7 +44,7 @@ ops:
   RMSNormFwdOp:
     ref_api: "torch.nn.functional.rms_norm"
     family: normalization
-    status: spec-only  # impl lacks dim param; fix in follow-up PR
+    status: implemented
 
     signature:
       inputs:


### PR DESCRIPTION
## Changes

- `tileops/ops_manifest.yaml`: `RMSNormFwdOp.status: spec-only → implemented`. Remove now-stale comment.

Code already conforms to the manifest spec (PR #1061). Per trust model, only `align-op@FLIP_STATUS` flips status — hence a separate one-line PR.

## Tests

- [x] `python scripts/validate_manifest.py --check-op RMSNormFwdOp` — passes.
- [x] `pytest tests/ops/test_rms_norm.py` (smoke + full) — 18/18 pass on H200, including tail-M (1025×4096) and dim=1 cases.
- [x] `pytest benchmarks/ops/bench_rms_norm.py -k llama-3.1-8b-decode-bfloat16` — produces numbers (M=1 decode shape).