### PR TITLE
[Feat][Ops] implement Argmax/Argmin dim=None full-tensor reduction

### DIFF
--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -26,7 +26,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     workload = ArgmaxTest(shape, dtype)
     inputs = workload.gen_inputs()
 
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     bm = ManifestBenchmark(_ARGMAX_OP, op, workload)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
@@ -59,7 +59,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype) -> None:
     workload = ArgminTest(shape, dtype)
     inputs = workload.gen_inputs()
 
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     bm = ManifestBenchmark(_ARGMIN_OP, op, workload)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -1,7 +1,9 @@
 """Benchmarks for argreduce ops (argmax, argmin).
 
 Measures latency, TFLOPS, and DRAM bandwidth against PyTorch baselines.
-Workload shapes and roofline formulas are loaded from the ops manifest (tileops/manifest/).
+Workload shapes, dtypes, and op-call parameters (e.g. ``dim``) are loaded
+from the ops manifest (``tileops/manifest/``) — the benchmark must not
+hard-code op parameters that are declared on manifest workload entries.
 """
 
 import pytest
@@ -21,12 +23,12 @@ _ARGMIN_OP = "ArgminFwdOp"
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ARGMAX_OP))
-def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
+@pytest.mark.parametrize("shape, dtype, extra", workloads_to_params(_ARGMAX_OP, include_extra=True))
+def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     workload = ArgmaxTest(shape, dtype)
     inputs = workload.gen_inputs()
 
-    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
+    op = ArgmaxFwdOp(dtype=dtype, **extra)
     bm = ManifestBenchmark(_ARGMAX_OP, op, workload)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
@@ -42,8 +44,10 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
         raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
+    dim = extra["dim"]
+
     def baseline_fn(x):
-        return x.argmax(dim=-1)
+        return x.argmax(dim=dim)
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
@@ -54,12 +58,12 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 # ===================================================================
 
 
-@pytest.mark.parametrize("shape, dtype", workloads_to_params(_ARGMIN_OP))
-def test_argmin_bench(shape: tuple, dtype: torch.dtype) -> None:
+@pytest.mark.parametrize("shape, dtype, extra", workloads_to_params(_ARGMIN_OP, include_extra=True))
+def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     workload = ArgminTest(shape, dtype)
     inputs = workload.gen_inputs()
 
-    op = ArgminFwdOp(dtype=dtype, dim=-1)
+    op = ArgminFwdOp(dtype=dtype, **extra)
     bm = ManifestBenchmark(_ARGMIN_OP, op, workload)
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
@@ -75,8 +79,10 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype) -> None:
         raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
+    dim = extra["dim"]
+
     def baseline_fn(x):
