### PR TITLE
[BugFix][CONV] Disable async copy for conv data loads

### DIFF
--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -5,20 +5,13 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.convolution import Conv1dKernel, Conv2d1x1Kernel, Conv2dKernel, Conv3dKernel
+from tileops.kernels.convolution import (
+    Conv1dKernel,
+    Conv2d1x1Kernel,
+    Conv2dKernel,
+    Conv3dKernel,
+)
 from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
-
-SKIPPED_CONV2D_CASES = {
-    (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False),
-    (2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False),
-    (1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), torch.float16, False),
-}
-
-SKIPPED_CONV3D_CASES = {
-    (1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False),
-    (1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False),
-    (1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False),
-}
 
 
 class Conv1dFixture(FixtureBase):
@@ -369,8 +362,6 @@ def test_conv2d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    if (n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune) in SKIPPED_CONV2D_CASES:
-        pytest.skip("Temporarily skipping known Conv2d failures under TileLang 0.1.9 (#1039).")
     test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
     op = Conv2dOp(
         n=n,
@@ -391,7 +382,6 @@ def test_conv2d(
 
 @pytest.mark.smoke
 def test_conv2d_accepts_zero_bias() -> None:
-    pytest.skip("Temporarily skipping known Conv2d zero-bias failure under TileLang 0.1.9 (#1039).")
     op = Conv2dOp(
         n=1,
         c_in=32,
@@ -572,8 +562,6 @@ def test_conv3d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    if (n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune) in SKIPPED_CONV3D_CASES:
-        pytest.skip("Temporarily skipping known Conv3d failures under TileLang 0.1.9 (#1039).")
     test = Conv3dTest(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
     op = Conv3dOp(
         n=n,
@@ -595,7 +583,6 @@ def test_conv3d(
 
 @pytest.mark.smoke
 def test_conv3d_accepts_zero_bias() -> None:
-    pytest.skip("Temporarily skipping known Conv3d zero-bias failure under TileLang 0.1.9 (#1039).")
     op = Conv3dOp(
         n=1,
         c_in=8,

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -422,7 +422,7 @@ def _conv2d_kernel(
     out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
     k_total = kernel_h * kernel_w * c_in
 
-    # TODO: Re-enable automatic async copy after TileLang fixes scalar cp.async
+    # TODO(#1105): Re-enable automatic async copy after TileLang fixes scalar cp.async
     # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
     @tilelang.jit(
         out_idx=[2],
@@ -946,7 +946,7 @@ def _conv3d_kernel(
     out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
     k_total = kernel_d * kernel_h * kernel_w * c_in
 
-    # TODO: Re-enable automatic async copy after TileLang fixes scalar cp.async
+    # TODO(#1105): Re-enable automatic async copy after TileLang fixes scalar cp.async
     # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
     @tilelang.jit(
         out_idx=[2],

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -422,7 +422,11 @@ def _conv2d_kernel(
     out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
     k_total = kernel_h * kernel_w * c_in
 
-    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    @tilelang.jit(
+        out_idx=[2],
+        compile_flags=["-O3", "-DENABLE_BF16"],
+        pass_configs={"tl.enable_async_copy": False},
+    )
     def _conv2d_func(
         block_m: int,
         block_n: int,
@@ -491,14 +495,7 @@ def _conv2d_kernel(
                                 T.cast(0.0, dtype),
                             )
 
-                    for i, j in T.Parallel(block_k, block_n):
-                        k_idx = k_iter * block_k + i
-                        oc = bx * block_n + j
-                        weight_shared[i, j] = T.if_then_else(
-                            (k_idx < k_total) & (oc < c_out),
-                            weight_flat[k_idx, oc],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
 
                     T.gemm(data_shared, weight_shared, out_local)
 

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -491,7 +491,14 @@ def _conv2d_kernel(
                                 T.cast(0.0, dtype),
                             )
 
-                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        oc = bx * block_n + j
+                        weight_shared[i, j] = T.if_then_else(
+                            (k_idx < k_total) & (oc < c_out),
+                            weight_flat[k_idx, oc],
+                            T.cast(0.0, dtype),
+                        )
 
                     T.gemm(data_shared, weight_shared, out_local)
 
@@ -1004,7 +1011,14 @@ def _conv3d_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        oc = bx * block_n + j
+                        weight_shared[i, j] = T.if_then_else(
+                            (k_idx < k_total) & (oc < c_out),
+                            weight_flat[k_idx, oc],
+                            T.cast(0.0, dtype),
+                        )
                     T.gemm(data_shared, weight_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -422,6 +422,8 @@ def _conv2d_kernel(
     out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
     k_total = kernel_h * kernel_w * c_in
 
+    # TODO: Re-enable automatic async copy after TileLang fixes scalar cp.async
+    # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
     @tilelang.jit(
         out_idx=[2],
         compile_flags=["-O3", "-DENABLE_BF16"],
@@ -944,7 +946,13 @@ def _conv3d_kernel(
     out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
     k_total = kernel_d * kernel_h * kernel_w * c_in
 
-    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    # TODO: Re-enable automatic async copy after TileLang fixes scalar cp.async
+    # widening for vectorized manual data loads. Keep weight T.copy eligible for TMA.
+    @tilelang.jit(
+        out_idx=[2],
+        compile_flags=["-O3", "-DENABLE_BF16"],
+        pass_configs={"tl.enable_async_copy": False},
+    )
     def _conv3d_func(
         block_m: int,
         block_n: int,
@@ -1008,14 +1016,7 @@ def _conv3d_kernel(
                             T.cast(0.0, dtype),
                         )
 
-                    for i, j in T.Parallel(block_k, block_n):
-                        k_idx = k_iter * block_k + i
-                        oc = bx * block_n + j
-                        weight_shared[i, j] = T.if_then_else(
-                            (k_idx < k_total) & (oc < c_out),
-                            weight_flat[k_idx, oc],
-                            T.cast(0.0, dtype),
-                        )
+                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
                     T.gemm(data_shared, weight_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):


### PR DESCRIPTION
Closes #1105

## Summary

- Disable TileLang automatic async-copy injection for the generic Conv2d and Conv3d kernels with `pass_configs={"tl.enable_async_copy": False}`.
- Keep convolution weight tile loads as `T.copy(...)` so they remain eligible for TileLang TMA lowering.
- Add `TODO(#1105)` comments at both JIT sites explaining that this is a temporary workaround until TileLang fixes scalar `cp.async` widening for vectorized manual data loads.
- Re-enable the previously skipped Conv2d and Conv3d correctness cases now that the affected paths compile and pass.

## Test plan

- [x] pre-commit passed during commit and push hooks
- [x] `CUDA_VISIBLE_DEVICES=<target_gpu> TMPDIR=<repo>/.tmp/tvm_tmp conda run -n tileops-dev python -m pytest tests/ops/test_convolution.py -vvs`

Result:

```text
36 passed in 73.41s (0:01:13)
```

## Structural Readiness

All checks passed.

## Benchmark

**Environment**: NVIDIA H200 fixed at 1830 MHz, CUDA 12.8, PyTorch 2.9.0+cu128, TileLang 0.1.9

### Conv2d

All 13 official Conv2d benchmark cases completed successfully with autotuning enabled. Under the same test conditions, compared with the old-code TileLang 0.1.8 baseline:

| Op | Shape group | dtype | Cases | Average latency change |
|----|-------------|-------|------:|-----------------------:|
| Conv2d | All official benchmark shapes | fp16/bf16 | 13 | -3.6% |
| Conv2d | Non-1x1 convolution shapes | fp16/bf16 | 7 | -3.8% |
| Conv2d | 1x1 convolution shapes | fp16/bf16 | 6 | -3.5% |

**Takeaways:**
- Keeping weight loads as `T.copy(...)` preserves the TMA-friendly path and avoids the large performance regression seen with guarded scalar weight loads.
- Disabling automatic async-copy injection for generic Conv2d avoids the TileLang 0.1.9 scalar `cp.async` widening failure without reducing benchmark throughput under the measured conditions.
- PyTorch 2.10.0+cu128 
**Benchmark command:**

```bash
CUDA_VISIBLE_DEVICES=<target_gpu> TMPDIR=<repo>/.tmp/tvm_tmp \
conda run -n tileops-dev python -m pytest \
benchmarks/ops/bench_convolution.py::test_conv2d_bench -vvs
```

## Regression

### Root Cause Analysis

Issue #1105 is caused by a TileLang 0.1.9 lowering/codegen path, not by NVCC. In the generic convolution kernels, manual `data_shared` loads are scalar fp16/bf16 global-to-shared stores inside a vectorized `T.Parallel` loop. When the weight `T.copy(...)` is recognized as a TMA producer, TileLang's warp-specialized producer scheduling can also mark the manual SIMT data producer for async-copy handling.

The relevant TileLang 0.1.9 source locations are:

- `src/transform/producer_consumer_ws.cc`: classifies generic `T.copy` as a TMA producer when bulk-load checks pass, and annotates SIMT producers for pipeline-managed async-copy scheduling in mixed producer groups.
- `src/transform/lower_ptx_async_copy.cc:80-89`: tracks `ForKind::kVectorized` loop extents in `current_vectorized_lanes_`.
- `src/transform/lower_ptx_async_copy.cc:401-412`: validates the expected final `cp.async` byte width using `effective_lanes * dtype_bits * current_vectorized_lanes_`.
- `src/transform/lower_ptx_async_copy.cc:489-508`: creates `tl::ptx_cp_async` with the per-access logical element count.
- `src/transform/vectorize_loop.cc:702-767`: is expected to widen vectorized `tl::ptx_cp_async` calls by multiplying the logical element count by the vector size.
- `src/target/codegen_cuda.cc:59-90`: performs the final legality check and rejects `tl::ptx_cp_async` widths outside `{4, 8, 16}` bytes.

For the Conv2d `smoke-fp16-3x3` reproducer, the scalar fp16 load has `effective_lanes=1`, while the surrounding vectorized loop contributes `current_vectorized_lanes_=8`. The pass therefore predicts:

```text
1 * 16 bits * 8 = 128 bits = 16 bytes
```

That predicted width is legal for PTX `cp.async`, so TileLang injects `tl::ptx_cp_async`. However, the injected intrinsic still carries the scalar logical element count (`num_elems=1`) and relies on a later vectorization pass to widen it to `num_elems=8`. In the failing path that widening does not survive, so CUDA codegen eventually sees:

```text
num_elems=1, dtype=fp16 => 2 bytes
```

and correctly rejects it:

```text
tl::ptx_cp_async requires a final PTX byte width in {4, 8, 16}, but got 2
```

This patch avoids the faulty automatic `cp.async` rewrite for the generic Conv2d/Conv3d manual data-load paths. It deliberately does not disable TMA or replace weight `T.copy(...)`, because doing so regresses larger convolution cases where the weight tile load benefits from TMA.

## Additional context

The ideal long-term fix should be in TileLang:

- `InjectPTXAsyncCopy` should not leave a scalar-width `tl::ptx_cp_async` in IR when its legality depends on a later vectorization pass.
- If later vectorization cannot widen the intrinsic to a legal 4/8/16-byte transfer, TileLang should fall back to normal load/store before CUDA codegen.
- CUDA codegen should remain the final validation layer, not the first place where this cross-pass contract failure is discovered.

Once TileLang guarantees that failed widening falls back safely, the `tl.enable_async_copy=False` workaround in Conv2d and Conv3d can be removed.