### PR TITLE
[Feat][Ops] add dim=None implicit-axis for Softmax/LogSoftmaxFwdOp; flip both to status: implemented

### DIFF
--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -538,33 +538,15 @@ def test_logsumexp_accepts_multidim() -> None:
     assert torch.allclose(y, y_ref, atol=1e-5, rtol=1e-5)
 
 
-# ===================================================================
-# dim=None implicit-axis tests (PyTorch parity)
-#
-# Per the manifest, ``dim`` defaults to ``None`` (PyTorch's deprecated
-# implicit-axis fallback). The op resolves to PyTorch's ``_get_softmax_dim``
-# choice at forward time: 0 for ``ndim in {0, 1, 3}`` else 1, with a
-# UserWarning. These tests exercise 1D / 2D / 3D × {fp16, bf16, fp32} and
-# assert bit-equivalence with ``F.softmax(x, dim=None)`` /
-# ``F.log_softmax(x, dim=None)`` within the standard tolerances.
-# ===================================================================
-
-
 class SoftmaxImplicitDimFixture(FixtureBase):
-    # Smoke covers one dtype per rank (1D fp32, 2D fp16, 3D bf16) so all three
-    # dtypes appear in smoke and each ndim in {1, 2, 3} (the three implicit-axis
-    # branches: ndim=1->0, ndim=2->1, ndim=3->0) is exercised at least once.
-    # Full fills in the remaining dtype × ndim cells.
+    # Smoke covers each ndim branch (1D, 2D, 3D) and each dtype at least once.
     PARAMS = [
         (
             "shape, dtype",
             [
-                # Smoke: one per dtype, one per ndim branch (1D, 2D, 3D).
                 pytest.param((256,), torch.float32, marks=pytest.mark.smoke),
                 pytest.param((32, 256), torch.float16, marks=pytest.mark.smoke),
                 pytest.param((4, 16, 32), torch.bfloat16, marks=pytest.mark.smoke),
-                # Full: distinct shapes per ndim × dtype to broaden coverage
-                # without colliding with smoke shapes.
                 pytest.param((300,), torch.float16, marks=pytest.mark.full),
                 pytest.param((300,), torch.bfloat16, marks=pytest.mark.full),
                 pytest.param((32, 300), torch.float32, marks=pytest.mark.full),
@@ -577,7 +559,6 @@ class SoftmaxImplicitDimFixture(FixtureBase):
 
 
 def _expected_implicit_dim(ndim: int) -> int:
-    """Mirror torch.nn.functional._get_softmax_dim for test reference."""
     return 0 if ndim in (0, 1, 3) else 1
 
 
@@ -592,7 +573,6 @@ def test_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) -> Non
     with _warnings.catch_warnings(record=True) as caught:
         _warnings.simplefilter("always")
         y = op(x)
-        # Must emit the same UserWarning PyTorch emits for dim=None.
         assert any(
             issubclass(w.category, UserWarning) and "Implicit dimension choice" in str(w.message)
             for w in caught
@@ -636,36 +616,14 @@ def test_log_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) ->
     )
 
 
-# ===================================================================
-# dim=None must not mutate self.dim — reused op instance across ranks.
-#
-# Regression for the bug where forward() resolved ``dim=None`` by writing
-# the resolved scalar back to ``self.dim``: the second call with a
-# different-rank input would then reuse the stale resolved axis (and a
-# stale ``self.N``) and either pick the wrong axis or raise a spurious
-# committed-N mismatch. PyTorch's ``F.softmax(x, dim=None)`` re-resolves
-# per call, so the same op instance must accept inputs of different ranks.
-# ===================================================================
-
-
 @pytest.mark.smoke
 def test_softmax_dim_none_reused_across_ranks() -> None:
-    """SoftmaxFwdOp(dim=None) must re-resolve per call (no self.dim mutation).
-
-    Mirrors the exact reproducer from review F001: a single op instance
-    constructed with ``N=4, dim=None`` must accept inputs of different
-    ranks. Pre-fix, the first rank-1 call wrote ``self.dim=0`` and the
-    rank-2 call then raised ``committed N=4 does not match x.shape[0]=2``.
-    """
+    """SoftmaxFwdOp(dim=None) must re-resolve per call across input ranks."""
     import warnings as _warnings
     op = SoftmaxFwdOp(N=4, dtype=torch.float32, dim=None)
 
-    # Rank 1: implicit dim resolves to 0; N = x.shape[0] = 4 (matches committed N).
     x1 = torch.randn(4, dtype=torch.float32, device="cuda")
-    # Rank 2: implicit dim resolves to 1; N = x.shape[1] = 4 (matches committed N).
-    # This is the case that previously raised due to self.dim mutation.
     x2 = torch.randn(2, 4, dtype=torch.float32, device="cuda")
-    # Rank 3: implicit dim resolves to 0; N = x.shape[0] = 4 (matches committed N).
     x3 = torch.randn(4, 3, 5, dtype=torch.float32, device="cuda")
 
     with _warnings.catch_warnings():
@@ -677,7 +635,6 @@ def test_softmax_dim_none_reused_across_ranks() -> None:
         y2_ref = F.softmax(x2.float(), dim=None)
         y3_ref = F.softmax(x3.float(), dim=None)
 
-    # self.dim must remain None across calls (no mutation).
     assert op.dim is None, f"op.dim was mutated to {op.dim!r}; expected None"
 
     atol, rtol = _get_tolerances(torch.float32)

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -636,5 +636,82 @@ def test_log_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) ->
     )
 
 
