### PR TITLE
[Refactor][Manifest] flatten yaml top-level ops key

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -4,7 +4,7 @@ The [`tileops/manifest/`](../tileops/manifest/) package is the **source of truth
 
 ## Layout
 
-The manifest is split across one YAML file per op family — `elementwise.yaml`, `reduction.yaml`, `attention.yaml`, `normalization.yaml`, `moe.yaml`, `scan.yaml`, `convolution.yaml`. Each file has a single top-level `ops:` mapping. The `tileops.manifest` package merges all files at load time; duplicate op names across files are an error.
+The manifest is split across one YAML file per op family — `elementwise.yaml`, `reduction.yaml`, `attention.yaml`, `normalization.yaml`, `moe.yaml`, `scan.yaml`, `convolution.yaml`. Each file is a flat top-level mapping of op name → entry (no wrapper key). The `tileops.manifest` package merges all files at load time; duplicate op names across files are an error.
 
 - **Add or edit an op**: edit the family file matching the op's `family` field. Use `ruamel.yaml` for round-trip edits.
 - **Read programmatically**: `from tileops.manifest import load_manifest, load_workloads, manifest_files`. `load_manifest()` returns the merged `ops` dict.
@@ -202,7 +202,7 @@ The base class emits a once-per-type runtime warning if the default `_cache_key`
 
 ## Manifest Key Format
 
-Each entry in `ops:` is keyed by the **Python class name** of the Op — PascalCase with a mandatory direction suffix and `Op` suffix:
+Each top-level entry is keyed by the **Python class name** of the Op — PascalCase with a mandatory direction suffix and `Op` suffix:
 
 ```
 {PascalCaseName}{Direction}Op
@@ -429,44 +429,47 @@ These rules are `shape_rules` (Python expressions) rather than a new manifest fi
 **Full entry — RMSNorm:**
 
 ```yaml
-ops:
-  RMSNormFwdOp:
-    family: normalization
-    ref_api: "torch.nn.functional.rms_norm"
-    status: implemented
+RMSNormFwdOp:
+  family: normalization
+  ref_api: "torch.nn.functional.rms_norm"
+  status: implemented
 
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-        weight: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: int, default: -1}
-        eps: {type: float, default: 1e-6}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "y.shape == x.shape"
-        - "weight.shape == (x.shape[dim],)"
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+      weight: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: int, default: -1}
+      eps: {type: float, default: 1e-6}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "y.shape == x.shape"
+      - "weight.shape == (x.shape[dim],)"
 
-    workloads:
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  workloads:
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:dim])"
-        N: "x.shape[dim]"
-      flops: "4 * M * N"
-      bytes: "(2 * M * N + N) * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:dim])"
+      N: "x.shape[dim]"
+    flops: "4 * M * N"
+    bytes: "(2 * M * N + N) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/rms_norm.py
-      op: tileops/ops/norm/rms_norm.py
-      test: tests/ops/test_rms_norm.py
-      bench: benchmarks/ops/bench_rms_norm.py
+  source:
+    kernel: tileops/kernels/norm/rms_norm.py
+    op: tileops/ops/norm/rms_norm.py
+    test: tests/ops/test_rms_norm.py
+    bench: benchmarks/ops/bench_rms_norm.py
 ```
+
+Each family file is a flat top-level mapping of op name → entry. There is no
+wrapper key. The `tileops.manifest` loader merges all family files into one
+dict; op names must remain unique across files.
 
 ## Benchmark Pattern
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -467,10 +467,6 @@ RMSNormFwdOp:
     bench: benchmarks/ops/bench_rms_norm.py
 ```
 
-Each family file is a flat top-level mapping of op name → entry. There is no
-wrapper key. The `tileops.manifest` loader merges all family files into one
-dict; op names must remain unique across files.
-
 ## Benchmark Pattern
 
 Benchmarks must use manifest-driven workloads. See [testing.md](testing.md)

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -2933,8 +2933,7 @@ def validate_manifest(
         ops = load_manifest()
     else:
         with open(manifest_path) as f:
-            data = yaml.safe_load(f)
-        ops = data.get("ops", {})
+            ops = yaml.safe_load(f) or {}
 
     # Fail fast: --check-op with a name not in the manifest
     if check_op is not None and check_op not in ops:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -2934,6 +2934,11 @@ def validate_manifest(
     else:
         with open(manifest_path) as f:
             ops = yaml.safe_load(f) or {}
+        if not isinstance(ops, dict):
+            return [
+                f"--manifest-path: {manifest_path} must contain a top-level "
+                f"mapping of op name -> entry, got {type(ops).__name__}"
+            ], []
 
     # Fail fast: --check-op with a name not in the manifest
     if check_op is not None and check_op not in ops:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -3040,7 +3040,7 @@ class TestCheckOp:
         # Build a temp manifest and call validate_manifest directly.
         manifest_file = tmp_path / "ops_manifest.yaml"
         import yaml
-        manifest_file.write_text(yaml.safe_dump({"ops": {"my_op": entry}}))
+        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
 
         # Without check_op: spec-only op skips L1-L4
         errors_no_flag, warnings_no_flag = validator.validate_manifest(
@@ -3071,7 +3071,7 @@ class TestCheckOp:
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         import yaml
-        manifest_file.write_text(yaml.safe_dump({"ops": {"my_op": entry}}))
+        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
 
         errors, warnings = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -3089,7 +3089,7 @@ class TestCheckOp:
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         import yaml
-        manifest_file.write_text(yaml.safe_dump({"ops": {"my_op": entry}}))
+        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
 
         errors, warnings = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -3106,7 +3106,7 @@ class TestCheckOp:
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         import yaml
-        manifest_file.write_text(yaml.safe_dump({"ops": {"my_op": entry}}))
+        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
 
         errors, warnings = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -3134,7 +3134,7 @@ class TestCheckOp:
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         manifest_file.write_text(yaml.safe_dump(
-            {"ops": {"target_op": target_entry, "other_op": other_entry}},
+            {"target_op": target_entry, "other_op": other_entry},
         ))
 
         # With check_op="target_op": only target_op is validated.
@@ -3171,7 +3171,7 @@ class TestCheckOp:
 
         manifest_file = tmp_path / "ops_manifest.yaml"
         manifest_file.write_text(yaml.safe_dump(
-            {"ops": {"target_op": target_entry, "other_op": other_entry}},
+            {"target_op": target_entry, "other_op": other_entry},
         ))
 
         # With check_op="target_op": the invalid variant_of on other_op
@@ -3217,11 +3217,11 @@ class TestCheckOp:
         broken_variant["variant_of"] = "primary_op"
 
         manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({"ops": {
+        manifest_file.write_text(yaml.safe_dump({
             "primary_op": primary,
             "good_variant": valid_variant,
             "bad_variant": broken_variant,
-        }}))
+        }))
 
         # check_op="primary_op" must catch the R16 violation on bad_variant
         errors, _ = validator.validate_manifest(
@@ -3263,10 +3263,10 @@ class TestCheckOp:
         }
 
         manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({"ops": {
+        manifest_file.write_text(yaml.safe_dump({
             "primary_op": primary,
             "broken_var": broken_variant,
-        }}))
+        }))
 
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -3117,6 +3117,23 @@ class TestCheckOp:
             f"Expected error about 'nonexistent_op' not found in manifest, got: {errors}"
         )
 
+    def test_manifest_path_non_mapping_root_reports_error(self, validator, tmp_path):
+        """A manifest yaml whose root is not a mapping yields a schema error,
+        not an AttributeError on .items()."""
+        import yaml
+
+        manifest_file = tmp_path / "ops_manifest.yaml"
+        # Top-level sequence — common malformed shape (e.g. accidental list).
+        manifest_file.write_text(yaml.safe_dump(["my_op", "other_op"]))
+
+        errors, _ = validator.validate_manifest(
+            manifest_path=manifest_file,
+            repo_root=tmp_path,
+        )
+        assert any("top-level mapping" in e for e in errors), (
+            f"Expected a top-level-mapping error, got: {errors}"
+        )
+
     def test_check_op_scopes_to_single_op(self, validator, tmp_path):
         """--check-op validates only the named op; unrelated ops are not processed."""
         import yaml

--- a/tileops/manifest/__init__.py
+++ b/tileops/manifest/__init__.py
@@ -45,6 +45,11 @@ def load_manifest() -> dict[str, Any]:
     for path in manifest_files():
         text = path.read_text(encoding="utf-8")
         ops = yaml.safe_load(text) or {}
+        if not isinstance(ops, dict):
+            raise ValueError(
+                f"manifest file {path.name} must contain a top-level mapping of "
+                f"op name -> entry, got {type(ops).__name__}"
+            )
         for name, entry in ops.items():
             if name in merged:
                 raise ValueError(

--- a/tileops/manifest/__init__.py
+++ b/tileops/manifest/__init__.py
@@ -44,8 +44,7 @@ def load_manifest() -> dict[str, Any]:
     origin: dict[str, str] = {}
     for path in manifest_files():
         text = path.read_text(encoding="utf-8")
-        data = yaml.safe_load(text) or {}
-        ops = data.get("ops") or {}
+        ops = yaml.safe_load(text) or {}
         for name, entry in ops.items():
             if name in merged:
                 raise ValueError(
@@ -54,10 +53,6 @@ def load_manifest() -> dict[str, Any]:
             merged[name] = entry
             origin[name] = path.name
     return merged
-
-
-# Backwards-compatible private alias.
-_load_manifest = load_manifest
 
 
 def load_workloads(op_name: str) -> list[dict[str, Any]]:
@@ -77,7 +72,6 @@ def load_workloads(op_name: str) -> list[dict[str, Any]]:
 
 
 __all__ = [
-    "_load_manifest",
     "load_manifest",
     "load_workloads",
     "manifest_files",

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -4,562 +4,561 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  MultiHeadAttentionFwdOp:
-    ref_api: "torch.nn.functional.scaled_dot_product_attention"
-    family: attention
-    status: implemented
+MultiHeadAttentionFwdOp:
+  ref_api: "torch.nn.functional.scaled_dot_product_attention"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-      shape_rules:
-        - "q.shape == (B, S, H, D)"
-        - "k.shape == (B, S, H, D)"
-        - "v.shape == (B, S, H, D)"
-        - "o.shape == (B, S, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+    shape_rules:
+      - "q.shape == (B, S, H, D)"
+      - "k.shape == (B, S, H, D)"
+      - "v.shape == (B, S, H, D)"
+      - "o.shape == (B, S, H, D)"
 
-    workloads:
-      # Llama-3.1-8B (H=32, D=128)
-      - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-      - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
-      # Llama-3.1-70B (H=64, D=128)
-      - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-      - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+  workloads:
+    # Llama-3.1-8B (H=32, D=128)
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    # Llama-3.1-70B (H=64, D=128)
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
 
-    roofline:
-      func: "tileops.perf.formulas.mha_fwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.mha_fwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_fwd.py
-      kernel_map:
-        mha_fwd_kernel: MHAFwdKernel
-      op: tileops/ops/attention/mha.py
-      test: tests/ops/attention/test_mha.py
-      bench: benchmarks/ops/attention/bench_mha.py
+  source:
+    kernel: tileops/kernels/attention/gqa_fwd.py
+    kernel_map:
+      mha_fwd_kernel: MHAFwdKernel
+    op: tileops/ops/attention/mha.py
+    test: tests/ops/attention/test_mha.py
+    bench: benchmarks/ops/attention/bench_mha.py
 
-  MultiHeadAttentionBwdOp:
-    ref_api: "torch.nn.functional.scaled_dot_product_attention"
-    family: attention
-    status: implemented
+MultiHeadAttentionBwdOp:
+  ref_api: "torch.nn.functional.scaled_dot_product_attention"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-        o: {dtype: "same_as(q)"}
-        do: {dtype: "same_as(q)"}
-        lse: {dtype: "float32"}
-      outputs:
-        dq: {dtype: "same_as(q)"}
-        dk: {dtype: "same_as(q)"}
-        dv: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-      shape_rules:
-        - "q.shape == (B, S, H, D)"
-        - "k.shape == (B, S, H, D)"
-        - "v.shape == (B, S, H, D)"
-        - "o.shape == (B, S, H, D)"
-        - "do.shape == (B, S, H, D)"
-        - "lse.shape == (B, H, S)"
-        - "dq.shape == (B, S, H, D)"
-        - "dk.shape == (B, S, H, D)"
-        - "dv.shape == (B, S, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+      o: {dtype: "same_as(q)"}
+      do: {dtype: "same_as(q)"}
+      lse: {dtype: "float32"}
+    outputs:
+      dq: {dtype: "same_as(q)"}
+      dk: {dtype: "same_as(q)"}
+      dv: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+    shape_rules:
+      - "q.shape == (B, S, H, D)"
+      - "k.shape == (B, S, H, D)"
+      - "v.shape == (B, S, H, D)"
+      - "o.shape == (B, S, H, D)"
+      - "do.shape == (B, S, H, D)"
+      - "lse.shape == (B, H, S)"
+      - "dq.shape == (B, S, H, D)"
+      - "dk.shape == (B, S, H, D)"
+      - "dv.shape == (B, S, H, D)"
 
-    workloads:
-      # Llama-3.1-8B (H=32, D=128)
-      - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-      - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
-      # Llama-3.1-70B (H=64, D=128)
-      - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-      - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+  workloads:
+    # Llama-3.1-8B (H=32, D=128)
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 32, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    # Llama-3.1-70B (H=64, D=128)
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 64, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
 
-    roofline:
-      func: "tileops.perf.formulas.mha_bwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.mha_bwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_bwd.py
-      kernel_map:
-        mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        mha_bwd_kernel: MHABwdKernel
-        mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
-      op: tileops/ops/attention/mha.py
-      test: tests/ops/attention/test_mha.py
-      bench: benchmarks/ops/attention/bench_mha.py
+  source:
+    kernel: tileops/kernels/attention/gqa_bwd.py
+    kernel_map:
+      mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
+      mha_bwd_kernel: MHABwdKernel
+      mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
+    op: tileops/ops/attention/mha.py
+    test: tests/ops/attention/test_mha.py
+    bench: benchmarks/ops/attention/bench_mha.py
 
-  GroupedQueryAttentionFwdOp:
-    ref_api: "torch.nn.functional.scaled_dot_product_attention"
-    family: attention
-    status: implemented
+GroupedQueryAttentionFwdOp:
+  ref_api: "torch.nn.functional.scaled_dot_product_attention"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-      shape_rules:
-        - "q.shape == (B, S, H, D)"
-        - "k.shape == (B, S, H_kv, D)"
-        - "v.shape == (B, S, H_kv, D)"
-        - "o.shape == (B, S, H, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+    shape_rules:
+      - "q.shape == (B, S, H, D)"
+      - "k.shape == (B, S, H_kv, D)"
+      - "v.shape == (B, S, H_kv, D)"
+      - "o.shape == (B, S, H, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128)
-      - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-      - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128)
-      - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-      - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128)
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128)
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_fwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_fwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_fwd.py
-      kernel_map:
-        gqa_fwd_kernel: GQAFwdKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa.py
-      bench: benchmarks/ops/attention/bench_gqa.py
+  source:
+    kernel: tileops/kernels/attention/gqa_fwd.py
+    kernel_map:
+      gqa_fwd_kernel: GQAFwdKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa.py
+    bench: benchmarks/ops/attention/bench_gqa.py
 
-  GroupedQueryAttentionBwdOp:
-    ref_api: "torch.nn.functional.scaled_dot_product_attention"
-    family: attention
-    status: implemented
+GroupedQueryAttentionBwdOp:
+  ref_api: "torch.nn.functional.scaled_dot_product_attention"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-        o: {dtype: "same_as(q)"}
-        do: {dtype: "same_as(q)"}
-        lse: {dtype: "float32"}
-      outputs:
-        dq: {dtype: "same_as(q)"}
-        dk: {dtype: "same_as(q)"}
-        dv: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-      shape_rules:
-        - "q.shape == (B, S, H, D)"
-        - "k.shape == (B, S, H_kv, D)"
-        - "v.shape == (B, S, H_kv, D)"
-        - "o.shape == (B, S, H, D)"
-        - "do.shape == (B, S, H, D)"
-        - "lse.shape == (B, H, S)"
-        - "dq.shape == (B, S, H, D)"
-        - "dk.shape == (B, S, H_kv, D)"
-        - "dv.shape == (B, S, H_kv, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+      o: {dtype: "same_as(q)"}
+      do: {dtype: "same_as(q)"}
+      lse: {dtype: "float32"}
+    outputs:
+      dq: {dtype: "same_as(q)"}
+      dk: {dtype: "same_as(q)"}
+      dv: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+    shape_rules:
+      - "q.shape == (B, S, H, D)"
+      - "k.shape == (B, S, H_kv, D)"
+      - "v.shape == (B, S, H_kv, D)"
+      - "o.shape == (B, S, H, D)"
+      - "do.shape == (B, S, H, D)"
+      - "lse.shape == (B, H, S)"
+      - "dq.shape == (B, S, H, D)"
+      - "dk.shape == (B, S, H_kv, D)"
+      - "dv.shape == (B, S, H_kv, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128)
-      - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
-      - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128)
-      - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
-      - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128)
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128)
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_bwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_bwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_bwd.py
-      kernel_map:
-        gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-        gqa_bwd_kernel: GQABwdKernel
-        gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa.py
-      bench: benchmarks/ops/attention/bench_gqa.py
+  source:
+    kernel: tileops/kernels/attention/gqa_bwd.py
+    kernel_map:
+      gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
+      gqa_bwd_kernel: GQABwdKernel
+      gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa.py
+    bench: benchmarks/ops/attention/bench_gqa.py
 
-  # ---------------------------------------------------------------------------
-  # attention — decode (single-query against KV cache)
-  # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# attention — decode (single-query against KV cache)
+# ---------------------------------------------------------------------------
 
-  MultiHeadAttentionDecodeWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+MultiHeadAttentionDecodeWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params: {}
-      shape_rules:
-        - "q.shape == (B, S_q, H, D)"
-        - "k.shape == (B, N_kv, H, D)"
-        - "v.shape == (B, N_kv, H, D)"
-        - "o.shape == (B, S_q, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params: {}
+    shape_rules:
+      - "q.shape == (B, S_q, H, D)"
+      - "k.shape == (B, N_kv, H, D)"
+      - "v.shape == (B, N_kv, H, D)"
+      - "o.shape == (B, S_q, H, D)"
 
