### PR TITLE
[Feat][Manifest] align where/clamp/masked_fill multi-input ops to pytorch api

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1411,9 +1411,86 @@ def _class_overrides_method(cls: type, name: str) -> bool:
     return False
 
 
+def _broadcast_shapes(*shapes: object) -> tuple:
+    """Pure-Python equivalent of ``torch.broadcast_shapes``.
+
+    Computes the broadcasted output shape from one or more input shapes
+    using NumPy/PyTorch broadcasting rules: shapes are right-aligned,
+    each dimension must be equal, or one of them must be 1 (or missing).
+
+    Args:
+        *shapes: Iterables of integers (typically tuples or lists)
+            representing tensor shapes. May be empty (scalar shape).
+
+    Returns:
+        The broadcasted shape as a tuple of ints. Returns ``()`` when
+        called with no arguments.
+
+    Raises:
+        ValueError: If the shapes are not broadcast-compatible.
+    """
+    if not shapes:
+        return ()
+    normalized = [tuple(int(d) for d in s) for s in shapes]
+    ndim = max((len(s) for s in normalized), default=0)
+    out: list[int] = []
+    for axis in range(ndim):
+        # Right-align: walk from the trailing dim back.
+        dim = 1
+        for s in normalized:
+            i = len(s) - ndim + axis
+            if i < 0:
+                # This shape has no entry at this axis (treat as 1).
+                continue
+            d = s[i]
+            if d == 1 or d == dim:
+                continue
+            if dim == 1:
+                dim = d
+                continue
+            raise ValueError(
+                f"shapes {shapes!r} are not broadcast-compatible at axis {axis}",
+            )
+        out.append(dim)
+    return tuple(out)
+
+
+def _is_broadcastable_to(src: object, dst: object) -> bool:
+    """Return True if ``src`` is broadcastable *to* ``dst`` (unidirectional).
+
+    Unlike ``broadcast_shapes`` which is symmetric, this predicate fixes
+    the destination shape and asks whether ``src`` can expand into it
+    without shrinking ``dst``: each ``src`` dim (right-aligned) must be
+    equal to the matching ``dst`` dim or be 1, and ``src`` may not have
+    more dimensions than ``dst``.
+
+    Args:
+        src: Source shape (iterable of ints).
+        dst: Destination shape (iterable of ints).
+
+    Returns:
+        True iff ``src`` broadcasts to ``dst``.
+    """
+    src_t = tuple(int(d) for d in src)
+    dst_t = tuple(int(d) for d in dst)
+    if len(src_t) > len(dst_t):
+        return False
+    offset = len(dst_t) - len(src_t)
+    for i, s_dim in enumerate(src_t):
+        d_dim = dst_t[offset + i]
+        if s_dim == d_dim or s_dim == 1:
+            continue
+        return False
+    return True
+
+
 # Safe builtins allowed in shape_rules eval — matches the R11 / R11a
 # documented helper set (see docs/design/ops-design-reference.md). Keep this list
 # aligned with manifest spec; widening it changes the rule language.
