### PR TITLE
[Doc] move tileops-skills.md out of docs/design/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Activate a virtual environment, then `make install` (deps + pre-commit hooks).
 
 - [trust-model.md](docs/design/trust-model.md) — trust boundaries (manifest → test → implementation → benchmark), workloads layer contract
 - [testing.md](docs/design/testing.md) — test/benchmark framework, core abstractions, tolerances, reporting rules
-- [tileops-skills.md](docs/design/tileops-skills.md) — developer decision guide: which repo-provided skill to use for which task
+- [tileops-skills.md](docs/tileops-skills.md) — developer decision guide: which repo-provided skill to use for which task
 
 ## Reading the ops manifest
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,11 +14,11 @@ Design-first, spec-driven documentation for TileOPs. [`tileops/manifest/`](../ti
 
 ## Process
 
-| Document                                      | Scope                                                                                                |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [trust-model.md](design/trust-model.md)       | Trust boundaries between manifest → test → implementation → benchmark; workloads layer contract.     |
-| [testing.md](design/testing.md)               | Test and benchmark framework: core abstractions, tolerances, reporting rules.                        |
-| [tileops-skills.md](design/tileops-skills.md) | Developer decision guide: which repo-provided skill to use for which task, with composition diagram. |
+| Document                                | Scope                                                                                                |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [trust-model.md](design/trust-model.md) | Trust boundaries between manifest → test → implementation → benchmark; workloads layer contract.     |
+| [testing.md](design/testing.md)         | Test and benchmark framework: core abstractions, tolerances, reporting rules.                        |
+| [tileops-skills.md](tileops-skills.md)  | Developer decision guide: which repo-provided skill to use for which task, with composition diagram. |
 
 ## Performance Guides
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -6,11 +6,11 @@ Naming is **verb-noun**. The verb is the action; the noun is the scope (`op`, `f
 
 ## At a glance
 
-|                | Orchestrator                                                 | Atomic                                                                                                                                                                                                                                |
-| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **per op**     | [`align-op`](../../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../../.claude/skills/test-op/SKILL.md) · [`implement-op`](../../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../../.claude/skills/bench-op/SKILL.md) |
-| **per family** | [`align-family`](../../.claude/skills/align-family/SKILL.md) | [`audit-family`](../../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                          |
-| **manifest**   | —                                                            | [`add-manifest`](../../.claude/skills/add-manifest/SKILL.md) · [`fix-manifest`](../../.claude/skills/fix-manifest/SKILL.md)                                                                                                           |
+|                | Orchestrator                                              | Atomic                                                                                                                                                                                                                    |
+| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **per op**     | [`align-op`](../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../.claude/skills/test-op/SKILL.md) · [`implement-op`](../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../.claude/skills/bench-op/SKILL.md) |
+| **per family** | [`align-family`](../.claude/skills/align-family/SKILL.md) | [`audit-family`](../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                 |
+| **manifest**   | —                                                         | [`add-manifest`](../.claude/skills/add-manifest/SKILL.md) · [`fix-manifest`](../.claude/skills/fix-manifest/SKILL.md)                                                                                                     |
 
 Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging. Manifest skills are standalone editors of `tileops/manifest/` and have no orchestrator: they precede op-layer work, not contain it.
 
@@ -38,7 +38,7 @@ Brings a single op into alignment with its manifest entry. Classifies into one o
 - **Cases.** `green` (no code yet → calls `scaffold-op`), `redesign` (archive + rescaffold + port), `minor` (in-place edit via `implement-op`).
 - **Use when.** You want to add or re-align a single op after a manifest or design-doc change.
 - **Don't use when.** You need to batch-migrate a whole family — use `align-family` instead.
-- **Contract:** [SKILL.md](../../.claude/skills/align-op/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/align-op/SKILL.md)
 
 ### `align-family`  ·  per-family orchestrator
 
@@ -46,7 +46,7 @@ Drives the historical migration of an entire op family. Audits, delegates each p
 
 - **Use when.** You have a whole family of spec-only ops to migrate.
 - **Don't use when.** Only one op needs attention — use `align-op`.
-- **Contract:** [SKILL.md](../../.claude/skills/align-family/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/align-family/SKILL.md)
 
 ### `scaffold-op`  ·  per-op atomic
 
@@ -55,7 +55,7 @@ Writes a new T2 (L1-direct) op file from one manifest entry by following the 7-s
 - **Use when.** Called by `align-op` on the green path; rarely needed standalone.
 - **Don't use when.** `source.op` already exists — PRE_CHECK refuses. Use `align-op --mode=redesign`, which archives the old file first.
 - **Don't expect.** Family protocol variables (`_op_kind`, `_kernel_key`, …) or optional hooks (`_pad_value`, `_validate_dim`, …). Those are op-specific business logic, outside the 17 mechanical slots.
-- **Contract:** [SKILL.md](../../.claude/skills/scaffold-op/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/scaffold-op/SKILL.md)
 
 ### `implement-op`  ·  per-op atomic
 
@@ -63,28 +63,28 @@ Edits an existing op file to match the manifest-declared interface, making spec 
 
 - **Use when.** Called by orchestrators.
 - **Don't use when.** The change is a structural rewrite — `align-op --mode=redesign` archives the old file and regenerates cleanly before implementing.
-- **Contract:** [SKILL.md](../../.claude/skills/implement-op/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/implement-op/SKILL.md)
 
 ### `test-op`  ·  per-op atomic
 
 Writes tests for the target spec using PyTorch as ground truth; verifies they fail on current code (the TDD seed before `implement-op`).
 
 - **Use when.** Called by orchestrators.
-- **Contract:** [SKILL.md](../../.claude/skills/test-op/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/test-op/SKILL.md)
 
 ### `bench-op`  ·  per-op atomic
 
 Fixes the benchmark file to compile against the new op interface. Runs it, fixes errors, repeats until it produces numbers.
 
 - **Use when.** Called by orchestrators.
-- **Contract:** [SKILL.md](../../.claude/skills/bench-op/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/bench-op/SKILL.md)
 
 ### `audit-family`  ·  per-family atomic
 
 Compares each op's code signature against its manifest spec, classifies gaps (`ready` / `semantic_gap` / `blocked`), writes `.foundry/migrations/<family>.json`.
 
 - **Use when.** You want read-only inspection of a family's current conformance. Also called internally by `align-family`.
-- **Contract:** [SKILL.md](../../.claude/skills/audit-family/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/audit-family/SKILL.md)
 
 ### `add-manifest` · manifest atomic
 
@@ -92,7 +92,7 @@ Reads a reference-API docs URL (PyTorch / equivalent) and writes the auto-deriva
 
 - **Use when.** Adding a new op, or re-aligning a stale entry whose signature / shape rules / dtype combos / roofline have drifted from the reference.
 - **Don't use when.** The gap is `kernel_map` or `static_dims` — those come from on-disk op / kernel code, not the reference; use `fix-manifest`.
-- **Contract:** [SKILL.md](../../.claude/skills/add-manifest/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/add-manifest/SKILL.md)
 
 ### `fix-manifest` · manifest atomic
 
@@ -101,7 +101,7 @@ Surgical patch of an existing manifest entry for fields **derived from on-disk o
 - **Allowed fields.** `kernel_map`, `static_dims` only. Reference-derivable fields (`signature.*`, `shape_rules`, `dtype_combos`, `roofline`) belong to `add-manifest`.
 - **Use when.** Validator says `kernel_map` or `static_dims` is missing on an existing entry. `kernel_map` is the most common case — it's required by `align-op`'s PRE_CHECK.
 - **Don't use when.** The entry doesn't exist (`add-manifest`); the gap is in a reference-derivable field (`add-manifest` re-aligns the whole entry from the reference URL); you want to flip `status` (that is `align-op`'s `FLIP_STATUS`).
-- **Contract:** [SKILL.md](../../.claude/skills/fix-manifest/SKILL.md)
+- **Contract:** [SKILL.md](../.claude/skills/fix-manifest/SKILL.md)
 
 ## Composition
 


### PR DESCRIPTION
## Summary

- Move `docs/design/tileops-skills.md` → `docs/tileops-skills.md`. It is a developer user guide for picking the right repo skill, not a design document, so it does not belong under `docs/design/`.
- Update cross-references in `CLAUDE.md` and `docs/README.md`.
- Rebase the moved file's relative links to `.claude/skills/...` (one fewer `../`).

## Test plan

- [x] pre-commit passed
- [x] no code changes; doc-only move