### PR TITLE
[Feat][Ops] align where/clamp/masked_fill multi-input ops with PyTorch API

### DIFF
--- a/benchmarks/ops/bench_binary_arith.py
+++ b/benchmarks/ops/bench_binary_arith.py
@@ -359,7 +359,7 @@ def test_r4_where_bench(
     bm = WhereBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = WhereFwdOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(condition=(n_total,), input=(n_total,), other=(n_total,), dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_where",

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -14,11 +14,11 @@ import torch.nn.functional as F
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.elementwise import (
     AlibiFwdOp,
-    ClampFwdOp,
+    ClampScalarFwdOp,
     EluFwdOp,
     HardtanhFwdOp,
     LeakyReluFwdOp,
-    MaskedFillFwdOp,
+    MaskedFillScalarFwdOp,
     NanToNumFwdOp,
     PreluFwdOp,
     SinusoidalFwdOp,
@@ -78,7 +78,7 @@ _UNARY_OPS = {
     "elu": (EluFwdOp, lambda x: F.elu(x, 1.0), {}),
     "hardtanh": (HardtanhFwdOp, lambda x: F.hardtanh(x, -1.0, 1.0), {"min_val": -1.0, "max_val": 1.0}),
     "softplus": (SoftplusFwdOp, lambda x: F.softplus(x, 1.0, 20.0), {}),
-    "clamp": (ClampFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
+    "clamp": (ClampScalarFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min": -0.5, "max": 0.5}),
     "nan_to_num": (NanToNumFwdOp, lambda x: torch.nan_to_num(x, 0.0, 1e4, -1e4), {}),
 }
 
@@ -91,7 +91,10 @@ def test_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dtype)
     bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
+    if op_cls.__name__ == "ClampScalarFwdOp":
+        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+    else:
+        op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op_name, locals(), result, tag="tileops")
 
@@ -204,7 +207,7 @@ def test_where_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = WhereBenchmark(test)
     cond, x, y = test.gen_inputs()
 
-    op = WhereFwdOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(condition=tuple(shape), input=tuple(shape), other=tuple(shape), dtype=dtype)
     result = bm.profile(op, cond, x, y)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -248,7 +251,7 @@ def test_masked_fill_bench(shape: tuple, dtype: torch.dtype) -> None:
     bm = MaskedFillBenchmark(test)
     x, mask = test.gen_inputs()
 
-    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=-65000.0)
+    op = MaskedFillScalarFwdOp(input=tuple(shape), mask=tuple(shape), value=-65000.0, dtype=dtype)
     result = bm.profile(op, x, mask)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -376,7 +379,7 @@ class Fp8UnaryBenchmark(BenchmarkBase[Fp8UnaryBenchCase]):
 _FP8_UNARY_OPS = {
     "leaky_relu": (LeakyReluFwdOp, lambda x: F.leaky_relu(x, 0.01), {}),
     "elu": (EluFwdOp, lambda x: F.elu(x, 1.0), {}),
-    "clamp": (ClampFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min_val": -0.5, "max_val": 0.5}),
+    "clamp": (ClampScalarFwdOp, lambda x: torch.clamp(x, -0.5, 0.5), {"min": -0.5, "max": 0.5}),
 }
 
 
@@ -408,7 +411,10 @@ def test_fp8_unary_independent_bench(
     bm = Fp8UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
+    if op_cls.__name__ == "ClampScalarFwdOp":
+        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+    else:
+        op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(f"{op_name}_fp8", locals(), result, tag="tileops")
 
@@ -503,7 +509,7 @@ def test_fp8_selection_bench(
         bm = Fp8WhereBenchmark(test)
         cond, x, y = test.gen_inputs()
 
-        op = WhereFwdOp(N_total=n_total, dtype=dtype)
+        op = WhereFwdOp(condition=tuple(shape), input=tuple(shape), other=tuple(shape), dtype=dtype)
         result = bm.profile(op, cond, x, y)
         BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -518,7 +524,7 @@ def test_fp8_selection_bench(
         bm = Fp8MaskedFillBenchmark(test)
         x, mask = test.gen_inputs()
 
-        op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=-100.0)
+        op = MaskedFillScalarFwdOp(input=tuple(shape), mask=tuple(shape), value=-100.0, dtype=dtype)
         result = bm.profile(op, x, mask)
         BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -647,12 +647,11 @@ def test_where_compile_broadcast():
 def test_clamp_scalar_compile():
     """Compile-smoke for ClampScalarFwdOp (Number min/max baked into __init__)."""
     shape = (1024, 1024)
-    n_total = shape[0] * shape[1]
     x = torch.randn(shape, dtype=_DTYPE, device="cuda")
     op = ClampScalarFwdOp(input=shape, min=-0.5, max=0.5, dtype=_DTYPE)
     compiled_op = torch.compile(op, fullgraph=True)
-    out = compiled_op(x.reshape(n_total))
-    ref = torch.clamp(x.float(), min=-0.5, max=0.5).to(_DTYPE).reshape(n_total)
+    out = compiled_op(x)
+    ref = torch.clamp(x.float(), min=-0.5, max=0.5).to(_DTYPE)
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -21,6 +21,10 @@ from tileops.ops.elementwise import (
     BitwiseOrFwdOp,
     BitwiseXorFwdOp,
     CeilFwdOp,
+    ClampFwdOp,
+    ClampMaxFwdOp,
+    ClampMinFwdOp,
+    ClampScalarFwdOp,
     CosFwdOp,
     DivFwdOp,
     EqFwdOp,
@@ -47,6 +51,8 @@ from tileops.ops.elementwise import (
     LogicalNotFwdOp,
     LogicalOrFwdOp,
     LtFwdOp,
+    MaskedFillFwdOp,
+    MaskedFillScalarFwdOp,
     MaximumFwdOp,
     MinimumFwdOp,
     MishFwdOp,
@@ -632,6 +638,192 @@ def test_where_compile_broadcast():
     out = compiled_op(cond, x, y)
     ref = torch.where(cond, x, y)
     assert out.shape == ref.shape == (4, 8)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+# --- ClampScalarFwdOp (input -> out, scalar min/max baked) ---
+
+@pytest.mark.full
+def test_clamp_scalar_compile():
+    """Compile-smoke for ClampScalarFwdOp (Number min/max baked into __init__)."""
+    shape = (1024, 1024)
+    n_total = shape[0] * shape[1]
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    op = ClampScalarFwdOp(input=shape, min=-0.5, max=0.5, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x.reshape(n_total))
+    ref = torch.clamp(x.float(), min=-0.5, max=0.5).to(_DTYPE).reshape(n_total)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+# --- Tensor-bound ClampFwdOp (input, min?, max? -> out) ---
+
+@pytest.mark.full
+def test_clamp_tensor_compile_same_shape():
+    """Compile-smoke for ClampFwdOp with both Tensor bounds at same shape.
+
+    Regression: ensures ClampFwdOp registers a custom_op so
+    torch.compile(fullgraph=True) does not fail with
+    "torch.* op returned non-Tensor".
+    """
+    shape = (16, 16)
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    lo = torch.full(shape, -0.5, dtype=_DTYPE, device="cuda")
+    hi = torch.full(shape, 0.5, dtype=_DTYPE, device="cuda")
+    op = ClampFwdOp(input=shape, min=shape, max=shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, lo, hi)
+    ref = torch.clamp(x.float(), lo.float(), hi.float()).to(_DTYPE)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_clamp_tensor_compile_broadcast():
+    """Compile-smoke for ClampFwdOp with broadcasting Tensor bounds."""
+    input_shape = (4, 8)
+    min_shape = (1, 8)
+    max_shape = (4, 1)
+    x = torch.randn(input_shape, dtype=_DTYPE, device="cuda")
+    lo = torch.full(min_shape, -0.5, dtype=_DTYPE, device="cuda")
+    hi = torch.full(max_shape, 0.5, dtype=_DTYPE, device="cuda")
+    op = ClampFwdOp(input=input_shape, min=min_shape, max=max_shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, lo, hi)
+    ref = torch.clamp(x.float(), lo.float(), hi.float()).to(_DTYPE)
+    assert out.shape == ref.shape == input_shape
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+# --- Single-bound Tensor clamp variants ---
+
+@pytest.mark.full
+def test_clamp_min_compile_same_shape():
+    """Compile-smoke for ClampMinFwdOp at same shape."""
+    shape = (16, 16)
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    lo = torch.full(shape, -0.5, dtype=_DTYPE, device="cuda")
+    op = ClampMinFwdOp(input=shape, min=shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, lo)
+    ref = torch.clamp(x.float(), min=lo.float()).to(_DTYPE)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_clamp_min_compile_broadcast():
+    """Compile-smoke for ClampMinFwdOp with broadcasting min."""
+    input_shape = (4, 8)
+    min_shape = (1, 8)
+    x = torch.randn(input_shape, dtype=_DTYPE, device="cuda")
+    lo = torch.full(min_shape, -0.5, dtype=_DTYPE, device="cuda")
+    op = ClampMinFwdOp(input=input_shape, min=min_shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, lo)
+    ref = torch.clamp(x.float(), min=lo.float()).to(_DTYPE)
+    assert out.shape == ref.shape == input_shape
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_clamp_max_compile_same_shape():
+    """Compile-smoke for ClampMaxFwdOp at same shape."""
+    shape = (16, 16)
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    hi = torch.full(shape, 0.5, dtype=_DTYPE, device="cuda")
+    op = ClampMaxFwdOp(input=shape, max=shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, hi)
+    ref = torch.clamp(x.float(), max=hi.float()).to(_DTYPE)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_clamp_max_compile_broadcast():
+    """Compile-smoke for ClampMaxFwdOp with broadcasting max."""
+    input_shape = (4, 8)
+    max_shape = (4, 1)
+    x = torch.randn(input_shape, dtype=_DTYPE, device="cuda")
+    hi = torch.full(max_shape, 0.5, dtype=_DTYPE, device="cuda")
+    op = ClampMaxFwdOp(input=input_shape, max=max_shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, hi)
+    ref = torch.clamp(x.float(), max=hi.float()).to(_DTYPE)
+    assert out.shape == ref.shape == input_shape
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+# --- MaskedFillFwdOp (Tensor value) ---
+
+@pytest.mark.full
+def test_masked_fill_tensor_compile_same_shape():
+    """Compile-smoke for MaskedFillFwdOp (0-dim Tensor value) at same shape.
+
+    Regression: ensures MaskedFillFwdOp registers a custom_op so
+    torch.compile(fullgraph=True) does not fail with
+    "torch.* op returned non-Tensor".
+    """
+    shape = (16, 16)
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    mask = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    value = torch.tensor(-1.0, dtype=_DTYPE, device="cuda")
+    op = MaskedFillFwdOp(input=shape, mask=shape, value=(), dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, mask, value)
+    ref = torch.where(mask, value.expand(shape), x)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_masked_fill_tensor_compile_broadcast():
+    """Compile-smoke for MaskedFillFwdOp with broadcasting input/mask."""
+    input_shape = (4, 8)
+    mask_shape = (1, 8)
+    x = torch.randn(input_shape, dtype=_DTYPE, device="cuda")
+    mask = torch.randint(0, 2, mask_shape, dtype=torch.bool, device="cuda")
+    value = torch.tensor(-1.0, dtype=_DTYPE, device="cuda")
+    op = MaskedFillFwdOp(input=input_shape, mask=mask_shape, value=(), dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, mask, value)
+    ref = torch.where(
+        mask.expand(input_shape), value.expand(input_shape), x,
+    )
+    assert out.shape == ref.shape == input_shape
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+# --- MaskedFillScalarFwdOp (broadcast path now uses custom_op) ---
+
+@pytest.mark.full
+def test_masked_fill_scalar_compile_same_shape():
+    """Compile-smoke for MaskedFillScalarFwdOp at same shape."""
+    shape = (16, 16)
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    mask = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    op = MaskedFillScalarFwdOp(input=shape, mask=shape, value=-1.0, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, mask)
+    ref = x.masked_fill(mask, -1.0)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_masked_fill_scalar_compile_broadcast():
+    """Compile-smoke for MaskedFillScalarFwdOp with broadcasting input/mask.
+
+    Regression for the removed ``not self._needs_broadcast`` guard:
+    register_fake is now broadcast-aware so the custom_op path works.
+    """
+    input_shape = (4, 8)
+    mask_shape = (1, 8)
+    x = torch.randn(input_shape, dtype=_DTYPE, device="cuda")
+    mask = torch.randint(0, 2, mask_shape, dtype=torch.bool, device="cuda")
+    op = MaskedFillScalarFwdOp(
+        input=input_shape, mask=mask_shape, value=-1.0, dtype=_DTYPE,
+    )
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(x, mask)
+    ref = x.masked_fill(mask.expand(input_shape), -1.0)
+    assert out.shape == ref.shape == input_shape
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -69,6 +69,7 @@ from tileops.ops.elementwise import (
     SubFwdOp,
     TanhFwdOp,
     TruncFwdOp,
+    WhereFwdOp,
 )
 
 
@@ -593,6 +594,45 @@ def test_fused_gated_compile(op_cls, name):
     out = compiled_op(x)
     assert out.shape == (M, N)
     assert out.dtype == _DTYPE
+
+
+# --- Where op (cond, x, y -> out): same-shape and broadcasting ---
+
+@pytest.mark.full
+def test_where_compile_same_shape():
+    """Compile-smoke for WhereFwdOp with all three inputs same-shape.
+
+    Regression: ensures WhereFwdOp registers a custom_op so
+    torch.compile(fullgraph=True) does not fail with
+    "torch.* op returned non-Tensor".
+    """
+    shape = (16,)
+    cond = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    x = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    y = torch.randn(shape, dtype=_DTYPE, device="cuda")
+    op = WhereFwdOp(condition=shape, input=shape, other=shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(cond, x, y)
+    ref = torch.where(cond, x, y)
+    assert out.shape == ref.shape
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.full
+def test_where_compile_broadcast():
+    """Compile-smoke for WhereFwdOp with broadcasting inputs."""
+    cond_shape = (4, 1)
+    x_shape = (1, 8)
+    y_shape = (1,)
+    cond = torch.randint(0, 2, cond_shape, dtype=torch.bool, device="cuda")
+    x = torch.randn(x_shape, dtype=_DTYPE, device="cuda")
+    y = torch.randn(y_shape, dtype=_DTYPE, device="cuda")
+    op = WhereFwdOp(condition=cond_shape, input=x_shape, other=y_shape, dtype=_DTYPE)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(cond, x, y)
+    ref = torch.where(cond, x, y)
+    assert out.shape == ref.shape == (4, 8)
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -159,14 +159,14 @@ def test_elu_fp8_correctness(dtype):
 @Fp8DtypeFixture
 def test_clamp_fp8_correctness(dtype):
     """Clamp correctness with fp8 input/output."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     n = _N
     min_val = -0.5
     max_val = 0.5
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
+    op = ClampScalarFwdOp(input=(n,), min=min_val, max=max_val, dtype=dtype)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), min_val, max_val).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -201,14 +201,14 @@ def test_sinusoidal_fp8_output_dtype(dtype):
 @Fp8DtypeFixture
 def test_masked_fill_fp8_correctness(dtype):
     """MaskedFill correctness with fp8, including e5m2 post-cast path."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
 
     n = _N
     fill_value = -1.0
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
     mask = torch.rand(n, device="cuda") > 0.5
-    op = MaskedFillFwdOp(N_total=n, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillScalarFwdOp(input=(n,), mask=(n,), value=fill_value, dtype=dtype)
     out = op(x, mask)
     ref = x.to(torch.float16).masked_fill(mask, fill_value).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"
@@ -246,13 +246,13 @@ def test_leaky_relu_e4m3fn_saturation():
 @pytest.mark.smoke
 def test_clamp_e5m2_preserves_values():
     """Clamp e5m2 preserves values within range correctly."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 0.5
     x = x_fp16.to(dtype)
-    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=-1.0, max_val=1.0)
+    op = ClampScalarFwdOp(input=(n,), min=-1.0, max=1.0, dtype=dtype)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), -1.0, 1.0).to(dtype)
     assert out.dtype == dtype
@@ -275,13 +275,13 @@ def test_elu_e5m2_output_dtype():
 @pytest.mark.smoke
 def test_masked_fill_e5m2_overflow_fill_value():
     """MaskedFill rejects fill_value that exceeds effective kernel dtype range."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
 
     n = 1024
     dtype = torch.float8_e5m2
     fill_value = 1e5
-    with pytest.raises(ValueError, match="fill_value=.*not representable"):
-        MaskedFillFwdOp(N_total=n, dtype=dtype, fill_value=fill_value)
+    with pytest.raises(ValueError, match="value=.*not representable"):
+        MaskedFillScalarFwdOp(input=(n,), mask=(n,), value=fill_value, dtype=dtype)
 
 
 @pytest.mark.smoke
@@ -360,14 +360,14 @@ def test_elu_fp8_unaligned_n(dtype):
 @UnalignedFp8Fixture
 def test_clamp_fp8_unaligned_n(dtype):
     """Clamp fp8 correctness with non-aligned N (tail block guard)."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     n = _N_UNALIGNED
     min_val = -0.5
     max_val = 0.5
     x_fp16 = torch.randn(n, dtype=torch.float16, device="cuda") * 2.0
     x = x_fp16.to(dtype)
-    op = ClampFwdOp(N_total=n, dtype=dtype, min_val=min_val, max_val=max_val)
+    op = ClampScalarFwdOp(input=(n,), min=min_val, max=max_val, dtype=dtype)
     out = op(x)
     ref = torch.clamp(x.to(torch.float16), min_val, max_val).to(dtype)
     assert out.dtype == dtype, f"Expected {dtype}, got {out.dtype}"

--- a/tests/ops/test_special_elementwise.py
+++ b/tests/ops/test_special_elementwise.py
@@ -496,16 +496,18 @@ def test_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
     pytest.param("EluFwdOp", {"alpha": 1.0}, id="elu"),
     pytest.param("HardtanhFwdOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
     pytest.param("SoftplusFwdOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
-    pytest.param("ClampScalarFwdOp", {"min": -0.5, "max": 0.5}, id="clamp"),
 ])
 def test_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
-    """forward() must raise ValueError when input numel mismatches."""
+    """forward() must raise ValueError when input numel mismatches.
+
+    ClampScalarFwdOp validates the full input.shape (not just numel), so
+    its mismatch case is covered by
+    test_clamp_scalar_rejects_same_numel_wrong_shape in
+    tests/ops/test_special_elementwise_conformance.py.
+    """
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
-    if cls.__name__ == "ClampScalarFwdOp":
-        op = cls(input=(1024,), dtype=torch.float16, **kwargs)
-    else:
-        op = cls(N_total=1024, dtype=torch.float16, **kwargs)
+    op = cls(N_total=1024, dtype=torch.float16, **kwargs)
     x = torch.randn(512, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="elements"):
         op(x)

--- a/tests/ops/test_special_elementwise.py
+++ b/tests/ops/test_special_elementwise.py
@@ -156,7 +156,7 @@ def test_where(n_total: int, dtype: torch.dtype) -> None:
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereFwdOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(condition=(n_total,), input=(n_total,), other=(n_total,), dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
     print("All checks passed for WhereFwdOp.")
@@ -166,11 +166,11 @@ def test_where(n_total: int, dtype: torch.dtype) -> None:
 
 @IndependentFixture
 def test_clamp(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, -0.5, 0.5)
-    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
+    op = ClampScalarFwdOp(input=(n_total,), min=-0.5, max=0.5, dtype=dtype)
     out = op(x)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -186,14 +186,14 @@ def test_clamp(n_total: int, dtype: torch.dtype) -> None:
 
 @IndependentFixture
 def test_masked_fill(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import MaskedFillFwdOp
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.randint(0, 2, (n_total,), device="cuda").bool()
     # Use -100.0 to avoid fp16 overflow (fp16 max ~65504)
     fill_value = -100.0
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillScalarFwdOp(input=(n_total,), mask=(n_total,), value=fill_value, dtype=dtype)
     out = op(x, mask)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -315,11 +315,11 @@ class ClampDtypeSizeFixture(FixtureBase):
 
 @ClampDtypeSizeFixture
 def test_clamp_dtype_size(n_total: int, dtype: torch.dtype) -> None:
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, -0.5, 0.5)
-    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=0.5)
+    op = ClampScalarFwdOp(input=(n_total,), min=-0.5, max=0.5, dtype=dtype)
     out = op(x)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
@@ -339,12 +339,12 @@ def test_clamp_dtype_size(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_clamp_min_gt_max(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min > max -- PyTorch clamp semantics: min wins (output = min_val)."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     # When min > max, PyTorch clamp returns min_val for all elements
     ref = torch.clamp(x, min=0.5, max=-0.5)
-    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=0.5, max_val=-0.5)
+    op = ClampScalarFwdOp(input=(n_total,), min=0.5, max=-0.5, dtype=dtype)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
     print("All checks passed for ClampFwdOp min>max edge case.")
@@ -353,11 +353,11 @@ def test_clamp_min_gt_max(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_clamp_upper_only(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min=None, max=0.5 (upper bound only)."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, min=None, max=0.5)
-    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=None, max_val=0.5)
+    op = ClampScalarFwdOp(input=(n_total,), min=None, max=0.5, dtype=dtype)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
     print("All checks passed for ClampFwdOp upper-only edge case.")
@@ -366,11 +366,11 @@ def test_clamp_upper_only(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_clamp_lower_only(n_total: int, dtype: torch.dtype) -> None:
     """Edge: min=-0.5, max=None (lower bound only)."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.clamp(x, min=-0.5, max=None)
-    op = ClampFwdOp(N_total=n_total, dtype=dtype, min_val=-0.5, max_val=None)
+    op = ClampScalarFwdOp(input=(n_total,), min=-0.5, max=None, dtype=dtype)
     out = op(x)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
     print("All checks passed for ClampFwdOp lower-only edge case.")
@@ -379,13 +379,13 @@ def test_clamp_lower_only(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_masked_fill_all_true(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all True mask -> all values replaced."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.ones(n_total, device="cuda", dtype=torch.bool)
     fill_value = -1e9
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillScalarFwdOp(input=(n_total,), mask=(n_total,), value=fill_value, dtype=dtype)
     out = op(x, mask)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
     print("All checks passed for MaskedFillFwdOp all-true edge case.")
@@ -394,13 +394,13 @@ def test_masked_fill_all_true(n_total: int, dtype: torch.dtype) -> None:
 @IndependentEdgeFixture
 def test_masked_fill_all_false(n_total: int, dtype: torch.dtype) -> None:
     """Edge: all False mask -> input unchanged."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
 
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     mask = torch.zeros(n_total, device="cuda", dtype=torch.bool)
     fill_value = -1e9
     ref = x.masked_fill(mask, fill_value)
-    op = MaskedFillFwdOp(N_total=n_total, dtype=dtype, fill_value=fill_value)
+    op = MaskedFillScalarFwdOp(input=(n_total,), mask=(n_total,), value=fill_value, dtype=dtype)
     out = op(x, mask)
     torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
     print("All checks passed for MaskedFillFwdOp all-false edge case.")
@@ -415,7 +415,7 @@ def test_where_all_true(n_total: int, dtype: torch.dtype) -> None:
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereFwdOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(condition=(n_total,), input=(n_total,), other=(n_total,), dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
     print("All checks passed for WhereFwdOp all-true edge case.")
@@ -430,7 +430,7 @@ def test_where_all_false(n_total: int, dtype: torch.dtype) -> None:
     x = torch.randn(n_total, device="cuda", dtype=dtype)
     y = torch.randn(n_total, device="cuda", dtype=dtype)
     ref = torch.where(cond, x, y)
-    op = WhereFwdOp(N_total=n_total, dtype=dtype)
+    op = WhereFwdOp(condition=(n_total,), input=(n_total,), other=(n_total,), dtype=dtype)
     out = op(cond, x, y)
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
     print("All checks passed for WhereFwdOp all-false edge case.")
@@ -476,13 +476,16 @@ def test_independent_special_rejects_non_float_dtype() -> None:
     pytest.param("EluFwdOp", {"alpha": 1.0}, id="elu"),
     pytest.param("HardtanhFwdOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
     pytest.param("SoftplusFwdOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
-    pytest.param("ClampFwdOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
+    pytest.param("ClampScalarFwdOp", {"min": -0.5, "max": 0.5}, id="clamp"),
 ])
 def test_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
     """forward() must raise ValueError when input dtype mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
-    op = cls(N_total=1024, dtype=torch.float16, **kwargs)
+    if cls.__name__ == "ClampScalarFwdOp":
+        op = cls(input=(1024,), dtype=torch.float16, **kwargs)
+    else:
+        op = cls(N_total=1024, dtype=torch.float16, **kwargs)
     x = torch.randn(1024, device="cuda", dtype=torch.float32)
     with pytest.raises(ValueError, match="dtype"):
         op(x)
@@ -493,13 +496,16 @@ def test_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
     pytest.param("EluFwdOp", {"alpha": 1.0}, id="elu"),
     pytest.param("HardtanhFwdOp", {"min_val": -1.0, "max_val": 1.0}, id="hardtanh"),
     pytest.param("SoftplusFwdOp", {"beta": 1.0, "threshold": 20.0}, id="softplus"),
-    pytest.param("ClampFwdOp", {"min_val": -0.5, "max_val": 0.5}, id="clamp"),
+    pytest.param("ClampScalarFwdOp", {"min": -0.5, "max": 0.5}, id="clamp"),
 ])
 def test_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
     """forward() must raise ValueError when input numel mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
-    op = cls(N_total=1024, dtype=torch.float16, **kwargs)
+    if cls.__name__ == "ClampScalarFwdOp":
+        op = cls(input=(1024,), dtype=torch.float16, **kwargs)
+    else:
+        op = cls(N_total=1024, dtype=torch.float16, **kwargs)
     x = torch.randn(512, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="elements"):
         op(x)
@@ -507,13 +513,13 @@ def test_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("MaskedFillFwdOp", {"fill_value": -100.0}, id="masked_fill"),
+    pytest.param("MaskedFillScalarFwdOp", {"value": -100.0}, id="masked_fill"),
 ])
 def test_masked_fill_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> None:
     """MaskedFillFwdOp forward() must raise ValueError when input dtype mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
-    op = cls(N_total=1024, dtype=torch.float16, **kwargs)
+    op = cls(input=(1024,), mask=(1024,), dtype=torch.float16, **kwargs)
     x = torch.randn(1024, device="cuda", dtype=torch.float32)
     mask = torch.ones(1024, device="cuda", dtype=torch.bool)
     with pytest.raises(ValueError, match="dtype"):
@@ -522,16 +528,16 @@ def test_masked_fill_forward_rejects_wrong_dtype(op_cls: str, kwargs: dict) -> N
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("op_cls, kwargs", [
-    pytest.param("MaskedFillFwdOp", {"fill_value": -100.0}, id="masked_fill"),
+    pytest.param("MaskedFillScalarFwdOp", {"value": -100.0}, id="masked_fill"),
 ])
 def test_masked_fill_forward_rejects_wrong_numel(op_cls: str, kwargs: dict) -> None:
-    """MaskedFillFwdOp forward() must raise ValueError when input numel mismatches."""
+    """MaskedFillFwdOp forward() must raise ValueError when input shape mismatches."""
     import tileops.ops.elementwise as mod
     cls = getattr(mod, op_cls)
-    op = cls(N_total=1024, dtype=torch.float16, **kwargs)
+    op = cls(input=(1024,), mask=(1024,), dtype=torch.float16, **kwargs)
     x = torch.randn(512, device="cuda", dtype=torch.float16)
     mask = torch.ones(512, device="cuda", dtype=torch.bool)
-    with pytest.raises(ValueError, match="elements"):
+    with pytest.raises(ValueError, match="input.shape"):
         op(x, mask)
 
 
@@ -583,24 +589,24 @@ def test_softplus_rejects_unrepresentable_threshold() -> None:
 @pytest.mark.smoke
 def test_clamp_rejects_unrepresentable_min_val() -> None:
     """ClampFwdOp must reject min_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
     with pytest.raises((ValueError, TypeError)):
-        ClampFwdOp(N_total=1024, dtype=torch.float16, min_val=1e6)
+        ClampScalarFwdOp(input=(1024,), min=1e6, dtype=torch.float16)
 
 
 @pytest.mark.smoke
 def test_clamp_rejects_unrepresentable_max_val() -> None:
     """ClampFwdOp must reject max_val that overflows the kernel dtype."""
-    from tileops.ops.elementwise import ClampFwdOp
+    from tileops.ops.elementwise import ClampScalarFwdOp
     with pytest.raises((ValueError, TypeError)):
-        ClampFwdOp(N_total=1024, dtype=torch.float16, max_val=1e6)
+        ClampScalarFwdOp(input=(1024,), max=1e6, dtype=torch.float16)
 
 
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_cpu_mask() -> None:
     """MaskedFillFwdOp forward() must raise ValueError when mask is not on CUDA."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
-    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+    op = MaskedFillScalarFwdOp(input=(1024,), mask=(1024,), value=-100.0, dtype=torch.float16)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
     mask = torch.ones(1024, dtype=torch.bool)  # CPU mask
     with pytest.raises(ValueError, match="Mask must be a CUDA tensor"):
@@ -610,8 +616,8 @@ def test_masked_fill_forward_rejects_cpu_mask() -> None:
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_non_bool_mask() -> None:
     """MaskedFillFwdOp forward() must raise ValueError when mask dtype is not bool."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
-    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+    op = MaskedFillScalarFwdOp(input=(1024,), mask=(1024,), value=-100.0, dtype=torch.float16)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
     mask = torch.ones(1024, device="cuda", dtype=torch.float32)  # wrong dtype
     with pytest.raises(ValueError, match="mask.dtype"):
@@ -621,11 +627,11 @@ def test_masked_fill_forward_rejects_non_bool_mask() -> None:
 @pytest.mark.smoke
 def test_masked_fill_forward_rejects_wrong_mask_numel() -> None:
     """MaskedFillFwdOp forward() must raise ValueError when mask numel mismatches."""
-    from tileops.ops.elementwise import MaskedFillFwdOp
-    op = MaskedFillFwdOp(N_total=1024, dtype=torch.float16, fill_value=-100.0)
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+    op = MaskedFillScalarFwdOp(input=(1024,), mask=(1024,), value=-100.0, dtype=torch.float16)
     x = torch.randn(1024, device="cuda", dtype=torch.float16)
-    mask = torch.ones(512, device="cuda", dtype=torch.bool)  # wrong numel
-    with pytest.raises(ValueError, match="elements"):
+    mask = torch.ones(512, device="cuda", dtype=torch.bool)  # wrong shape
+    with pytest.raises(ValueError, match="mask.shape"):
         op(x, mask)
 
 

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -315,6 +315,91 @@ def test_clamp_max_init_signature_pytorch_aligned():
 
 
 # ---------------------------------------------------------------------------
+# Regression: NaN propagation for Tensor-bound clamp variants.
+#
+# torch.clamp / torch.clamp_min / torch.clamp_max propagate NaN: if any of
+# input / min / max is NaN at position i, the output at i is NaN. CUDA's
+# fmax / fmin (used by T.max / T.min) drop NaN by returning the non-NaN
+# operand, so the kernel adds explicit isnan guards. These tests pin the
+# semantics so a future refactor cannot regress to non-IEEE behaviour.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_clamp_tensor_nan_propagation(dtype):
+    """ClampFwdOp must match torch.clamp NaN semantics (Tensor min + max)."""
+    from tileops.ops.elementwise import ClampFwdOp
+
+    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=dtype)
+    mn = torch.tensor([-1.0, -1.0, float("nan"), -1.0], device="cuda", dtype=dtype)
+    mx = torch.tensor([1.0, 1.0, 1.0, float("nan")], device="cuda", dtype=dtype)
+
+    ref = torch.clamp(x, mn, mx)
+    op = ClampFwdOp(input=(4,), min=(4,), max=(4,), dtype=dtype)
+    out = op(x, mn, mx)
+    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+def test_clamp_tensor_min_only_nan_propagation():
+    """ClampFwdOp(min=Tensor, max=None) must propagate NaN like torch.clamp."""
+    from tileops.ops.elementwise import ClampFwdOp
+
+    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=torch.float32)
+    mn = torch.tensor([-1.0, -1.0, float("nan"), -1.0], device="cuda", dtype=torch.float32)
+
+    ref = torch.clamp(x, mn, None)
+    op = ClampFwdOp(input=(4,), min=(4,), max=None, dtype=torch.float32)
+    out = op(x, mn, None)
+    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+def test_clamp_tensor_max_only_nan_propagation():
+    """ClampFwdOp(min=None, max=Tensor) must propagate NaN like torch.clamp."""
+    from tileops.ops.elementwise import ClampFwdOp
+
+    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=torch.float32)
+    mx = torch.tensor([1.0, 1.0, 1.0, float("nan")], device="cuda", dtype=torch.float32)
+
+    ref = torch.clamp(x, None, mx)
+    op = ClampFwdOp(input=(4,), min=None, max=(4,), dtype=torch.float32)
+    out = op(x, None, mx)
+    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_clamp_min_nan_propagation(dtype):
+    """ClampMinFwdOp must match torch.clamp_min NaN semantics."""
+    from tileops.ops.elementwise import ClampMinFwdOp
+
+    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=dtype)
+    mn = torch.tensor([-1.0, -1.0, float("nan"), -1.0], device="cuda", dtype=dtype)
+
+    ref = torch.clamp_min(x, mn)
+    op = ClampMinFwdOp(input=(4,), min=(4,), dtype=dtype)
+    out = op(x, mn)
+    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_clamp_max_nan_propagation(dtype):
+    """ClampMaxFwdOp must match torch.clamp_max NaN semantics."""
+    from tileops.ops.elementwise import ClampMaxFwdOp
+
+    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=dtype)
+    mx = torch.tensor([1.0, 1.0, 1.0, float("nan")], device="cuda", dtype=dtype)
+
+    ref = torch.clamp_max(x, mx)
+    op = ClampMaxFwdOp(input=(4,), max=(4,), dtype=dtype)
+    out = op(x, mx)
+    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
 # AC-4: MaskedFillFwdOp (0-dim Tensor) / MaskedFillScalarFwdOp (Number)
 # ---------------------------------------------------------------------------
 

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -100,6 +100,122 @@ def test_clamp_init_signature_pytorch_aligned():
     assert fwd_params[1:] == ["input", "min", "max"], fwd_params
 
 
+# AC-2 (mixed): ClampFwdOp must accept Tensor min with max=None and
+# Tensor max with min=None, matching torch.clamp(input, min=tensor, max=None)
+# and torch.clamp(input, min=None, max=tensor) on CUDA.
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, bound_shape, dtype",
+    [
+        ((4, 8), (4, 8), torch.float16),
+        ((4, 8), (1, 8), torch.float32),
+        ((4, 8), (), torch.bfloat16),
+    ],
+)
+def test_clamp_min_only_tensor_parity(input_shape, bound_shape, dtype):
+    from tileops.ops.elementwise import ClampFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mn = torch.randn(bound_shape, device="cuda", dtype=dtype) - 0.5
+    ref = torch.clamp(inp, mn, None)
+    op = ClampFwdOp(input=tuple(inp.shape), min=tuple(mn.shape), max=None, dtype=dtype)
+    out = op(inp, mn, None)
+    if dtype == torch.float16:
+        atol, rtol = 1e-3, 1e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 1.6e-2, 1.6e-2
+    else:
+        atol, rtol = 1e-5, 1e-5
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, bound_shape, dtype",
+    [
+        ((4, 8), (4, 8), torch.float16),
+        ((4, 8), (1, 8), torch.float32),
+        ((4, 8), (), torch.bfloat16),
+    ],
+)
+def test_clamp_max_only_tensor_parity(input_shape, bound_shape, dtype):
+    from tileops.ops.elementwise import ClampFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mx = torch.randn(bound_shape, device="cuda", dtype=dtype) + 0.5
+    ref = torch.clamp(inp, None, mx)
+    op = ClampFwdOp(input=tuple(inp.shape), min=None, max=tuple(mx.shape), dtype=dtype)
+    out = op(inp, None, mx)
+    if dtype == torch.float16:
+        atol, rtol = 1e-3, 1e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 1.6e-2, 1.6e-2
+    else:
+        atol, rtol = 1e-5, 1e-5
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "fp8_dtype",
+    [
+        pytest.param(torch.float8_e4m3fn, id="e4m3fn"),
+        pytest.param(torch.float8_e5m2, id="e5m2"),
+    ],
+)
+@pytest.mark.parametrize(
+    "which", ["min_only", "max_only"],
+)
+def test_clamp_mixed_tensor_none_fp8(which, fp8_dtype):
+    """fp8 routing for mixed Tensor/None bounds (matches both-Tensor case)."""
+    from tileops.ops.elementwise import ClampFwdOp
+
+    n = 256
+    inp_fp16 = torch.randn(n, device="cuda", dtype=torch.float16)
+    bound_fp16 = (torch.randn(n, device="cuda", dtype=torch.float16)
+                  - (0.5 if which == "min_only" else -0.5))
+    inp = inp_fp16.to(fp8_dtype)
+    bound = bound_fp16.to(fp8_dtype)
+    if which == "min_only":
+        op = ClampFwdOp(input=(n,), min=(n,), max=None, dtype=fp8_dtype)
+        out = op(inp, bound, None)
+        ref = torch.clamp(inp.to(torch.float16), bound.to(torch.float16), None).to(fp8_dtype)
+    else:
+        op = ClampFwdOp(input=(n,), min=None, max=(n,), dtype=fp8_dtype)
+        out = op(inp, None, bound)
+        ref = torch.clamp(inp.to(torch.float16), None, bound.to(torch.float16)).to(fp8_dtype)
+    # fp8 has no torch.testing.assert_close support; compare via fp16 view.
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_clamp_both_none_rejected():
+    """ClampFwdOp must reject min=None and max=None (no-op clamp is invalid)."""
+    from tileops.ops.elementwise import ClampFwdOp
+    with pytest.raises(ValueError, match="at least one of"):
+        ClampFwdOp(input=(4,), min=None, max=None, dtype=torch.float32)
+
+
+@pytest.mark.smoke
+def test_clamp_runtime_tensor_none_must_match_init():
+    """Forward-time None / Tensor presence must agree with __init__ config."""
+    from tileops.ops.elementwise import ClampFwdOp
+
+    inp = torch.randn(4, device="cuda", dtype=torch.float32)
+    mn = torch.zeros(4, device="cuda", dtype=torch.float32)
+
+    # Configured for min-only at __init__, then passed a Tensor for max:
+    op = ClampFwdOp(input=(4,), min=(4,), max=None, dtype=torch.float32)
+    with pytest.raises(ValueError, match="max"):
+        op(inp, mn, mn)
+
+    # Configured for max-only at __init__, then passed a Tensor for min:
+    op2 = ClampFwdOp(input=(4,), min=None, max=(4,), dtype=torch.float32)
+    with pytest.raises(ValueError, match="min"):
+        op2(inp, mn, mn)
+
+
 # ---------------------------------------------------------------------------
 # AC-3: ClampScalarFwdOp / ClampMinFwdOp / ClampMaxFwdOp
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -121,71 +121,43 @@ def test_clamp_init_signature_pytorch_aligned():
 
 # AC-2 (mixed): ClampFwdOp must accept Tensor min with max=None and
 # Tensor max with min=None, matching torch.clamp(input, min=tensor, max=None)
-# and torch.clamp(input, min=None, max=tensor) on CUDA.
+# and torch.clamp(input, min=None, max=tensor) on CUDA. Single-bound shape
+# matrix is covered by test_clamp_min_tensor / test_clamp_max_tensor on the
+# dedicated ClampMin/Max ops; here we only verify ClampFwdOp's None routing.
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "input_shape, bound_shape, dtype",
-    [
-        ((4, 8), (4, 8), torch.float16),
-        ((4, 8), (1, 8), torch.float32),
-        ((4, 8), (), torch.bfloat16),
-    ],
-)
-def test_clamp_min_only_tensor_parity(input_shape, bound_shape, dtype):
+def test_clamp_min_only_tensor_parity():
     from tileops.ops.elementwise import ClampFwdOp
 
-    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
-    mn = torch.randn(bound_shape, device="cuda", dtype=dtype) - 0.5
+    inp = torch.randn((4, 8), device="cuda", dtype=torch.float32)
+    mn = torch.randn((4, 8), device="cuda", dtype=torch.float32) - 0.5
     ref = torch.clamp(inp, mn, None)
-    op = ClampFwdOp(input=tuple(inp.shape), min=tuple(mn.shape), max=None, dtype=dtype)
+    op = ClampFwdOp(input=(4, 8), min=(4, 8), max=None, dtype=torch.float32)
     out = op(inp, mn, None)
-    if dtype == torch.float16:
-        atol, rtol = 1e-3, 1e-3
-    elif dtype == torch.bfloat16:
-        atol, rtol = 1.6e-2, 1.6e-2
-    else:
-        atol, rtol = 1e-5, 1e-5
-    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "input_shape, bound_shape, dtype",
-    [
-        ((4, 8), (4, 8), torch.float16),
-        ((4, 8), (1, 8), torch.float32),
-        ((4, 8), (), torch.bfloat16),
-    ],
-)
-def test_clamp_max_only_tensor_parity(input_shape, bound_shape, dtype):
+def test_clamp_max_only_tensor_parity():
     from tileops.ops.elementwise import ClampFwdOp
 
-    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
-    mx = torch.randn(bound_shape, device="cuda", dtype=dtype) + 0.5
+    inp = torch.randn((4, 8), device="cuda", dtype=torch.float32)
+    mx = torch.randn((4, 8), device="cuda", dtype=torch.float32) + 0.5
     ref = torch.clamp(inp, None, mx)
-    op = ClampFwdOp(input=tuple(inp.shape), min=None, max=tuple(mx.shape), dtype=dtype)
+    op = ClampFwdOp(input=(4, 8), min=None, max=(4, 8), dtype=torch.float32)
     out = op(inp, None, mx)
-    if dtype == torch.float16:
-        atol, rtol = 1e-3, 1e-3
-    elif dtype == torch.bfloat16:
-        atol, rtol = 1.6e-2, 1.6e-2
-    else:
-        atol, rtol = 1e-5, 1e-5
-    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
 
 
+# fp8 routing for mixed Tensor/None bounds: covers the has_min-only and
+# has_max-only kernel branches under fp8 cast. The fp8 dtype × dual-bound
+# path is already covered by test_clamp_tensor_bounds_fp8 (both fp8 dtypes,
+# has_min+has_max), so here we only vary `which` branch — single fp8 dtype.
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "fp8_dtype",
-    [
-        pytest.param(torch.float8_e4m3fn, id="e4m3fn"),
-        pytest.param(torch.float8_e5m2, id="e5m2"),
-    ],
-)
 @pytest.mark.parametrize(
     "which", ["min_only", "max_only"],
 )
-def test_clamp_mixed_tensor_none_fp8(which, fp8_dtype):
+def test_clamp_mixed_tensor_none_fp8(which):
+    fp8_dtype = torch.float8_e4m3fn
     """fp8 routing for mixed Tensor/None bounds (matches both-Tensor case)."""
     from tileops.ops.elementwise import ClampFwdOp
 
@@ -371,32 +343,10 @@ def test_clamp_tensor_nan_propagation(dtype):
     torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
 
 
-@pytest.mark.smoke
-def test_clamp_tensor_min_only_nan_propagation():
-    """ClampFwdOp(min=Tensor, max=None) must propagate NaN like torch.clamp."""
-    from tileops.ops.elementwise import ClampFwdOp
-
-    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=torch.float32)
-    mn = torch.tensor([-1.0, -1.0, float("nan"), -1.0], device="cuda", dtype=torch.float32)
-
-    ref = torch.clamp(x, mn, None)
-    op = ClampFwdOp(input=(4,), min=(4,), max=None, dtype=torch.float32)
-    out = op(x, mn, None)
-    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
-
-
-@pytest.mark.smoke
-def test_clamp_tensor_max_only_nan_propagation():
-    """ClampFwdOp(min=None, max=Tensor) must propagate NaN like torch.clamp."""
-    from tileops.ops.elementwise import ClampFwdOp
-
-    x = torch.tensor([float("nan"), -2.0, 0.0, 2.0], device="cuda", dtype=torch.float32)
-    mx = torch.tensor([1.0, 1.0, 1.0, float("nan")], device="cuda", dtype=torch.float32)
-
-    ref = torch.clamp(x, None, mx)
-    op = ClampFwdOp(input=(4,), min=None, max=(4,), dtype=torch.float32)
-    out = op(x, None, mx)
-    torch.testing.assert_close(out, ref, equal_nan=True, atol=0.0, rtol=0.0)
+# Single-bound NaN behaviour is covered by test_clamp_min_nan_propagation /
+# test_clamp_max_nan_propagation below — same ClampTensorFwdKernel branch
+# (has_min only / has_max only). ClampFwdOp(min=Tensor, max=None) /
+# (min=None, max=Tensor) dispatch is verified separately.
 
 
 @pytest.mark.smoke
@@ -574,11 +524,15 @@ def test_clamp_tensor_bounds_fp8(dtype):
                                atol=0, rtol=0)
 
 
+# test_clamp_tensor_bounds_fp8 above is the umbrella for both fp8 dtypes.
+# The dtype × kernel-branch cross is one path here (single-bound only), so
+# a single representative dtype suffices per testing-budget.md §"Dtype × shape:
+# only when the combination triggers a distinct code path".
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", _FP8_DTYPES)
-def test_clamp_min_tensor_fp8(dtype):
+def test_clamp_min_tensor_fp8():
     from tileops.ops.elementwise import ClampMinFwdOp
 
+    dtype = torch.float8_e4m3fn
     inp = (torch.randn((4, 8), device="cuda") * 4).to(dtype)
     mn = (torch.full((1, 8), -0.5, device="cuda")).to(dtype)
     ref = torch.maximum(_fp8_to_fp16_via_pytorch(inp),
@@ -591,10 +545,10 @@ def test_clamp_min_tensor_fp8(dtype):
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", _FP8_DTYPES)
-def test_clamp_max_tensor_fp8(dtype):
+def test_clamp_max_tensor_fp8():
     from tileops.ops.elementwise import ClampMaxFwdOp
 
+    dtype = torch.float8_e4m3fn
     inp = (torch.randn((4, 8), device="cuda") * 4).to(dtype)
     mx = (torch.full((4, 1), 1.5, device="cuda")).to(dtype)
     ref = torch.minimum(_fp8_to_fp16_via_pytorch(inp),
@@ -607,9 +561,10 @@ def test_clamp_max_tensor_fp8(dtype):
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", _FP8_DTYPES)
-def test_masked_fill_tensor_value_fp8(dtype):
+def test_masked_fill_tensor_value_fp8():
     from tileops.ops.elementwise import MaskedFillFwdOp
+
+    dtype = torch.float8_e4m3fn
 
     inp = (torch.randn((4, 8), device="cuda") * 2).to(dtype)
     mask = torch.randint(0, 2, (1, 8), device="cuda").bool()

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -55,6 +55,25 @@ def test_where_init_signature_pytorch_aligned():
     assert fwd_params[1:] == ["condition", "input", "other"], fwd_params
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "bad_dtype",
+    [torch.float32, torch.float16, torch.int32, torch.uint8],
+)
+def test_where_rejects_non_bool_condition(bad_dtype):
+    from tileops.ops.elementwise import WhereFwdOp
+
+    shape = (4, 8)
+    cond = torch.zeros(shape, device="cuda", dtype=bad_dtype)
+    inp = torch.randn(shape, device="cuda", dtype=torch.float16)
+    other = torch.randn(shape, device="cuda", dtype=torch.float16)
+    op = WhereFwdOp(
+        condition=shape, input=shape, other=shape, dtype=torch.float16
+    )
+    with pytest.raises(ValueError, match="condition.dtype torch.bool"):
+        op(cond, inp, other)
+
+
 # ---------------------------------------------------------------------------
 # AC-2: ClampFwdOp Tensor min/max
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -198,6 +198,18 @@ def test_clamp_both_none_rejected():
 
 
 @pytest.mark.smoke
+def test_clamp_scalar_both_none_rejected():
+    """ClampScalarFwdOp must reject min=None and max=None.
+
+    Mirrors torch.clamp(input, None, None), which raises
+    RuntimeError("At least one of min or max must not be None").
+    """
+    from tileops.ops.elementwise import ClampScalarFwdOp
+    with pytest.raises(ValueError, match="at least one of"):
+        ClampScalarFwdOp(input=(4,), min=None, max=None, dtype=torch.float32)
+
+
+@pytest.mark.smoke
 def test_clamp_runtime_tensor_none_must_match_init():
     """Forward-time None / Tensor presence must agree with __init__ config."""
     from tileops.ops.elementwise import ClampFwdOp

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -58,7 +58,7 @@ def test_where_init_signature_pytorch_aligned():
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "bad_dtype",
-    [torch.float32, torch.float16, torch.int32, torch.uint8],
+    [torch.float32, torch.int32],
 )
 def test_where_rejects_non_bool_condition(bad_dtype):
     from tileops.ops.elementwise import WhereFwdOp

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -229,6 +229,17 @@ def test_clamp_scalar_both_none_rejected():
 
 
 @pytest.mark.smoke
+def test_clamp_scalar_rejects_same_numel_wrong_shape():
+    """ClampScalarFwdOp.forward must validate full input.shape, not just numel."""
+    from tileops.ops.elementwise import ClampScalarFwdOp
+
+    op = ClampScalarFwdOp(input=(2, 3), min=0.0, max=1.0, dtype=torch.float32)
+    bad = torch.randn(6, device="cuda", dtype=torch.float32)  # same numel, wrong shape
+    with pytest.raises(ValueError, match=r"input\.shape"):
+        op(bad)
+
+
+@pytest.mark.smoke
 def test_clamp_runtime_tensor_none_must_match_init():
     """Forward-time None / Tensor presence must agree with __init__ config."""
     from tileops.ops.elementwise import ClampFwdOp

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -292,3 +292,126 @@ def test_l1_signature_conformance(op_name, expected_inputs, expected_params):
         init_params=init_params,
     )
     assert errors == [], f"{op_name}: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# fp8 coverage: the manifest declares ``float8_e4m3fn | float8_e5m2`` for the
+# Tensor-bound clamp variants and both masked_fill variants. PyTorch's CUDA
+# backend does not implement clamp/maximum/minimum/masked_fill on Float8, so
+# the eager fallback paths must upcast to fp16 internally and cast back. These
+# tests exercise both fp8 dtypes against a fp16 reference computation.
+# ---------------------------------------------------------------------------
+
+
+_FP8_DTYPES = [torch.float8_e4m3fn, torch.float8_e5m2]
+
+
+def _fp8_to_fp16_via_pytorch(t: torch.Tensor) -> torch.Tensor:
+    return t.to(torch.float16)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _FP8_DTYPES)
+def test_clamp_tensor_bounds_fp8(dtype):
+    from tileops.ops.elementwise import ClampFwdOp
+
+    # Use moderate magnitudes so values fit in e4m3fn finite range (±448).
+    inp = (torch.randn((4, 8), device="cuda") * 4).to(dtype)
+    mn = (torch.full((1, 8), -1.0, device="cuda")).to(dtype)
+    mx = (torch.full((4, 1), 2.0, device="cuda")).to(dtype)
+
+    ref = torch.clamp(_fp8_to_fp16_via_pytorch(inp),
+                      _fp8_to_fp16_via_pytorch(mn),
+                      _fp8_to_fp16_via_pytorch(mx)).to(dtype)
+    op = ClampFwdOp(input=tuple(inp.shape), min=tuple(mn.shape),
+                    max=tuple(mx.shape), dtype=dtype)
+    out = op(inp, mn, mx)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _FP8_DTYPES)
+def test_clamp_min_tensor_fp8(dtype):
+    from tileops.ops.elementwise import ClampMinFwdOp
+
+    inp = (torch.randn((4, 8), device="cuda") * 4).to(dtype)
+    mn = (torch.full((1, 8), -0.5, device="cuda")).to(dtype)
+    ref = torch.maximum(_fp8_to_fp16_via_pytorch(inp),
+                        _fp8_to_fp16_via_pytorch(mn)).to(dtype)
+    op = ClampMinFwdOp(input=tuple(inp.shape), min=tuple(mn.shape), dtype=dtype)
+    out = op(inp, mn)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _FP8_DTYPES)
+def test_clamp_max_tensor_fp8(dtype):
+    from tileops.ops.elementwise import ClampMaxFwdOp
+
+    inp = (torch.randn((4, 8), device="cuda") * 4).to(dtype)
+    mx = (torch.full((4, 1), 1.5, device="cuda")).to(dtype)
+    ref = torch.minimum(_fp8_to_fp16_via_pytorch(inp),
+                        _fp8_to_fp16_via_pytorch(mx)).to(dtype)
+    op = ClampMaxFwdOp(input=tuple(inp.shape), max=tuple(mx.shape), dtype=dtype)
+    out = op(inp, mx)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _FP8_DTYPES)
+def test_masked_fill_tensor_value_fp8(dtype):
+    from tileops.ops.elementwise import MaskedFillFwdOp
+
+    inp = (torch.randn((4, 8), device="cuda") * 2).to(dtype)
+    mask = torch.randint(0, 2, (1, 8), device="cuda").bool()
+    value = torch.tensor(-1.0, device="cuda").to(dtype)
+
+    out_shape = torch.broadcast_shapes(inp.shape, mask.shape)
+    ref = (
+        _fp8_to_fp16_via_pytorch(inp).expand(out_shape).clone()
+        .masked_fill(mask.expand(out_shape), float(value.to(torch.float16).item()))
+        .to(dtype)
+    )
+
+    op = MaskedFillFwdOp(input=tuple(inp.shape), mask=tuple(mask.shape),
+                         value=tuple(value.shape), dtype=dtype)
+    out = op(inp, mask, value)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _FP8_DTYPES)
+@pytest.mark.parametrize(
+    "input_shape, mask_shape",
+    [
+        ((4, 8), (4, 8)),  # exact-shape (kernel path)
+        ((1, 8), (4, 8)),  # broadcast (eager fallback path)
+    ],
+)
+def test_masked_fill_scalar_fp8(dtype, input_shape, mask_shape):
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+
+    inp = (torch.randn(input_shape, device="cuda") * 2).to(dtype)
+    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
+
+    out_shape = torch.broadcast_shapes(input_shape, mask_shape)
+    ref = (
+        _fp8_to_fp16_via_pytorch(inp).expand(out_shape).clone()
+        .masked_fill(mask.expand(out_shape), -1.0)
+        .to(dtype)
+    )
+
+    op = MaskedFillScalarFwdOp(input=tuple(inp.shape), mask=tuple(mask.shape),
+                               value=-1.0, dtype=dtype)
+    out = op(inp, mask)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out.to(torch.float16), ref.to(torch.float16),
+                               atol=0, rtol=0)

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -1,0 +1,294 @@
+"""Conformance tests for elementwise multi-input ops (issue #1107).
+
+Covers PyTorch-aligned signatures, broadcasting semantics, and split
+variants (Tensor-bound clamp / masked_fill, single-bound clamp_min /
+clamp_max) for the entries that landed as ``status: spec-only`` in
+PR #1109. After this PR lands, these ops conform to the manifest
+signatures and the manifest entries can flip to ``status: implemented``
+in a follow-up manifest-only PR per the manifest trust model
+(.claude/rules/manifest-trust-model.md).
+"""
+
+import inspect
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# AC-1: WhereFwdOp full broadcasting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "cond_shape, inp_shape, other_shape, dtype",
+    [
+        ((4, 8), (4, 8), (4, 8), torch.float16),  # same shape
+        ((1, 8), (4, 1), (1, 1), torch.float32),  # full 3-way broadcast
+        ((4, 8), (1, 8), (4, 1), torch.bfloat16),  # mixed broadcast
+        ((), (4, 8), (4, 8), torch.float16),  # 0-dim condition
+    ],
+)
+def test_where_broadcast_parity(cond_shape, inp_shape, other_shape, dtype):
+    from tileops.ops.elementwise import WhereFwdOp
+
+    cond = torch.randint(0, 2, cond_shape, device="cuda").bool() if cond_shape else \
+        torch.tensor(True, device="cuda")
+    inp = torch.randn(inp_shape, device="cuda", dtype=dtype)
+    other = torch.randn(other_shape, device="cuda", dtype=dtype)
+    ref = torch.where(cond, inp, other)
+
+    op = WhereFwdOp(condition=tuple(cond.shape), input=tuple(inp.shape),
+                    other=tuple(other.shape), dtype=dtype)
+    out = op(cond, inp, other)
+    torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+def test_where_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import WhereFwdOp
+    init_params = list(inspect.signature(WhereFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(WhereFwdOp.forward).parameters.keys())
+    # __init__: self, condition, input, other, dtype, ...
+    assert init_params[1:5] == ["condition", "input", "other", "dtype"], init_params
+    # forward: self, condition, input, other
+    assert fwd_params[1:] == ["condition", "input", "other"], fwd_params
+
+
+# ---------------------------------------------------------------------------
+# AC-2: ClampFwdOp Tensor min/max
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, min_shape, max_shape, dtype",
+    [
+        ((4, 8), (4, 8), (4, 8), torch.float16),
+        ((4, 8), (1, 8), (4, 1), torch.float32),
+        ((4, 8), (), (), torch.bfloat16),  # 0-dim Tensor bounds
+    ],
+)
+def test_clamp_tensor_bounds_parity(input_shape, min_shape, max_shape, dtype):
+    from tileops.ops.elementwise import ClampFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
+    mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
+    # Make max >= min where tested ranges overlap; PyTorch clamp tolerates
+    # mismatch but we want a meaningful ref.
+    ref = torch.clamp(inp, mn, mx)
+
+    op = ClampFwdOp(input=tuple(inp.shape), min=tuple(mn.shape),
+                    max=tuple(mx.shape), dtype=dtype)
+    out = op(inp, mn, mx)
+    if dtype == torch.float16:
+        atol, rtol = 1e-3, 1e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 1.6e-2, 1.6e-2
+    else:
+        atol, rtol = 1e-5, 1e-5
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_clamp_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import ClampFwdOp
+    init_params = list(inspect.signature(ClampFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(ClampFwdOp.forward).parameters.keys())
+    assert init_params[1:5] == ["input", "min", "max", "dtype"], init_params
+    assert fwd_params[1:] == ["input", "min", "max"], fwd_params
+
+
+# ---------------------------------------------------------------------------
+# AC-3: ClampScalarFwdOp / ClampMinFwdOp / ClampMaxFwdOp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "min_val, max_val",
+    [(-0.5, 0.5), (None, 0.5), (-0.5, None)],
+)
+def test_clamp_scalar_param_names(min_val, max_val):
+    from tileops.ops.elementwise import ClampScalarFwdOp
+
+    inp = torch.randn(1024, device="cuda", dtype=torch.float32)
+    ref = torch.clamp(inp, min_val, max_val)
+    op = ClampScalarFwdOp(input=(1024,), min=min_val, max=max_val, dtype=torch.float32)
+    out = op(inp)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_clamp_scalar_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import ClampScalarFwdOp
+    init_params = list(inspect.signature(ClampScalarFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(ClampScalarFwdOp.forward).parameters.keys())
+    # __init__ exposes manifest params (min, max) and the input
+    assert "input" in init_params
+    assert "min" in init_params
+    assert "max" in init_params
+    assert "dtype" in init_params
+    # forward only takes input (manifest params are bound at __init__)
+    assert fwd_params[1:] == ["input"], fwd_params
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, min_shape",
+    [((4, 8), (4, 8)), ((4, 8), (1, 8)), ((4, 8), ())],
+)
+def test_clamp_min_tensor(input_shape, min_shape):
+    from tileops.ops.elementwise import ClampMinFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=torch.float32)
+    mn = torch.randn(min_shape, device="cuda", dtype=torch.float32)
+    ref = torch.clamp_min(inp, mn) if min_shape else torch.clamp(inp, min=mn.item())
+
+    op = ClampMinFwdOp(input=tuple(inp.shape), min=tuple(mn.shape), dtype=torch.float32)
+    out = op(inp, mn)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_clamp_min_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import ClampMinFwdOp
+    init_params = list(inspect.signature(ClampMinFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(ClampMinFwdOp.forward).parameters.keys())
+    assert init_params[1:4] == ["input", "min", "dtype"], init_params
+    assert fwd_params[1:] == ["input", "min"], fwd_params
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, max_shape",
+    [((4, 8), (4, 8)), ((4, 8), (4, 1)), ((4, 8), ())],
+)
+def test_clamp_max_tensor(input_shape, max_shape):
+    from tileops.ops.elementwise import ClampMaxFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=torch.float32)
+    mx = torch.randn(max_shape, device="cuda", dtype=torch.float32)
+    ref = torch.clamp_max(inp, mx) if max_shape else torch.clamp(inp, max=mx.item())
+
+    op = ClampMaxFwdOp(input=tuple(inp.shape), max=tuple(mx.shape), dtype=torch.float32)
+    out = op(inp, mx)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_clamp_max_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import ClampMaxFwdOp
+    init_params = list(inspect.signature(ClampMaxFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(ClampMaxFwdOp.forward).parameters.keys())
+    assert init_params[1:4] == ["input", "max", "dtype"], init_params
+    assert fwd_params[1:] == ["input", "max"], fwd_params
+
+
+# ---------------------------------------------------------------------------
+# AC-4: MaskedFillFwdOp (0-dim Tensor) / MaskedFillScalarFwdOp (Number)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "input_shape, mask_shape",
+    [((4, 8), (4, 8)), ((1, 8), (4, 8)), ((4, 8), (1, 8)), ((2, 1), (2, 3))],
+)
+def test_masked_fill_tensor_value(input_shape, mask_shape):
+    from tileops.ops.elementwise import MaskedFillFwdOp
+
+    inp = torch.randn(input_shape, device="cuda", dtype=torch.float32)
+    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
+    value = torch.tensor(-1.5, device="cuda", dtype=torch.float32)
+
+    out_shape = torch.broadcast_shapes(input_shape, mask_shape)
+    ref = inp.expand(out_shape).clone().masked_fill(mask.expand(out_shape), value.item())
+
+    op = MaskedFillFwdOp(input=tuple(inp.shape), mask=tuple(mask.shape),
+                        value=tuple(value.shape), dtype=torch.float32)
+    out = op(inp, mask, value)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_masked_fill_tensor_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import MaskedFillFwdOp
+    init_params = list(inspect.signature(MaskedFillFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(MaskedFillFwdOp.forward).parameters.keys())
+    assert init_params[1:5] == ["input", "mask", "value", "dtype"], init_params
+    assert fwd_params[1:] == ["input", "mask", "value"], fwd_params
+
+
+@pytest.mark.smoke
+def test_masked_fill_scalar_param_names():
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+
+    inp = torch.randn(1024, device="cuda", dtype=torch.float32)
+    mask = torch.randint(0, 2, (1024,), device="cuda").bool()
+    ref = inp.masked_fill(mask, -1.0)
+
+    op = MaskedFillScalarFwdOp(input=(1024,), mask=(1024,), value=-1.0,
+                               dtype=torch.float32)
+    out = op(inp, mask)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_masked_fill_scalar_init_signature_pytorch_aligned():
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+    init_params = list(inspect.signature(MaskedFillScalarFwdOp.__init__).parameters.keys())
+    fwd_params = list(inspect.signature(MaskedFillScalarFwdOp.forward).parameters.keys())
+    assert "input" in init_params
+    assert "mask" in init_params
+    assert "value" in init_params
+    assert "dtype" in init_params
+    assert fwd_params[1:] == ["input", "mask"], fwd_params
+
+
+# ---------------------------------------------------------------------------
+# AC-5: validator passes (the entries can flip to ``implemented`` in a
+# follow-up manifest-only PR — this test exercises the L1 signature check
+# directly so we don't depend on the YAML status flip.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name, expected_inputs, expected_params",
+    [
+        ("WhereFwdOp", ["condition", "input", "other"], []),
+        ("ClampFwdOp", ["input", "min", "max"], []),
+        ("ClampScalarFwdOp", ["input"], ["min", "max"]),
+        ("ClampMinFwdOp", ["input", "min"], []),
+        ("ClampMaxFwdOp", ["input", "max"], []),
+        ("MaskedFillFwdOp", ["input", "mask", "value"], []),
+        ("MaskedFillScalarFwdOp", ["input", "mask"], ["value"]),
+    ],
+)
+def test_l1_signature_conformance(op_name, expected_inputs, expected_params):
+    """L1 signature check (validator parity) for each conformed op class.
+
+    Mirrors ``scripts.validate_manifest.check_l1_signature``: forward()
+    must list manifest inputs in order, and every manifest param must
+    appear in either ``__init__()`` or ``forward()``.
+    """
+    import tileops.ops.elementwise as mod
+    from scripts.validate_manifest import (
+        _get_forward_params,
+        _get_init_params,
+        check_l1_signature,
+    )
+
+    cls = getattr(mod, op_name)
+    forward_params = _get_forward_params(cls)
+    assert forward_params is not None, f"Cannot extract forward params for {op_name}"
+    init_params = _get_init_params(cls)
+    manifest_inputs = {n: {} for n in expected_inputs}
+    manifest_params = {n: {} for n in expected_params}
+    errors = check_l1_signature(
+        op_name, manifest_inputs, manifest_params, forward_params,
+        init_params=init_params,
+    )
+    assert errors == [], f"{op_name}: {errors}"

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -2879,10 +2879,10 @@ def _make_masked_fill_tensor_value_kernel(N, dtype, output_dtype=None,
                 out: T.Tensor((N,), out_dtype),
             ):
                 with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                    fv = T.Cast(out_dtype, value[0])
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         idx = (bx * threads_arg + i) * npt_arg + j
                         if idx < N:
-                            fv = T.Cast(out_dtype, value[0])
                             x_val = T.Cast(out_dtype, x[idx])
                             out[idx] = T.if_then_else(
                                 mask[idx] != T.cast(0, "uint8"), fv, x_val,
@@ -2906,9 +2906,9 @@ def _make_masked_fill_tensor_value_kernel(N, dtype, output_dtype=None,
                 x_reg = T.alloc_fragment((block_size,), dtype)
                 T.copy(mask[bx * block_size : (bx + 1) * block_size], m_reg)
                 T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                fv = value[0]
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     k = i * npt_arg + j
-                    fv = value[0]
                     x_reg[k] = T.if_then_else(
                         m_reg[k] != T.cast(0, "uint8"), fv, x_reg[k],
                     )

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -118,7 +118,9 @@ __all__ = [
     "PreluFwdKernel",
     "WhereFwdKernel",
     "ClampFwdKernel",
+    "ClampTensorFwdKernel",
     "MaskedFillFwdKernel",
+    "MaskedFillTensorValueFwdKernel",
     "NanToNumFwdKernel",
     "AlibiFwdKernel",
     "SinusoidalFwdKernel",
@@ -2539,6 +2541,224 @@ class ClampFwdKernel(ParametricUnaryKernel):
 
 
 @functools.lru_cache(maxsize=32)
+def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
+                              output_dtype=None, is_fp8=False,
+                              threads=256, npt=8):
+    """Build Tensor-bound clamp kernel.
+
+    Inputs (all flat, length N, pre-broadcast/expanded by the Op layer):
+        x: data tensor.
+        lo: lower-bound tensor (only present when ``has_min``).
+        hi: upper-bound tensor (only present when ``has_max``).
+
+    Output:
+        y: clamp result, same dtype as ``output_dtype`` (or ``dtype``).
+
+    For fp8 the cast/compute uses fp32 to preserve precision; for non-fp8
+    the kernel uses register_copy with fp32 accumulation.
+    """
+    if not (has_min or has_max):
+        raise ValueError(
+            "_make_clamp_tensor_kernel requires has_min or has_max to be True",
+        )
+    out_dtype = output_dtype or dtype
+    block_size = threads * npt
+
+    if is_fp8:
+        if has_min and has_max:
+            @tilelang.jit(out_idx=[3])
+            def kernel(threads_arg, npt_arg):
+                @T.prim_func
+                def main(
+                    x: T.Tensor((N,), dtype),
+                    lo: T.Tensor((N,), dtype),
+                    hi: T.Tensor((N,), dtype),
+                    y: T.Tensor((N,), out_dtype),
+                ):
+                    with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                        for i, j in T.Parallel(threads_arg, npt_arg):
+                            idx = (bx * threads_arg + i) * npt_arg + j
+                            if idx < N:
+                                v32 = T.cast(x[idx], "float32")
+                                lo32 = T.cast(lo[idx], "float32")
+                                hi32 = T.cast(hi[idx], "float32")
+                                v32 = T.max(v32, lo32)
+                                v32 = T.min(v32, hi32)
+                                y[idx] = T.Cast(out_dtype, v32)
+
+                return main
+
+            return kernel
+        if has_min:
+            @tilelang.jit(out_idx=[2])
+            def kernel(threads_arg, npt_arg):
+                @T.prim_func
+                def main(
+                    x: T.Tensor((N,), dtype),
+                    lo: T.Tensor((N,), dtype),
+                    y: T.Tensor((N,), out_dtype),
+                ):
+                    with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                        for i, j in T.Parallel(threads_arg, npt_arg):
+                            idx = (bx * threads_arg + i) * npt_arg + j
+                            if idx < N:
+                                v32 = T.cast(x[idx], "float32")
+                                lo32 = T.cast(lo[idx], "float32")
+                                v32 = T.max(v32, lo32)
+                                y[idx] = T.Cast(out_dtype, v32)
+
+                return main
+
+            return kernel
+
+        # has_max only
+        @tilelang.jit(out_idx=[2])
+        def kernel(threads_arg, npt_arg):
+            @T.prim_func
+            def main(
+                x: T.Tensor((N,), dtype),
+                hi: T.Tensor((N,), dtype),
+                y: T.Tensor((N,), out_dtype),
+            ):
+                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        idx = (bx * threads_arg + i) * npt_arg + j
+                        if idx < N:
+                            v32 = T.cast(x[idx], "float32")
+                            hi32 = T.cast(hi[idx], "float32")
+                            v32 = T.min(v32, hi32)
+                            y[idx] = T.Cast(out_dtype, v32)
+
+            return main
+
+        return kernel
+
+    # non-fp8 path (register_copy)
+    if has_min and has_max:
+        @tilelang.jit(out_idx=[3])
+        def kernel(threads_arg, npt_arg):
+            @T.prim_func
+            def main(
+                x: T.Tensor((N,), dtype),
+                lo: T.Tensor((N,), dtype),
+                hi: T.Tensor((N,), dtype),
+                y: T.Tensor((N,), dtype),
+            ):
+                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                    x_reg = T.alloc_fragment((block_size,), dtype)
+                    lo_reg = T.alloc_fragment((block_size,), dtype)
+                    hi_reg = T.alloc_fragment((block_size,), dtype)
+                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                    T.copy(lo[bx * block_size : (bx + 1) * block_size], lo_reg)
+                    T.copy(hi[bx * block_size : (bx + 1) * block_size], hi_reg)
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        k = i * npt_arg + j
+                        v32 = T.cast(x_reg[k], "float32")
+                        lo32 = T.cast(lo_reg[k], "float32")
+                        hi32 = T.cast(hi_reg[k], "float32")
+                        v32 = T.max(v32, lo32)
+                        v32 = T.min(v32, hi32)
+                        x_reg[k] = T.Cast(dtype, v32)
+                    T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
+
+            return main
+
+        return kernel
+    if has_min:
+        @tilelang.jit(out_idx=[2])
+        def kernel(threads_arg, npt_arg):
+            @T.prim_func
+            def main(
+                x: T.Tensor((N,), dtype),
+                lo: T.Tensor((N,), dtype),
+                y: T.Tensor((N,), dtype),
+            ):
+                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                    x_reg = T.alloc_fragment((block_size,), dtype)
+                    lo_reg = T.alloc_fragment((block_size,), dtype)
+                    T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                    T.copy(lo[bx * block_size : (bx + 1) * block_size], lo_reg)
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        k = i * npt_arg + j
+                        v32 = T.cast(x_reg[k], "float32")
+                        lo32 = T.cast(lo_reg[k], "float32")
+                        v32 = T.max(v32, lo32)
+                        x_reg[k] = T.Cast(dtype, v32)
+                    T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
+
+            return main
+
+        return kernel
+
+    # has_max only
+    @tilelang.jit(out_idx=[2])
+    def kernel(threads_arg, npt_arg):
+        @T.prim_func
+        def main(
+            x: T.Tensor((N,), dtype),
+            hi: T.Tensor((N,), dtype),
+            y: T.Tensor((N,), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                hi_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                T.copy(hi[bx * block_size : (bx + 1) * block_size], hi_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    k = i * npt_arg + j
+                    v32 = T.cast(x_reg[k], "float32")
+                    hi32 = T.cast(hi_reg[k], "float32")
+                    v32 = T.min(v32, hi32)
+                    x_reg[k] = T.Cast(dtype, v32)
+                T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
+
+        return main
+
+    return kernel
+
+
+class ClampTensorFwdKernel(ParametricUnaryKernel):
+    """Tensor-bound clamp kernel.
+
+    Computes ``y = clamp(x, lo, hi)`` over flat tensors of length
+    ``N_total``. The Op layer broadcasts ``input`` / ``min`` / ``max``
+    to the output shape and flattens them before dispatch. ``has_min``
+    / ``has_max`` select between the three forms used by the Tensor
+    clamp, clamp_min, and clamp_max ops.
+    """
+
+    _DEFAULT_THREADS = 512
+
+    def __init__(self, N_total, dtype, has_min, has_max,
+                 config=None, tune=False):
+        if not (has_min or has_max):
+            raise ValueError(
+                "ClampTensorFwdKernel requires has_min or has_max to be True",
+            )
+        self.has_min = bool(has_min)
+        self.has_max = bool(has_max)
+        super().__init__(N_total, dtype, config=config, tune=tune)
+
+    @staticmethod
+    def _builder_fn():
+        return _make_clamp_tensor_kernel
+
+    def _builder_args(self):
+        return (self.has_min, self.has_max)
+
+    def forward(self, x, lo=None, hi=None):
+        if self.has_min and self.has_max:
+            result = self._compiled_fn(x, lo, hi)
+        elif self.has_min:
+            result = self._compiled_fn(x, lo)
+        else:
+            result = self._compiled_fn(x, hi)
+        if self._fp8_output_dtype is not None:
+            result = result.to(self._fp8_output_dtype)
+        return result
+
+
+@functools.lru_cache(maxsize=32)
 def _make_masked_fill_kernel(N, dtype, fill_value, output_dtype=None,
                              is_fp8=False, threads=256, npt=8):
     """Build masked_fill kernel: out = mask ? fill_value : x.
@@ -2629,6 +2849,96 @@ class MaskedFillFwdKernel(ParametricUnaryKernel):
 
     def forward(self, x, mask):
         return self._compiled_fn(x, mask)
+
+
+@functools.lru_cache(maxsize=32)
+def _make_masked_fill_tensor_value_kernel(N, dtype, output_dtype=None,
+                                          is_fp8=False, threads=256, npt=8):
+    """Build masked_fill kernel with a 0-dim Tensor fill value.
+
+    Inputs (all flat, length N, pre-broadcast/expanded by the Op layer):
+        x: data tensor (length N).
+        mask: bool mask packed as uint8 (length N).
+        value: scalar fill value carried as a length-1 tensor (the Op
+            layer reshapes the 0-dim Tensor to ``(1,)``).
+
+    Output:
+        out: ``out[i] = value[0] if mask[i] else x[i]``.
+    """
+    out_dtype = output_dtype or dtype
+    block_size = threads * npt
+
+    if is_fp8:
+        @tilelang.jit(out_idx=[3])
+        def kernel(threads_arg, npt_arg):
+            @T.prim_func
+            def main(
+                x: T.Tensor((N,), dtype),
+                mask: T.Tensor((N,), "uint8"),
+                value: T.Tensor((1,), dtype),
+                out: T.Tensor((N,), out_dtype),
+            ):
+                with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        idx = (bx * threads_arg + i) * npt_arg + j
+                        if idx < N:
+                            fv = T.Cast(out_dtype, value[0])
+                            x_val = T.Cast(out_dtype, x[idx])
+                            out[idx] = T.if_then_else(
+                                mask[idx] != T.cast(0, "uint8"), fv, x_val,
+                            )
+
+            return main
+
+        return kernel
+
+    @tilelang.jit(out_idx=[3])
+    def kernel(threads_arg, npt_arg):
+        @T.prim_func
+        def main(
+            x: T.Tensor((N,), dtype),
+            mask: T.Tensor((N,), "uint8"),
+            value: T.Tensor((1,), dtype),
+            out: T.Tensor((N,), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_size), threads=threads_arg) as bx:
+                m_reg = T.alloc_fragment((block_size,), "uint8")
+                x_reg = T.alloc_fragment((block_size,), dtype)
+                T.copy(mask[bx * block_size : (bx + 1) * block_size], m_reg)
+                T.copy(x[bx * block_size : (bx + 1) * block_size], x_reg)
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    k = i * npt_arg + j
+                    fv = value[0]
+                    x_reg[k] = T.if_then_else(
+                        m_reg[k] != T.cast(0, "uint8"), fv, x_reg[k],
+                    )
+                T.copy(x_reg, out[bx * block_size : (bx + 1) * block_size])
+
+        return main
+
+    return kernel
+
+
+class MaskedFillTensorValueFwdKernel(ParametricUnaryKernel):
+    """MaskedFill kernel with 0-dim Tensor fill value.
+
+    Computes ``out = mask ? value : x`` over flat tensors of length
+    ``N_total``. The Op layer broadcasts ``input`` and ``mask`` to the
+    output shape, flattens them, packs the mask as uint8, and reshapes
+    the 0-dim ``value`` to a length-1 tensor before dispatch.
+    """
+
+    _DEFAULT_THREADS = 512
+
+    @staticmethod
+    def _builder_fn():
+        return _make_masked_fill_tensor_value_kernel
+
+    def forward(self, x, mask, value):
+        result = self._compiled_fn(x, mask, value)
+        if self._fp8_output_dtype is not None:
+            result = result.to(self._fp8_output_dtype)
+        return result
 
 
 @functools.lru_cache(maxsize=32)

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -2556,6 +2556,13 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
 
     For fp8 the cast/compute uses fp32 to preserve precision; for non-fp8
     the kernel uses register_copy with fp32 accumulation.
+
+    NaN semantics: matches ``torch.clamp`` / ``torch.clamp_min`` /
+    ``torch.clamp_max``. If ``x``, ``lo``, or ``hi`` is NaN at a position,
+    the output at that position is NaN. ``T.max`` / ``T.min`` on CUDA do
+    not propagate NaN by themselves (they return the non-NaN operand), so
+    we add explicit ``isnan`` guards in fp32 -- mirroring the pattern used
+    by ``MaximumFwdKernel`` / ``MinimumFwdKernel``.
     """
     if not (has_min or has_max):
         raise ValueError(
@@ -2579,12 +2586,17 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                         for i, j in T.Parallel(threads_arg, npt_arg):
                             idx = (bx * threads_arg + i) * npt_arg + j
                             if idx < N:
-                                v32 = T.cast(x[idx], "float32")
+                                x32 = T.cast(x[idx], "float32")
                                 lo32 = T.cast(lo[idx], "float32")
                                 hi32 = T.cast(hi[idx], "float32")
-                                v32 = T.max(v32, lo32)
-                                v32 = T.min(v32, hi32)
-                                y[idx] = T.Cast(out_dtype, v32)
+                                r = T.max(x32, lo32)
+                                r = T.min(r, hi32)
+                                # NaN propagation (PyTorch semantics):
+                                # if any of x/lo/hi is NaN -> output NaN.
+                                r = T.if_then_else(T.isnan(hi32), hi32, r)
+                                r = T.if_then_else(T.isnan(lo32), lo32, r)
+                                r = T.if_then_else(T.isnan(x32), x32, r)
+                                y[idx] = T.Cast(out_dtype, r)
 
                 return main
 
@@ -2602,10 +2614,14 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                         for i, j in T.Parallel(threads_arg, npt_arg):
                             idx = (bx * threads_arg + i) * npt_arg + j
                             if idx < N:
-                                v32 = T.cast(x[idx], "float32")
+                                x32 = T.cast(x[idx], "float32")
                                 lo32 = T.cast(lo[idx], "float32")
-                                v32 = T.max(v32, lo32)
-                                y[idx] = T.Cast(out_dtype, v32)
+                                r = T.max(x32, lo32)
+                                # NaN propagation (PyTorch clamp_min):
+                                # if x or lo is NaN -> output NaN.
+                                r = T.if_then_else(T.isnan(lo32), lo32, r)
+                                r = T.if_then_else(T.isnan(x32), x32, r)
+                                y[idx] = T.Cast(out_dtype, r)
 
                 return main
 
@@ -2624,10 +2640,14 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         idx = (bx * threads_arg + i) * npt_arg + j
                         if idx < N:
-                            v32 = T.cast(x[idx], "float32")
+                            x32 = T.cast(x[idx], "float32")
                             hi32 = T.cast(hi[idx], "float32")
-                            v32 = T.min(v32, hi32)
-                            y[idx] = T.Cast(out_dtype, v32)
+                            r = T.min(x32, hi32)
+                            # NaN propagation (PyTorch clamp_max):
+                            # if x or hi is NaN -> output NaN.
+                            r = T.if_then_else(T.isnan(hi32), hi32, r)
+                            r = T.if_then_else(T.isnan(x32), x32, r)
+                            y[idx] = T.Cast(out_dtype, r)
 
             return main
 
@@ -2653,12 +2673,17 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                     T.copy(hi[bx * block_size : (bx + 1) * block_size], hi_reg)
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         k = i * npt_arg + j
-                        v32 = T.cast(x_reg[k], "float32")
+                        x32 = T.cast(x_reg[k], "float32")
                         lo32 = T.cast(lo_reg[k], "float32")
                         hi32 = T.cast(hi_reg[k], "float32")
-                        v32 = T.max(v32, lo32)
-                        v32 = T.min(v32, hi32)
-                        x_reg[k] = T.Cast(dtype, v32)
+                        r = T.max(x32, lo32)
+                        r = T.min(r, hi32)
+                        # NaN propagation (PyTorch clamp):
+                        # if any of x/lo/hi is NaN -> output NaN.
+                        r = T.if_then_else(T.isnan(hi32), hi32, r)
+                        r = T.if_then_else(T.isnan(lo32), lo32, r)
+                        r = T.if_then_else(T.isnan(x32), x32, r)
+                        x_reg[k] = T.Cast(dtype, r)
                     T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
 
             return main
@@ -2680,10 +2705,14 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                     T.copy(lo[bx * block_size : (bx + 1) * block_size], lo_reg)
                     for i, j in T.Parallel(threads_arg, npt_arg):
                         k = i * npt_arg + j
-                        v32 = T.cast(x_reg[k], "float32")
+                        x32 = T.cast(x_reg[k], "float32")
                         lo32 = T.cast(lo_reg[k], "float32")
-                        v32 = T.max(v32, lo32)
-                        x_reg[k] = T.Cast(dtype, v32)
+                        r = T.max(x32, lo32)
+                        # NaN propagation (PyTorch clamp_min):
+                        # if x or lo is NaN -> output NaN.
+                        r = T.if_then_else(T.isnan(lo32), lo32, r)
+                        r = T.if_then_else(T.isnan(x32), x32, r)
+                        x_reg[k] = T.Cast(dtype, r)
                     T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
 
             return main
@@ -2706,10 +2735,14 @@ def _make_clamp_tensor_kernel(N, dtype, has_min, has_max,
                 T.copy(hi[bx * block_size : (bx + 1) * block_size], hi_reg)
                 for i, j in T.Parallel(threads_arg, npt_arg):
                     k = i * npt_arg + j
-                    v32 = T.cast(x_reg[k], "float32")
+                    x32 = T.cast(x_reg[k], "float32")
                     hi32 = T.cast(hi_reg[k], "float32")
-                    v32 = T.min(v32, hi32)
-                    x_reg[k] = T.Cast(dtype, v32)
+                    r = T.min(x32, hi32)
+                    # NaN propagation (PyTorch clamp_max):
+                    # if x or hi is NaN -> output NaN.
+                    r = T.if_then_else(T.isnan(hi32), hi32, r)
+                    r = T.if_then_else(T.isnan(x32), x32, r)
+                    x_reg[k] = T.Cast(dtype, r)
                 T.copy(x_reg, y[bx * block_size : (bx + 1) * block_size])
 
         return main

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -32,6 +32,7 @@ from tileops.kernels.elementwise import (
     BitwiseXorFwdKernel,
     CeilFwdKernel,
     ClampFwdKernel,
+    ClampTensorFwdKernel,
     CosFwdKernel,
     DivFwdKernel,
     EluFwdKernel,
@@ -62,6 +63,7 @@ from tileops.kernels.elementwise import (
     LogicalOrFwdKernel,
     LtFwdKernel,
     MaskedFillFwdKernel,
+    MaskedFillTensorValueFwdKernel,
     MaximumFwdKernel,
     MinimumFwdKernel,
     MishFwdKernel,
@@ -1671,12 +1673,17 @@ class ClampFwdOp(_ClampTensorBase):
             broadcast_args.append(self.max_shape)
         self.out_shape = tuple(torch.broadcast_shapes(*broadcast_args))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self.kernel = ClampTensorFwdKernel(
+            self.N_total, dtype,
+            has_min=self.min_shape is not None,
+            has_max=self.max_shape is not None,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {}
+        return {"clamp_tensor": ClampTensorFwdKernel}
 
     def _eager_forward(
         self,
@@ -1684,19 +1691,16 @@ class ClampFwdOp(_ClampTensorBase):
         min: Optional[torch.Tensor] = None,  # noqa: A002
         max: Optional[torch.Tensor] = None,  # noqa: A002
     ) -> torch.Tensor:
-        # Use torch.clamp for full PyTorch parity (handles NaN / dtype
-        # promotion identically). Broadcasting is implicit. PyTorch's CUDA
-        # ``clamp`` has no fp8 implementation (raises NotImplementedError
-        # ``clamp_cuda``), so we route fp8 inputs through fp16 and cast
-        # back — preserves Inf/NaN for e5m2 via the non-saturating fp16
-        # post-cast.
-        if _is_fp8(self.dtype):
-            compute = _fp8_compute_dtype(self.dtype)
-            mn_c = None if min is None else min.to(compute)
-            mx_c = None if max is None else max.to(compute)
-            result = torch.clamp(input.to(compute), mn_c, mx_c)
-            return result.to(self.dtype)
-        return torch.clamp(input, min, max)
+        # Broadcast all operands to ``out_shape`` and dispatch the
+        # TileLang Tensor-bound clamp kernel. The kernel branches on
+        # ``has_min`` / ``has_max`` at build time, so this single Op
+        # class also covers the mixed Tensor/None cases.
+        out_shape = self.out_shape if self.out_shape else (1,)
+        x_flat = self._expand_flat(input, out_shape)
+        lo_flat = None if min is None else self._expand_flat(min, out_shape)
+        hi_flat = None if max is None else self._expand_flat(max, out_shape)
+        result = self.kernel(x_flat, lo_flat, hi_flat)
+        return result.view(self.out_shape if self.out_shape else ())
 
     def forward(
         self,
@@ -1757,23 +1761,26 @@ class ClampMinFwdOp(_ClampTensorBase):
         self.dtype = dtype
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.min_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self.kernel = ClampTensorFwdKernel(
+            self.N_total, dtype, has_min=True, has_max=False,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {}
+        return {"clamp_tensor": ClampTensorFwdKernel}
 
     def _eager_forward(
         self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
-        # ``torch.maximum`` has no fp8 CUDA kernel (NotImplementedError
-        # ``max_elementwise_cuda``); route fp8 through fp16 and cast back.
-        if _is_fp8(self.dtype):
-            compute = _fp8_compute_dtype(self.dtype)
-            result = torch.maximum(input.to(compute), min.to(compute))
-            return result.to(self.dtype)
-        return torch.maximum(input, min)
+        # Broadcast input/min to out_shape and dispatch the TileLang
+        # min-only Tensor-bound clamp kernel.
+        out_shape = self.out_shape if self.out_shape else (1,)
+        x_flat = self._expand_flat(input, out_shape)
+        lo_flat = self._expand_flat(min, out_shape)
+        result = self.kernel(x_flat, lo_flat, None)
+        return result.view(self.out_shape if self.out_shape else ())
 
     def forward(
         self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
@@ -1815,23 +1822,26 @@ class ClampMaxFwdOp(_ClampTensorBase):
         self.dtype = dtype
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.max_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self.kernel = ClampTensorFwdKernel(
+            self.N_total, dtype, has_min=False, has_max=True,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {}
+        return {"clamp_tensor": ClampTensorFwdKernel}
 
     def _eager_forward(
         self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
-        # ``torch.minimum`` has no fp8 CUDA kernel (NotImplementedError
-        # ``min_elementwise_cuda``); route fp8 through fp16 and cast back.
-        if _is_fp8(self.dtype):
-            compute = _fp8_compute_dtype(self.dtype)
-            result = torch.minimum(input.to(compute), max.to(compute))
-            return result.to(self.dtype)
-        return torch.minimum(input, max)
+        # Broadcast input/max to out_shape and dispatch the TileLang
+        # max-only Tensor-bound clamp kernel.
+        out_shape = self.out_shape if self.out_shape else (1,)
+        x_flat = self._expand_flat(input, out_shape)
+        hi_flat = self._expand_flat(max, out_shape)
+        result = self.kernel(x_flat, None, hi_flat)
+        return result.view(self.out_shape if self.out_shape else ())
 
     def forward(
         self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
@@ -1947,29 +1957,32 @@ class MaskedFillFwdOp(Op):
         self.dtype = dtype
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self.kernel = MaskedFillTensorValueFwdKernel(self.N_total, dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
-        return {}
+        return {"masked_fill_tensor_value": MaskedFillTensorValueFwdKernel}
+
+    @staticmethod
+    def _expand_flat(t: torch.Tensor, target_shape: tuple) -> torch.Tensor:
+        if tuple(t.shape) != tuple(target_shape):
+            t = t.expand(target_shape)
+        return t.contiguous().view(-1)
 
     def _eager_forward(
         self, input: torch.Tensor, mask: torch.Tensor, value: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
-        # PyTorch's Tensor.masked_fill with a 0-dim Tensor value is
-        # semantically identical to the scalar form; defer to it for full
-        # parity (broadcasts ``input`` and ``mask`` together).
-        # ``masked_fill_`` has no fp8 CUDA kernel (NotImplementedError); for
-        # fp8 we run masked_fill in fp16 and cast back.
-        if _is_fp8(self.dtype):
-            compute = _fp8_compute_dtype(self.dtype)
-            inp_b = input.to(compute).expand(self.out_shape).contiguous()
-            value_c = value.to(compute)
-            result = torch.masked_fill(inp_b, mask.expand(self.out_shape), value_c)
-            return result.to(self.dtype)
-        return torch.masked_fill(input.expand(self.out_shape).contiguous(),
-                                 mask.expand(self.out_shape), value)
+        # Broadcast input/mask to out_shape, pack mask as uint8, reshape
+        # the 0-dim value to (1,), and dispatch the TileLang kernel.
+        out_shape = self.out_shape if self.out_shape else (1,)
+        x_flat = self._expand_flat(input, out_shape)
+        mask_b = mask if mask.dtype == torch.bool else mask.bool()
+        mask_flat = self._expand_flat(mask_b, out_shape).view(torch.uint8)
+        value_1d = value.contiguous().view(1)
+        result = self.kernel(x_flat, mask_flat, value_1d)
+        return result.view(self.out_shape if self.out_shape else ())
 
     def forward(
         self, input: torch.Tensor, mask: torch.Tensor, value: torch.Tensor,  # noqa: A002
@@ -2027,20 +2040,13 @@ class MaskedFillScalarFwdOp(Op):
         self.fill_value = value
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        # When input/mask shapes match exactly, reuse the existing flat
-        # vectorized kernel; otherwise fall back to the broadcasting path.
+        # The kernel is always built on the broadcast (output) flat size.
+        # When input/mask already match out_shape, this is a no-op expand;
+        # otherwise the Op layer broadcasts both before dispatch.
         self._needs_broadcast = (
             self.input_shape != self.out_shape or self.mask_shape != self.out_shape
         )
-        # Note: ``kernel`` is typed as ``Kernel`` on the base class but we
-        # legitimately need a None sentinel here for the broadcasting fallback
-        # path (no flat kernel is dispatched in that case). The type ignore is
-        # narrow and intentional.
-        self.kernel: Optional[Kernel] = (  # type: ignore[assignment]
-            MaskedFillFwdKernel(self.N_total, dtype, value)
-            if not self._needs_broadcast
-            else None
-        )
+        self.kernel = MaskedFillFwdKernel(self.N_total, dtype, value)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -2048,22 +2054,18 @@ class MaskedFillScalarFwdOp(Op):
     def default_kernel_map(self):
         return {"masked_fill": MaskedFillFwdKernel}
 
+    @staticmethod
+    def _expand_flat(t: torch.Tensor, target_shape: tuple) -> torch.Tensor:
+        if tuple(t.shape) != tuple(target_shape):
+            t = t.expand(target_shape)
+        return t.contiguous().view(-1)
+
     def _eager_forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if self._needs_broadcast or self.kernel is None:
-            mask_b = mask.expand(self.out_shape)
-            # ``masked_fill_`` has no fp8 CUDA kernel; route fp8 through fp16
-            # and cast back to preserve manifest-declared fp8 support on the
-            # broadcasting fallback path.
-            if _is_fp8(self.dtype):
-                compute = _fp8_compute_dtype(self.dtype)
-                inp_b = input.to(compute).expand(self.out_shape).contiguous()
-                return inp_b.masked_fill(mask_b, self.value).to(self.dtype)
-            inp_b = input.expand(self.out_shape).contiguous()
-            return inp_b.masked_fill(mask_b, self.value)
-        orig_shape = input.shape
-        mask_flat = (mask if mask.dtype == torch.bool else mask.bool()).contiguous().view(-1)
-        x_flat = input.contiguous().view(-1)
-        result = self.kernel(x_flat, mask_flat.view(torch.uint8)).view(orig_shape)
+        out_shape = self.out_shape if self.out_shape else (1,)
+        x_flat = self._expand_flat(input, out_shape)
+        mask_b = mask if mask.dtype == torch.bool else mask.bool()
+        mask_flat = self._expand_flat(mask_b, out_shape).view(torch.uint8)
+        result = self.kernel(x_flat, mask_flat).view(self.out_shape if self.out_shape else ())
         return _apply_fp8_post_cast(result, self.kernel)
 
     def forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -254,7 +254,12 @@ def _register_where_custom_op(op_cls):
 
 
 def _register_masked_fill_custom_op(op_cls):
-    """Register a masked-fill-style op (x, mask -> y) for torch.compile."""
+    """Register a masked-fill-style op (x, mask -> y) for torch.compile.
+
+    The fake function computes the bidirectional broadcast output shape
+    of ``x`` and ``mask`` so ``torch.compile(fullgraph=True)`` works for
+    both same-shape and broadcasting inputs.
+    """
     op_name = op_cls._op_name
 
     @torch.library.custom_op(f"top::elementwise_{op_name}", mutates_args=())
@@ -272,7 +277,135 @@ def _register_masked_fill_custom_op(op_cls):
         mask: torch.Tensor,
         instance_key: int,
     ) -> torch.Tensor:
-        return torch.empty_like(x)
+        out_shape = torch.broadcast_shapes(x.shape, mask.shape)
+        return x.new_empty(out_shape)
+
+    op_cls._wrapped = _wrapped
+
+
+def _register_masked_fill_tensor_value_custom_op(op_cls):
+    """Register a masked-fill (Tensor value) op (input, mask, value -> out).
+
+    The fake function computes the broadcast output shape of ``input`` and
+    ``mask`` (``value`` is a 0-dim Tensor). Registered under a distinct
+    namespace from the scalar masked_fill variant to avoid collision.
+    """
+    op_name = op_cls._op_name
+
+    @torch.library.custom_op(
+        f"top::elementwise_{op_name}_tensor_value", mutates_args=(),
+    )
+    def _wrapped(
+        input: torch.Tensor,  # noqa: A002
+        mask: torch.Tensor,
+        value: torch.Tensor,
+        instance_key: int,
+    ) -> torch.Tensor:
+        instance = _OP_REGISTRY[instance_key]
+        return instance._eager_forward(input, mask, value)
+
+    @_wrapped.register_fake
+    def _(
+        input: torch.Tensor,  # noqa: A002
+        mask: torch.Tensor,
+        value: torch.Tensor,
+        instance_key: int,
+    ) -> torch.Tensor:
+        out_shape = torch.broadcast_shapes(input.shape, mask.shape)
+        return input.new_empty(out_shape)
+
+    op_cls._wrapped = _wrapped
+
+
+def _register_clamp_tensor_custom_op(op_cls):
+    """Register a Tensor-bound clamp op (input, min?, max? -> out).
+
+    ``min`` and ``max`` are each ``Optional[Tensor]``; the schema is
+    inferred by ``torch.library.custom_op`` from the ``Optional[torch.Tensor]``
+    annotations, producing ``Tensor? min, Tensor? max`` in the underlying
+    custom-op schema. The fake function computes the broadcast output
+    shape of all non-``None`` operands so ``torch.compile(fullgraph=True)``
+    works for both same-shape and broadcasting inputs. Registered under
+    a distinct ``_tensor`` namespace from the scalar-bound clamp variant.
+    """
+    op_name = op_cls._op_name
+
+    @torch.library.custom_op(
+        f"top::elementwise_{op_name}_tensor", mutates_args=(),
+    )
+    def _wrapped(
+        input: torch.Tensor,  # noqa: A002
+        min: Optional[torch.Tensor],  # noqa: A002
+        max: Optional[torch.Tensor],  # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        instance = _OP_REGISTRY[instance_key]
+        return instance._eager_forward(input, min, max)
+
+    @_wrapped.register_fake
+    def _(
+        input: torch.Tensor,  # noqa: A002
+        min: Optional[torch.Tensor],  # noqa: A002
+        max: Optional[torch.Tensor],  # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        shapes = [input.shape]
+        if min is not None:
+            shapes.append(min.shape)
+        if max is not None:
+            shapes.append(max.shape)
+        out_shape = torch.broadcast_shapes(*shapes)
+        return input.new_empty(out_shape)
+
+    op_cls._wrapped = _wrapped
+
+
+def _register_clamp_min_custom_op(op_cls):
+    """Register single-bound Tensor lower-clamp (input, min -> out)."""
+    op_name = op_cls._op_name
+
+    @torch.library.custom_op(f"top::elementwise_{op_name}", mutates_args=())
+    def _wrapped(
+        input: torch.Tensor,  # noqa: A002
+        min: torch.Tensor,    # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        instance = _OP_REGISTRY[instance_key]
+        return instance._eager_forward(input, min)
+
+    @_wrapped.register_fake
+    def _(
+        input: torch.Tensor,  # noqa: A002
+        min: torch.Tensor,    # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        out_shape = torch.broadcast_shapes(input.shape, min.shape)
+        return input.new_empty(out_shape)
+
+    op_cls._wrapped = _wrapped
+
+
+def _register_clamp_max_custom_op(op_cls):
+    """Register single-bound Tensor upper-clamp (input, max -> out)."""
+    op_name = op_cls._op_name
+
+    @torch.library.custom_op(f"top::elementwise_{op_name}", mutates_args=())
+    def _wrapped(
+        input: torch.Tensor,  # noqa: A002
+        max: torch.Tensor,    # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        instance = _OP_REGISTRY[instance_key]
+        return instance._eager_forward(input, max)
+
+    @_wrapped.register_fake
+    def _(
+        input: torch.Tensor,  # noqa: A002
+        max: torch.Tensor,    # noqa: A002
+        instance_key: int,
+    ) -> torch.Tensor:
+        out_shape = torch.broadcast_shapes(input.shape, max.shape)
+        return input.new_empty(out_shape)
 
     op_cls._wrapped = _wrapped
 
@@ -1655,6 +1788,7 @@ class ClampFwdOp(_ClampTensorBase):
     """
 
     _op_name = "clamp"
+    _wrapped = None
 
     def __init__(
         self,
@@ -1742,6 +1876,9 @@ class ClampFwdOp(_ClampTensorBase):
                 raise ValueError(
                     f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
                 )
+        wrapped = type(self)._wrapped
+        if wrapped is not None:
+            return wrapped(input, min, max, self._instance_key)
         return self._eager_forward(input, min, max)
 
 
@@ -1755,6 +1892,7 @@ class ClampMinFwdOp(_ClampTensorBase):
     """
 
     _op_name = "clamp_min"
+    _wrapped = None
 
     def __init__(
         self,
@@ -1803,6 +1941,9 @@ class ClampMinFwdOp(_ClampTensorBase):
                 raise ValueError(
                     f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
                 )
+        wrapped = type(self)._wrapped
+        if wrapped is not None:
+            return wrapped(input, min, self._instance_key)
         return self._eager_forward(input, min)
 
 
@@ -1816,6 +1957,7 @@ class ClampMaxFwdOp(_ClampTensorBase):
     """
 
     _op_name = "clamp_max"
+    _wrapped = None
 
     def __init__(
         self,
@@ -1864,6 +2006,9 @@ class ClampMaxFwdOp(_ClampTensorBase):
                 raise ValueError(
                     f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
                 )
+        wrapped = type(self)._wrapped
+        if wrapped is not None:
+            return wrapped(input, max, self._instance_key)
         return self._eager_forward(input, max)
 
 
@@ -2016,6 +2161,9 @@ class MaskedFillFwdOp(Op):
             )
         if tuple(value.shape) != ():
             raise ValueError(f"Expected value.shape (), got {tuple(value.shape)}")
+        wrapped = type(self)._wrapped
+        if wrapped is not None:
+            return wrapped(input, mask, value, self._instance_key)
         return self._eager_forward(input, mask, value)
 
 
@@ -2097,7 +2245,7 @@ class MaskedFillScalarFwdOp(Op):
                 f"Expected mask.shape {self.mask_shape}, got {tuple(mask.shape)}"
             )
         wrapped = type(self)._wrapped
-        if wrapped is not None and not self._needs_broadcast:
+        if wrapped is not None:
             return wrapped(input, mask, self._instance_key)
         return self._eager_forward(input, mask)
 
@@ -2286,9 +2434,8 @@ for _cls in [SiluAndMulFwdOp, GeluAndMulFwdOp, GeluTanhAndMulFwdOp]:
 
 # --- Independent unary-like ops (6 ops: x -> y with baked params) ---
 # ClampScalarFwdOp is the scalar-bound clamp (single-tensor input + min/max
-# baked into __init__); the Tensor-bound ClampFwdOp / ClampMinFwdOp /
-# ClampMaxFwdOp variants do not register a unary custom op because they
-# take multiple tensor inputs.
+# baked into __init__). The Tensor-bound ClampFwdOp / ClampMinFwdOp /
+# ClampMaxFwdOp variants register their own multi-input custom_ops below.
 for _cls in [
     LeakyReluFwdOp, EluFwdOp, HardtanhFwdOp, SoftplusFwdOp, ClampScalarFwdOp,
     NanToNumFwdOp,
@@ -2298,11 +2445,24 @@ for _cls in [
 # --- PReLU op (1 op: x, weight -> y) ---
 _register_prelu_custom_op(PreluFwdOp)
 
-# --- MaskedFill scalar variant (1 op: input, mask -> out) ---
-# The Tensor-value MaskedFillFwdOp uses an eager broadcasting path and is
-# not registered as a custom_op because the 0-dim Tensor value cannot be
-# folded into a static schema cleanly.
+# --- Tensor-bound clamp variants (3 ops: multi-tensor inputs -> out) ---
+# Registered under distinct custom_op namespaces from ClampScalarFwdOp:
+# ``top::elementwise_clamp_tensor`` (Optional Tensor min/max),
+# ``top::elementwise_clamp_min`` and ``top::elementwise_clamp_max`` for the
+# single-bound variants. register_fake is broadcast-aware so
+# torch.compile(fullgraph=True) traces correctly for both same-shape and
+# broadcasting inputs.
+_register_clamp_tensor_custom_op(ClampFwdOp)
+_register_clamp_min_custom_op(ClampMinFwdOp)
+_register_clamp_max_custom_op(ClampMaxFwdOp)
+
+# --- MaskedFill variants (input, mask[, value] -> out) ---
+# Both register broadcast-aware fake functions so torch.compile(fullgraph=True)
+# works for same-shape and broadcasting inputs. The Tensor-value variant is
+# registered under a distinct ``_tensor_value`` namespace to avoid colliding
+# with the scalar variant's ``top::elementwise_masked_fill``.
 _register_masked_fill_custom_op(MaskedFillScalarFwdOp)
+_register_masked_fill_tensor_value_custom_op(MaskedFillFwdOp)
 
 # --- Where op (1 op: cond, x, y -> out) ---
 # The fake function is broadcast-aware so torch.compile(fullgraph=True)

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -2071,8 +2071,10 @@ class ClampScalarFwdOp(Op):
             raise ValueError("Input must be a CUDA tensor")
         if input.dtype != self.dtype:
             raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
+        if tuple(input.shape) != self.input_shape:
+            raise ValueError(
+                f"Expected input.shape {self.input_shape}, got {tuple(input.shape)}"
+            )
         wrapped = type(self)._wrapped
         if wrapped is not None:
             return wrapped(input, self._instance_key)

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1732,6 +1732,10 @@ class WhereFwdOp(Op):
     ) -> torch.Tensor:
         if not (condition.is_cuda and input.is_cuda and other.is_cuda):
             raise ValueError("Inputs must be CUDA tensors")
+        if condition.dtype != torch.bool:
+            raise ValueError(
+                f"Expected condition.dtype torch.bool, got {condition.dtype}"
+            )
         if input.dtype != self.dtype:
             raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
         if other.dtype != self.dtype:

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -222,7 +222,12 @@ def _register_prelu_custom_op(op_cls):
 
 
 def _register_where_custom_op(op_cls):
-    """Register a where-style op (cond, x, y -> out) for torch.compile."""
+    """Register a where-style op (cond, x, y -> out) for torch.compile.
+
+    The fake function computes the broadcast output shape from
+    ``cond`` / ``x`` / ``y`` so that ``torch.compile(fullgraph=True)``
+    works for both same-shape and broadcasting inputs.
+    """
     op_name = op_cls._op_name
 
     @torch.library.custom_op(f"top::elementwise_{op_name}", mutates_args=())
@@ -242,7 +247,8 @@ def _register_where_custom_op(op_cls):
         y: torch.Tensor,
         instance_key: int,
     ) -> torch.Tensor:
-        return torch.empty_like(x)
+        out_shape = torch.broadcast_shapes(cond.shape, x.shape, y.shape)
+        return x.new_empty(out_shape)
 
     op_cls._wrapped = _wrapped
 
@@ -2297,6 +2303,11 @@ _register_prelu_custom_op(PreluFwdOp)
 # not registered as a custom_op because the 0-dim Tensor value cannot be
 # folded into a static schema cleanly.
 _register_masked_fill_custom_op(MaskedFillScalarFwdOp)
+
+# --- Where op (1 op: cond, x, y -> out) ---
+# The fake function is broadcast-aware so torch.compile(fullgraph=True)
+# traces correctly for both same-shape and broadcasting inputs.
+_register_where_custom_op(WhereFwdOp)
 
 # --- Generative ops (2 ops: no tensor input -> out) ---
 _register_generative_custom_op(

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1881,6 +1881,11 @@ class ClampScalarFwdOp(Op):
         max: Optional[float] = None,  # noqa: A002
         dtype: torch.dtype = torch.float32,
     ):
+        if min is None and max is None:
+            raise ValueError(
+                "ClampScalarFwdOp requires at least one of `min` or `max` to be a "
+                "Number; both None is not a valid clamp."
+            )
         if min is not None:
             _validate_scalar_param_repr("min", min, dtype, self._op_name)
         if max is not None:

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1626,20 +1626,24 @@ class _ClampTensorBase(Op):
 
 
 class ClampFwdOp(_ClampTensorBase):
-    """Clamp with Tensor lower and upper bounds (broadcasting).
+    """Clamp with Tensor lower and/or upper bounds (broadcasting).
 
-    Conforms to ``torch.clamp(input, min: Tensor, max: Tensor)``: all three
-    operands broadcast together. Implemented by expanding to the broadcast
-    shape and applying ``torch.maximum``/``torch.minimum`` via PyTorch ops
-    (the elementwise kernel layer is reused for the unary ``input`` path
-    only; the bound tensors are folded in eagerly to keep the broadcasting
-    logic in one place).
+    Conforms to ``torch.clamp(input, min, max)`` where ``min`` and ``max``
+    are each either a Tensor or ``None``. At least one of the two bounds
+    must be a Tensor. All Tensor operands broadcast together. The
+    primary spec entry in ``tileops/manifest/`` covers the both-Tensor
+    form; the mixed Tensor/``None`` cases are runtime-equivalent to
+    ``ClampMinFwdOp`` / ``ClampMaxFwdOp`` and are accepted here so callers
+    can mirror PyTorch's ``torch.clamp`` API directly.
 
     Args:
         input: Shape of the input tensor.
-        min: Shape of the lower-bound tensor.
-        max: Shape of the upper-bound tensor.
+        min: Shape of the lower-bound tensor, or ``None`` for no lower bound.
+        max: Shape of the upper-bound tensor, or ``None`` for no upper bound.
         dtype: Torch dtype for all operands.
+
+    Raises:
+        ValueError: If both ``min`` and ``max`` are ``None``.
     """
 
     _op_name = "clamp"
@@ -1647,17 +1651,25 @@ class ClampFwdOp(_ClampTensorBase):
     def __init__(
         self,
         input: tuple,  # noqa: A002 — manifest-aligned PyTorch param name
-        min: tuple,    # noqa: A002 — manifest-aligned PyTorch param name
-        max: tuple,    # noqa: A002 — manifest-aligned PyTorch param name
-        dtype: torch.dtype,
+        min: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
+        max: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
+        dtype: torch.dtype = torch.float32,
     ):
+        if min is None and max is None:
+            raise ValueError(
+                "ClampFwdOp requires at least one of `min` or `max` to be a "
+                "Tensor shape; both None is not a valid clamp."
+            )
         self.input_shape = tuple(input)
-        self.min_shape = tuple(min)
-        self.max_shape = tuple(max)
+        self.min_shape = None if min is None else tuple(min)
+        self.max_shape = None if max is None else tuple(max)
         self.dtype = dtype
-        self.out_shape = tuple(
-            torch.broadcast_shapes(self.input_shape, self.min_shape, self.max_shape)
-        )
+        broadcast_args = [self.input_shape]
+        if self.min_shape is not None:
+            broadcast_args.append(self.min_shape)
+        if self.max_shape is not None:
+            broadcast_args.append(self.max_shape)
+        self.out_shape = tuple(torch.broadcast_shapes(*broadcast_args))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -1667,7 +1679,10 @@ class ClampFwdOp(_ClampTensorBase):
         return {}
 
     def _eager_forward(
-        self, input: torch.Tensor, min: torch.Tensor, max: torch.Tensor,  # noqa: A002
+        self,
+        input: torch.Tensor,  # noqa: A002
+        min: Optional[torch.Tensor] = None,  # noqa: A002
+        max: Optional[torch.Tensor] = None,  # noqa: A002
     ) -> torch.Tensor:
         # Use torch.clamp for full PyTorch parity (handles NaN / dtype
         # promotion identically). Broadcasting is implicit. PyTorch's CUDA
@@ -1677,20 +1692,40 @@ class ClampFwdOp(_ClampTensorBase):
         # post-cast.
         if _is_fp8(self.dtype):
             compute = _fp8_compute_dtype(self.dtype)
-            result = torch.clamp(input.to(compute), min.to(compute), max.to(compute))
+            mn_c = None if min is None else min.to(compute)
+            mx_c = None if max is None else max.to(compute)
+            result = torch.clamp(input.to(compute), mn_c, mx_c)
             return result.to(self.dtype)
         return torch.clamp(input, min, max)
 
     def forward(
-        self, input: torch.Tensor, min: torch.Tensor, max: torch.Tensor,  # noqa: A002
+        self,
+        input: torch.Tensor,  # noqa: A002
+        min: Optional[torch.Tensor] = None,  # noqa: A002
+        max: Optional[torch.Tensor] = None,  # noqa: A002
     ) -> torch.Tensor:
-        if not (input.is_cuda and min.is_cuda and max.is_cuda):
-            raise ValueError("Inputs must be CUDA tensors")
-        for name, t, expected in [
-            ("input", input, self.input_shape),
-            ("min", min, self.min_shape),
-            ("max", max, self.max_shape),
-        ]:
+        # Validate that the runtime None / Tensor pattern matches what
+        # __init__ was configured for — the broadcast shape and the
+        # presence of each bound is baked in at construction.
+        if (min is None) != (self.min_shape is None):
+            raise ValueError(
+                f"min was {'None' if self.min_shape is None else 'a Tensor shape'} at "
+                f"__init__ but {'None' if min is None else 'a Tensor'} at forward()"
+            )
+        if (max is None) != (self.max_shape is None):
+            raise ValueError(
+                f"max was {'None' if self.max_shape is None else 'a Tensor shape'} at "
+                f"__init__ but {'None' if max is None else 'a Tensor'} at forward()"
+            )
+        tensors = [("input", input, self.input_shape)]
+        if min is not None:
+            tensors.append(("min", min, self.min_shape))
+        if max is not None:
+            tensors.append(("max", max, self.max_shape))
+        for _, t, _ in tensors:
+            if not t.is_cuda:
+                raise ValueError("Inputs must be CUDA tensors")
+        for name, t, expected in tensors:
             if t.dtype != self.dtype:
                 raise ValueError(f"Expected {name}.dtype {self.dtype}, got {t.dtype}")
             if tuple(t.shape) != expected:

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -414,7 +414,11 @@ __all__ = [
     "PreluFwdOp",
     "WhereFwdOp",
     "ClampFwdOp",
+    "ClampScalarFwdOp",
+    "ClampMinFwdOp",
+    "ClampMaxFwdOp",
     "MaskedFillFwdOp",
+    "MaskedFillScalarFwdOp",
     "NanToNumFwdOp",
     "AlibiFwdOp",
     "SinusoidalFwdOp",
@@ -1497,20 +1501,41 @@ class PreluFwdOp(Op):
 
 
 class WhereFwdOp(Op):
-    """Where: out = cond ? x : y.
+    """Where: out = condition ? input : other (with full PyTorch broadcasting).
+
+    Conforms to ``torch.where(condition, input, other)``: ``condition`` is a
+    bool tensor and ``input`` / ``other`` may broadcast with each other and
+    with ``condition`` to produce the output. The Op layer expands all
+    three inputs to the broadcast shape and dispatches the existing flat
+    where kernel on ``N_total = product(broadcast_shape)`` elements.
 
     Args:
-        N_total: Total number of elements (flattened).
-        dtype: Torch dtype for x and y.
+        condition: Shape of the condition tensor (any shape broadcastable
+            with ``input`` / ``other``).
+        input: Shape of the value-when-true tensor.
+        other: Shape of the value-when-false tensor.
+        dtype: Torch dtype for ``input`` / ``other``.
     """
 
     _op_name = "where"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype):
-        self.N_total = N_total
+    def __init__(
+        self,
+        condition: tuple,
+        input: tuple,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: tuple,
+        dtype: torch.dtype,
+    ):
+        self.condition_shape = tuple(condition)
+        self.input_shape = tuple(input)
+        self.other_shape = tuple(other)
         self.dtype = dtype
-        self.kernel = WhereFwdKernel(N_total, dtype)
+        self.out_shape = tuple(
+            torch.broadcast_shapes(self.condition_shape, self.input_shape, self.other_shape)
+        )
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self.kernel = WhereFwdKernel(self.N_total, dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1518,56 +1543,267 @@ class WhereFwdOp(Op):
     def default_kernel_map(self):
         return {"where": WhereFwdKernel}
 
+    @staticmethod
+    def _expand_flat(t: torch.Tensor, target_shape: tuple) -> torch.Tensor:
+        """Expand ``t`` to ``target_shape`` and return a contiguous flat view."""
+        if tuple(t.shape) != tuple(target_shape):
+            t = t.expand(target_shape)
+        return t.contiguous().view(-1)
+
     def _eager_forward(
-        self, cond: torch.Tensor, x: torch.Tensor, y: torch.Tensor,
+        self, condition: torch.Tensor, input: torch.Tensor, other: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
-        orig_shape = x.shape
-        # Fast path: cast to bool if needed, then flatten + pack to uint8
-        # for vectorized T.copy in the kernel.
-        cond_flat = (cond if cond.dtype == torch.bool else cond.bool()).contiguous().view(-1)
-        x_flat = x.contiguous().view(-1)
-        y_flat = y.contiguous().view(-1)
-        return self.kernel(cond_flat.view(torch.uint8), x_flat, y_flat).view(orig_shape)
+        out_shape = self.out_shape if self.out_shape else (1,)
+        cond_b = condition if condition.dtype == torch.bool else condition.bool()
+        cond_flat = self._expand_flat(cond_b, out_shape).view(torch.uint8)
+        x_flat = self._expand_flat(input, out_shape)
+        y_flat = self._expand_flat(other, out_shape)
+        result = self.kernel(cond_flat, x_flat, y_flat).view(out_shape if self.out_shape else ())
+        return result
 
     def forward(
-        self, cond: torch.Tensor, x: torch.Tensor, y: torch.Tensor,
+        self, condition: torch.Tensor, input: torch.Tensor, other: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
-        if not x.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if not (condition.is_cuda and input.is_cuda and other.is_cuda):
+            raise ValueError("Inputs must be CUDA tensors")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if other.dtype != self.dtype:
+            raise ValueError(f"Expected other.dtype {self.dtype}, got {other.dtype}")
+        if tuple(condition.shape) != self.condition_shape:
+            raise ValueError(
+                f"Expected condition.shape {self.condition_shape}, got {tuple(condition.shape)}"
+            )
+        if tuple(input.shape) != self.input_shape:
+            raise ValueError(
+                f"Expected input.shape {self.input_shape}, got {tuple(input.shape)}"
+            )
+        if tuple(other.shape) != self.other_shape:
+            raise ValueError(
+                f"Expected other.shape {self.other_shape}, got {tuple(other.shape)}"
+            )
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(cond, x, y, self._instance_key)
-        return self._eager_forward(cond, x, y)
+            return wrapped(condition, input, other, self._instance_key)
+        return self._eager_forward(condition, input, other)
 
 
-class ClampFwdOp(Op):
-    """Clamp: y = clamp(x, min, max) with optional bounds.
+class _ClampTensorBase(Op):
+    """Shared infrastructure for Tensor-bound clamp variants (broadcasting)."""
+
+    _wrapped = None
+
+    @staticmethod
+    def _expand_flat(t: torch.Tensor, target_shape: tuple) -> torch.Tensor:
+        if tuple(t.shape) != tuple(target_shape):
+            t = t.expand(target_shape)
+        return t.contiguous().view(-1)
+
+
+class ClampFwdOp(_ClampTensorBase):
+    """Clamp with Tensor lower and upper bounds (broadcasting).
+
+    Conforms to ``torch.clamp(input, min: Tensor, max: Tensor)``: all three
+    operands broadcast together. Implemented by expanding to the broadcast
+    shape and applying ``torch.maximum``/``torch.minimum`` via PyTorch ops
+    (the elementwise kernel layer is reused for the unary ``input`` path
+    only; the bound tensors are folded in eagerly to keep the broadcasting
+    logic in one place).
 
     Args:
-        N_total: Total number of elements (flattened).
+        input: Shape of the input tensor.
+        min: Shape of the lower-bound tensor.
+        max: Shape of the upper-bound tensor.
+        dtype: Torch dtype for all operands.
+    """
+
+    _op_name = "clamp"
+
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002 — manifest-aligned PyTorch param name
+        min: tuple,    # noqa: A002 — manifest-aligned PyTorch param name
+        max: tuple,    # noqa: A002 — manifest-aligned PyTorch param name
+        dtype: torch.dtype,
+    ):
+        self.input_shape = tuple(input)
+        self.min_shape = tuple(min)
+        self.max_shape = tuple(max)
+        self.dtype = dtype
+        self.out_shape = tuple(
+            torch.broadcast_shapes(self.input_shape, self.min_shape, self.max_shape)
+        )
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    @property
+    def default_kernel_map(self):
+        return {}
+
+    def _eager_forward(
+        self, input: torch.Tensor, min: torch.Tensor, max: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        # Use torch.clamp for full PyTorch parity (handles NaN / dtype
+        # promotion identically). Broadcasting is implicit.
+        return torch.clamp(input, min, max)
+
+    def forward(
+        self, input: torch.Tensor, min: torch.Tensor, max: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        if not (input.is_cuda and min.is_cuda and max.is_cuda):
+            raise ValueError("Inputs must be CUDA tensors")
+        for name, t, expected in [
+            ("input", input, self.input_shape),
+            ("min", min, self.min_shape),
+            ("max", max, self.max_shape),
+        ]:
+            if t.dtype != self.dtype:
+                raise ValueError(f"Expected {name}.dtype {self.dtype}, got {t.dtype}")
+            if tuple(t.shape) != expected:
+                raise ValueError(
+                    f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
+                )
+        return self._eager_forward(input, min, max)
+
+
+class ClampMinFwdOp(_ClampTensorBase):
+    """Single-bound Tensor lower clamp (``torch.clamp_min``).
+
+    Args:
+        input: Shape of the input tensor.
+        min: Shape of the lower-bound tensor.
         dtype: Torch dtype.
-        min_val: Lower bound (None = no lower bound).
-        max_val: Upper bound (None = no upper bound).
+    """
+
+    _op_name = "clamp_min"
+
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002
+        min: tuple,    # noqa: A002
+        dtype: torch.dtype,
+    ):
+        self.input_shape = tuple(input)
+        self.min_shape = tuple(min)
+        self.dtype = dtype
+        self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.min_shape))
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    @property
+    def default_kernel_map(self):
+        return {}
+
+    def _eager_forward(
+        self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        return torch.maximum(input, min)
+
+    def forward(
+        self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        if not (input.is_cuda and min.is_cuda):
+            raise ValueError("Inputs must be CUDA tensors")
+        for name, t, expected in [
+            ("input", input, self.input_shape),
+            ("min", min, self.min_shape),
+        ]:
+            if t.dtype != self.dtype:
+                raise ValueError(f"Expected {name}.dtype {self.dtype}, got {t.dtype}")
+            if tuple(t.shape) != expected:
+                raise ValueError(
+                    f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
+                )
+        return self._eager_forward(input, min)
+
+
+class ClampMaxFwdOp(_ClampTensorBase):
+    """Single-bound Tensor upper clamp (``torch.clamp_max``).
+
+    Args:
+        input: Shape of the input tensor.
+        max: Shape of the upper-bound tensor.
+        dtype: Torch dtype.
+    """
+
+    _op_name = "clamp_max"
+
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002
+        max: tuple,    # noqa: A002
+        dtype: torch.dtype,
+    ):
+        self.input_shape = tuple(input)
+        self.max_shape = tuple(max)
+        self.dtype = dtype
+        self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.max_shape))
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    @property
+    def default_kernel_map(self):
+        return {}
+
+    def _eager_forward(
+        self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        return torch.minimum(input, max)
+
+    def forward(
+        self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        if not (input.is_cuda and max.is_cuda):
+            raise ValueError("Inputs must be CUDA tensors")
+        for name, t, expected in [
+            ("input", input, self.input_shape),
+            ("max", max, self.max_shape),
+        ]:
+            if t.dtype != self.dtype:
+                raise ValueError(f"Expected {name}.dtype {self.dtype}, got {t.dtype}")
+            if tuple(t.shape) != expected:
+                raise ValueError(
+                    f"Expected {name}.shape {expected}, got {tuple(t.shape)}"
+                )
+        return self._eager_forward(input, max)
+
+
+class ClampScalarFwdOp(Op):
+    """Scalar-bound clamp (``torch.clamp(input, min: Number|None, max: Number|None)``).
+
+    Args:
+        input: Shape of the input tensor.
+        min: Lower bound (Number or None).
+        max: Upper bound (Number or None).
+        dtype: Torch dtype.
     """
 
     _op_name = "clamp"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype,
-                 min_val: Optional[float] = None, max_val: Optional[float] = None):
-        if min_val is not None:
-            _validate_scalar_param_repr("min_val", min_val, dtype, self._op_name)
-        if max_val is not None:
-            _validate_scalar_param_repr("max_val", max_val, dtype, self._op_name)
-        self.N_total = N_total
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002
+        min: Optional[float] = None,  # noqa: A002
+        max: Optional[float] = None,  # noqa: A002
+        dtype: torch.dtype = torch.float32,
+    ):
+        if min is not None:
+            _validate_scalar_param_repr("min", min, dtype, self._op_name)
+        if max is not None:
+            _validate_scalar_param_repr("max", max, dtype, self._op_name)
+        self.input_shape = tuple(input)
+        self.N_total = prod(self.input_shape) if self.input_shape else 1
         self.dtype = dtype
-        self.min_val = min_val
-        self.max_val = max_val
-        self.kernel = ClampFwdKernel(N_total, dtype, min_val=min_val, max_val=max_val)
+        self.min = min
+        self.max = max
+        # Backwards-compat aliases for legacy callers.
+        self.min_val = min
+        self.max_val = max
+        self.kernel = ClampFwdKernel(self.N_total, dtype, min_val=min, max_val=max)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1575,42 +1811,148 @@ class ClampFwdOp(Op):
     def default_kernel_map(self):
         return {"clamp": ClampFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
 class MaskedFillFwdOp(Op):
-    """MaskedFill: out = mask ? fill_value : x.
+    """MaskedFill with 0-dim Tensor value (``torch.Tensor.masked_fill(mask, value: Tensor)``).
+
+    Output shape is the bidirectional broadcast of ``input`` and ``mask``;
+    ``value`` must be a 0-dim Tensor. The Op expands ``input`` and ``mask``
+    to the broadcast shape and dispatches the existing flat scalar kernel
+    using ``value.item()`` as the fill literal — this keeps the
+    fast vectorized kernel path while satisfying the manifest's Tensor-value
+    contract (the kernel reads ``value`` once at forward time, which is
+    consistent with the 0-dim semantics).
 
     Args:
-        N_total: Total number of elements (flattened).
-        dtype: Torch dtype.
-        fill_value: Scalar value to fill where mask is True.
+        input: Shape of the input tensor.
+        mask: Shape of the mask tensor (bool).
+        value: Shape of the value tensor (must be ``()`` per the manifest).
+        dtype: Torch dtype for ``input`` / ``value``.
     """
 
     _op_name = "masked_fill"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype, fill_value: float):
-        _validate_scalar_param_repr("fill_value", fill_value, dtype, self._op_name)
-        self.N_total = N_total
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002
+        mask: tuple,
+        value: tuple,
+        dtype: torch.dtype,
+    ):
+        if tuple(value) != ():
+            raise ValueError(
+                f"MaskedFillFwdOp requires a 0-dim value Tensor; got shape {tuple(value)}"
+            )
+        self.input_shape = tuple(input)
+        self.mask_shape = tuple(mask)
+        self.value_shape = tuple(value)
         self.dtype = dtype
-        self.fill_value = fill_value
-        self.kernel = MaskedFillFwdKernel(N_total, dtype, fill_value)
+        self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    @property
+    def default_kernel_map(self):
+        return {}
+
+    def _eager_forward(
+        self, input: torch.Tensor, mask: torch.Tensor, value: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        # PyTorch's Tensor.masked_fill with a 0-dim Tensor value is
+        # semantically identical to the scalar form; defer to it for full
+        # parity (broadcasts ``input`` and ``mask`` together).
+        return torch.masked_fill(input.expand(self.out_shape).contiguous(),
+                                 mask.expand(self.out_shape), value)
+
+    def forward(
+        self, input: torch.Tensor, mask: torch.Tensor, value: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        if not (input.is_cuda and mask.is_cuda and value.is_cuda):
+            raise ValueError("Inputs must be CUDA tensors")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if mask.dtype != torch.bool:
+            raise ValueError(f"Expected mask.dtype torch.bool, got {mask.dtype}")
+        if value.dtype != self.dtype:
+            raise ValueError(f"Expected value.dtype {self.dtype}, got {value.dtype}")
+        if tuple(input.shape) != self.input_shape:
+            raise ValueError(
+                f"Expected input.shape {self.input_shape}, got {tuple(input.shape)}"
+            )
+        if tuple(mask.shape) != self.mask_shape:
+            raise ValueError(
+                f"Expected mask.shape {self.mask_shape}, got {tuple(mask.shape)}"
+            )
+        if tuple(value.shape) != ():
+            raise ValueError(f"Expected value.shape (), got {tuple(value.shape)}")
+        return self._eager_forward(input, mask, value)
+
+
+class MaskedFillScalarFwdOp(Op):
+    """MaskedFill with Number (scalar) value.
+
+    Conforms to ``torch.Tensor.masked_fill(mask, value: Number)``. Output
+    shape follows the bidirectional broadcast of ``input`` and ``mask``.
+
+    Args:
+        input: Shape of the input tensor.
+        mask: Shape of the mask tensor (bool).
+        value: Scalar fill value.
+        dtype: Torch dtype.
+    """
+
+    _op_name = "masked_fill"
+    _wrapped = None
+
+    def __init__(
+        self,
+        input: tuple,  # noqa: A002
+        mask: tuple,
+        value: float = 0.0,
+        dtype: torch.dtype = torch.float32,
+    ):
+        _validate_scalar_param_repr("value", value, dtype, self._op_name)
+        self.input_shape = tuple(input)
+        self.mask_shape = tuple(mask)
+        self.dtype = dtype
+        self.value = value
+        # Backwards-compat alias.
+        self.fill_value = value
+        self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
+        self.N_total = prod(self.out_shape) if self.out_shape else 1
+        # When input/mask shapes match exactly, reuse the existing flat
+        # vectorized kernel; otherwise fall back to the broadcasting path.
+        self._needs_broadcast = (
+            self.input_shape != self.out_shape or self.mask_shape != self.out_shape
+        )
+        # Note: ``kernel`` is typed as ``Kernel`` on the base class but we
+        # legitimately need a None sentinel here for the broadcasting fallback
+        # path (no flat kernel is dispatched in that case). The type ignore is
+        # narrow and intentional.
+        self.kernel: Optional[Kernel] = (  # type: ignore[assignment]
+            MaskedFillFwdKernel(self.N_total, dtype, value)
+            if not self._needs_broadcast
+            else None
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1618,34 +1960,38 @@ class MaskedFillFwdOp(Op):
     def default_kernel_map(self):
         return {"masked_fill": MaskedFillFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        # Fast path: cast to bool if needed, then flatten + pack to uint8
-        # for vectorized T.copy in the kernel.
+    def _eager_forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if self._needs_broadcast or self.kernel is None:
+            inp_b = input.expand(self.out_shape).contiguous()
+            mask_b = mask.expand(self.out_shape)
+            return inp_b.masked_fill(mask_b, self.value)
+        orig_shape = input.shape
         mask_flat = (mask if mask.dtype == torch.bool else mask.bool()).contiguous().view(-1)
-        x_flat = x.contiguous().view(-1)
+        x_flat = input.contiguous().view(-1)
         result = self.kernel(x_flat, mask_flat.view(torch.uint8)).view(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if tuple(input.shape) != self.input_shape:
+            raise ValueError(
+                f"Expected input.shape {self.input_shape}, got {tuple(input.shape)}"
+            )
         if not mask.is_cuda:
             raise ValueError("Mask must be a CUDA tensor")
         if mask.dtype != torch.bool:
             raise ValueError(f"Expected mask.dtype torch.bool, got {mask.dtype}")
-        if mask.numel() != self.N_total:
+        if tuple(mask.shape) != self.mask_shape:
             raise ValueError(
-                f"Expected mask with {self.N_total} elements, got {mask.numel()}"
+                f"Expected mask.shape {self.mask_shape}, got {tuple(mask.shape)}"
             )
         wrapped = type(self)._wrapped
-        if wrapped is not None:
-            return wrapped(x, mask, self._instance_key)
-        return self._eager_forward(x, mask)
+        if wrapped is not None and not self._needs_broadcast:
+            return wrapped(input, mask, self._instance_key)
+        return self._eager_forward(input, mask)
 
 
 class NanToNumFwdOp(Op):
@@ -1831,19 +2177,24 @@ for _cls in [SiluAndMulFwdOp, GeluAndMulFwdOp, GeluTanhAndMulFwdOp]:
     _register_fused_gated_custom_op(_cls)
 
 # --- Independent unary-like ops (6 ops: x -> y with baked params) ---
+# ClampScalarFwdOp is the scalar-bound clamp (single-tensor input + min/max
+# baked into __init__); the Tensor-bound ClampFwdOp / ClampMinFwdOp /
+# ClampMaxFwdOp variants do not register a unary custom op because they
+# take multiple tensor inputs.
 for _cls in [
-    LeakyReluFwdOp, EluFwdOp, HardtanhFwdOp, SoftplusFwdOp, ClampFwdOp, NanToNumFwdOp,
+    LeakyReluFwdOp, EluFwdOp, HardtanhFwdOp, SoftplusFwdOp, ClampScalarFwdOp,
+    NanToNumFwdOp,
 ]:
     _register_unary_custom_op(_cls)
 
 # --- PReLU op (1 op: x, weight -> y) ---
 _register_prelu_custom_op(PreluFwdOp)
 
-# --- Where op (1 op: cond, x, y -> out) ---
-_register_where_custom_op(WhereFwdOp)
-
-# --- MaskedFill op (1 op: x, mask -> y) ---
-_register_masked_fill_custom_op(MaskedFillFwdOp)
+# --- MaskedFill scalar variant (1 op: input, mask -> out) ---
+# The Tensor-value MaskedFillFwdOp uses an eager broadcasting path and is
+# not registered as a custom_op because the 0-dim Tensor value cannot be
+# folded into a static schema cleanly.
+_register_masked_fill_custom_op(MaskedFillScalarFwdOp)
 
 # --- Generative ops (2 ops: no tensor input -> out) ---
 _register_generative_custom_op(

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -499,6 +499,31 @@ def _apply_fp8_post_cast(result: torch.Tensor, kernel) -> torch.Tensor:
     return result
 
 
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+
+
+def _is_fp8(dtype: torch.dtype) -> bool:
+    """Return True iff ``dtype`` is one of the supported fp8 dtypes."""
+    return dtype in _FP8_DTYPES
+
+
+def _fp8_compute_dtype(dtype: torch.dtype) -> torch.dtype:
+    """Return the compute dtype used to emulate fp8 elementwise fallbacks.
+
+    PyTorch's CUDA backend does not implement ``clamp``/``maximum``/
+    ``minimum``/``masked_fill_`` on Float8 tensors (raises NotImplementedError
+    on ``clamp_cuda`` / ``max_elementwise_cuda`` / ``min_elementwise_cuda`` /
+    ``masked_fill_``). Both e4m3fn (finite range ±448) and e5m2 (finite range
+    ±57344) fit in fp16, so we upcast to fp16, run the op, and cast back. The
+    final cast preserves Inf/NaN for e5m2 (PyTorch's fp16->e5m2 conversion is
+    non-saturating) and saturates for e4m3fn (matching PyTorch's default
+    fp16->e4m3fn behaviour).
+    """
+    if not _is_fp8(dtype):
+        raise ValueError(f"_fp8_compute_dtype expects an fp8 dtype, got {dtype}")
+    return torch.float16
+
+
 class UnaryOp(Op):
     """Template base class for unary elementwise ops.
 
@@ -1645,7 +1670,15 @@ class ClampFwdOp(_ClampTensorBase):
         self, input: torch.Tensor, min: torch.Tensor, max: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
         # Use torch.clamp for full PyTorch parity (handles NaN / dtype
-        # promotion identically). Broadcasting is implicit.
+        # promotion identically). Broadcasting is implicit. PyTorch's CUDA
+        # ``clamp`` has no fp8 implementation (raises NotImplementedError
+        # ``clamp_cuda``), so we route fp8 inputs through fp16 and cast
+        # back — preserves Inf/NaN for e5m2 via the non-saturating fp16
+        # post-cast.
+        if _is_fp8(self.dtype):
+            compute = _fp8_compute_dtype(self.dtype)
+            result = torch.clamp(input.to(compute), min.to(compute), max.to(compute))
+            return result.to(self.dtype)
         return torch.clamp(input, min, max)
 
     def forward(
@@ -1699,6 +1732,12 @@ class ClampMinFwdOp(_ClampTensorBase):
     def _eager_forward(
         self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
+        # ``torch.maximum`` has no fp8 CUDA kernel (NotImplementedError
+        # ``max_elementwise_cuda``); route fp8 through fp16 and cast back.
+        if _is_fp8(self.dtype):
+            compute = _fp8_compute_dtype(self.dtype)
+            result = torch.maximum(input.to(compute), min.to(compute))
+            return result.to(self.dtype)
         return torch.maximum(input, min)
 
     def forward(
@@ -1751,6 +1790,12 @@ class ClampMaxFwdOp(_ClampTensorBase):
     def _eager_forward(
         self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
     ) -> torch.Tensor:
+        # ``torch.minimum`` has no fp8 CUDA kernel (NotImplementedError
+        # ``min_elementwise_cuda``); route fp8 through fp16 and cast back.
+        if _is_fp8(self.dtype):
+            compute = _fp8_compute_dtype(self.dtype)
+            result = torch.minimum(input.to(compute), max.to(compute))
+            return result.to(self.dtype)
         return torch.minimum(input, max)
 
     def forward(
@@ -1880,6 +1925,14 @@ class MaskedFillFwdOp(Op):
         # PyTorch's Tensor.masked_fill with a 0-dim Tensor value is
         # semantically identical to the scalar form; defer to it for full
         # parity (broadcasts ``input`` and ``mask`` together).
+        # ``masked_fill_`` has no fp8 CUDA kernel (NotImplementedError); for
+        # fp8 we run masked_fill in fp16 and cast back.
+        if _is_fp8(self.dtype):
+            compute = _fp8_compute_dtype(self.dtype)
+            inp_b = input.to(compute).expand(self.out_shape).contiguous()
+            value_c = value.to(compute)
+            result = torch.masked_fill(inp_b, mask.expand(self.out_shape), value_c)
+            return result.to(self.dtype)
         return torch.masked_fill(input.expand(self.out_shape).contiguous(),
                                  mask.expand(self.out_shape), value)
 
@@ -1962,8 +2015,15 @@ class MaskedFillScalarFwdOp(Op):
 
     def _eager_forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002
         if self._needs_broadcast or self.kernel is None:
-            inp_b = input.expand(self.out_shape).contiguous()
             mask_b = mask.expand(self.out_shape)
+            # ``masked_fill_`` has no fp8 CUDA kernel; route fp8 through fp16
+            # and cast back to preserve manifest-declared fp8 support on the
+            # broadcasting fallback path.
+            if _is_fp8(self.dtype):
+                compute = _fp8_compute_dtype(self.dtype)
+                inp_b = input.to(compute).expand(self.out_shape).contiguous()
+                return inp_b.masked_fill(mask_b, self.value).to(self.dtype)
+            inp_b = input.expand(self.out_shape).contiguous()
             return inp_b.masked_fill(mask_b, self.value)
         orig_shape = input.shape
         mask_flat = (mask if mask.dtype == torch.bool else mask.bool()).contiguous().view(-1)


### PR DESCRIPTION
Closes #1107

## Summary

- Align `WhereFwdOp`, `ClampFwdOp` (Tensor bounds + mixed Tensor/None), `ClampScalarFwdOp` / `ClampMinFwdOp` / `ClampMaxFwdOp`, `MaskedFillFwdOp` (0-dim Tensor value), and `MaskedFillScalarFwdOp` with their `tileops/manifest/` signatures and the public PyTorch API (parameter names, `__init__` shape, broadcasting semantics).
- Add real TileLang kernels for tensor-bound clamp (`ClampTensorFwdKernel`, with `has_min` / `has_max` codegen branches) and 0-dim Tensor `masked_fill` (`MaskedFillTensorValueFwdKernel`); broadcasting `WhereFwdOp` with broadcast-aware fake; mixed Tensor/None bounds for `ClampFwdOp`; `ClampScalarFwdOp` rejects `min=None and max=None` (matches `torch.clamp`); fp8 eager fallback now routes through fp16 for the new multi-input ops.
- Restore `WhereFwdOp` `torch.library.custom_op` registration so `torch.compile(fullgraph=True)` keeps working with broadcasting.
- **Manifest is intentionally untouched** per `.claude/rules/manifest-trust-model.md` — the `status: spec-only → implemented` flip lands in a follow-up manifest-only PR.

## Test plan

- [x] AC-1: `WhereFwdOp` supports full `torch.where` broadcasting (parity tests over broadcastable shape sets).
- [x] AC-2: `ClampFwdOp` supports Tensor min/max and mixed Tensor/None; parameter names match the manifest.
- [x] AC-3: `ClampScalarFwdOp`, `ClampMinFwdOp`, `ClampMaxFwdOp` implemented with `Number|None` scalar bounds and PyTorch-aligned `__init__` shape.
- [x] AC-4: `MaskedFillFwdOp` accepts a 0-dim Tensor value; `MaskedFillScalarFwdOp` accepts a `Number` scalar value; both with PyTorch-aligned `__init__` shape and parameter names.
- [x] AC-5: All listed spec-only entries are ready to flip to `status: implemented` in the follow-up manifest-only PR; `scripts/validate_manifest.py` keeps passing before and after the flip.
- [x] AC-6 (changed-file scope): no regressions in the changed-file scope — `pytest tests/ops/test_special_elementwise.py tests/ops/test_special_elementwise_conformance.py tests/ops/test_elementwise_independent_fp8.py tests/ops/test_elementwise_compile.py tests/test_validate_manifest.py` all pass (440 tests). The full `tests/ops/` baseline currently has 3 pre-existing GQA `T.tma_copy` tilelang-compat failures unrelated to this PR — to be tracked in a separate follow-up issue.
- [x] pre-commit passed on all changed files (ruff, codespell, end-of-file, yaml, gitleaks, etc.).

## Structural Readiness

All checks passed.

## Test node delta

```
File                                                 Base    HEAD    Delta
--------------------------------------------------------------------------
tests/ops/test_elementwise_compile.py                  60      73      +13
tests/ops/test_elementwise_independent_fp8.py          54      54        0
tests/ops/test_softmax.py                             134     126       -8
tests/ops/test_special_elementwise.py                  64      63       -1
tests/ops/test_special_elementwise_conformance.py     new      60    (new)
--------------------------------------------------------------------------
TOTAL                                                 312     376      +64

Growth: +20.5%
```

**Justification:** the +64 nodes are one representative per code-path equivalence class (per `.claude/domain-rules/testing-budget.md` and `docs/design/testing.md` §"Test case policy"):

- `test_special_elementwise_conformance.py` (+60, new file): one parity test per AC — `WhereFwdOp` broadcasting (AC-1) and non-bool condition rejection, `ClampFwdOp` Tensor min/max + min-only / max-only None-routing dispatch (AC-2), `Clamp{Scalar,Min,Max}FwdOp` scalar variants + both-None rejection + same-numel-wrong-shape rejection (AC-3), `MaskedFillFwdOp` 0-dim Tensor value + `MaskedFillScalarFwdOp` Number value (AC-4), fp8 fallback parity (umbrella test covers both fp8 dtypes; per-branch fp8 tests use a single representative dtype since the cast path is dtype-agnostic), NaN propagation in `ClampTensorFwdKernel` (one parity test per kernel branch: has_min+has_max, has_min only, has_max only).
- `test_elementwise_compile.py` (+13): `torch.compile(fullgraph=True)` smoke per newly-registered Op × {same-shape, broadcast}. Guards against the regression class where `custom_op` registration is dropped and `torch.compile` returns non-Tensor (caught once already during this PR for `WhereFwdOp` and again for the tensor-bound clamp / masked_fill variants).
- `test_special_elementwise.py` (−1): dropped the `clamp` parametrize case from `test_forward_rejects_wrong_numel`; `ClampScalarFwdOp` is now covered by the stricter shape-level rejection test in the conformance file.
- `test_softmax.py` (−8): pre-existing softmax matrix slim, unrelated to this PR.

## Follow-up

Issues:
- #1128 — flip 7 elementwise/clamp/masked_fill ops to `status: implemented` (manifest-only)
- #1129 — 3 pre-existing GQA `T.tma_copy` tilelang-compat failures in `tests/ops/` (independent of #1)