### PR TITLE
[Refactor][Skill] review-tileops prompt: trim redundancy, fold verify into Task

### DIFF
--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,12 +1,21 @@
 Run before approving any PR that adds or modifies tests. If any check fails, request changes; do not approve until the developer pushes a triage commit.
 
-- [ ] Classify every new or changed test case as **keep** / **shrink** / **delete**:
-  - **keep** — guards a distinct code path or dtype per `docs/design/testing.md §Test case policy`.
-  - **shrink** — Cartesian expansion; fold to "boundary + one representative interior point".
-  - **delete** — same-failure-mode duplicate of a kept case.
-- [ ] For each `shrink` / `delete`, post a review comment with the node ID and the kept case it duplicates or the axis to fold.
+- [ ] **Per-case verdict (blocker default).** For every test case added or modified in this PR, post an inline comment on the test definition with one of:
+
+  - `keep — guards <distinct code path or dtype>` (no action required) — per `docs/design/testing.md §Test case policy`.
+  - `shrink — fold to <axis>` (**BLOCKER**) — Cartesian expansion; fold to "boundary + one representative interior point".
+  - `delete — duplicate of <node ID>` (**BLOCKER**) — same-failure-mode duplicate of a kept case.
+
+  Cases left without a verdict comment count as untriaged and are also **BLOCKER**. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
+
+- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main`. If existing-file growth > 25% AND any added case lacks a verdict comment, REQUEST_CHANGES with the full list of unjustified node IDs in the summary.
+
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
+
 - [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
+
 - [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` and record only the final state: what the PR does (Summary, scoped to the merged diff) + verification facts (test plan, pre-commit, structural readiness, test node delta). Strip dev-process narration — per-round fix history, tally IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer changelogs, abandoned approaches. Those belong in commit history / review threads. If found in the body, REQUEST_CHANGES.
