### PR TITLE
[Bench] Fix nightly benchmark interface regressions

### DIFF
--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -102,7 +102,7 @@ def test_fused_topk_bench(
     dtype = torch.bfloat16
     test = FusedTopKTest(num_tokens, num_experts, top_k, scoring_func, renormalize, dtype)
     bm = FusedTopKBenchmark(test)
-    gating_output = test.gen_inputs()
+    (gating_output,) = test.gen_inputs()
 
     # TileOPs
     op = FusedTopKOp(num_tokens, num_experts, top_k, scoring_func, renormalize)

--- a/benchmarks/ops/bench_reduce_multidim.py
+++ b/benchmarks/ops/bench_reduce_multidim.py
@@ -580,12 +580,16 @@ class CumulativeMultidimBenchmark(BenchmarkBase[CumulativeMultidimTest]):
 
 
 def _make_cumulative_op(M, N, dtype, op_kind):
+    import inspect
+
     from tileops.ops.reduction.cumprod import CumprodFwdOp
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     op_map = {"cumsum": CumsumFwdOp, "cumprod": CumprodFwdOp}
     cls = op_map[op_kind]
-    return cls(M=M, N=N, dtype=dtype)
+    if "M" in inspect.signature(cls.__init__).parameters:
+        return cls(M=M, N=N, dtype=dtype)
+    return cls(N=N, dtype=dtype, dim=-1)
 
 
 @CumulativeMultidimFixture


### PR DESCRIPTION
## Summary

- unpack the single-tensor `FusedTopKTest.gen_inputs()` result before passing it to `FusedTopKOp`
- make the cumulative multidim benchmark helper compatible with both the legacy `M/N/dtype` constructor and the current `N/dtype/dim` constructor contract

## Scope

This is a narrow benchmark bugfix PR. It does not change:

- op public APIs
- kernels
- manifest/YAML entries
- benchmark shape coverage
- roofline or workload policy

Fixes #1111.
Fixes #1112.

## Validation

Ran in the nightly test image with GPU2 and data7 cache:

```bash
ruff check benchmarks/ops/bench_moe_fused_topk.py benchmarks/ops/bench_reduce_multidim.py
pytest -q benchmarks/ops/bench_moe_fused_topk.py benchmarks/ops/bench_reduce_multidim.py::test_cumulative_multidim_bench
```

Result:

```text
15 passed
```
