### PR TITLE
[Refactor][Scan] migrate cumsum + cumprod to canonical static_dims pattern

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -24,6 +24,8 @@
 
 - **Abbreviation casing in filenames**: Filenames use all-lowercase with underscores. Multi-word abbreviations keep all letters lowercase — `rms_norm.py`, `ssd_decode.py`. Do not capitalize a single letter (e.g. `Ssd_decode.py` is wrong).
 
+- **Docstring style: Google**. All Python docstrings (modules, classes, public functions / methods) follow Google style: one-sentence summary on the opening line, blank line, then optional sections `Args:`, `Returns:`, `Raises:`, `Example:`. Internal helpers may use a single-line summary docstring. Do NOT mix Sphinx-style (`:param x:`) or NumPy-style (separate header lines for each param) into the same file.
+
 - **Expand abbreviations on first use in docstrings**: When SSM, SSD, or other domain abbreviations first appear in a module or class docstring, write the full form followed by the abbreviation in parentheses. Subsequent uses in the same file can use the abbreviation alone.
 
   - SSM → State Space Model (SSM)

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -71,7 +71,7 @@ def _make_op(m: int, n: int, dtype: torch.dtype, op_kind: str):
         "cumprod": CumprodFwdOp,
     }
     cls = op_map[op_kind]
-    return cls(M=m, N=n, dtype=dtype)
+    return cls(N=n, dtype=dtype)
 
 
 @CumulativeBenchFixture

--- a/docs/ops-design-reference.md
+++ b/docs/ops-design-reference.md
@@ -269,14 +269,14 @@ Slot-keyed rule dictionary consumed on demand by [ops-design.md](ops-design.md) 
 
 Per-family protocol variables, declared by L2 bases and overridden by L3 ops.
 
