### PR TITLE
[Chore][Skill] move follow-up skill (formerly create-follow-up-issue) under TileOPs

### DIFF
--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,4 +1,4 @@
-Run before approving any PR that adds or modifies tests. If any check fails, request changes; do not approve until the developer pushes a triage commit.
+Run before approving any PR. Apply each item below if its scope matches the diff. If any applicable check fails, request changes; do not approve until the developer pushes a triage commit.
 
 - [ ] **Per-case verdict (blocker default).** Triage every test case added or modified in this PR as one of `keep` / `shrink` / `delete`. Inline comments are required only for blocker verdicts; clean test PRs stay clean (no per-case inline noise) — consistent with `criteria.md §3` (`Clean — no issues.`).
 
@@ -17,5 +17,7 @@ Run before approving any PR that adds or modifies tests. If any check fails, req
 - [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` and record only the final state: what the PR does (Summary, scoped to the merged diff) + verification facts (test plan, pre-commit, structural readiness, test node delta). Strip dev-process narration — per-round fix history, tally IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer changelogs, abandoned approaches. Those belong in commit history / review threads. If found in the body, REQUEST_CHANGES.
 
 - [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
+
+- [ ] **Skill edits (`.claude/skills/**`) — tightening pass before APPROVE.** Require the developer to condense the skill's wording without changing what it instructs. Verify: semantics preserved, every step has exactly one valid execution path, no example included unless it is load-bearing, and any retained example references durable concepts rather than implementation details that age out.
 
 - [ ] On the triage commit, re-run every check above before approving.

--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -8,7 +8,7 @@ Run before approving any PR. Apply each item below if its scope matches the diff
 
   Cases the reviewer cannot classify with confidence count as untriaged → **BLOCKER, inline required** asking the developer for the rationale. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
 
-- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main`. If existing-file growth > 25% AND any case carries an unresolved blocker verdict (`shrink` / `delete`) or remains untriaged, REQUEST_CHANGES with the full list of affected node IDs in the summary. (Absence of an inline comment is not a blocker on its own — silent `keep` is the default.)
+- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main` (prereq: `upstream` remote points to tile-ai/TileOPs and is fresh — `git fetch upstream` first). If existing-file growth > 25% AND any case carries an unresolved blocker verdict (`shrink` / `delete`) or remains untriaged, REQUEST_CHANGES with the full list of affected node IDs in the summary. (Absence of an inline comment is not a blocker on its own — silent `keep` is the default.)
 
 - [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
 

--- a/.claude/skills/create-follow-up-issue/SKILL.md
+++ b/.claude/skills/create-follow-up-issue/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: create-follow-up-issue
+description: Introspect a development session and generate follow-up issues for deferred work, discovered problems, and coverage gaps. Max 3 issues per invocation.
+---
+
+## Arguments
+
+| Argument   | Required | Description                                              |
+| ---------- | -------- | -------------------------------------------------------- |
+| `<PR_URL>` | No       | GitHub PR URL. If omitted, inferred from current branch. |
+
+## Contract
+
+- **Input**: PR reference + conversation history (if available)
+- **Output**: up to 3 follow-up issues + in-scope suggestions committed into the PR + remaining out-of-scope suggestions listed in PR body
+- **Termination**: PR body updated — with issues, applied-fix commit, out-of-scope suggestions, or explicit "no follow-up" declaration
+
+## Modes
+
+- **Session-rich**: conversation history available. Introspection is primary signal; PR supplements.
+- **Session-poor**: no session context. Use PR diff + human reviewer comments.
+
+## Steps
+
+### 1. GATE
+
+Resolve PR. Try explicit URL first, else current branch:
+
+```bash
+gh pr view <PR_URL_or_empty> --json number,title,url,body,baseRefName
+OWNER_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+```
+
+Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REPO`.
+
+**Fail** → terminate: `No PR found. Provide a PR URL (/create-follow-up-issue <url>), or run on a branch with an associated PR.`
+
+### 2. COLLECT (parallel)
+
+| Source                  | How                                                                    |
+| ----------------------- | ---------------------------------------------------------------------- |
+| Code diff               | `git diff $BASE_BRANCH...HEAD`                                         |
+| Session history         | Scan conversation for deferrals, workarounds, surprises, blocked items |
+| In-code markers         | Grep changed files for `TODO`, `FIXME`, `HACK`, `XXX`                  |
+| Human reviewer comments | `gh api` — see below                                                   |
+
+**Reviewer comment extraction** (excludes PR author and bots):
+
+```bash
+PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q '.author.login')
+
+# Inline review comments
+gh api repos/$OWNER_REPO/pulls/$PR_NUMBER/comments --paginate \
+  --jq '[.[] | select(.user.login != env.PR_AUTHOR and .user.type != "Bot"
+         and (.user.login | test("copilot|gemini|github-actions"; "i") | not))]'
+
+# General PR comments
+gh api repos/$OWNER_REPO/issues/$PR_NUMBER/comments --paginate \
+  --jq '[.[] | select(.user.login != env.PR_AUTHOR and .user.type != "Bot"
+         and (.user.login | test("copilot|gemini|github-actions"; "i") | not))]'
+```
+
+### 3. CLASSIFY
+
+**Issue-worthy** (→ follow-up issue):
+
+| Category             | Signal                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Scope deferral**   | "not in this PR", "follow-up needed", explicitly deferred                                                          |
+| **Fragile coupling** | Workarounds, monkey-patches, breakable assumptions                                                                 |
+| **Coverage gap**     | Untested cases, missing edge cases, skipped benchmarks                                                             |
+| **Consistency gap**  | *Doc drift*: implementation changed, docs/manifest not updated. *Spec drift*: same problem exists in other modules |
+
+**Suggestion** (→ no issue). Split by scope:
+
+| Sub-tier         | Signal                                                                                                                                                                                                              | Disposition                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **In-scope**     | Touches only files already in this PR's diff; fix is small, mechanical, low-risk (style, naming, formatting, local refactor, obvious typo); does not change observable behavior beyond what this PR already changes | Apply directly in this PR (step 6.5) |
+| **Out-of-scope** | Touches files outside this PR's diff, OR would expand PR's behavioral surface, OR is judgment-dependent (API naming debate, design tradeoff)                                                                        | List as text in PR body (step 7)     |
+
+When uncertain, classify as out-of-scope — do not silently enlarge the PR's diff.
+
+**Termination gate:** Zero issue-worthy items AND zero in-scope suggestions → skip to step 7. Do not manufacture follow-ups.
+
+### 4. MERGE
+
+Reduce to **max 3 issues**:
+
+- Same module + multiple problems → merge
+- Same root cause + multiple locations → merge
+- Different modules, independent → keep separate
+- Still >3 after merging → force-merge smallest into most related candidate
+
+### 5. PRESENT
+
+Show candidates in **dependency order** (prerequisites first). Wait for user confirmation.
+
+```
+Follow-up candidates from PR #<number>: <title>
+──────────────────────────────────────────────────
+1. [TYPE][SCOPE] <title>
+   Category: <category> | Summary: <1-2 sentences>
+
+2. [TYPE][SCOPE] <title>          ← parallel with #1
+   Category: <category> | Summary: <1-2 sentences>
+
+3. [TYPE][SCOPE] <title>          ← depends on #1
+   Category: <category> | Summary: <1-2 sentences>
+
+Execution order: {#1, #2} → #3
+
+In-scope fixes (apply directly in this PR):
+  - <file:line> — <nit>
+
+Out-of-scope suggestions (PR body text only):
+  - <nit>
+
+Actions: confirm all / drop by number / edit / move <item> to out-of-scope
+```
+
+### 6. CREATE
+
+Ensure label exists:
+
+```bash
+gh label list --search "follow-up" --json name --jq '.[].name' | grep -qx "follow-up" \
+  || gh label create "follow-up" --description "Generated from dev session introspection" --color "c5def5"
+```
+
+For each confirmed item, invoke `foundry:creating-issue` with `--from-draft <tmpfile>`:
+
+```markdown
+---
+type: <FEAT|BUG|PERF|REFACTOR|DOCS|TEST>
+component: <affected module>
+labels:
+  - follow-up
+target_repo: <OWNER_REPO>
+---
+
+# Description
+## Symptom / Motivation
+Discovered during PR #<PR_NUMBER> (<PR_TITLE>).
+<what was observed, why it matters>
+
+## Root Cause Analysis
+<why not addressed in source PR — scope, complexity, risk>
+
+## Related Files
+- <paths from diff or session>
+
+# Goal
+<one sentence>
+
+# Plan
+<!-- type: proposal -->
+1. <step>
+2. <step>
+
+# Constraints
+- Must not regress PR #<PR_NUMBER>
+
+# Acceptance Criteria
+- [ ] AC-1: Modified files pass unit tests
+```
+
+### 6.5. APPLY IN-SCOPE FIXES
+
+For each confirmed in-scope suggestion:
+
+1. Verify file is in PR diff (`git diff --name-only $BASE_BRANCH...HEAD`). If not, demote to out-of-scope and skip.
+1. Apply edit with the Edit tool.
+1. Run the most relevant fast check for the file type (e.g., `pre-commit run --files <paths>`, or unit tests for the touched module). Not the full suite.
+
+Commit the batch as a single commit on the current branch:
+
+```bash
+git add <files>
+git commit -m "[Chore] apply in-scope follow-up suggestions from PR #$PR_NUMBER review
+
+- <one line per applied fix: file:line — what changed>
+"
+git push
+```
+
+Constraints:
+
+- If a fix fails its check or adds unrelated diff noise → `git restore` that file and demote to out-of-scope before committing the rest.
+- Never force-push. Never amend existing commits.
+
+Record `APPLIED_FIXES` (file:line + one-line summary per fix) for step 7.
+
+### 7. UPDATE PR BODY
+
+Update existing PR body to match the final implementation (fix summary/description if the plan changed during development). Then append `## Follow-up`.
+
+```bash
+CURRENT_BODY=$(gh pr view $PR_NUMBER --json body -q '.body')
+gh pr edit $PR_NUMBER --body "$CURRENT_BODY
+
+$FOLLOWUP_SECTION"
+```
+
+Omit empty sections entirely — do not write "none".
+
+**Section blocks (compose as needed):**
+
+```markdown
+## Follow-up
+
+Issues:
+- #<N> — <one-line summary>
+- #<N> — <one-line summary> (depends on #<N>)
+
+Applied in this PR:
+- <file:line> — <one-line summary>
+
+Out-of-scope suggestions:
+- <nit>
+```
+
+**Clean close** (nothing in any bucket):
+
+```markdown
+## Follow-up
+
+No follow-up issues or suggestions.
+```
+
+## Output
+
+```
+PR #<number> body updated.
+  Issues: #<N>, #<N> (or "none")
+  Applied in-PR: <count> (or "none") — commit <sha>
+  Out-of-scope suggestions: <count> (or "none")
+  Execution order: {#1, #2} → #3
+```

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -46,20 +46,15 @@ Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REP
 | In-code markers         | Grep changed files for `TODO`, `FIXME`, `HACK`, `XXX`                  |
 | Human reviewer comments | `gh api` — see below                                                   |
 
-**Reviewer comment extraction** (excludes PR author and bots):
+**Reviewer comment extraction** (excludes PR author and bots). Apply the same filter to both endpoints — inline review comments and general PR comments:
 
 ```bash
 export PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q '.author.login')
+FILTER='[.[] | select(.user.login != env.PR_AUTHOR and .user.type != "Bot"
+        and (.user.login | test("copilot|gemini|github-actions"; "i") | not))]'
 
-# Inline review comments
-gh api repos/$OWNER_REPO/pulls/$PR_NUMBER/comments --paginate \
-  --jq '[.[] | select(.user.login != env.PR_AUTHOR and .user.type != "Bot"
-         and (.user.login | test("copilot|gemini|github-actions"; "i") | not))]'
-
-# General PR comments
-gh api repos/$OWNER_REPO/issues/$PR_NUMBER/comments --paginate \
-  --jq '[.[] | select(.user.login != env.PR_AUTHOR and .user.type != "Bot"
-         and (.user.login | test("copilot|gemini|github-actions"; "i") | not))]'
+gh api "repos/$OWNER_REPO/pulls/$PR_NUMBER/comments"  --paginate --jq "$FILTER"
+gh api "repos/$OWNER_REPO/issues/$PR_NUMBER/comments" --paginate --jq "$FILTER"
 ```
 
 ### 3. CLASSIFY
@@ -75,10 +70,10 @@ gh api repos/$OWNER_REPO/issues/$PR_NUMBER/comments --paginate \
 
 **Suggestion** (→ no issue). Split by scope:
 
-| Sub-tier         | Signal                                                                                                                                                                                                              | Disposition                          |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| **In-scope**     | Touches only files already in this PR's diff; fix is small, mechanical, low-risk (style, naming, formatting, local refactor, obvious typo); does not change observable behavior beyond what this PR already changes | Apply directly in this PR (step 6.5) |
-| **Out-of-scope** | Touches files outside this PR's diff, OR would expand PR's behavioral surface, OR is judgment-dependent (API naming debate, design tradeoff)                                                                        | Print in stdout report (step 7)      |
+| Sub-tier         | Signal                                                                                                                          | Disposition                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **In-scope**     | Touches only files in this PR's diff; fix is small, mechanical, low-risk; does not expand the PR's observable behavior          | Apply directly in this PR (step 6.5) |
+| **Out-of-scope** | Touches files outside this PR's diff, OR expands the PR's behavioral surface, OR is judgment-dependent (subjective design call) | Print in stdout report (step 7)      |
 
 When uncertain, classify as out-of-scope — do not silently enlarge the PR's diff.
 
@@ -114,7 +109,7 @@ Execution order: {#1, #2} → #3
 In-scope fixes (apply directly in this PR):
   - <file:line> — <nit>
 
-Out-of-scope suggestions (PR body text only):
+Out-of-scope suggestions (deferred — printed in step 7, not committed):
   - <nit>
 
 Actions: confirm all / drop by number / edit / move <item> to out-of-scope
@@ -194,9 +189,9 @@ Record `APPLIED_FIXES` (file:line + one-line summary per fix) for step 7.
 
 ### 7. REPORT
 
-**Do not edit the PR body.** The review skill's approval gate is the single point that asks the developer to refresh the body — duplicating that here causes write conflicts and stale text. This skill ends with a stdout report; the developer folds the relevant pieces into the PR body when the reviewer asks.
+**Do not edit the PR body.** The review skill owns body updates at its approval gate; this skill prints a stdout report only.
 
-Print the report to stdout. Omit empty sections entirely — do not write "none" inside a section, just drop the heading.
+Omit empty sections entirely — do not write "none" inside a section, just drop the heading.
 
 ```
 PR #<PR_NUMBER> follow-up complete.

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -29,11 +29,11 @@ description: Introspect a development session and generate follow-up issues for 
 Resolve PR:
 
 ```bash
-gh pr view <PR_NUMBER> --json number,title,url,body,baseRefName
+gh pr view <PR_NUMBER> --json number,title,url,body
 OWNER_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 ```
 
-Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REPO`.
+Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `OWNER_REPO`.
 
 **Fail** (PR not found) → terminate: `PR #<PR_NUMBER> not found in $OWNER_REPO.`
 
@@ -41,7 +41,7 @@ Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REP
 
 | Source                  | How                                                                    |
 | ----------------------- | ---------------------------------------------------------------------- |
-| Code diff               | `git diff $BASE_BRANCH...HEAD`                                         |
+| Code diff               | `gh pr diff "$PR_NUMBER"`                                              |
 | Session history         | Scan conversation for deferrals, workarounds, surprises, blocked items |
 | In-code markers         | Grep changed files for `TODO`, `FIXME`, `HACK`, `XXX`                  |
 | Human reviewer comments | `gh api` — see below                                                   |
@@ -70,14 +70,14 @@ gh api "repos/$OWNER_REPO/issues/$PR_NUMBER/comments" --paginate --jq "$FILTER"
 
 **Suggestion** (→ no issue). Split by scope:
 
-| Sub-tier         | Signal                                                                                                                          | Disposition                          |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| **In-scope**     | Touches only files in this PR's diff; fix is small, mechanical, low-risk; does not expand the PR's observable behavior          | Apply directly in this PR (step 6.5) |
-| **Out-of-scope** | Touches files outside this PR's diff, OR expands the PR's behavioral surface, OR is judgment-dependent (subjective design call) | Print in stdout report (step 7)      |
+| Sub-tier         | Signal                                                                                                                          | Disposition                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **In-scope**     | Touches only files in this PR's diff; fix is small, mechanical, low-risk; does not expand the PR's observable behavior          | Apply directly in this PR (step 7) |
+| **Out-of-scope** | Touches files outside this PR's diff, OR expands the PR's behavioral surface, OR is judgment-dependent (subjective design call) | Print in stdout report (step 8)    |
 
 When uncertain, classify as out-of-scope — do not silently enlarge the PR's diff.
 
-**Termination gate:** Zero issue-worthy items AND zero in-scope suggestions → skip to step 7 (print empty report). Do not manufacture follow-ups.
+**Termination gate:** Zero issue-worthy items AND zero in-scope suggestions → skip to step 8 (print empty report). Do not manufacture follow-ups.
 
 ### 4. MERGE
 
@@ -109,7 +109,7 @@ Execution order: {#1, #2} → #3
 In-scope fixes (apply directly in this PR):
   - <file:line> — <nit>
 
-Out-of-scope suggestions (deferred — printed in step 7, not committed):
+Out-of-scope suggestions (deferred — printed in step 8, not committed):
   - <nit>
 
 Actions: confirm all / drop by number / edit / move <item> to out-of-scope
@@ -161,11 +161,11 @@ Discovered during PR #<PR_NUMBER> (<PR_TITLE>).
 - [ ] AC-1: Modified files pass unit tests
 ```
 
-### 6.5. APPLY IN-SCOPE FIXES
+### 7. APPLY IN-SCOPE FIXES
 
 For each confirmed in-scope suggestion:
 
-1. Verify file is in PR diff (`git diff --name-only $BASE_BRANCH...HEAD`). If not, demote to out-of-scope and skip.
+1. Verify the file is in the PR diff with `gh pr diff --name-only "$PR_NUMBER"`. If not, demote to out-of-scope and skip.
 1. Apply edit with the Edit tool.
 1. Run the most relevant fast check for the file type (e.g., `pre-commit run --files <paths>`, or unit tests for the touched module). Not the full suite.
 
@@ -185,9 +185,9 @@ Constraints:
 - If a fix fails its check or adds unrelated diff noise → `git restore` that file and demote to out-of-scope before committing the rest.
 - Never force-push. Never amend existing commits.
 
-Record `APPLIED_FIXES` (file:line + one-line summary per fix) for step 7.
+Record `APPLIED_FIXES` (file:line + one-line summary per fix) for step 8.
 
-### 7. REPORT
+### 8. REPORT
 
 **Do not edit the PR body.** The review skill owns body updates at its approval gate; this skill prints a stdout report only.
 

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -1,19 +1,19 @@
 ---
-name: create-follow-up-issue
+name: follow-up
 description: Introspect a development session and generate follow-up issues for deferred work, discovered problems, and coverage gaps. Max 3 issues per invocation.
 ---
 
 ## Arguments
 
-| Argument   | Required | Description                                              |
-| ---------- | -------- | -------------------------------------------------------- |
-| `<PR_URL>` | No       | GitHub PR URL. If omitted, inferred from current branch. |
+| Argument      | Required | Description                      |
+| ------------- | -------- | -------------------------------- |
+| `<PR_NUMBER>` | Yes      | TileOPs PR number (e.g. `1131`). |
 
 ## Contract
 
 - **Input**: PR reference + conversation history (if available)
-- **Output**: up to 3 follow-up issues + in-scope suggestions committed into the PR + remaining out-of-scope suggestions listed in PR body
-- **Termination**: PR body updated — with issues, applied-fix commit, out-of-scope suggestions, or explicit "no follow-up" declaration
+- **Output**: up to 3 follow-up issues + in-scope suggestions committed into the PR + remaining out-of-scope suggestions printed to stdout for the developer to fold into the PR body at the reviewer's approval gate
+- **Termination**: issues created (if any) + applied-fix commit pushed (if any) + a stdout report listing what was created/applied/deferred. **Never edit the PR body** — the review skill owns body updates.
 
 ## Modes
 
@@ -24,16 +24,18 @@ description: Introspect a development session and generate follow-up issues for 
 
 ### 1. GATE
 
-Resolve PR. Try explicit URL first, else current branch:
+`<PR_NUMBER>` is required. If missing, terminate immediately: `Missing PR number. Usage: /follow-up <PR_NUMBER>`.
+
+Resolve PR:
 
 ```bash
-gh pr view <PR_URL_or_empty> --json number,title,url,body,baseRefName
+gh pr view <PR_NUMBER> --json number,title,url,body,baseRefName
 OWNER_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 ```
 
 Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REPO`.
 
-**Fail** → terminate: `No PR found. Provide a PR URL (/create-follow-up-issue <url>), or run on a branch with an associated PR.`
+**Fail** (PR not found) → terminate: `PR #<PR_NUMBER> not found in $OWNER_REPO.`
 
 ### 2. COLLECT (parallel)
 
@@ -76,11 +78,11 @@ gh api repos/$OWNER_REPO/issues/$PR_NUMBER/comments --paginate \
 | Sub-tier         | Signal                                                                                                                                                                                                              | Disposition                          |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | **In-scope**     | Touches only files already in this PR's diff; fix is small, mechanical, low-risk (style, naming, formatting, local refactor, obvious typo); does not change observable behavior beyond what this PR already changes | Apply directly in this PR (step 6.5) |
-| **Out-of-scope** | Touches files outside this PR's diff, OR would expand PR's behavioral surface, OR is judgment-dependent (API naming debate, design tradeoff)                                                                        | List as text in PR body (step 7)     |
+| **Out-of-scope** | Touches files outside this PR's diff, OR would expand PR's behavioral surface, OR is judgment-dependent (API naming debate, design tradeoff)                                                                        | Print in stdout report (step 7)      |
 
 When uncertain, classify as out-of-scope — do not silently enlarge the PR's diff.
 
-**Termination gate:** Zero issue-worthy items AND zero in-scope suggestions → skip to step 7. Do not manufacture follow-ups.
+**Termination gate:** Zero issue-worthy items AND zero in-scope suggestions → skip to step 7 (print empty report). Do not manufacture follow-ups.
 
 ### 4. MERGE
 
@@ -190,49 +192,30 @@ Constraints:
 
 Record `APPLIED_FIXES` (file:line + one-line summary per fix) for step 7.
 
-### 7. UPDATE PR BODY
+### 7. REPORT
 
-Update existing PR body to match the final implementation (fix summary/description if the plan changed during development). Then append `## Follow-up`.
+**Do not edit the PR body.** The review skill's approval gate is the single point that asks the developer to refresh the body — duplicating that here causes write conflicts and stale text. This skill ends with a stdout report; the developer folds the relevant pieces into the PR body when the reviewer asks.
 
-```bash
-CURRENT_BODY=$(gh pr view $PR_NUMBER --json body -q '.body')
-gh pr edit $PR_NUMBER --body "$CURRENT_BODY
+Print the report to stdout. Omit empty sections entirely — do not write "none" inside a section, just drop the heading.
 
-$FOLLOWUP_SECTION"
 ```
+PR #<PR_NUMBER> follow-up complete.
 
-Omit empty sections entirely — do not write "none".
-
-**Section blocks (compose as needed):**
-
-```markdown
-## Follow-up
-
-Issues:
+Issues created:
 - #<N> — <one-line summary>
 - #<N> — <one-line summary> (depends on #<N>)
 
-Applied in this PR:
+Applied in this PR (commit <sha>):
 - <file:line> — <one-line summary>
 
-Out-of-scope suggestions:
+Out-of-scope suggestions (fold into PR body at the reviewer's approval gate):
 - <nit>
+
+Execution order: {#1, #2} → #3
 ```
 
 **Clean close** (nothing in any bucket):
 
-```markdown
-## Follow-up
-
-No follow-up issues or suggestions.
 ```
-
-## Output
-
-```
-PR #<number> body updated.
-  Issues: #<N>, #<N> (or "none")
-  Applied in-PR: <count> (or "none") — commit <sha>
-  Out-of-scope suggestions: <count> (or "none")
-  Execution order: {#1, #2} → #3
+PR #<PR_NUMBER>: no follow-up issues or suggestions.
 ```

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -49,7 +49,7 @@ Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `BASE_BRANCH`, `OWNER_REP
 **Reviewer comment extraction** (excludes PR author and bots):
 
 ```bash
-PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q '.author.login')
+export PR_AUTHOR=$(gh pr view $PR_NUMBER --json author -q '.author.login')
 
 # Inline review comments
 gh api repos/$OWNER_REPO/pulls/$PR_NUMBER/comments --paginate \

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -146,5 +146,5 @@ align-op <op_name>                       ← per-op orchestrator
 
 - **Per-skill blocks above** mirror each skill's `description` frontmatter. Edit the frontmatter first; update the matching block here to stay consistent.
 - **At-a-glance matrix, intent table, use/don't-use rules, composition diagram, trust-model table**: hand-maintained. Add entries when a new skill lands; remove when one is retired.
-- **Authoritative skill list (op-development scope)**: this guide covers op-, family-, and manifest-scoped skills only. Among those, every directory under `.claude/skills/` should appear in the at-a-glance matrix and have a block in "Skills in detail". Process / workflow skills (those that operate on PRs or sessions, not on ops) are out of scope and live with their workflow docs.
+- **Authoritative skill list (op-development scope)**: this guide covers op-, family-, and manifest-scoped skills only. Every in-scope skill must appear in the at-a-glance matrix and have a block in "Skills in detail". Process / workflow skills (those that operate on PRs or sessions, not on ops) are out of scope; they live in `.claude/skills/` alongside in-scope skills but are documented with their workflow guides, not here.
 - **Lint automation**: none at 7-skill scale. Revisit if drift becomes observable or the count passes ~15.

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -146,5 +146,5 @@ align-op <op_name>                       ← per-op orchestrator
 
 - **Per-skill blocks above** mirror each skill's `description` frontmatter. Edit the frontmatter first; update the matching block here to stay consistent.
 - **At-a-glance matrix, intent table, use/don't-use rules, composition diagram, trust-model table**: hand-maintained. Add entries when a new skill lands; remove when one is retired.
-- **Authoritative skill list**: `ls .claude/skills/` is the source of truth. Every directory there should appear in the at-a-glance matrix and have a block in "Skills in detail".
+- **Authoritative skill list (op-development scope)**: this guide covers op-, family-, and manifest-scoped skills only. Among those, every directory under `.claude/skills/` should appear in the at-a-glance matrix and have a block in "Skills in detail". Process / workflow skills (those that operate on PRs or sessions, not on ops) are out of scope and live with their workflow docs.
 - **Lint automation**: none at 7-skill scale. Revisit if drift becomes observable or the count passes ~15.


### PR DESCRIPTION
## Summary

- Move `create-follow-up-issue` skill from `~/.claude/skills/` (the personal ibuki config) into this repo at `.claude/skills/create-follow-up-issue/SKILL.md`.
- Skill is generic but in practice only used here; versioning it with the project means edits go through normal review.

## Test plan

- [x] pre-commit passed (mdformat, codespell, gitleaks)
- [ ] N/A — pure relocation, no code paths changed

## Additional context

Skill content is unchanged from the ibuki copy. Removal commit on the ibuki side stays local until a separate `/push-ibuki`.