-    workloads:
-      # Llama-3.1-8B (H=32, D=128), short KV
-      - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
-      # Llama-3.1-8B, long KV
-      - {q_shape: [8, 1, 32, 128], kv_shape: [8, 32768, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
-      # Llama-3.1-70B (H=64, D=128), short KV
-      - {q_shape: [16, 1, 64, 128], kv_shape: [16, 4096, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
-      # Llama-3.1-70B, long KV
-      - {q_shape: [4, 1, 64, 128], kv_shape: [4, 32768, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
+  workloads:
+    # Llama-3.1-8B (H=32, D=128), short KV
+    - {q_shape: [32, 1, 32, 128], kv_shape: [32, 4096, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
+    # Llama-3.1-8B, long KV
+    - {q_shape: [8, 1, 32, 128], kv_shape: [8, 32768, 32, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
+    # Llama-3.1-70B (H=64, D=128), short KV
+    - {q_shape: [16, 1, 64, 128], kv_shape: [16, 4096, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
+    # Llama-3.1-70B, long KV
+    - {q_shape: [4, 1, 64, 128], kv_shape: [4, 32768, 64, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
 
-    roofline:
-      func: "tileops.perf.formulas.mha_decode_roofline"
+  roofline:
+    func: "tileops.perf.formulas.mha_decode_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/mha_decode.py
-      kernel_map:
-        mha_decode_kernel: MHADecodeKernel
-      op: tileops/ops/attention/mha.py
-      test: tests/ops/attention/test_mha_decode.py
-      bench: benchmarks/ops/attention/bench_mha_decode.py
+  source:
+    kernel: tileops/kernels/attention/mha_decode.py
+    kernel_map:
+      mha_decode_kernel: MHADecodeKernel
+    op: tileops/ops/attention/mha.py
+    test: tests/ops/attention/test_mha_decode.py
+    bench: benchmarks/ops/attention/bench_mha_decode.py
 
-  MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-        real_seqlen_kv: {dtype: "int32"}
-        block_table: {dtype: "int32"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        page_size: {type: int}
-        is_causal: {type: bool, default: false}
-      shape_rules:
-        - "q.shape == (B, S_q, H, D)"
-        - "k.shape == (N_kv, H, D)"
-        - "v.shape == (N_kv, H, D)"
-        - "real_seqlen_kv.shape == (B,)"
-        - "block_table.shape == (B, num_pages)"
-        - "o.shape == (B, S_q, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+      real_seqlen_kv: {dtype: "int32"}
+      block_table: {dtype: "int32"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      page_size: {type: int}
+      is_causal: {type: bool, default: false}
+    shape_rules:
+      - "q.shape == (B, S_q, H, D)"
+      - "k.shape == (N_kv, H, D)"
+      - "v.shape == (N_kv, H, D)"
+      - "real_seqlen_kv.shape == (B,)"
+      - "block_table.shape == (B, num_pages)"
+      - "o.shape == (B, S_q, H, D)"
 
-    workloads:
-      # Llama-3.1-8B (H=32, D=128), short KV, page_size=1
-      - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
-      # Llama-3.1-8B, short KV, page_size=64
-      - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
-      # Llama-3.1-8B, long KV, page_size=1
-      - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
-      # Llama-3.1-8B, long KV, page_size=64
-      - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
-      # Llama-3.1-70B (H=64, D=128), short KV, page_size=1
-      - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
-      # Llama-3.1-70B, short KV, page_size=64
-      - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
-      # Llama-3.1-70B, long KV, page_size=1
-      - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
-      # Llama-3.1-70B, long KV, page_size=64
-      - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
+  workloads:
+    # Llama-3.1-8B (H=32, D=128), short KV, page_size=1
+    - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
+    # Llama-3.1-8B, short KV, page_size=64
+    - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
+    # Llama-3.1-8B, long KV, page_size=1
+    - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
+    # Llama-3.1-8B, long KV, page_size=64
+    - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
+    # Llama-3.1-70B (H=64, D=128), short KV, page_size=1
+    - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
+    # Llama-3.1-70B, short KV, page_size=64
+    - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
+    # Llama-3.1-70B, long KV, page_size=1
+    - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
+    # Llama-3.1-70B, long KV, page_size=64
+    - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
 
-    roofline:
-      func: "tileops.perf.formulas.mha_decode_paged_roofline"
+  roofline:
+    func: "tileops.perf.formulas.mha_decode_paged_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/mha_decode_paged.py
-      kernel_map:
-        mha_decode_paged_kernel: MHADecodePagedKernel
-      op: tileops/ops/attention/mha.py
-      test: tests/ops/attention/test_mha_decode_paged.py
-      bench: benchmarks/ops/attention/bench_mha_decode_paged.py
+  source:
+    kernel: tileops/kernels/attention/mha_decode_paged.py
+    kernel_map:
+      mha_decode_paged_kernel: MHADecodePagedKernel
+    op: tileops/ops/attention/mha.py
+    test: tests/ops/attention/test_mha_decode_paged.py
+    bench: benchmarks/ops/attention/bench_mha_decode_paged.py
 
-  GroupedQueryAttentionDecodeWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+GroupedQueryAttentionDecodeWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params: {}
-      shape_rules:
-        - "q.shape == (B, H, D)"
-        - "k.shape == (B, N_kv, H_kv, D)"
-        - "v.shape == (B, N_kv, H_kv, D)"
-        - "o.shape == (B, H, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params: {}
+    shape_rules:
+      - "q.shape == (B, H, D)"
+      - "k.shape == (B, N_kv, H_kv, D)"
+      - "v.shape == (B, N_kv, H_kv, D)"
+      - "o.shape == (B, H, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV
-      - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
-      # Llama-3.1-8B, long KV
-      - {q_shape: [8, 32, 128], kv_shape: [8, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV
-      - {q_shape: [16, 64, 128], kv_shape: [16, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
-      # Llama-3.1-70B, long KV
-      - {q_shape: [4, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV
+    - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k"}
+    # Llama-3.1-8B, long KV
+    - {q_shape: [8, 32, 128], kv_shape: [8, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV
+    - {q_shape: [16, 64, 128], kv_shape: [16, 4096, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k"}
+    # Llama-3.1-70B, long KV
+    - {q_shape: [4, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_decode_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_decode_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_decode.py
-      kernel_map:
-        gqa_decode_kernel: GQADecodeKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa_decode.py
-      bench: benchmarks/ops/attention/bench_gqa_decode.py
+  source:
+    kernel: tileops/kernels/attention/gqa_decode.py
+    kernel_map:
+      gqa_decode_kernel: GQADecodeKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa_decode.py
+    bench: benchmarks/ops/attention/bench_gqa_decode.py
 
-  GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-        real_seqlen_kv: {dtype: "int32"}
-        block_table: {dtype: "int32"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        page_size: {type: int}
-      shape_rules:
-        - "q.shape == (B, H, D)"
-        - "k.shape == (N_kv, H_kv, D)"
-        - "v.shape == (N_kv, H_kv, D)"
-        - "real_seqlen_kv.shape == (B,)"
-        - "block_table.shape == (B, num_pages)"
-        - "o.shape == (B, H, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+      real_seqlen_kv: {dtype: "int32"}
+      block_table: {dtype: "int32"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      page_size: {type: int}
+    shape_rules:
+      - "q.shape == (B, H, D)"
+      - "k.shape == (N_kv, H_kv, D)"
+      - "v.shape == (N_kv, H_kv, D)"
+      - "real_seqlen_kv.shape == (B,)"
+      - "block_table.shape == (B, num_pages)"
+      - "o.shape == (B, H, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV, page_size=1
-      - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
-      # Llama-3.1-8B, short KV, page_size=64
-      - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
-      # Llama-3.1-8B, long KV, page_size=1
-      - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
-      # Llama-3.1-8B, long KV, page_size=64
-      - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV, page_size=1
-      - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
-      # Llama-3.1-70B, short KV, page_size=64
-      - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
-      # Llama-3.1-70B, long KV, page_size=1
-      - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
-      # Llama-3.1-70B, long KV, page_size=64
-      - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV, page_size=1
+    - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
+    # Llama-3.1-8B, short KV, page_size=64
+    - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
+    # Llama-3.1-8B, long KV, page_size=1
+    - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
+    # Llama-3.1-8B, long KV, page_size=64
+    - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV, page_size=1
+    - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
+    # Llama-3.1-70B, short KV, page_size=64
+    - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
+    # Llama-3.1-70B, long KV, page_size=1
+    - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
+    # Llama-3.1-70B, long KV, page_size=64
+    - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_decode_paged_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_decode_paged_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_decode_paged.py
-      kernel_map:
-        gqa_decode_paged_kernel: GQADecodePagedKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa_decode_paged.py
-      bench: benchmarks/ops/attention/bench_gqa_decode_paged.py
+  source:
+    kernel: tileops/kernels/attention/gqa_decode_paged.py
+    kernel_map:
+      gqa_decode_paged_kernel: GQADecodePagedKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa_decode_paged.py
+    bench: benchmarks/ops/attention/bench_gqa_decode_paged.py
 
-  # ---------------------------------------------------------------------------
-  # attention — sliding window
-  # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# attention — sliding window
+# ---------------------------------------------------------------------------
 
-  GroupedQueryAttentionSlidingWindowFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+GroupedQueryAttentionSlidingWindowFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-        window_size_left: {type: int, default: -1}
-        window_size_right: {type: int, default: -1}
-      shape_rules:
-        - "q.shape == (B, S, H, D)"
-        - "k.shape == (B, S, H_kv, D)"
-        - "v.shape == (B, S, H_kv, D)"
-        - "o.shape == (B, S, H, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+      window_size_left: {type: int, default: -1}
+      window_size_right: {type: int, default: -1}
+    shape_rules:
+      - "q.shape == (B, S, H, D)"
+      - "k.shape == (B, S, H_kv, D)"
+      - "v.shape == (B, S, H_kv, D)"
+      - "o.shape == (B, S, H, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
-      - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
-      - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128)
-      - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
-      - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
+    - {q_shape: [4, 512, 32, 128], kv_shape: [4, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
+    - {q_shape: [2, 2048, 32, 128], kv_shape: [2, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128)
+    - {q_shape: [2, 512, 64, 128], kv_shape: [2, 512, 8, 128], is_causal: true, window_size_left: 256, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
+    - {q_shape: [1, 2048, 64, 128], kv_shape: [1, 2048, 8, 128], is_causal: true, window_size_left: 1024, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_sliding_window_fwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_sliding_window_fwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_sliding_window_fwd.py
-      kernel_map:
-        gqa_sliding_window_fwd: GQASlidingWindowFwdKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa_sliding_window.py
-      bench: benchmarks/ops/attention/bench_gqa_sliding_window.py
+  source:
+    kernel: tileops/kernels/attention/gqa_sliding_window_fwd.py
+    kernel_map:
+      gqa_sliding_window_fwd: GQASlidingWindowFwdKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa_sliding_window.py
+    bench: benchmarks/ops/attention/bench_gqa_sliding_window.py
 
-  GroupedQueryAttentionSlidingWindowVarlenFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+GroupedQueryAttentionSlidingWindowVarlenFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        k: {dtype: "same_as(q)"}
-        v: {dtype: "same_as(q)"}
-        cu_seqlens_q: {dtype: "int32"}
-        cu_seqlens_k: {dtype: "int32"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        is_causal: {type: bool, default: true}
-        window_size_left: {type: int, default: -1}
-        window_size_right: {type: int, default: -1}
-        max_seqlen_q: {type: int}
-      shape_rules:
-        - "q.shape == (total_q, H, D)"
-        - "k.shape == (total_k, H_kv, D)"
-        - "v.shape == (total_k, H_kv, D)"
-        - "cu_seqlens_q.shape == (B + 1,)"
-        - "cu_seqlens_k.shape == (B + 1,)"
-        - "o.shape == (total_q, H, D)"
-        - "H % H_kv == 0"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      k: {dtype: "same_as(q)"}
+      v: {dtype: "same_as(q)"}
+      cu_seqlens_q: {dtype: "int32"}
+      cu_seqlens_k: {dtype: "int32"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      is_causal: {type: bool, default: true}
+      window_size_left: {type: int, default: -1}
+      window_size_right: {type: int, default: -1}
+      max_seqlen_q: {type: int}
+    shape_rules:
+      - "q.shape == (total_q, H, D)"
+      - "k.shape == (total_k, H_kv, D)"
+      - "v.shape == (total_k, H_kv, D)"
+      - "cu_seqlens_q.shape == (B + 1,)"
+      - "cu_seqlens_k.shape == (B + 1,)"
+      - "o.shape == (total_q, H, D)"
+      - "H % H_kv == 0"
 
-    workloads:
-      # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
-      - {total_q: 2048, total_k: 2048, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
-      - {total_q: 8192, total_k: 8192, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
-      # Llama-3.1-70B (H=64, H_kv=8, D=128)
-      - {total_q: 2048, total_k: 2048, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
-      - {total_q: 8192, total_k: 8192, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
+  workloads:
+    # Llama-3.1-8B (H=32, H_kv=8, D=128), short seq
+    - {total_q: 2048, total_k: 2048, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-8b-short-w256"}
+    - {total_q: 8192, total_k: 8192, batch: 4, heads: 32, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-8b-long-w1024"}
+    # Llama-3.1-70B (H=64, H_kv=8, D=128)
+    - {total_q: 2048, total_k: 2048, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 256, max_seqlen_q: 512, dtypes: [float16, bfloat16], label: "llama-3.1-70b-short-w256"}
+    - {total_q: 8192, total_k: 8192, batch: 4, heads: 64, heads_kv: 8, dim: 128, is_causal: true, window_size_left: 1024, max_seqlen_q: 2048, dtypes: [float16, bfloat16], label: "llama-3.1-70b-long-w1024"}
 
-    roofline:
-      func: "tileops.perf.formulas.gqa_sliding_window_varlen_fwd_roofline"
+  roofline:
+    func: "tileops.perf.formulas.gqa_sliding_window_varlen_fwd_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
-      kernel_map:
-        gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdKernel
-      op: tileops/ops/attention/gqa.py
-      test: tests/ops/attention/test_gqa_sliding_window_varlen.py
-      bench: benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+  source:
+    kernel: tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
+    kernel_map:
+      gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdKernel
+    op: tileops/ops/attention/gqa.py
+    test: tests/ops/attention/test_gqa_sliding_window_varlen.py
+    bench: benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
 
-  # ---------------------------------------------------------------------------
-  # attention — Multi-Head Latent Attention / DeepSeek Sparse Attention decode
-  # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# attention — Multi-Head Latent Attention / DeepSeek Sparse Attention decode
+# ---------------------------------------------------------------------------
 
-  MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        q_pe: {dtype: "same_as(q)"}
-        k: {dtype: "same_as(q)"}
-        k_pe: {dtype: "same_as(q)"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        pe_dim: {type: int}
-      shape_rules:
-        - "q.shape == (B, H, D)"
-        - "q_pe.shape == (B, H, pe_dim)"
-        - "k.shape == (B, N_kv, H_kv, D)"
-        - "k_pe.shape == (B, N_kv, H_kv, pe_dim)"
-        - "o.shape == (B, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      q_pe: {dtype: "same_as(q)"}
+      k: {dtype: "same_as(q)"}
+      k_pe: {dtype: "same_as(q)"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      pe_dim: {type: int}
+    shape_rules:
+      - "q.shape == (B, H, D)"
+      - "q_pe.shape == (B, H, pe_dim)"
+      - "k.shape == (B, N_kv, H_kv, D)"
+      - "k_pe.shape == (B, N_kv, H_kv, pe_dim)"
+      - "o.shape == (B, H, D)"
 
-    workloads:
-      # DeepSeek-V2 (H=128, H_kv=1, D=128, pe_dim=64), short KV
-      - {q_shape: [32, 128, 128], q_pe_shape: [32, 128, 64], kv_shape: [32, 4096, 1, 128], k_pe_shape: [32, 4096, 1, 64], pe_dim: 64, dtypes: [float16, bfloat16], label: "deepseek-v2-4k"}
-      # DeepSeek-V2, long KV
-      - {q_shape: [8, 128, 128], q_pe_shape: [8, 128, 64], kv_shape: [8, 32768, 1, 128], k_pe_shape: [8, 32768, 1, 64], pe_dim: 64, dtypes: [float16, bfloat16], label: "deepseek-v2-32k"}
-      # DeepSeek-V3 (H=128, H_kv=1, D=128, pe_dim=64), short KV
-      - {q_shape: [16, 128, 128], q_pe_shape: [16, 128, 64], kv_shape: [16, 4096, 1, 128], k_pe_shape: [16, 4096, 1, 64], pe_dim: 64, dtypes: [bfloat16], label: "deepseek-v3-4k"}
-      # DeepSeek-V3, long KV
-      - {q_shape: [4, 128, 128], q_pe_shape: [4, 128, 64], kv_shape: [4, 32768, 1, 128], k_pe_shape: [4, 32768, 1, 64], pe_dim: 64, dtypes: [bfloat16], label: "deepseek-v3-32k"}
+  workloads:
+    # DeepSeek-V2 (H=128, H_kv=1, D=128, pe_dim=64), short KV
+    - {q_shape: [32, 128, 128], q_pe_shape: [32, 128, 64], kv_shape: [32, 4096, 1, 128], k_pe_shape: [32, 4096, 1, 64], pe_dim: 64, dtypes: [float16, bfloat16], label: "deepseek-v2-4k"}
+    # DeepSeek-V2, long KV
+    - {q_shape: [8, 128, 128], q_pe_shape: [8, 128, 64], kv_shape: [8, 32768, 1, 128], k_pe_shape: [8, 32768, 1, 64], pe_dim: 64, dtypes: [float16, bfloat16], label: "deepseek-v2-32k"}
+    # DeepSeek-V3 (H=128, H_kv=1, D=128, pe_dim=64), short KV
+    - {q_shape: [16, 128, 128], q_pe_shape: [16, 128, 64], kv_shape: [16, 4096, 1, 128], k_pe_shape: [16, 4096, 1, 64], pe_dim: 64, dtypes: [bfloat16], label: "deepseek-v3-4k"}
+    # DeepSeek-V3, long KV
+    - {q_shape: [4, 128, 128], q_pe_shape: [4, 128, 64], kv_shape: [4, 32768, 1, 128], k_pe_shape: [4, 32768, 1, 64], pe_dim: 64, dtypes: [bfloat16], label: "deepseek-v3-32k"}
 
-    roofline:
-      func: "tileops.perf.formulas.deepseek_mla_decode_roofline"
+  roofline:
+    func: "tileops.perf.formulas.deepseek_mla_decode_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/deepseek_mla_decode.py
-      kernel_map:
-        mla_decode_kernel: MLADecodeKernel
-      op: tileops/ops/attention/deepseek_mla.py
-      test: tests/ops/attention/test_deepseek_mla_decode.py
-      bench: benchmarks/ops/attention/bench_deepseek_mla_decode.py
+  source:
+    kernel: tileops/kernels/attention/deepseek_mla_decode.py
+    kernel_map:
+      mla_decode_kernel: MLADecodeKernel
+    op: tileops/ops/attention/deepseek_mla.py
+    test: tests/ops/attention/test_deepseek_mla_decode.py
+    bench: benchmarks/ops/attention/bench_deepseek_mla_decode.py
 
-  DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
-    ref_api: "none"
-    family: attention
-    status: implemented
+DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
+  ref_api: "none"
+  family: attention
+  status: implemented
 
-    signature:
-      inputs:
-        q: {dtype: "float16 | bfloat16"}
-        kv: {dtype: "same_as(q)"}
-        indices: {dtype: "int32"}
-      outputs:
-        o: {dtype: "same_as(q)"}
-      params:
-        dim_tail: {type: int}
-        topk: {type: int}
-        stride_kv: {type: int}
-        q_start_index_s: {type: int}
-        is_causal: {type: bool, default: true}
-        sm_scale: {type: float, default: null}
-      shape_rules:
-        - "q.shape == (B, S, H, D + dim_tail)"
-        - "kv.shape == (B, S_kv, H_kv, D + dim_tail)"
-        - "indices.shape == (B, S, H_kv, topk)"
-        - "o.shape == (B, S, H, D)"
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16"}
+      kv: {dtype: "same_as(q)"}
+      indices: {dtype: "int32"}
+    outputs:
+      o: {dtype: "same_as(q)"}
+    params:
+      dim_tail: {type: int}
+      topk: {type: int}
+      stride_kv: {type: int}
+      q_start_index_s: {type: int}
+      is_causal: {type: bool, default: true}
+      sm_scale: {type: float, default: null}
+    shape_rules:
+      - "q.shape == (B, S, H, D + dim_tail)"
+      - "kv.shape == (B, S_kv, H_kv, D + dim_tail)"
+      - "indices.shape == (B, S, H_kv, topk)"
+      - "o.shape == (B, S, H, D)"
 
-    workloads:
-      # DeepSeek-V2 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
-      - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-4k"}
-      - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-32k"}
-      # DeepSeek-V3 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
-      - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-4k"}
-      - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-32k"}
+  workloads:
+    # DeepSeek-V2 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
+    - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-4k"}
+    - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-32k"}
+    # DeepSeek-V3 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
+    - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-4k"}
+    - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-32k"}
 
-    roofline:
-      func: "tileops.perf.formulas.deepseek_dsa_decode_roofline"
+  roofline:
+    func: "tileops.perf.formulas.deepseek_dsa_decode_roofline"
 
-    source:
-      kernel: tileops/kernels/attention/deepseek_dsa_decode.py
-      kernel_map:
-        sparse_mla_kernel: SparseMlaKernel
-      op: tileops/ops/attention/deepseek_dsa.py
-      test: tests/ops/attention/test_deepseek_dsa_decode.py
-      bench: benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+  source:
+    kernel: tileops/kernels/attention/deepseek_dsa_decode.py
+    kernel_map:
+      sparse_mla_kernel: SparseMlaKernel
+    op: tileops/ops/attention/deepseek_dsa.py
+    test: tests/ops/attention/test_deepseek_dsa_decode.py
+    bench: benchmarks/ops/attention/bench_deepseek_dsa_decode.py

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -4,116 +4,115 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  Conv1dFwdOp:
-    ref_api: "torch.nn.functional.conv1d"
-    # Equivalent to torch.nn.functional.conv1d (bias=None)
-    family: convolution
-    status: spec-only  # TODO: impl lacks dilation, groups, string padding
+Conv1dFwdOp:
+  ref_api: "torch.nn.functional.conv1d"
+  # Equivalent to torch.nn.functional.conv1d (bias=None)
+  family: convolution
+  status: spec-only  # TODO: impl lacks dilation, groups, string padding
 
-    signature:
-      inputs:
-        input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, L_in]"}
-        weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kW]"}
-      outputs:
-        output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
-      params:
-        stride: {type: "int | tuple[int]", default: 1}
-        padding: {type: "int | tuple[int] | str", default: 0}
-        dilation: {type: "int | tuple[int]", default: 1}
-        groups: {type: int, default: 1}
-      shape_rules:
-        - "C_in % groups == 0"
-        - "C_out % groups == 0"
-        - "C_in_g == C_in // groups"
-        # Normalize tuple params to scalar (conv1d tuples are always 1-element)
-        - "_s == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
-        - "_p == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
-        - "_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
-        # String padding validation
-        - "not isinstance(_p, str) or _p in ('valid', 'same')"
-        - "_p != 'same' or _s == 1"
-        - "L_out == L_in if _p == 'same' else (L_in + 2 * (0 if _p == 'valid' else _p) - _d * (kW - 1) - 1) // _s + 1"
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, L_in]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kW]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
+    params:
+      stride: {type: "int | tuple[int]", default: 1}
+      padding: {type: "int | tuple[int] | str", default: 0}
+      dilation: {type: "int | tuple[int]", default: 1}
+      groups: {type: int, default: 1}
+    shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
+      # Normalize tuple params to scalar (conv1d tuples are always 1-element)
+      - "_s == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      # String padding validation
+      - "not isinstance(_p, str) or _p in ('valid', 'same')"
+      - "_p != 'same' or _s == 1"
+      - "L_out == L_in if _p == 'same' else (L_in + 2 * (0 if _p == 'valid' else _p) - _d * (kW - 1) - 1) // _s + 1"
 
-    # Workloads selected from three dominant Conv1d model families:
-    #   Whisper (OpenAI ASR)  — https://huggingface.co/openai/whisper-large-v3
-    #     src: transformers/models/whisper/modeling_whisper.py WhisperEncoder (nn.Conv1d)
-    #   Wav2Vec2 (Meta ASR)   — https://huggingface.co/facebook/wav2vec2-base
-    #     src: transformers/models/wav2vec2/modeling_wav2vec2.py Wav2Vec2NoLayerNormConvLayer (nn.Conv1d)
-    #   EnCodec (Meta codec)  — https://huggingface.co/facebook/encodec_24khz
-    #     src: transformers/models/encodec/modeling_encodec.py EncodecEncoder (EncodecConv1d → nn.Conv1d)
-    # Selection criteria: cover small/large kernel, narrow/wide channels,
-    #   short/long sequences, and different pipeline stages (entry vs deep layer).
-    workloads:
-      # Whisper-large encoder conv1: mel spectrogram → hidden (most common ASR entry point)
-      - {input_shape: [1, 80, 3000], C_out: 1280, kW: 3, dtypes: [float16, bfloat16], label: "whisper-large-conv1"}
-      # Wav2Vec2 feature extractor layer1: raw 1s waveform, large kernel + stride downsampling
-      - {input_shape: [1, 1, 16000], C_out: 512, kW: 10, stride: 5, dtypes: [float16, bfloat16], label: "wav2vec2-layer1"}
-      # EnCodec SEANet encoder init: raw 1s audio @24kHz, narrow channels
-      - {input_shape: [1, 1, 24000], C_out: 32, kW: 7, dtypes: [float16, bfloat16], label: "encodec-init"}
-      # EnCodec SEANet deep block: short sequence, wide channels, large kernel
-      - {input_shape: [1, 128, 600], C_out: 256, kW: 10, dtypes: [float16, bfloat16], label: "encodec-deep"}
+  # Workloads selected from three dominant Conv1d model families:
+  #   Whisper (OpenAI ASR)  — https://huggingface.co/openai/whisper-large-v3
+  #     src: transformers/models/whisper/modeling_whisper.py WhisperEncoder (nn.Conv1d)
+  #   Wav2Vec2 (Meta ASR)   — https://huggingface.co/facebook/wav2vec2-base
+  #     src: transformers/models/wav2vec2/modeling_wav2vec2.py Wav2Vec2NoLayerNormConvLayer (nn.Conv1d)
+  #   EnCodec (Meta codec)  — https://huggingface.co/facebook/encodec_24khz
+  #     src: transformers/models/encodec/modeling_encodec.py EncodecEncoder (EncodecConv1d → nn.Conv1d)
+  # Selection criteria: cover small/large kernel, narrow/wide channels,
+  #   short/long sequences, and different pipeline stages (entry vs deep layer).
+  workloads:
+    # Whisper-large encoder conv1: mel spectrogram → hidden (most common ASR entry point)
+    - {input_shape: [1, 80, 3000], C_out: 1280, kW: 3, dtypes: [float16, bfloat16], label: "whisper-large-conv1"}
+    # Wav2Vec2 feature extractor layer1: raw 1s waveform, large kernel + stride downsampling
+    - {input_shape: [1, 1, 16000], C_out: 512, kW: 10, stride: 5, dtypes: [float16, bfloat16], label: "wav2vec2-layer1"}
+    # EnCodec SEANet encoder init: raw 1s audio @24kHz, narrow channels
+    - {input_shape: [1, 1, 24000], C_out: 32, kW: 7, dtypes: [float16, bfloat16], label: "encodec-init"}
+    # EnCodec SEANet deep block: short sequence, wide channels, large kernel
+    - {input_shape: [1, 128, 600], C_out: 256, kW: 10, dtypes: [float16, bfloat16], label: "encodec-deep"}
 
-    roofline:
-      flops: "2 * N * C_out * L_out * C_in_g * kW"
-      bytes: "(N * C_in * L_in + C_out * C_in_g * kW + N * C_out * L_out) * elem_bytes"
+  roofline:
+    flops: "2 * N * C_out * L_out * C_in_g * kW"
+    bytes: "(N * C_in * L_in + C_out * C_in_g * kW + N * C_out * L_out) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/convolution.py
-      kernel_map:
-        conv1d_kernel: Conv1dKernel
-      op: tileops/ops/convolution.py
-      test: tests/ops/test_convolution.py
-      bench: benchmarks/ops/bench_convolution.py
-      bench_manifest_driven: false
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv1d_kernel: Conv1dKernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false
 
-  Conv1dBiasFwdOp:
-    ref_api: "torch.nn.functional.conv1d"
-    # Equivalent to torch.nn.functional.conv1d (bias≠None)
-    family: convolution
-    status: spec-only  # TODO: impl lacks dilation, groups, string padding
-    variant_of: Conv1dFwdOp
+Conv1dBiasFwdOp:
+  ref_api: "torch.nn.functional.conv1d"
+  # Equivalent to torch.nn.functional.conv1d (bias≠None)
+  family: convolution
+  status: spec-only  # TODO: impl lacks dilation, groups, string padding
+  variant_of: Conv1dFwdOp
 
-    signature:
-      inputs:
-        input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, L_in]"}
-        weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kW]"}
-        bias: {dtype: "same_as(input)", shape: "[C_out]"}
-      outputs:
-        output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
-      params:
-        stride: {type: "int | tuple[int]", default: 1}
-        padding: {type: "int | tuple[int] | str", default: 0}
-        dilation: {type: "int | tuple[int]", default: 1}
-        groups: {type: int, default: 1}
-      shape_rules:
-        - "C_in % groups == 0"
-        - "C_out % groups == 0"
-        - "C_in_g == C_in // groups"
-        - "_s == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
-        - "_p == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
-        - "_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
-        - "not isinstance(_p, str) or _p in ('valid', 'same')"
-        - "_p != 'same' or _s == 1"
-        - "L_out == L_in if _p == 'same' else (L_in + 2 * (0 if _p == 'valid' else _p) - _d * (kW - 1) - 1) // _s + 1"
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, L_in]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kW]"}
+      bias: {dtype: "same_as(input)", shape: "[C_out]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, L_out]"}
+    params:
+      stride: {type: "int | tuple[int]", default: 1}
+      padding: {type: "int | tuple[int] | str", default: 0}
+      dilation: {type: "int | tuple[int]", default: 1}
+      groups: {type: int, default: 1}
+    shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
+      - "_s == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "not isinstance(_p, str) or _p in ('valid', 'same')"
+      - "_p != 'same' or _s == 1"
+      - "L_out == L_in if _p == 'same' else (L_in + 2 * (0 if _p == 'valid' else _p) - _d * (kW - 1) - 1) // _s + 1"
 
-    # Same shapes as conv1d_fwd; bias adds negligible memory traffic
-    workloads:
-      - {input_shape: [1, 80, 3000], C_out: 1280, kW: 3, dtypes: [float16, bfloat16], label: "whisper-large-conv1"}
-      - {input_shape: [1, 1, 16000], C_out: 512, kW: 10, stride: 5, dtypes: [float16, bfloat16], label: "wav2vec2-layer1"}
-      - {input_shape: [1, 1, 24000], C_out: 32, kW: 7, dtypes: [float16, bfloat16], label: "encodec-init"}
-      - {input_shape: [1, 128, 600], C_out: 256, kW: 10, dtypes: [float16, bfloat16], label: "encodec-deep"}
+  # Same shapes as conv1d_fwd; bias adds negligible memory traffic
+  workloads:
+    - {input_shape: [1, 80, 3000], C_out: 1280, kW: 3, dtypes: [float16, bfloat16], label: "whisper-large-conv1"}
+    - {input_shape: [1, 1, 16000], C_out: 512, kW: 10, stride: 5, dtypes: [float16, bfloat16], label: "wav2vec2-layer1"}
+    - {input_shape: [1, 1, 24000], C_out: 32, kW: 7, dtypes: [float16, bfloat16], label: "encodec-init"}
+    - {input_shape: [1, 128, 600], C_out: 256, kW: 10, dtypes: [float16, bfloat16], label: "encodec-deep"}
 
-    roofline:
-      # bias adds one addition per output element
-      flops: "2 * N * C_out * L_out * C_in_g * kW + N * C_out * L_out"
-      bytes: "(N * C_in * L_in + C_out * C_in_g * kW + C_out + N * C_out * L_out) * elem_bytes"
+  roofline:
+    # bias adds one addition per output element
+    flops: "2 * N * C_out * L_out * C_in_g * kW + N * C_out * L_out"
+    bytes: "(N * C_in * L_in + C_out * C_in_g * kW + C_out + N * C_out * L_out) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/convolution.py
-      kernel_map:
-        conv1d_kernel: Conv1dKernel
-      op: tileops/ops/convolution.py
-      test: tests/ops/test_convolution.py
-      bench: benchmarks/ops/bench_convolution.py
-      bench_manifest_driven: false
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv1d_kernel: Conv1dKernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false

--- a/tileops/manifest/elementwise.yaml
+++ b/tileops/manifest/elementwise.yaml
@@ -4,2027 +4,2026 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  ExpFwdOp:
-    ref_api: "torch.exp"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  LogFwdOp:
-    ref_api: "torch.log"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  SqrtFwdOp:
-    ref_api: "torch.sqrt"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  RsqrtFwdOp:
-    ref_api: "torch.rsqrt"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  AbsFwdOp:
-    ref_api: "torch.abs"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  NegFwdOp:
-    ref_api: "torch.neg"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  ReciprocalFwdOp:
-    ref_api: "torch.reciprocal"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  SignFwdOp:
-    ref_api: "torch.sign"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      # 2 comparisons per element (sign uses two compares + selects)
-      flops: "2 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  SinFwdOp:
-    ref_api: "torch.sin"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  CosFwdOp:
-    ref_api: "torch.cos"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  FloorFwdOp:
-    ref_api: "torch.floor"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  CeilFwdOp:
-    ref_api: "torch.ceil"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  RoundFwdOp:
-    ref_api: "torch.round"
-    family: elementwise
-    status: spec-only  # impl ignores 'decimals' param (kernel only supports decimals=0); fix in follow-up
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        decimals: {type: int, default: 0}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  TruncFwdOp:
-    ref_api: "torch.trunc"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  ErfFwdOp:
-    ref_api: "torch.erf"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  Log1pFwdOp:
-    ref_api: "torch.log1p"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      # log(1 + x): 1 add + 1 log
-      flops: "2 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  Expm1FwdOp:
-    ref_api: "torch.expm1"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      # exp(x) - 1: 1 exp + 1 sub
-      flops: "2 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_unary_math.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  SigmoidFwdOp:
-    ref_api: "torch.sigmoid"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      # sigmoid(x) = 1 / (1 + exp(-x)): ~4 ops/elem
-      flops: "4 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  TanhFwdOp:
-    ref_api: "torch.tanh"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      # tanh(x) = 2 * sigmoid(2x) - 1: ~5 ops/elem (1 mul for 2x + 4 sigmoid ops)
-      flops: "5 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  LogicalNotFwdOp:
-    ref_api: "torch.logical_not"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "bool"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [bool, float16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [bool], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "N_total * elem_bytes + N_total"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_logical.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  BitwiseNotFwdOp:
-    ref_api: "torch.bitwise_not"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [int32, int64], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [int32], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_bitwise.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  IsnanFwdOp:
-    ref_api: "torch.isnan"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "bool"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "N_total * elem_bytes + N_total"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  IsinfFwdOp:
-    ref_api: "torch.isinf"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "bool"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "N_total * elem_bytes + N_total"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  IsfiniteFwdOp:
-    ref_api: "torch.isfinite"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        y: {dtype: "bool"}
-      shape_rules:
-        - "y.shape == x.shape"
-
-    workloads:
-      - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(x.shape)"
-      flops: "N_total"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "N_total * elem_bytes + N_total"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_unary_elementwise.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise -- unary functional activations (torch.nn.functional.<op>)
-  # All ops operate elementwise over arbitrary-rank tensors; output shape == input shape.
-  # ---------------------------------------------------------------------------
-
-  ReluFwdOp:
-    ref_api: "torch.nn.functional.relu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # Hidden-state activation (Llama-3.1-8B prefill)
-      - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-prefill"}
-      # Decode (single token)
-      - {input_shape: [1, 4096], dtypes: [bfloat16], label: "hidden-state-decode"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # 1 compare + 1 select per element = 2 fp ops
-      flops: "2 * N"
-      # Read input + write output
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  GeluFwdOp:
-    ref_api: "torch.nn.functional.gelu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        approximate: {type: str, default: "none"}
-      shape_rules:
-        - "approximate in ('none', 'tanh')"
-        - "output.shape == input.shape"
-
-    workloads:
-      # Llama-3.1-8B FFN intermediate (hidden_dim=14336)
-      - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
-      - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # erf-based: ~8 fp ops per element (mul, erf, add, mul, mul); tanh approx similar
-      flops: "8 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  SiluFwdOp:
-    ref_api: "torch.nn.functional.silu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # Llama-3.1-8B SwiGLU FFN intermediate
-      - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
-      - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # sigmoid (exp + add + recip ~3) + mul = 4 fp ops per element
-      flops: "4 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  HardswishFwdOp:
-    ref_api: "torch.nn.functional.hardswish"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # Mobile-style activation map (NHW C, e.g. MobileNetV3 stage)
-      - {input_shape: [32, 96, 56, 56], dtypes: [float16, bfloat16], label: "mbv3-stage2"}
-      - {input_shape: [32, 240, 28, 28], dtypes: [float16, bfloat16], label: "mbv3-stage3"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # add (1) + clamp (2 cmp + 2 sel = 4) + mul (1) + div (1) = 7 fp ops per element
-      flops: "7 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  HardsigmoidFwdOp:
-    ref_api: "torch.nn.functional.hardsigmoid"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # SE-block gating (B, C, 1, 1)
-      - {input_shape: [32, 240, 1, 1], dtypes: [float16, bfloat16], label: "mbv3-se-gate"}
-      - {input_shape: [32, 960, 1, 1], dtypes: [float16, bfloat16], label: "mbv3-se-gate-deep"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # add (1) + clamp (2 cmp + 2 sel = 4) + div (1) = 6 fp ops per element
-      flops: "6 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  MishFwdOp:
-    ref_api: "torch.nn.functional.mish"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # YOLO-style feature map activation
-      - {input_shape: [16, 256, 80, 80], dtypes: [float16, bfloat16], label: "yolo-p3"}
-      - {input_shape: [16, 512, 40, 40], dtypes: [float16, bfloat16], label: "yolo-p4"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # softplus (exp + log1p ~ 3) + tanh (~3) + mul = 7 fp ops per element
-      flops: "7 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  SeluFwdOp:
-    ref_api: "torch.nn.functional.selu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # SNN-style fully connected activation
-      - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "snn-fc"}
-      - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "snn-fc-wide"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # branch select + (exp + sub + mul) on negative branch + mul by lambda ~ 5 fp ops per element
-      flops: "5 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  LeakyReluFwdOp:
-    ref_api: "torch.nn.functional.leaky_relu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        negative_slope: {type: float, default: 0.01}
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # GAN feature map activation
-      - {input_shape: [16, 256, 64, 64], dtypes: [float16, bfloat16], label: "gan-feat"}
-      - {input_shape: [16, 512, 32, 32], dtypes: [float16, bfloat16], label: "gan-feat-deep"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # compare + mul + select = 3 fp ops per element
-      flops: "3 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  EluFwdOp:
-    ref_api: "torch.nn.functional.elu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        alpha: {type: float, default: 1.0}
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # MLP hidden activation
-      - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "mlp-hidden"}
-      - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "mlp-hidden-wide"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # compare + (exp + sub + mul) on negative branch ~ 5 fp ops per element
-      flops: "5 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  HardtanhFwdOp:
-    ref_api: "torch.nn.functional.hardtanh"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        min_val: {type: float, default: -1.0}
-        max_val: {type: float, default: 1.0}
-        inplace: {type: bool, default: false}
-      shape_rules:
-        - "min_val <= max_val"
-        - "output.shape == input.shape"
-
-    workloads:
-      # Quantization-friendly bounded activation
-      - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "bounded-hidden"}
-      - {input_shape: [16, 256, 56, 56], dtypes: [float16, bfloat16], label: "bounded-conv-feat"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # 2 compares + 2 selects per element
-      flops: "4 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  SoftplusFwdOp:
-    ref_api: "torch.nn.functional.softplus"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      params:
-        beta: {type: float, default: 1.0}
-        threshold: {type: float, default: 20.0}
-      shape_rules:
-        - "output.shape == input.shape"
-
-    workloads:
-      # Distribution-modeling MLP activation
-      - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "mlp-hidden"}
-      - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "mlp-hidden-wide"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-      # mul (beta*x) + threshold compare + (exp + log1p + div) on log-branch ~ 6 fp ops per element
-      flops: "6 * N"
-      bytes: "2 * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  PreluFwdOp:
-    ref_api: "torch.nn.functional.prelu"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        weight: {dtype: "same_as(input)"}
-      outputs:
-        output: {dtype: "same_as(input)"}
-      shape_rules:
-        # PyTorch prelu: weight is either scalar or per-channel along dim 1
-        # for inputs with ndim >= 2; 1-D inputs accept scalar weight only.
-        - "weight.ndim == 0 or (weight.ndim == 1 and (weight.shape[0] == 1 or (input.ndim >= 2 and weight.shape[0] == input.shape[1])))"
-        - "output.shape == input.shape"
-
-    workloads:
-      # PReLU CNN feature map (per-channel weight)
-      - {input_shape: [16, 256, 56, 56], weight_shape: [256], dtypes: [float16, bfloat16], label: "cnn-feat-per-channel"}
-      - {input_shape: [16, 512, 28, 28], weight_shape: [512], dtypes: [float16, bfloat16], label: "cnn-feat-per-channel-deep"}
-
-    roofline:
-      vars:
-        N: "product(input.shape)"
-        W: "1 if weight.ndim == 0 or weight.shape[0] == 1 else weight.shape[0]"
-      # compare + mul + select per element
-      flops: "3 * N"
-      # Read input (N) + read weight (small, ~C) + write output (N)
-      bytes: "(2 * N + W) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_activation.py
-      bench: benchmarks/ops/bench_activation.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise — multi-input parametric ops (where, clamp, masked_fill, nan_to_num)
-  # ---------------------------------------------------------------------------
-
-  WhereFwdOp:
-    ref_api: "torch.where"
-    family: elementwise
-    # status: spec-only — current tileops/ops/elementwise.py:WhereFwdOp does
-    # not conform to this spec:
-    #   - __init__ signature is (N_total, dtype) instead of the
-    #     PyTorch-aligned (condition, input, other) form.
-    #   - forward parameter names are (cond, x, y) instead of
-    #     (condition, input, other).
-    # Code conforms to this spec in a follow-up PR per the manifest trust
-    # model (.claude/rules/manifest-trust-model.md).
-    status: spec-only
-
-    signature:
-      inputs:
-        condition: {dtype: "bool"}
-        input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "condition.shape == input.shape"
-        - "other.shape == input.shape"
-        - "out.shape == input.shape"
-
-    workloads:
-      - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      # Mixed-dtype op (bool condition + float input/other) — inline mode cannot
-      # express byte accounting because elem_bytes binds to the first input's
-      # dtype (condition = bool = 1 byte). Per docs/roofline.md §2.2, ops whose
-      # bytes depend on multiple input dtypes must use func mode.
-      func: "tileops.perf.formulas.where_fwd_roofline"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_independent_elementwise.py
-      bench_manifest_driven: false
-
-  ClampFwdOp:
-    ref_api: "torch.clamp"
-    # Scalar-bound variant: PyTorch's torch.clamp also accepts Tensor min/max;
-    # the manifest tracks the scalar (Number) slice that the kernel implements.
-    family: elementwise
-    # status: spec-only — current tileops/ops/elementwise.py:ClampFwdOp does
-    # not conform to this spec:
-    #   - __init__ takes (N_total, dtype, min_val, max_val) instead of the
-    #     PyTorch-aligned (input, min, max) form.
-    #   - param names are (min_val, max_val) instead of (min, max).
-    #   - forward parameter is named `x` instead of `input`.
-    # Code conforms to this spec in a follow-up PR per the manifest trust
-    # model (.claude/rules/manifest-trust-model.md).
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        min: {type: "float | None", default: null}
-        max: {type: "float | None", default: null}
-      shape_rules:
-        - "out.shape == input.shape"
-
-    workloads:
-      - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(input.shape)"
-      # At most one max + one min per element
-      flops: "2 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_independent_elementwise.py
-      bench_manifest_driven: false
-
-  MaskedFillFwdOp:
-    ref_api: "torch.Tensor.masked_fill"
-    # Scalar-value variant: PyTorch's masked_fill also accepts a 0-dim Tensor
-    # value; the manifest tracks the scalar (Number) slice that the kernel
-    # implements.
-    family: elementwise
-    # status: spec-only — current tileops/ops/elementwise.py:MaskedFillFwdOp
-    # does not conform to this spec:
-    #   - __init__ takes (N_total, dtype, fill_value) instead of the
-    #     PyTorch-aligned (input, mask, value) form.
-    #   - param name is `fill_value` instead of `value`.
-    #   - forward parameter is named `x` instead of `input`.
-    # Code conforms to this spec in a follow-up PR per the manifest trust
-    # model (.claude/rules/manifest-trust-model.md).
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-        mask: {dtype: "bool"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        value: {type: float, default: 0.0}
-      shape_rules:
-        - "mask.shape == input.shape"
-        - "out.shape == input.shape"
-
-    workloads:
-      - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(input.shape)"
-      # One predicated select per element
-      flops: "N_total"
-      # Read input + read mask (1 byte) + write out
-      bytes: "N_total + 2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_independent_elementwise.py
-      bench_manifest_driven: false
-
-  NanToNumFwdOp:
-    ref_api: "torch.nan_to_num"
-    family: elementwise
-    # status: spec-only — current tileops/ops/elementwise.py:NanToNumFwdOp
-    # does not conform to this spec:
-    #   - __init__ takes (N_total, dtype, nan_val, posinf_val, neginf_val)
-    #     instead of the PyTorch-aligned (input, nan, posinf, neginf) form.
-    #   - param names are (nan_val, posinf_val, neginf_val) instead of
-    #     (nan, posinf, neginf).
-    #   - posinf/neginf default to 1e4/-1e4 instead of None (PyTorch's
-    #     default sentinel meaning "use dtype max/min").
-    #   - forward parameter is named `x` instead of `input`.
-    # Code conforms to this spec in a follow-up PR per the manifest trust
-    # model (.claude/rules/manifest-trust-model.md).
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        nan: {type: float, default: 0.0}
-        posinf: {type: "float | None", default: null}
-        neginf: {type: "float | None", default: null}
-      shape_rules:
-        - "out.shape == input.shape"
-
-    workloads:
-      - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-      - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
-
-    roofline:
-      vars:
-        N_total: "product(input.shape)"
-      # isnan + isposinf + isneginf + 3 conditional selects per element
-      flops: "6 * N_total"
-      bytes: "2 * N_total * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_special_elementwise.py
-      bench: benchmarks/ops/bench_independent_elementwise.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise -- binary arithmetic ops (broadcast, output: same_as(input))
-  # ---------------------------------------------------------------------------
-
-  AddFwdOp:
-    ref_api: "torch.add"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        alpha: {type: "int | float", default: 1}
-      shape_rules:
-        # Output follows PyTorch broadcasting; numel uses the broadcast shape.
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # 1 multiply (alpha * other) + 1 add per output element
-      flops: "2 * N"
-      # Read input + read other + write out
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  SubFwdOp:
-    ref_api: "torch.sub"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        alpha: {type: "int | float", default: 1}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # 1 multiply (alpha * other) + 1 subtract per output element
-      flops: "2 * N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  MulFwdOp:
-    ref_api: "torch.mul"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  DivFwdOp:
-    ref_api: "torch.div"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        rounding_mode: {type: "str | None", default: null}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-        - "rounding_mode is None or rounding_mode in ('trunc', 'floor')"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  RemainderFwdOp:
-    ref_api: "torch.remainder"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # remainder ~= div + floor + mul + sub per element
-      flops: "4 * N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  PowFwdOp:
-    ref_api: "torch.pow"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        exponent: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, exponent.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, exponent.shape))"
-      # pow ~= exp(exponent * log(input)) ~= 3 ops per element
-      flops: "3 * N"
-      bytes: "(product(input.shape) + product(exponent.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  FloorDivideFwdOp:
-    ref_api: "torch.floor_divide"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # div + floor per element
-      flops: "2 * N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  LerpFwdOp:
-    ref_api: "torch.lerp"
-    # Scalar-weight variant: PyTorch's torch.lerp also accepts a Tensor
-    # weight (see LerpTensorFwdOp); this entry tracks the scalar (Number)
-    # slice that the existing kernel implements.
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        end: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      params:
-        weight: {type: float, default: 0.5}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, end.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, end.shape))"
-      # sub + mul + add per element
-      flops: "3 * N"
-      bytes: "(product(input.shape) + product(end.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  LerpTensorFwdOp:
-    ref_api: "torch.lerp"
-    # Tensor-weight variant: weight is a tensor that broadcasts together
-    # with input and end (PyTorch's torch.lerp(input, end, weight: Tensor)
-    # overload). No kernel implementation yet — spec-only placeholder.
-    family: elementwise
-    status: spec-only
-    variant_of: LerpFwdOp
-
-    signature:
-      inputs:
-        input: {dtype: "float16 | bfloat16 | float32"}
-        end: {dtype: "same_as(input)"}
-        weight: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, end.shape, weight.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, end.shape, weight.shape))"
-      # sub + mul + add per element
-      flops: "3 * N"
-      bytes: "(product(input.shape) + product(end.shape) + product(weight.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  MaximumFwdOp:
-    ref_api: "torch.maximum"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # one comparison-and-select per element
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  MinimumFwdOp:
-    ref_api: "torch.minimum"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_binary_arith.py
-      bench: benchmarks/ops/bench_binary_arith.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise -- binary comparison ops (broadcast, output: bool)
-  # ---------------------------------------------------------------------------
-
-  EqFwdOp:
-    ref_api: "torch.eq"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      # 1 byte per bool output
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  NeFwdOp:
-    ref_api: "torch.ne"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  GtFwdOp:
-    ref_api: "torch.gt"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  LtFwdOp:
-    ref_api: "torch.lt"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  GeFwdOp:
-    ref_api: "torch.ge"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  LeFwdOp:
-    ref_api: "torch.le"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_comparison.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise -- binary logical ops (broadcast, output: bool)
-  # ---------------------------------------------------------------------------
-
-  LogicalAndFwdOp:
-    ref_api: "torch.logical_and"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      # 2 nonzero comparisons + 1 logical-and per element
-      flops: "3 * N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_logical.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  LogicalOrFwdOp:
-    ref_api: "torch.logical_or"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "bool"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "3 * N"
-      bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_logical.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  # ---------------------------------------------------------------------------
-  # elementwise -- binary bitwise ops (broadcast, output: same_as(input))
-  # ---------------------------------------------------------------------------
-
-  BitwiseAndFwdOp:
-    ref_api: "torch.bitwise_and"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_bitwise.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  BitwiseOrFwdOp:
-    ref_api: "torch.bitwise_or"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_bitwise.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
-
-  BitwiseXorFwdOp:
-    ref_api: "torch.bitwise_xor"
-    family: elementwise
-    status: spec-only
-
-    signature:
-      inputs:
-        input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
-        other: {dtype: "same_as(input)"}
-      outputs:
-        out: {dtype: "same_as(input)"}
-      shape_rules:
-        - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
-
-    workloads: []
-
-    roofline:
-      vars:
-        N: "product(torch.broadcast_shapes(input.shape, other.shape))"
-      flops: "N"
-      bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/elementwise.py
-      op: tileops/ops/elementwise.py
-      test: tests/ops/test_bitwise.py
-      bench: benchmarks/ops/bench_binary_elementwise.py
-      bench_manifest_driven: false
+ExpFwdOp:
+  ref_api: "torch.exp"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+LogFwdOp:
+  ref_api: "torch.log"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+SqrtFwdOp:
+  ref_api: "torch.sqrt"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+RsqrtFwdOp:
+  ref_api: "torch.rsqrt"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+AbsFwdOp:
+  ref_api: "torch.abs"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+NegFwdOp:
+  ref_api: "torch.neg"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+ReciprocalFwdOp:
+  ref_api: "torch.reciprocal"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+SignFwdOp:
+  ref_api: "torch.sign"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    # 2 comparisons per element (sign uses two compares + selects)
+    flops: "2 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+SinFwdOp:
+  ref_api: "torch.sin"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+CosFwdOp:
+  ref_api: "torch.cos"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+FloorFwdOp:
+  ref_api: "torch.floor"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+CeilFwdOp:
+  ref_api: "torch.ceil"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+RoundFwdOp:
+  ref_api: "torch.round"
+  family: elementwise
+  status: spec-only  # impl ignores 'decimals' param (kernel only supports decimals=0); fix in follow-up
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      decimals: {type: int, default: 0}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+TruncFwdOp:
+  ref_api: "torch.trunc"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+ErfFwdOp:
+  ref_api: "torch.erf"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+Log1pFwdOp:
+  ref_api: "torch.log1p"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    # log(1 + x): 1 add + 1 log
+    flops: "2 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+Expm1FwdOp:
+  ref_api: "torch.expm1"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    # exp(x) - 1: 1 exp + 1 sub
+    flops: "2 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_unary_math.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+SigmoidFwdOp:
+  ref_api: "torch.sigmoid"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    # sigmoid(x) = 1 / (1 + exp(-x)): ~4 ops/elem
+    flops: "4 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+TanhFwdOp:
+  ref_api: "torch.tanh"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    # tanh(x) = 2 * sigmoid(2x) - 1: ~5 ops/elem (1 mul for 2x + 4 sigmoid ops)
+    flops: "5 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+LogicalNotFwdOp:
+  ref_api: "torch.logical_not"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "bool"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [bool, float16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [bool], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "N_total * elem_bytes + N_total"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_logical.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+BitwiseNotFwdOp:
+  ref_api: "torch.bitwise_not"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [int32, int64], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [int32], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_bitwise.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+IsnanFwdOp:
+  ref_api: "torch.isnan"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "bool"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "N_total * elem_bytes + N_total"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+IsinfFwdOp:
+  ref_api: "torch.isinf"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "bool"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "N_total * elem_bytes + N_total"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+IsfiniteFwdOp:
+  ref_api: "torch.isfinite"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      y: {dtype: "bool"}
+    shape_rules:
+      - "y.shape == x.shape"
+
+  workloads:
+    - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(x.shape)"
+    flops: "N_total"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "N_total * elem_bytes + N_total"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_unary_elementwise.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise -- unary functional activations (torch.nn.functional.<op>)
+# All ops operate elementwise over arbitrary-rank tensors; output shape == input shape.
+# ---------------------------------------------------------------------------
+
+ReluFwdOp:
+  ref_api: "torch.nn.functional.relu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # Hidden-state activation (Llama-3.1-8B prefill)
+    - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-prefill"}
+    # Decode (single token)
+    - {input_shape: [1, 4096], dtypes: [bfloat16], label: "hidden-state-decode"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # 1 compare + 1 select per element = 2 fp ops
+    flops: "2 * N"
+    # Read input + write output
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+GeluFwdOp:
+  ref_api: "torch.nn.functional.gelu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      approximate: {type: str, default: "none"}
+    shape_rules:
+      - "approximate in ('none', 'tanh')"
+      - "output.shape == input.shape"
+
+  workloads:
+    # Llama-3.1-8B FFN intermediate (hidden_dim=14336)
+    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
+    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # erf-based: ~8 fp ops per element (mul, erf, add, mul, mul); tanh approx similar
+    flops: "8 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+SiluFwdOp:
+  ref_api: "torch.nn.functional.silu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # Llama-3.1-8B SwiGLU FFN intermediate
+    - {input_shape: [2048, 14336], dtypes: [float16, bfloat16], label: "llama-3.1-8b-ffn-prefill"}
+    - {input_shape: [1, 14336], dtypes: [bfloat16], label: "llama-3.1-8b-ffn-decode"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # sigmoid (exp + add + recip ~3) + mul = 4 fp ops per element
+    flops: "4 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+HardswishFwdOp:
+  ref_api: "torch.nn.functional.hardswish"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # Mobile-style activation map (NHW C, e.g. MobileNetV3 stage)
+    - {input_shape: [32, 96, 56, 56], dtypes: [float16, bfloat16], label: "mbv3-stage2"}
+    - {input_shape: [32, 240, 28, 28], dtypes: [float16, bfloat16], label: "mbv3-stage3"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # add (1) + clamp (2 cmp + 2 sel = 4) + mul (1) + div (1) = 7 fp ops per element
+    flops: "7 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+HardsigmoidFwdOp:
+  ref_api: "torch.nn.functional.hardsigmoid"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # SE-block gating (B, C, 1, 1)
+    - {input_shape: [32, 240, 1, 1], dtypes: [float16, bfloat16], label: "mbv3-se-gate"}
+    - {input_shape: [32, 960, 1, 1], dtypes: [float16, bfloat16], label: "mbv3-se-gate-deep"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # add (1) + clamp (2 cmp + 2 sel = 4) + div (1) = 6 fp ops per element
+    flops: "6 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+MishFwdOp:
+  ref_api: "torch.nn.functional.mish"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # YOLO-style feature map activation
+    - {input_shape: [16, 256, 80, 80], dtypes: [float16, bfloat16], label: "yolo-p3"}
+    - {input_shape: [16, 512, 40, 40], dtypes: [float16, bfloat16], label: "yolo-p4"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # softplus (exp + log1p ~ 3) + tanh (~3) + mul = 7 fp ops per element
+    flops: "7 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+SeluFwdOp:
+  ref_api: "torch.nn.functional.selu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # SNN-style fully connected activation
+    - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "snn-fc"}
+    - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "snn-fc-wide"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # branch select + (exp + sub + mul) on negative branch + mul by lambda ~ 5 fp ops per element
+    flops: "5 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+LeakyReluFwdOp:
+  ref_api: "torch.nn.functional.leaky_relu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      negative_slope: {type: float, default: 0.01}
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # GAN feature map activation
+    - {input_shape: [16, 256, 64, 64], dtypes: [float16, bfloat16], label: "gan-feat"}
+    - {input_shape: [16, 512, 32, 32], dtypes: [float16, bfloat16], label: "gan-feat-deep"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # compare + mul + select = 3 fp ops per element
+    flops: "3 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+EluFwdOp:
+  ref_api: "torch.nn.functional.elu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      alpha: {type: float, default: 1.0}
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # MLP hidden activation
+    - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "mlp-hidden"}
+    - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "mlp-hidden-wide"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # compare + (exp + sub + mul) on negative branch ~ 5 fp ops per element
+    flops: "5 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+HardtanhFwdOp:
+  ref_api: "torch.nn.functional.hardtanh"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      min_val: {type: float, default: -1.0}
+      max_val: {type: float, default: 1.0}
+      inplace: {type: bool, default: false}
+    shape_rules:
+      - "min_val <= max_val"
+      - "output.shape == input.shape"
+
+  workloads:
+    # Quantization-friendly bounded activation
+    - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "bounded-hidden"}
+    - {input_shape: [16, 256, 56, 56], dtypes: [float16, bfloat16], label: "bounded-conv-feat"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # 2 compares + 2 selects per element
+    flops: "4 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+SoftplusFwdOp:
+  ref_api: "torch.nn.functional.softplus"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    params:
+      beta: {type: float, default: 1.0}
+      threshold: {type: float, default: 20.0}
+    shape_rules:
+      - "output.shape == input.shape"
+
+  workloads:
+    # Distribution-modeling MLP activation
+    - {input_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "mlp-hidden"}
+    - {input_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "mlp-hidden-wide"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+    # mul (beta*x) + threshold compare + (exp + log1p + div) on log-branch ~ 6 fp ops per element
+    flops: "6 * N"
+    bytes: "2 * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+PreluFwdOp:
+  ref_api: "torch.nn.functional.prelu"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      weight: {dtype: "same_as(input)"}
+    outputs:
+      output: {dtype: "same_as(input)"}
+    shape_rules:
+      # PyTorch prelu: weight is either scalar or per-channel along dim 1
+      # for inputs with ndim >= 2; 1-D inputs accept scalar weight only.
+      - "weight.ndim == 0 or (weight.ndim == 1 and (weight.shape[0] == 1 or (input.ndim >= 2 and weight.shape[0] == input.shape[1])))"
+      - "output.shape == input.shape"
+
+  workloads:
+    # PReLU CNN feature map (per-channel weight)
+    - {input_shape: [16, 256, 56, 56], weight_shape: [256], dtypes: [float16, bfloat16], label: "cnn-feat-per-channel"}
+    - {input_shape: [16, 512, 28, 28], weight_shape: [512], dtypes: [float16, bfloat16], label: "cnn-feat-per-channel-deep"}
+
+  roofline:
+    vars:
+      N: "product(input.shape)"
+      W: "1 if weight.ndim == 0 or weight.shape[0] == 1 else weight.shape[0]"
+    # compare + mul + select per element
+    flops: "3 * N"
+    # Read input (N) + read weight (small, ~C) + write output (N)
+    bytes: "(2 * N + W) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_activation.py
+    bench: benchmarks/ops/bench_activation.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise — multi-input parametric ops (where, clamp, masked_fill, nan_to_num)
+# ---------------------------------------------------------------------------
+
+WhereFwdOp:
+  ref_api: "torch.where"
+  family: elementwise
+  # status: spec-only — current tileops/ops/elementwise.py:WhereFwdOp does
+  # not conform to this spec:
+  #   - __init__ signature is (N_total, dtype) instead of the
+  #     PyTorch-aligned (condition, input, other) form.
+  #   - forward parameter names are (cond, x, y) instead of
+  #     (condition, input, other).
+  # Code conforms to this spec in a follow-up PR per the manifest trust
+  # model (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      condition: {dtype: "bool"}
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "condition.shape == input.shape"
+      - "other.shape == input.shape"
+      - "out.shape == input.shape"
+
+  workloads:
+    - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    # Mixed-dtype op (bool condition + float input/other) — inline mode cannot
+    # express byte accounting because elem_bytes binds to the first input's
+    # dtype (condition = bool = 1 byte). Per docs/roofline.md §2.2, ops whose
+    # bytes depend on multiple input dtypes must use func mode.
+    func: "tileops.perf.formulas.where_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+ClampFwdOp:
+  ref_api: "torch.clamp"
+  # Scalar-bound variant: PyTorch's torch.clamp also accepts Tensor min/max;
+  # the manifest tracks the scalar (Number) slice that the kernel implements.
+  family: elementwise
+  # status: spec-only — current tileops/ops/elementwise.py:ClampFwdOp does
+  # not conform to this spec:
+  #   - __init__ takes (N_total, dtype, min_val, max_val) instead of the
+  #     PyTorch-aligned (input, min, max) form.
+  #   - param names are (min_val, max_val) instead of (min, max).
+  #   - forward parameter is named `x` instead of `input`.
+  # Code conforms to this spec in a follow-up PR per the manifest trust
+  # model (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      min: {type: "float | None", default: null}
+      max: {type: "float | None", default: null}
+    shape_rules:
+      - "out.shape == input.shape"
+
+  workloads:
+    - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(input.shape)"
+    # At most one max + one min per element
+    flops: "2 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+MaskedFillFwdOp:
+  ref_api: "torch.Tensor.masked_fill"
+  # Scalar-value variant: PyTorch's masked_fill also accepts a 0-dim Tensor
+  # value; the manifest tracks the scalar (Number) slice that the kernel
+  # implements.
+  family: elementwise
+  # status: spec-only — current tileops/ops/elementwise.py:MaskedFillFwdOp
+  # does not conform to this spec:
+  #   - __init__ takes (N_total, dtype, fill_value) instead of the
+  #     PyTorch-aligned (input, mask, value) form.
+  #   - param name is `fill_value` instead of `value`.
+  #   - forward parameter is named `x` instead of `input`.
+  # Code conforms to this spec in a follow-up PR per the manifest trust
+  # model (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      mask: {dtype: "bool"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      value: {type: float, default: 0.0}
+    shape_rules:
+      - "mask.shape == input.shape"
+      - "out.shape == input.shape"
+
+  workloads:
+    - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(input.shape)"
+    # One predicated select per element
+    flops: "N_total"
+    # Read input + read mask (1 byte) + write out
+    bytes: "N_total + 2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+NanToNumFwdOp:
+  ref_api: "torch.nan_to_num"
+  family: elementwise
+  # status: spec-only — current tileops/ops/elementwise.py:NanToNumFwdOp
+  # does not conform to this spec:
+  #   - __init__ takes (N_total, dtype, nan_val, posinf_val, neginf_val)
+  #     instead of the PyTorch-aligned (input, nan, posinf, neginf) form.
+  #   - param names are (nan_val, posinf_val, neginf_val) instead of
+  #     (nan, posinf, neginf).
+  #   - posinf/neginf default to 1e4/-1e4 instead of None (PyTorch's
+  #     default sentinel meaning "use dtype max/min").
+  #   - forward parameter is named `x` instead of `input`.
+  # Code conforms to this spec in a follow-up PR per the manifest trust
+  # model (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      nan: {type: float, default: 0.0}
+      posinf: {type: "float | None", default: null}
+      neginf: {type: "float | None", default: null}
+    shape_rules:
+      - "out.shape == input.shape"
+
+  workloads:
+    - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+    - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+
+  roofline:
+    vars:
+      N_total: "product(input.shape)"
+    # isnan + isposinf + isneginf + 3 conditional selects per element
+    flops: "6 * N_total"
+    bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise -- binary arithmetic ops (broadcast, output: same_as(input))
+# ---------------------------------------------------------------------------
+
+AddFwdOp:
+  ref_api: "torch.add"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      alpha: {type: "int | float", default: 1}
+    shape_rules:
+      # Output follows PyTorch broadcasting; numel uses the broadcast shape.
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # 1 multiply (alpha * other) + 1 add per output element
+    flops: "2 * N"
+    # Read input + read other + write out
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+SubFwdOp:
+  ref_api: "torch.sub"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      alpha: {type: "int | float", default: 1}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # 1 multiply (alpha * other) + 1 subtract per output element
+    flops: "2 * N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+MulFwdOp:
+  ref_api: "torch.mul"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+DivFwdOp:
+  ref_api: "torch.div"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      rounding_mode: {type: "str | None", default: null}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+      - "rounding_mode is None or rounding_mode in ('trunc', 'floor')"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+RemainderFwdOp:
+  ref_api: "torch.remainder"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # remainder ~= div + floor + mul + sub per element
+    flops: "4 * N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+PowFwdOp:
+  ref_api: "torch.pow"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      exponent: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, exponent.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, exponent.shape))"
+    # pow ~= exp(exponent * log(input)) ~= 3 ops per element
+    flops: "3 * N"
+    bytes: "(product(input.shape) + product(exponent.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+FloorDivideFwdOp:
+  ref_api: "torch.floor_divide"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # div + floor per element
+    flops: "2 * N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+LerpFwdOp:
+  ref_api: "torch.lerp"
+  # Scalar-weight variant: PyTorch's torch.lerp also accepts a Tensor
+  # weight (see LerpTensorFwdOp); this entry tracks the scalar (Number)
+  # slice that the existing kernel implements.
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      end: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    params:
+      weight: {type: float, default: 0.5}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, end.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, end.shape))"
+    # sub + mul + add per element
+    flops: "3 * N"
+    bytes: "(product(input.shape) + product(end.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+LerpTensorFwdOp:
+  ref_api: "torch.lerp"
+  # Tensor-weight variant: weight is a tensor that broadcasts together
+  # with input and end (PyTorch's torch.lerp(input, end, weight: Tensor)
+  # overload). No kernel implementation yet — spec-only placeholder.
+  family: elementwise
+  status: spec-only
+  variant_of: LerpFwdOp
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32"}
+      end: {dtype: "same_as(input)"}
+      weight: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, end.shape, weight.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, end.shape, weight.shape))"
+    # sub + mul + add per element
+    flops: "3 * N"
+    bytes: "(product(input.shape) + product(end.shape) + product(weight.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+MaximumFwdOp:
+  ref_api: "torch.maximum"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # one comparison-and-select per element
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+MinimumFwdOp:
+  ref_api: "torch.minimum"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_binary_arith.py
+    bench: benchmarks/ops/bench_binary_arith.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise -- binary comparison ops (broadcast, output: bool)
+# ---------------------------------------------------------------------------
+
+EqFwdOp:
+  ref_api: "torch.eq"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    # 1 byte per bool output
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+NeFwdOp:
+  ref_api: "torch.ne"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+GtFwdOp:
+  ref_api: "torch.gt"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+LtFwdOp:
+  ref_api: "torch.lt"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+GeFwdOp:
+  ref_api: "torch.ge"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+LeFwdOp:
+  ref_api: "torch.le"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_comparison.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise -- binary logical ops (broadcast, output: bool)
+# ---------------------------------------------------------------------------
+
+LogicalAndFwdOp:
+  ref_api: "torch.logical_and"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    # 2 nonzero comparisons + 1 logical-and per element
+    flops: "3 * N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_logical.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+LogicalOrFwdOp:
+  ref_api: "torch.logical_or"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "bool"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "3 * N"
+    bytes: "(product(input.shape) + product(other.shape)) * elem_bytes + N"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_logical.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+# ---------------------------------------------------------------------------
+# elementwise -- binary bitwise ops (broadcast, output: same_as(input))
+# ---------------------------------------------------------------------------
+
+BitwiseAndFwdOp:
+  ref_api: "torch.bitwise_and"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_bitwise.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+BitwiseOrFwdOp:
+  ref_api: "torch.bitwise_or"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_bitwise.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false
+
+BitwiseXorFwdOp:
+  ref_api: "torch.bitwise_xor"
+  family: elementwise
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
+      other: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == tuple(torch.broadcast_shapes(input.shape, other.shape))"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N: "product(torch.broadcast_shapes(input.shape, other.shape))"
+    flops: "N"
+    bytes: "(product(input.shape) + product(other.shape) + N) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_bitwise.py
+    bench: benchmarks/ops/bench_binary_elementwise.py
+    bench_manifest_driven: false

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -4,321 +4,320 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  MoePermutePaddedFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
+MoePermutePaddedFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
 
-    signature:
-      inputs:
-        hidden_states: {dtype: "float16 | bfloat16"}
-        topk_ids: {dtype: "int32"}
-      outputs:
-        perm_h_pad: {dtype: "same_as(hidden_states)"}
-        padded_offsets: {dtype: "int32"}
-        padded_sizes: {dtype: "int32"}
-        expert_first_token_offset: {dtype: "int64"}
-        fwd_idx: {dtype: "int32"}
-      params:
-        total_tokens: {type: int}
-        top_k: {type: int}
-        num_experts: {type: int}
-        hidden_size: {type: int}
-      shape_rules:
-        - "hidden_states.shape == (total_tokens, hidden_size)"
+  signature:
+    inputs:
+      hidden_states: {dtype: "float16 | bfloat16"}
+      topk_ids: {dtype: "int32"}
+    outputs:
+      perm_h_pad: {dtype: "same_as(hidden_states)"}
+      padded_offsets: {dtype: "int32"}
+      padded_sizes: {dtype: "int32"}
+      expert_first_token_offset: {dtype: "int64"}
+      fwd_idx: {dtype: "int32"}
+    params:
+      total_tokens: {type: int}
+      top_k: {type: int}
+      num_experts: {type: int}
+      hidden_size: {type: int}
+    shape_rules:
+      - "hidden_states.shape == (total_tokens, hidden_size)"
 
-    workloads:
-      # Kimi K2: H=7168, E=384, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-prefill"}
-      # DeepSeek-V3: H=7168, E=256, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
-      # Qwen3-235B-A22B: H=7168, E=128, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
-      # Qwen3-30B-A3B: H=3072, E=128, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
+  workloads:
+    # Kimi K2: H=7168, E=384, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-prefill"}
+    # DeepSeek-V3: H=7168, E=256, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+    # Qwen3-235B-A22B: H=7168, E=128, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
+    # Qwen3-30B-A3B: H=3072, E=128, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
 
-    roofline:
-      # Permute is memory-bound (no compute); flops = 0
-      flops: "0"
-      # hidden_states read [T, H] + perm_h_pad write [T*K, H] + metadata
-      bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
+  roofline:
+    # Permute is memory-bound (no compute); flops = 0
+    flops: "0"
+    # hidden_states read [T, H] + perm_h_pad write [T*K, H] + metadata
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
 
-    source:
-      kernel: tileops/kernels/moe/permute_padded.py
-      op: tileops/ops/moe/permute_padded.py
-      test: tests/ops/test_moe_permute.py
-      bench: benchmarks/ops/bench_moe_permute.py
-      bench_manifest_driven: true
+  source:
+    kernel: tileops/kernels/moe/permute_padded.py
+    op: tileops/ops/moe/permute_padded.py
+    test: tests/ops/test_moe_permute.py
+    bench: benchmarks/ops/bench_moe_permute.py
+    bench_manifest_driven: true
 
-  MoePermuteAlignFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only  # impl uses numel instead of total_tokens/top_k; fix in follow-up PR
+MoePermuteAlignFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only  # impl uses numel instead of total_tokens/top_k; fix in follow-up PR
 
-    signature:
-      inputs:
-        topk_ids: {dtype: "int32"}
-      outputs:
-        sorted_token_ids: {dtype: "int32"}
-        expert_ids: {dtype: "int32"}
-        num_tokens_post_pad: {dtype: "int32"}
-      params:
-        total_tokens: {type: int}
-        top_k: {type: int}
-        num_experts: {type: int}
-        block_size: {type: int, default: 64}
-      shape_rules:
-        - "topk_ids.shape == (total_tokens, top_k)"
+  signature:
+    inputs:
+      topk_ids: {dtype: "int32"}
+    outputs:
+      sorted_token_ids: {dtype: "int32"}
+      expert_ids: {dtype: "int32"}
+      num_tokens_post_pad: {dtype: "int32"}
+    params:
+      total_tokens: {type: int}
+      top_k: {type: int}
+      num_experts: {type: int}
+      block_size: {type: int, default: 64}
+    shape_rules:
+      - "topk_ids.shape == (total_tokens, top_k)"
 
-    workloads:
-      # Kimi K2: E=384, K=8, block_size=64
-      - {total_tokens: 1, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-prefill"}
-      # DeepSeek-V3: E=256, K=8, block_size=64
-      - {total_tokens: 1, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-prefill"}
-      # Qwen3: E=128, K=8, block_size=64
-      - {total_tokens: 1, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-prefill"}
+  workloads:
+    # Kimi K2: E=384, K=8, block_size=64
+    - {total_tokens: 1, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 384, block_size: 64, dtypes: [int32], label: "kimi-k2-prefill"}
+    # DeepSeek-V3: E=256, K=8, block_size=64
+    - {total_tokens: 1, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 256, block_size: 64, dtypes: [int32], label: "deepseek-v3-prefill"}
+    # Qwen3: E=128, K=8, block_size=64
+    - {total_tokens: 1, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 128, block_size: 64, dtypes: [int32], label: "qwen3-prefill"}
 
-    roofline:
-      # Permute-align is integer index computation; no FLOPs
-      flops: "0"
-      # topk_ids read + sorted_token_ids write + expert_ids write + num_post_pad write (all int32)
-      bytes: "total_tokens * top_k * 4 + (total_tokens * top_k + (num_experts + 1) * (block_size - 1)) * 4 + ceil((total_tokens * top_k + (num_experts + 1) * (block_size - 1)) / block_size) * 4 + 4"
+  roofline:
+    # Permute-align is integer index computation; no FLOPs
+    flops: "0"
+    # topk_ids read + sorted_token_ids write + expert_ids write + num_post_pad write (all int32)
+    bytes: "total_tokens * top_k * 4 + (total_tokens * top_k + (num_experts + 1) * (block_size - 1)) * 4 + ceil((total_tokens * top_k + (num_experts + 1) * (block_size - 1)) / block_size) * 4 + 4"
 
-    source:
-      kernel: tileops/kernels/moe/permute_align.py
-      op: tileops/ops/moe/permute_align.py
-      test: tests/ops/test_moe_permute_align.py
-      bench: benchmarks/ops/bench_moe_permute_align.py
-      bench_manifest_driven: true
+  source:
+    kernel: tileops/kernels/moe/permute_align.py
+    op: tileops/ops/moe/permute_align.py
+    test: tests/ops/test_moe_permute_align.py
+    bench: benchmarks/ops/bench_moe_permute_align.py
+    bench_manifest_driven: true
 
-  MoePermuteNopadFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
+MoePermuteNopadFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
 
-    signature:
-      inputs:
-        hidden_states: {dtype: "float16 | bfloat16"}
-        topk_ids: {dtype: "int32"}
-      outputs:
-        perm_h: {dtype: "same_as(hidden_states)"}
-        true_offsets: {dtype: "int32"}
-        true_sizes: {dtype: "int32"}
-        expert_first_token_offset: {dtype: "int64"}
-        fwd_idx: {dtype: "int32"}
-      params:
-        total_tokens: {type: int}
-        top_k: {type: int}
-        num_experts: {type: int}
-        hidden_size: {type: int}
-      shape_rules:
-        - "hidden_states.shape == (total_tokens, hidden_size)"
+  signature:
+    inputs:
+      hidden_states: {dtype: "float16 | bfloat16"}
+      topk_ids: {dtype: "int32"}
+    outputs:
+      perm_h: {dtype: "same_as(hidden_states)"}
+      true_offsets: {dtype: "int32"}
+      true_sizes: {dtype: "int32"}
+      expert_first_token_offset: {dtype: "int64"}
+      fwd_idx: {dtype: "int32"}
+    params:
+      total_tokens: {type: int}
+      top_k: {type: int}
+      num_experts: {type: int}
+      hidden_size: {type: int}
+    shape_rules:
+      - "hidden_states.shape == (total_tokens, hidden_size)"
 
-    workloads:
-      # Kimi K2: H=7168, E=384, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-prefill"}
-      # DeepSeek-V3: H=7168, E=256, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
-      # Qwen3-235B-A22B: H=7168, E=128, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
-      # Qwen3-30B-A3B: H=3072, E=128, K=8
-      - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-decode"}
-      - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-small"}
-      - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-medium"}
-      - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
+  workloads:
+    # Kimi K2: H=7168, E=384, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-prefill"}
+    # DeepSeek-V3: H=7168, E=256, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+    # Qwen3-235B-A22B: H=7168, E=128, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
+    # Qwen3-30B-A3B: H=3072, E=128, K=8
+    - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-decode"}
+    - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-small"}
+    - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-medium"}
+    - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
 
-    roofline:
-      # Permute is memory-bound; flops = 0
-      flops: "0"
-      # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-      bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
+  roofline:
+    # Permute is memory-bound; flops = 0
+    flops: "0"
+    # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
 
-    source:
-      kernel: tileops/kernels/moe/permute_nopad.py
-      op: tileops/ops/moe/permute_nopad.py
-      test: tests/ops/test_moe_permute.py
-      bench: benchmarks/ops/bench_moe_permute_nopad.py
-      bench_manifest_driven: true
+  source:
+    kernel: tileops/kernels/moe/permute_nopad.py
+    op: tileops/ops/moe/permute_nopad.py
+    test: tests/ops/test_moe_permute.py
+    bench: benchmarks/ops/bench_moe_permute_nopad.py
+    bench_manifest_driven: true
 
-  MoeUnpermuteFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
+MoeUnpermuteFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only  # impl uses num_tokens instead of total_tokens; fix in follow-up PR
 
-    signature:
-      inputs:
-        mm2_pad: {dtype: "float16 | bfloat16"}
-        fwd_idx: {dtype: "int32"}
-        topk_weights: {dtype: "float32"}
-      outputs:
-        output: {dtype: "same_as(mm2_pad)"}
-      params:
-        total_tokens: {type: int}
-        top_k: {type: int}
-        hidden_size: {type: int}
-      shape_rules:
-        - "output.shape == (total_tokens, hidden_size)"
+  signature:
+    inputs:
+      mm2_pad: {dtype: "float16 | bfloat16"}
+      fwd_idx: {dtype: "int32"}
+      topk_weights: {dtype: "float32"}
+    outputs:
+      output: {dtype: "same_as(mm2_pad)"}
+    params:
+      total_tokens: {type: int}
+      top_k: {type: int}
+      hidden_size: {type: int}
+    shape_rules:
+      - "output.shape == (total_tokens, hidden_size)"
 
-    workloads:
-      # Kimi K2 / DeepSeek-V3 / Qwen3-235B-A22B: H=7168, K=8
-      - {total_tokens: 1, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-decode"}
-      - {total_tokens: 32, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-small"}
-      - {total_tokens: 512, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-medium"}
-      - {total_tokens: 4096, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-prefill"}
-      # Qwen3-30B-A3B: H=3072, K=8
-      - {total_tokens: 1, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-decode"}
-      - {total_tokens: 32, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-small"}
-      - {total_tokens: 512, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-medium"}
-      - {total_tokens: 4096, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-prefill"}
+  workloads:
+    # Kimi K2 / DeepSeek-V3 / Qwen3-235B-A22B: H=7168, K=8
+    - {total_tokens: 1, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-decode"}
+    - {total_tokens: 32, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-small"}
+    - {total_tokens: 512, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-medium"}
+    - {total_tokens: 4096, top_k: 8, hidden_size: 7168, dtypes: [bfloat16], label: "large-hidden-prefill"}
+    # Qwen3-30B-A3B: H=3072, K=8
+    - {total_tokens: 1, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-decode"}
+    - {total_tokens: 32, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-small"}
+    - {total_tokens: 512, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-medium"}
+    - {total_tokens: 4096, top_k: 8, hidden_size: 3072, dtypes: [bfloat16], label: "small-hidden-prefill"}
 
-    roofline:
-      # multiply + add per element per expert slot: 2 * T*K * H
-      flops: "2 * total_tokens * top_k * hidden_size"
-      # mm2_pad read [T*K, H] + output write [T, H] + fwd_idx read [T*K]*4 + topk_weights read [T*K]*4
-      bytes: "(total_tokens * top_k * hidden_size + total_tokens * hidden_size) * elem_bytes + total_tokens * top_k * 4 + total_tokens * top_k * 4"
+  roofline:
+    # multiply + add per element per expert slot: 2 * T*K * H
+    flops: "2 * total_tokens * top_k * hidden_size"
+    # mm2_pad read [T*K, H] + output write [T, H] + fwd_idx read [T*K]*4 + topk_weights read [T*K]*4
+    bytes: "(total_tokens * top_k * hidden_size + total_tokens * hidden_size) * elem_bytes + total_tokens * top_k * 4 + total_tokens * top_k * 4"
 
-    source:
-      kernel: tileops/kernels/moe/unpermute.py
-      op: tileops/ops/moe/unpermute.py
-      test: tests/ops/test_moe_unpermute.py
-      bench: benchmarks/ops/bench_moe_unpermute.py
-      bench_manifest_driven: true
+  source:
+    kernel: tileops/kernels/moe/unpermute.py
+    op: tileops/ops/moe/unpermute.py
+    test: tests/ops/test_moe_unpermute.py
+    bench: benchmarks/ops/bench_moe_unpermute.py
+    bench_manifest_driven: true
 
-  FusedMoeExpertsFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only
+FusedMoeExpertsFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only
 
-    signature:
-      inputs:
-        hidden_states: {dtype: "float16 | bfloat16"}
-        w_gate_up: {dtype: "same_as(hidden_states)"}
-        w_down: {dtype: "same_as(hidden_states)"}
-        topk_weights: {dtype: "float32"}
-        topk_ids: {dtype: "int32"}
-      outputs:
-        output: {dtype: "same_as(hidden_states)"}
-      params:
-        num_tokens: {type: int}
-        num_experts: {type: int}
-        top_k: {type: int}
-        hidden_size: {type: int}
-        ffn_size: {type: int}
-        routed_scaling_factor: {type: float, default: 1.0}
-      shape_rules:
-        - "output.shape == hidden_states.shape"
+  signature:
+    inputs:
+      hidden_states: {dtype: "float16 | bfloat16"}
+      w_gate_up: {dtype: "same_as(hidden_states)"}
+      w_down: {dtype: "same_as(hidden_states)"}
+      topk_weights: {dtype: "float32"}
+      topk_ids: {dtype: "int32"}
+    outputs:
+      output: {dtype: "same_as(hidden_states)"}
+    params:
+      num_tokens: {type: int}
+      num_experts: {type: int}
+      top_k: {type: int}
+      hidden_size: {type: int}
+      ffn_size: {type: int}
+      routed_scaling_factor: {type: float, default: 1.0}
+    shape_rules:
+      - "output.shape == hidden_states.shape"
 
-    workloads:
-      - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+  workloads:
+    - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
 
-    roofline:
-      flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
-      bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
+  roofline:
+    flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
+    bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
 
-    source:
-      kernel: tileops/ops/moe/fused_moe_experts.py
-      op: tileops/ops/moe/fused_moe_experts.py
-      test: tests/ops/test_moe_fused_moe.py
-      bench: benchmarks/ops/bench_moe_fused_moe.py
+  source:
+    kernel: tileops/ops/moe/fused_moe_experts.py
+    op: tileops/ops/moe/fused_moe_experts.py
+    test: tests/ops/test_moe_fused_moe.py
+    bench: benchmarks/ops/bench_moe_fused_moe.py
 
-  FusedMoeExpertsPaddedFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only
+FusedMoeExpertsPaddedFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only
 
-    signature:
-      inputs:
-        hidden_states: {dtype: "float16 | bfloat16"}
-        w_gate_up: {dtype: "same_as(hidden_states)"}
-        w_down: {dtype: "same_as(hidden_states)"}
-        topk_weights: {dtype: "float32"}
-        topk_ids: {dtype: "int32"}
-      outputs:
-        output: {dtype: "same_as(hidden_states)"}
-      params:
-        num_tokens: {type: int}
-        num_experts: {type: int}
-        top_k: {type: int}
-        hidden_size: {type: int}
-        ffn_size: {type: int}
-        routed_scaling_factor: {type: float, default: 1.0}
-      shape_rules:
-        - "output.shape == hidden_states.shape"
+  signature:
+    inputs:
+      hidden_states: {dtype: "float16 | bfloat16"}
+      w_gate_up: {dtype: "same_as(hidden_states)"}
+      w_down: {dtype: "same_as(hidden_states)"}
+      topk_weights: {dtype: "float32"}
+      topk_ids: {dtype: "int32"}
+    outputs:
+      output: {dtype: "same_as(hidden_states)"}
+    params:
+      num_tokens: {type: int}
+      num_experts: {type: int}
+      top_k: {type: int}
+      hidden_size: {type: int}
+      ffn_size: {type: int}
+      routed_scaling_factor: {type: float, default: 1.0}
+    shape_rules:
+      - "output.shape == hidden_states.shape"
 
-    workloads:
-      - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+  workloads:
+    - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
 
-    roofline:
-      flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
-      bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
+  roofline:
+    flops: "num_tokens * top_k * 6 * ffn_size * hidden_size"
+    bytes: "(num_experts * 3 * ffn_size * hidden_size + 2 * num_tokens * hidden_size) * elem_bytes"
 
-    source:
-      kernel: tileops/ops/moe/fused_moe_experts.py
-      op: tileops/ops/moe/fused_moe_experts.py
-      test: tests/ops/test_moe_fused_moe.py
-      bench: benchmarks/ops/bench_moe_fused_moe.py
+  source:
+    kernel: tileops/ops/moe/fused_moe_experts.py
+    op: tileops/ops/moe/fused_moe_experts.py
+    test: tests/ops/test_moe_fused_moe.py
+    bench: benchmarks/ops/bench_moe_fused_moe.py
 
-  MoeGroupedGemmNopadFwdOp:
-    ref_api: "none"
-    family: moe
-    status: spec-only
+MoeGroupedGemmNopadFwdOp:
+  ref_api: "none"
+  family: moe
+  status: spec-only
 
-    signature:
-      inputs:
-        a: {dtype: "float16 | bfloat16"}
-        b: {dtype: "same_as(a)"}
-        true_sizes: {dtype: "int32"}
-        true_offsets: {dtype: "int32"}
-      outputs:
-        c: {dtype: "same_as(a)"}
-      params:
-        numel: {type: int}
-        num_experts: {type: int}
-        n: {type: int}
-        k: {type: int}
-      shape_rules:
-        - "c.shape == (numel, n)"
+  signature:
+    inputs:
+      a: {dtype: "float16 | bfloat16"}
+      b: {dtype: "same_as(a)"}
+      true_sizes: {dtype: "int32"}
+      true_offsets: {dtype: "int32"}
+    outputs:
+      c: {dtype: "same_as(a)"}
+    params:
+      numel: {type: int}
+      num_experts: {type: int}
+      n: {type: int}
+      k: {type: int}
+    shape_rules:
+      - "c.shape == (numel, n)"
 
-    workloads:
-      - {numel: 4096, num_experts: 256, n: 4096, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-gate-up"}
+  workloads:
+    - {numel: 4096, num_experts: 256, n: 4096, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-gate-up"}
 
-    roofline:
-      flops: "2 * numel * n * k"
-      bytes: "(numel * k + num_experts * n * k + numel * n) * elem_bytes"
+  roofline:
+    flops: "2 * numel * n * k"
+    bytes: "(numel * k + num_experts * n * k + numel * n) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
-      op: tileops/ops/moe/moe_grouped_gemm_nopad.py
-      test: tests/ops/test_moe_fused_moe.py
-      bench: benchmarks/ops/bench_moe_fused_moe.py
+  source:
+    kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
+    op: tileops/ops/moe/moe_grouped_gemm_nopad.py
+    test: tests/ops/test_moe_fused_moe.py
+    bench: benchmarks/ops/bench_moe_fused_moe.py

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -4,500 +4,499 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  RMSNormFwdOp:
-    ref_api: "torch.nn.functional.rms_norm"
-    family: normalization
-    status: implemented
+RMSNormFwdOp:
+  ref_api: "torch.nn.functional.rms_norm"
+  family: normalization
+  status: implemented
 
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-        weight: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: int, default: -1}
-        eps: {type: float, default: 1.0e-6}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "weight.shape == (x.shape[dim],)"
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+      weight: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: int, default: -1}
+      eps: {type: float, default: 1.0e-6}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "weight.shape == (x.shape[dim],)"
 
-    workloads:
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
-      # Llama-3.1-70B (hidden_dim=8192)
-      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
-      # Llama-3.1-405B (hidden_dim=16384)
-      - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-      - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  workloads:
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    # Llama-3.1-70B (hidden_dim=8192)
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    # Llama-3.1-405B (hidden_dim=16384)
+    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
-      # Per row: N squares + (N-1) adds + div + add + rsqrt + N muls (normalize) + N muls (weight) ≈ 4N
-      flops: "4 * M * N"
-      # Read x (M*N) + read weight (N) + write y (M*N), x elem_size
-      bytes: "(2 * M * N + N) * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "x.shape[dim % x.ndim]"
+    # Per row: N squares + (N-1) adds + div + add + rsqrt + N muls (normalize) + N muls (weight) ≈ 4N
+    flops: "4 * M * N"
+    # Read x (M*N) + read weight (N) + write y (M*N), x elem_size
+    bytes: "(2 * M * N + N) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/rms_norm.py
-      kernel_map:
-        rms_norm: RMSNormKernel
-      op: tileops/ops/norm/rms_norm.py
-      test: tests/ops/test_rms_norm.py
-      bench: benchmarks/ops/bench_rms_norm.py
+  source:
+    kernel: tileops/kernels/norm/rms_norm.py
+    kernel_map:
+      rms_norm: RMSNormKernel
+    op: tileops/ops/norm/rms_norm.py
+    test: tests/ops/test_rms_norm.py
+    bench: benchmarks/ops/bench_rms_norm.py
 
-  LayerNormFwdOp:
-    ref_api: "torch.nn.functional.layer_norm"
-    family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+LayerNormFwdOp:
+  ref_api: "torch.nn.functional.layer_norm"
+  family: normalization
+  status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        weight: {dtype: "same_as(x)"}
-        bias: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        N: "x.shape[-1]"
-      shape_rules:
-        - "weight.shape == (x.shape[-1],)"
-        - "bias.shape == (x.shape[-1],)"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      weight: {dtype: "same_as(x)"}
+      bias: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      N: "x.shape[-1]"
+    shape_rules:
+      - "weight.shape == (x.shape[-1],)"
+      - "bias.shape == (x.shape[-1],)"
+      - "y.shape == x.shape"
 
-    workloads:
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
-      # Llama-3.1-70B (hidden_dim=8192)
-      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
-      # Llama-3.1-405B (hidden_dim=16384)
-      - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-      - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  workloads:
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    # Llama-3.1-70B (hidden_dim=8192)
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    # Llama-3.1-405B (hidden_dim=16384)
+    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:-1])"
-        N: "x.shape[-1]"
-      # Per row: N mean + N variance + N normalize + N scale + N bias ≈ 5N
-      flops: "5 * M * N"
-      # Read x (M*N) + read weight (N) + read bias (N) + write y (M*N)
-      bytes: "(2 * M * N + 2 * N) * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:-1])"
+      N: "x.shape[-1]"
+    # Per row: N mean + N variance + N normalize + N scale + N bias ≈ 5N
+    flops: "5 * M * N"
+    # Read x (M*N) + read weight (N) + read bias (N) + write y (M*N)
+    bytes: "(2 * M * N + 2 * N) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/layer_norm.py
-      kernel_map:
-        layer_norm: LayerNormKernel
-      op: tileops/ops/norm/layer_norm.py
-      test: tests/ops/test_layer_norm.py
-      bench: benchmarks/ops/bench_layer_norm.py
+  source:
+    kernel: tileops/kernels/norm/layer_norm.py
+    kernel_map:
+      layer_norm: LayerNormKernel
+    op: tileops/ops/norm/layer_norm.py
+    test: tests/ops/test_layer_norm.py
+    bench: benchmarks/ops/bench_layer_norm.py
 
-  AdaLayerNormFwdOp:
-    ref_api: "none"
-    family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+AdaLayerNormFwdOp:
+  ref_api: "none"
+  family: normalization
+  status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        scale: {dtype: "same_as(x)"}
-        shift: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        N: "x.shape[-1]"
-      shape_rules:
-        - "scale.shape == x.shape"
-        - "shift.shape == x.shape"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      scale: {dtype: "same_as(x)"}
+      shift: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      N: "x.shape[-1]"
+    shape_rules:
+      - "scale.shape == x.shape"
+      - "shift.shape == x.shape"
+      - "y.shape == x.shape"
 
-    workloads:
-      # DiT-XL/2 (hidden_dim=1152)
-      - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  workloads:
+    # DiT-XL/2 (hidden_dim=1152)
+    - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:-1])"
-        N: "x.shape[-1]"
-      # Per row: N mean + N variance + N normalize + N scale + N shift ≈ 5N
-      flops: "5 * M * N"
-      # Read x + read scale + read shift + write y = 4*M*N
-      bytes: "4 * M * N * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:-1])"
+      N: "x.shape[-1]"
+    # Per row: N mean + N variance + N normalize + N scale + N shift ≈ 5N
+    flops: "5 * M * N"
+    # Read x + read scale + read shift + write y = 4*M*N
+    bytes: "4 * M * N * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/ada_layer_norm.py
-      kernel_map:
-        ada_layer_norm: AdaLayerNormKernel
-      op: tileops/ops/norm/ada_layer_norm.py
-      test: tests/ops/test_ada_layer_norm.py
-      bench: benchmarks/ops/bench_ada_layer_norm.py
+  source:
+    kernel: tileops/kernels/norm/ada_layer_norm.py
+    kernel_map:
+      ada_layer_norm: AdaLayerNormKernel
+    op: tileops/ops/norm/ada_layer_norm.py
+    test: tests/ops/test_ada_layer_norm.py
+    bench: benchmarks/ops/bench_ada_layer_norm.py
 
-  AdaLayerNormZeroFwdOp:
-    ref_api: "none"
-    family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+AdaLayerNormZeroFwdOp:
+  ref_api: "none"
+  family: normalization
+  status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        scale: {dtype: "same_as(x)"}
-        shift: {dtype: "same_as(x)"}
-        gate: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        N: "x.shape[-1]"
-      shape_rules:
-        - "scale.shape == x.shape"
-        - "shift.shape == x.shape"
-        - "gate.shape == x.shape"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      scale: {dtype: "same_as(x)"}
+      shift: {dtype: "same_as(x)"}
+      gate: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      N: "x.shape[-1]"
+    shape_rules:
+      - "scale.shape == x.shape"
+      - "shift.shape == x.shape"
+      - "gate.shape == x.shape"
+      - "y.shape == x.shape"
 
-    workloads:
-      # DiT-XL/2 (hidden_dim=1152)
-      - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  workloads:
+    # DiT-XL/2 (hidden_dim=1152)
+    - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:-1])"
-        N: "x.shape[-1]"
-      # Per row: N mean + N variance + N normalize + N scale + N shift + N gate ≈ 6N
-      flops: "6 * M * N"
-      # Read x + read scale + read shift + read gate + write y = 5*M*N
-      bytes: "5 * M * N * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:-1])"
+      N: "x.shape[-1]"
+    # Per row: N mean + N variance + N normalize + N scale + N shift + N gate ≈ 6N
+    flops: "6 * M * N"
+    # Read x + read scale + read shift + read gate + write y = 5*M*N
+    bytes: "5 * M * N * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/ada_layer_norm_zero.py
-      kernel_map:
-        ada_layer_norm: AdaLayerNormKernel
-      op: tileops/ops/norm/ada_layer_norm_zero.py
-      test: tests/ops/test_ada_layer_norm_zero.py
-      bench: benchmarks/ops/bench_ada_layer_norm.py
+  source:
+    kernel: tileops/kernels/norm/ada_layer_norm_zero.py
+    kernel_map:
+      ada_layer_norm: AdaLayerNormKernel
+    op: tileops/ops/norm/ada_layer_norm_zero.py
+    test: tests/ops/test_ada_layer_norm_zero.py
+    bench: benchmarks/ops/bench_ada_layer_norm.py
 
-  FusedAddLayerNormFwdOp:
-    ref_api: "none"
-    family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+FusedAddLayerNormFwdOp:
+  ref_api: "none"
+  family: normalization
+  status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        residual: {dtype: "same_as(x)"}
-        weight: {dtype: "same_as(x)"}
-        bias: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-        residual_out: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        N: "x.shape[-1]"
-      shape_rules:
-        - "residual.shape == x.shape"
-        - "weight.shape == (x.shape[-1],)"
-        - "bias.shape == (x.shape[-1],)"
-        - "y.shape == x.shape"
-        - "residual_out.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      residual: {dtype: "same_as(x)"}
+      weight: {dtype: "same_as(x)"}
+      bias: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+      residual_out: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      N: "x.shape[-1]"
+    shape_rules:
+      - "residual.shape == x.shape"
+      - "weight.shape == (x.shape[-1],)"
+      - "bias.shape == (x.shape[-1],)"
+      - "y.shape == x.shape"
+      - "residual_out.shape == x.shape"
 
-    workloads:
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
-      # Llama-3.1-70B (hidden_dim=8192)
-      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+  workloads:
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    # Llama-3.1-70B (hidden_dim=8192)
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:-1])"
-        N: "x.shape[-1]"
-      # Per row: N add (residual) + N mean + N variance + N normalize + N scale + N bias ≈ 6N
-      flops: "6 * M * N"
-      # Read x + read residual + read weight + read bias + write y + write residual_out
-      bytes: "(4 * M * N + 2 * N) * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:-1])"
+      N: "x.shape[-1]"
+    # Per row: N add (residual) + N mean + N variance + N normalize + N scale + N bias ≈ 6N
+    flops: "6 * M * N"
+    # Read x + read residual + read weight + read bias + write y + write residual_out
+    bytes: "(4 * M * N + 2 * N) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/fused_add_norm.py
-      kernel_map:
-        fused_add_layer_norm: FusedAddLayerNormKernel
-      op: tileops/ops/norm/fused_add_layer_norm.py
-      test: tests/ops/test_fused_add_layer_norm.py
-      bench: benchmarks/ops/bench_fused_add_layer_norm.py
+  source:
+    kernel: tileops/kernels/norm/fused_add_norm.py
+    kernel_map:
+      fused_add_layer_norm: FusedAddLayerNormKernel
+    op: tileops/ops/norm/fused_add_layer_norm.py
+    test: tests/ops/test_fused_add_layer_norm.py
+    bench: benchmarks/ops/bench_fused_add_layer_norm.py
 
-  FusedAddRMSNormFwdOp:
-    ref_api: "none"
-    family: normalization
-    status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
+FusedAddRMSNormFwdOp:
+  ref_api: "none"
+  family: normalization
+  status: spec-only  # impl __init__ takes M in addition to N; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-        residual: {dtype: "same_as(x)"}
-        weight: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-        residual_out: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-6}
-      static_dims:
-        N: "x.shape[-1]"
-      shape_rules:
-        - "residual.shape == x.shape"
-        - "weight.shape == (x.shape[-1],)"
-        - "y.shape == x.shape"
-        - "residual_out.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+      residual: {dtype: "same_as(x)"}
+      weight: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+      residual_out: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-6}
+    static_dims:
+      N: "x.shape[-1]"
+    shape_rules:
+      - "residual.shape == x.shape"
+      - "weight.shape == (x.shape[-1],)"
+      - "y.shape == x.shape"
+      - "residual_out.shape == x.shape"
 
-    workloads:
-      # Llama-3.1-8B (hidden_dim=4096)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-      - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
-      # Llama-3.1-70B (hidden_dim=8192)
-      - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-      - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
-      # Llama-3.1-405B (hidden_dim=16384)
-      - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-      - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  workloads:
+    # Llama-3.1-8B (hidden_dim=4096)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+    # Llama-3.1-70B (hidden_dim=8192)
+    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+    # Llama-3.1-405B (hidden_dim=16384)
+    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:-1])"
-        N: "x.shape[-1]"
-      # Per row: N add (residual) + N squares + (N-1) adds + rsqrt + N normalize + N weight ≈ 5N
-      flops: "5 * M * N"
-      # Read x + read residual + read weight + write y + write residual_out
-      bytes: "(4 * M * N + N) * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:-1])"
+      N: "x.shape[-1]"
+    # Per row: N add (residual) + N squares + (N-1) adds + rsqrt + N normalize + N weight ≈ 5N
+    flops: "5 * M * N"
+    # Read x + read residual + read weight + write y + write residual_out
+    bytes: "(4 * M * N + N) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/fused_add_norm.py
-      kernel_map:
-        fused_add_rms_norm: FusedAddRMSNormKernel
-      op: tileops/ops/norm/fused_add_rms_norm.py
-      test: tests/ops/test_fused_add_rms_norm.py
-      bench: benchmarks/ops/bench_fused_add_rms_norm.py
+  source:
+    kernel: tileops/kernels/norm/fused_add_norm.py
+    kernel_map:
+      fused_add_rms_norm: FusedAddRMSNormKernel
+    op: tileops/ops/norm/fused_add_rms_norm.py
+    test: tests/ops/test_fused_add_rms_norm.py
+    bench: benchmarks/ops/bench_fused_add_rms_norm.py
 
-  # ---------------------------------------------------------------------------
-  # norm — spatial-norm ops (operate over spatial/channel dims, shape: [N, C, *spatial])
-  # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# norm — spatial-norm ops (operate over spatial/channel dims, shape: [N, C, *spatial])
+# ---------------------------------------------------------------------------
 
-  BatchNormFwdOp:
-    ref_api: "torch.nn.functional.batch_norm"
-    family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+BatchNormFwdOp:
+  ref_api: "torch.nn.functional.batch_norm"
+  family: normalization
+  status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        weight: {dtype: "float32"}
-        bias: {dtype: "float32"}
-        running_mean: {dtype: "float32"}
-        running_var: {dtype: "float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-        mean: {dtype: "float32"}
-        rstd: {dtype: "float32"}
-      params:
-        training: {type: bool, default: true}
-        eps: {type: float, default: 1.0e-5}
-        momentum: {type: float, default: 0.1}
-      static_dims:
-        C: "x.shape[1]"
-      shape_rules:
-        - "weight.shape == (x.shape[1],)"
-        - "bias.shape == (x.shape[1],)"
-        - "running_mean.shape == (x.shape[1],)"
-        - "running_var.shape == (x.shape[1],)"
-        - "y.shape == x.shape"
-        - "mean.shape == (x.shape[1],)"
-        - "rstd.shape == (x.shape[1],)"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      weight: {dtype: "float32"}
+      bias: {dtype: "float32"}
+      running_mean: {dtype: "float32"}
+      running_var: {dtype: "float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+      mean: {dtype: "float32"}
+      rstd: {dtype: "float32"}
+    params:
+      training: {type: bool, default: true}
+      eps: {type: float, default: 1.0e-5}
+      momentum: {type: float, default: 0.1}
+    static_dims:
+      C: "x.shape[1]"
+    shape_rules:
+      - "weight.shape == (x.shape[1],)"
+      - "bias.shape == (x.shape[1],)"
+      - "running_mean.shape == (x.shape[1],)"
+      - "running_var.shape == (x.shape[1],)"
+      - "y.shape == x.shape"
+      - "mean.shape == (x.shape[1],)"
+      - "rstd.shape == (x.shape[1],)"
 
-    workloads:
-      # ResNet-50 stages
-      - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
-      - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
-      - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
-      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
-      # Large spatial
-      - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+  workloads:
+    # ResNet-50 stages
+    - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+    - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+    - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+    # Large spatial
+    - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
 
-    roofline:
-      vars:
-        C: "x.shape[1]"
-        L: "product(x.shape) // x.shape[1]"
-      # 2-pass: compute mean/var over L elements per channel, then normalize. ≈ 10*C*L
-      flops: "10 * C * L"
-      # Read x + write y (elem_bytes each) + float32 params (weight, bias, running_mean, running_var)
-      bytes: "2 * C * L * elem_bytes + 4 * C * 4"
+  roofline:
+    vars:
+      C: "x.shape[1]"
+      L: "product(x.shape) // x.shape[1]"
+    # 2-pass: compute mean/var over L elements per channel, then normalize. ≈ 10*C*L
+    flops: "10 * C * L"
+    # Read x + write y (elem_bytes each) + float32 params (weight, bias, running_mean, running_var)
+    bytes: "2 * C * L * elem_bytes + 4 * C * 4"
 
-    source:
-      kernel: tileops/kernels/norm/batch_norm.py
-      kernel_map:
-        fwd_train_kernel: BatchNormFwdTrainKernel
-        fwd_infer_kernel: BatchNormFwdInferKernel
-      op: tileops/ops/norm/batch_norm.py
-      test: tests/ops/test_batch_norm.py
-      bench: benchmarks/ops/bench_batch_norm.py
+  source:
+    kernel: tileops/kernels/norm/batch_norm.py
+    kernel_map:
+      fwd_train_kernel: BatchNormFwdTrainKernel
+      fwd_infer_kernel: BatchNormFwdInferKernel
+    op: tileops/ops/norm/batch_norm.py
+    test: tests/ops/test_batch_norm.py
+    bench: benchmarks/ops/bench_batch_norm.py
 
-  BatchNormBwdOp:
-    ref_api: "torch.nn.functional.batch_norm"
-    family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+BatchNormBwdOp:
+  ref_api: "torch.nn.functional.batch_norm"
+  family: normalization
+  status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        grad_out: {dtype: "float32 | float16 | bfloat16"}
-        x: {dtype: "same_as(grad_out)"}
-        weight: {dtype: "float32"}
-        mean: {dtype: "float32"}
-        rstd: {dtype: "float32"}
-      outputs:
-        grad_x: {dtype: "same_as(grad_out)"}
-        grad_weight: {dtype: "float32"}
-        grad_bias: {dtype: "float32"}
-      params: {}
-      static_dims:
-        C: "grad_out.shape[1]"
-      shape_rules:
-        - "x.shape == grad_out.shape"
-        - "weight.shape == (grad_out.shape[1],)"
-        - "mean.shape == (grad_out.shape[1],)"
-        - "rstd.shape == (grad_out.shape[1],)"
-        - "grad_x.shape == grad_out.shape"
-        - "grad_weight.shape == (grad_out.shape[1],)"
-        - "grad_bias.shape == (grad_out.shape[1],)"
+  signature:
+    inputs:
+      grad_out: {dtype: "float32 | float16 | bfloat16"}
+      x: {dtype: "same_as(grad_out)"}
+      weight: {dtype: "float32"}
+      mean: {dtype: "float32"}
+      rstd: {dtype: "float32"}
+    outputs:
+      grad_x: {dtype: "same_as(grad_out)"}
+      grad_weight: {dtype: "float32"}
+      grad_bias: {dtype: "float32"}
+    params: {}
+    static_dims:
+      C: "grad_out.shape[1]"
+    shape_rules:
+      - "x.shape == grad_out.shape"
+      - "weight.shape == (grad_out.shape[1],)"
+      - "mean.shape == (grad_out.shape[1],)"
+      - "rstd.shape == (grad_out.shape[1],)"
+      - "grad_x.shape == grad_out.shape"
+      - "grad_weight.shape == (grad_out.shape[1],)"
+      - "grad_bias.shape == (grad_out.shape[1],)"
 
-    workloads:
-      # ResNet-50 stages (same as fwd)
-      - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
-      - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
-      - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
-      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
-      # Large spatial
-      - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+  workloads:
+    # ResNet-50 stages (same as fwd)
+    - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+    - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+    - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+    # Large spatial
+    - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
 
-    roofline:
-      vars:
-        C: "grad_out.shape[1]"
-        L: "product(grad_out.shape) // grad_out.shape[1]"
-      # Backward: 3 reductions + elementwise ≈ 8*C*L
-      flops: "8 * C * L"
-      # Read grad_out + x + write grad_x (elem_bytes each) + float32 read weight + write grad_weight, grad_bias
-      bytes: "3 * C * L * elem_bytes + 3 * C * 4"
+  roofline:
+    vars:
+      C: "grad_out.shape[1]"
+      L: "product(grad_out.shape) // grad_out.shape[1]"
+    # Backward: 3 reductions + elementwise ≈ 8*C*L
+    flops: "8 * C * L"
+    # Read grad_out + x + write grad_x (elem_bytes each) + float32 read weight + write grad_weight, grad_bias
+    bytes: "3 * C * L * elem_bytes + 3 * C * 4"
 
-    source:
-      kernel: tileops/kernels/norm/batch_norm.py
-      kernel_map:
-        bwd_kernel: BatchNormBwdKernel
-      op: tileops/ops/norm/batch_norm.py
-      test: tests/ops/test_batch_norm.py
-      bench: benchmarks/ops/bench_batch_norm.py
+  source:
+    kernel: tileops/kernels/norm/batch_norm.py
+    kernel_map:
+      bwd_kernel: BatchNormBwdKernel
+    op: tileops/ops/norm/batch_norm.py
+    test: tests/ops/test_batch_norm.py
+    bench: benchmarks/ops/bench_batch_norm.py
 
-  GroupNormFwdOp:
-    ref_api: "torch.nn.functional.group_norm"
-    family: normalization
-    status: spec-only  # impl uses G instead of groups; fix in follow-up PR
+GroupNormFwdOp:
+  ref_api: "torch.nn.functional.group_norm"
+  family: normalization
+  status: spec-only  # impl uses G instead of groups; fix in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        weight: {dtype: "same_as(x)"}
-        bias: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        groups: {type: int}
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        C: "x.shape[1]"
-      shape_rules:
-        - "weight.shape == (x.shape[1],)"
-        - "bias.shape == (x.shape[1],)"
-        - "x.shape[1] % groups == 0"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      weight: {dtype: "same_as(x)"}
+      bias: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      groups: {type: int}
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      C: "x.shape[1]"
+    shape_rules:
+      - "weight.shape == (x.shape[1],)"
+      - "bias.shape == (x.shape[1],)"
+      - "x.shape[1] % groups == 0"
+      - "y.shape == x.shape"
 
-    workloads:
-      # Typical CV shapes
-      - {x_shape: [8, 128, 32, 32], groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
-      - {x_shape: [4, 256, 28, 28], groups: 32, dtypes: [float16], label: "wider-channel-g32"}
-      - {x_shape: [4, 128, 30, 30], groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
+  workloads:
+    # Typical CV shapes
+    - {x_shape: [8, 128, 32, 32], groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
+    - {x_shape: [4, 256, 28, 28], groups: 32, dtypes: [float16], label: "wider-channel-g32"}
+    - {x_shape: [4, 128, 30, 30], groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
 
-    roofline:
-      vars:
-        N: "x.shape[0]"
-        C: "x.shape[1]"
-        spatial_size: "product(x.shape[2:])"
-      # Per element: subtract mean + square for var + normalize + scale + bias ≈ 5
-      flops: "5 * N * C * spatial_size"
-      # Read x + write y + read weight (C) + read bias (C)
-      bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
+  roofline:
+    vars:
+      N: "x.shape[0]"
+      C: "x.shape[1]"
+      spatial_size: "product(x.shape[2:])"
+    # Per element: subtract mean + square for var + normalize + scale + bias ≈ 5
+    flops: "5 * N * C * spatial_size"
+    # Read x + write y + read weight (C) + read bias (C)
+    bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/group_norm.py
-      kernel_map:
-        group_norm: GroupNormKernel
-      op: tileops/ops/norm/group_norm.py
-      test: tests/ops/test_group_norm.py
-      bench: benchmarks/ops/bench_group_norm.py
+  source:
+    kernel: tileops/kernels/norm/group_norm.py
+    kernel_map:
+      group_norm: GroupNormKernel
+    op: tileops/ops/norm/group_norm.py
+    test: tests/ops/test_group_norm.py
+    bench: benchmarks/ops/bench_group_norm.py
 
-  InstanceNormFwdOp:
-    ref_api: "torch.nn.functional.instance_norm"
-    family: normalization
-    status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
+InstanceNormFwdOp:
+  ref_api: "torch.nn.functional.instance_norm"
+  family: normalization
+  status: spec-only  # impl __init__ takes N and spatial in addition to C; align with static_dims in follow-up PR
 
-    signature:
-      inputs:
-        x: {dtype: "float32 | float16 | bfloat16"}
-        weight: {dtype: "same_as(x)"}
-        bias: {dtype: "same_as(x)"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        eps: {type: float, default: 1.0e-5}
-      static_dims:
-        C: "x.shape[1]"
-      shape_rules:
-        - "weight.shape == (x.shape[1],)"
-        - "bias.shape == (x.shape[1],)"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float32 | float16 | bfloat16"}
+      weight: {dtype: "same_as(x)"}
+      bias: {dtype: "same_as(x)"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      eps: {type: float, default: 1.0e-5}
+    static_dims:
+      C: "x.shape[1]"
+    shape_rules:
+      - "weight.shape == (x.shape[1],)"
+      - "bias.shape == (x.shape[1],)"
+      - "y.shape == x.shape"
 
-    workloads:
-      # Typical CV shapes (style transfer, image generation)
-      - {x_shape: [8, 128, 32, 32], dtypes: [float16, bfloat16], label: "image"}
-      - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "wider-channel"}
-      - {x_shape: [4, 64, 30, 30], dtypes: [float16], label: "tail-spatial"}
+  workloads:
+    # Typical CV shapes (style transfer, image generation)
+    - {x_shape: [8, 128, 32, 32], dtypes: [float16, bfloat16], label: "image"}
+    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "wider-channel"}
+    - {x_shape: [4, 64, 30, 30], dtypes: [float16], label: "tail-spatial"}
 
-    roofline:
-      vars:
-        N: "x.shape[0]"
-        C: "x.shape[1]"
-        spatial_size: "product(x.shape[2:])"
-      # Same as GroupNorm (InstanceNorm = GroupNorm with G=C)
-      flops: "5 * N * C * spatial_size"
-      # Read x + write y + read weight (C) + read bias (C)
-      bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
+  roofline:
+    vars:
+      N: "x.shape[0]"
+      C: "x.shape[1]"
+      spatial_size: "product(x.shape[2:])"
+    # Same as GroupNorm (InstanceNorm = GroupNorm with G=C)
+    flops: "5 * N * C * spatial_size"
+    # Read x + write y + read weight (C) + read bias (C)
+    bytes: "(2 * N * C * spatial_size + 2 * C) * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/norm/group_norm.py
-      kernel_map:
-        group_norm: GroupNormKernel
-      op: tileops/ops/norm/instance_norm.py
-      test: tests/ops/test_instance_norm.py
-      bench: benchmarks/ops/bench_instance_norm.py
+  source:
+    kernel: tileops/kernels/norm/group_norm.py
+    kernel_map:
+      group_norm: GroupNormKernel
+    op: tileops/ops/norm/instance_norm.py
+    test: tests/ops/test_instance_norm.py
+    bench: benchmarks/ops/bench_instance_norm.py

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -4,914 +4,913 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  SoftmaxFwdOp:
-    ref_api: "torch.nn.functional.softmax"
-    family: reduction
-    status: spec-only  # impl/tests still accept float32; manifest x dtype is float16 | bfloat16 only. Flip to implemented when dtype parity matches.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
-        # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
-        # dtype). The current manifest dtype DSL cannot express
-        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
-        # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: int, default: -1}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.shape == x.shape"
-
-    workloads:
-      # Attention weight matrices (batch * heads, seq, seq)
-      - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
-      - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
-      # LM head logits (batch, vocab_size)
-      - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
-      # Per row: max (N), subtract+exp (2N), sum (N), div (N) = 5N
-      flops: "5 * M * N"
-      # Read x + write y
-      bytes: "2 * M * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/softmax.py
-      kernel_map:
-        softmax_fwd: SoftmaxKernel
-      op: tileops/ops/reduction/softmax.py
-      test: tests/ops/test_softmax.py
-      bench: benchmarks/ops/bench_softmax.py
-      bench_manifest_driven: true
-
-  LogSoftmaxFwdOp:
-    ref_api: "torch.nn.functional.log_softmax"
-    family: reduction
-    status: spec-only  # impl/tests still accept float32; manifest x dtype is float16 | bfloat16 only. Flip to implemented when dtype parity matches.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
-        # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
-        # dtype). The current manifest dtype DSL cannot express
-        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
-        # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: int, default: -1}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.shape == x.shape"
-
-    workloads:
-      # Attention weight matrices
-      - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
-      - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
-      # LM head logits
-      - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
-      # Per row: max (N), subtract+exp (2N), sum (N), log+subtract (2N) = 6N
-      flops: "6 * M * N"
-      # Read x + write y
-      bytes: "2 * M * N * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/softmax.py
-      kernel_map:
-        softmax_fwd: SoftmaxKernel
-      op: tileops/ops/reduction/log_softmax.py
-      test: tests/ops/test_softmax.py
-      bench: benchmarks/ops/bench_softmax.py
-      bench_manifest_driven: true
-
-  LogSumExpFwdOp:
-    ref_api: "torch.logsumexp"
-    family: reduction
-    status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, int) or len(dim) > 0"
-        - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim})))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim})][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Attention weight matrices
-      - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
-      - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
-      # LM head logits
-      - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
-      # Per row: max (N), subtract+exp (2N), sum (N), log+add (2) = 4N + 2
-      flops: "4 * M * N"
-      # Read x (M*N) + write y (M)
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/logsumexp.py
-      kernel_map:
-        logsumexp_fwd: LogSumExpKernel
-      op: tileops/ops/reduction/logsumexp.py
-      test: tests/ops/test_softmax.py
-      bench: benchmarks/ops/bench_softmax.py
-      bench_manifest_driven: true
-
-  # ---------------------------------------------------------------------------
-  # reduction -- simple reductions (dim + keepdim)
-  # ---------------------------------------------------------------------------
-
-  SumFwdOp:
-    ref_api: "torch.sum"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
-        # dtype). The current manifest dtype DSL cannot express
-        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
-        # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state reduction (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
-      # Long sequence reduction
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
-      # Non-last-axis reduction (exercises dim=0 path)
-      - {x_shape: [2048, 4096], dtypes: [bfloat16], dim: 0, label: "hidden-state-reduce-dim0"}
-      # Keepdim variant (exercises keepdim forwarding through the baseline)
-      - {x_shape: [2048, 4096], dtypes: [bfloat16], dim: -1, keepdim: true, label: "hidden-state-reduce-keepdim"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # N-1 additions per output element
-      flops: "M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  MeanFwdOp:
-    ref_api: "torch.mean"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
-        # dtype). The current manifest dtype DSL cannot express
-        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
-        # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state reduction (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
-      # Long sequence reduction
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # N additions + 1 division per output element
-      flops: "M * (N + 1)"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  AmaxFwdOp:
-    ref_api: "torch.amax"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state reduction (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
-      # Long sequence reduction
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # N-1 comparisons per output element
-      flops: "M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  AminFwdOp:
-    ref_api: "torch.amin"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state reduction (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
-      # Long sequence reduction
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # N-1 comparisons per output element
-      flops: "M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  ProdFwdOp:
-    ref_api: "torch.prod"
-    family: reduction
-    status: spec-only
-    # NOTE: torch.prod has two overloads -- prod(input) for full reduction (no
-    # dim arg) and prod(input, dim, keepdim=False) where dim is a required int.
-    # Unlike torch.sum, torch.prod's dim overload rejects dim=None at runtime
-    # ("Please look up dimensions by name, got: name = None"), so the manifest
-    # types dim as int only. Full-reduction support (the no-dim overload) is
-    # not expressed in the manifest signature; the op layer must handle it
-    # separately if/when implemented.
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
-        # dtype). The current manifest dtype DSL cannot express
-        # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
-        # omitted here; tracked as BLOCKED on missing-manifest-capability.
-        dim: {type: int, default: -1}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - 1)"
-        - "not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i != dim % x.ndim][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state reduction (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
-      # Long sequence reduction
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i != dim % x.ndim)"
-        N: "x.shape[dim % x.ndim]"
-      # N-1 multiplications per output element
-      flops: "M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  # ---------------------------------------------------------------------------
-  # reduction -- Welford reductions (correction + dim + keepdim)
-  # ---------------------------------------------------------------------------
-
-  VarFwdOp:
-    ref_api: "torch.var"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        correction: {type: int, default: 1}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state variance (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-var"}
-      # Long sequence variance
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-var"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # Welford: mean update (2 ops) + variance update (3 ops) per element = 5N
-      flops: "5 * M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  StdFwdOp:
-    ref_api: "torch.std"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        correction: {type: int, default: 1}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state std (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-std"}
-      # Long sequence std
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-std"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # Welford (5N) + sqrt per output element
-      flops: "5 * M * N + M"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  VarMeanFwdOp:
-    ref_api: "torch.var_mean"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        var: {dtype: "same_as(x)"}
-        mean: {dtype: "same_as(x)"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        correction: {type: int, default: 1}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "var.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(var.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(var.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(var.ndim))"
-        - "mean.ndim == var.ndim"
-        - "mean.shape == var.shape"
-
-    workloads:
-      # Hidden state var+mean (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-var-mean"}
-      # Long sequence var+mean
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-var-mean"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # Welford: single pass computes both mean and variance
-      flops: "5 * M * N"
-      # Read x + write var + write mean
-      bytes: "(M * N + 2 * M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/reduce.py
-      kernel_map:
-        reduce: ReduceKernel
-      op: tileops/ops/reduction/reduce.py
-      test: tests/ops/test_reduce.py
-      bench: benchmarks/ops/bench_reduce.py
-      bench_manifest_driven: true
-
-  # ---------------------------------------------------------------------------
-  # reduction -- argmax/argmin (output dtype: int64)
-  # ---------------------------------------------------------------------------
-
-  ArgmaxFwdOp:
-    ref_api: "torch.argmax"
-    family: reduction
-    status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "int64"}
-      params:
-        dim: {type: "int | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
-        - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
-        - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
-        - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
-
-    workloads:
-      # LM head argmax (batch, vocab_size) -- greedy decoding
-      - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmax"}
-      # Hidden state argmax
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmax"}
-
-    roofline:
-      vars:
-        M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
-      # N-1 comparisons per output element
-      flops: "M * N"
-      # Read x (elem_bytes) + write y (8 bytes for int64)
-      bytes: "M * N * elem_bytes + M * 8"
-
-    source:
-      kernel: tileops/kernels/reduction/argreduce.py
-      kernel_map:
-        argreduce: ArgreduceKernel
-      op: tileops/ops/reduction/argmax.py
-      test: tests/ops/test_argreduce.py
-      bench: benchmarks/ops/bench_argreduce.py
-
-  ArgminFwdOp:
-    ref_api: "torch.argmin"
-    family: reduction
-    status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "int64"}
-      params:
-        dim: {type: "int | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "dim is None or -x.ndim <= dim < x.ndim"
-        - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
-        - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
-        - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
-        - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
-
-    workloads:
-      # LM head argmin
-      - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmin"}
-      # Hidden state argmin
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmin"}
-
-    roofline:
-      vars:
-        M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
-      # N-1 comparisons per output element
-      flops: "M * N"
-      # Read x (elem_bytes) + write y (8 bytes for int64)
-      bytes: "M * N * elem_bytes + M * 8"
-
-    source:
-      kernel: tileops/kernels/reduction/argreduce.py
-      kernel_map:
-        argreduce: ArgreduceKernel
-      op: tileops/ops/reduction/argmin.py
-      test: tests/ops/test_argreduce.py
-      bench: benchmarks/ops/bench_argreduce.py
-
-  # ---------------------------------------------------------------------------
-  # reduction -- logical reductions (output dtype: bool)
-  # ---------------------------------------------------------------------------
-
-  AllFwdOp:
-    ref_api: "torch.all"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | bool"}
-      outputs:
-        y: {dtype: "bool"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      # PyTorch: torch.all(x, dim=()) / dim=[] is a no-op (returns x.shape),
-      # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
-      # list/tuple yields an empty reduction set.
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Mask validation (batch, seq_len)
-      - {x_shape: [32, 4096], dtypes: [bool], label: "mask-validation-4k"}
-      - {x_shape: [32, 32768], dtypes: [bool], label: "mask-validation-32k"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-      # N-1 logical AND per output element
-      flops: "M * N"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "M * N * elem_bytes + M"
-
-    source:
-      kernel: tileops/kernels/reduction/logical_reduce.py
-      kernel_map:
-        logical_reduce: LogicalReduceKernel
-      op: tileops/ops/reduction/all_op.py
-      test: tests/ops/test_logical_reduce.py
-      bench: benchmarks/ops/bench_logical_reduce.py
-      bench_manifest_driven: true
-
-  AnyFwdOp:
-    ref_api: "torch.any"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32 | bool"}
-      outputs:
-        y: {dtype: "bool"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      # PyTorch: torch.any(x, dim=()) / dim=[] is a no-op (returns x.shape),
-      # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
-      # list/tuple yields an empty reduction set.
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Mask validation (batch, seq_len)
-      - {x_shape: [32, 4096], dtypes: [bool], label: "mask-validation-4k"}
-      - {x_shape: [32, 32768], dtypes: [bool], label: "mask-validation-32k"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
-      # N-1 logical OR per output element
-      flops: "M * N"
-      # Read x (elem_bytes) + write y (1 byte for bool)
-      bytes: "M * N * elem_bytes + M"
-
-    source:
-      kernel: tileops/kernels/reduction/logical_reduce.py
-      kernel_map:
-        logical_reduce: LogicalReduceKernel
-      op: tileops/ops/reduction/any_op.py
-      test: tests/ops/test_logical_reduce.py
-      bench: benchmarks/ops/bench_logical_reduce.py
-      bench_manifest_driven: true
-
-  CountNonzeroFwdOp:
-    ref_api: "torch.count_nonzero"
-    family: reduction
-    status: spec-only  # dim=None not yet implemented; update when impl lands
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "int64"}
-      params:
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-      shape_rules:
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "y.ndim == x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
-        - "y.shape == tuple(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-
-    workloads:
-      # Sparsity analysis (batch, hidden_dim)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "sparsity-hidden"}
-      # Sparse attention mask
-      - {x_shape: [32, 32768], dtypes: [float16], label: "sparsity-seq"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # Compare + conditional add per element
-      flops: "2 * M * N"
-      # Read x (elem_bytes) + write y (8 bytes for int64)
-      bytes: "M * N * elem_bytes + M * 8"
-
-    source:
-      kernel: tileops/kernels/reduction/logical_reduce.py
-      kernel_map:
-        logical_reduce: LogicalReduceKernel
-      op: tileops/ops/reduction/count_nonzero.py
-      test: tests/ops/test_logical_reduce.py
-      bench: benchmarks/ops/bench_logical_reduce.py
-      bench_manifest_driven: true
-
-  # ---------------------------------------------------------------------------
-  # reduction -- vector norms (output dtype: same_as(x))
-  # ---------------------------------------------------------------------------
-
-  L1NormFwdOp:
-    ref_api: "torch.linalg.vector_norm"
-    family: reduction
-    status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
-        # x.to(dtype) before reduction; returns the requested dtype). The
-        # current manifest dtype DSL cannot express that conditional, so dtype
-        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
-        ord: {type: "int | float", default: 1}
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "ord == 1"
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state L1 norm (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-l1"}
-      # Long sequence L1 norm
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-l1"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # abs + add per element
-      flops: "2 * M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/vector_norm.py
-      kernel_map:
-        vector_norm: VectorNormKernel
-      op: tileops/ops/reduction/l1_norm.py
-      test: tests/ops/test_vector_norm.py
-      bench: benchmarks/ops/bench_vector_norm.py
-      bench_manifest_driven: true
-
-  L2NormFwdOp:
-    ref_api: "torch.linalg.vector_norm"
-    family: reduction
-    status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
-        # x.to(dtype) before reduction; returns the requested dtype). The
-        # current manifest dtype DSL cannot express that conditional, so dtype
-        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
-        ord: {type: "int | float", default: 2}
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "ord == 2"
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state L2 norm (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-l2"}
-      # Long sequence L2 norm
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-l2"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # square + add per element, then sqrt
-      flops: "2 * M * N + M"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/vector_norm.py
-      kernel_map:
-        vector_norm: VectorNormKernel
-      op: tileops/ops/reduction/l2_norm.py
-      test: tests/ops/test_vector_norm.py
-      bench: benchmarks/ops/bench_vector_norm.py
-      bench_manifest_driven: true
-
-  InfNormFwdOp:
-    ref_api: "torch.linalg.vector_norm"
-    family: reduction
-    status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
-
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
-        # x.to(dtype) before reduction; returns the requested dtype). The
-        # current manifest dtype DSL cannot express that conditional, so dtype
-        # is omitted here; tracked as BLOCKED on missing-manifest-capability.
-        ord: {type: "int | float", default: .inf}
-        dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
-        keepdim: {type: bool, default: false}
-      shape_rules:
-        - "ord == float('inf')"
-        - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
-        - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
-        - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
-        - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
-
-    workloads:
-      # Hidden state inf norm (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-inf"}
-      # Long sequence inf norm
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-inf"}
-
-    roofline:
-      vars:
-        M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-        N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
-      # abs + max per element
-      flops: "2 * M * N"
-      # Read x + write y
-      bytes: "(M * N + M) * elem_bytes"
-
-    source:
-      kernel: tileops/kernels/reduction/vector_norm.py
-      kernel_map:
-        vector_norm: VectorNormKernel
-      op: tileops/ops/reduction/inf_norm.py
-      test: tests/ops/test_vector_norm.py
-      bench: benchmarks/ops/bench_vector_norm.py
-      bench_manifest_driven: true
+SoftmaxFwdOp:
+  ref_api: "torch.nn.functional.softmax"
+  family: reduction
+  status: spec-only  # impl/tests still accept float32; manifest x dtype is float16 | bfloat16 only. Flip to implemented when dtype parity matches.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
+      # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
+      # dtype). The current manifest dtype DSL cannot express
+      # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+      # omitted here; tracked as BLOCKED on missing-manifest-capability.
+      dim: {type: int, default: -1}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "-x.ndim <= dim < x.ndim"
+      - "y.shape == x.shape"
+
+  workloads:
+    # Attention weight matrices (batch * heads, seq, seq)
+    - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
+    - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
+    # LM head logits (batch, vocab_size)
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "x.shape[dim % x.ndim]"
+    # Per row: max (N), subtract+exp (2N), sum (N), div (N) = 5N
+    flops: "5 * M * N"
+    # Read x + write y
+    bytes: "2 * M * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/softmax.py
+    kernel_map:
+      softmax_fwd: SoftmaxKernel
+    op: tileops/ops/reduction/softmax.py
+    test: tests/ops/test_softmax.py
+    bench: benchmarks/ops/bench_softmax.py
+    bench_manifest_driven: true
+
+LogSoftmaxFwdOp:
+  ref_api: "torch.nn.functional.log_softmax"
+  family: reduction
+  status: spec-only  # impl/tests still accept float32; manifest x dtype is float16 | bfloat16 only. Flip to implemented when dtype parity matches.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dim=None (deprecated, emits a warning and
+      # picks an implicit axis) and dtype=<torch.dtype> (returns the requested
+      # dtype). The current manifest dtype DSL cannot express
+      # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+      # omitted here; tracked as BLOCKED on missing-manifest-capability.
+      dim: {type: int, default: -1}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "-x.ndim <= dim < x.ndim"
+      - "y.shape == x.shape"
+
+  workloads:
+    # Attention weight matrices
+    - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
+    - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
+    # LM head logits
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "x.shape[dim % x.ndim]"
+    # Per row: max (N), subtract+exp (2N), sum (N), log+subtract (2N) = 6N
+    flops: "6 * M * N"
+    # Read x + write y
+    bytes: "2 * M * N * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/softmax.py
+    kernel_map:
+      softmax_fwd: SoftmaxKernel
+    op: tileops/ops/reduction/log_softmax.py
+    test: tests/ops/test_softmax.py
+    bench: benchmarks/ops/bench_softmax.py
+    bench_manifest_driven: true
+
+LogSumExpFwdOp:
+  ref_api: "torch.logsumexp"
+  family: reduction
+  status: spec-only  # impl __init__ omits N (derived at forward); align with static_dims in follow-up PR
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...]", default: -1}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, int) or len(dim) > 0"
+      - "isinstance(dim, int) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - (1 if isinstance(dim, int) else len({d % x.ndim for d in dim})))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim})][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Attention weight matrices
+    - {x_shape: [32, 32, 4096], dtypes: [float16, bfloat16], label: "attn-weights-4k"}
+    - {x_shape: [32, 32, 32768], dtypes: [bfloat16], label: "attn-weights-32k"}
+    # LM head logits
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-logits"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim}))"
+    # Per row: max (N), subtract+exp (2N), sum (N), log+add (2) = 4N + 2
+    flops: "4 * M * N"
+    # Read x (M*N) + write y (M)
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/logsumexp.py
+    kernel_map:
+      logsumexp_fwd: LogSumExpKernel
+    op: tileops/ops/reduction/logsumexp.py
+    test: tests/ops/test_softmax.py
+    bench: benchmarks/ops/bench_softmax.py
+    bench_manifest_driven: true
+
+# ---------------------------------------------------------------------------
+# reduction -- simple reductions (dim + keepdim)
+# ---------------------------------------------------------------------------
+
+SumFwdOp:
+  ref_api: "torch.sum"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+      # dtype). The current manifest dtype DSL cannot express
+      # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+      # omitted here; tracked as BLOCKED on missing-manifest-capability.
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state reduction (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
+    # Long sequence reduction
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
+    # Non-last-axis reduction (exercises dim=0 path)
+    - {x_shape: [2048, 4096], dtypes: [bfloat16], dim: 0, label: "hidden-state-reduce-dim0"}
+    # Keepdim variant (exercises keepdim forwarding through the baseline)
+    - {x_shape: [2048, 4096], dtypes: [bfloat16], dim: -1, keepdim: true, label: "hidden-state-reduce-keepdim"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # N-1 additions per output element
+    flops: "M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+MeanFwdOp:
+  ref_api: "torch.mean"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+      # dtype). The current manifest dtype DSL cannot express
+      # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+      # omitted here; tracked as BLOCKED on missing-manifest-capability.
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state reduction (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
+    # Long sequence reduction
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # N additions + 1 division per output element
+    flops: "M * (N + 1)"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+AmaxFwdOp:
+  ref_api: "torch.amax"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state reduction (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
+    # Long sequence reduction
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # N-1 comparisons per output element
+    flops: "M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+AminFwdOp:
+  ref_api: "torch.amin"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state reduction (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
+    # Long sequence reduction
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # N-1 comparisons per output element
+    flops: "M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+ProdFwdOp:
+  ref_api: "torch.prod"
+  family: reduction
+  status: spec-only
+  # NOTE: torch.prod has two overloads -- prod(input) for full reduction (no
+  # dim arg) and prod(input, dim, keepdim=False) where dim is a required int.
+  # Unlike torch.sum, torch.prod's dim overload rejects dim=None at runtime
+  # ("Please look up dimensions by name, got: name = None"), so the manifest
+  # types dim as int only. Full-reduction support (the no-dim overload) is
+  # not expressed in the manifest signature; the op layer must handle it
+  # separately if/when implemented.
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (returns the requested
+      # dtype). The current manifest dtype DSL cannot express
+      # "y.dtype = dtype if dtype is not None else x.dtype", so dtype is
+      # omitted here; tracked as BLOCKED on missing-manifest-capability.
+      dim: {type: int, default: -1}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "-x.ndim <= dim < x.ndim"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - 1)"
+      - "not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i != dim % x.ndim][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state reduction (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-reduce"}
+    # Long sequence reduction
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-reduce"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i != dim % x.ndim)"
+      N: "x.shape[dim % x.ndim]"
+    # N-1 multiplications per output element
+    flops: "M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+# ---------------------------------------------------------------------------
+# reduction -- Welford reductions (correction + dim + keepdim)
+# ---------------------------------------------------------------------------
+
+VarFwdOp:
+  ref_api: "torch.var"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      correction: {type: int, default: 1}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state variance (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-var"}
+    # Long sequence variance
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-var"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # Welford: mean update (2 ops) + variance update (3 ops) per element = 5N
+    flops: "5 * M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+StdFwdOp:
+  ref_api: "torch.std"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      correction: {type: int, default: 1}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state std (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-std"}
+    # Long sequence std
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-std"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # Welford (5N) + sqrt per output element
+    flops: "5 * M * N + M"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+VarMeanFwdOp:
+  ref_api: "torch.var_mean"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      var: {dtype: "same_as(x)"}
+      mean: {dtype: "same_as(x)"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      correction: {type: int, default: 1}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "var.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(var.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(var.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(var.ndim))"
+      - "mean.ndim == var.ndim"
+      - "mean.shape == var.shape"
+
+  workloads:
+    # Hidden state var+mean (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-var-mean"}
+    # Long sequence var+mean
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-var-mean"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # Welford: single pass computes both mean and variance
+    flops: "5 * M * N"
+    # Read x + write var + write mean
+    bytes: "(M * N + 2 * M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/reduce.py
+    kernel_map:
+      reduce: ReduceKernel
+    op: tileops/ops/reduction/reduce.py
+    test: tests/ops/test_reduce.py
+    bench: benchmarks/ops/bench_reduce.py
+    bench_manifest_driven: true
+
+# ---------------------------------------------------------------------------
+# reduction -- argmax/argmin (output dtype: int64)
+# ---------------------------------------------------------------------------
+
+ArgmaxFwdOp:
+  ref_api: "torch.argmax"
+  family: reduction
+  status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "int64"}
+    params:
+      dim: {type: "int | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or -x.ndim <= dim < x.ndim"
+      - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
+      - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
+      - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+      - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
+
+  workloads:
+    # LM head argmax (batch, vocab_size) -- greedy decoding
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmax"}
+    # Hidden state argmax
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmax"}
+
+  roofline:
+    vars:
+      M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
+    # N-1 comparisons per output element
+    flops: "M * N"
+    # Read x (elem_bytes) + write y (8 bytes for int64)
+    bytes: "M * N * elem_bytes + M * 8"
+
+  source:
+    kernel: tileops/kernels/reduction/argreduce.py
+    kernel_map:
+      argreduce: ArgreduceKernel
+    op: tileops/ops/reduction/argmax.py
+    test: tests/ops/test_argreduce.py
+    bench: benchmarks/ops/bench_argreduce.py
+
+ArgminFwdOp:
+  ref_api: "torch.argmin"
+  family: reduction
+  status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "int64"}
+    params:
+      dim: {type: "int | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "dim is None or -x.ndim <= dim < x.ndim"
+      - "y.ndim == (x.ndim if keepdim else (x.ndim - 1 if dim is not None else 0))"
+      - "dim is not None or not keepdim or all(y.shape[i] == 1 for i in range(x.ndim))"
+      - "dim is None or not keepdim or all(y.shape[i] == (1 if i == dim % x.ndim else x.shape[i]) for i in range(x.ndim))"
+      - "dim is None or keepdim or all(y.shape[i] == (x.shape[i] if i < dim % x.ndim else x.shape[i + 1]) for i in range(y.ndim))"
+
+  workloads:
+    # LM head argmin
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmin"}
+    # Hidden state argmin
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmin"}
+
+  roofline:
+    vars:
+      M: "1 if dim is None else product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "product(x.shape) if dim is None else x.shape[dim % x.ndim]"
+    # N-1 comparisons per output element
+    flops: "M * N"
+    # Read x (elem_bytes) + write y (8 bytes for int64)
+    bytes: "M * N * elem_bytes + M * 8"
+
+  source:
+    kernel: tileops/kernels/reduction/argreduce.py
+    kernel_map:
+      argreduce: ArgreduceKernel
+    op: tileops/ops/reduction/argmin.py
+    test: tests/ops/test_argreduce.py
+    bench: benchmarks/ops/bench_argreduce.py
+
+# ---------------------------------------------------------------------------
+# reduction -- logical reductions (output dtype: bool)
+# ---------------------------------------------------------------------------
+
+AllFwdOp:
+  ref_api: "torch.all"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | bool"}
+    outputs:
+      y: {dtype: "bool"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    # PyTorch: torch.all(x, dim=()) / dim=[] is a no-op (returns x.shape),
+    # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
+    # list/tuple yields an empty reduction set.
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Mask validation (batch, seq_len)
+    - {x_shape: [32, 4096], dtypes: [bool], label: "mask-validation-4k"}
+    - {x_shape: [32, 32768], dtypes: [bool], label: "mask-validation-32k"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+    # N-1 logical AND per output element
+    flops: "M * N"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "M * N * elem_bytes + M"
+
+  source:
+    kernel: tileops/kernels/reduction/logical_reduce.py
+    kernel_map:
+      logical_reduce: LogicalReduceKernel
+    op: tileops/ops/reduction/all_op.py
+    test: tests/ops/test_logical_reduce.py
+    bench: benchmarks/ops/bench_logical_reduce.py
+    bench_manifest_driven: true
+
+AnyFwdOp:
+  ref_api: "torch.any"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32 | bool"}
+    outputs:
+      y: {dtype: "bool"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    # PyTorch: torch.any(x, dim=()) / dim=[] is a no-op (returns x.shape),
+    # unlike sum/mean/amax. Only dim=None triggers full reduction; empty
+    # list/tuple yields an empty reduction set.
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Mask validation (batch, seq_len)
+    - {x_shape: [32, 4096], dtypes: [bool], label: "mask-validation-4k"}
+    - {x_shape: [32, 32768], dtypes: [bool], label: "mask-validation-32k"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) else set(range(x.ndim))))"
+    # N-1 logical OR per output element
+    flops: "M * N"
+    # Read x (elem_bytes) + write y (1 byte for bool)
+    bytes: "M * N * elem_bytes + M"
+
+  source:
+    kernel: tileops/kernels/reduction/logical_reduce.py
+    kernel_map:
+      logical_reduce: LogicalReduceKernel
+    op: tileops/ops/reduction/any_op.py
+    test: tests/ops/test_logical_reduce.py
+    bench: benchmarks/ops/bench_logical_reduce.py
+    bench_manifest_driven: true
+
+CountNonzeroFwdOp:
+  ref_api: "torch.count_nonzero"
+  family: reduction
+  status: spec-only  # dim=None not yet implemented; update when impl lands
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "int64"}
+    params:
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+    shape_rules:
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "y.ndim == x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))"
+      - "y.shape == tuple(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+
+  workloads:
+    # Sparsity analysis (batch, hidden_dim)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "sparsity-hidden"}
+    # Sparse attention mask
+    - {x_shape: [32, 32768], dtypes: [float16], label: "sparsity-seq"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # Compare + conditional add per element
+    flops: "2 * M * N"
+    # Read x (elem_bytes) + write y (8 bytes for int64)
+    bytes: "M * N * elem_bytes + M * 8"
+
+  source:
+    kernel: tileops/kernels/reduction/logical_reduce.py
+    kernel_map:
+      logical_reduce: LogicalReduceKernel
+    op: tileops/ops/reduction/count_nonzero.py
+    test: tests/ops/test_logical_reduce.py
+    bench: benchmarks/ops/bench_logical_reduce.py
+    bench_manifest_driven: true
+
+# ---------------------------------------------------------------------------
+# reduction -- vector norms (output dtype: same_as(x))
+# ---------------------------------------------------------------------------
+
+L1NormFwdOp:
+  ref_api: "torch.linalg.vector_norm"
+  family: reduction
+  status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+      # x.to(dtype) before reduction; returns the requested dtype). The
+      # current manifest dtype DSL cannot express that conditional, so dtype
+      # is omitted here; tracked as BLOCKED on missing-manifest-capability.
+      ord: {type: "int | float", default: 1}
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "ord == 1"
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state L1 norm (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-l1"}
+    # Long sequence L1 norm
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-l1"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # abs + add per element
+    flops: "2 * M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/vector_norm.py
+    kernel_map:
+      vector_norm: VectorNormKernel
+    op: tileops/ops/reduction/l1_norm.py
+    test: tests/ops/test_vector_norm.py
+    bench: benchmarks/ops/bench_vector_norm.py
+    bench_manifest_driven: true
+
+L2NormFwdOp:
+  ref_api: "torch.linalg.vector_norm"
+  family: reduction
+  status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+      # x.to(dtype) before reduction; returns the requested dtype). The
+      # current manifest dtype DSL cannot express that conditional, so dtype
+      # is omitted here; tracked as BLOCKED on missing-manifest-capability.
+      ord: {type: "int | float", default: 2}
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "ord == 2"
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state L2 norm (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-l2"}
+    # Long sequence L2 norm
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-l2"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # square + add per element, then sqrt
+    flops: "2 * M * N + M"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/vector_norm.py
+    kernel_map:
+      vector_norm: VectorNormKernel
+    op: tileops/ops/reduction/l2_norm.py
+    test: tests/ops/test_vector_norm.py
+    bench: benchmarks/ops/bench_vector_norm.py
+    bench_manifest_driven: true
+
+InfNormFwdOp:
+  ref_api: "torch.linalg.vector_norm"
+  family: reduction
+  status: spec-only  # dim=[]/() (manifest treats as full reduction) not yet implemented; _ReduceOpBase.normalize_dim raises on empty. Flip to implemented when empty-dim path lands.
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      # NOTE: PyTorch also accepts dtype=<torch.dtype> (equivalent to
+      # x.to(dtype) before reduction; returns the requested dtype). The
+      # current manifest dtype DSL cannot express that conditional, so dtype
+      # is omitted here; tracked as BLOCKED on missing-manifest-capability.
+      ord: {type: "int | float", default: .inf}
+      dim: {type: "int | list[int] | tuple[int, ...] | None", default: null}
+      keepdim: {type: bool, default: false}
+    shape_rules:
+      - "ord == float('inf')"
+      - "dim is None or all(-x.ndim <= d < x.ndim for d in ([dim] if isinstance(dim, int) else dim))"
+      - "isinstance(dim, (int, type(None))) or len({d % x.ndim for d in dim}) == len(dim)"
+      - "y.ndim == (x.ndim if keepdim else x.ndim - len({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      - "not keepdim or all(y.shape[i] == (1 if i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))) else x.shape[i]) for i in range(x.ndim))"
+      - "keepdim or all(y.shape[k] == x.shape[[i for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim)))][k]] for k in range(y.ndim))"
+
+  workloads:
+    # Hidden state inf norm (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-inf"}
+    # Long sequence inf norm
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-inf"}
+
+  roofline:
+    vars:
+      M: "product(x.shape[i] for i in range(x.ndim) if i not in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+      N: "product(x.shape[i] for i in ({dim % x.ndim} if isinstance(dim, int) else {d % x.ndim for d in dim} if isinstance(dim, (list, tuple)) and len(dim) > 0 else set(range(x.ndim))))"
+    # abs + max per element
+    flops: "2 * M * N"
+    # Read x + write y
+    bytes: "(M * N + M) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/reduction/vector_norm.py
+    kernel_map:
+      vector_norm: VectorNormKernel
+    op: tileops/ops/reduction/inf_norm.py
+    test: tests/ops/test_vector_norm.py
+    bench: benchmarks/ops/bench_vector_norm.py
+    bench_manifest_driven: true

--- a/tileops/manifest/scan.yaml
+++ b/tileops/manifest/scan.yaml
@@ -4,85 +4,84 @@
 # other family files by tileops.manifest at runtime. See docs/manifest.md
 # for the full schema.
 
-ops:
-  CumsumFwdOp:
-    ref_api: "torch.cumsum"
-    family: scan
-    status: implemented
+CumsumFwdOp:
+  ref_api: "torch.cumsum"
+  family: scan
+  status: implemented
 
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: int, default: -1}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: int, default: -1}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "-x.ndim <= dim < x.ndim"
+      - "y.shape == x.shape"
 
-    workloads:
-      # Hidden state cumulative sum (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-scan"}
-      # Long sequence cumulative sum
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-scan"}
+  workloads:
+    # Hidden state cumulative sum (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-scan"}
+    # Long sequence cumulative sum
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-scan"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
-      # N-1 additions per scan line
-      flops: "M * N"
-      # Read x + write y
-      bytes: "2 * M * N * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "x.shape[dim % x.ndim]"
+    # N-1 additions per scan line
+    flops: "M * N"
+    # Read x + write y
+    bytes: "2 * M * N * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/reduction/cumulative.py
-      kernel_map:
-        cumulative_fwd: CumulativeKernel
-      op: tileops/ops/reduction/cumsum.py
-      test: tests/ops/test_cumulative.py
-      bench: benchmarks/ops/bench_cumulative.py
+  source:
+    kernel: tileops/kernels/reduction/cumulative.py
+    kernel_map:
+      cumulative_fwd: CumulativeKernel
+    op: tileops/ops/reduction/cumsum.py
+    test: tests/ops/test_cumulative.py
+    bench: benchmarks/ops/bench_cumulative.py
 
-  CumprodFwdOp:
-    ref_api: "torch.cumprod"
-    family: scan
-    status: implemented
+CumprodFwdOp:
+  ref_api: "torch.cumprod"
+  family: scan
+  status: implemented
 
-    signature:
-      inputs:
-        x: {dtype: "float16 | bfloat16 | float32"}
-      outputs:
-        y: {dtype: "same_as(x)"}
-      params:
-        dim: {type: int, default: -1}
-      static_dims:
-        N: "x.shape[dim]"
-      shape_rules:
-        - "-x.ndim <= dim < x.ndim"
-        - "y.shape == x.shape"
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16 | float32"}
+    outputs:
+      y: {dtype: "same_as(x)"}
+    params:
+      dim: {type: int, default: -1}
+    static_dims:
+      N: "x.shape[dim]"
+    shape_rules:
+      - "-x.ndim <= dim < x.ndim"
+      - "y.shape == x.shape"
 
-    workloads:
-      # Hidden state cumulative product (Llama-3.1-8B)
-      - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-scan"}
-      # Long sequence cumulative product
-      - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-scan"}
+  workloads:
+    # Hidden state cumulative product (Llama-3.1-8B)
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-scan"}
+    # Long sequence cumulative product
+    - {x_shape: [64, 32768], dtypes: [bfloat16], label: "long-seq-scan"}
 
-    roofline:
-      vars:
-        M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
-        N: "x.shape[dim % x.ndim]"
-      # N-1 multiplications per scan line
-      flops: "M * N"
-      # Read x + write y
-      bytes: "2 * M * N * elem_bytes"
+  roofline:
+    vars:
+      M: "product(x.shape[:dim % x.ndim]) * product(x.shape[dim % x.ndim + 1:])"
+      N: "x.shape[dim % x.ndim]"
+    # N-1 multiplications per scan line
+    flops: "M * N"
+    # Read x + write y
+    bytes: "2 * M * N * elem_bytes"
 
-    source:
-      kernel: tileops/kernels/reduction/cumulative.py
-      kernel_map:
-        cumulative_fwd: CumulativeKernel
-      op: tileops/ops/reduction/cumprod.py
-      test: tests/ops/test_cumulative.py
-      bench: benchmarks/ops/bench_cumulative.py
+  source:
+    kernel: tileops/kernels/reduction/cumulative.py
+    kernel_map:
+      cumulative_fwd: CumulativeKernel
+    op: tileops/ops/reduction/cumprod.py
+    test: tests/ops/test_cumulative.py
+    bench: benchmarks/ops/bench_cumulative.py


### PR DESCRIPTION
## Summary

- Each family yaml previously wrapped its entries under a top-level `ops:` key, costing one indent level on every entry without serving any purpose — family scope is already conveyed by the filename, and the loader just unwrapped the key.
- Flatten the format: each family file is now a direct mapping of op name → entry. Updated 8 yaml files (4546 lines), the `tileops.manifest` loader, the `--manifest-path` branch in `scripts/validate_manifest.py`, the `tests/test_validate_manifest.py` fixtures, and the example in `docs/manifest.md`.
- Pre-release project, so no compat shim — the old format is no longer accepted.

## Test plan

- [x] pre-commit passed (full hook suite on all changed files)
- [x] `python scripts/validate_manifest.py` → `All manifest checks passed.`
- [x] `pytest tests/test_validate_manifest.py tests/test_gpu_smoke_policy.py` → 176 passed
- [x] `from tileops.manifest import load_manifest` smoke check → 114 ops loaded

## Regression

- Loader migration is mechanical (`data.get("ops") or {}` → `yaml.safe_load(...) or {}`). All 114 ops load identically; downstream consumers (`load_workloads`, `validate_manifest`) untouched.
- `_load_manifest` private alias removed (no remaining callers in repo).

## Additional context

There is no near-term plan for family-level metadata. If that need arises later, a wrapper can be reintroduced — YAGNI for now.