-| Variable                  | Family          | Purpose                                                   |
-| ------------------------- | --------------- | --------------------------------------------------------- |
-| `_kernel_key`             | norm, reduction | Kernel-map lookup key                                     |
-| `_kernel_cls`             | norm, reduction | Kernel class reference                                    |
-| `_op_kind`                | reduction       | Reduction kind string (`"sum"`, `"mean"`, `"std"`, etc.)  |
-| `_kernel_handles_padding` | reduction       | `True` → kernel uses masked loads, skip host-side padding |
-| `_op_name`                | elementwise     | `torch.library.custom_op` registration key                |
-| `kernel_cls`              | elementwise     | Kernel class reference                                    |
+| Variable                  | Family          | Purpose                                                                                                          |
+| ------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `_kernel_key`             | norm, reduction | Kernel-map lookup key                                                                                            |
+| `_kernel_cls`             | norm, reduction | Kernel class reference                                                                                           |
+| `_op_kind`                | reduction, scan | Kernel-dispatch op-kind string (`"sum"` / `"prod"` for `CumulativeOp`; `"sum"`, `"mean"`, … for `_ReduceOpBase`) |
+| `_kernel_handles_padding` | reduction       | `True` → kernel uses masked loads, skip host-side padding                                                        |
+| `_op_name`                | elementwise     | `torch.library.custom_op` registration key                                                                       |
+| `kernel_cls`              | elementwise     | Kernel class reference                                                                                           |
 
 **The `scaffold-op` skill does NOT emit these variables** — kernel-dispatch-convention-dependent (e.g., `VectorNormKernel` uses `{"l1", "l2", "inf"}`, `ReduceKernel` uses `{"sum", "mean", ...}`); filled in during family-specific refactoring (future skill). Adding a new protocol variable requires updating the L2 base, all concrete ops, and the manifest schema if applicable.
 

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -280,6 +280,26 @@ See [Kernel base class attributes](ops-design-reference.md#base-class-protocol) 
 
 The scaffold emits T2 (L1-direct) ops only. Once a family accumulates 2-3 ops sharing an identical `forward()` flow, extract an L2 family base via refactoring; concrete ops then become T1 thin wrappers declaring family protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, …). This transformation is driven by a separate family-specific skill, not the scaffold-op. See [Development Path](ops-design-reference.md#development-path) for when to extract an L2 base and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the step-by-step process.
 
+### Canonical L2 family-base shape
+
+Family bases that follow the canonical static_dims pattern (Step 3) share the same skeleton regardless of family. Examples in tree:
+
+| Base class                                                    | Family        | Subclasses                    |
+| ------------------------------------------------------------- | ------------- | ----------------------------- |
+| [`RowNormOp`](../tileops/ops/norm/norm_base.py)               | normalization | `RMSNormFwdOp`                |
+| [`CumulativeOp`](../tileops/ops/reduction/cumulative_base.py) | scan          | `CumsumFwdOp`, `CumprodFwdOp` |
+
+Each canonical L2 base provides:
+
+- **Kw-only ctor** binding `static_dims` (e.g., `N`) + `signature.params` (e.g., `dim`, `eps`); never binds `M` (derived at forward).
+- **Lazy kernel cache** keyed by `M` (`self._kernel_cache: Dict[int, Kernel]`).
+- **`_run(x[, ...])` helper** that performs the shared pipeline `validate → movedim(dim → -1) → reshape (M, N) → kernel → trim → reshape → movedim(-1 → dim)`. Subclasses' `forward()` is typically a one-liner that calls `_run`.
+- **`_validate_and_normalize_dim()`** that asserts shape / dtype / range, then sets `self._static_axes = frozenset({(0, dim_norm)})` so `Op._cache_key` consumers see the committed axis (param-dependent `static_dims` per R20).
+- **`eval_roofline()`** that reads `self._last_roofline_mn` (set inside `_run`); raises `RuntimeError` if forward has not run yet (same convention as `_ReduceOpBase`).
+- **Subclass-only protocol variables** that pick the kernel branch (e.g., `_op_kind = "sum" | "prod"` for `CumulativeOp`; `_kernel_key` + `_kernel_cls` for `RowNormOp`). See [Family-Base Protocol](ops-design-reference.md#base-class-protocol).
+
+When introducing a new canonical L2 base, mirror this skeleton and add a row to the protocol table in the reference appendix.
+
 ## Further Reference
 
 - [Slot Rules](ops-design-reference.md#slot-rules) — full Rule / Derivation / Example / Common mistakes per slot

--- a/docs/ops-design.md
+++ b/docs/ops-design.md
@@ -280,26 +280,6 @@ See [Kernel base class attributes](ops-design-reference.md#base-class-protocol) 
 
 The scaffold emits T2 (L1-direct) ops only. Once a family accumulates 2-3 ops sharing an identical `forward()` flow, extract an L2 family base via refactoring; concrete ops then become T1 thin wrappers declaring family protocol variables (`_op_kind`, `_kernel_key`, `_kernel_cls`, …). This transformation is driven by a separate family-specific skill, not the scaffold-op. See [Development Path](ops-design-reference.md#development-path) for when to extract an L2 base and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the step-by-step process.
 
-### Canonical L2 family-base shape
-
-Family bases that follow the canonical static_dims pattern (Step 3) share the same skeleton regardless of family. Examples in tree:
-
-| Base class                                                    | Family        | Subclasses                    |
-| ------------------------------------------------------------- | ------------- | ----------------------------- |
-| [`RowNormOp`](../tileops/ops/norm/norm_base.py)               | normalization | `RMSNormFwdOp`                |
-| [`CumulativeOp`](../tileops/ops/reduction/cumulative_base.py) | scan          | `CumsumFwdOp`, `CumprodFwdOp` |
-
-Each canonical L2 base provides:
-
-- **Kw-only ctor** binding `static_dims` (e.g., `N`) + `signature.params` (e.g., `dim`, `eps`); never binds `M` (derived at forward).
-- **Lazy kernel cache** keyed by `M` (`self._kernel_cache: Dict[int, Kernel]`).
-- **`_run(x[, ...])` helper** that performs the shared pipeline `validate → movedim(dim → -1) → reshape (M, N) → kernel → trim → reshape → movedim(-1 → dim)`. Subclasses' `forward()` is typically a one-liner that calls `_run`.
-- **`_validate_and_normalize_dim()`** that asserts shape / dtype / range, then sets `self._static_axes = frozenset({(0, dim_norm)})` so `Op._cache_key` consumers see the committed axis (param-dependent `static_dims` per R20).
-- **`eval_roofline()`** that reads `self._last_roofline_mn` (set inside `_run`); raises `RuntimeError` if forward has not run yet (same convention as `_ReduceOpBase`).
-- **Subclass-only protocol variables** that pick the kernel branch (e.g., `_op_kind = "sum" | "prod"` for `CumulativeOp`; `_kernel_key` + `_kernel_cls` for `RowNormOp`). See [Family-Base Protocol](ops-design-reference.md#base-class-protocol).
-
-When introducing a new canonical L2 base, mirror this skeleton and add a row to the protocol table in the reference appendix.
-
 ## Further Reference
 
 - [Slot Rules](ops-design-reference.md#slot-rules) — full Rule / Derivation / Example / Common mistakes per slot

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -146,7 +146,7 @@ def test_cumsum_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     test = CumulativeTest(m, n, dtype, "cumsum")
-    op = CumsumFwdOp(M=m, N=n, dtype=dtype)
+    op = CumsumFwdOp(N=n, dtype=dtype)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
@@ -156,7 +156,7 @@ def test_cumsum_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = CumsumFwdOp(M=m, N=n, dtype=dtype)
+    op = CumsumFwdOp(N=n, dtype=dtype)
     ref = x.contiguous().float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -168,8 +168,7 @@ def test_cumsum_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    M = batch * seq
-    op = CumsumFwdOp(M=M, N=hidden, dtype=dtype)
+    op = CumsumFwdOp(N=hidden, dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -181,8 +180,7 @@ def test_cumsum_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    M = b0 * b1 * b2
-    op = CumsumFwdOp(M=M, N=n, dtype=dtype)
+    op = CumsumFwdOp(N=n, dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -194,7 +192,7 @@ def test_cumsum_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = CumsumFwdOp(M=1, N=n, dtype=dtype)
+    op = CumsumFwdOp(N=n, dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -211,7 +209,7 @@ def test_cumprod_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     test = CumulativeTest(m, n, dtype, "cumprod", use_small_range=True)
-    op = CumprodFwdOp(M=m, N=n, dtype=dtype)
+    op = CumprodFwdOp(N=n, dtype=dtype)
     test.check(op, *test.gen_inputs(), **_cumprod_tol(dtype))
 
 
@@ -221,7 +219,7 @@ def test_cumprod_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.rand(m, n * 2, dtype=dtype, device="cuda") * 0.01 + 0.99
     x = x_full[:, :n]
-    op = CumprodFwdOp(M=m, N=n, dtype=dtype)
+    op = CumprodFwdOp(N=n, dtype=dtype)
     ref = x.contiguous().float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -233,8 +231,7 @@ def test_cumprod_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> No
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(batch, seq, hidden, dtype=dtype, device="cuda") * 0.01 + 0.99
-    M = batch * seq
-    op = CumprodFwdOp(M=M, N=hidden, dtype=dtype)
+    op = CumprodFwdOp(N=hidden, dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -246,8 +243,7 @@ def test_cumprod_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> No
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(b0, b1, b2, n, dtype=dtype, device="cuda") * 0.01 + 0.99
-    M = b0 * b1 * b2
-    op = CumprodFwdOp(M=M, N=n, dtype=dtype)
+    op = CumprodFwdOp(N=n, dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -259,7 +255,7 @@ def test_cumprod_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(n, dtype=dtype, device="cuda") * 0.01 + 0.99
-    op = CumprodFwdOp(M=1, N=n, dtype=dtype)
+    op = CumprodFwdOp(N=n, dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -262,5 +262,47 @@ def test_cumprod_1d(n: int, dtype: torch.dtype) -> None:
     assert torch.allclose(y, ref, **tol), f"1D cumprod max err: {(y - ref).abs().max()}"
 
 
+class CumulativeDimAxis1Fixture(FixtureBase):
+    PARAMS = [
+        ("batch, hidden, seq, dtype", [
+            pytest.param(2, 512, 256, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(2, 512, 256, torch.bfloat16, marks=pytest.mark.smoke),
+        ]),
+    ]
+
+
+@CumulativeDimAxis1Fixture
+def test_cumsum_dim_axis1(
+    batch: int, hidden: int, seq: int, dtype: torch.dtype
+) -> None:
+    """Cumsum along dim=1 (3D) — exercises movedim choreography in `_run`."""
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    x = torch.randn(batch, hidden, seq, dtype=dtype, device="cuda")
+    op = CumsumFwdOp(N=hidden, dtype=dtype, dim=1)
+    ref = x.float().cumsum(dim=1).to(dtype)
+    y = op(x)
+    atol = 1e-2 if dtype == torch.float16 else 1.6e-2
+    assert torch.allclose(y, ref, atol=atol, rtol=atol), \
+        f"cumsum dim=1 max err: {(y - ref).abs().max()}"
+
+
+@CumulativeDimAxis1Fixture
+def test_cumprod_dim_axis1(
+    batch: int, hidden: int, seq: int, dtype: torch.dtype
+) -> None:
+    """Cumprod along dim=1 (3D) — exercises movedim choreography in `_run`."""
+    from tileops.ops.reduction.cumprod import CumprodFwdOp
+
+    # Values close to 1 to avoid over/underflow in cumprod over hidden dim.
+    x = torch.rand(batch, hidden, seq, dtype=dtype, device="cuda") * 0.01 + 0.99
+    op = CumprodFwdOp(N=hidden, dtype=dtype, dim=1)
+    ref = x.float().cumprod(dim=1).to(dtype)
+    y = op(x)
+    tol = _cumprod_tol(dtype)
+    assert torch.allclose(y, ref, **tol), \
+        f"cumprod dim=1 max err: {(y - ref).abs().max()}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -8,9 +8,25 @@ __all__ = ["RMSNormFwdOp"]
 
 
 class RMSNormFwdOp(RowNormOp):
-    """Standalone RMS Norm operator.
+    """Standalone Root Mean Square (RMS) Norm operator.
 
-    y = x * rsqrt(mean(x^2, dim) + eps) * weight
+    Computes ``y = x * rsqrt(mean(x ** 2, dim) + eps) * weight``.
+
+    Args:
+        N: Reduction dimension size (statically committed at ctor;
+            corresponds to manifest ``static_dims.N = "x.shape[dim]"``).
+        dtype: Data type (float16 or bfloat16).
+        dim: Reduction axis (default -1). Negative values are normalized
+            at forward time.
+        eps: Epsilon for numerical stability (default ``1e-6``).
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = RMSNormFwdOp(N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        >>> w = torch.randn(4096, dtype=torch.float16, device="cuda")
+        >>> y = op(x, w)  # shape: (1024, 4096)
     """
 
     _kernel_key = "rms_norm"

--- a/tileops/ops/reduction/cumprod.py
+++ b/tileops/ops/reduction/cumprod.py
@@ -1,99 +1,23 @@
 """Cumulative product operator (L2 Op layer).
 
 Provides:
-  - CumprodFwdOp: y = cumprod(x, dim=-1)
+  - CumprodFwdOp: y = cumprod(x, dim)
 
-Follows the validate -> reshape -> kernel -> trim -> reshape pattern
-and supports 1D-4D input with dim=-1. Output has the same shape as input.
-Alignment padding is handled inside the kernel via masked loads.
+Output has the same shape and dtype as input. Alignment padding is handled
+inside the kernel via masked loads.
 """
-
-from typing import Dict, Optional
 
 import torch
 
-from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
-from tileops.kernels.reduction.cumulative import CumulativeKernel
-
-from ..op_base import Op
+from .cumulative_base import CumulativeOp
 
 __all__ = ["CumprodFwdOp"]
 
 
-class CumprodFwdOp(Op):
-    """Cumulative product operator: y = cumprod(x, dim=-1).
+class CumprodFwdOp(CumulativeOp):
+    """Cumulative product operator: y = cumprod(x, dim)."""
 
-    Output has the same shape and dtype as input.
-
-    Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
-        dtype: Data type (float32, float16, or bfloat16).
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
-
-    Example:
-        >>> op = CumprodFwdOp(M=1024, N=4096, dtype=torch.float16)
-        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
-        >>> y = op(x)  # shape: (1024, 4096)
-    """
-
-    def __init__(
-        self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-    ):
-        self.M = M
-        self.N = N
-        self.dtype = dtype
-        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["cumulative_fwd"](
-            M,
-            N,
-            "prod",
-            dtype,
-            tune=tune,
-        )
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"cumulative_fwd": CumulativeKernel}
+    _op_kind = "prod"
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the cumulative product op.
-
-        Accepts 1D-4D input. Operates along dim=-1.
-
-        Args:
-            x: Input tensor with last dim == N.
-
-        Returns:
-            Output tensor with the same shape as input.
-        """
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.shape[-1] != self.N:
-            raise ValueError(f"Expected last dim {self.N}, got {x.shape[-1]}")
-
-        orig_shape = x.shape
-
-        # Flatten leading dims: (..., N) -> (M, N)
-        x = x.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(f"Expected M={self.M} (product of leading dims), got {M_actual}")
-
-        # Alignment padding is handled inside the kernel via masked loads.
-        y = self.kernel(x)
-
-        # Trim padding (kernel output is N_padded-wide) and restore shape
-        if self.N_padded != self.N:
-            y = y[:, : self.N]
-        return y.reshape(orig_shape)
+        return self._run(x)

--- a/tileops/ops/reduction/cumprod.py
+++ b/tileops/ops/reduction/cumprod.py
@@ -15,7 +15,25 @@ __all__ = ["CumprodFwdOp"]
 
 
 class CumprodFwdOp(CumulativeOp):
-    """Cumulative product operator: y = cumprod(x, dim)."""
+    """Cumulative product operator: ``y = cumprod(x, dim)``.
+
+    Output has the same shape and dtype as ``x``. Alignment padding is
+    handled inside the kernel via masked loads.
+
+    Args:
+        N: Reduction dimension size (statically committed at ctor;
+            corresponds to manifest ``static_dims.N = "x.shape[dim]"``).
+        dtype: Data type (float32, float16, or bfloat16).
+        dim: Reduction axis (default -1). Negative values are normalized
+            at forward time.
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = CumprodFwdOp(N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda") * 0.01 + 0.99
+        >>> y = op(x)  # shape: (1024, 4096)
+    """
 
     _op_kind = "prod"
 

--- a/tileops/ops/reduction/cumsum.py
+++ b/tileops/ops/reduction/cumsum.py
@@ -15,7 +15,25 @@ __all__ = ["CumsumFwdOp"]
 
 
 class CumsumFwdOp(CumulativeOp):
-    """Cumulative sum operator: y = cumsum(x, dim)."""
+    """Cumulative sum operator: ``y = cumsum(x, dim)``.
+
+    Output has the same shape and dtype as ``x``. Alignment padding is
+    handled inside the kernel via masked loads.
+
+    Args:
+        N: Reduction dimension size (statically committed at ctor;
+            corresponds to manifest ``static_dims.N = "x.shape[dim]"``).
+        dtype: Data type (float32, float16, or bfloat16).
+        dim: Reduction axis (default -1). Negative values are normalized
+            at forward time.
+        kernel_map: Optional override for kernel dispatch.
+        tune: Whether to autotune (default False).
+
+    Example:
+        >>> op = CumsumFwdOp(N=4096, dtype=torch.float16)
+        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
+        >>> y = op(x)  # shape: (1024, 4096)
+    """
 
     _op_kind = "sum"
 

--- a/tileops/ops/reduction/cumsum.py
+++ b/tileops/ops/reduction/cumsum.py
@@ -1,99 +1,23 @@
 """Cumulative sum operator (L2 Op layer).
 
 Provides:
-  - CumsumFwdOp: y = cumsum(x, dim=-1)
+  - CumsumFwdOp: y = cumsum(x, dim)
 
-Follows the validate -> reshape -> kernel -> trim -> reshape pattern
-and supports 1D-4D input with dim=-1. Output has the same shape as input.
-Alignment padding is handled inside the kernel via masked loads.
+Output has the same shape and dtype as input. Alignment padding is handled
+inside the kernel via masked loads.
 """
-
-from typing import Dict, Optional
 
 import torch
 
-from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
-from tileops.kernels.reduction.cumulative import CumulativeKernel
-
-from ..op_base import Op
+from .cumulative_base import CumulativeOp
 
 __all__ = ["CumsumFwdOp"]
 
 
-class CumsumFwdOp(Op):
-    """Cumulative sum operator: y = cumsum(x, dim=-1).
+class CumsumFwdOp(CumulativeOp):
+    """Cumulative sum operator: y = cumsum(x, dim)."""
 
-    Output has the same shape and dtype as input.
-
-    Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
-        dtype: Data type (float32, float16, or bfloat16).
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
-
-    Example:
-        >>> op = CumsumFwdOp(M=1024, N=4096, dtype=torch.float16)
-        >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
-        >>> y = op(x)  # shape: (1024, 4096)
-    """
-
-    def __init__(
-        self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-    ):
-        self.M = M
-        self.N = N
-        self.dtype = dtype
-        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["cumulative_fwd"](
-            M,
-            N,
-            "sum",
-            dtype,
-            tune=tune,
-        )
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"cumulative_fwd": CumulativeKernel}
+    _op_kind = "sum"
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the cumulative sum op.
-
-        Accepts 1D-4D input. Operates along dim=-1.
-
-        Args:
-            x: Input tensor with last dim == N.
-
-        Returns:
-            Output tensor with the same shape as input.
-        """
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.shape[-1] != self.N:
-            raise ValueError(f"Expected last dim {self.N}, got {x.shape[-1]}")
-
-        orig_shape = x.shape
-
-        # Flatten leading dims: (..., N) -> (M, N)
-        x = x.contiguous().reshape(-1, self.N)
-        M_actual = x.shape[0]
-        if M_actual != self.M:
-            raise ValueError(f"Expected M={self.M} (product of leading dims), got {M_actual}")
-
-        # Alignment padding is handled inside the kernel via masked loads.
-        y = self.kernel(x)
-
-        # Trim padding (kernel output is N_padded-wide) and restore shape
-        if self.N_padded != self.N:
-            y = y[:, : self.N]
-        return y.reshape(orig_shape)
+        return self._run(x)

--- a/tileops/ops/reduction/cumulative_base.py
+++ b/tileops/ops/reduction/cumulative_base.py
@@ -1,0 +1,137 @@
+"""CumulativeOp base class for scan operators (cumsum, cumprod).
+
+Implements the canonical static_dims pattern from docs/ops-design.md § Step 3:
+ctor binds only `static_dims` (`N`) + `signature.params` (`dim`); `M` (the
+leading-dims product) is derived at forward time, kernels are built lazily
+and cached by `M`.
+
+Forward pipeline: validate -> movedim(dim → -1) -> reshape (M, N) -> kernel
+(handles alignment via masked loads) -> trim -> reshape -> movedim(-1 → dim).
+"""
+
+from abc import abstractmethod
+from typing import Dict, Optional, Tuple
+
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
+from tileops.kernels.reduction.cumulative import CumulativeKernel
+
+from ..op_base import Op
+
+__all__ = ["CumulativeOp"]
+
+
+class CumulativeOp(Op):
+    """Abstract base for cumulative scan operators with a user-selectable axis.
+
+    Subclasses must override `_op_kind` (class attribute) — the kernel's
+    op-kind dispatch string (`"sum"` or `"prod"`).
+
+    Args:
+        N: Reduction dimension size (statically committed at ctor).
+        dtype: Data type (float32, float16, or bfloat16).
+        dim: Reduction axis (default -1). Negative values are normalized at
+            forward time (`dim % x.ndim`).
+        kernel_map: Optional kernel override dict.
+        tune: If True, autotune tile configs.
+    """
+
+    _op_kind: str
+
+    # `static_dims.N = x.shape[dim]` is param-dependent (depends on `dim`),
+    # so the static-axis frozenset is bound at forward time after dim
+    # normalization, not at the class level (per docs/ops-design.md § Step 3).
+    _static_axes: frozenset = frozenset()
+
+    def __init__(
+        self,
+        *,
+        N: int,
+        dtype: torch.dtype,
+        dim: int = -1,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        self.N = N
+        self.dtype = dtype
+        self.dim = dim
+        self.tune = tune
+        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[int, Kernel] = {}
+        self._last_roofline_mn: Optional[Tuple[int, int]] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"cumulative_fwd": CumulativeKernel}
+
+    def eval_roofline(self) -> Tuple[int, int]:
+        if self._last_roofline_mn is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind dynamic input shape (M)"
+            )
+        M, N = self._last_roofline_mn
+        elem_bytes = self.dtype.itemsize
+        # Per row: N-1 ops (running sum/prod) ≈ M*N flops total.
+        # Read x + write y = 2 * M * N elements.
+        return (M * N, 2 * M * N * elem_bytes)
+
+    def _get_kernel(self, M: int) -> Kernel:
+        """Return a kernel built for (M, self.N), caching by M."""
+        if M not in self._kernel_cache:
+            self._kernel_cache[M] = self.kernel_map["cumulative_fwd"](
+                M, self.N, self._op_kind, self.dtype, tune=self.tune,
+            )
+        return self._kernel_cache[M]
+
+    def _validate_and_normalize_dim(self, x: torch.Tensor) -> int:
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.dtype != self.dtype:
+            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        ndim = x.ndim
+        if not (-ndim <= self.dim < ndim):
+            raise ValueError(
+                f"dim={self.dim} out of range for {ndim}-D input"
+            )
+        dim_norm = self.dim % ndim
+        if x.shape[dim_norm] != self.N:
+            raise ValueError(
+                f"Expected x.shape[{self.dim}]={self.N}, "
+                f"got {x.shape[dim_norm]}"
+            )
+        # Bind the dynamic static-axis (param-dependent N axis) so
+        # Op-layer cache-key / introspection consumers see the committed axis.
+        self._static_axes = frozenset({(0, dim_norm)})
+        return dim_norm
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Subclasses implement: validate, movedim, kernel call, restore."""
+        raise NotImplementedError
+
+    def _run(self, x: torch.Tensor) -> torch.Tensor:
+        """Shared forward implementation. Subclasses call this from `forward`."""
+        ndim = x.ndim
+        dim_norm = self._validate_and_normalize_dim(x)
+
+        if dim_norm != ndim - 1:
+            x = x.movedim(dim_norm, -1)
+        post_move_shape = tuple(x.shape)
+        x = x.contiguous().reshape(-1, self.N)
+        M = x.shape[0]
+
+        # Alignment padding is handled inside the kernel via masked loads.
+        y = self._get_kernel(M)(x)
+        self._last_roofline_mn = (M, self.N)
+
+        # Kernel output is N_padded-wide along last dim; trim to N.
+        if self.N_padded != self.N:
+            y = y[:, : self.N]
+        y = y.reshape(post_move_shape)
+        if dim_norm != ndim - 1:
+            y = y.movedim(-1, dim_norm)
+        return y

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2276,7 +2276,7 @@ ops:
   CumsumFwdOp:
     ref_api: "torch.cumsum"
     family: scan
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:
@@ -2317,7 +2317,7 @@ ops:
   CumprodFwdOp:
     ref_api: "torch.cumprod"
     family: scan
-    status: spec-only
+    status: implemented
 
     signature:
       inputs:


### PR DESCRIPTION
## Summary

- Add `CumulativeOp` L2 base under `tileops/ops/reduction/cumulative_base.py` (kw-only ctor binding `static_dims.N` + `signature.params.dim`, lazy kernel cache by `M`, dim-aware `_run` helper, `eval_roofline` via `_last_roofline_mn`, `_static_axes` bound at forward).
- Migrate `CumsumFwdOp` and `CumprodFwdOp` to thin subclasses of `CumulativeOp` (each declares only `_op_kind` + a 1-line `forward`); restore Args + Example docstrings on both per Google style.
- Restore Args + Example docstring on `RMSNormFwdOp` (omitted when it became a thin `RowNormOp` subclass in #1061).
- Update test (`tests/ops/test_cumulative.py`) and benchmark (`benchmarks/ops/bench_cumulative.py`) call-sites to the new kw-only API; add `test_cumsum_dim_axis1` + `test_cumprod_dim_axis1` covering the non-default-dim movedim path.
- Flip `CumsumFwdOp.status` and `CumprodFwdOp.status` from `spec-only` to `implemented` in `tileops/ops_manifest.yaml`.
- Extend Family-Base Protocol table in `docs/ops-design-reference.md`: scan family added to the `_op_kind` row.
- Add Google-style docstring rule to `.claude/rules/code-style.md`.

## Test plan

- [x] pre-commit passed
- [x] pytest passed (`pytest tests/ops/test_cumulative.py -m smoke` — 28/28 on H200; cumsum + cumprod, 1D–3D, fp16 / bf16 / fp32, including new dim=1 cases)
- [x] validator passed (`python scripts/validate_manifest.py --check-op CumsumFwdOp` and `--check-op CumprodFwdOp`)

## Structural Readiness

<!-- Agent-generated — do not edit. -->

| Section | Status |
|---|---|
| Correctness & Safety | OK — `_validate_and_normalize_dim` checks dtype / device / shape / dim range; raises `ValueError`. |
| Kernel Structure | Unchanged — this PR is op-layer only; `CumulativeKernel` not modified. |
| Op Structure | OK — `_op_kind` is a class attribute on each subclass; forward owns pre/post-processing; delegates only `self._get_kernel(M)(x)` to the kernel. Status now `implemented`. |
| Benchmark | Pre-existing `benchmarks/ops/bench_cumulative.py` still works (call-site updated). Two warnings remain about ManifestBenchmark adoption — pre-existing, unrelated to this PR. |
| Delivery | Unit tests for default dim and dim=1; cumprod tolerance applied per dtype. Status flip blocked on validator + pytest, both pass. |

## Regression

- Default `dim=-1` path is identical in behavior to the legacy `(M, N)` API: same `reshape(-1, N)`, same kernel, same `N_padded` masking. Existing 24 unit tests (all default-dim) pass unchanged after migration.
- Non-default `dim` path is new functionality (was rejected by the legacy ctor accepting only `M, N`). Covered by 4 new H200 tests on 3-D `(2, 512, 256)` fp16 / bf16.