### PR TITLE
[Doc][Skills] regroup tileops-skills.md by scope and document all skills

### DIFF
--- a/.claude/skills/resolve-tileops/SKILL.md
+++ b/.claude/skills/resolve-tileops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resolve-tileops
-description: Per-round driver of stateful Claude-driven review-resolution on a tile-ai/TileOPs PR (developer side). Designed for /loop dynamic mode — re-fires until a terminal action. Outer caller must run preflight.sh once before starting the loop. State persists in `.foundry/runs/{issue-<N> | pr-<PR>}/resolve/`.
+description: Per-round driver of stateful agent-driven review-resolution on a tile-ai/TileOPs PR (developer side). Designed for /loop dynamic mode — re-fires until a terminal action. Outer caller must run preflight.sh once before starting the loop. State persists in `.foundry/runs/{issue-<N> | pr-<PR>}/resolve/`.
 ---
 
 ## Arguments
@@ -9,7 +9,7 @@ description: Per-round driver of stateful Claude-driven review-resolution on a t
 | ------------- | -------- | -------------------------------- |
 | `<PR_NUMBER>` | Yes      | TileOPs PR number (e.g. `1133`). |
 
-Resolution work runs in **this Claude session** — no external subagent.
+Resolution work runs in **this session** — no external subagent.
 
 ## Step 1: Pre-round
 

--- a/.claude/skills/review-tileops/loading.yaml
+++ b/.claude/skills/review-tileops/loading.yaml
@@ -5,8 +5,8 @@
 # review checks BOTH bracket tokens against `match` below; any token that
 # matches contributes its checklists. Multi-match across the two tokens
 # unions; no-match in either contributes nothing. If both miss, the
-# review runs without any domain-specific checklist (Codex applies its
-# general judgment).
+# review runs without any domain-specific checklist (the external
+# reviewer applies its general judgment).
 #
 # Add a new entry here when a new type or scope earns a dedicated
 # checklist; do NOT add path-based triggers — keep title-driven matching

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -2,7 +2,7 @@
 
 Skills this repo provides for TileOPs op development: what each does, when to use it, when not to. Authoritative per-skill contracts live in each `SKILL.md`; this page is the human-facing map.
 
-Naming is verb-noun. The verb is the action; the noun is the scope (`op`, `family`, `manifest`, or a workflow target like `tileops` / a PR session).
+Skill names are hyphenated command names. Op- and manifest-scoped skills use **verb-scope** (verb is the action; scope is `op`, `family`, or `manifest`). Workflow skills may use a workflow target or phrase instead — e.g. `review-tileops`, `resolve-tileops`, `follow-up`.
 
 ## At a glance
 
@@ -141,7 +141,7 @@ Introspect a development session and generate follow-up issues for deferred work
 
 - **Use when.** A PR is wrapping up and you want to capture deferred work or discovered gaps as issues, plus optionally apply in-scope fixes onto the PR branch.
 - **Don't use when.** You need to file a single ad-hoc bug — open an issue directly.
-- **Trust model.** Creates issues, may push an applied-fix commit to the PR branch, and prints out-of-scope suggestions to stdout. Never edits the PR body — that belongs to the review skill.
+- **Trust model.** Creates issues, may push an applied-fix commit to the PR branch, and prints out-of-scope suggestions to stdout. Never edits the PR body — that belongs to the review skill. Does not write `tileops/manifest/` outside the standard manifest skills.
 - **Contract:** [SKILL.md](../.claude/skills/follow-up/SKILL.md)
 
 ## Composition

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -115,7 +115,7 @@ Surgical patch of an existing manifest entry for fields **derived from on-disk o
 
 ### workflow
 
