### PR TITLE
[Feat][Skill] add MAX_IDLE / wall-clock backstops to review and resolve loops

### DIFF
--- a/.claude/skills/resolve-tileops/SKILL.md
+++ b/.claude/skills/resolve-tileops/SKILL.md
@@ -25,9 +25,9 @@ MESSAGE=$(echo "$PRE" | jq -r .message)
 
 Branch on `ACTION`:
 
-- `terminate-success` / `terminate-diverged` / `terminate-external` —
-  write retrospective (see below), print `MESSAGE`, **return without
-  ScheduleWakeup**.
+- `terminate-success` / `terminate-diverged` / `terminate-external` /
+  `terminate-stalled` — write retrospective (see below), print
+  `MESSAGE`, **return without ScheduleWakeup**.
 - `idle` — print `MESSAGE`, ScheduleWakeup with `delaySeconds=180`,
   `prompt=/resolve-tileops <PR>`, `reason="PR #<PR> idle — polling"`. Return.
 - `continue` — proceed to Step 2.

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -67,7 +67,8 @@ jq -n --arg pr "$PR" --arg repo "$REPO" '{
   round:0, max_rounds:15,
   last_processed_review_id:0,
   last_processed_review_comment_id:0,
-  last_pushed_sha:null
+  last_pushed_sha:null,
+  consecutive_idle:0, max_idle:5
 }' > "$META"
 
 echo "preflight: state initialized for PR #$PR at $META" >&2

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -68,7 +68,7 @@ jq -n --arg pr "$PR" --arg repo "$REPO" '{
   last_processed_review_id:0,
   last_processed_review_comment_id:0,
   last_pushed_sha:null,
-  consecutive_idle:0, max_idle:20
+  consecutive_idle:0
 }' > "$META"
 
 echo "preflight: state initialized for PR #$PR at $META" >&2

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -68,7 +68,7 @@ jq -n --arg pr "$PR" --arg repo "$REPO" '{
   last_processed_review_id:0,
   last_processed_review_comment_id:0,
   last_pushed_sha:null,
-  consecutive_idle:0, max_idle:5
+  consecutive_idle:0, max_idle:20
 }' > "$META"
 
 echo "preflight: state initialized for PR #$PR at $META" >&2

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -48,7 +48,7 @@ LAST_REVIEW_COMMENT_ID_PREV=$(jq -r '.last_processed_review_comment_id' "$META")
 # continue. Hitting max_idle terminates the loop so a dead counterpart
 # (e.g. review-loop crashed) doesn't leave us polling forever.
 CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
-MAX_IDLE=$(jq -r '.max_idle // 5' "$META")
+MAX_IDLE=$(jq -r '.max_idle // 20' "$META")
 
 PR_JSON=$(gh pr view "$PR" --repo "$REPO" --json state,headRefOid,isDraft 2>/dev/null) \
   || { echo "round-pre: gh pr view failed" >&2; exit 1; }

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -44,6 +44,11 @@ ROUND=$(jq -r '.round' "$META")
 MAX_ROUNDS=$(jq -r '.max_rounds' "$META")
 LAST_REVIEW_ID_PREV=$(jq -r '.last_processed_review_id' "$META")
 LAST_REVIEW_COMMENT_ID_PREV=$(jq -r '.last_processed_review_comment_id' "$META")
+# Stall safety net. Increment on idle (no progress this round), reset on
+# continue. Hitting max_idle terminates the loop so a dead counterpart
+# (e.g. review-loop crashed) doesn't leave us polling forever.
+CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
+MAX_IDLE=$(jq -r '.max_idle // 5' "$META")
 
 PR_JSON=$(gh pr view "$PR" --repo "$REPO" --json state,headRefOid,isDraft 2>/dev/null) \
   || { echo "round-pre: gh pr view failed" >&2; exit 1; }
