### PR TITLE
[Doc] Trim CLAUDE.md and add ops_manifest.yaml reading rule

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,5 +1,3 @@
-- No GitHub issue numbers or ad-hoc issue annotations in source/test files. Issue refs belong in commit messages and PR descriptions only.
-
 - Every `tileops/kernels/*` subpackage must have an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
 
 - Relative imports for intra-package references (e.g. `from .op import Op`); absolute `tileops.*` imports for cross-package references.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,3 +1,5 @@
+- No GitHub issue numbers or ad-hoc issue annotations in source/test files. Issue refs belong in commit messages and PR descriptions only.
+
 - Every `tileops/kernels/*` subpackage must have an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
 
 - Relative imports for intra-package references (e.g. `from .op import Op`); absolute `tileops.*` imports for cross-package references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Activate a virtual environment, then `make install` (deps + pre-commit hooks).
 
 ## Reading `ops_manifest.yaml`
 
-This file is thousands of lines — never slurp it as text. To inspect an entry, parse it (`yaml.safe_load`) and index by op name. For edits, use a round-trip parser (`ruamel.yaml`) to preserve comments and key order. Reserve `Read`/`grep` for targeted line lookups, not structural reading.
+This file is thousands of lines — never slurp it as text. To inspect an entry, parse it (`yaml.safe_load`) and index the top-level `ops` dictionary by op name. For edits, use a round-trip parser (`ruamel.yaml`) to preserve comments and key order. Reserve `Read`/`grep` for targeted line lookups, not structural reading.
 
 ## Domain Rules (load on demand)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,7 @@ This project follows **design-first, spec-driven** development: design docs and 
 
 ## Development Environment
 
-1. Clone repository: `git clone https://github.com/tile-ai/TileOPs && cd TileOPs`
-1. Create and activate a virtual environment (venv, conda, etc.)
-1. Install dependencies and pre-commit hooks: `make install`
+Activate a virtual environment, then `make install` (deps + pre-commit hooks).
 
 ## Key References
 
@@ -28,20 +26,9 @@ This project follows **design-first, spec-driven** development: design docs and 
 - [testing.md](docs/testing.md) — test/benchmark framework, core abstractions, tolerances, reporting rules
 - [tileops-skills.md](docs/tileops-skills.md) — developer decision guide: which repo-provided skill to use for which task
 
-### External
+## Reading `ops_manifest.yaml`
 
-- [TileOPs.github.io](https://github.com/tile-ai/TileOPs.github.io) — auto-generated documentation site (API reference, perf tables, support matrix)
-
-## Collaboration Rules for Claude
-
-- Prefer minimal, targeted changes and avoid unrelated refactoring.
-- After code changes, run the most relevant tests first.
-- If unrelated failures appear, report them but do not fix them in the same task.
-- Add necessary docs and tests when introducing files/interfaces.
-- Response should include: change summary, affected paths, validation steps, and next suggestions.
-- No GitHub issue numbers or ad-hoc issue annotations in source/test files. Issue refs belong in commit messages and PR descriptions only.
-- When orchestrating sub-agents: verify clean worktree (`git diff --quiet && git diff --cached --quiet`) after each sub-agent returns. If dirty, commit on behalf using a descriptive message (e.g., `Sub-agent [name]: [task summary]`).
-- Write commit messages in `[Type] description` or `[Type][Scope] description` format per `COMMIT_MSG_PATTERN` in `.claude/conventions/types.sh` (scope is optional). Not CI-enforced, but expected for readability.
+This file is thousands of lines — never slurp it as text. To inspect an entry, parse it (`yaml.safe_load`) and index by op name. For edits, use a round-trip parser (`ruamel.yaml`) to preserve comments and key order. Reserve `Read`/`grep` for targeted line lookups, not structural reading.
 
 ## Domain Rules (load on demand)
 


### PR DESCRIPTION
## Summary

- Drop redundant `Collaboration Rules for Claude` section — items are already enforced by skills (verification-before-completion, foundry:committing-changes, sub-agent orchestration).
- Drop `External` link section and the stale `git clone` step from `Development Environment`.
- Add a top-level `Reading ops_manifest.yaml` note: the file is too large to slurp as text — parse via `yaml.safe_load` and edit via `ruamel.yaml` round-trip; `Read`/`grep` only for targeted line lookups.

## Test plan

- [x] pre-commit passed