### PR TITLE
[Fix][CI] rerun core preflight checks on ready_for_review

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -150,19 +150,27 @@ jobs:
           fi
 
           # `benchmark-contract-tests` is intentionally skipped on PRs that
-          # don't touch its inputs (see detect-changes), so accept `skipped`
-          # as well as `success` here — only genuine failures should block
-          # the ready_for_review short-circuit.
+          # don't touch its inputs (see detect-changes). Keep that job
+          # skippable, but still require the core preflight checks to be
+          # successful so `ready_for_review` re-runs them and unblocks
+          # gpu-smoke.
           CHECKS=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs" --jq '
             [
               .check_runs
               | group_by(.name)
               | map(max_by(.id))[]
               | select(.name == "pre-commit" or .name == "gitleaks" or .name == "actionlint" or .name == "benchmark-contract-tests")
-              | .conclusion
+              | {name: .name, conclusion: .conclusion}
             ]
           ')
-          ALL_OK=$(echo "$CHECKS" | jq 'all(. == "success" or . == "skipped")')
+          ALL_OK=$(echo "$CHECKS" | jq '
+            all(
+              if .name == "benchmark-contract-tests"
+              then (.conclusion == "success" or .conclusion == "skipped")
+              else (.conclusion == "success")
+              end
+            )
+          ')
           COUNT=$(echo "$CHECKS" | jq 'length')
           if [[ "$ALL_OK" == "true" && "$COUNT" -ge 4 ]]; then
             echo "CI already passed for SHA $HEAD_SHA; skipping"


### PR DESCRIPTION
## Summary

Fix a `ready_for_review` regression in `Preflight Checks` where `ci-gate` can treat draft-phase skipped checks as reusable success and short-circuit the core preflight rerun. That leaves `pre-commit`, `gitleaks`, and `actionlint` skipped on the new PR state, which blocks `gpu-smoke` in `ci-prereq` until it times out.

This change narrows the ready-for-review short-circuit so only `benchmark-contract-tests` may conclude `skipped`; the core checks still need to conclude `success` before the workflow is skipped.

Closes #1085.

## Regression

The regression was introduced when `ci-gate` started accepting `skipped` conclusions for ready-for-review suppression in order to support path-based skipping of `benchmark-contract-tests`. That was too broad because it also covered the core preflight checks and prevented them from re-running after draft exit.

## Test plan

- [x] Parsed `.github/workflows/preflight.yml` as valid YAML
- [x] Commit hooks passed during `git commit`
- [x] Verify on a ready_for_review PR that `pre-commit`, `gitleaks`, and `actionlint` re-run while `benchmark-contract-tests` may still skip
- [x] Verify `gpu-smoke` no longer stalls in `ci-prereq`