+# ===================================================================
+# dim=None must not mutate self.dim — reused op instance across ranks.
+#
+# Regression for the bug where forward() resolved ``dim=None`` by writing
+# the resolved scalar back to ``self.dim``: the second call with a
+# different-rank input would then reuse the stale resolved axis (and a
+# stale ``self.N``) and either pick the wrong axis or raise a spurious
+# committed-N mismatch. PyTorch's ``F.softmax(x, dim=None)`` re-resolves
+# per call, so the same op instance must accept inputs of different ranks.
+# ===================================================================
+
+
+@pytest.mark.smoke
+def test_softmax_dim_none_reused_across_ranks() -> None:
+    """SoftmaxFwdOp(dim=None) must re-resolve per call (no self.dim mutation).
+
+    Mirrors the exact reproducer from review F001: a single op instance
+    constructed with ``N=4, dim=None`` must accept inputs of different
+    ranks. Pre-fix, the first rank-1 call wrote ``self.dim=0`` and the
+    rank-2 call then raised ``committed N=4 does not match x.shape[0]=2``.
+    """
+    import warnings as _warnings
+    op = SoftmaxFwdOp(N=4, dtype=torch.float32, dim=None)
+
+    # Rank 1: implicit dim resolves to 0; N = x.shape[0] = 4 (matches committed N).
+    x1 = torch.randn(4, dtype=torch.float32, device="cuda")
+    # Rank 2: implicit dim resolves to 1; N = x.shape[1] = 4 (matches committed N).
+    # This is the case that previously raised due to self.dim mutation.
+    x2 = torch.randn(2, 4, dtype=torch.float32, device="cuda")
+    # Rank 3: implicit dim resolves to 0; N = x.shape[0] = 4 (matches committed N).
+    x3 = torch.randn(4, 3, 5, dtype=torch.float32, device="cuda")
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", UserWarning)
+        y1 = op(x1)
+        y2 = op(x2)
+        y3 = op(x3)
+        y1_ref = F.softmax(x1.float(), dim=None)
+        y2_ref = F.softmax(x2.float(), dim=None)
+        y3_ref = F.softmax(x3.float(), dim=None)
+
+    # self.dim must remain None across calls (no mutation).
+    assert op.dim is None, f"op.dim was mutated to {op.dim!r}; expected None"
+
+    atol, rtol = _get_tolerances(torch.float32)
+    assert torch.allclose(y1, y1_ref, atol=atol, rtol=rtol)
+    assert torch.allclose(y2, y2_ref, atol=atol, rtol=rtol)
+    assert torch.allclose(y3, y3_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_log_softmax_dim_none_reused_across_ranks() -> None:
+    """LogSoftmaxFwdOp(dim=None) must re-resolve per call (no self.dim mutation)."""
+    import warnings as _warnings
+    op = LogSoftmaxFwdOp(N=4, dtype=torch.float32, dim=None)
+
+    x1 = torch.randn(4, dtype=torch.float32, device="cuda")
+    x2 = torch.randn(2, 4, dtype=torch.float32, device="cuda")
+    x3 = torch.randn(4, 3, 5, dtype=torch.float32, device="cuda")
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", UserWarning)
+        y1 = op(x1)
+        y2 = op(x2)
+        y3 = op(x3)
+        y1_ref = F.log_softmax(x1.float(), dim=None)
+        y2_ref = F.log_softmax(x2.float(), dim=None)
+        y3_ref = F.log_softmax(x3.float(), dim=None)
+
+    assert op.dim is None, f"op.dim was mutated to {op.dim!r}; expected None"
+
+    atol, rtol = _get_tolerances(torch.float32)
+    assert torch.allclose(y1, y1_ref, atol=atol, rtol=rtol)
+    assert torch.allclose(y2, y2_ref, atol=atol, rtol=rtol)
+    assert torch.allclose(y3, y3_ref, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -538,5 +538,103 @@ def test_logsumexp_accepts_multidim() -> None:
     assert torch.allclose(y, y_ref, atol=1e-5, rtol=1e-5)
 
 
+# ===================================================================
+# dim=None implicit-axis tests (PyTorch parity)
+#
+# Per the manifest, ``dim`` defaults to ``None`` (PyTorch's deprecated
+# implicit-axis fallback). The op resolves to PyTorch's ``_get_softmax_dim``
+# choice at forward time: 0 for ``ndim in {0, 1, 3}`` else 1, with a
+# UserWarning. These tests exercise 1D / 2D / 3D × {fp16, bf16, fp32} and
+# assert bit-equivalence with ``F.softmax(x, dim=None)`` /
+# ``F.log_softmax(x, dim=None)`` within the standard tolerances.
+# ===================================================================
+
+
+class SoftmaxImplicitDimFixture(FixtureBase):
+    # Smoke covers one dtype per rank (1D fp32, 2D fp16, 3D bf16) so all three
+    # dtypes appear in smoke and each ndim in {1, 2, 3} (the three implicit-axis
+    # branches: ndim=1->0, ndim=2->1, ndim=3->0) is exercised at least once.
+    # Full fills in the remaining dtype × ndim cells.
+    PARAMS = [
+        (
+            "shape, dtype",
+            [
+                # Smoke: one per dtype, one per ndim branch (1D, 2D, 3D).
+                pytest.param((256,), torch.float32, marks=pytest.mark.smoke),
+                pytest.param((32, 256), torch.float16, marks=pytest.mark.smoke),
+                pytest.param((4, 16, 32), torch.bfloat16, marks=pytest.mark.smoke),
+                # Full: distinct shapes per ndim × dtype to broaden coverage
+                # without colliding with smoke shapes.
+                pytest.param((300,), torch.float16, marks=pytest.mark.full),
+                pytest.param((300,), torch.bfloat16, marks=pytest.mark.full),
+                pytest.param((32, 300), torch.float32, marks=pytest.mark.full),
+                pytest.param((32, 300), torch.bfloat16, marks=pytest.mark.full),
+                pytest.param((2, 16, 64), torch.float32, marks=pytest.mark.full),
+                pytest.param((2, 16, 64), torch.float16, marks=pytest.mark.full),
+            ],
+        ),
+    ]
+
+
+def _expected_implicit_dim(ndim: int) -> int:
+    """Mirror torch.nn.functional._get_softmax_dim for test reference."""
+    return 0 if ndim in (0, 1, 3) else 1
+
+
+@SoftmaxImplicitDimFixture
+def test_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) -> None:
+    """SoftmaxFwdOp(dim=None) must match F.softmax(x, dim=None) and warn."""
+    import warnings as _warnings
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    expected_dim = _expected_implicit_dim(x.ndim)
+    op = SoftmaxFwdOp(N=shape[expected_dim], dtype=dtype, dim=None)
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        y = op(x)
+        # Must emit the same UserWarning PyTorch emits for dim=None.
+        assert any(
+            issubclass(w.category, UserWarning) and "Implicit dimension choice" in str(w.message)
+            for w in caught
+        ), f"Expected implicit-dim UserWarning, got {[str(w.message) for w in caught]}"
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", UserWarning)
+        y_ref = F.softmax(x.float(), dim=None).to(dtype)
+
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"dim=None softmax (shape={shape}, dtype={dtype}) failed, "
+        f"max err: {(y - y_ref).abs().max()}"
+    )
+
+
+@SoftmaxImplicitDimFixture
+def test_log_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) -> None:
+    """LogSoftmaxFwdOp(dim=None) must match F.log_softmax(x, dim=None) and warn."""
+    import warnings as _warnings
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+    expected_dim = _expected_implicit_dim(x.ndim)
+    op = LogSoftmaxFwdOp(N=shape[expected_dim], dtype=dtype, dim=None)
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        y = op(x)
+        assert any(
+            issubclass(w.category, UserWarning) and "Implicit dimension choice" in str(w.message)
+            for w in caught
+        ), f"Expected implicit-dim UserWarning, got {[str(w.message) for w in caught]}"
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore", UserWarning)
+        y_ref = F.log_softmax(x.float(), dim=None).to(dtype)
+
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
+        f"dim=None log_softmax (shape={shape}, dtype={dtype}) failed, "
+        f"max err: {(y - y_ref).abs().max()}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -547,12 +547,6 @@ class SoftmaxImplicitDimFixture(FixtureBase):
                 pytest.param((256,), torch.float32, marks=pytest.mark.smoke),
                 pytest.param((32, 256), torch.float16, marks=pytest.mark.smoke),
                 pytest.param((4, 16, 32), torch.bfloat16, marks=pytest.mark.smoke),
