### PR TITLE
[Fix][Skill] review-tileops loop: codex --cd, prompt cleanup, worktree cleanup

### DIFF
--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -7,9 +7,6 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 - [ ] For each `shrink` / `delete`, post a review comment with the node ID and the kept case it duplicates or the axis to fold.
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 - [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
-- [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` AND record only:
-  - what the PR finally does (Summary, scoped to the merged diff);
-  - test plan / pre-commit status / structural readiness / test node delta — verification facts about the final state.
-    Strip any development-process narration: per-round fix history, tally thread IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer change logs, abandoned approaches, "originally we did X then switched to Y". Those belong in the PR commit history or review threads, not the body. If the body still contains them, request changes and have the developer rewrite it before approving.
+- [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` and record only the final state: what the PR does (Summary, scoped to the merged diff) + verification facts (test plan, pre-commit, structural readiness, test node delta). Strip dev-process narration — per-round fix history, tally IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer changelogs, abandoned approaches. Those belong in commit history / review threads. If found in the body, REQUEST_CHANGES.
 - [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -7,6 +7,9 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 - [ ] For each `shrink` / `delete`, post a review comment with the node ID and the kept case it duplicates or the axis to fold.
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 - [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
-- [ ] PR body conforms to `.foundry/mold/pr-body-template.md` and reflects the final state of the diff (no stale process narration). If not, request changes and have the developer update it before approving.
+- [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` AND record only:
+  - what the PR finally does (Summary, scoped to the merged diff);
+  - test plan / pre-commit status / structural readiness / test node delta — verification facts about the final state.
+    Strip any development-process narration: per-round fix history, tally thread IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer change logs, abandoned approaches, "originally we did X then switched to Y". Those belong in the PR commit history or review threads, not the body. If the body still contains them, request changes and have the developer rewrite it before approving.
 - [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -8,4 +8,5 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 - [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
 - [ ] PR body conforms to `.foundry/mold/pr-body-template.md` and reflects the final state of the diff (no stale process narration). If not, request changes and have the developer update it before approving.
+- [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/doc.md
+++ b/.claude/review-checklists/doc.md
@@ -2,7 +2,7 @@ For `[Doc]` and `[Design]`.
 
 A flag in this domain names one of: a contradiction (cite file:line on both sides), a missing follow-up reference, a scope violation (quote the offending line), or a re-introduced removal (cite the prior commit).
 
-# Design docs (`docs/design/*.md`)
+#### Design docs (`docs/design/*.md`)
 
 TileOps is a design-first project. Design docs guide agent development; tight scope keeps agents on top-level decisions instead of mechanics. Also load `.claude/domain-rules/design-docs.md`.
 
@@ -11,7 +11,7 @@ TileOps is a design-first project. Design docs guide agent development; tight sc
 - [ ] **Concise.** Flag content that does not constrain the decision — history narration, illustrative examples, rationale that doesn't explain a choice.
 - [ ] **Drift-free.** If the doc states a target the code or manifest doesn't satisfy, the PR includes the change or links a follow-up issue.
 
-# Other docs
+#### Other docs
 
 Covers READMEs, `CLAUDE.md` family, agent-facing skill docs, and source comments. Lighter bar — only consistency and drift matter.
 

--- a/.claude/review-checklists/feature.md
+++ b/.claude/review-checklists/feature.md
@@ -1,6 +1,6 @@
 For `[Feat]` and `[Enhancement]`. If the PR adds an op/kernel, the structural axis is covered by `.foundry/mold/op-readiness-checklist.md` (filled by author into `## Structural Readiness`). This checklist covers cross-cutting axes only.
 
-# Checklist
+#### Checklist
 
 - [ ] Op/kernel public interface matches its `tileops/manifest/` entry. No entry → wrong PR order
 - [ ] Diff does not modify `tileops/manifest/` (`.claude/rules/manifest-trust-model.md`)

--- a/.claude/review-checklists/manifest.md
+++ b/.claude/review-checklists/manifest.md
@@ -7,7 +7,7 @@ Two non-negotiable principles cut across every event:
 - **Reference semantic alignment.** Any change to an op's spec (signature, shape rules, dtype combos, roofline vars) must map back to an authoritative reference — PyTorch public API for `torch.nn.*` / `torch.nn.functional.*` names; the paper or vendor docs otherwise. Reverse-engineering from current TileOps code is forbidden — spec is upstream of code.
 - **`status` field truthfulness.** `status: implemented` is a hard claim that code conforms to the entry. The reviewer's job is to *disprove* it, not to take it on faith. Status flips that don't reflect actual conformance corrupt the trust model.
 
-# Add-manifest (new entry)
+#### Add-manifest (new entry)
 
 PRs from the `add-manifest` skill, or any PR that adds a previously-absent op entry.
 
@@ -18,7 +18,7 @@ PRs from the `add-manifest` skill, or any PR that adds a previously-absent op en
 - [ ] **Validator green.** `scripts/validate_manifest.py` passes with no checks disabled.
 - [ ] **No code change.** Diff does not modify `tileops/ops/` or `tileops/kernels/`.
 
-# Fix-manifest (patch existing entry)
+#### Fix-manifest (patch existing entry)
 
 PRs from the `fix-manifest` skill — patches one missing structural field (`kernel_map`, `static_dims`) on an existing entry.
 
@@ -27,7 +27,7 @@ PRs from the `fix-manifest` skill — patches one missing structural field (`ker
 - [ ] **Validator green.**
 - [ ] **No code change.** Diff does not modify `tileops/ops/` or `tileops/kernels/`.
 
-# Status flip (`spec-only` ↔ `implemented`)
+#### Status flip (`spec-only` ↔ `implemented`)
 
 Often bundled with a `[Refactor][Ops]` op-migration PR.
 

--- a/.claude/review-checklists/refactor.md
+++ b/.claude/review-checklists/refactor.md
@@ -1,11 +1,11 @@
 For `[Refactor]`.
 
-# Checklist
+#### Checklist
 
 - [ ] Any `xfail` / `skip` / loosened assertion has a `FIXME(staged-rollout)` block per `.claude/rules/code-style.md`
 - [ ] If the op has a manifest entry, signature still matches it
 
-# Sub-types
+#### Sub-types
 
 - `[Refactor][Manifest]` → load `manifest.md` instead. `tileops/ops/` and `tileops/kernels/` must NOT change in the same PR.
 - `[Refactor][Ops]` / `[Refactor][<Family>]` that flips `status` → also load `manifest.md`.

--- a/.claude/review-checklists/testing.md
+++ b/.claude/review-checklists/testing.md
@@ -4,7 +4,7 @@ Load `.claude/domain-rules/testing-budget.md` and `docs/design/testing.md §Test
 
 **Burden of proof flips above threshold.** If growth crosses the threshold below, the author justifies; reviewer silence is not approval.
 
-# Checklist
+#### Checklist
 
 - [ ] **Trigger.** Compute `delta_pct = (HEAD − Base) / Base × 100` from the PR body's `## Test node delta`. If `delta_pct > 10%`, every check below is required; otherwise this file is informational.
 - [ ] **Per-case purpose stated.** Each new case (or each new parametrize cell) serves exactly one of: dtype correctness / kernel-branch shape coverage / feature coverage / regression — per `docs/design/testing.md §Test case policy`. The PR body justification names which, with file:line.

--- a/.claude/skills/review-tileops/criteria.md
+++ b/.claude/skills/review-tileops/criteria.md
@@ -1,4 +1,4 @@
-# 1. Submit
+### 1. Submit
 
 ```bash
 gh api repos/tile-ai/TileOPs/pulls/<N>/reviews \
@@ -9,7 +9,7 @@ gh api repos/tile-ai/TileOPs/pulls/<N>/reviews \
 
 `<EVENT>`: `REQUEST_CHANGES` if any blocking issue, `APPROVE` if clean, `COMMENT` for non-blocking questions only.
 
-# 2. Inline format
+### 2. Inline format
 
 ```
 <what is wrong and why> → <what to change>
@@ -17,7 +17,7 @@ gh api repos/tile-ai/TileOPs/pulls/<N>/reviews \
 
 One comment per issue. Name the function, variable, or pattern. The reader is an agent that executes fixes literally.
 
-# 3. Summary format (markdown)
+### 3. Summary format (markdown)
 
 The summary is for what does **not** fit in an inline comment. Per-file issues belong inline (§2), not in a summary list. Omit empty sections.
 
@@ -35,7 +35,7 @@ Hard rules:
 - Per-file/per-line items go in the `comments=[...]` array of §1, never in the summary body.
 - Clean PR: one line, `Clean — no issues.`
 
-# 4. Hard rules
+### 4. Hard rules
 
 - Read every changed file in full — diff alone lacks context.
 - Do not comment outside the PR diff.

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -210,6 +210,7 @@ if [[ ! -f "$META" ]]; then
     last_codex_event: null,
     last_criteria_mtime: 0,
     consecutive_codex_failures: 0,
+    consecutive_request_changes: 0,
     status: "active"
   }' > "$META"
 fi
@@ -248,6 +249,7 @@ compose_prompt() {
   local last_sha="$8"
   local last_event="$9"
   local inbox_block="${10}"
+  local consecutive_rc="${11}"
   local out="$snap.prompt.md"
 
   {
@@ -304,26 +306,26 @@ compose_prompt() {
       echo ""
     fi
 
-    if [[ "$n" -ge 7 ]]; then
-      cat <<'ANCHOR'
-## Round 7+ — Design re-anchoring (mandatory)
+    if [[ "$consecutive_rc" -ge 3 ]]; then
+      cat <<ANCHOR
+## Divergence trigger — design re-anchoring (mandatory)
 
-The bottom-up checklist is failing to converge. Re-anchor top-down.
+This PR has been REQUEST_CHANGES for $consecutive_rc rounds in a row. Stop iterating bottom-up. Re-anchor top-down.
 
-1. **Re-read from disk** (not memory): `docs/design/architecture.md`, `docs/design/ops-design.md`, plus any design doc named by your active checklist items.
-2. **Audit the blocker thread.** One root concern, or local patches on a moving target?
-3. **Question your anchor.** Cite the design passage that grounds the blocker. No citation possible → overfitted.
+1. **Re-read from disk** (not memory): \`docs/design/architecture.md\`, \`docs/design/ops-design.md\`, plus any design doc named by an active guard.
+2. **Audit the recurring blocker.** One root design concern, or local patches on a moving target?
+3. **Question your anchor.** Cite the design passage that grounds the blocker. No citation possible → you've over-fitted on trivial details.
 4. **Decide:**
    - **Reaffirm** — cite the passage inline.
    - **Withdraw** — retract explicitly. Remaining unease becomes a summary question, not a blocker.
    - **Reframe** — restate once at the design level with citation; stop relitigating surface variants.
 
 Required line at the top of the summary (before the trailer):
-```
-Round-7 introspection: <reaffirmed|withdrawn|reframed> — <one-line reason>
-```
+\`\`\`
+Divergence introspection: <reaffirmed|withdrawn|reframed> — <one-line reason>
+\`\`\`
 
-Stop bickering with the developer over minor details. If `reaffirmed` and the author shows no movement for 2+ further rounds, state in the summary that the PR is stalling and recommend human review.
+If reaffirmed and the next round still doesn't converge, recommend human review in the summary.
 
 ANCHOR
     fi
@@ -624,8 +626,10 @@ while true; do
     INCLUDE_PROCEDURE=1
   fi
 
+  CONSECUTIVE_RC=$(jq -r '.consecutive_request_changes // 0' "$META")
   compose_prompt "$SNAP" "$NEXT_ROUND" "$INCLUDE_CRITERIA" "$INCLUDE_PROCEDURE" \
-    "$DIFF_FILE" "$PR_STATE" "$HEAD_SHA" "$LAST_SHA" "$LAST_EVENT" "$INBOX_BLOCK"
+    "$DIFF_FILE" "$PR_STATE" "$HEAD_SHA" "$LAST_SHA" "$LAST_EVENT" "$INBOX_BLOCK" \
+    "$CONSECUTIVE_RC"
 
   log "round $NEXT_ROUND — invoking codex"
   if ! run_codex_round "$SNAP"; then
@@ -643,11 +647,17 @@ while true; do
   BLOCKERS=$(printf '%s' "$TRAILER" | sed -nE 's/.*blockers=([0-9]+).*/\1/p')
 
   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  if [[ "$EVENT" == "REQUEST_CHANGES" ]]; then
+    NEW_RC=$((CONSECUTIVE_RC + 1))
+  else
+    NEW_RC=0
+  fi
   jq --argjson r "$NEXT_ROUND" --arg sha "$HEAD_SHA" --arg now "$NOW" \
      --argjson hid "$LATEST_HUMAN_ID" --arg ev "$EVENT" \
-     --argjson cm "$CRITERIA_MTIME" \
+     --argjson cm "$CRITERIA_MTIME" --argjson rc "$NEW_RC" \
      '.round=$r | .last_reviewed_sha=$sha | .last_human_comment_id=$hid
       | .last_codex_event=$ev | .last_criteria_mtime=$cm
+      | .consecutive_request_changes=$rc
       | .consecutive_codex_failures=0 | .last_reviewed_at=$now' \
      "$META" > "$META.tmp" && mv "$META.tmp" "$META"
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -252,14 +252,14 @@ compose_prompt() {
     echo ""
 
     if [[ "$include_criteria" == "1" ]]; then
-      echo "## Review output format (criteria.md)"
+      echo "## Review output format"
       echo ""
       cat "$CRITERIA_PATH"
       echo ""
     fi
 
     if [[ "$include_procedure" == "1" ]]; then
-      echo "## Review procedure (procedure.md)"
+      echo "## Review procedure"
       echo ""
       cat "$PROCEDURE_PATH"
       echo ""

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -209,7 +209,6 @@ if [[ ! -f "$META" ]]; then
     last_human_comment_id: 0,
     last_codex_event: null,
     last_criteria_mtime: 0,
-    last_procedure_mtime: 0,
     consecutive_codex_failures: 0,
     status: "active"
   }' > "$META"
@@ -527,17 +526,21 @@ while true; do
   LAST_HUMAN_ID_PREV=$(jq -r .last_human_comment_id "$META")
   LATEST_HUMAN_ID=$(latest_human_comment_id)
 
-  # Resume / restart: if local meta says we approved last time, ask GitHub
-  # whether that approval is still standing. If a new commit was pushed
-  # the codebase's branch protection auto-dismisses approvals, in which
-  # case we drop back to a fresh review on the current head. If GitHub
-  # still shows APPROVED, exit immediately (no second round needed).
+  # Resume / restart: if local meta says we approved last time, converge
+  # only if GitHub still shows APPROVED *and* nothing has changed since
+  # the approval. New commits auto-dismiss approvals (state goes
+  # DISMISSED), but new issue/review comments do not — so a comments-
+  # changed check is still required to avoid silently skipping unread
+  # human feedback. Any miss → fall through to a fresh round on the
+  # current head.
   if [[ "$LAST_EVENT" == "APPROVE" ]]; then
     GH_REVIEW_STATE=$(latest_reviewer_review_state)
-    if [[ "$GH_REVIEW_STATE" == "APPROVED" ]]; then
+    if [[ "$GH_REVIEW_STATE" == "APPROVED" \
+          && "$HEAD_SHA" == "$LAST_SHA" \
+          && "$LATEST_HUMAN_ID" == "$LAST_HUMAN_ID_PREV" ]]; then
       converge_and_exit
     fi
-    log "local APPROVE but GitHub state=$GH_REVIEW_STATE (likely dismissed by new commit) — re-reviewing current head"
+    log "prior APPROVE no longer current (gh=$GH_REVIEW_STATE, head_changed=$([[ "$HEAD_SHA" != "$LAST_SHA" ]] && echo y || echo n), comments_changed=$([[ "$LATEST_HUMAN_ID" != "$LAST_HUMAN_ID_PREV" ]] && echo y || echo n)) — re-reviewing current head"
     jq '.last_codex_event="DISMISSED" | .last_reviewed_sha=null' \
       "$META" > "$META.tmp" && mv "$META.tmp" "$META"
     LAST_EVENT="DISMISSED"
@@ -607,13 +610,10 @@ while true; do
   fi
 
   # procedure.md is round-1-only: round 2+ replaces it with the short
-  # "iteration round" block in compose_prompt (verify last round's
-  # blockers are fixed; flag any newly introduced issues). criteria.md
-  # uses an mtime gate — re-inline only when the format spec changed
-  # since last inclusion (Codex's session memory carries unchanged
-  # content forward).
+  # "iteration round" block in compose_prompt. criteria.md uses an mtime
+  # gate — re-inline only when the format spec changed since last
+  # inclusion (Codex's session memory carries unchanged content forward).
   CRITERIA_MTIME=$(stat -c %Y "$CRITERIA_PATH")
-  PROCEDURE_MTIME=$(stat -c %Y "$PROCEDURE_PATH")
   LAST_CRITERIA_MTIME=$(jq -r '.last_criteria_mtime // 0' "$META")
   INCLUDE_CRITERIA=0
   INCLUDE_PROCEDURE=0
@@ -645,10 +645,9 @@ while true; do
   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   jq --argjson r "$NEXT_ROUND" --arg sha "$HEAD_SHA" --arg now "$NOW" \
      --argjson hid "$LATEST_HUMAN_ID" --arg ev "$EVENT" \
-     --argjson cm "$CRITERIA_MTIME" --argjson pm "$PROCEDURE_MTIME" \
+     --argjson cm "$CRITERIA_MTIME" \
      '.round=$r | .last_reviewed_sha=$sha | .last_human_comment_id=$hid
       | .last_codex_event=$ev | .last_criteria_mtime=$cm
-      | .last_procedure_mtime=$pm
       | .consecutive_codex_failures=0 | .last_reviewed_at=$now' \
      "$META" > "$META.tmp" && mv "$META.tmp" "$META"
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -403,6 +403,30 @@ run_codex_round() {
   return 1
 }
 
+# State of the reviewer's most recent review on the PR — APPROVED,
+# CHANGES_REQUESTED, COMMENTED, or DISMISSED (returned by GitHub when a
+# stale-approval rule retracts an APPROVE on new commits). Returns
+# "NONE" if there's no review yet or the call fails.
+latest_reviewer_review_state() {
+  gh api "repos/$REPO/pulls/$PR/reviews" \
+    --jq "[.[]|select(.user.login==\"$REVIEWER_LOGIN\")]|sort_by(.submitted_at)|last|.state // \"NONE\"" \
+    2>/dev/null || echo NONE
+}
+
+# Final convergence path: introspection + retrospective + worktree cleanup, exit 0.
+converge_and_exit() {
+  log "converged — APPROVE on PR #$PR. running introspection + retrospective"
+  set_meta_status "success"
+  set_task_review_event APPROVE
+  run_introspection
+  run_retrospective
+  log "checklist-suggestions: $RUN_DIR/checklist-suggestions.md"
+  log "retrospective:        $RUN_DIR/retrospective.md"
+  cleanup_pr_worktree
+  log "worktree removed: $WORKTREE_DIR"
+  exit 0
+}
+
 # Parse the trailer from the latest reviewer-login review on the PR.
 parse_trailer() {
   local body trailer
@@ -497,20 +521,21 @@ while true; do
   LAST_HUMAN_ID_PREV=$(jq -r .last_human_comment_id "$META")
   LATEST_HUMAN_ID=$(latest_human_comment_id)
 
-  # Convergence: prior round APPROVE, head sha unchanged, no new comments.
-  if [[ "$LAST_EVENT" == "APPROVE" \
-        && "$HEAD_SHA" == "$LAST_SHA" \
-        && "$LATEST_HUMAN_ID" == "$LAST_HUMAN_ID_PREV" ]]; then
-    log "converged — APPROVE on stable sha, no new comments. running introspection + retrospective"
-    set_meta_status "success"
-    set_task_review_event APPROVE
-    run_introspection
-    run_retrospective
-    log "checklist-suggestions: $RUN_DIR/checklist-suggestions.md"
-    log "retrospective:        $RUN_DIR/retrospective.md"
-    cleanup_pr_worktree
-    log "worktree removed: $WORKTREE_DIR"
-    exit 0
+  # Resume / restart: if local meta says we approved last time, ask GitHub
+  # whether that approval is still standing. If a new commit was pushed
+  # the codebase's branch protection auto-dismisses approvals, in which
+  # case we drop back to a fresh review on the current head. If GitHub
+  # still shows APPROVED, exit immediately (no second round needed).
+  if [[ "$LAST_EVENT" == "APPROVE" ]]; then
+    GH_REVIEW_STATE=$(latest_reviewer_review_state)
+    if [[ "$GH_REVIEW_STATE" == "APPROVED" ]]; then
+      converge_and_exit
+    fi
+    log "local APPROVE but GitHub state=$GH_REVIEW_STATE (likely dismissed by new commit) — re-reviewing current head"
+    jq '.last_codex_event="DISMISSED" | .last_reviewed_sha=null' \
+      "$META" > "$META.tmp" && mv "$META.tmp" "$META"
+    LAST_EVENT="DISMISSED"
+    LAST_SHA="null"
   fi
 
   # Anything new since last round?
@@ -632,6 +657,12 @@ while true; do
 
   log "round $NEXT_ROUND done — event=$EVENT blockers=$BLOCKERS sha=${HEAD_SHA:0:7}"
 
-  # Loop will check convergence at the top of the next iteration.
+  # APPROVE this round → exit immediately. If the developer pushes a new
+  # commit later that auto-dismisses the approval, re-running the loop
+  # picks it up via the GitHub-state check at the top of the iteration.
+  if [[ "$EVENT" == "APPROVE" ]]; then
+    converge_and_exit
+  fi
+
   sleep "$POLL_INTERVAL"
 done

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -279,7 +279,7 @@ compose_prompt() {
     if [[ "$n" -eq 1 ]]; then
       echo "## Project-specific regression guards"
       echo ""
-      echo "These are project-specific defenses against known classes of regression. Apply them in addition to free-form review, not instead of it."
+      echo "Apply alongside the free-form review, not in place of it."
       echo ""
       jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
         local path="$CHECKLISTS_DIR/$cl"
@@ -296,12 +296,12 @@ compose_prompt() {
     else
       echo "## Iteration round (round $n of $MAX_ROUNDS)"
       echo ""
-      echo "Developer pushed changes / replied since the last review. Strictly verify:"
+      echo "Developer pushed / replied. Verify both:"
       echo ""
-      echo "1. Are the prior blockers actually resolved? Read the changed source, not just the developer's reply."
-      echo "2. Did the new commits introduce any new problems?"
+      echo "1. Prior blockers actually fixed (read the changed source, not the reply)."
+      echo "2. No new problems introduced by the new commits."
       echo ""
-      echo "Procedure and checklists from round 1 still apply — they are in your session memory."
+      echo "Round 1's procedure and guards still apply — already in session memory."
       echo ""
     fi
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -402,6 +402,10 @@ run_codex_round() {
 
     attempt=$((attempt+1))
     log "codex attempt $attempt empty/failed; retrying in 10s …"
+    # Surface the tail of the events file so the human log shows *why*
+    # — otherwise repeated failures look identical and the cause stays
+    # buried in $events.
+    tail -n 5 "$events" 2>/dev/null | sed 's/^/  | /' >&2 || true
     sleep 10
   done
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -110,6 +110,10 @@ cleanup_pr_worktree() {
     git -C "$REPO_PATH" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 \
       || rm -rf "$WORKTREE_DIR"
   fi
+  # Drop stale worktree admin entries left over if `worktree remove` failed
+  # and we fell back to `rm -rf`. Without this, the next `worktree add` to
+  # this path would fail with "already registered".
+  git -C "$REPO_PATH" worktree prune >/dev/null 2>&1 || true
   git -C "$REPO_PATH" update-ref -d "$PR_REF" 2>/dev/null || true
 }
 sync_pr_worktree

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -273,20 +273,7 @@ compose_prompt() {
     fi
 
     if [[ "$n" -eq 1 ]]; then
-      local title type scope
-      title=$(jq -r .title "$CONTEXT")
-      type=$(jq -r .type "$CONTEXT")
-      scope=$(jq -r .scope "$CONTEXT")
-      echo "## PR classification"
-      echo ""
-      echo "- Title: \`$title\`"
-      echo "- Type: \`[$type]\`   Scope: \`[$scope]\`"
-      echo "- Loaded checklists:"
-      jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
-        echo "  - \`.claude/review-checklists/$cl\`"
-      done
-      echo ""
-      echo "## Checklist content"
+      echo "## Checklists"
       echo ""
       jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
         local path="$CHECKLISTS_DIR/$cl"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -379,9 +379,13 @@ run_codex_round() {
         --json --output-last-message "$lastmsg" --cd "$WORKTREE_DIR" \
         "$(cat "$prompt_file")" > "$events" 2>&1 || true
     else
-      codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
-        --json --output-last-message "$lastmsg" --cd "$WORKTREE_DIR" \
-        "$(cat "$prompt_file")" > "$events" 2>&1 || true
+      # `codex exec resume` does not accept --cd; the session already
+      # remembers its cwd from the initial `exec`, but cd anyway as a
+      # belt-and-suspenders for source-file lookups.
+      ( cd "$WORKTREE_DIR" && \
+        codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
+          --json --output-last-message "$lastmsg" \
+          "$(cat "$prompt_file")" ) > "$events" 2>&1 || true
     fi
 
     if [[ -s "$lastmsg" ]]; then
@@ -425,9 +429,10 @@ run_codex_oneoff() {
   if [[ "$sid" == "null" || -z "$sid" ]]; then
     return 1
   fi
-  codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
-    --output-last-message "$outfile" --cd "$WORKTREE_DIR" \
-    "$prompt" >/dev/null 2>&1 || true
+  ( cd "$WORKTREE_DIR" && \
+    codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
+      --output-last-message "$outfile" \
+      "$prompt" ) >/dev/null 2>&1 || true
   [[ -s "$outfile" ]]
 }
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -100,6 +100,18 @@ sync_pr_worktree() {
     git -C "$WORKTREE_DIR" reset --hard "$target" >/dev/null
   fi
 }
+
+# Drop the per-PR worktree and ref. Called on APPROVE convergence so the
+# loop doesn't leave a full repo checkout sitting on disk per merged PR.
+# Other state under $RUN_DIR (logs, prompts, retrospective) stays for
+# postmortem inspection.
+cleanup_pr_worktree() {
+  if [[ -e "$WORKTREE_DIR" ]]; then
+    git -C "$REPO_PATH" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 \
+      || rm -rf "$WORKTREE_DIR"
+  fi
+  git -C "$REPO_PATH" update-ref -d "$PR_REF" 2>/dev/null || true
+}
 sync_pr_worktree
 
 # Task-level meta.json (cross-stage state, shared with future foundry-pipeline
@@ -498,6 +510,8 @@ while true; do
     run_retrospective
     log "checklist-suggestions: $RUN_DIR/checklist-suggestions.md"
     log "retrospective:        $RUN_DIR/retrospective.md"
+    cleanup_pr_worktree
+    log "worktree removed: $WORKTREE_DIR"
     exit 0
   fi
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -303,10 +303,12 @@ compose_prompt() {
     else
       echo "## Iteration round (round $n of $MAX_ROUNDS)"
       echo ""
-      echo "Developer pushed changes since the last review. Verify:"
+      echo "Developer pushed changes / replied since the last review. Strictly verify:"
       echo ""
-      echo "1. Are the prior blockers actually resolved?"
-      echo "2. Were any new problems introduced by the new commits?"
+      echo "1. Are the prior blockers actually resolved? Read the changed source, not just the developer's reply."
+      echo "2. Did the new commits introduce any new problems?"
+      echo ""
+      echo "Procedure and checklists from round 1 still apply — they are in your session memory."
       echo ""
     fi
 
@@ -586,19 +588,21 @@ while true; do
     : > "$RUN_DIR/inbox.md"
   fi
 
-  # criteria.md / procedure.md mtime checks — round 1 always inlines both,
-  # later rounds only re-inline when the file changed since last inclusion
-  # (Codex's session memory carries unchanged content forward).
+  # procedure.md is round-1-only: round 2+ replaces it with the short
+  # "iteration round" block in compose_prompt (verify last round's
+  # blockers are fixed; flag any newly introduced issues). criteria.md
+  # uses an mtime gate — re-inline only when the format spec changed
+  # since last inclusion (Codex's session memory carries unchanged
+  # content forward).
   CRITERIA_MTIME=$(stat -c %Y "$CRITERIA_PATH")
   PROCEDURE_MTIME=$(stat -c %Y "$PROCEDURE_PATH")
   LAST_CRITERIA_MTIME=$(jq -r '.last_criteria_mtime // 0' "$META")
-  LAST_PROCEDURE_MTIME=$(jq -r '.last_procedure_mtime // 0' "$META")
   INCLUDE_CRITERIA=0
   INCLUDE_PROCEDURE=0
   if [[ "$NEXT_ROUND" -eq 1 || "$CRITERIA_MTIME" -gt "$LAST_CRITERIA_MTIME" ]]; then
     INCLUDE_CRITERIA=1
   fi
-  if [[ "$NEXT_ROUND" -eq 1 || "$PROCEDURE_MTIME" -gt "$LAST_PROCEDURE_MTIME" ]]; then
+  if [[ "$NEXT_ROUND" -eq 1 ]]; then
     INCLUDE_PROCEDURE=1
   fi
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -662,11 +662,18 @@ while true; do
 
   log "round $NEXT_ROUND done — event=$EVENT blockers=$BLOCKERS sha=${HEAD_SHA:0:7}"
 
-  # APPROVE this round → exit immediately. If the developer pushes a new
-  # commit later that auto-dismisses the approval, re-running the loop
-  # picks it up via the GitHub-state check at the top of the iteration.
+  # APPROVE this round → exit, but re-check stability first. HEAD_SHA
+  # and LATEST_HUMAN_ID were snapshotted before Codex ran (potentially
+  # minutes ago); a push or non-reviewer comment arriving during the
+  # review must not be silently skipped. If anything moved, fall
+  # through to sleep + next iteration, which will pick up the change.
   if [[ "$EVENT" == "APPROVE" ]]; then
-    converge_and_exit
+    POST_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
+    POST_HUMAN_ID=$(latest_human_comment_id)
+    if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" && "$POST_HUMAN_ID" == "$LATEST_HUMAN_ID" ]]; then
+      converge_and_exit
+    fi
+    log "APPROVE produced but state moved during review (head_changed=$([[ "$POST_HEAD_SHA" != "$HEAD_SHA" ]] && echo y || echo n), comments_changed=$([[ "$POST_HUMAN_ID" != "$LATEST_HUMAN_ID" ]] && echo y || echo n)) — falling through"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -277,7 +277,9 @@ compose_prompt() {
     fi
 
     if [[ "$n" -eq 1 ]]; then
-      echo "## Checklists"
+      echo "## Project-specific regression guards"
+      echo ""
+      echo "These are project-specific defenses against known classes of regression. Apply them in addition to free-form review, not instead of it."
       echo ""
       jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
         local path="$CHECKLISTS_DIR/$cl"

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,6 +1,6 @@
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
-1. **Free-form review.** Before consulting any checklist, review the diff as code: logic errors, off-by-one and other edge cases, wrong/misused APIs, race conditions, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, confusing names, missing tests for the new behavior. Capture every concern as a candidate finding. The project-specific guards in step 3 are a regression net, not the boundary of your job.
-1. **Apply each loaded project-specific guard.** Walk its bullets against the diff and the source files. Note any items that flag. Add to the candidate findings from step 2.
+1. **Free-form review.** Read the diff as code. Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. Guards in step 3 are a regression net, not the boundary of your job.
+1. **Apply each loaded project-specific guard.** Walk its bullets against the diff. Merge any new findings into step-2's list.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.
 1. **Approval-gate decision.** If the diff touches `tests/` AND your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every check. Downgrade to `REQUEST_CHANGES` if any fail.
 1. **Compose inline comments** per `criteria.md` §2 — one per issue, format `<what is wrong and why> → <what to change>`. Name the function, variable, or pattern.

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,8 +1,4 @@
-# Review procedure
-
-Single source of truth for "one review pass on one tile-ai/TileOPs PR". Loaded by both `SKILL.md` (manual single-shot) and `loop.sh` (each round of the autonomous loop). The wrapper handles preflight, input gathering, and bookkeeping; this file is only the review behavior itself.
-
-## Steps
+### Steps
 
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
 1. **Apply each loaded checklist.** Walk its bullets against the diff and the source files. Note any items that flag.

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,19 +1,6 @@
 # Review procedure
 
-Single source of truth for "one review pass on one tile-ai/TileOPs PR". Followed verbatim by:
-
-- `SKILL.md` — manual single-shot via Claude / Codex session.
-- `loop.sh` — per-PR autonomous loop, each round.
-
-Both modes wrap this procedure with mode-specific concerns (preflight, input gathering, round bookkeeping, trailer for the loop driver). The review behavior itself lives only here.
-
-## Assumed inputs
-
-The caller has already ensured:
-
-- `preflight.sh` has run and `GH_CONFIG_DIR` is exported to the reviewer identity.
-- The PR has been classified per `loading.yaml`; the list of applicable checklist files is known.
-- The diff (full or incremental), unresolved review threads, recent non-reviewer comments, and CI status are accessible (either pre-fetched on disk or fetchable on demand).
+Single source of truth for "one review pass on one tile-ai/TileOPs PR". Loaded by both `SKILL.md` (manual single-shot) and `loop.sh` (each round of the autonomous loop). The wrapper handles preflight, input gathering, and bookkeeping; this file is only the review behavior itself.
 
 ## Steps
 

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,5 +1,5 @@
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
-1. **Free-form review.** Read the diff as code. Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. Guards in step 3 are a regression net, not the boundary of your job.
+1. **Free-form review.** Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. Guards in step 3 are a regression net, not the boundary of your job.
 1. **Apply each loaded project-specific guard.** Walk its bullets against the diff. Merge any new findings into step-2's list.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.
 1. **Approval-gate decision.** If the diff touches `tests/` AND your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every check. Downgrade to `REQUEST_CHANGES` if any fail.

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,5 +1,3 @@
-### Steps
-
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
 1. **Apply each loaded checklist.** Walk its bullets against the diff and the source files. Note any items that flag.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,5 +1,6 @@
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
-1. **Apply each loaded checklist.** Walk its bullets against the diff and the source files. Note any items that flag.
+1. **Free-form review.** Before consulting any checklist, review the diff as code: logic errors, off-by-one and other edge cases, wrong/misused APIs, race conditions, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, confusing names, missing tests for the new behavior. Capture every concern as a candidate finding. The project-specific guards in step 3 are a regression net, not the boundary of your job.
+1. **Apply each loaded project-specific guard.** Walk its bullets against the diff and the source files. Note any items that flag. Add to the candidate findings from step 2.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.
 1. **Approval-gate decision.** If the diff touches `tests/` AND your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every check. Downgrade to `REQUEST_CHANGES` if any fail.
 1. **Compose inline comments** per `criteria.md` §2 — one per issue, format `<what is wrong and why> → <what to change>`. Name the function, variable, or pattern.

--- a/review_loop.sh
+++ b/review_loop.sh
@@ -1,1 +1,0 @@
-.claude/skills/review-tileops/loop.sh

--- a/review_loop.sh
+++ b/review_loop.sh
@@ -1,0 +1,1 @@
+.claude/skills/review-tileops/loop.sh


### PR DESCRIPTION
## Summary

Multi-fix + refactor of `.claude/skills/review-tileops/` so the autonomous loop converges correctly and the prompt it sends to Codex is concise and well-scoped.

- **Loop fix:** drop unsupported `--cd` flag from `codex exec resume` (broke every round 2+); commit on APPROVE and immediately exit (with re-fetched HEAD/comments to avoid race); on restart, query GitHub review state and re-review when the prior approval is dismissed (or when comments arrived after it).
- **Worktree:** create per-PR detached worktree, remove on convergence, prune stale metadata.
- **Prompt:** start with a free-form review pass before applying project-specific guards (anti-anchoring); reorganize headings so inlined `criteria.md` / `procedure.md` / checklists nest cleanly under their wrappers; round 2+ skips re-inlining `procedure.md` and the round-1 PR-classification preamble.
- **Divergence:** after 3 consecutive `REQUEST_CHANGES`, inject a design re-anchor block that forces codex to read design docs and reaffirm / withdraw / reframe the recurring blocker.
- **Approval-gate:** require PR body to follow `pr-body-template.md` and contain only final-state facts (no dev-process narration).
- **Diagnostics:** tail codex stderr on retry; log codex events file path on failure.

## Test plan

- [x] pre-commit passed
- [x] `bash -n loop.sh` syntax check passed
- [x] live-run on PR #1121: round 2 resume failure (the original `--cd` bug) reproduced and fixed; loop reached APPROVE and converged