-        return x.argmin(dim=-1)
+        return x.argmin(dim=dim)
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -5,11 +5,24 @@ Each op reduces along a configurable dim and returns int64 indices.
 Uses exact match (torch.equal) instead of allclose.
 """
 
+from typing import cast
+
 import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
 from workloads.argreduce import ArgmaxTest as _ArgmaxWorkload
+
+
+def _call(op, x: torch.Tensor) -> torch.Tensor:
+    """Invoke a single-output argreduce op and narrow the return to ``Tensor``.
+
+    The shared ``OpBase.__call__`` is typed as ``Union[Tensor, tuple]`` to
+    accommodate ops with multiple outputs.  Argreduce ops always return a
+    single ``Tensor``; this helper keeps the call sites well-typed without
+    sprinkling ``cast(...)`` everywhere.
+    """
+    return cast(torch.Tensor, op(x))
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -143,7 +156,8 @@ class ArgreduceTest(_ArgmaxWorkload, TestBase):
         super().__init__((m, n), dtype)
         self.op_kind = op_kind
 
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+    def ref_program(self, *inputs: torch.Tensor) -> torch.Tensor:
+        (x,) = inputs
         if self.op_kind == "argmax":
             return x.argmax(dim=-1)
         elif self.op_kind == "argmin":
@@ -173,7 +187,7 @@ def test_argmax_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     test = ArgreduceTest(m, n, dtype, "argmax")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -183,9 +197,9 @@ def test_argmax_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     ref = x.contiguous().argmax(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"non-contig argmax mismatch: {(y != ref).sum().item()}"
 
@@ -195,9 +209,9 @@ def test_argmax_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     ref = x.argmax(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D argmax mismatch: {(y != ref).sum().item()}"
 
@@ -207,9 +221,9 @@ def test_argmax_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     ref = x.argmax(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D argmax mismatch: {(y != ref).sum().item()}"
 
@@ -219,9 +233,9 @@ def test_argmax_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype)
+    op = ArgmaxFwdOp(dtype=dtype, dim=-1)
     ref = x.argmax(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y.view_as(ref), ref), "1D argmax mismatch"
 
@@ -234,7 +248,7 @@ def test_argmax_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=0)
     ref = x.argmax(dim=0)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D dim=0 argmax mismatch: {(y != ref).sum().item()}"
@@ -248,7 +262,7 @@ def test_argmax_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
     ref = x.argmax(dim=0, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D dim=0 keepdim argmax mismatch: {(y != ref).sum().item()}"
@@ -262,7 +276,7 @@ def test_argmax_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=0)
     ref = x.argmax(dim=0)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D dim=0 argmax mismatch: {(y != ref).sum().item()}"
@@ -276,7 +290,7 @@ def test_argmax_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=0, keepdim=True)
     ref = x.argmax(dim=0, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D dim=0 keepdim argmax mismatch: {(y != ref).sum().item()}"
@@ -290,7 +304,7 @@ def test_argmax_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
     ref = x.argmax(dim=dim, keepdim=keepdim)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"spec dim={dim} argmax mismatch: {(y != ref).sum().item()}"
@@ -306,7 +320,7 @@ def test_argmin_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     test = ArgreduceTest(m, n, dtype, "argmin")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     test.check(op, *test.gen_inputs(), compare=_exact_compare)
 
 
@@ -316,9 +330,9 @@ def test_argmin_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     ref = x.contiguous().argmin(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"non-contig argmin mismatch: {(y != ref).sum().item()}"
 
@@ -328,9 +342,9 @@ def test_argmin_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     ref = x.argmin(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D argmin mismatch: {(y != ref).sum().item()}"
 
@@ -340,9 +354,9 @@ def test_argmin_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     ref = x.argmin(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D argmin mismatch: {(y != ref).sum().item()}"
 
@@ -352,9 +366,9 @@ def test_argmin_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype)
+    op = ArgminFwdOp(dtype=dtype, dim=-1)
     ref = x.argmin(dim=-1)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert torch.equal(y.view_as(ref), ref), "1D argmin mismatch"
 
@@ -367,7 +381,7 @@ def test_argmin_3d_dim0(batch: int, seq: int, hidden: int, dtype: torch.dtype) -
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=0)
     ref = x.argmin(dim=0)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D dim=0 argmin mismatch: {(y != ref).sum().item()}"
@@ -381,7 +395,7 @@ def test_argmin_3d_dim0_keepdim(batch: int, seq: int, hidden: int, dtype: torch.
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
     ref = x.argmin(dim=0, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"3D dim=0 keepdim argmin mismatch: {(y != ref).sum().item()}"
@@ -395,7 +409,7 @@ def test_argmin_4d_dim0(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=0)
     ref = x.argmin(dim=0)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D dim=0 argmin mismatch: {(y != ref).sum().item()}"
@@ -409,7 +423,7 @@ def test_argmin_4d_dim0_keepdim(b0: int, b1: int, b2: int, n: int, dtype: torch.
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=0, keepdim=True)
     ref = x.argmin(dim=0, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"4D dim=0 keepdim argmin mismatch: {(y != ref).sum().item()}"
@@ -423,7 +437,7 @@ def test_argmin_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
     ref = x.argmin(dim=dim, keepdim=keepdim)
-    y = op(x)
+    y = _call(op, x)
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert y.dtype == torch.int64
     assert torch.equal(y, ref), f"spec dim={dim} argmin mismatch: {(y != ref).sum().item()}"
@@ -501,7 +515,7 @@ def test_argmax_dim_none(shape: tuple, dtype: torch.dtype) -> None:
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=None)
     ref = torch.argmax(x)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert torch.equal(y, ref), (
@@ -517,7 +531,7 @@ def test_argmax_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgmaxFwdOp(dtype=dtype, dim=None, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     expected_shape = tuple(1 for _ in shape)
     assert y.dtype == torch.int64
     assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"
@@ -536,7 +550,7 @@ def test_argmin_dim_none(shape: tuple, dtype: torch.dtype) -> None:
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=None)
     ref = torch.argmin(x)
-    y = op(x)
+    y = _call(op, x)
     assert y.dtype == torch.int64
     assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
     assert torch.equal(y, ref), (
@@ -552,7 +566,7 @@ def test_argmin_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
     op = ArgminFwdOp(dtype=dtype, dim=None, keepdim=True)
-    y = op(x)
+    y = _call(op, x)
     expected_shape = tuple(1 for _ in shape)
     assert y.dtype == torch.int64
     assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -438,11 +438,11 @@ def test_argmin_spec_dim(shape: tuple, dim: int, keepdim: bool, dtype: torch.dty
 @pytest.mark.parametrize("op_cls_path, dim", [
     ("tileops.ops.reduction.argmax.ArgmaxFwdOp", [0, 1]),
     ("tileops.ops.reduction.argmin.ArgminFwdOp", [0, 1]),
-    ("tileops.ops.reduction.argmax.ArgmaxFwdOp", None),
-    ("tileops.ops.reduction.argmin.ArgminFwdOp", None),
+    ("tileops.ops.reduction.argmax.ArgmaxFwdOp", (0, 1)),
+    ("tileops.ops.reduction.argmin.ArgminFwdOp", (0, 1)),
 ])
 def test_argreduce_rejects_multidim(op_cls_path: str, dim) -> None:
-    """Argreduce ops only support scalar dim; list/tuple/None must raise."""
+    """Argreduce ops only support scalar dim or None; list/tuple must raise."""
     import importlib
 
     module_path, cls_name = op_cls_path.rsplit(".", 1)
@@ -451,6 +451,115 @@ def test_argreduce_rejects_multidim(op_cls_path: str, dim) -> None:
 
     with pytest.raises((TypeError, ValueError)):
         op_cls(dtype=torch.float16, dim=dim)
+
+
+# ---------------------------------------------------------------------------
+# dim=None (full-tensor reduction) tests
+# ---------------------------------------------------------------------------
+
+
+class ArgreduceDimNoneFixture(FixtureBase):
+    """Full-tensor reduction (dim=None) across ndim in {1, 2, 3, 4}.
+
+    Shapes are kept modest so the flattened 1D row fits comfortably within
+    the argreduce kernel's shared-memory budget across fp16/bf16/fp32.
+    """
+
+    PARAMS = [
+        (
+            "shape, dtype",
+            [
+                # 1D
+                pytest.param((512,), torch.float16, marks=pytest.mark.smoke),
+                pytest.param((512,), torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param((512,), torch.float32, marks=pytest.mark.smoke),
+                # 2D
+                pytest.param((16, 64), torch.float16, marks=pytest.mark.smoke),
+                pytest.param((16, 64), torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param((16, 64), torch.float32, marks=pytest.mark.smoke),
+                # 3D
+                pytest.param((4, 8, 32), torch.float16, marks=pytest.mark.smoke),
+                pytest.param((4, 8, 32), torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param((4, 8, 32), torch.float32, marks=pytest.mark.smoke),
+                # 4D
+                pytest.param((2, 4, 8, 16), torch.float16, marks=pytest.mark.smoke),
+                pytest.param((2, 4, 8, 16), torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param((2, 4, 8, 16), torch.float32, marks=pytest.mark.smoke),
+                # Non-aligned flat size (300 is not a multiple of 256)
+                pytest.param((10, 30), torch.float16, marks=pytest.mark.full),
+                pytest.param((10, 30), torch.float32, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+@ArgreduceDimNoneFixture
+def test_argmax_dim_none(shape: tuple, dtype: torch.dtype) -> None:
+    """ArgmaxFwdOp(dim=None) matches torch.argmax(x) on the flattened tensor."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=None)
+    ref = torch.argmax(x)
+    y = op(x)
+    assert y.dtype == torch.int64
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert torch.equal(y, ref), (
+        f"dim=None argmax mismatch on shape={shape} dtype={dtype}: "
+        f"got {y.item()} expected {ref.item()}"
+    )
+
+
+@ArgreduceDimNoneFixture
+def test_argmax_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
+    """ArgmaxFwdOp(dim=None, keepdim=True) returns all-ones shape with flat index."""
+    from tileops.ops.reduction.argmax import ArgmaxFwdOp
+
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    op = ArgmaxFwdOp(dtype=dtype, dim=None, keepdim=True)
+    y = op(x)
+    expected_shape = tuple(1 for _ in shape)
+    assert y.dtype == torch.int64
+    assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"
+    # Flat-index value must equal torch.argmax(x).
+    ref_flat = torch.argmax(x)
+    assert torch.equal(y.reshape(()), ref_flat), (
+        f"dim=None keepdim argmax value mismatch on shape={shape} dtype={dtype}"
+    )
+
+
+@ArgreduceDimNoneFixture
+def test_argmin_dim_none(shape: tuple, dtype: torch.dtype) -> None:
+    """ArgminFwdOp(dim=None) matches torch.argmin(x) on the flattened tensor."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=None)
+    ref = torch.argmin(x)
+    y = op(x)
+    assert y.dtype == torch.int64
+    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
+    assert torch.equal(y, ref), (
+        f"dim=None argmin mismatch on shape={shape} dtype={dtype}: "
+        f"got {y.item()} expected {ref.item()}"
+    )
+
+
+@ArgreduceDimNoneFixture
+def test_argmin_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
+    """ArgminFwdOp(dim=None, keepdim=True) returns all-ones shape with flat index."""
+    from tileops.ops.reduction.argmin import ArgminFwdOp
+
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    op = ArgminFwdOp(dtype=dtype, dim=None, keepdim=True)
+    y = op(x)
+    expected_shape = tuple(1 for _ in shape)
+    assert y.dtype == torch.int64
+    assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"
+    ref_flat = torch.argmin(x)
+    assert torch.equal(y.reshape(()), ref_flat), (
+        f"dim=None keepdim argmin value mismatch on shape={shape} dtype={dtype}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -473,35 +473,30 @@ def test_argreduce_rejects_multidim(op_cls_path: str, dim) -> None:
 
 
 class ArgreduceDimNoneFixture(FixtureBase):
-    """Full-tensor reduction (dim=None) across ndim in {1, 2, 3, 4}.
+    """Full-tensor reduction (dim=None).
 
-    Shapes are kept modest so the flattened 1D row fits comfortably within
-    the argreduce kernel's shared-memory budget across fp16/bf16/fp32.
+    Coverage rationale (testing.md §Test case policy):
+      - dtype dispatch: one 2D shape across {fp16, bf16, fp32}.
+      - ndim shape branches (flatten path): 1D / 3D / 4D in fp16 only;
+        ndim and dtype are not crossed since the flatten code path is
+        dtype-independent.
+      - One non-aligned flat size as full coverage (tail handling).
     """
 
     PARAMS = [
         (
             "shape, dtype",
             [
-                # 1D
-                pytest.param((512,), torch.float16, marks=pytest.mark.smoke),
-                pytest.param((512,), torch.bfloat16, marks=pytest.mark.smoke),
-                pytest.param((512,), torch.float32, marks=pytest.mark.smoke),
-                # 2D
+                # dtype dispatch on a single 2D shape
                 pytest.param((16, 64), torch.float16, marks=pytest.mark.smoke),
                 pytest.param((16, 64), torch.bfloat16, marks=pytest.mark.smoke),
                 pytest.param((16, 64), torch.float32, marks=pytest.mark.smoke),
-                # 3D
+                # ndim shape coverage (flatten path is dtype-agnostic)
+                pytest.param((512,), torch.float16, marks=pytest.mark.smoke),
                 pytest.param((4, 8, 32), torch.float16, marks=pytest.mark.smoke),
-                pytest.param((4, 8, 32), torch.bfloat16, marks=pytest.mark.smoke),
-                pytest.param((4, 8, 32), torch.float32, marks=pytest.mark.smoke),
-                # 4D
                 pytest.param((2, 4, 8, 16), torch.float16, marks=pytest.mark.smoke),
-                pytest.param((2, 4, 8, 16), torch.bfloat16, marks=pytest.mark.smoke),
-                pytest.param((2, 4, 8, 16), torch.float32, marks=pytest.mark.smoke),
-                # Non-aligned flat size (300 is not a multiple of 256)
+                # Non-aligned flat size (tail handling)
                 pytest.param((10, 30), torch.float16, marks=pytest.mark.full),
-                pytest.param((10, 30), torch.float32, marks=pytest.mark.full),
             ],
         ),
     ]
