### PR TITLE
[Fix][Reduction] Fix bugs in logical and norm reductions

### DIFF
--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.reduction.logical_reduce import LogicalReduceKernel
 from workloads.logical_reduce import AnyTest as _AnyWorkload
 
 # ---------------------------------------------------------------------------
@@ -151,6 +152,22 @@ class LogicalReduceTest(_AnyWorkload, TestBase):
         elif self.op_kind == "count_nonzero":
             return torch.count_nonzero(x, dim=-1).to(torch.int64)
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
+
+
+class _TailBlockLogicalReduceKernel(LogicalReduceKernel):
+    """Force tiled tests to cover tail-M masking with block_m > M."""
+
+    _TAIL_BLOCK_M = 4
+    _TAIL_TILE_N = 8192
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self._needs_tiling, "tail-M regression test must use the tiled kernel"
+        self.config = {
+            "block_m": self._TAIL_BLOCK_M,
+            "threads": 128,
+            "tile_n": self._TAIL_TILE_N,
+        }
 
 
 def _exact_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
@@ -642,9 +659,15 @@ def test_logical_reduce_long_sequence_tiled(op_kind: str, dtype: torch.dtype) ->
         "count_nonzero": CountNonzeroFwdOp,
     }
     test = LogicalReduceTest(3, 33024, dtype, op_kind)
-    op = op_map[op_kind](dtype=dtype)
+    op = op_map[op_kind](
+        dtype=dtype,
+        kernel_map={"logical_reduce": _TailBlockLogicalReduceKernel},
+    )
     compare = _exact_compare_int64 if op_kind == "count_nonzero" else _exact_compare
     test.check(op, *test.gen_inputs(), compare=compare)