@@ -127,6 +132,24 @@ if [[ -z "$ACTION" \
 fi
 
 [[ -z "$ACTION" ]] && ACTION="continue"
+
+# Stall counter: increment on idle, reset on continue. If idle persists
+# beyond max_idle, escalate to terminate-stalled — protects against the
+# review-loop dying silently while we poll forever.
+if [[ "$ACTION" == "idle" ]]; then
+  NEW_IDLE=$((CONSECUTIVE_IDLE + 1))
+  if (( NEW_IDLE >= MAX_IDLE )); then
+    ACTION="terminate-stalled"
+    MESSAGE="No reviewer activity for $NEW_IDLE consecutive rounds (max_idle=$MAX_IDLE) — terminating."
+  fi
+  jq --argjson n "$NEW_IDLE" '.consecutive_idle=$n' "$META" \
+    > "$META.tmp" && mv "$META.tmp" "$META"
+elif [[ "$ACTION" == "continue" ]]; then
+  if (( CONSECUTIVE_IDLE != 0 )); then
+    jq '.consecutive_idle=0' "$META" \
+      > "$META.tmp" && mv "$META.tmp" "$META"
+  fi
+fi
 
 NEXT_ROUND=$((ROUND + 1))
 SNAP_PREFIX=""

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -45,10 +45,13 @@ MAX_ROUNDS=$(jq -r '.max_rounds' "$META")
 LAST_REVIEW_ID_PREV=$(jq -r '.last_processed_review_id' "$META")
 LAST_REVIEW_COMMENT_ID_PREV=$(jq -r '.last_processed_review_comment_id' "$META")
 # Stall safety net. Increment on idle (no progress this round), reset on
-# continue. Hitting max_idle terminates the loop so a dead counterpart
-# (e.g. review-loop crashed) doesn't leave us polling forever.
+# continue. Hitting MAX_IDLE terminates the loop so a dead counterpart
+# (e.g. review-loop crashed) doesn't leave us polling forever. Hardcoded
+# rather than read from meta.json so a state file from an older skill
+# version with a stricter threshold doesn't silently override the
+# current floor.
 CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
-MAX_IDLE=$(jq -r '.max_idle // 20' "$META")
+MAX_IDLE=20
 
 PR_JSON=$(gh pr view "$PR" --repo "$REPO" --json state,headRefOid,isDraft 2>/dev/null) \
   || { echo "round-pre: gh pr view failed" >&2; exit 1; }

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -26,10 +26,14 @@ MAX_ROUNDS=15
 POLL_INTERVAL=180
 CODEX_RETRY=3
 # Stall safety: terminate after this many consecutive idle polls (no new
-# commits / comments). With POLL_INTERVAL=180s, MAX_IDLE=5 ≈ 15min — short
-# enough that a dead resolve-loop counterpart doesn't burn cycles
-# indefinitely, long enough to absorb agent / CI / network slowness.
-MAX_IDLE=5
+# commits / comments). MAX_IDLE * POLL_INTERVAL must comfortably exceed
+# the longest legitimate in-progress counterpart round (codex review on a
+# large PR, or a developer round of edit + test + push). 20 polls * 180s
+# = 60min — wide enough that a single slow but live counterpart round
+# does not trip terminate-stalled, narrow enough that a truly dead
+# counterpart still exits within the hour. Wall-clock cap below caps
+# absolute runaway risk.
+MAX_IDLE=20
 # Belt-and-suspenders: hard wall-clock cap independent of round/idle
 # accounting, in case a logic bug skips both. Far above any realistic PR
 # lifetime (hours), low enough that a runaway is bounded to a day.

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -25,6 +25,16 @@ REPO="tile-ai/TileOPs"
 MAX_ROUNDS=15
 POLL_INTERVAL=180
 CODEX_RETRY=3
+# Stall safety: terminate after this many consecutive idle polls (no new
+# commits / comments). With POLL_INTERVAL=180s, MAX_IDLE=5 ≈ 15min — short
+# enough that a dead resolve-loop counterpart doesn't burn cycles
+# indefinitely, long enough to absorb agent / CI / network slowness.
+MAX_IDLE=5
+# Belt-and-suspenders: hard wall-clock cap independent of round/idle
+# accounting, in case a logic bug skips both. Far above any realistic PR
+# lifetime (hours), low enough that a runaway is bounded to a day.
+MAX_WALL_CLOCK_HOURS=24
+LOOP_START_EPOCH=$(date +%s)
 REPO_PATH="$(git rev-parse --show-toplevel)"
 
 CRITERIA_PATH="$SKILL_DIR/criteria.md"
@@ -211,6 +221,7 @@ if [[ ! -f "$META" ]]; then
     last_criteria_mtime: 0,
     consecutive_codex_failures: 0,
     consecutive_request_changes: 0,
+    consecutive_idle: 0,
     status: "active"
   }' > "$META"
 fi
@@ -504,6 +515,15 @@ log "loop started — PR #$PR, MAX_ROUNDS=$MAX_ROUNDS, POLL_INTERVAL=${POLL_INTE
 while true; do
   ROUND=$(jq -r .round "$META")
 
+  # Wall-clock backstop: independent of round/idle accounting, in case a
+  # logic bug skips both. Runs before any GitHub API call.
+  WALL_CLOCK_S=$(( $(date +%s) - LOOP_START_EPOCH ))
+  if (( WALL_CLOCK_S > MAX_WALL_CLOCK_HOURS * 3600 )); then
+    log "wall-clock cap (${MAX_WALL_CLOCK_HOURS}h) exceeded — runaway, exiting"
+    set_meta_status "runaway"
+    exit 6
+  fi
+
   # External / hard-cutoff terminations come first.
   PR_VIEW=$(gh pr view "$PR" --repo "$REPO" --json state,headRefOid,isDraft 2>/dev/null) \
     || { log "gh pr view failed; sleeping ${POLL_INTERVAL}s"; sleep "$POLL_INTERVAL"; continue; }
@@ -552,7 +572,16 @@ while true; do
   if [[ "$ROUND" -gt 0 \
         && "$HEAD_SHA" == "$LAST_SHA" \
         && "$LATEST_HUMAN_ID" == "$LAST_HUMAN_ID_PREV" ]]; then
-    log "no new commits / comments — sleeping ${POLL_INTERVAL}s"
+    CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
+    NEW_IDLE=$((CONSECUTIVE_IDLE + 1))
+    jq --argjson n "$NEW_IDLE" '.consecutive_idle=$n' "$META" \
+      > "$META.tmp" && mv "$META.tmp" "$META"
+    if (( NEW_IDLE >= MAX_IDLE )); then
+      log "idle for $NEW_IDLE consecutive polls (MAX_IDLE=$MAX_IDLE) — stalled, exiting"
+      set_meta_status "stalled"
+      exit 5
+    fi
+    log "no new commits / comments — idle $NEW_IDLE/$MAX_IDLE, sleeping ${POLL_INTERVAL}s"
     sleep "$POLL_INTERVAL"
     continue
   fi
@@ -657,7 +686,9 @@ while true; do
      '.round=$r | .last_reviewed_sha=$sha | .last_human_comment_id=$hid
       | .last_codex_event=$ev | .last_criteria_mtime=$cm
       | .consecutive_request_changes=$rc
-      | .consecutive_codex_failures=0 | .last_reviewed_at=$now' \
+      | .consecutive_codex_failures=0
+      | .consecutive_idle=0
+      | .last_reviewed_at=$now' \
      "$META" > "$META.tmp" && mv "$META.tmp" "$META"
 
   jq -n --argjson r "$NEXT_ROUND" --arg now "$NOW" \


### PR DESCRIPTION
## Summary

Both `review-tileops/loop.sh` and `resolve-tileops` (round-pre.sh) poll GitHub independently without waiting on each other. Previously, if one loop died silently the other could keep idling forever. This PR adds layered termination guarantees so any failure mode exits within a bounded wall-clock window.

- **Symmetric `MAX_IDLE=20`** on both loops (≈60 min at the 180 s poll cadence) — wide enough that a single slow but live counterpart round (codex review on a large PR, or a developer round of edit + test + push) does not falsely trip terminate-stalled, narrow enough that a truly dead counterpart still exits within the hour:
  - `resolve`: `round-pre.sh` increments `consecutive_idle` when `action=idle`, resets on `continue`; threshold flips the action to `terminate-stalled`. `SKILL.md` adds `terminate-stalled` to the existing terminal-action branch (writes retrospective, no `ScheduleWakeup`). The constant is hardcoded in the script (not stored in `meta.json`) so a state file from an older skill version with a stricter threshold cannot silently override the current floor.
  - `review`: `loop.sh` increments `consecutive_idle` on the no-new-activity branch, resets after a successful codex round; threshold logs + sets `status=stalled` + `exit 5`.
- **Wall-clock backstop on `review/loop.sh`** (`MAX_WALL_CLOCK_HOURS=24`): independent of round/idle accounting — terminates with `status=runaway` and `exit 6` if a logic bug ever skips both counters. `resolve-loop` doesn't need this; it inherits the host Claude session's lifetime.

Together with the existing `terminate-success` / `terminate-diverged` / `terminate-external` paths, every loop now has four (review: five) independent exit conditions and cannot deadlock or livelock indefinitely.

## Test plan

- [x] `bash -n` on all four edited scripts.
- [ ] Verify `terminate-stalled` fires after 20 idle rounds on a quiet PR (manual).
- [ ] Verify `consecutive_idle` resets to 0 after a productive round.
- [ ] Confirm review-loop wall-clock cap doesn't fire under normal use (no PR runs >24 h in practice).