@@ -509,69 +504,42 @@ class ArgreduceDimNoneFixture(FixtureBase):
 
 @ArgreduceDimNoneFixture
 def test_argmax_dim_none(shape: tuple, dtype: torch.dtype) -> None:
-    """ArgmaxFwdOp(dim=None) matches torch.argmax(x) on the flattened tensor."""
+    """ArgmaxFwdOp(dim=None) matches torch.argmax(x); covers keepdim={False, True}."""
     from tileops.ops.reduction.argmax import ArgmaxFwdOp
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=None)
-    ref = torch.argmax(x)
-    y = _call(op, x)
-    assert y.dtype == torch.int64
-    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
-    assert torch.equal(y, ref), (
-        f"dim=None argmax mismatch on shape={shape} dtype={dtype}: "
-        f"got {y.item()} expected {ref.item()}"
-    )
-
-
-@ArgreduceDimNoneFixture
-def test_argmax_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
-    """ArgmaxFwdOp(dim=None, keepdim=True) returns all-ones shape with flat index."""
-    from tileops.ops.reduction.argmax import ArgmaxFwdOp
-
-    x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgmaxFwdOp(dtype=dtype, dim=None, keepdim=True)
-    y = _call(op, x)
-    expected_shape = tuple(1 for _ in shape)
-    assert y.dtype == torch.int64
-    assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"
-    # Flat-index value must equal torch.argmax(x).
     ref_flat = torch.argmax(x)