-                pytest.param((300,), torch.float16, marks=pytest.mark.full),
-                pytest.param((300,), torch.bfloat16, marks=pytest.mark.full),
-                pytest.param((32, 300), torch.float32, marks=pytest.mark.full),
-                pytest.param((32, 300), torch.bfloat16, marks=pytest.mark.full),
-                pytest.param((2, 16, 64), torch.float32, marks=pytest.mark.full),
-                pytest.param((2, 16, 64), torch.float16, marks=pytest.mark.full),
             ],
         ),
     ]

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -7,7 +7,7 @@
 SoftmaxFwdOp:
   ref_api: "torch.nn.functional.softmax"
   family: reduction
-  status: spec-only  # impl __init__ defaults dim=-1 (PyTorch default is None, deprecated implicit-axis); dtype kwarg not supported. Flip to implemented when both gaps close.
+  status: implemented
 
   signature:
     inputs:
@@ -57,7 +57,7 @@ SoftmaxFwdOp:
 LogSoftmaxFwdOp:
   ref_api: "torch.nn.functional.log_softmax"
   family: reduction
-  status: spec-only  # impl __init__ defaults dim=-1 (PyTorch default is None, deprecated implicit-axis); dtype kwarg not supported. Flip to implemented when both gaps close.
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -35,12 +35,10 @@ SoftmaxFwdOp:
 
   roofline:
     vars:
-      # dim defaults to None in the manifest (PyTorch's deprecated implicit-axis).
-      # Concrete benchmark workloads do not set dim, so we treat None as the
-      # impl's effective default (-1 = last axis) for roofline accounting.
-      M: "product(x.shape[:(dim if dim is not None else -1) % x.ndim]) * product(x.shape[(dim if dim is not None else -1) % x.ndim + 1:])"
-      N: "x.shape[(dim if dim is not None else -1) % x.ndim]"
-    # Per row: max (N), subtract+exp (2N), sum (N), div (N) = 5N
+      # When dim is None, resolve via PyTorch's _get_softmax_dim:
+      # 0 for ndim in {0, 1, 3}, else 1 — matches the runtime path.
+      M: "product(x.shape[:(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim]) * product(x.shape[(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim + 1:])"
+      N: "x.shape[(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim]"
     flops: "5 * M * N"
     # Read x + write y
     bytes: "2 * M * N * elem_bytes"
@@ -87,9 +85,8 @@ LogSoftmaxFwdOp:
   roofline:
     vars:
       # See SoftmaxFwdOp.roofline.vars for the dim=None fallback rationale.
-      M: "product(x.shape[:(dim if dim is not None else -1) % x.ndim]) * product(x.shape[(dim if dim is not None else -1) % x.ndim + 1:])"
-      N: "x.shape[(dim if dim is not None else -1) % x.ndim]"
-    # Per row: max (N), subtract+exp (2N), sum (N), log+subtract (2N) = 6N
+      M: "product(x.shape[:(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim]) * product(x.shape[(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim + 1:])"
+      N: "x.shape[(dim if dim is not None else (0 if x.ndim in (0, 1, 3) else 1)) % x.ndim]"
     flops: "6 * M * N"
     # Read x + write y
     bytes: "2 * M * N * elem_bytes"

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -9,6 +9,7 @@ from the input tensor at forward time, and kernels are cached by
 ``(M, N)`` to avoid rebuilds.
 """
 
+import warnings
 from math import prod
 from typing import Dict, List, Optional, Union
 
@@ -21,6 +22,31 @@ from ..op_base import Op
 from ._multidim import EmptyDimPolicy, flatten_for_multidim, normalize_dim, restore_multidim_shape
 
 __all__ = ["_SoftmaxBaseOp"]
+
+
+def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
+    """Resolve ``dim=None`` to a scalar axis matching PyTorch's implicit choice.
+
+    Mirrors ``torch.nn.functional._get_softmax_dim``: pick 0 for
+    ``ndim in {0, 1, 3}`` else 1, and emit the same deprecation
+    ``UserWarning`` PyTorch emits.
+
+    Args:
+        name: Op name used in the warning message (e.g. ``"softmax"``).
+        ndim: Rank of the input tensor.
+
+    Returns:
+        Resolved scalar reduction axis (non-negative).
+    """
+    warnings.warn(
+        f"Implicit dimension choice for {name} has been deprecated. "
+        "Change the call to include dim=X as an argument.",
+        UserWarning,
+        stacklevel=3,
+    )
+    if ndim == 0 or ndim == 1 or ndim == 3:
+        return 0
+    return 1
 
 
 class _SoftmaxBaseOp(Op):
@@ -95,6 +121,14 @@ class _SoftmaxBaseOp(Op):
         """
         self._validate(x)
         orig_shape = x.shape
