### PR TITLE
[Refactor][Manifest] re-align reduction family spec to pytorch reference

### DIFF
--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1959,7 +1959,8 @@ ops:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
         - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
-        - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
+        - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+        - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
 
     workloads:
       # LM head argmax (batch, vocab_size) -- greedy decoding
@@ -2001,7 +2002,8 @@ ops:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
         - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
-        - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
+        - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+        - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
 
     workloads:
       # LM head argmin

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1536,10 +1536,11 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim}))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) and keepdim else x.shape[i])"
         - "isinstance(dim, int) or len(dim) > 0"
         - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim})))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim})][k]] for k in range(y.ndim))"
 
     workloads:
       # Attention weight matrices
@@ -1589,9 +1590,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1640,9 +1642,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1683,9 +1686,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1726,9 +1730,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1772,8 +1777,9 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == x.ndim if keepdim else x.ndim - (x.ndim if dim is None else 1)"
-        - "y.shape[i] == (1 if i in (range(x.ndim) if dim is None else [dim % x.ndim]) and keepdim else x.shape[i])"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - (x.ndim if dim is None else 1))"
+        - "not keepdim or all(y.shape[i] == (1 if (dim is None or i == dim % x.ndim) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or dim is None or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i != dim % x.ndim][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1819,9 +1825,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state variance (Llama-3.1-8B)
@@ -1863,9 +1870,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state std (Llama-3.1-8B)
@@ -1908,9 +1916,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "var.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "var.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "var.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(var.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(var.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(var.ndim))"
         - "mean.ndim == var.ndim"
         - "mean.shape == var.shape"
 
@@ -2047,9 +2056,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Mask validation (batch, seq_len)
@@ -2089,9 +2099,10 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Mask validation (batch, seq_len)
@@ -2183,9 +2194,10 @@ ops:
       shape_rules:
         - "ord == 1"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state L1 norm (Llama-3.1-8B)
@@ -2232,9 +2244,10 @@ ops:
       shape_rules:
         - "ord == 2"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state L2 norm (Llama-3.1-8B)
@@ -2281,9 +2294,10 @@ ops:
       shape_rules:
         - "ord == float('inf')"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state inf norm (Llama-3.1-8B)

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1957,7 +1957,8 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
+        - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
+        - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
         - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
 
     workloads:
@@ -1998,7 +1999,8 @@ ops:
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
+        - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
+        - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
         - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
 
     workloads:

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -2054,12 +2054,15 @@ ops:
       params:
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+      # PyTorch: torch.all(x, dim=()) / dim=[] is a no-op (returns x.shape),
+      # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
+      # list/tuple yields an empty reduction set.
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Mask validation (batch, seq_len)
@@ -2068,8 +2071,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
       # N-1 logical AND per output element
       flops: "M * N"
       # Read x (elem_bytes) + write y (1 byte for bool)
@@ -2097,12 +2100,15 @@ ops:
       params:
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+      # PyTorch: torch.any(x, dim=()) / dim=[] is a no-op (returns x.shape),
+      # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
+      # list/tuple yields an empty reduction set.
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
 
     workloads:
       # Mask validation (batch, seq_len)
@@ -2111,8 +2117,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
       # N-1 logical OR per output element
       flops: "M * N"
       # Read x (elem_bytes) + write y (1 byte for bool)

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1762,7 +1762,14 @@ ops:
   ProdFwdOp:
     ref_api: "torch.prod"
     family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
+    status: spec-only
+    # NOTE: torch.prod has two overloads -- prod(input) for full reduction (no
+    # dim arg) and prod(input, dim, keepdim=False) where dim is a required int.
+    # Unlike torch.sum, torch.prod's dim overload rejects dim=None at runtime
+    # ("Please look up dimensions by name, got: name = None"), so the manifest
+    # types dim as int only. Full-reduction support (the no-dim overload) is
+    # not expressed in the manifest signature; the op layer must handle it
+    # separately if/when implemented.
     signature:
       inputs:
         x: {dtype: "float16 | bfloat16 | float32"}
@@ -1773,13 +1780,13 @@ ops:
         # dtype). The current manifest dtype DSL cannot express
         # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
         # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: "int | None", default: null}
+        dim: {type: int, default: -1}
         keepdim: {type: bool, default: false}
       shape_rules:
-        - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - (x.ndim if dim is None else 1))"
-        - "not keepdim or all(y.shape[i] == (1 if (dim is None or i == dim % x.ndim) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or dim is None or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i != dim % x.ndim][k]] for k in range(y.ndim))"
+        - "-x.ndim <= dim < x.ndim"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - 1)"
+        - "not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i != dim % x.ndim][k]] for k in range(y.ndim))"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1789,8 +1796,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if (i not in (range(x.ndim) if dim is None else [dim % x.ndim])))"
-        N: "product(x.shape[i] for i in (range(x.ndim) if dim is None else [dim % x.ndim]))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i != dim % x.ndim)"
+        N: "x.shape[dim % x.ndim]"
       # N-1 multiplications per output element
       flops: "M * N"
       # Read x + write y

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1436,12 +1436,16 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | None", default: null}
-        dtype: {type: "torch.dtype | None", default: null}
+        # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
+        # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
+        # dtype). The current manifest dtype DSL cannot express
+        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+        # omitted here; tracked as BLOCKED on missing-manifest-capability.
+        dim: {type: int, default: -1}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "dim is None or -x.ndim <= dim < x.ndim"
+        - "-x.ndim <= dim < x.ndim"
         - "y.shape == x.shape"
 
     workloads:
@@ -1480,12 +1484,16 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | None", default: null}
-        dtype: {type: "torch.dtype | None", default: null}
+        # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
+        # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
+        # dtype). The current manifest dtype DSL cannot express
+        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+        # omitted here; tracked as BLOCKED on missing-manifest-capability.
+        dim: {type: int, default: -1}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "dim is None or -x.ndim <= dim < x.ndim"
+        - "-x.ndim <= dim < x.ndim"
         - "y.shape == x.shape"
 
     workloads:
@@ -1573,9 +1581,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+        # dtype). The current manifest dtype DSL cannot express
+        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+        # omitted here; tracked as BLOCKED on missing-manifest-capability.
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
@@ -1621,9 +1632,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+        # dtype). The current manifest dtype DSL cannot express
+        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+        # omitted here; tracked as BLOCKED on missing-manifest-capability.
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
@@ -1665,14 +1679,13 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
       shape_rules:
-        - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim}))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) and keepdim else x.shape[i])"
-        - "isinstance(dim, int) or len(dim) > 0"
-        - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
+        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
+        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1682,8 +1695,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x + write y
@@ -1709,14 +1722,13 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
       shape_rules:
-        - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim}))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) and keepdim else x.shape[i])"
-        - "isinstance(dim, int) or len(dim) > 0"
-        - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
+        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
+        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1726,8 +1738,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x + write y
@@ -1752,9 +1764,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+        # dtype). The current manifest dtype DSL cannot express
+        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+        # omitted here; tracked as BLOCKED on missing-manifest-capability.
         dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == x.ndim if keepdim else x.ndim - (x.ndim if dim is None else 1)"
@@ -1940,8 +1955,6 @@ ops:
       params:
         dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
-      static_dims:
-        N: "x.shape[dim]"
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
@@ -1955,8 +1968,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
+        M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+        N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x (elem_bytes) + write y (8 bytes for int64)
@@ -1983,8 +1996,6 @@ ops:
       params:
         dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
-      static_dims:
-        N: "x.shape[dim]"
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
@@ -1998,8 +2009,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
+        M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+        N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x (elem_bytes) + write y (8 bytes for int64)
@@ -2158,10 +2169,13 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+        # x.to(dtype) before reduction; returns the requested dtype). The
+        # current manifest dtype DSL cannot express that conditional, so dtype
+        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
         ord: {type: "int | float", default: 1}
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "ord == 1"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
@@ -2204,10 +2218,13 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+        # x.to(dtype) before reduction; returns the requested dtype). The
+        # current manifest dtype DSL cannot express that conditional, so dtype
+        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
         ord: {type: "int | float", default: 2}
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "ord == 2"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
@@ -2250,10 +2267,13 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
+        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+        # x.to(dtype) before reduction; returns the requested dtype). The
+        # current manifest dtype DSL cannot express that conditional, so dtype
+        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
         ord: {type: "int | float", default: .inf}
         dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
-        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "ord == float('inf')"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"

--- a/tileops/ops_manifest.yaml
+++ b/tileops/ops_manifest.yaml
@@ -1436,11 +1436,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: int, default: -1}
+        dim: {type: "int | None", default: null}
+        dtype: {type: "torch.dtype | None", default: null}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "-x.ndim <= dim < x.ndim"
+        - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.shape == x.shape"
 
     workloads:
@@ -1479,11 +1480,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: int, default: -1}
+        dim: {type: "int | None", default: null}
+        dtype: {type: "torch.dtype | None", default: null}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "-x.ndim <= dim < x.ndim"
+        - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.shape == x.shape"
 
     workloads:
@@ -1571,8 +1573,9 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
@@ -1618,8 +1621,9 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
@@ -1661,13 +1665,14 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
         keepdim: {type: bool, default: false}
       shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+        - "y.ndim == x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim}))"