-    assert torch.equal(y.reshape(()), ref_flat), (
+
+    y = _call(ArgmaxFwdOp(dtype=dtype, dim=None), x)
+    assert y.dtype == torch.int64
+    assert y.shape == ref_flat.shape, f"shape mismatch: {y.shape} vs {ref_flat.shape}"
+    assert torch.equal(y, ref_flat), f"dim=None argmax mismatch on shape={shape} dtype={dtype}"
+
+    y_keep = _call(ArgmaxFwdOp(dtype=dtype, dim=None, keepdim=True), x)
+    expected_shape = tuple(1 for _ in shape)
+    assert y_keep.shape == expected_shape, f"keepdim shape mismatch: {y_keep.shape} vs {expected_shape}"
+    assert torch.equal(y_keep.reshape(()), ref_flat), (
         f"dim=None keepdim argmax value mismatch on shape={shape} dtype={dtype}"
     )
 
 
 @ArgreduceDimNoneFixture
 def test_argmin_dim_none(shape: tuple, dtype: torch.dtype) -> None:
-    """ArgminFwdOp(dim=None) matches torch.argmin(x) on the flattened tensor."""
+    """ArgminFwdOp(dim=None) matches torch.argmin(x); covers keepdim={False, True}."""
     from tileops.ops.reduction.argmin import ArgminFwdOp
 
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=None)
-    ref = torch.argmin(x)
-    y = _call(op, x)
-    assert y.dtype == torch.int64
-    assert y.shape == ref.shape, f"shape mismatch: {y.shape} vs {ref.shape}"
-    assert torch.equal(y, ref), (
-        f"dim=None argmin mismatch on shape={shape} dtype={dtype}: "
-        f"got {y.item()} expected {ref.item()}"
-    )
-
-
-@ArgreduceDimNoneFixture
-def test_argmin_dim_none_keepdim(shape: tuple, dtype: torch.dtype) -> None:
-    """ArgminFwdOp(dim=None, keepdim=True) returns all-ones shape with flat index."""
-    from tileops.ops.reduction.argmin import ArgminFwdOp
-
-    x = torch.randn(*shape, dtype=dtype, device="cuda")
-    op = ArgminFwdOp(dtype=dtype, dim=None, keepdim=True)
-    y = _call(op, x)
-    expected_shape = tuple(1 for _ in shape)
-    assert y.dtype == torch.int64
-    assert y.shape == expected_shape, f"shape mismatch: {y.shape} vs {expected_shape}"
     ref_flat = torch.argmin(x)
