### PR TITLE
[Doc][Review] add approval-gate + extract shared pre-review meta-rules

### DIFF
--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -9,4 +9,5 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 - [ ] For each `shrink` / `delete`, post a review comment with the node ID and the kept case it duplicates or the axis to fold.
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 - [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
+- [ ] PR body conforms to `.foundry/mold/pr-body-template.md` and reflects the final state of the diff (no stale process narration). If not, request changes and have the developer update it before approving.
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,0 +1,32 @@
+# Approval gate
+
+Last step before a reviewer gives approve on a PR that adds or modifies tests. This is a mechanism, not a style suggestion: if a check fails, withhold approve until the developer pushes a triage commit.
+
+## Why this exists
+
+Issue acceptance criteria may mandate exhaustive matrices (e.g. full dtype × shape combinations) so a developer agent cannot claim "done" by hitting a lucky subset. That trust-model role ends at approval. The suite checked into `main` follows `docs/design/testing.md §Test case policy`, not the AC text — "AC-N required this matrix" is not a defense.
+
+## Reviewer action
+
+For every new or changed test case in the PR, classify:
+
+- **keep** — guards a distinct code path or dtype per `docs/design/testing.md §Test case policy`.
+- **shrink** — Cartesian expansion to fold to "boundary + one representative interior point".
+- **delete** — same-failure-mode duplicate of a kept case.
+
+If anything is `shrink` or `delete`:
+
+1. Post review comments naming the node IDs to fold or drop, and the kept case each duplicates.
+1. Request changes. **Do not approve** until the developer pushes a triage commit addressing every cited case.
+1. Re-run this gate on the triage commit.
+
+## Critical-path floor
+
+Triage must not delete the last guarding case for a critical code path identified in `docs/design/testing.md §Test case policy`:
+
+- tile boundary (shape not divisible by tile size)
+- vectorization alignment (shape not aligned to vector width)
+- degenerate dimension (size = 1)
+- dispatch branch (different shape ranges → different kernel variants)
+
+When in doubt, keep one.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,32 +1,12 @@
 # Approval gate
 
-Last step before a reviewer gives approve on a PR that adds or modifies tests. This is a mechanism, not a style suggestion: if a check fails, withhold approve until the developer pushes a triage commit.
+Run before approving any PR that adds or modifies tests. If any check fails, request changes; do not approve until the developer pushes a triage commit.
 
-## Why this exists
-
-Issue acceptance criteria may mandate exhaustive matrices (e.g. full dtype × shape combinations) so a developer agent cannot claim "done" by hitting a lucky subset. That trust-model role ends at approval. The suite checked into `main` follows `docs/design/testing.md §Test case policy`, not the AC text — "AC-N required this matrix" is not a defense.
-
-## Reviewer action
-
-For every new or changed test case in the PR, classify:
-
-- **keep** — guards a distinct code path or dtype per `docs/design/testing.md §Test case policy`.
-- **shrink** — Cartesian expansion to fold to "boundary + one representative interior point".
-- **delete** — same-failure-mode duplicate of a kept case.
-
-If anything is `shrink` or `delete`:
-
-1. Post review comments naming the node IDs to fold or drop, and the kept case each duplicates.
-1. Request changes. **Do not approve** until the developer pushes a triage commit addressing every cited case.
-1. Re-run this gate on the triage commit.
-
-## Critical-path floor
-
-Triage must not delete the last guarding case for a critical code path identified in `docs/design/testing.md §Test case policy`:
-
-- tile boundary (shape not divisible by tile size)
-- vectorization alignment (shape not aligned to vector width)
-- degenerate dimension (size = 1)
-- dispatch branch (different shape ranges → different kernel variants)
-
-When in doubt, keep one.
+- [ ] Classify every new or changed test case as **keep** / **shrink** / **delete**:
+  - **keep** — guards a distinct code path or dtype per `docs/design/testing.md §Test case policy`.
+  - **shrink** — Cartesian expansion; fold to "boundary + one representative interior point".
+  - **delete** — same-failure-mode duplicate of a kept case.
+- [ ] For each `shrink` / `delete`, post a review comment with the node ID and the kept case it duplicates or the axis to fold.
+- [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
+- [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
+- [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/doc.md
+++ b/.claude/review-checklists/doc.md
@@ -2,12 +2,7 @@
 
 For `[Doc]` and `[Design]`.
 
-## How to apply
-
-- **Open set, not exhaustive.** The agent may add checks for the PR's specifics; the items below are the floor.
-- **Every check must be concrete and decidable.** A check names one of: a contradiction (cite file:line on both sides), a missing follow-up reference, a scope violation (quote the offending line), or a re-introduced removal (cite the prior commit). Anything else does not qualify.
-- **Vague feedback is forbidden.** Phrases like "consider revising", "may want to clarify", "could be clearer" are not flags — either locate the violation or stay silent.
-- **Stance is reviewer-restraint.** Do not push the author to add design-doc content beyond what fixes a flagged item.
+A flag in this domain names one of: a contradiction (cite file:line on both sides), a missing follow-up reference, a scope violation (quote the offending line), or a re-introduced removal (cite the prior commit).
 
 ## Design docs (`docs/design/*.md`)
 

--- a/.claude/review-checklists/manifest.md
+++ b/.claude/review-checklists/manifest.md
@@ -4,12 +4,6 @@ For `[Maintain]`, `[Refactor][Manifest]`, and any PR that flips a manifest entry
 
 Load `.claude/domain-rules/manifest-spec.md` before reviewing.
 
-## How to apply
-
-- **Open set, not exhaustive.** The agent may add checks for the PR's specifics; the items below are the floor.
-- **Every check must be concrete and decidable.** Cite the entry path, the field name, the reference URL, the test name, or the offending diff line. "Looks reasonable", "may want to verify", "consider double-checking" do not qualify.
-- **Stance.** Reviewer verifies alignment with the reference; does not propose new spec content beyond what fixes a flagged item.
-
 Two non-negotiable principles cut across every event:
 
 - **Reference semantic alignment.** Any change to an op's spec (signature, shape rules, dtype combos, roofline vars) must map back to an authoritative reference — PyTorch public API for `torch.nn.*` / `torch.nn.functional.*` names; the paper or vendor docs otherwise. Reverse-engineering from current TileOps code is forbidden — spec is upstream of code.

--- a/.claude/review-checklists/pre-review.md
+++ b/.claude/review-checklists/pre-review.md
@@ -1,0 +1,7 @@
+# Pre-review
+
+Common rules for every checklist in this folder. Load this file before any specific checklist.
+
+- **Open set, not exhaustive.** The items in each checklist are the floor; add PR-specific checks as needed.
+- **Concrete and decidable.** Every flag cites a concrete pointer — file:line, entry path, field name, parametrize axis, reference URL, test name, or the offending diff line. "Looks reasonable", "may want to verify", "consider revising", "could be clearer" do not qualify.
+- **Reviewer restraint.** Verify alignment with the existing reference, spec, or convention; do not propose new content beyond what fixes a flagged item.

--- a/.claude/review-checklists/testing.md
+++ b/.claude/review-checklists/testing.md
@@ -14,3 +14,9 @@ Load `.claude/domain-rules/testing-budget.md` and `docs/design/testing.md §Test
 - [ ] **Trigger.** Compute `delta_pct = (HEAD − Base) / Base × 100` from the PR body's `## Test node delta`. If `delta_pct > 10%`, every check below is required; otherwise this file is informational.
 - [ ] **Per-case purpose stated.** Each new case (or each new parametrize cell) serves exactly one of: dtype correctness / kernel-branch shape coverage / feature coverage / regression — per `docs/design/testing.md §Test case policy`. The PR body justification names which, with file:line.
 - [ ] **No Cartesian-product expansion.** Reject parametrize stacks whose growth is the product of two or more axes' cardinalities without a per-cell rationale. Crossing axes is allowed only when each cell maps to a distinct code path the author can name; otherwise the stack is a performance sweep, not a UT.
+
+## AC text does not bind the merged suite
+
+Issue acceptance criteria may mandate exhaustive matrices (e.g. full dtype × shape combinations) so a developer agent cannot claim "done" by hitting a lucky subset. That role ends at approval. The suite checked into `main` follows the policy above, not the AC text — "AC-N required this matrix" is not a defense against the checks above.
+
+If any new case fails a check, request changes naming the node IDs to drop or fold, and wait for a triage commit before approving. Never delete the last guarding case for a critical path (tile boundary, vectorization alignment, degenerate dim, dispatch branch).

--- a/.claude/review-checklists/testing.md
+++ b/.claude/review-checklists/testing.md
@@ -4,19 +4,10 @@ For PRs that add or modify files under `tests/`. Single focus: justify the test 
 
 Load `.claude/domain-rules/testing-budget.md` and `docs/design/testing.md §Test case policy` before reviewing.
 
-## How to apply
-
-- **Concrete and decidable.** Cite the test file:line, the parametrize axis, or the offending fixture row. "Looks like too many tests" does not qualify.
-- **Burden of proof flips above threshold.** If growth crosses the threshold below, the author justifies; reviewer silence is not approval.
+**Burden of proof flips above threshold.** If growth crosses the threshold below, the author justifies; reviewer silence is not approval.
 
 ## Checklist
 
 - [ ] **Trigger.** Compute `delta_pct = (HEAD − Base) / Base × 100` from the PR body's `## Test node delta`. If `delta_pct > 10%`, every check below is required; otherwise this file is informational.
 - [ ] **Per-case purpose stated.** Each new case (or each new parametrize cell) serves exactly one of: dtype correctness / kernel-branch shape coverage / feature coverage / regression — per `docs/design/testing.md §Test case policy`. The PR body justification names which, with file:line.
 - [ ] **No Cartesian-product expansion.** Reject parametrize stacks whose growth is the product of two or more axes' cardinalities without a per-cell rationale. Crossing axes is allowed only when each cell maps to a distinct code path the author can name; otherwise the stack is a performance sweep, not a UT.
-
-## AC text does not bind the merged suite
-
-Issue acceptance criteria may mandate exhaustive matrices (e.g. full dtype × shape combinations) so a developer agent cannot claim "done" by hitting a lucky subset. That role ends at approval. The suite checked into `main` follows the policy above, not the AC text — "AC-N required this matrix" is not a defense against the checks above.
-
-If any new case fails a check, request changes naming the node IDs to drop or fold, and wait for a triage commit before approving. Never delete the last guarding case for a critical path (tile boundary, vectorization alignment, degenerate dim, dispatch branch).

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -95,18 +95,6 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 - **Growth on existing files**: include script output and a one-line justification in PR description.
 - **New test files only**: no delta to report — follow the policy above.
 
-### Test triage before merge
-
-Issue acceptance criteria may demand exhaustive matrices (e.g. full dtype × shape combinations) to keep developer agents honest. That role ends at approval — the suite checked into `main` follows [Test case policy](#test-case-policy), not the AC text.
-
-Before approving a PR that adds or modifies tests, the reviewer triages each new/changed case:
-
-- **keep** — guards a distinct code path or dtype per [Test case policy](#test-case-policy).
-- **shrink** — Cartesian expansion to fold to "boundary + one representative interior point".
-- **delete** — same-failure-mode duplicate of a kept case.
-
-If anything is `shrink` or `delete`, request changes naming the node IDs and wait for a triage commit before approving. Never delete the last guarding case for a critical path (tile boundary, vectorization alignment, degenerate dim, dispatch branch).
-
 ### Testing layers
 
 | Layer             | Responsibility                                      | Shape source                                             |

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -95,6 +95,25 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 - **Growth on existing files**: include script output and a one-line justification in PR description.
 - **New test files only**: no delta to report — follow the policy above.
 
+### Test triage before merge
+
+Issue acceptance criteria (AC) are written for the **development phase**: they may demand exhaustive coverage (full dtype × shape × layout matrices) so that a developer agent cannot claim "done" by hitting a lucky subset. That trust-model role ends at approval — the suite checked into `main` must follow [Test case policy](#test-case-policy), not the AC text.
+
+**Reviewer is the gate.** Before giving approval on a PR that adds or modifies tests, the reviewer must triage the new/changed cases and classify each one:
+
+- **keep** — covers a distinct code path or dtype per [Test case policy](#test-case-policy).
+- **shrink** — combinatorial expansion (e.g. shapes × dtypes Cartesian product) that should be folded to "boundary + one representative interior point". The reviewer cites the specific cases to drop.
+- **delete** — same-failure-mode redundancy with an already-kept case. The reviewer cites the kept case it duplicates.
+
+**Outcome:**
+
+- If all new cases are `keep` → approve.
+- Otherwise → request changes, list the `shrink` / `delete` items by node ID, and let the developer push a triage commit. Do not approve until triage lands.
+
+**Why a separate step:** the AC and the merged suite serve different consumers (reward-hacking defense vs. long-term CI health). Forcing them to be the same set either weakens AC (developer cherry-picks) or bloats CI (every PR drags its full proof matrix forward). Triage at the review gate is what reconciles them.
+
+**Critical-path floor:** triage must not delete the last guarding case for a code path identified in [Test case policy](#test-case-policy) (tile boundary, vectorization alignment, degenerate dim, dispatch branch). When in doubt, keep one.
+
 ### Testing layers
 
 | Layer             | Responsibility                                      | Shape source                                             |

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -97,22 +97,15 @@ python scripts/test_node_delta.py --base origin/release   # different base branc
 
 ### Test triage before merge
 
-Issue acceptance criteria (AC) are written for the **development phase**: they may demand exhaustive coverage (full dtype × shape × layout matrices) so that a developer agent cannot claim "done" by hitting a lucky subset. That trust-model role ends at approval — the suite checked into `main` must follow [Test case policy](#test-case-policy), not the AC text.
+Issue acceptance criteria may demand exhaustive matrices (e.g. full dtype × shape combinations) to keep developer agents honest. That role ends at approval — the suite checked into `main` follows [Test case policy](#test-case-policy), not the AC text.
 
-**Reviewer is the gate.** Before giving approval on a PR that adds or modifies tests, the reviewer must triage the new/changed cases and classify each one:
+Before approving a PR that adds or modifies tests, the reviewer triages each new/changed case:
 
-- **keep** — covers a distinct code path or dtype per [Test case policy](#test-case-policy).
-- **shrink** — combinatorial expansion (e.g. shapes × dtypes Cartesian product) that should be folded to "boundary + one representative interior point". The reviewer cites the specific cases to drop.
-- **delete** — same-failure-mode redundancy with an already-kept case. The reviewer cites the kept case it duplicates.
+- **keep** — guards a distinct code path or dtype per [Test case policy](#test-case-policy).
+- **shrink** — Cartesian expansion to fold to "boundary + one representative interior point".
+- **delete** — same-failure-mode duplicate of a kept case.
 
-**Outcome:**
-
-- If all new cases are `keep` → approve.
-- Otherwise → request changes, list the `shrink` / `delete` items by node ID, and let the developer push a triage commit. Do not approve until triage lands.
-
-**Why a separate step:** the AC and the merged suite serve different consumers (reward-hacking defense vs. long-term CI health). Forcing them to be the same set either weakens AC (developer cherry-picks) or bloats CI (every PR drags its full proof matrix forward). Triage at the review gate is what reconciles them.
-
-**Critical-path floor:** triage must not delete the last guarding case for a code path identified in [Test case policy](#test-case-policy) (tile boundary, vectorization alignment, degenerate dim, dispatch branch). When in doubt, keep one.
+If anything is `shrink` or `delete`, request changes naming the node IDs and wait for a triage commit before approving. Never delete the last guarding case for a critical path (tile boundary, vectorization alignment, degenerate dim, dispatch branch).
 
 ### Testing layers
 


### PR DESCRIPTION
## Summary

- Add `.claude/review-checklists/approval-gate.md` — action checklist run before approving any PR that adds or modifies tests; classifies new cases as keep / shrink / delete and gates approval on a triage commit.
- Add `.claude/review-checklists/pre-review.md` — common meta-rules (open-set / concrete-and-decidable / reviewer-restraint) loaded before any specific checklist.
- Strip the duplicated meta-rules from `manifest.md`, `doc.md`, and `testing.md`; each per-domain file now carries only its trigger, domain-specific caveats, and the checklist itself.

## Test plan

- [x] pre-commit passed