+
+        # PyTorch implicit-axis fallback for scalar-dim ops (softmax, log_softmax):
+        # when ``dim=None`` and the op does not support multi-dim full-reduction,
+        # resolve to PyTorch's _get_softmax_dim choice and emit the same
+        # deprecation UserWarning. Mutating ``self.dim`` here keeps a single
+        # source of truth for kernel-cache keying / introspection consumers.
+        if self.dim is None and not self._supports_multidim:
+            self.dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
 
         # --- multi-dim path (includes dim=None for full reduction) ---
         if isinstance(self.dim, (list, tuple)) or self.dim is None:

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -44,7 +44,7 @@ def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
         UserWarning,
         stacklevel=3,
     )
-    if ndim == 0 or ndim == 1 or ndim == 3:
+    if ndim in (0, 1, 3):
         return 0
     return 1
 

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -122,23 +122,20 @@ class _SoftmaxBaseOp(Op):
         self._validate(x)
         orig_shape = x.shape
 
-        # PyTorch implicit-axis fallback for scalar-dim ops (softmax, log_softmax):
-        # when ``dim=None`` and the op does not support multi-dim full-reduction,
-        # resolve to PyTorch's _get_softmax_dim choice and emit the same
-        # deprecation UserWarning. Mutating ``self.dim`` here keeps a single
-        # source of truth for kernel-cache keying / introspection consumers.
-        if self.dim is None and not self._supports_multidim:
-            self.dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
+        # Resolve dim=None per call (don't mutate self.dim) so the same op
+        # instance accepts inputs of different ranks, matching F.softmax.
+        effective_dim: Union[int, List[int], None] = self.dim
+        if effective_dim is None and not self._supports_multidim:
+            effective_dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
 
-        # --- multi-dim path (includes dim=None for full reduction) ---
-        if isinstance(self.dim, (list, tuple)) or self.dim is None:
+        if isinstance(effective_dim, (list, tuple)) or effective_dim is None:
             if not self._supports_multidim:
                 raise ValueError(
                     f"{type(self).__name__} does not support multi-dim reduction. "
                     "Use a scalar dim."
                 )
             dims = normalize_dim(
-                self.dim, x.ndim, empty_dim_policy=self._empty_dim_policy,
+                effective_dim, x.ndim, empty_dim_policy=self._empty_dim_policy,
             )
             # Bind the dynamic static-axes (param-dependent reduction axes) so
             # the Op-layer cache-key / introspection consumers see the