+    kernel = op._kernel_cache[(3, 33024)]
+    assert kernel.config["block_m"] > test.shape[0]
+    assert kernel.config["tile_n"] > 0
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -621,5 +621,31 @@ def test_count_nonzero_smoke_bool(m: int, n: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), compare=_exact_compare_int64)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_kind, dtype",
+    [
+        ("any", torch.bool),
+        ("all", torch.bool),
+        ("count_nonzero", torch.float16),
+    ],
+)
+def test_logical_reduce_long_sequence_tiled(op_kind: str, dtype: torch.dtype) -> None:
+    """Exercise the N-tiled path with a tail-M block."""
+    from tileops.ops.reduction.all_op import AllFwdOp
+    from tileops.ops.reduction.any_op import AnyFwdOp
+    from tileops.ops.reduction.count_nonzero import CountNonzeroFwdOp
+
+    op_map = {
+        "any": AnyFwdOp,
+        "all": AllFwdOp,
+        "count_nonzero": CountNonzeroFwdOp,
+    }
+    test = LogicalReduceTest(3, 33024, dtype, op_kind)
+    op = op_map[op_kind](dtype=dtype)
+    compare = _exact_compare_int64 if op_kind == "count_nonzero" else _exact_compare
+    test.check(op, *test.gen_inputs(), compare=compare)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -562,5 +562,16 @@ def test_empty_dim_full_reduction_3d_dtypes(
     allclose_compare(y, ref, atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_kind", ["l1", "l2", "inf"])
+def test_vector_norm_long_sequence_tiled(op_kind: str) -> None:
+    """Exercise the N-tiled path with a tail-M block."""
+    dtype = torch.bfloat16
+    test = VectorNormTest(3, 33024, dtype, op_kind)
+    op = _make_op(dtype, op_kind)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase, allclose_compare
+from tileops.kernels.reduction.vector_norm import VectorNormKernel
 from workloads.vector_norm import L1NormTest as _L1NormWorkload
 
 # ---------------------------------------------------------------------------
@@ -109,6 +110,22 @@ class VectorNormTest(_L1NormWorkload, TestBase):
         return ref.to(self.dtype)
 
 
+class _TailBlockVectorNormKernel(VectorNormKernel):
+    """Force tiled tests to cover tail-M masking with block_m > M."""
+
+    _TAIL_BLOCK_M = 4
+    _TAIL_TILE_N = 8192
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self._needs_tiling, "tail-M regression test must use the tiled kernel"
+        self.config = {
+            "block_m": self._TAIL_BLOCK_M,
+            "threads": 128,
+            "tile_n": self._TAIL_TILE_N,
+        }
+
+
 def _get_tolerances(dtype: torch.dtype):
     """Return (atol, rtol) for the given dtype."""
     if dtype == torch.float32:
@@ -132,7 +149,13 @@ def _make_1d_input(n: int, dtype: torch.dtype) -> torch.Tensor:
     return torch.randn(n, dtype=dtype, device="cuda")
 
 
-def _make_op(dtype: torch.dtype, op_kind: str, dim: int = -1, keepdim: bool = False):
+def _make_op(
+    dtype: torch.dtype,
+    op_kind: str,
+    dim: int = -1,
+    keepdim: bool = False,
+    kernel_map=None,
+):
     """Create the appropriate Op for the given op_kind."""
     from tileops.ops.reduction.inf_norm import InfNormFwdOp
     from tileops.ops.reduction.l1_norm import L1NormFwdOp
@@ -144,7 +167,7 @@ def _make_op(dtype: torch.dtype, op_kind: str, dim: int = -1, keepdim: bool = Fa
         "inf": InfNormFwdOp,
     }
     cls = op_map[op_kind]
-    return cls(dtype=dtype, dim=dim, keepdim=keepdim)
+    return cls(dtype=dtype, dim=dim, keepdim=keepdim, kernel_map=kernel_map)
 
 
 # ---------------------------------------------------------------------------
@@ -568,9 +591,16 @@ def test_vector_norm_long_sequence_tiled(op_kind: str) -> None:
     """Exercise the N-tiled path with a tail-M block."""
     dtype = torch.bfloat16
     test = VectorNormTest(3, 33024, dtype, op_kind)
-    op = _make_op(dtype, op_kind)
+    op = _make_op(
+        dtype,
+        op_kind,
+        kernel_map={"vector_norm": _TailBlockVectorNormKernel},
+    )
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    kernel = op._kernel_cache[(3, 33024)]
+    assert kernel.config["block_m"] > test.shape[0]
+    assert kernel.config["tile_n"] > 0
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -5,9 +5,8 @@ Casts input to bool (0/1 as float32), then reduces:
   - all: reduce_min (1 if all elements are non-zero)
   - count_nonzero: reduce_sum (count of non-zero elements per row)
 
-Operates on 2D (M, N_padded) tensors; the Op layer handles reshape.
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions.
+Operates on raw 2D (M, N) tensors; the kernel handles 256-element alignment
+padding internally via masked loads with the appropriate identity value.
 
 Output is bool for any/all, int64 for count_nonzero.
 """
@@ -23,8 +22,10 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
-    SHARED_MEMORY_BUDGET_BYTES,
+    MAX_SINGLE_TILE_COLS,
     align_up,
+    compute_tile_n,
+    device_smem_budget,
 )
 
 __all__ = ["LogicalReduceKernel", "to_logical_float32"]
@@ -60,6 +61,13 @@ def to_logical_float32(x: torch.Tensor) -> torch.Tensor:
     return ((x.real != 0) | (x.imag != 0)).to(torch.float32)
 
 
+def _pad_value_for_op(op_kind: str) -> float:
+    """Return the identity value for masked padding."""
+    if op_kind == "all":
+        return 1.0
+    return 0.0
+
+
 # ---------------------------------------------------------------------------
 # Logical reduce kernel
 # ---------------------------------------------------------------------------
@@ -84,30 +92,39 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
         A TileLang JIT-compiled kernel factory accepting (block_m, threads).
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
-
-    if op_kind == "count_nonzero":
-        return _count_nonzero_kernel(M, N_padded, dtype)
+    _needs_pad = N_padded != N
+    _pad_val = _pad_value_for_op(op_kind)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.macro
         def compute(
-            x: T.Tensor[(M, N_padded), dtype],
-            out: T.Tensor[(M,), "int8"],  # noqa: F821
+            x: T.Tensor[(M, N), dtype],
+            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
                 x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                 bool_vals = T.alloc_fragment((block_m, N_padded), "float32")
                 result = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment((block_m,), "int8")
+                out_local = T.alloc_fragment(
+                    (block_m,), "int8" if op_kind != "count_nonzero" else "int64"
+                )
 
-                # Load via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                if _needs_pad:
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < N),
+                            T.cast(x[pid_m * block_m + i, j], "float32"),
+                            T.cast(_pad_val, "float32"),
+                        )
+                else:
+                    # Load via shared memory
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                # Cast to fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    # Cast to fp32
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Cast to bool (0.0 or 1.0)
                 for i, j in T.Parallel(block_m, N_padded):
@@ -115,24 +132,29 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
 
                 if op_kind == "any":
                     # any: result is 1 if max(bool_vals) == 1
-                    # Padding is 0 (neutral for OR/max)
                     T.reduce_max(bool_vals, result, dim=1)
-                else:
+                elif op_kind == "all":
                     # all: result is 1 if min(bool_vals) == 1
-                    # Padding is 1 (neutral for AND/min)
                     T.reduce_min(bool_vals, result, dim=1)
+                else:
+                    # count_nonzero: sum of bool values per row
+                    T.reduce_sum(bool_vals, result, dim=1)
 
-                # Cast result to int8 (bool representation: 0 or 1)
-                for i in T.Parallel(block_m):
-                    out_local[i] = T.cast(result[i] > 0.5, "int8")
+                if op_kind == "count_nonzero":
+                    for i in T.Parallel(block_m):
+                        out_local[i] = T.cast(result[i], "int64")
+                else:
+                    # Cast result to int8 (bool representation: 0 or 1)
+                    for i in T.Parallel(block_m):
+                        out_local[i] = T.cast(result[i] > 0.5, "int8")
 
                 # Write output
                 T.copy(out_local, out[pid_m * block_m])
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
-            out: T.Tensor[(M,), "int8"],  # noqa: F821
+            x: T.Tensor[(M, N), dtype],
+            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
         ):
             compute(x, out)
 
@@ -142,61 +164,78 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
 
 
 @functools.lru_cache(maxsize=32)
-def _count_nonzero_kernel(M: int, N_padded: int, dtype: str):
-    """Build a TileLang count_nonzero kernel.
+def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int):
+    """Build a tiled TileLang any/all/count_nonzero kernel.
 
-    Cast input to bool (0.0 or 1.0 in float32), then reduce_sum over
-    each row. Output is int64 (count of non-zero elements per row).
-
-    Args:
-        M: Number of rows (product of all leading dimensions).
-        N_padded: Padded hidden dimension (already aligned).
-        dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
-
-    Returns:
-        A TileLang JIT-compiled kernel factory accepting (block_m, threads).
+    Iterates over the reduction dimension in chunks of ``tile_n`` columns,
+    avoiding TileLang's single-fragment column limit at 32768 columns.
     """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    num_tiles = (N_padded + tile_n - 1) // tile_n
+    _pad_val = _pad_value_for_op(op_kind)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.macro
         def compute(
-            x: T.Tensor[(M, N_padded), dtype],
-            out: T.Tensor[(M,), "int64"],  # noqa: F821
+            x: T.Tensor[(M, N), dtype],
+            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                bool_vals = T.alloc_fragment((block_m, N_padded), "float32")
-                result = T.alloc_fragment((block_m,), "float32")
-                out_local = T.alloc_fragment((block_m,), "int64")
+                x_f32 = T.alloc_fragment((block_m, tile_n), "float32")
+                bool_vals = T.alloc_fragment((block_m, tile_n), "float32")
+                acc = T.alloc_fragment((block_m,), "float32")
+                tile_acc = T.alloc_fragment((block_m,), "float32")
+                out_local = T.alloc_fragment(
+                    (block_m,), "int8" if op_kind != "count_nonzero" else "int64"
+                )
 
-                # Load via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                if op_kind == "all":
+                    T.fill(acc, 1.0)
+                else:
+                    T.fill(acc, 0.0)
 
-                # Cast to fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                for t in T.Serial(num_tiles):
+                    for i, j in T.Parallel(block_m, tile_n):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                            T.cast(
+                                x[pid_m * block_m + i, t * tile_n + j],
+                                "float32",
+                            ),
+                            T.cast(_pad_val, "float32"),
+                        )
 
-                # Cast to bool (0.0 or 1.0)
-                for i, j in T.Parallel(block_m, N_padded):
-                    bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
+                    for i, j in T.Parallel(block_m, tile_n):
+                        bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
 
-                # count_nonzero: sum of bool values per row
-                # Padding is 0 (neutral for sum)
-                T.reduce_sum(bool_vals, result, dim=1)
+                    if op_kind == "any":
+                        T.reduce_max(bool_vals, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = T.max(acc[i], tile_acc[i])
+                    elif op_kind == "all":
+                        T.reduce_min(bool_vals, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = T.min(acc[i], tile_acc[i])
+                    else:
+                        T.reduce_sum(bool_vals, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = acc[i] + tile_acc[i]
 
-                # Cast result to int64
-                for i in T.Parallel(block_m):
-                    out_local[i] = T.cast(result[i], "int64")
+                if op_kind == "count_nonzero":
+                    for i in T.Parallel(block_m):
+                        out_local[i] = T.cast(acc[i], "int64")
+                else:
+                    for i in T.Parallel(block_m):
+                        out_local[i] = T.cast(acc[i] > 0.5, "int8")
 
                 # Write output
                 T.copy(out_local, out[pid_m * block_m])
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
-            out: T.Tensor[(M,), "int64"],  # noqa: F821
+            x: T.Tensor[(M, N), dtype],
+            out: T.Tensor[(M,), "int8" if op_kind != "count_nonzero" else "int64"],  # noqa: F821
         ):
             compute(x, out)
 
@@ -226,8 +265,34 @@ def _logical_reduce_fwd_wrapped(
     return out_raw.bool()
 
 
+@torch.library.custom_op("top::logical_reduce_tiled_fwd", mutates_args=())
+def _logical_reduce_tiled_fwd_wrapped(
+    M: int,
+    N: int,
+    op_kind: str,
+    dtype_str: str,
+    tile_n: int,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    out_raw = _logical_reduce_kernel_tiled(
+        M, N, op_kind, dtype_str, tile_n
+    )(block_m, threads)(x)
+    if op_kind == "count_nonzero":
+        return out_raw.to(torch.int64)
+    return out_raw.bool()
+
+
 @_logical_reduce_fwd_wrapped.register_fake
 def _(M, N, op_kind, dtype_str, block_m, threads, x):
+    if op_kind == "count_nonzero":
+        return torch.empty((M,), dtype=torch.int64, device=x.device)
+    return torch.empty((M,), dtype=torch.bool, device=x.device)
+
+
+@_logical_reduce_tiled_fwd_wrapped.register_fake
+def _(M, N, op_kind, dtype_str, tile_n, block_m, threads, x):
     if op_kind == "count_nonzero":
         return torch.empty((M,), dtype=torch.int64, device=x.device)
     return torch.empty((M,), dtype=torch.bool, device=x.device)
@@ -241,9 +306,10 @@ def _(M, N, op_kind, dtype_str, block_m, threads, x):
 class LogicalReduceKernel(Kernel):
     """Any / all / count_nonzero forward kernel.
 
-    Supports SM80+ architectures. Uses 256-element alignment for shared
-    memory copies. Casts input to bool (0/1) and reduces via max (any),
-    min (all), or sum (count_nonzero).
+    Supports SM80+ architectures. Handles 256-element alignment padding inside
+    the kernel. Casts input to bool (0/1) and reduces via max (any), min (all),
+    or sum (count_nonzero). Uses an N-tiled fallback for long rows that exceed
+    TileLang's single-fragment column limit.
 
     Output dtype is bool for any/all and int64 for count_nonzero.
 
@@ -288,45 +354,152 @@ class LogicalReduceKernel(Kernel):
             _FLOAT32_STORAGE_DTYPE if dtype in _UNSUPPORTED_STORAGE_DTYPES else dtype
         )
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.kernel = _logical_reduce_kernel(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_to_str(self._kernel_dtype),
+        self._elem_bytes = torch.tensor([], dtype=self._kernel_dtype).element_size()
+        self._smem_budget = device_smem_budget()
+        self._needs_tiling = (
+            self.N_padded > MAX_SINGLE_TILE_COLS
+            or self.N_padded * self._elem_bytes > self._smem_budget
         )
+        self.kernel = None
+        if not self._needs_tiling:
+            self.kernel = _logical_reduce_kernel(
+                self.M,
+                self.N,
+                self.op_kind,
+                self.dtype_to_str(self._kernel_dtype),
+            )
         self.init_config(config, tune)
+        if self._needs_tiling and not tune:
+            bm = self.config.get("block_m", 1)
+            if "tile_n" not in self.config or self.config["tile_n"] == 0:
+                self.config["tile_n"] = self._tile_n_for_block_m(bm)
+
+    def _tile_n_for_block_m(self, block_m: int) -> int:
+        """Return tile_n for a given block_m (0 means no tiling needed)."""
+        budget = self._smem_budget
+        if self.N_padded <= MAX_SINGLE_TILE_COLS:
+            single = compute_tile_n(
+                block_m, self._elem_bytes, self.N_padded, budget=budget,
+            )
+            if single == self.N_padded:
+                return 0
+
+        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
+        effective_budget = min(budget, col_budget)
+        return compute_tile_n(
+            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
+        )
 
     @property
     def default_config(self) -> dict:
         """Select default block_m based on shared memory budget."""
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self._kernel_dtype).element_size()
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 128}
+        if not self._needs_tiling:
+            smem_per_row = self.N_padded * self._elem_bytes
+            max_block_m = self._smem_budget // smem_per_row
+            block_m = 1
+            for bm in [1, 2, 4, 8]:
+                if bm <= max_block_m:
+                    block_m = bm
+            return {"block_m": block_m, "threads": 128}
+
+        best_bm = 1
+        best_tile_n = self._tile_n_for_block_m(1)
+        for bm in [2, 4, 8]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
+            curr_num = (self.N_padded + tn - 1) // tn
+            if curr_num < best_num:
+                best_bm = bm
+                best_tile_n = tn
+        return {"block_m": best_bm, "threads": 128, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self._kernel_dtype).element_size()
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        if not self._needs_tiling:
+            smem_per_row = self.N_padded * self._elem_bytes
+            max_block_m = self._smem_budget // smem_per_row
+            block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
+            threads_list = [128, 256]
+            configs = list(itertools.product(block_ms, threads_list))
+            return [{"block_m": bm, "threads": t} for bm, t in configs]
+
+        configs = []
+        for bm in [1, 2, 4, 8]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn == 0:
+                continue
+            for t in [128, 256]:
+                configs.append({"block_m": bm, "threads": t, "tile_n": tn})
+        return configs if configs else [self.default_config]
+
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+        """Autotune logical reduce, benchmarking tiled configs directly."""
+        if not self._needs_tiling:
+            return super().autotune(warmup=warmup, rep=rep)
+
+        configs = self.autotune_configs
+        if not configs:
+            self.config = self.default_config
+            return
+
+        print(f'Start autotuning {self.__class__.__name__} (tiled path)...')
+
+        device = torch.cuda.current_device()
+        x = torch.randn(self.M, self.N, dtype=self._kernel_dtype, device=device)
+
+        best_config = configs[0]
+        best_time = float('inf')
+
+        for cfg in configs:
+            self.config = cfg
+            for _ in range(warmup):
+                self.forward(x)
+            torch.cuda.synchronize()
+
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(rep):
+                self.forward(x)
+            end.record()
+            torch.cuda.synchronize()
+            elapsed = start.elapsed_time(end) / rep
+
+            if elapsed < best_time:
+                best_time = elapsed
+                best_config = cfg
+
+        self.config = best_config
+        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the any/all/count_nonzero kernel.
 
         Args:
-            x: Input tensor of shape (M, N_padded). Must have dtype matching
+            x: Input tensor of shape (M, N). Must have dtype matching
                _kernel_dtype (float32 when the original dtype is bool).
 
         Returns:
             Output tensor of shape (M,) with dtype bool (any/all) or int64
             (count_nonzero).
         """
+        if self._needs_tiling:
+            return _logical_reduce_tiled_fwd_wrapped(
+                self.M,
+                self.N,
+                self.op_kind,
+                self.dtype_to_str(self._kernel_dtype),
+                self.config["tile_n"],
+                self.config["block_m"],
+                self.config["threads"],
+                x,
+            )
         return _logical_reduce_fwd_wrapped(
             self.M,
             self.N,

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -5,9 +5,8 @@ Computes vector norms along the last dimension:
   - l2: sqrt(sum(x^2))
   - inf: max(|x|)
 
-Operates on 2D (M, N_padded) tensors; the Op layer handles reshape.
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions.
+Operates on raw 2D (M, N) tensors; the kernel handles 256-element alignment
+padding internally via masked loads with zero identity values.
 
 Output dtype matches input dtype; internal computation in fp32.
 """
@@ -23,8 +22,10 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
     DEFAULT_ALIGNMENT,
-    SHARED_MEMORY_BUDGET_BYTES,
+    MAX_SINGLE_TILE_COLS,
     align_up,
+    compute_tile_n,
+    device_smem_budget,
 )
 
 __all__ = ["VectorNormKernel"]
@@ -56,12 +57,13 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
         A TileLang JIT-compiled kernel factory accepting (block_m, threads).
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _needs_pad = N_padded != N
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M, N), dtype],
             out: T.Tensor[(M,), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
@@ -71,12 +73,20 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
                 acc = T.alloc_fragment((block_m,), "float32")
                 out_local = T.alloc_fragment((block_m,), dtype)
 
-                # Load via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                if _needs_pad:
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < N),
+                            T.cast(x[pid_m * block_m + i, j], "float32"),
+                            T.cast(0.0, "float32"),
+                        )
+                else:
+                    # Load via shared memory
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                # Cast to fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    # Cast to fp32
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 if op_kind == "l1":
                     # l1 norm: sum(|x|)
@@ -111,6 +121,78 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
     return _func
 
 
+@functools.lru_cache(maxsize=32)
+def _vector_norm_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int):
+    """Build a tiled TileLang l1/l2/inf norm kernel.
+
+    Iterates over the reduction dimension in chunks of ``tile_n`` columns,
+    avoiding TileLang's single-fragment column limit at 32768 columns.
+    """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    num_tiles = (N_padded + tile_n - 1) // tile_n
+
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m, threads):
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            out: T.Tensor[(M,), dtype],
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                x_f32 = T.alloc_fragment((block_m, tile_n), "float32")
+                transformed = T.alloc_fragment((block_m, tile_n), "float32")
+                acc = T.alloc_fragment((block_m,), "float32")
+                tile_acc = T.alloc_fragment((block_m,), "float32")
+                out_local = T.alloc_fragment((block_m,), dtype)
+
+                T.fill(acc, 0.0)
+
+                for t in T.Serial(num_tiles):
+                    for i, j in T.Parallel(block_m, tile_n):
+                        x_f32[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                            T.cast(
+                                x[pid_m * block_m + i, t * tile_n + j],
+                                "float32",
+                            ),
+                            T.cast(0.0, "float32"),
+                        )
+
+                    if op_kind == "l1":
+                        for i, j in T.Parallel(block_m, tile_n):
+                            transformed[i, j] = T.abs(x_f32[i, j])
+                        T.reduce_sum(transformed, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = acc[i] + tile_acc[i]
+                    elif op_kind == "l2":
+                        for i, j in T.Parallel(block_m, tile_n):
+                            transformed[i, j] = x_f32[i, j] * x_f32[i, j]
+                        T.reduce_sum(transformed, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = acc[i] + tile_acc[i]
+                    else:
+                        # Note: T.reduce_max does not propagate NaN.
+                        # NaN handling remains in the Op layer.
+                        for i, j in T.Parallel(block_m, tile_n):
+                            transformed[i, j] = T.abs(x_f32[i, j])
+                        T.reduce_max(transformed, tile_acc, dim=1)
+                        for i in T.Parallel(block_m):
+                            acc[i] = T.max(acc[i], tile_acc[i])
+
+                if op_kind == "l2":
+                    for i in T.Parallel(block_m):
+                        acc[i] = T.sqrt(acc[i])
+
+                for i in T.Parallel(block_m):
+                    out_local[i] = T.cast(acc[i], dtype)
+
+                T.copy(out_local, out[pid_m * block_m])
+
+        return main
+
+    return _func
+
+
 # ---------------------------------------------------------------------------
 # custom_op wrappers for torch.compile compatibility
 # ---------------------------------------------------------------------------
@@ -129,8 +211,29 @@ def _vector_norm_fwd_wrapped(
     return _vector_norm_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
 
 
+@torch.library.custom_op("top::vector_norm_tiled_fwd", mutates_args=())
+def _vector_norm_tiled_fwd_wrapped(
+    M: int,
+    N: int,
+    op_kind: str,
+    dtype_str: str,
+    tile_n: int,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _vector_norm_kernel_tiled(
+        M, N, op_kind, dtype_str, tile_n
+    )(block_m, threads)(x)
+
+
 @_vector_norm_fwd_wrapped.register_fake
 def _(M, N, op_kind, dtype_str, block_m, threads, x):
+    return torch.empty((M,), dtype=x.dtype, device=x.device)
+
+
+@_vector_norm_tiled_fwd_wrapped.register_fake
+def _(M, N, op_kind, dtype_str, tile_n, block_m, threads, x):
     return torch.empty((M,), dtype=x.dtype, device=x.device)
 
 
@@ -142,9 +245,10 @@ def _(M, N, op_kind, dtype_str, block_m, threads, x):
 class VectorNormKernel(Kernel):
     """L1 / L2 / Inf norm forward kernel.
 
-    Supports SM80+ architectures. Uses 256-element alignment for shared
-    memory copies. Computes norms via abs+sum (l1), square+sum+sqrt (l2),
-    or abs+max (inf).
+    Supports SM80+ architectures. Handles 256-element alignment padding inside
+    the kernel. Computes norms via abs+sum (l1), square+sum+sqrt (l2), or
+    abs+max (inf). Uses an N-tiled fallback for long rows that exceed
+    TileLang's single-fragment column limit.
 
     Output dtype matches input dtype; internal computation in fp32.
 
@@ -178,43 +282,150 @@ class VectorNormKernel(Kernel):
         self.op_kind = op_kind
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.kernel = _vector_norm_kernel(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_to_str(self.dtype),
+        self._elem_bytes = torch.tensor([], dtype=dtype).element_size()
+        self._smem_budget = device_smem_budget()
+        self._needs_tiling = (
+            self.N_padded > MAX_SINGLE_TILE_COLS
+            or self.N_padded * self._elem_bytes > self._smem_budget
         )
+        self.kernel = None
+        if not self._needs_tiling:
+            self.kernel = _vector_norm_kernel(
+                self.M,
+                self.N,
+                self.op_kind,
+                self.dtype_to_str(self.dtype),
+            )
         self.init_config(config, tune)
+        if self._needs_tiling and not tune:
+            bm = self.config.get("block_m", 1)
+            if "tile_n" not in self.config or self.config["tile_n"] == 0:
+                self.config["tile_n"] = self._tile_n_for_block_m(bm)
+
+    def _tile_n_for_block_m(self, block_m: int) -> int:
+        """Return tile_n for a given block_m (0 means no tiling needed)."""
+        budget = self._smem_budget
+        if self.N_padded <= MAX_SINGLE_TILE_COLS:
+            single = compute_tile_n(
+                block_m, self._elem_bytes, self.N_padded, budget=budget,
+            )
+            if single == self.N_padded:
+                return 0
+
+        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
+        effective_budget = min(budget, col_budget)
+        return compute_tile_n(
+            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
+        )
 
     @property
     def default_config(self) -> dict:
         """Select default block_m based on shared memory budget."""
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 128}
+        if not self._needs_tiling:
+            smem_per_row = self.N_padded * self._elem_bytes
+            max_block_m = self._smem_budget // smem_per_row
+            block_m = 1
+            for bm in [1, 2, 4, 8]:
+                if bm <= max_block_m:
+                    block_m = bm
+            return {"block_m": block_m, "threads": 128}
+
+        best_bm = 1
+        best_tile_n = self._tile_n_for_block_m(1)
+        for bm in [2, 4, 8]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
+            curr_num = (self.N_padded + tn - 1) // tn
+            if curr_num < best_num:
+                best_bm = bm
+                best_tile_n = tn
+        return {"block_m": best_bm, "threads": 128, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        if not self._needs_tiling:
+            smem_per_row = self.N_padded * self._elem_bytes
+            max_block_m = self._smem_budget // smem_per_row
+            block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
+            threads_list = [128, 256]
+            configs = list(itertools.product(block_ms, threads_list))
+            return [{"block_m": bm, "threads": t} for bm, t in configs]
+
+        configs = []
+        for bm in [1, 2, 4, 8]:
+            try:
+                tn = self._tile_n_for_block_m(bm)
+            except ValueError:
+                continue
+            if tn == 0:
+                continue
+            for t in [128, 256]:
+                configs.append({"block_m": bm, "threads": t, "tile_n": tn})
+        return configs if configs else [self.default_config]
+
+    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+        """Autotune vector norm, benchmarking tiled configs directly."""
+        if not self._needs_tiling:
+            return super().autotune(warmup=warmup, rep=rep)
+
+        configs = self.autotune_configs
+        if not configs:
+            self.config = self.default_config
+            return
+
+        print(f'Start autotuning {self.__class__.__name__} (tiled path)...')
+
+        device = torch.cuda.current_device()
+        x = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
+
+        best_config = configs[0]
+        best_time = float('inf')
+
+        for cfg in configs:
+            self.config = cfg
+            for _ in range(warmup):
+                self.forward(x)
+            torch.cuda.synchronize()
+
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(rep):
+                self.forward(x)
+            end.record()
+            torch.cuda.synchronize()
+            elapsed = start.elapsed_time(end) / rep
+
+            if elapsed < best_time:
+                best_time = elapsed
+                best_config = cfg
+
+        self.config = best_config
+        print(f'Best config: {self.config}')
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the l1/l2/inf norm kernel.
 
         Args:
-            x: Input tensor of shape (M, N_padded).
+            x: Input tensor of shape (M, N).
 
         Returns:
             Output tensor of shape (M,) with same dtype as input.
         """
+        if self._needs_tiling:
+            return _vector_norm_tiled_fwd_wrapped(
+                self.M,
+                self.N,
+                self.op_kind,
+                self.dtype_to_str(self.dtype),
+                self.config["tile_n"],
+                self.config["block_m"],
+                self.config["threads"],
+                x,
+            )
         return _vector_norm_fwd_wrapped(
             self.M,
             self.N,

--- a/tileops/ops/reduction/all_op.py
+++ b/tileops/ops/reduction/all_op.py
@@ -1,8 +1,9 @@
 """AllFwdOp: returns bool indicating if all elements are non-zero along ``dim``.
 
 The Op layer validates inputs, normalizes ``dim``, reshapes to 2D (M, N),
-pads to alignment (with 1, which is neutral for AND/all), calls the kernel,
-and reshapes the output back.  Output dtype is always bool.
+calls the kernel, and reshapes the output back.  Alignment padding is handled
+inside the kernel with 1, which is neutral for AND/all.  Output dtype is always
+bool.
 
 Supports any numeric dtype as input including torch.bool, int32, int64, and
 complex types. Inputs with unsupported TileLang storage dtypes (bool, int32,
@@ -55,6 +56,7 @@ class AllFwdOp(_ReduceOpBase):
     _op_kind = "all"
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
+    _kernel_handles_padding = True
 
     def __init__(
         self,

--- a/tileops/ops/reduction/any_op.py
+++ b/tileops/ops/reduction/any_op.py
@@ -1,8 +1,9 @@
 """AnyFwdOp: returns bool indicating if any element is non-zero along ``dim``.
 
 The Op layer validates inputs, normalizes ``dim``, reshapes to 2D (M, N),
-pads to alignment (with 0, which is neutral for OR/any), calls the kernel,
-and reshapes the output back.  Output dtype is always bool.
+calls the kernel, and reshapes the output back.  Alignment padding is handled
+inside the kernel with 0, which is neutral for OR/any.  Output dtype is always
+bool.
 
 Supports any numeric dtype as input including torch.bool, int32, int64, and
 complex types. Inputs with unsupported TileLang storage dtypes (bool, int32,
@@ -55,6 +56,7 @@ class AnyFwdOp(_ReduceOpBase):
     _op_kind = "any"
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
+    _kernel_handles_padding = True
 
     def __init__(
         self,

--- a/tileops/ops/reduction/count_nonzero.py
+++ b/tileops/ops/reduction/count_nonzero.py
@@ -1,8 +1,9 @@
 """CountNonzeroFwdOp: counts non-zero elements along ``dim``, returning int64.
 
 The Op layer validates inputs, normalizes ``dim``, reshapes to 2D (M, N),
-pads to alignment (with 0, which is neutral for sum/count), calls the kernel,
-and reshapes the output back.  Output dtype is always int64.
+calls the kernel, and reshapes the output back.  Alignment padding is handled
+inside the kernel with 0, which is neutral for sum/count.  Output dtype is
+always int64.
 
 Supports any numeric dtype as input including torch.bool, int32, int64, and
 complex types. Inputs with unsupported TileLang storage dtypes (bool, int32,
@@ -62,6 +63,7 @@ class CountNonzeroFwdOp(_ReduceOpBase):
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
     _empty_dim_policy: EmptyDimPolicy = "full"
+    _kernel_handles_padding = True
 
     def __init__(
         self,

--- a/tileops/ops/reduction/inf_norm.py
+++ b/tileops/ops/reduction/inf_norm.py
@@ -1,9 +1,9 @@
 """InfNormFwdOp: computes infinity norm (max absolute value) along a given dim.
 
-The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment
-(with 0.0, which is neutral for max of absolute values), calls the kernel,
-and reshapes the output back. Output dtype matches input dtype; internal
-computation in fp32.
+The Op layer validates inputs, reshapes to 2D (M, N), calls the kernel, and
+reshapes the output back. Alignment padding is handled inside the kernel with
+0.0, which is neutral for max of absolute values. Output dtype matches input
+dtype; internal computation in fp32.
 
 NaN propagation: T.reduce_max in TileLang does not propagate NaN (it drops
 NaN values). To match torch.linalg.vector_norm(ord=inf) semantics, the Op
@@ -51,6 +51,7 @@ class InfNormFwdOp(_ReduceOpBase):
     _op_kind = "inf"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
+    _kernel_handles_padding = True
     _required_ord: Union[int, float] = inf
     _empty_dim_policy: EmptyDimPolicy = "full"
 

--- a/tileops/ops/reduction/l1_norm.py
+++ b/tileops/ops/reduction/l1_norm.py
@@ -1,8 +1,9 @@
 """L1NormFwdOp: computes L1 norm (sum of absolute values) along a given dim.
 
-The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment
-(with 0.0, which is neutral for sum), calls the kernel, and reshapes the
-output back. Output dtype matches input dtype; internal computation in fp32.
+The Op layer validates inputs, reshapes to 2D (M, N), calls the kernel, and
+reshapes the output back. Alignment padding is handled inside the kernel with
+0.0, which is neutral for sum. Output dtype matches input dtype; internal
+computation in fp32.
 """
 
 from typing import Dict, List, Optional, Union
@@ -41,6 +42,7 @@ class L1NormFwdOp(_ReduceOpBase):
     _op_kind = "l1"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
+    _kernel_handles_padding = True
     _required_ord: Union[int, float] = 1
     _empty_dim_policy: EmptyDimPolicy = "full"
 

--- a/tileops/ops/reduction/l2_norm.py
+++ b/tileops/ops/reduction/l2_norm.py
@@ -1,8 +1,9 @@
 """L2NormFwdOp: computes L2 norm (Euclidean norm) along a given dim.
 
-The Op layer validates inputs, reshapes to 2D (M, N), pads to alignment
-(with 0.0, which is neutral for sum of squares), calls the kernel, and reshapes
-the output back. Output dtype matches input dtype; internal computation in fp32.
+The Op layer validates inputs, reshapes to 2D (M, N), calls the kernel, and
+reshapes the output back. Alignment padding is handled inside the kernel with
+0.0, which is neutral for sum of squares. Output dtype matches input dtype;
+internal computation in fp32.
 """
 
 from typing import Dict, List, Optional, Union
@@ -41,6 +42,7 @@ class L2NormFwdOp(_ReduceOpBase):
     _op_kind = "l2"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
+    _kernel_handles_padding = True
     _required_ord: Union[int, float] = 2
     _empty_dim_policy: EmptyDimPolicy = "full"
 

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -3,11 +3,11 @@
 Each op reduces along the configured ``dim`` and supports arbitrary-rank input.
 The ``dim`` parameter accepts ``int`` or ``list[int]`` for multi-dim reduction.
 The Op layer validates inputs, reshapes to 2D (M, N), and calls the kernel.
-For simple and Welford reduce ops, alignment padding is handled inside the
-kernel via masked loads with identity-element fills, eliminating host-side
-``F.pad`` from the forward path.  Other ops that inherit ``_ReduceOpBase``
-(argreduce, logical, vector_norm) continue to use host-side padding until
-their kernels are converted.
+For simple, Welford, logical reduce, and vector norm ops, alignment padding is
+handled inside the kernel via masked loads with identity-element fills,
+eliminating host-side ``F.pad`` from the forward path. Other ops that inherit
+``_ReduceOpBase`` continue to use host-side padding until their kernels are
+converted.
 Kernels are cached by ``(M, N)`` so that the same op instance can handle
 varying shapes.
 """


### PR DESCRIPTION
## Summary
- move logical reduce and vector norm alignment padding into the TileLang kernels
- add N-tiled fallback paths for logical reduce and vector norm when rows exceed the single-fragment column limit
- cover the 32k logical reduce/vector norm cases that failed in nightly benchmark

Fixes #958

## Validation
- `ruff check tileops/kernels/reduction/logical_reduce.py tileops/kernels/reduction/vector_norm.py tileops/ops/reduction/any_op.py tileops/ops/reduction/all_op.py tileops/ops/reduction/count_nonzero.py tileops/ops/reduction/l1_norm.py tileops/ops/reduction/l2_norm.py tileops/ops/reduction/inf_norm.py tileops/ops/reduction/reduce.py tests/ops/test_logical_reduce.py tests/ops/test_vector_norm.py`
- `pytest -q tests/ops/test_logical_reduce.py::test_logical_reduce_long_sequence_tiled tests/ops/test_vector_norm.py::test_vector_norm_long_sequence_tiled`
- `pytest -q tests/ops/test_logical_reduce.py tests/ops/test_vector_norm.py -m smoke`
- `pytest -q tests/ops/test_logical_reduce.py tests/ops/test_vector_norm.py -k 300`
- `pytest -q benchmarks/ops/bench_logical_reduce.py::test_any_bench[mask-validation-32k-bool] benchmarks/ops/bench_logical_reduce.py::test_all_bench[mask-validation-32k-bool] benchmarks/ops/bench_logical_reduce.py::test_count_nonzero_bench[sparsity-seq-float16] benchmarks/ops/bench_vector_norm.py::test_l1_norm_bench[long-seq-l1-bfloat16] benchmarks/ops/bench_vector_norm.py::test_l2_norm_bench[long-seq-l2-bfloat16] benchmarks/ops/bench_vector_norm.py::test_inf_norm_bench[long-seq-inf-bfloat16]`