-Workflow skills operate on PRs and sessions, not on ops. Per the [trust model](#trust-model--who-may-write-what), they do not write `tileops/manifest/`, op files, kernel files, tests, or benchmarks; they read PRs, post review comments, drive resolution rounds, or open follow-up issues.
+Workflow skills operate on PRs and sessions, not on ops. Per the [trust model](#trust-model--who-may-write-what), they never write `tileops/manifest/` outside the standard manifest skills. Other write scopes vary per skill — see each block's **Trust model** line.
 
 **review-tileops** · workflow atomic
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -2,17 +2,18 @@
 
 Skills this repo provides for TileOPs op development: what each does, when to use it, when not to. Authoritative per-skill contracts live in each `SKILL.md`; this page is the human-facing map.
 
-Naming is **verb-noun**. The verb is the action; the noun is the scope (`op`, `family`, or `manifest`).
+Naming is verb-noun. The verb is the action; the noun is the scope (`op`, `family`, `manifest`, or a workflow target like `tileops` / a PR session).
 
 ## At a glance
 
-|                | Orchestrator                                              | Atomic                                                                                                                                                                                                                    |
-| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **per op**     | [`align-op`](../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../.claude/skills/test-op/SKILL.md) · [`implement-op`](../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../.claude/skills/bench-op/SKILL.md) |
-| **per family** | [`align-family`](../.claude/skills/align-family/SKILL.md) | [`audit-family`](../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                 |
-| **manifest**   | —                                                         | [`add-manifest`](../.claude/skills/add-manifest/SKILL.md) · [`fix-manifest`](../.claude/skills/fix-manifest/SKILL.md)                                                                                                     |
+|               | Orchestrator                                              | Atomic                                                                                                                                                                                                                    |
+| ------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| per op        | [`align-op`](../.claude/skills/align-op/SKILL.md)         | [`scaffold-op`](../.claude/skills/scaffold-op/SKILL.md) · [`test-op`](../.claude/skills/test-op/SKILL.md) · [`implement-op`](../.claude/skills/implement-op/SKILL.md) · [`bench-op`](../.claude/skills/bench-op/SKILL.md) |
+| per op family | [`align-family`](../.claude/skills/align-family/SKILL.md) | [`audit-family`](../.claude/skills/audit-family/SKILL.md)                                                                                                                                                                 |
+| manifest      | —                                                         | [`add-manifest`](../.claude/skills/add-manifest/SKILL.md) · [`fix-manifest`](../.claude/skills/fix-manifest/SKILL.md)                                                                                                     |
+| workflow      | —                                                         | [`review-tileops`](../.claude/skills/review-tileops/SKILL.md) · [`resolve-tileops`](../.claude/skills/resolve-tileops/SKILL.md) · [`follow-up`](../.claude/skills/follow-up/SKILL.md)                                     |
 
-Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging. Manifest skills are standalone editors of `tileops/manifest/` and have no orchestrator: they precede op-layer work, not contain it.
+Orchestrators are the day-to-day entry points. Atomics are their sub-skills — standalone invocation is for debugging. Manifest skills are standalone editors of `tileops/manifest/` and have no orchestrator: they precede op-layer work, not contain it. Workflow skills operate on PRs / sessions rather than on ops; they have no orchestrator and run independently of the op-development pipeline.
 
 ## What do I want to do?
 
@@ -26,12 +27,17 @@ Orchestrators are the day-to-day entry points. Atomics are their sub-skills — 
 | Patch `kernel_map` or `static_dims` on an existing manifest entry  | `/fix-manifest <op_name>`                  |
 | Scaffold a fresh op file, bypassing the orchestrator               | `/scaffold-op <op_name>`                   |
 | Debug one atomic phase by hand                                     | `/test-op` · `/implement-op` · `/bench-op` |
+| Run the Codex review loop on a TileOPs PR until APPROVE            | `/review-tileops <PR>`                     |
+| Resolve reviewer feedback on a TileOPs PR (per-round driver)       | `/resolve-tileops <PR>`                    |
+| Generate follow-up issues for deferred work after a PR             | `/follow-up <PR>`                          |
 
 ## Skills in detail
 
-Each block names the skill, its one-line purpose, clear **use when** / **don't use when** guidance, and a link to the authoritative `SKILL.md`.
+Each block names the skill, its one-line purpose, clear **use when** / **don't use when** guidance, and a link to the authoritative `SKILL.md`. Skills are grouped by scope: per-op, per-op-family, manifest, and workflow.
 
-### `align-op`  ·  per-op orchestrator
+### per-op
+
+**align-op** · per-op orchestrator
 
 Brings a single op into alignment with its manifest entry. Classifies into one of three cases and dispatches internally; runs the shared downstream (test → bench → validate → flip status → report).
 
@@ -40,15 +46,7 @@ Brings a single op into alignment with its manifest entry. Classifies into one o
 - **Don't use when.** You need to batch-migrate a whole family — use `align-family` instead.
 - **Contract:** [SKILL.md](../.claude/skills/align-op/SKILL.md)
 
-### `align-family`  ·  per-family orchestrator
-
-Drives the historical migration of an entire op family. Audits, delegates each per-op alignment to `align-op`, then handles family-scoped concerns: cross-op cleanup (dual-path removal) and PR creation. The family orchestrator never calls `test-op` / `implement-op` / `bench-op` directly and never writes `tileops/manifest/`.
-
-- **Use when.** You have a whole family of spec-only ops to migrate.
-- **Don't use when.** Only one op needs attention — use `align-op`.
-- **Contract:** [SKILL.md](../.claude/skills/align-family/SKILL.md)
-
-### `scaffold-op`  ·  per-op atomic
+**scaffold-op** · per-op atomic
 
 Writes a new T2 (L1-direct) op file from one manifest entry by following the 7-step playbook in `docs/design/ops-design.md`. Emits the 17 mechanical slots.
 
@@ -57,7 +55,7 @@ Writes a new T2 (L1-direct) op file from one manifest entry by following the 7-s
 - **Don't expect.** Family protocol variables (`_op_kind`, `_kernel_key`, …) or optional hooks (`_pad_value`, `_validate_dim`, …). Those are op-specific business logic, outside the 17 mechanical slots.
 - **Contract:** [SKILL.md](../.claude/skills/scaffold-op/SKILL.md)
 
-### `implement-op`  ·  per-op atomic
+**implement-op** · per-op atomic
 
 Edits an existing op file to match the manifest-declared interface, making spec tests pass.
 
@@ -65,28 +63,40 @@ Edits an existing op file to match the manifest-declared interface, making spec 
 - **Don't use when.** The change is a structural rewrite — `align-op --mode=redesign` archives the old file and regenerates cleanly before implementing.
 - **Contract:** [SKILL.md](../.claude/skills/implement-op/SKILL.md)
 
-### `test-op`  ·  per-op atomic
+**test-op** · per-op atomic
 
 Writes tests for the target spec using PyTorch as ground truth; verifies they fail on current code (the TDD seed before `implement-op`).
 
 - **Use when.** Called by orchestrators.
 - **Contract:** [SKILL.md](../.claude/skills/test-op/SKILL.md)
 
-### `bench-op`  ·  per-op atomic
+**bench-op** · per-op atomic
 
 Fixes the benchmark file to compile against the new op interface. Runs it, fixes errors, repeats until it produces numbers.
 
 - **Use when.** Called by orchestrators.
 - **Contract:** [SKILL.md](../.claude/skills/bench-op/SKILL.md)
 
-### `audit-family`  ·  per-family atomic
+### per-op-family
+
+**align-family** · per-family orchestrator
+
+Drives the historical migration of an entire op family. Audits, delegates each per-op alignment to `align-op`, then handles family-scoped concerns: cross-op cleanup (dual-path removal) and PR creation. The family orchestrator never calls `test-op` / `implement-op` / `bench-op` directly and never writes `tileops/manifest/`.
+
+- **Use when.** You have a whole family of spec-only ops to migrate.
+- **Don't use when.** Only one op needs attention — use `align-op`.
+- **Contract:** [SKILL.md](../.claude/skills/align-family/SKILL.md)
+
+**audit-family** · per-family atomic
 
 Compares each op's code signature against its manifest spec, classifies gaps (`ready` / `semantic_gap` / `blocked`), writes `.foundry/migrations/<family>.json`.
 
 - **Use when.** You want read-only inspection of a family's current conformance. Also called internally by `align-family`.
 - **Contract:** [SKILL.md](../.claude/skills/audit-family/SKILL.md)
 
-### `add-manifest` · manifest atomic
+### manifest
+
+**add-manifest** · manifest atomic
 
 Reads a reference-API docs URL (PyTorch / equivalent) and writes the auto-derivable fields of a manifest entry (`signature.{inputs,outputs,params,shape_rules,dtype_combos}`, `roofline` for well-known ops). Idempotent: human-curated fields (`workloads`, `parity_opt_out`, `source.*`, `status`, `family`, `ref_api`) are preserved verbatim if the entry already exists, defaulted otherwise. Same invocation works for greenfield and re-alignment.
 
@@ -94,7 +104,7 @@ Reads a reference-API docs URL (PyTorch / equivalent) and writes the auto-deriva
 - **Don't use when.** The gap is `kernel_map` or `static_dims` — those come from on-disk op / kernel code, not the reference; use `fix-manifest`.
 - **Contract:** [SKILL.md](../.claude/skills/add-manifest/SKILL.md)
 
-### `fix-manifest` · manifest atomic
+**fix-manifest** · manifest atomic
 
 Surgical patch of an existing manifest entry for fields **derived from on-disk op / kernel evidence** — `source.kernel_map` and `signature.static_dims`. Diagnoses the missing field via the validator, reads the op file to infer the patch payload, writes the single-field change, opens a manifest PR.
 
@@ -102,6 +112,37 @@ Surgical patch of an existing manifest entry for fields **derived from on-disk o
 - **Use when.** Validator says `kernel_map` or `static_dims` is missing on an existing entry. `kernel_map` is the most common case — it's required by `align-op`'s PRE_CHECK.
 - **Don't use when.** The entry doesn't exist (`add-manifest`); the gap is in a reference-derivable field (`add-manifest` re-aligns the whole entry from the reference URL); you want to flip `status` (that is `align-op`'s `FLIP_STATUS`).
 - **Contract:** [SKILL.md](../.claude/skills/fix-manifest/SKILL.md)
+
+### workflow
+
+Workflow skills operate on PRs and sessions, not on ops. Per the [trust model](#trust-model--who-may-write-what), they do not write `tileops/manifest/`, op files, kernel files, tests, or benchmarks; they read PRs, post review comments, drive resolution rounds, or open follow-up issues.
+
+**review-tileops** · workflow atomic
+
+Single-shot review of a `tile-ai/TileOPs` PR as a separate GitHub identity from the PR author. Loads the matching domain checklists from `.claude/review-checklists/` based on the PR title's `[type][scope]` tokens, inspects the diff, and submits one atomic review.
+
+- **Use when.** You want a Codex-style review on a TileOPs PR. For an autonomous multi-round loop until APPROVE, run `bash .claude/skills/review-tileops/loop.sh <PR>` instead of the single-shot command.
+- **Don't use when.** You are the PR author and want to address feedback — use `resolve-tileops`.
+- **Trust model.** Reads PR + repo state, posts review comments. Does not modify code, manifest, tests, or benchmarks.
+- **Contract:** [SKILL.md](../.claude/skills/review-tileops/SKILL.md)
+
+**resolve-tileops** · workflow atomic
+
+Per-round driver of stateful Claude-driven review-resolution on a `tile-ai/TileOPs` PR (developer side). Designed for `/loop` dynamic mode — re-fires until a terminal action. State persists in `.foundry/runs/{issue-<N> | pr-<PR>}/resolve/`.
+
+- **Use when.** You are the PR author and want to address reviewer feedback on a TileOPs PR across multiple rounds.
+- **Don't use when.** You want to *produce* a review — use `review-tileops`. The resolution work itself runs in the current Claude session; the outer caller must run `preflight.sh` once before starting the loop.
+- **Trust model.** Edits the PR's branch (code, tests, benchmarks, docs as needed); does not write `tileops/manifest/` outside the standard manifest skills.
+- **Contract:** [SKILL.md](../.claude/skills/resolve-tileops/SKILL.md)
+
+**follow-up** · workflow atomic
+
+Introspect a development session and generate follow-up issues for deferred work, discovered problems, and coverage gaps. Max 3 issues per invocation. Operates in *session-rich* mode (uses conversation history as primary signal) or *session-poor* mode (uses PR diff + reviewer comments).
+
+- **Use when.** A PR is wrapping up and you want to capture deferred work or discovered gaps as issues, plus optionally apply in-scope fixes onto the PR branch.
+- **Don't use when.** You need to file a single ad-hoc bug — open an issue directly.
+- **Trust model.** Creates issues, may push an applied-fix commit to the PR branch, and prints out-of-scope suggestions to stdout. Never edits the PR body — that belongs to the review skill.
+- **Contract:** [SKILL.md](../.claude/skills/follow-up/SKILL.md)
 
 ## Composition
 
@@ -130,9 +171,9 @@ align-op <op_name>                       ← per-op orchestrator
     └─ [orchestrator] REPORT
 ```
 
-`align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest. Among the op- and family-scoped skills, `align-op`'s `FLIP_STATUS` is the only manifest writer (and writes only the `status` field). Manifest-scoped skills (`add-manifest`, `fix-manifest`) write disjoint slices — see the trust-model table below.
+`align-family`'s per-op loop is a single `align-op` invocation — the family orchestrator does not call `test-op` / `implement-op` / `bench-op` directly, and it never writes the manifest. Among the op- and family-scoped skills, `align-op`'s `FLIP_STATUS` is the only manifest writer (and writes only the `status` field). Manifest-scoped skills (`add-manifest`, `fix-manifest`) write disjoint slices — see the trust-model table below. Workflow skills (`review-tileops`, `resolve-tileops`, `follow-up`) compose at the PR level rather than the op level and are not part of the diagram above.
 
-## Trust model  ·  who may write what
+## Trust model · who may write what
 
 | Resource                          | Writer                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -146,5 +187,5 @@ align-op <op_name>                       ← per-op orchestrator
 
 - **Per-skill blocks above** mirror each skill's `description` frontmatter. Edit the frontmatter first; update the matching block here to stay consistent.
 - **At-a-glance matrix, intent table, use/don't-use rules, composition diagram, trust-model table**: hand-maintained. Add entries when a new skill lands; remove when one is retired.
-- **Authoritative skill list (op-development scope)**: this guide covers op-, family-, and manifest-scoped skills only. Every in-scope skill must appear in the at-a-glance matrix and have a block in "Skills in detail". Process / workflow skills (those that operate on PRs or sessions, not on ops) are out of scope; they live in `.claude/skills/` alongside in-scope skills but are documented with their workflow guides, not here.
-- **Lint automation**: none at 7-skill scale. Revisit if drift becomes observable or the count passes ~15.
+- **Authoritative skill list**: this guide covers every skill in `.claude/skills/`. Each skill must appear in the at-a-glance matrix under its scope row (per op / per op family / manifest / workflow) and have a block in "Skills in detail" under the matching H3 category.
+- **Lint automation**: none at the current scale. Revisit if drift becomes observable or the count passes ~15.

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -27,7 +27,7 @@ Orchestrators are the day-to-day entry points. Atomics are their sub-skills — 
 | Patch `kernel_map` or `static_dims` on an existing manifest entry  | `/fix-manifest <op_name>`                  |
 | Scaffold a fresh op file, bypassing the orchestrator               | `/scaffold-op <op_name>`                   |
 | Debug one atomic phase by hand                                     | `/test-op` · `/implement-op` · `/bench-op` |
-| Run the Codex review loop on a TileOPs PR until APPROVE            | `/review-tileops <PR>`                     |
+| Run the review loop on a TileOPs PR until APPROVE                  | `/review-tileops <PR>`                     |
 | Resolve reviewer feedback on a TileOPs PR (per-round driver)       | `/resolve-tileops <PR>`                    |
 | Generate follow-up issues for deferred work after a PR             | `/follow-up <PR>`                          |
 
@@ -115,34 +115,13 @@ Surgical patch of an existing manifest entry for fields **derived from on-disk o
 
 ### workflow
 
-Workflow skills operate on PRs and sessions, not on ops. Per the [trust model](#trust-model--who-may-write-what), they never write `tileops/manifest/` outside the standard manifest skills. Other write scopes vary per skill — see each block's **Trust model** line.
+Workflow skills operate on PRs and sessions, not on ops. They never write `tileops/manifest/` outside the standard manifest skills (see the [trust-model table](#trust-model--who-may-write-what)). See each skill's contract for its full write scope.
 
-**review-tileops** · workflow atomic
-
-Single-shot review of a `tile-ai/TileOPs` PR as a separate GitHub identity from the PR author. Loads the matching domain checklists from `.claude/review-checklists/` based on the PR title's `[type][scope]` tokens, inspects the diff, and submits one atomic review.
-
-- **Use when.** You want a Codex-style review on a TileOPs PR. For an autonomous multi-round loop until APPROVE, run `bash .claude/skills/review-tileops/loop.sh <PR>` instead of the single-shot command.
-- **Don't use when.** You are the PR author and want to address feedback — use `resolve-tileops`.
-- **Trust model.** Reads PR + repo state, posts review comments. Does not modify code, manifest, tests, or benchmarks.
-- **Contract:** [SKILL.md](../.claude/skills/review-tileops/SKILL.md)
-
-**resolve-tileops** · workflow atomic
-
-Per-round driver of stateful Claude-driven review-resolution on a `tile-ai/TileOPs` PR (developer side). Designed for `/loop` dynamic mode — re-fires until a terminal action. State persists in `.foundry/runs/{issue-<N> | pr-<PR>}/resolve/`.
-
-- **Use when.** You are the PR author and want to address reviewer feedback on a TileOPs PR across multiple rounds.
-- **Don't use when.** You want to *produce* a review — use `review-tileops`. The resolution work itself runs in the current Claude session; the outer caller must run `preflight.sh` once before starting the loop.
-- **Trust model.** Edits the PR's branch (code, tests, benchmarks, docs as needed); does not write `tileops/manifest/` outside the standard manifest skills.
-- **Contract:** [SKILL.md](../.claude/skills/resolve-tileops/SKILL.md)
-
-**follow-up** · workflow atomic
-
-Introspect a development session and generate follow-up issues for deferred work, discovered problems, and coverage gaps. Max 3 issues per invocation. Operates in *session-rich* mode (uses conversation history as primary signal) or *session-poor* mode (uses PR diff + reviewer comments).
-
-- **Use when.** A PR is wrapping up and you want to capture deferred work or discovered gaps as issues, plus optionally apply in-scope fixes onto the PR branch.
-- **Don't use when.** You need to file a single ad-hoc bug — open an issue directly.
-- **Trust model.** Creates issues, may push an applied-fix commit to the PR branch, and prints out-of-scope suggestions to stdout. Never edits the PR body — that belongs to the review skill. Does not write `tileops/manifest/` outside the standard manifest skills.
-- **Contract:** [SKILL.md](../.claude/skills/follow-up/SKILL.md)
+| Skill               | What it does                                                                               | Contract                                               |
+| ------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| **review-tileops**  | Reviews a TileOPs PR as a separate GitHub identity, loading domain checklists by PR title. | [SKILL.md](../.claude/skills/review-tileops/SKILL.md)  |
+| **resolve-tileops** | Drives stateful, multi-round resolution of reviewer feedback on a PR (developer side).     | [SKILL.md](../.claude/skills/resolve-tileops/SKILL.md) |
+| **follow-up**       | Generates follow-up issues for deferred work and coverage gaps from a session or PR.       | [SKILL.md](../.claude/skills/follow-up/SKILL.md)       |
 
 ## Composition
 

--- a/docs/tileops-skills.md
+++ b/docs/tileops-skills.md
@@ -2,7 +2,7 @@
 
 Skills this repo provides for TileOPs op development: what each does, when to use it, when not to. Authoritative per-skill contracts live in each `SKILL.md`; this page is the human-facing map.
 
-Skill names are hyphenated command names. Op- and manifest-scoped skills use **verb-scope** (verb is the action; scope is `op`, `family`, or `manifest`). Workflow skills may use a workflow target or phrase instead — e.g. `review-tileops`, `resolve-tileops`, `follow-up`.
+Skill names are hyphenated command names. Op-, family-, and manifest-scoped skills use **verb-scope** (verb is the action; scope is `op`, `family`, or `manifest`). Workflow skills may use a workflow target or phrase instead — e.g. `review-tileops`, `resolve-tileops`, `follow-up`.
 
 ## At a glance
 


### PR DESCRIPTION
Closes #1136

## Summary

- Regroup `docs/tileops-skills.md` "Skills in detail" under four H3 sections by scope: per-op, per-op-family, manifest, workflow.
- Add per-skill blocks for every directory under `.claude/skills/` (including `review-tileops`, `resolve-tileops`, `follow-up`) so the doc covers all 12 skills.
- Update the at-a-glance matrix row labels to "per op" / "per op family" / "manifest" / "workflow" in that order, with the workflow row referencing the three workflow skills.
- Drop the Maintenance carve-out that previously excluded "process / workflow skills" from the guide; this guide now covers every skill in `.claude/skills/`.

## Test plan

- [x] AC-1: `awk` between `## Skills in detail` and the next H2 prints exactly the four required H3 sections in order.
- [x] AC-2: Diff between `.claude/skills/` directories and bold-led skill names in the doc is empty; each of 12 skills appears exactly once.
- [x] AC-3: Matrix row labels read per op / per op family / manifest / workflow in order; workflow row links to review-tileops, resolve-tileops, follow-up.
- [x] AC-4: Maintenance section no longer carves out process / workflow skills as out of scope.
- [x] AC-5: All `.claude/skills/<name>/SKILL.md` links resolve; `mdformat --check` and `pre-commit run --files docs/tileops-skills.md` pass.

## Additional context

Doc-only change. No kernel/op or test files touched, so Structural Readiness, Benchmark, and Test node delta sections are omitted per template guidance.