@@ -159,19 +156,20 @@ class _SoftmaxBaseOp(Op):
 
         # --- single-dim path ---
         # Validate and normalize dim (match PyTorch IndexError behavior).
-        if self.dim < -x.ndim or self.dim >= x.ndim:
+        assert isinstance(effective_dim, int)
+        if effective_dim < -x.ndim or effective_dim >= x.ndim:
             raise IndexError(
                 f"Dimension out of range (expected to be in range of "
-                f"[{-x.ndim}, {x.ndim - 1}], but got {self.dim})"
+                f"[{-x.ndim}, {x.ndim - 1}], but got {effective_dim})"
             )
-        dim = self.dim % x.ndim
+        dim = effective_dim % x.ndim
 
         # N = size along reduction dim, M = product of all other dims.
         N = x.shape[dim]
         if self.N is not None and N != self.N:
             raise ValueError(
                 f"{type(self).__name__}: committed N={self.N} does not match "
-                f"x.shape[{self.dim}]={N}"
+                f"x.shape[{effective_dim}]={N}"
             )
         # Bind the dynamic static-axis (param-dependent N axis) so the
         # Op-layer cache-key / introspection consumers see the committed axis.

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -11,7 +11,7 @@ from the input tensor at forward time, and kernels are cached by
 
 import warnings
 from math import prod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -25,19 +25,7 @@ __all__ = ["_SoftmaxBaseOp"]
 
 
 def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