-    assert torch.equal(y.reshape(()), ref_flat), (
+
+    y = _call(ArgminFwdOp(dtype=dtype, dim=None), x)
+    assert y.dtype == torch.int64
+    assert y.shape == ref_flat.shape, f"shape mismatch: {y.shape} vs {ref_flat.shape}"
+    assert torch.equal(y, ref_flat), f"dim=None argmin mismatch on shape={shape} dtype={dtype}"
+
+    y_keep = _call(ArgminFwdOp(dtype=dtype, dim=None, keepdim=True), x)
+    expected_shape = tuple(1 for _ in shape)
+    assert y_keep.shape == expected_shape, f"keepdim shape mismatch: {y_keep.shape} vs {expected_shape}"
+    assert torch.equal(y_keep.reshape(()), ref_flat), (
         f"dim=None keepdim argmin value mismatch on shape={shape} dtype={dtype}"
     )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -72,7 +72,7 @@ class TestBase(WorkloadBase):
 
     def check(self,
               op,
-              *inputs: tuple[torch.Tensor],
+              *inputs: torch.Tensor,
               compare=None,
               atol: float = 1e-08,
               rtol: float = 1e-05) -> None:

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -559,9 +559,9 @@ ArgmaxFwdOp:
 
   workloads:
     # LM head argmax (batch, vocab_size) -- greedy decoding
-    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmax"}
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], dim: -1, label: "lm-head-argmax"}
     # Hidden state argmax
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmax"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], dim: -1, label: "hidden-state-argmax"}
 
   roofline:
     vars:
@@ -602,9 +602,9 @@ ArgminFwdOp:
 
   workloads:
     # LM head argmin
-    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], label: "lm-head-argmin"}
+    - {x_shape: [4, 102400], dtypes: [float16, bfloat16], dim: -1, label: "lm-head-argmin"}
     # Hidden state argmin
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "hidden-state-argmin"}
+    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], dim: -1, label: "hidden-state-argmin"}
 
   roofline:
     vars:

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -540,7 +540,7 @@ VarMeanFwdOp:
 ArgmaxFwdOp:
   ref_api: "torch.argmax"
   family: reduction
-  status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
+  status: implemented
 
   signature:
     inputs:
@@ -583,7 +583,7 @@ ArgmaxFwdOp:
 ArgminFwdOp:
   ref_api: "torch.argmin"
   family: reduction
-  status: spec-only  # dim=None (full-tensor reduction) not yet implemented; _validate_dim rejects None. Flip to implemented when full-reduction path lands.
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/ops/reduction/argmax.py
+++ b/tileops/ops/reduction/argmax.py
@@ -51,12 +51,18 @@ class ArgmaxFwdOp(_ReduceOpBase):
         )
 
     def _validate_dim(self) -> None:
-        """Argmax only supports single-dim reduction."""
-        if not isinstance(self.dim, int):
-            raise ValueError(
-                f"ArgmaxFwdOp only supports scalar dim (int), "
-                f"got {type(self.dim).__name__}: {self.dim!r}"
-            )
+        """Argmax accepts a scalar ``int`` dim or ``None`` (full-tensor reduction).
+
+        ``dim=None`` matches ``torch.argmax(x)`` semantics: the input is
+        treated as a contiguous flattened 1D buffer and the returned index
+        is into that flattened tensor.
+        """
+        if self.dim is None or isinstance(self.dim, int):
+            return
+        raise ValueError(
+            f"ArgmaxFwdOp only supports scalar dim (int) or None, "
+            f"got {type(self.dim).__name__}: {self.dim!r}"
+        )
 
     def _pad_value(self) -> float:
         """Pad with -inf so padded positions never win argmax."""