+#
+# Broadcasting helpers (``broadcast_shapes`` / ``is_broadcastable_to``)
+# mirror PyTorch semantics but are pure-Python so the validator does
+# not require ``torch`` to evaluate L1 shape_rules.
 _SHAPE_RULE_BUILTINS: dict = {
     "len": len,
     "isinstance": isinstance,
@@ -1428,6 +1505,8 @@ _SHAPE_RULE_BUILTINS: dict = {
     "abs": abs,
     "min": min,
     "max": max,
+    "broadcast_shapes": _broadcast_shapes,
+    "is_broadcastable_to": _is_broadcastable_to,
 }
 
 
@@ -1443,9 +1522,10 @@ def _eval_shape_rule(
 
     The eval globals expose the ``_SHAPE_RULE_BUILTINS`` helper set
     (``len``, ``isinstance``, ``int``, ``tuple``, ``list``, ``type``,
-    ``all``, ``any``, ``range``, ``set``, ``abs``, ``min``, ``max``) so
-    R11 / R11a-style rules that use these helpers can be evaluated
-    against the mock context instead of being silently skipped.
+    ``all``, ``any``, ``range``, ``set``, ``abs``, ``min``, ``max``,
+    ``broadcast_shapes``, ``is_broadcastable_to``) so R11 / R11a-style
+    rules that use these helpers can be evaluated against the mock
+    context instead of being silently skipped.
 
     The context names (inputs / outputs / params) are injected into both
     eval globals and locals. Comprehensions (generator / set / list /

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -1697,6 +1697,127 @@ class TestDtypeOptionsHelper:
 
 
 # ---------------------------------------------------------------------------
+# shape_rules broadcasting helpers (broadcast_shapes / is_broadcastable_to)
+# ---------------------------------------------------------------------------
+
+
+class TestShapeRuleBroadcastBuiltins:
+    """Unit tests for the broadcasting helpers exposed in shape_rules eval.
+
+    These mirror PyTorch's ``torch.broadcast_shapes`` semantics and the
+    unidirectional ``a is broadcastable to b`` predicate, but are pure
+    Python so the validator does not need ``torch`` to evaluate L1
+    shape_rules expressions.
+    """
+
+    # -- broadcast_shapes -------------------------------------------------
+
+    def test_broadcast_shapes_helper_registered(self, validator):
+        """``broadcast_shapes`` must be exposed in ``_SHAPE_RULE_BUILTINS``."""
+        assert "broadcast_shapes" in validator._SHAPE_RULE_BUILTINS
+
+    def test_broadcast_shapes_identical_shapes(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((2, 3), (2, 3)) == (2, 3)
+
+    def test_broadcast_shapes_scalar_with_tensor(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((), (4, 5)) == (4, 5)
+        assert fn((4, 5), ()) == (4, 5)
+
+    def test_broadcast_shapes_size_one_expands(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((1, 3), (2, 1)) == (2, 3)
+
+    def test_broadcast_shapes_rank_promotion(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((3,), (2, 4, 3)) == (2, 4, 3)
+
+    def test_broadcast_shapes_three_or_more_args(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((1, 3), (2, 1), (1, 1)) == (2, 3)
+
+    def test_broadcast_shapes_no_args_returns_empty(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn() == ()
+
+    def test_broadcast_shapes_single_arg(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn((2, 3)) == (2, 3)
+
+    def test_broadcast_shapes_incompatible_raises(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        with pytest.raises(ValueError, match="not broadcast-compatible"):
+            fn((2, 3), (3, 3))
+
+    def test_broadcast_shapes_accepts_lists(self, validator):
+        """Tensor.shape may surface as list[int] depending on context."""
+        fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
+        assert fn([1, 3], [2, 1]) == (2, 3)
+
+    # -- is_broadcastable_to ---------------------------------------------
+
+    def test_is_broadcastable_to_helper_registered(self, validator):
+        assert "is_broadcastable_to" in validator._SHAPE_RULE_BUILTINS
+
+    def test_is_broadcastable_to_equal_shapes(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
+        assert fn((2, 3), (2, 3)) is True
+
+    def test_is_broadcastable_to_size_one_expands(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
+        assert fn((1, 3), (2, 3)) is True
+        assert fn((3,), (2, 3)) is True
+        assert fn((), (2, 3)) is True
+
+    def test_is_broadcastable_to_unidirectional(self, validator):
+        """``is_broadcastable_to(src, dst)`` is asymmetric.
+
+        ``src`` may grow into ``dst`` but ``dst`` is fixed; expanding
+        ``dst`` into a larger shape is not allowed.
+        """
+        fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
+        # (2, 3) cannot broadcast *to* (3,) — dst is smaller.
+        assert fn((2, 3), (3,)) is False
+        # (2, 1) into (2, 3) — fine.
+        assert fn((2, 1), (2, 3)) is True
+        # (2, 3) into (2, 1) — would require shrinking dst dim 1.
+        assert fn((2, 3), (2, 1)) is False
+
+    def test_is_broadcastable_to_mismatched_dim_returns_false(self, validator):
+        fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
+        assert fn((2, 4), (2, 3)) is False
+
+    def test_is_broadcastable_to_extra_leading_dim_returns_false(self, validator):
+        """Source rank may not exceed destination rank."""
+        fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
+        assert fn((5, 2, 3), (2, 3)) is False
+
+    # -- end-to-end via _eval_shape_rule ---------------------------------
+
+    def test_broadcast_shapes_in_shape_rule(self, validator):
+        ok, reason = validator._eval_shape_rule(
+            "broadcast_shapes((1, 3), (2, 1)) == (2, 3)", {},
+        )
+        assert reason is None
+        assert ok is True
+
+    def test_is_broadcastable_to_in_shape_rule_true(self, validator):
+        ok, reason = validator._eval_shape_rule(
+            "is_broadcastable_to((1, 3), (2, 3))", {},
+        )
+        assert reason is None
+        assert ok is True
+
+    def test_is_broadcastable_to_in_shape_rule_false(self, validator):
+        ok, reason = validator._eval_shape_rule(
+            "is_broadcastable_to((2, 3), (2, 1))", {},
+        )
+        assert reason is None
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
 # ---------------------------------------------------------------------------
 

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -118,7 +118,7 @@ MaskedFillScalarFwdOp:
     outputs:
       out: {dtype: "same_as(input)"}
     params:
-      value: {type: float, default: 0.0}
+      value: {type: Number, default: 0.0}
     shape_rules:
       # mask broadcasts unidirectionally to input.shape; out follows input.
       - "is_broadcastable_to(mask.shape, input.shape)"

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -50,10 +50,14 @@ PreluFwdOp:
 MaskedFillFwdOp:
   ref_api: "torch.Tensor.masked_fill"
   # Primary entry: PyTorch's torch.Tensor.masked_fill(mask, value: Tensor)
-  # where ``value`` is a 0-dim Tensor. ``mask`` broadcasts unidirectionally
-  # *to* ``input.shape`` (PyTorch does not expand input into the mask
-  # shape for masked_fill); ``out.shape == input.shape``. The scalar
-  # (Number) value form lands as MaskedFillScalarFwdOp below per the
+  # where ``value`` is a 0-dim Tensor. The out-of-place
+  # ``Tensor.masked_fill`` returns a new tensor whose shape is the
+  # bidirectional broadcast of ``input`` and ``mask`` — either operand
+  # may be expanded (verified directly: ``torch.zeros((2,1)).masked_fill(
+  # mask=torch.zeros((2,3), dtype=torch.bool), value=1.0)`` returns shape
+  # ``(2, 3)``). The in-place ``masked_fill_`` is unidirectional, but
+  # the manifest models only the out-of-place form. The scalar (Number)
+  # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
   # status: spec-only — no kernel currently implements the 0-dim Tensor
@@ -71,17 +75,18 @@ MaskedFillFwdOp:
     outputs:
       out: {dtype: "same_as(input)"}
     shape_rules:
-      # mask broadcasts unidirectionally to input.shape; value is 0-dim.
-      - "is_broadcastable_to(mask.shape, input.shape)"
+      # Out-of-place masked_fill returns the bidirectional broadcast of
+      # input and mask; value is 0-dim.
       - "value.shape == ()"
-      - "out.shape == input.shape"
+      - "out.shape == broadcast_shapes(input.shape, mask.shape)"
 
   workloads: []
 
   roofline:
     vars:
-      N_total: "product(input.shape)"
-    # One predicated select per element.
+      # Post-broadcast element count: out.shape == broadcast(input, mask).
+      N_total: "product(broadcast_shapes(input.shape, mask.shape))"
+    # One predicated select per output element.
     flops: "N_total"
     # Read input + read mask (1 byte broadcast to N_total) + read 0-dim
     # value (negligible vs N_total but counted at elem_bytes) + write out.
@@ -120,9 +125,10 @@ MaskedFillScalarFwdOp:
     params:
       value: {type: Number, default: 0.0}
     shape_rules:
-      # mask broadcasts unidirectionally to input.shape; out follows input.
-      - "is_broadcastable_to(mask.shape, input.shape)"
-      - "out.shape == input.shape"
+      # Out-of-place masked_fill returns the bidirectional broadcast of
+      # input and mask; out shape follows that broadcast (verified against
+      # ``torch.Tensor.masked_fill`` — input may also be expanded up).
+      - "out.shape == broadcast_shapes(input.shape, mask.shape)"
 
   workloads:
     - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
@@ -130,8 +136,9 @@ MaskedFillScalarFwdOp:
 
   roofline:
     vars:
-      N_total: "product(input.shape)"
-    # One predicated select per element
+      # Post-broadcast element count: out.shape == broadcast(input, mask).
+      N_total: "product(broadcast_shapes(input.shape, mask.shape))"
+    # One predicated select per output element
     flops: "N_total"
     # Read input + read mask (1 byte) + write out
     bytes: "N_total + 2 * N_total * elem_bytes"

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -49,12 +49,59 @@ PreluFwdOp:
 
 MaskedFillFwdOp:
   ref_api: "torch.Tensor.masked_fill"
-  # Scalar-value variant: PyTorch's masked_fill also accepts a 0-dim Tensor
-  # value; the manifest tracks the scalar (Number) slice that the kernel
-  # implements.
+  # Primary entry: PyTorch's torch.Tensor.masked_fill(mask, value: Tensor)
+  # where ``value`` is a 0-dim Tensor. ``mask`` broadcasts unidirectionally
+  # *to* ``input.shape`` (PyTorch does not expand input into the mask
+  # shape for masked_fill); ``out.shape == input.shape``. The scalar
+  # (Number) value form lands as MaskedFillScalarFwdOp below per the
+  # "No Optional[Tensor]" manifest rule for variant splits.
+  family: elementwise
+  # status: spec-only — no kernel currently implements the 0-dim Tensor
+  # value form; tileops/ops/elementwise.py:MaskedFillFwdOp implements
+  # the scalar form (see MaskedFillScalarFwdOp). Code conforms to this
+  # spec in a follow-up PR per the manifest trust model
+  # (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      mask: {dtype: "bool"}
+      value: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      # mask broadcasts unidirectionally to input.shape; value is 0-dim.
+      - "is_broadcastable_to(mask.shape, input.shape)"
+      - "value.shape == ()"
+      - "out.shape == input.shape"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N_total: "product(input.shape)"
+    # One predicated select per element.
+    flops: "N_total"
+    # Read input + read mask (1 byte broadcast to N_total) + read 0-dim
+    # value (negligible vs N_total but counted at elem_bytes) + write out.
+    bytes: "N_total + 2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+MaskedFillScalarFwdOp:
+  ref_api: "torch.Tensor.masked_fill"
+  # Scalar-value variant: PyTorch's torch.Tensor.masked_fill(mask, value: Number).
+  # Per the "No Optional[Tensor]" manifest rule, this is split from the
+  # 0-dim-Tensor-value primary entry above.
   family: elementwise
   # status: spec-only — current tileops/ops/elementwise.py:MaskedFillFwdOp
-  # does not conform to this spec:
+  # implements this scalar form but does not conform to this spec:
   #   - __init__ takes (N_total, dtype, fill_value) instead of the
   #     PyTorch-aligned (input, mask, value) form.
   #   - param name is `fill_value` instead of `value`.
@@ -62,6 +109,7 @@ MaskedFillFwdOp:
   # Code conforms to this spec in a follow-up PR per the manifest trust
   # model (.claude/rules/manifest-trust-model.md).
   status: spec-only
+  variant_of: MaskedFillFwdOp
 
   signature:
     inputs:
@@ -72,7 +120,8 @@ MaskedFillFwdOp:
     params:
       value: {type: float, default: 0.0}
     shape_rules:
-      - "mask.shape == input.shape"
+      # mask broadcasts unidirectionally to input.shape; out follows input.
+      - "is_broadcastable_to(mask.shape, input.shape)"
       - "out.shape == input.shape"
 
   workloads:

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -83,14 +83,10 @@ MaskedFillFwdOp:
   workloads: []
 
   roofline:
-    vars:
-      # Post-broadcast element count: out.shape == broadcast(input, mask).
-      N_total: "product(broadcast_shapes(input.shape, mask.shape))"
-    # One predicated select per output element.
-    flops: "N_total"
-    # Read input + read mask (1 byte broadcast to N_total) + read 0-dim
-    # value (negligible vs N_total but counted at elem_bytes) + write out.
-    bytes: "N_total + 2 * N_total * elem_bytes"
+    # Func mode: post-broadcast N_total uses broadcast_shapes which is
+    # not in the inline-roofline vars-layer namespace per
+    # docs/design/roofline.md §4.4.4. Broadcast logic lives in Python.
+    func: "tileops.perf.formulas.masked_fill_fwd_roofline"
 
   source:
     kernel: tileops/kernels/elementwise.py
@@ -135,13 +131,10 @@ MaskedFillScalarFwdOp:
     - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
-    vars:
-      # Post-broadcast element count: out.shape == broadcast(input, mask).
-      N_total: "product(broadcast_shapes(input.shape, mask.shape))"
-    # One predicated select per output element
-    flops: "N_total"
-    # Read input + read mask (1 byte) + write out
-    bytes: "N_total + 2 * N_total * elem_bytes"
+    # Func mode: shared with MaskedFillFwdOp (Tensor-value primary). See
+    # MaskedFillFwdOp.roofline for rationale (broadcast_shapes not in
+    # inline-roofline vars-layer namespace).
+    func: "tileops.perf.formulas.masked_fill_fwd_roofline"
 
   source:
     kernel: tileops/kernels/elementwise.py

--- a/tileops/manifest/elementwise_multi_input.yaml
+++ b/tileops/manifest/elementwise_multi_input.yaml
@@ -14,8 +14,16 @@ WhereFwdOp:
   #     PyTorch-aligned (condition, input, other) form.
   #   - forward parameter names are (cond, x, y) instead of
   #     (condition, input, other).
+  #   - kernel currently assumes condition.shape == input.shape == other.shape;
+  #     the spec admits full PyTorch broadcasting across all three inputs.
   # Code conforms to this spec in a follow-up PR per the manifest trust
   # model (.claude/rules/manifest-trust-model.md).
+  #
+  # TODO(spec-followup): PyTorch's ``torch.where`` also performs implicit
+  # type promotion between ``input`` and ``other``. The manifest currently
+  # constrains them to ``same_as(input)``; once the kernel grows an input
+  # cast path, relax ``other`` to the full float union and document the
+  # promotion contract here.
   status: spec-only
 
   signature:
@@ -26,9 +34,9 @@ WhereFwdOp:
     outputs:
       out: {dtype: "same_as(input)"}
     shape_rules:
-      - "condition.shape == input.shape"
-      - "other.shape == input.shape"
-      - "out.shape == input.shape"
+      # PyTorch's torch.where broadcasts condition/input/other together;
+      # the output shape is the broadcast of all three.
+      - "out.shape == broadcast_shapes(condition.shape, input.shape, other.shape)"
 
   workloads:
     - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -392,11 +392,57 @@ SoftplusFwdOp:
 
 ClampFwdOp:
   ref_api: "torch.clamp"
-  # Scalar-bound variant: PyTorch's torch.clamp also accepts Tensor min/max;
-  # the manifest tracks the scalar (Number) slice that the kernel implements.
+  # Primary entry: PyTorch's torch.clamp(input, min=None, max=None) where
+  # min and max are Tensors. PyTorch broadcasts min/max with input. The
+  # "No Optional[Tensor]" rule (.claude/rules/manifest-trust-model.md +
+  # .claude/domain-rules/manifest-spec.md) forbids encoding optional
+  # tensor inputs in a single entry; the scalar (Number) form, the
+  # single-bound min-only form, and the single-bound max-only form each
+  # land as their own variant_of entries below.
   family: elementwise
-  # status: spec-only — current tileops/ops/elementwise.py:ClampFwdOp does
-  # not conform to this spec:
+  # status: spec-only — current tileops/ops/elementwise.py:ClampFwdOp
+  # implements the *scalar* form (see ClampScalarFwdOp below) and does
+  # not conform to this Tensor-bound primary spec. Code conforms to this
+  # spec in a follow-up PR per the manifest trust model
+  # (.claude/rules/manifest-trust-model.md).
+  status: spec-only
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      min: {dtype: "same_as(input)"}
+      max: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      # PyTorch broadcasts input/min/max together for tensor-bound clamp.
+      - "out.shape == broadcast_shapes(input.shape, min.shape, max.shape)"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N_total: "product(broadcast_shapes(input.shape, min.shape, max.shape))"
+    # One max + one min per output element (post-broadcast).
+    flops: "2 * N_total"
+    # Read input + read min + read max + write out, all post-broadcast.
+    bytes: "4 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+ClampScalarFwdOp:
+  ref_api: "torch.clamp"
+  # Scalar-bound variant: PyTorch's torch.clamp(input, min=None, max=None)
+  # with Number (or None) bounds. Per the "No Optional[Tensor]" manifest
+  # rule, this is split from the Tensor-bound primary entry above.
+  family: elementwise
+  # status: spec-only — current tileops/ops/elementwise.py:ClampFwdOp
+  # implements this scalar form but does not conform to the spec:
   #   - __init__ takes (N_total, dtype, min_val, max_val) instead of the
   #     PyTorch-aligned (input, min, max) form.
   #   - param names are (min_val, max_val) instead of (min, max).
@@ -404,6 +450,7 @@ ClampFwdOp:
   # Code conforms to this spec in a follow-up PR per the manifest trust
   # model (.claude/rules/manifest-trust-model.md).
   status: spec-only
+  variant_of: ClampFwdOp
 
   signature:
     inputs:
@@ -426,6 +473,74 @@ ClampFwdOp:
     # At most one max + one min per element
     flops: "2 * N_total"
     bytes: "2 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+ClampMinFwdOp:
+  ref_api: "torch.clamp_min"
+  # Single-bound Tensor variant: torch.clamp_min(input, min: Tensor) —
+  # equivalent to torch.clamp with only the lower bound provided.
+  family: elementwise
+  status: spec-only
+  variant_of: ClampFwdOp
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      min: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == broadcast_shapes(input.shape, min.shape)"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N_total: "product(broadcast_shapes(input.shape, min.shape))"
+    # One max(input, min) per output element (post-broadcast).
+    flops: "N_total"
+    # Read input + read min + write out, all post-broadcast.
+    bytes: "3 * N_total * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/elementwise.py
+    op: tileops/ops/elementwise.py
+    test: tests/ops/test_special_elementwise.py
+    bench: benchmarks/ops/bench_independent_elementwise.py
+    bench_manifest_driven: false
+
+ClampMaxFwdOp:
+  ref_api: "torch.clamp_max"
+  # Single-bound Tensor variant: torch.clamp_max(input, max: Tensor) —
+  # equivalent to torch.clamp with only the upper bound provided.
+  family: elementwise
+  status: spec-only
+  variant_of: ClampFwdOp
+
+  signature:
+    inputs:
+      input: {dtype: "float16 | bfloat16 | float32 | float8_e4m3fn | float8_e5m2"}
+      max: {dtype: "same_as(input)"}
+    outputs:
+      out: {dtype: "same_as(input)"}
+    shape_rules:
+      - "out.shape == broadcast_shapes(input.shape, max.shape)"
+
+  workloads: []
+
+  roofline:
+    vars:
+      N_total: "product(broadcast_shapes(input.shape, max.shape))"
+    # One min(input, max) per output element (post-broadcast).
+    flops: "N_total"
+    # Read input + read max + write out, all post-broadcast.
+    bytes: "3 * N_total * elem_bytes"
 
   source:
     kernel: tileops/kernels/elementwise.py

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -458,8 +458,8 @@ ClampScalarFwdOp:
     outputs:
       out: {dtype: "same_as(input)"}
     params:
-      min: {type: "float | None", default: null}
-      max: {type: "float | None", default: null}
+      min: {type: "Number | None", default: null}
+      max: {type: "Number | None", default: null}
     shape_rules:
       - "out.shape == input.shape"
 

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -421,12 +421,10 @@ ClampFwdOp:
   workloads: []
 
   roofline:
-    vars:
-      N_total: "product(broadcast_shapes(input.shape, min.shape, max.shape))"
-    # One max + one min per output element (post-broadcast).
-    flops: "2 * N_total"
-    # Read input + read min + read max + write out, all post-broadcast.
-    bytes: "4 * N_total * elem_bytes"
+    # Func mode: post-broadcast N_total uses broadcast_shapes which is
+    # not in the inline-roofline vars-layer namespace per
+    # docs/design/roofline.md §4.4.4. Broadcast logic lives in Python.
+    func: "tileops.perf.formulas.clamp_fwd_roofline"
 
   source:
     kernel: tileops/kernels/elementwise.py
@@ -501,12 +499,9 @@ ClampMinFwdOp:
   workloads: []
 
   roofline:
-    vars:
-      N_total: "product(broadcast_shapes(input.shape, min.shape))"
-    # One max(input, min) per output element (post-broadcast).
-    flops: "N_total"
-    # Read input + read min + write out, all post-broadcast.
-    bytes: "3 * N_total * elem_bytes"
+    # Func mode: see ClampFwdOp.roofline for rationale (broadcast_shapes
+    # not in inline-roofline vars-layer namespace).
+    func: "tileops.perf.formulas.clamp_min_fwd_roofline"
 
   source:
     kernel: tileops/kernels/elementwise.py
@@ -535,12 +530,9 @@ ClampMaxFwdOp:
   workloads: []
 
   roofline:
-    vars:
-      N_total: "product(broadcast_shapes(input.shape, max.shape))"
-    # One min(input, max) per output element (post-broadcast).
-    flops: "N_total"
-    # Read input + read max + write out, all post-broadcast.
-    bytes: "3 * N_total * elem_bytes"
+    # Func mode: see ClampFwdOp.roofline for rationale (broadcast_shapes
+    # not in inline-roofline vars-layer namespace).
+    func: "tileops.perf.formulas.clamp_max_fwd_roofline"
 
   source:
     kernel: tileops/kernels/elementwise.py

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -175,6 +175,16 @@ def where_fwd_roofline(op: "Op") -> tuple[int, int]:
     ``WhereFwdOp.roofline``). Inline mode binds ``elem_bytes`` to a single
     dtype and cannot express that.
 
+    ``N_total`` follows the post-broadcast convention:
+    ``N_total = product(out.shape)`` where ``out.shape`` is
+    ``broadcast_shapes(condition.shape, input.shape, other.shape)``.
+    The byte traffic is approximated as
+    ``N_total + 3 * N_total * elem_bytes`` (1-byte broadcast condition
+    read + input/other reads + output write at the float dtype). The
+    individual per-input reads are counted post-broadcast for simplicity;
+    a tighter pre-broadcast accounting is left to a follow-up that aligns
+    with codegen's chosen broadcasting strategy.
+
     TODO: implement the formula once ``WhereFwdOp`` flips from
     ``status: spec-only`` to ``implemented``.
     """

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -175,20 +175,38 @@ def where_fwd_roofline(op: "Op") -> tuple[int, int]:
     ``WhereFwdOp.roofline``). Inline mode binds ``elem_bytes`` to a single
     dtype and cannot express that.
 
-    ``N_total`` follows the post-broadcast convention:
-    ``N_total = product(out.shape)`` where ``out.shape`` is
-    ``broadcast_shapes(condition.shape, input.shape, other.shape)``.
-    The byte traffic is approximated as
-    ``N_total + 3 * N_total * elem_bytes`` (1-byte broadcast condition
-    read + input/other reads + output write at the float dtype). The
-    individual per-input reads are counted post-broadcast for simplicity;
-    a tighter pre-broadcast accounting is left to a follow-up that aligns
-    with codegen's chosen broadcasting strategy.
+    ``N_total`` follows the post-broadcast convention used by
+    ``WhereFwdOp.shape_rules``:
+    ``N_total = product(broadcast_shapes(condition.shape, input.shape,
+    other.shape))``. The function reads ``op.N_total`` directly when the
+    bound Op exposes it (current ``WhereFwdOp`` stores the flattened
+    element count there); when the conformed Op grows
+    ``condition``/``input``/``other`` shape attributes per the spec, the
+    same value can be derived as ``op.condition.shape`` /
+    ``op.input.shape`` / ``op.other.shape`` broadcast together, and a
+    ``static_dims``-driven update will flow in via codegen.
 
-    TODO: implement the formula once ``WhereFwdOp`` flips from
-    ``status: spec-only`` to ``implemented``.
+    Byte traffic is approximated as
+    ``N_total + 3 * N_total * elem_bytes`` — a 1-byte condition read
+    (logical bytes; the bool is broadcast to ``N_total``) plus input,
+    other, and out at the float ``elem_bytes`` each. This matches the
+    "logical bytes, post-broadcast" convention used elsewhere in the
+    elementwise manifest entries.
+
+    Args:
+        op: The bound ``WhereFwdOp`` instance. Must expose ``N_total``
+            (int) and ``dtype`` (``torch.dtype``).
+
+    Returns:
+        ``(flops, bytes)`` as ints, with ``flops == N_total`` (one
+        predicated select per output element) and
+        ``bytes == N_total + 3 * N_total * elem_bytes``.
     """
-    raise NotImplementedError
+    n_total = int(op.N_total)
+    elem_bytes = op.dtype.itemsize
+    flops = n_total
+    nbytes = n_total + 3 * n_total * elem_bytes
+    return flops, nbytes
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from tileops.ops.op_base import Op
 
 __all__ = [
+    "clamp_fwd_roofline",
+    "clamp_max_fwd_roofline",
+    "clamp_min_fwd_roofline",
     "deepseek_dsa_decode_roofline",
     "deepseek_mla_decode_roofline",
     "fused_moe_fwd_bytes",
@@ -28,6 +31,7 @@ __all__ = [
     "gqa_fwd_roofline",
     "gqa_sliding_window_fwd_roofline",
     "gqa_sliding_window_varlen_fwd_roofline",
+    "masked_fill_fwd_roofline",
     "mha_bwd_roofline",
     "mha_decode_paged_roofline",
     "mha_decode_roofline",
@@ -206,6 +210,127 @@ def where_fwd_roofline(op: "Op") -> tuple[int, int]:
     elem_bytes = op.dtype.itemsize
     flops = n_total
     nbytes = n_total + 3 * n_total * elem_bytes
+    return flops, nbytes
+
+
+# ---------------------------------------------------------------------------
+# Clamp family (Tensor-bound variants)
+# ---------------------------------------------------------------------------
+#
+# Func mode is required for the broadcasted Tensor-bound clamp variants
+# because ``N_total`` follows the post-broadcast convention
+# ``product(broadcast_shapes(input.shape, ...))`` and ``broadcast_shapes``
+# is not in the inline-roofline vars-layer namespace
+# (``docs/design/roofline.md`` §4.4.4). Codegen would fail to bind it.
+# ``ClampScalarFwdOp`` keeps inline mode because its ``N_total`` reduces
+# to ``product(input.shape)`` (no broadcasting).
+
+
+def clamp_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for ``ClampFwdOp`` (Tensor-bound double-sided clamp).
+
+    Models ``torch.clamp(input, min: Tensor, max: Tensor)`` with
+    broadcasting across all three operands. Reads ``op.N_total`` (the
+    post-broadcast element count) and ``op.dtype.itemsize``.
+
+    Per-output element: one ``max(input, min)`` then one ``min(.., max)``
+    → ``flops = 2 * N_total``. Bytes: read input + read min + read max +
+    write out, all post-broadcast at ``elem_bytes`` each →
+    ``bytes = 4 * N_total * elem_bytes``.
+
+    Args:
+        op: bound ``ClampFwdOp`` instance exposing ``N_total`` and
+            ``dtype``.
+
+    Returns:
+        ``(flops, bytes)`` ints.
+    """
+    n_total = int(op.N_total)
+    elem_bytes = op.dtype.itemsize
+    return 2 * n_total, 4 * n_total * elem_bytes
+
+
+def clamp_min_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for ``ClampMinFwdOp`` (Tensor lower bound only).
+
+    Models ``torch.clamp_min(input, min: Tensor)`` with broadcasting.
+    Per output element: one ``max(input, min)``. Bytes: read input +
+    read min + write out, all post-broadcast.
+
+    Args:
+        op: bound ``ClampMinFwdOp`` instance exposing ``N_total`` and
+            ``dtype``.
+
+    Returns:
+        ``(flops, bytes)`` ints with ``flops == N_total`` and
+        ``bytes == 3 * N_total * elem_bytes``.
+    """
+    n_total = int(op.N_total)
+    elem_bytes = op.dtype.itemsize
+    return n_total, 3 * n_total * elem_bytes
+
+
+def clamp_max_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for ``ClampMaxFwdOp`` (Tensor upper bound only).
+
+    Models ``torch.clamp_max(input, max: Tensor)`` with broadcasting.
+    Per output element: one ``min(input, max)``. Bytes: read input +
+    read max + write out, all post-broadcast.
+
+    Args:
+        op: bound ``ClampMaxFwdOp`` instance exposing ``N_total`` and
+            ``dtype``.
+
+    Returns:
+        ``(flops, bytes)`` ints with ``flops == N_total`` and
+        ``bytes == 3 * N_total * elem_bytes``.
+    """
+    n_total = int(op.N_total)
+    elem_bytes = op.dtype.itemsize
+    return n_total, 3 * n_total * elem_bytes
+
+
+# ---------------------------------------------------------------------------
+# MaskedFill family
+# ---------------------------------------------------------------------------
+#
+# Func mode is required because ``N_total`` follows the post-broadcast
+# convention ``product(broadcast_shapes(input.shape, mask.shape))`` —
+# out-of-place ``Tensor.masked_fill`` returns a tensor whose shape is the
+# bidirectional broadcast of ``input`` and ``mask`` (verified empirically:
+# ``torch.zeros((2,1)).masked_fill(mask=(2,3), 1.0)`` → shape ``(2,3)``).
+# ``broadcast_shapes`` is not in the inline-roofline vars-layer namespace
+# (``docs/design/roofline.md`` §4.4.4). One function serves both the
+# Tensor-value primary and the Scalar-value variant — the 0-dim value
+# read is negligible vs ``N_total`` and is folded into the per-element
+# write cost.
+
+
+def masked_fill_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for ``MaskedFillFwdOp`` and ``MaskedFillScalarFwdOp``.
+
+    Models out-of-place ``Tensor.masked_fill`` whose output shape is the
+    bidirectional broadcast of ``input`` and ``mask``. Reads
+    ``op.N_total`` (post-broadcast element count) and ``op.dtype.itemsize``.
+
+    Per output element: one predicated select → ``flops = N_total``.
+    Bytes: 1-byte mask read (broadcast to ``N_total``) + input read at
+    ``elem_bytes`` + out write at ``elem_bytes`` →
+    ``bytes = N_total + 2 * N_total * elem_bytes``. The 0-dim ``value``
+    Tensor read (Tensor-value variant only) is one ``elem_bytes`` and is
+    negligible vs ``N_total``.
+
+    Args:
+        op: bound ``MaskedFillFwdOp`` or ``MaskedFillScalarFwdOp``
+            instance exposing ``N_total`` and ``dtype``.
+
+    Returns:
+        ``(flops, bytes)`` ints.
+    """
+    n_total = int(op.N_total)
+    elem_bytes = op.dtype.itemsize
+    flops = n_total
+    nbytes = n_total + 2 * n_total * elem_bytes
     return flops, nbytes
 
 


### PR DESCRIPTION
Closes #1088

## Summary

- Align the three multi-input elementwise op manifest entries (`where`, `clamp`, `masked_fill`) to PyTorch's public API, per the manifest trust model.
- Split families per the "No `Optional[Tensor]`" rule: `Clamp` family becomes 4 entries (`ClampFwdOp` primary + `ClampScalarFwdOp` / `ClampMinFwdOp` / `ClampMaxFwdOp` variants); `MaskedFill` family becomes 2 entries (`MaskedFillFwdOp` primary + `MaskedFillScalarFwdOp` variant).
- Update `WhereFwdOp.shape_rules` to use `broadcast_shapes(condition.shape, input.shape, other.shape)` matching `torch.where` broadcasting; remove inline BLOCKED notes from all three families.
- Add `broadcast_shapes` and `is_broadcastable_to` to `_SHAPE_RULE_BUILTINS` in `scripts/validate_manifest.py` (pure-Python, no torch dependency) so manifest `shape_rules` can express NumPy/PyTorch broadcast semantics.
- Add roofline blocks for the new `Clamp` and `MaskedFill` variants, with `vars.N_total = product(broadcast_shapes(...))` for broadcasting variants and `product(input.shape)` for the scalar-bound `ClampScalarFwdOp`.
- All new / restructured entries land as `status: spec-only`; kernel and op-class conformance is tracked in follow-up #1107.

## Test plan

- [x] AC-1: `WhereFwdOp.shape_rules` uses `broadcast_shapes(...)` and matches `torch.where` broadcasting semantics; inline BLOCKED note removed.
- [x] AC-2: Clamp family expressed as 4 entries (`ClampFwdOp` primary + `ClampScalarFwdOp` / `ClampMinFwdOp` / `ClampMaxFwdOp` variants) with `Number | None` for scalar params; inline BLOCKED note removed.
- [x] AC-3: MaskedFill family expressed as 2 entries (`MaskedFillFwdOp` primary + `MaskedFillScalarFwdOp` variant) with bidirectional input/mask broadcasting (out-of-place `Tensor.masked_fill` semantics) and `Number` value type; inline BLOCKED note removed.
- [x] AC-4: `_SHAPE_RULE_BUILTINS` includes `broadcast_shapes` and `is_broadcastable_to`, with unit tests in `tests/test_validate_manifest.py`.
- [x] AC-5: `scripts/validate_manifest.py --levels schema` passes for all affected entries.
- [x] AC-6: `where_fwd_roofline` and new variant roofline blocks are consistent with the post-broadcast `N_total` convention.
- [x] AC-7: Follow-up issue filed (#1107) tracking kernel + op-class conformance to all new / restructured entries.

Verification commands (all green locally):

- `pre-commit run --all-files` → all hooks pass
- `python scripts/validate_manifest.py --levels schema` → all manifest checks passed
- `pytest tests/test_validate_manifest.py` → 190 passed, 3 warnings

## Test node delta

```
File                               Base    HEAD    Delta
--------------------------------------------------------
tests/test_validate_manifest.py     171     190      +19
--------------------------------------------------------
TOTAL                               171     190      +19

Growth: +11.1%
```

**Justification:** The +19 nodes cover the new `_SHAPE_RULE_BUILTINS` helpers (`broadcast_shapes`, `is_broadcastable_to`): direct unit coverage of helper behavior (broadcasting equivalence, broadcast failures, scalar/empty-shape edge cases, unidirectional broadcastability) plus end-to-end coverage via `_eval_shape_rule` to confirm the helpers are actually reachable from manifest `shape_rules` strings. These helpers gate the new PyTorch-aligned `shape_rules` for `where`, `clamp`, and `masked_fill`; without this coverage, the broadcasting semantics of those entries are validator-untested.