-    """Resolve ``dim=None`` to a scalar axis matching PyTorch's implicit choice.
-
-    Mirrors ``torch.nn.functional._get_softmax_dim``: pick 0 for
-    ``ndim in {0, 1, 3}`` else 1, and emit the same deprecation
-    ``UserWarning`` PyTorch emits.
-
-    Args:
-        name: Op name used in the warning message (e.g. ``"softmax"``).
-        ndim: Rank of the input tensor.
-
-    Returns:
-        Resolved scalar reduction axis (non-negative).
-    """
+    """Mirror ``torch.nn.functional._get_softmax_dim``: pick 0 for ``ndim in {0, 1, 3}`` else 1, with the same deprecation warning."""
     warnings.warn(
         f"Implicit dimension choice for {name} has been deprecated. "
         "Change the call to include dim=X as an argument.",
@@ -124,7 +112,7 @@ class _SoftmaxBaseOp(Op):
 
         # Resolve dim=None per call (don't mutate self.dim) so the same op
         # instance accepts inputs of different ranks, matching F.softmax.
-        effective_dim: Union[int, List[int], None] = self.dim
+        effective_dim: Union[int, List[int], Tuple[int, ...], None] = self.dim
         if effective_dim is None and not self._supports_multidim:
             effective_dim = _resolve_implicit_softmax_dim(self._op_kind, x.ndim)
 

--- a/tileops/ops/reduction/log_softmax.py
+++ b/tileops/ops/reduction/log_softmax.py
@@ -33,7 +33,11 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
         N: Reduction-dim size (statically committed at ctor; corresponds to
             manifest ``static_dims.N = "x.shape[dim]"``).
         dtype: Data type (float32, float16, or bfloat16).
-        dim: Reduction dimension (default -1).
+        dim: Reduction dimension (default ``None``, matching PyTorch's
+            ``torch.nn.functional.log_softmax``). When ``None``, the axis is
+            resolved at forward time using PyTorch's implicit-axis rule
+            (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
+            deprecation ``UserWarning`` is emitted.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -47,7 +51,7 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
         *,
         N: int,
         dtype: torch.dtype,
-        dim: int = -1,
+        dim: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -33,7 +33,11 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
         N: Reduction-dim size (statically committed at ctor; corresponds to
             manifest ``static_dims.N = "x.shape[dim]"``).
         dtype: Data type (float32, float16, or bfloat16).
-        dim: Reduction dimension (default -1).
+        dim: Reduction dimension (default ``None``, matching PyTorch's
+            ``torch.nn.functional.softmax``). When ``None``, the axis is
+            resolved at forward time using PyTorch's implicit-axis rule
+            (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
+            deprecation ``UserWarning`` is emitted.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -47,7 +51,7 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
         *,
         N: int,
         dtype: torch.dtype,
-        dim: int = -1,
+        dim: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):


### PR DESCRIPTION
Closes #1114

Follow-up to PR #1110.

## Summary

- `_SoftmaxBase.__init__` now accepts `dim: int | None`. When `dim=None`, the op resolves to PyTorch's implicit-axis (`0` for `ndim` in `{0, 1, 3}`, else `1`) and emits the same `UserWarning` (`Implicit dimension choice for ...`) that `torch.nn.functional.softmax` / `log_softmax` emit. The original constructor argument is preserved on `self.dim`; the resolved int is computed per-call from the input tensor and threaded into the kernel call (no `self.dim` mutation, safe across reused op instances / ranks).
- `SoftmaxFwdOp` and `LogSoftmaxFwdOp` flipped from `status: spec-only` → `status: implemented` in `tileops/manifest/reduction.yaml`. Inline gap-marker comments on the `status:` line removed. The `dtype=<torch.dtype>` BLOCKED NOTE in `params:` is preserved (out of scope for this issue).
- `tests/ops/test_softmax.py` extended with `dim=None` cases for both ops, plus reused-across-ranks regression tests asserting `op.dim` is not mutated. Deprecation `UserWarning` is suppressed in tests to keep CI logs clean.

## Test plan

- [x] AC-1: `pytest tests/ops/test_softmax.py -m "smoke or full"` → all rows pass (no fp32/fp16/bf16 rows skipped or xfailed).
- [x] AC-2: `dim=None` cases bit-equivalent with `F.softmax(x, dim=None)` / `F.log_softmax(x, dim=None)` (within tolerance).
- [x] AC-3: `python scripts/validate_manifest.py --check-op SoftmaxFwdOp` → "All manifest checks passed". Same for `LogSoftmaxFwdOp`.
- [x] AC-4: Both ops show `status: implemented` in `tileops/manifest/reduction.yaml`; inline gap-marker on `status:` line removed; `dtype=<torch.dtype>` NOTE in `params:` preserved.
- [x] AC-5: Both ops shipped in this single PR; PR description references PR #1110.
- [x] pre-commit passed on all changed files.

## Structural Readiness

All checks passed.

## Additional context

- Manifest changes in this PR are scoped to a `status` flip + gap-marker removal — no signature/interface changes — and are explicitly directed by the issue acceptance criteria (AC-4). This is consistent with the trust model intent (which forbids interface changes co-shipping with code), since no interface evolution is occurring.
- `dtype=<torch.dtype>` kwarg support and `fp64` remain out of scope per the issue constraints; the BLOCKED NOTE on `params:` stays.

## Test node delta

```
File                         Base    HEAD    Delta
--------------------------------------------------
tests/ops/test_softmax.py     126     134      +8
--------------------------------------------------
TOTAL                         126     134      +8

Growth: +6.3%
```

**Justification — coverage by axis, not AC count:**

- **Implicit-axis branch coverage (3 nodes):** one smoke row per ndim branch of PyTorch's implicit-dim rule — `(256,)` (1D → dim 0), `(32, 256)` (2D → dim 1), `(4, 16, 32)` (3D → dim 0). One row per branch is the minimum that exercises the resolver against `_expected_implicit_dim`.
- **Dtype parity (3 nodes, shared with branch coverage):** the same three smoke rows pin one dtype to each branch (fp32 / fp16 / bf16). Dtype × branch is intentionally collapsed — the resolver is dtype-independent, and the kernel's dtype handling is already covered by the explicit-`dim` matrix above.
- **Instance-reuse regression (2 nodes):** `test_softmax_dim_none_reused_across_ranks` and its log counterpart drive a single op instance through 1D / 2D / 3D inputs and assert `op.dim is None` afterwards. These guard the no-mutation invariant; one node per op is sufficient since the contract is shape-independent.

Total: 3 (softmax implicit-axis) + 3 (log_softmax implicit-axis) + 2 (reuse regressions) = 8 new nodes.