--- a/tileops/ops/reduction/argmax.py
+++ b/tileops/ops/reduction/argmax.py
@@ -20,13 +20,16 @@ __all__ = ["ArgmaxFwdOp"]
 class ArgmaxFwdOp(_ReduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgmaxFwdOp(dtype=..., dim=-1, keepdim=False)``.  M and N are
+    Construction: ``ArgmaxFwdOp(dtype=..., dim=None, keepdim=False)``.  M and N are
     derived from the input tensor at forward time, and kernels are cached
     by ``(M, N)`` to avoid rebuilds.
 
     Args:
         dtype: Input data type.
-        dim: Reduction dimension (default -1).
+        dim: Reduction dimension. ``None`` (the default) matches
+            ``torch.argmax(x)`` semantics: the input is treated as a
+            contiguous flattened 1D buffer and the returned index is into
+            that flattened tensor.
         keepdim: Whether to retain the reduced dimension as size 1.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
@@ -40,7 +43,7 @@ class ArgmaxFwdOp(_ReduceOpBase):
         self,
         *,
         dtype: torch.dtype,
-        dim: int = -1,
+        dim: Optional[int] = None,
         keepdim: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,

--- a/tileops/ops/reduction/argmin.py
+++ b/tileops/ops/reduction/argmin.py
@@ -51,12 +51,18 @@ class ArgminFwdOp(_ReduceOpBase):
         )
 
     def _validate_dim(self) -> None:
-        """Argmin only supports single-dim reduction."""
-        if not isinstance(self.dim, int):
-            raise ValueError(
-                f"ArgminFwdOp only supports scalar dim (int), "
-                f"got {type(self.dim).__name__}: {self.dim!r}"
-            )
+        """Argmin accepts a scalar ``int`` dim or ``None`` (full-tensor reduction).
+
+        ``dim=None`` matches ``torch.argmin(x)`` semantics: the input is
+        treated as a contiguous flattened 1D buffer and the returned index
+        is into that flattened tensor.
+        """
+        if self.dim is None or isinstance(self.dim, int):
+            return
+        raise ValueError(
+            f"ArgminFwdOp only supports scalar dim (int) or None, "
+            f"got {type(self.dim).__name__}: {self.dim!r}"
+        )
 
     def _pad_value(self) -> float:
         """Pad with +inf so padded positions never win argmin."""