+
 - [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
+
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,12 +1,12 @@
 Run before approving any PR that adds or modifies tests. If any check fails, request changes; do not approve until the developer pushes a triage commit.
 
-- [ ] **Per-case verdict (blocker default).** For every test case added or modified in this PR, post an inline comment on the test definition with one of:
+- [ ] **Per-case verdict (blocker default).** Triage every test case added or modified in this PR as one of `keep` / `shrink` / `delete`. Inline comments are required only for blocker verdicts; clean test PRs stay clean (no per-case inline noise) — consistent with `criteria.md §3` (`Clean — no issues.`).
 
-  - `keep — guards <distinct code path or dtype>` (no action required) — per `docs/design/testing.md §Test case policy`.
-  - `shrink — fold to <axis>` (**BLOCKER**) — Cartesian expansion; fold to "boundary + one representative interior point".
-  - `delete — duplicate of <node ID>` (**BLOCKER**) — same-failure-mode duplicate of a kept case.
+  - `keep — guards <distinct code path or dtype>` (no action required) — per `docs/design/testing.md §Test case policy`. **Do not** post inline.
+  - `shrink — fold to <axis>` (**BLOCKER, inline required**) — Cartesian expansion; fold to "boundary + one representative interior point".
+  - `delete — duplicate of <node ID>` (**BLOCKER, inline required**) — same-failure-mode duplicate of a kept case.
 
-  Cases left without a verdict comment count as untriaged and are also **BLOCKER**. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
+  Cases the reviewer cannot classify with confidence count as untriaged → **BLOCKER, inline required** asking the developer for the rationale. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
 
 - [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main`. If existing-file growth > 25% AND any added case lacks a verdict comment, REQUEST_CHANGES with the full list of unjustified node IDs in the summary.
 

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -8,7 +8,7 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 
   Cases the reviewer cannot classify with confidence count as untriaged → **BLOCKER, inline required** asking the developer for the rationale. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
 
-- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main`. If existing-file growth > 25% AND any added case lacks a verdict comment, REQUEST_CHANGES with the full list of unjustified node IDs in the summary.
+- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main`. If existing-file growth > 25% AND any case carries an unresolved blocker verdict (`shrink` / `delete`) or remains untriaged, REQUEST_CHANGES with the full list of affected node IDs in the summary. (Absence of an inline comment is not a blocker on its own — silent `keep` is the default.)
 
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 

--- a/.claude/skills/review-tileops/criteria.md
+++ b/.claude/skills/review-tileops/criteria.md
@@ -37,9 +37,8 @@ Hard rules:
 
 ### 4. Hard rules
 
-- Read every changed file in full — diff alone lacks context.
 - Do not comment outside the PR diff.
 - Do not invent issues on a clean PR.
-- No eager design-doc reads — only when a checklist item names a doc AND the diff makes that item ambiguous.
+- No eager design-doc reads — only when a guard names a doc AND the diff makes that item ambiguous, or the divergence trigger fires.
 - All review text in English.
 - All `gh` calls run with `GH_CONFIG_DIR` already exported by the caller. Repo is fixed at `tile-ai/TileOPs`.

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -294,16 +294,6 @@ compose_prompt() {
           echo ""
         fi
       done
-    else
-      echo "## Iteration round (round $n of $MAX_ROUNDS)"
-      echo ""
-      echo "Developer pushed / replied. Verify both:"
-      echo ""
-      echo "1. Prior blockers actually fixed (read the changed source, not the reply)."
-      echo "2. No new problems introduced by the new commits."
-      echo ""
-      echo "Round 1's procedure and guards still apply — already in session memory."
-      echo ""
     fi
 
     if [[ "$consecutive_rc" -ge 3 ]]; then
@@ -347,6 +337,15 @@ ANCHOR
 
     echo "## Task"
     echo ""
+    if [[ "$n" -gt 1 ]]; then
+      echo "Developer pushed / replied. Verify both:"
+      echo ""
+      echo "1. Prior blockers actually fixed (read the changed source, not the reply)."
+      echo "2. No new problems introduced by the new commits."
+      echo ""
+      echo "Round 1's procedure and guards still apply — already in session memory."
+      echo ""
+    fi
     echo "Read the diff at the path above and any changed source files referenced therein, in full. Apply the loaded checklists. Submit ONE atomic review on \`$REPO\` PR #$PR via \`gh\` per the format spec."
     echo ""
     echo "The summary body MUST end with this trailer line (the loop driver parses it; review is rejected without it):"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -338,10 +338,17 @@ ANCHOR
     echo "## Task"
     echo ""
     if [[ "$n" -gt 1 ]]; then
-      echo "Developer pushed / replied since the last round. Verify: (1) prior blockers actually fixed — read the changed source, not the reply; (2) no new problems from the new commits. Round 1's procedure and guards still apply (already in session memory)."
+      echo "Developer pushed / replied since the last round. Verify both:"
+      echo ""
+      echo "1. Prior blockers actually fixed — read the changed source, not the reply."
+      echo "2. No new problems from the new commits."
+      echo ""
+      echo "Round 1's procedure and guards still apply (already in session memory)."
       echo ""
     fi
-    echo "Run the procedure end to end and submit one atomic review. **Free-form review (procedure step 2) is the primary review step**; project-specific guards apply LAST as a regression net, not in place of it. The summary body MUST end with this trailer (the loop driver parses it; review is rejected without it):"
+    echo "Run the procedure end to end and submit one atomic review."
+    echo "**Free-form review (procedure step 2) is the primary review step**; project-specific guards apply LAST as a regression net, not in place of it."
+    echo "The summary body MUST end with this trailer (the loop driver parses it; review is rejected without it):"
     echo ""
     echo '```'
     echo "<!-- review-loop: event=APPROVE|REQUEST_CHANGES; blockers=<N>; sha=$(printf '%s' "$head_sha" | cut -c1-7) -->"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -271,7 +271,7 @@ compose_prompt() {
     fi
 
     if [[ -n "$inbox_block" ]]; then
-      echo "## Per-round guidance from human (inbox, one-shot)"
+      echo "## Per-round guidance from human"
       echo ""
       echo "$inbox_block"
       echo ""
@@ -279,8 +279,6 @@ compose_prompt() {
 
     if [[ "$n" -eq 1 ]]; then
       echo "## Project-specific regression guards"
-      echo ""
-      echo "Apply alongside the free-form review, not in place of it."
       echo ""
       jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
         local path="$CHECKLISTS_DIR/$cl"
@@ -338,23 +336,16 @@ ANCHOR
     echo "## Task"
     echo ""
     if [[ "$n" -gt 1 ]]; then
-      echo "Developer pushed / replied. Verify both:"
-      echo ""
-      echo "1. Prior blockers actually fixed (read the changed source, not the reply)."
-      echo "2. No new problems introduced by the new commits."
-      echo ""
-      echo "Round 1's procedure and guards still apply — already in session memory."
+      echo "Developer pushed / replied since the last round. Verify: (1) prior blockers actually fixed — read the changed source, not the reply; (2) no new problems from the new commits. Round 1's procedure and guards still apply (already in session memory)."
       echo ""
     fi
-    echo "Read the diff at the path above and any changed source files referenced therein, in full. Apply the loaded checklists. Submit ONE atomic review on \`$REPO\` PR #$PR via \`gh\` per the format spec."
-    echo ""
-    echo "The summary body MUST end with this trailer line (the loop driver parses it; review is rejected without it):"
+    echo "Run the procedure end to end and submit one atomic review. The summary body MUST end with this trailer (the loop driver parses it; review is rejected without it):"
     echo ""
     echo '```'
     echo "<!-- review-loop: event=APPROVE|REQUEST_CHANGES; blockers=<N>; sha=$(printf '%s' "$head_sha" | cut -c1-7) -->"
     echo '```'
     echo ""
-    echo "\`<N>\` = unresolved blockers after this review (0 for APPROVE)."
+    echo "\`<N>\` = unresolved blockers (0 for APPROVE)."
   } > "$out"
 }
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -280,6 +280,8 @@ compose_prompt() {
     if [[ "$n" -eq 1 ]]; then
       echo "## Project-specific regression guards"
       echo ""
+      echo "Apply LAST, after the free-form review. These catch known regression classes the free-form pass can miss — they do not replace it."
+      echo ""
       jq -r '.checklists[]' "$CONTEXT" | while read -r cl; do
         local path="$CHECKLISTS_DIR/$cl"
         if [[ -f "$path" ]]; then
@@ -339,7 +341,7 @@ ANCHOR
       echo "Developer pushed / replied since the last round. Verify: (1) prior blockers actually fixed — read the changed source, not the reply; (2) no new problems from the new commits. Round 1's procedure and guards still apply (already in session memory)."
       echo ""
     fi
-    echo "Run the procedure end to end and submit one atomic review. The summary body MUST end with this trailer (the loop driver parses it; review is rejected without it):"
+    echo "Run the procedure end to end and submit one atomic review. **Free-form review (procedure step 2) is the primary review step**; project-specific guards apply LAST as a regression net, not in place of it. The summary body MUST end with this trailer (the loop driver parses it; review is rejected without it):"
     echo ""
     echo '```'
     echo "<!-- review-loop: event=APPROVE|REQUEST_CHANGES; blockers=<N>; sha=$(printf '%s' "$head_sha" | cut -c1-7) -->"

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -1,7 +1,9 @@
+**Free-form review (step 2) is the primary review step.** Project-specific guards (step 4) are a regression net applied last — they exist because the free-form pass is fallible at known classes of issue, NOT because they replace it. Skipping or shortening step 2 to lean on guards is a failure mode.
+
 1. **Read every changed source file in full.** The diff alone lacks surrounding context.
-1. **Free-form review.** Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. Guards in step 3 are a regression net, not the boundary of your job.
-1. **Apply each loaded project-specific guard.** Walk its bullets against the diff. Merge any new findings into step-2's list.
+1. **Free-form review (primary).** Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. This is where the bulk of your reasoning belongs.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.
+1. **Apply each loaded project-specific guard (last, supplement).** Walk its bullets against the diff. Add anything new to the step-2 findings.
 1. **Approval-gate decision.** If the diff touches `tests/` AND your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every check. Downgrade to `REQUEST_CHANGES` if any fail.
 1. **Compose inline comments** per `criteria.md` §2 — one per issue, format `<what is wrong and why> → <what to change>`. Name the function, variable, or pattern.
 1. **Compose the summary** per `criteria.md` §3. Omit empty sections. A clean PR gets a single line: `Clean — no issues.`

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,4 @@ Empirical performance guidance lives under [`perf/`](perf/README.md). Each op ca
 
 ## External
 
-- [TileOPs.github.io](https://github.com/tile-ai/TileOPs.github.io) — auto-generated documentation site (API reference, perf tables, support matrix).
+- [TileOPs.github.io](https://tile-ai.github.io/TileOPs.github.io/) — auto-generated documentation site (API reference, perf tables, support matrix).


### PR DESCRIPTION
## Summary

- **Move iteration block into `## Task`.** Drop the standalone `## Iteration round (round N of M)` wrapper in round 2+. Round number is already in the prompt title, and the verify-prior-blockers / no-new-problems content is the actual task instruction — fold it under `## Task` as a one-line round-2+ prefix.
- **Trim redundancy with `procedure.md`.** procedure.md is in Codex's session memory after round 1. Drop everything in `compose_prompt` that restates it: the `## Project-specific regression guards` subtitle (handled by procedure.md step 2), the `(inbox, one-shot)` parenthetical, and the `## Task` body lines "Read the diff … Apply the loaded checklists. Submit ONE atomic review …" (steps 1/3/7).
- **Doc fix:** point the `TileOPs.github.io` link in `docs/README.md` at the actual Pages site (`tile-ai.github.io/TileOPs.github.io/`) rather than the source repo on GitHub.com.

## Test plan

- [x] pre-commit passed
- [x] `bash -n loop.sh` syntax check