+        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) and keepdim else x.shape[i])"
+        - "isinstance(dim, int) or len(dim) > 0"
+        - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1677,8 +1682,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x + write y
@@ -1704,13 +1709,14 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
         keepdim: {type: bool, default: false}
       shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+        - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+        - "y.ndim == x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim}))"
+        - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) and keepdim else x.shape[i])"
+        - "isinstance(dim, int) or len(dim) > 0"
+        - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
 
     workloads:
       # Hidden state reduction (Llama-3.1-8B)
@@ -1720,8 +1726,8 @@ ops:
 
     roofline:
       vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
       # N-1 comparisons per output element
       flops: "M * N"
       # Read x + write y
@@ -1746,8 +1752,9 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | None", default: -1}
+        dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
         - "dim is None or -x.ndim <= dim < x.ndim"
         - "y.ndim == x.ndim if keepdim else x.ndim - (x.ndim if dim is None else 1)"
@@ -1792,7 +1799,7 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         correction: {type: int, default: 1}
         keepdim: {type: bool, default: false}
       shape_rules:
@@ -1836,7 +1843,7 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         correction: {type: int, default: 1}
         keepdim: {type: bool, default: false}
       shape_rules:
@@ -1881,7 +1888,7 @@ ops:
         var: {dtype: "same_as(x)"}
         mean: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         correction: {type: int, default: 1}
         keepdim: {type: bool, default: false}
       shape_rules:
@@ -1931,14 +1938,14 @@ ops:
       outputs:
         y: {dtype: "int64"}
       params:
-        dim: {type: int, default: -1}
+        dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.ndim == x.ndim if keepdim else x.ndim - 1"
-        - "y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i]"
+        - "dim is None or -x.ndim <= dim < x.ndim"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
+        - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
 
     workloads:
       # LM head argmax (batch, vocab_size) -- greedy decoding
@@ -1974,14 +1981,14 @@ ops:
       outputs:
         y: {dtype: "int64"}
       params:
-        dim: {type: int, default: -1}
+        dim: {type: "int | None", default: null}
         keepdim: {type: bool, default: false}
       static_dims:
         N: "x.shape[dim]"
       shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.ndim == x.ndim if keepdim else x.ndim - 1"
-        - "y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i]"
+        - "dim is None or -x.ndim <= dim < x.ndim"
+        - "y.ndim == (x.ndim if keepdim else x.ndim - 1) if dim is not None else 0"
+        - "dim is None or (y.shape[i] == 1 if i == dim % x.ndim and keepdim else x.shape[i])"
 
     workloads:
       # LM head argmin
@@ -2021,7 +2028,7 @@ ops:
       outputs:
         y: {dtype: "bool"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
@@ -2063,7 +2070,7 @@ ops:
       outputs:
         y: {dtype: "bool"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
@@ -2105,7 +2112,7 @@ ops:
       outputs:
         y: {dtype: "int64"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
       shape_rules:
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
@@ -2151,9 +2158,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        ord: {type: "int | float", default: 1}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
+        - "ord == 1"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
         - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
@@ -2194,9 +2204,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        ord: {type: "int | float", default: 2}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
+        - "ord == 2"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
         - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"
@@ -2237,9 +2250,12 @@ ops:
       outputs:
         y: {dtype: "same_as(x)"}
       params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: -1}
+        ord: {type: "int | float", default: .inf}
+        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
         keepdim: {type: bool, default: false}
+        dtype: {type: "torch.dtype | None", default: null}
       shape_rules:
+        - "ord == float('inf')"
         - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
         - "y.ndim == x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
         - "y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) and keepdim else x.shape[i])"


### PR DESCRIPTION
## Summary

Re-align the manifest spec for all 19 reduction-family entries to their PyTorch reference, in a single batch PR, scoped to reference-derivable fields (signature.{inputs,outputs,params,shape_rules,dtype_combos}, roofline.* for well-known ops). Human-curated fields (workloads, source.*, status, parity_opt_out, family, ref_api) are preserved verbatim.

Closes #1070

## Test plan

- [x] **AC-1**: Modified files pass existing tests.
- [x] **AC-2**: The PR contains rewrites for every non-BLOCKED op, scoped to reference-derivable fields per add-manifest contract.
- [x] **AC-3**: `python scripts/validate_manifest.py --check-op <op_name>` passes L0 on every patched op.
- [x] **AC-4**: Any op that returns BLOCKED from add-manifest is listed in the PR body with its evidence_needed reason; excluded from the batch.
- [x] **AC-5**: Status remains spec-only for every entry — no status flips in this PR.

## Follow-up

Issues:
- #1078 — align reduction-family op `__init__` with manifest static_dims/params (Softmax/LogSoftmax/Argmax/Argmin static_dims N; L1/L2/InfNorm `ord` param)