--- a/tileops/ops/reduction/argmin.py
+++ b/tileops/ops/reduction/argmin.py
@@ -20,13 +20,16 @@ __all__ = ["ArgminFwdOp"]
 class ArgminFwdOp(_ReduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
-    Construction: ``ArgminFwdOp(dtype=..., dim=-1, keepdim=False)``.  M and N are
+    Construction: ``ArgminFwdOp(dtype=..., dim=None, keepdim=False)``.  M and N are
     derived from the input tensor at forward time, and kernels are cached
     by ``(M, N)`` to avoid rebuilds.
 
     Args:
         dtype: Input data type.
-        dim: Reduction dimension (default -1).
+        dim: Reduction dimension. ``None`` (the default) matches
+            ``torch.argmin(x)`` semantics: the input is treated as a
+            contiguous flattened 1D buffer and the returned index is into
+            that flattened tensor.
         keepdim: Whether to retain the reduced dimension as size 1.
         kernel_map: Optional custom kernel map.
         tune: Whether to autotune the kernel.
@@ -40,7 +43,7 @@ class ArgminFwdOp(_ReduceOpBase):
         self,
         *,
         dtype: torch.dtype,
-        dim: int = -1,
+        dim: Optional[int] = None,
         keepdim: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,

--- a/workloads/workload_base.py
+++ b/workloads/workload_base.py
@@ -7,9 +7,11 @@ Correctness-only logic (ref_program, check, tolerances) stays in tests/.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Callable, TypeVar
 
 import torch
+
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 
 class WorkloadBase(ABC):
@@ -58,7 +60,7 @@ class FixtureMeta(type):
     compatibility when pytest is already importable at module scope.
     """
 
-    def __call__(cls, fn):
+    def __call__(cls, fn: _F) -> _F:
         import pytest  # lazy import: pytest is only needed when applying parametrize decorators
 
         params = cls.get_params() if hasattr(cls, "get_params") else cls.PARAMS


### PR DESCRIPTION
Closes #1090

## Summary

- Allow `dim=None` in `ArgmaxFwdOp`/`ArgminFwdOp` to perform full-tensor argreduce, matching `torch.argmax(x)` / `torch.argmin(x)` semantics (flattened-tensor index, int64).
- `_validate_dim` accepts `None`; the op layer flattens the input and dispatches the existing 1D argreduce path. Output is `()` when `keepdim=False` and all-ones when `keepdim=True`.
- Align constructor defaults to the manifest: `dim: Optional[int] = None` (was `dim: int = -1`) for both ops, so `ArgmaxFwdOp()(x)` matches `torch.argmax(x)` instead of silently doing last-axis.
- Flip `ArgmaxFwdOp` / `ArgminFwdOp` manifest entries to `status: implemented` and remove the inline `dim=None` gap-marker comments (AC-4).
- Drive `dim` through manifest workload entries: declared `dim: -1` on the four Argmax/Argmin workloads and switched `bench_argreduce.py` to `workloads_to_params(_OP, include_extra=True)`, instantiating the op + baseline from `extra["dim"]` so the benchmark is fully manifest-driven.

## Test plan

- [x] AC-1: `ArgmaxFwdOp(dim=None)(x)` / `ArgminFwdOp(dim=None)(x)` match `torch.argmax(x)` / `torch.argmin(x)` across dtype dispatch (fp16/bf16/fp32) and ndim shape branches (1D / 3D / 4D), with `keepdim ∈ {False, True}` covered in each case.
- [x] AC-2: New `dim=None` cases in `tests/ops/test_argreduce.py` pass (`pytest tests/ops/test_argreduce.py -m smoke -q` → 64 passed).
- [x] AC-3: `python scripts/validate_manifest.py --check-op ArgmaxFwdOp` and `--check-op ArgminFwdOp` both report "All manifest checks passed".
- [x] AC-4: Both manifest entries show `status: implemented`; inline `dim=None` gap-marker comments removed.
- [x] Bench collection (`pytest --collect-only benchmarks/ops/bench_argreduce.py`) → 8 cases, `extra={"dim": -1}` for each.
- [x] pre-commit passed
- [x] pytest passed

## Structural Readiness

<!-- Agent-generated — do not edit. -->

- **Correctness & Safety**: PASS — `Op.forward` rejects non-CUDA tensors, dtype mismatch, and 0D inputs before kernel launch; `dim=None` derives `M=1`, `N=numel` via `flatten_for_multidim`; runtime validation uses `ValueError` / `IndexError`; output dtype is `int64`.
- **Kernel Structure**: SKIP — no kernel code changed for this issue; existing `ArgreduceKernel` already uses `T.prim_func` inside `tilelang.jit` and the builder is `lru_cache(maxsize=32)`.
- **Op Structure**: PASS — Op pre/post-processing remains in `_ReduceOpBase`; `ArgreduceKernel` retains `torch.library.custom_op` and `register_fake`; `default_config` / `autotune_configs` exist. Constructor defaults now match the manifest signature exactly.
- **Benchmark**: PASS — bench is driven by manifest workload params (`include_extra=True`); no hard-coded op params remain in `bench_argreduce.py`.
- **Delivery**: PASS — targeted unit tests pass; `dim=None` tests compare against `torch.argmax` / `torch.argmin`.

## Test node delta

```
File                           Base    HEAD    Delta
----------------------------------------------------
tests/ops/test_argreduce.py      70      84      +14
----------------------------------------------------
TOTAL                            70      84      +14
```

**Justification:** The dim=None coverage follows testing.md §Test case policy / testing-budget §11–12 — dtype and ndim are not crossed unless they guard distinct code paths. The fixture has 6 smoke rows (dtype dispatch on a single 2D shape × {fp16, bf16, fp32}, plus ndim shape coverage 1D / 3D / 4D in fp16 only since the flatten path is dtype-independent) plus 1 full row for non-aligned tail handling, consumed by two test functions (argmax / argmin) that each fold `keepdim ∈ {False, True}` into the body. Net: +14 nodes for the new feature.