### PR TITLE
[Bench] Skip known TileLang 0.1.9 benchmark failures

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -8,6 +8,74 @@ collect_ignore_glob = [
     "ops/attention/bench_deepseek_nsa*.py",
 ]
 
+TILELANG_019_BENCH_SKIP_REASON = (
+    "Temporarily skipped while tracking TileLang 0.1.9 benchmark migration "
+    "failures (#1067)."
+)
+
+TILELANG_019_BENCH_PATHS = {
+    # Linear attention / recurrent ops.
+    "benchmarks/ops/bench_deltanet.py",
+    "benchmarks/ops/bench_deltanet_recurrence.py",
+    "benchmarks/ops/bench_engram.py",
+    "benchmarks/ops/bench_gated_deltanet.py",
+    "benchmarks/ops/bench_gated_deltanet_recurrence.py",
+    "benchmarks/ops/bench_gla_chunkwise.py",
+    "benchmarks/ops/bench_gla_recurrence.py",
+    # Attention.
+    "benchmarks/ops/attention/bench_deepseek_dsa_decode.py",
+    "benchmarks/ops/attention/bench_deepseek_mla_decode.py",
+    "benchmarks/ops/attention/bench_gqa_decode.py",
+    "benchmarks/ops/attention/bench_gqa_decode_paged.py",
+    "benchmarks/ops/attention/bench_gqa_sliding_window.py",
+    "benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py",
+    "benchmarks/ops/attention/bench_mha.py",
+    "benchmarks/ops/attention/bench_mha_decode.py",
+    "benchmarks/ops/attention/bench_mha_decode_paged.py",
+    # Other operators.
+    "benchmarks/ops/bench_fft.py",
+    "benchmarks/ops/bench_mhc_post.py",
+    "benchmarks/ops/bench_mhc_pre.py",
+    "benchmarks/ops/bench_rope.py",
+    "benchmarks/ops/bench_topk_selector.py",
+    # Normalization.
+    "benchmarks/ops/bench_batch_norm.py",
+    "benchmarks/ops/bench_fused_add_layer_norm.py",
+    "benchmarks/ops/bench_instance_norm.py",
+    # MoE.
+    "benchmarks/ops/bench_moe_permute.py",
+    "benchmarks/ops/bench_moe_permute_align.py",
+    # GEMM.
+    "benchmarks/ops/bench_grouped_gemm.py",
+}
+
+TILELANG_019_BENCH_PREFIXES = (
+    "benchmarks/ops/attention/bench_gqa.py::test_gqa_bwd_bench",
+    "benchmarks/ops/bench_convolution.py::test_conv2d_bench",
+    "benchmarks/ops/bench_convolution.py::test_conv3d_bench",
+)
+
+TILELANG_019_BENCH_NODEIDS = {
+    "benchmarks/ops/bench_gemm.py::test_gemm_bench[wide-fp16]",
+    "benchmarks/ops/bench_group_norm.py::test_group_norm_bench[tail-spatial-g16-float16]",
+}
+
+
+def _normalized_benchmark_nodeid(item: pytest.Item) -> str:
+    nodeid = item.nodeid
+    if nodeid.startswith("benchmarks/"):
+        return nodeid
+    if nodeid.startswith("ops/"):
+        return f"benchmarks/{nodeid}"
+    return nodeid
+
+
+def _is_fp8_e4m3_benchmark(item: pytest.Item) -> bool:
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return False
+    return callspec.params.get("dtype") == torch.float8_e4m3fn
+
 
 @pytest.fixture(autouse=True)
 def setup() -> None:
@@ -22,6 +90,38 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     BenchmarkReport.dump("profile_run.log")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    tilelang_019_skip = pytest.mark.skip(reason=TILELANG_019_BENCH_SKIP_REASON)
+    fp8_e4m3_skip = pytest.mark.skip(
+        reason=(
+            "Temporarily skipped while tracking TileLang 0.1.9 fp8 e4m3 "
+            "benchmark migration failures (#1067)."
+        )
+    )
+
+    for item in items:
+        nodeid = _normalized_benchmark_nodeid(item)
+        path = nodeid.split("::", 1)[0]
+
+        if path in TILELANG_019_BENCH_PATHS:
+            item.add_marker(tilelang_019_skip)
+            continue
+
+        if nodeid.startswith(TILELANG_019_BENCH_PREFIXES):
+            item.add_marker(tilelang_019_skip)
+            continue
+
+        if nodeid in TILELANG_019_BENCH_NODEIDS:
+            item.add_marker(tilelang_019_skip)
+            continue
+
+        if (
+            path == "benchmarks/ops/bench_elementwise_fp8.py"
+            and _is_fp8_e4m3_benchmark(item)
+        ):
+            item.add_marker(fp8_e4m3_skip)
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
## Summary

Refs #1067.

This PR centralizes the known TileLang 0.1.9 benchmark skips in `benchmarks/conftest.py` so the benchmark suite can run without hitting the current migration failures or the observed group norm compile hang.

The skip list uses:
- file-level skips for benchmark files that are entirely blocked
- prefix-level skips for selected high-cardinality benchmark families
- exact nodeid skips for narrow cases such as `wide-fp16` GEMM and `tail-spatial-g16-float16` group norm
- dtype-specific skip for `torch.float8_e4m3fn` fp8 elementwise benchmarks using pytest callspec params

The nodeid matching is normalized so the skips work whether pytest is invoked from the repository root or from inside the `benchmarks/` directory.

## Validation

- `git diff --check -- benchmarks/conftest.py`
- `python3 -m py_compile benchmarks/conftest.py`
- Docker validation on GPU1 with `/data7` caches using `tileops-runner-sshd:nightly-tl019-fullstack-no-tileops-ldfix-registered-tmux`
  - confirmed runtime uses `tilelang 0.1.9`
  - `python3 -m pytest --collect-only -q benchmarks/ops`: 1049 tests collected
  - targeted skip smoke from repo root: group norm hang case and fp8 e4m3 case both skipped
  - targeted skip smoke from `cd benchmarks`: same two cases both skipped

Earlier nightly-style validation on the same skip set completed warmup and benchmark phases without hanging after the narrow group norm skip was added.
