### PR TITLE
[Fix][Skills] anchor review/resolve state to main checkout

### DIFF
--- a/.claude/review-checklists/approval-gate.md
+++ b/.claude/review-checklists/approval-gate.md
@@ -1,23 +1,35 @@
-Run before approving any PR. Apply each item below if its scope matches the diff. If any applicable check fails, request changes; do not approve until the developer pushes a triage commit.
+Run before approving any PR. Apply each item if its scope matches the diff. If any applicable check fails, REQUEST_CHANGES until the developer pushes a triage commit.
 
-- [ ] **Per-case verdict (blocker default).** Triage every test case added or modified in this PR as one of `keep` / `shrink` / `delete`. Inline comments are required only for blocker verdicts; clean test PRs stay clean (no per-case inline noise) — consistent with `criteria.md §3` (`Clean — no issues.`).
+## Tests
 
-  - `keep — guards <distinct code path or dtype>` (no action required) — per `docs/design/testing.md §Test case policy`. **Do not** post inline.
-  - `shrink — fold to <axis>` (**BLOCKER, inline required**) — Cartesian expansion; fold to "boundary + one representative interior point".
-  - `delete — duplicate of <node ID>` (**BLOCKER, inline required**) — same-failure-mode duplicate of a kept case.
+- [ ] **Per-case verdict.** Triage every added/modified test case as `keep` / `shrink` / `delete`. Inline only on blockers; clean test PRs stay clean (`criteria.md §3`).
 
-  Cases the reviewer cannot classify with confidence count as untriaged → **BLOCKER, inline required** asking the developer for the rationale. Every blocker must be resolved (case shrunk / deleted, or verdict downgraded to `keep` with rationale) before APPROVE.
+  | Verdict                        | When                                                                         | Inline?     |
+  | ------------------------------ | ---------------------------------------------------------------------------- | ----------- |
+  | `keep — guards <path/dtype>`   | distinct code path or dtype (per `docs/design/testing.md §Test case policy`) | no          |
+  | `shrink — fold to <axis>`      | Cartesian expansion; fold to "boundary + one representative interior point"  | **blocker** |
+  | `delete — duplicate of <node>` | same-failure-mode duplicate of a kept case                                   | **blocker** |
 
-- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main` (prereq: `upstream` remote points to tile-ai/TileOPs and is fresh — `git fetch upstream` first). If existing-file growth > 25% AND any case carries an unresolved blocker verdict (`shrink` / `delete`) or remains untriaged, REQUEST_CHANGES with the full list of affected node IDs in the summary. (Absence of an inline comment is not a blocker on its own — silent `keep` is the default.)
+  Cases the reviewer cannot classify with confidence count as untriaged → **blocker inline** asking the developer for rationale. Every blocker must be resolved (shrink / delete, or downgrade to `keep` with rationale) before APPROVE.
 
-- [ ] Reject "AC-N required this matrix" as a defense — AC text does not bind the merged suite.
+- [ ] **Numerical floor.** Run `python scripts/test_node_delta.py --base upstream/main` (prereq: `upstream` points to tile-ai/TileOPs and is fresh — `git fetch upstream` first). REQUEST_CHANGES with the full node-ID list if existing-file growth > 25% AND any case carries an unresolved `shrink`/`delete` blocker or is untriaged. Absence of an inline is not itself a blocker — silent `keep` is the default.
 
-- [ ] Critical-path floor: never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
+- [ ] **Critical-path floor.** Never remove the last guarding case for tile boundary, vectorization alignment, degenerate dimension (size = 1), or dispatch branch.
 
-- [ ] **PR body discipline.** Body must conform to `.foundry/mold/pr-body-template.md` and record only the final state: what the PR does (Summary, scoped to the merged diff) + verification facts (test plan, pre-commit, structural readiness, test node delta). Strip dev-process narration — per-round fix history, tally IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer changelogs, abandoned approaches. Those belong in commit history / review threads. If found in the body, REQUEST_CHANGES.
+- [ ] **No AC defense.** Reject "AC-N required this matrix" — AC text does not bind the merged suite.
 
-- [ ] **Batch-once.** If the only remaining issues are cleanup-class (keep / shrink / delete / rename / dedupe) with no correctness blockers left, surface every such item from the full diff in this single review pass. Do not defer to a later round. If you find yourself wanting to "leave it for next time", either include it now or demote it to advisory (no longer gates APPROVE).
+## Authoring discipline
 
-- [ ] **Skill edits (`.claude/skills/**`) — tightening pass before APPROVE.** Require the developer to condense the skill's wording without changing what it instructs. Verify: semantics preserved, every step has exactly one valid execution path, no example included unless it is load-bearing, and any retained example references durable concepts rather than implementation details that age out.
+- [ ] **PR body.** Conforms to `.foundry/mold/pr-body-template.md`; records final state only — what the PR does (Summary, scoped to the merged diff) + verification facts (test plan, pre-commit, structural readiness, test node delta). Strip dev-process narration: per-round fix history, tally IDs (`T001–T0NN`), "Driven by review iteration", reviewer-by-reviewer changelogs, abandoned approaches. Those belong in commit history / review threads. REQUEST_CHANGES if found.
 
-- [ ] On the triage commit, re-run every check above before approving.
+- [ ] **Replies.** Outcome only — `Done in <sha>.`, `Won't-fix: <one-line reason>.` No commit-by-commit narration, "what I tried", thread/tally IDs, root-cause essays, or design restatements. Process detail ages out and clutters the thread. REQUEST_CHANGES asking the developer to edit the comment to a one-liner if found.
+
+## Review process
+
+- [ ] **Batch-once.** If only cleanup-class issues (keep / shrink / delete / rename / dedupe) remain with no correctness blockers, surface every such item from the full diff in this single pass. Don't defer — either include now or demote to advisory (no longer gates APPROVE).
+
+- [ ] **Re-run on triage.** Re-run every applicable check above on the developer's triage commit before approving.
+
+## Scope-specific
+
+- [ ] **Skill edits (`.claude/skills/**`).** Require a tightening pass before APPROVE — condense wording without changing what the skill instructs. Verify: semantics preserved, every step has exactly one valid execution path, no example included unless load-bearing, retained examples reference durable concepts rather than implementation details that age out.

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -20,8 +20,16 @@ REPO="tile-ai/TileOPs"
 command -v gh >/dev/null 2>&1 || { echo "preflight: missing gh" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "preflight: missing jq" >&2; exit 1; }
 
-REPO_PATH="$(git rev-parse --show-toplevel 2>/dev/null)" \
+# Anchor state to the main checkout's `.foundry/runs/`, not cwd. When
+# invoked from a linked worktree (e.g. via foundry pipeline HANDOFF),
+# `--show-toplevel` returns the worktree path; using it would scatter
+# resolve state across worktrees. The shared `.git`'s parent is the
+# main checkout regardless of which worktree we run from.
+_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "preflight: not in a git repo" >&2; exit 1; }
+[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
+REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
+unset _gcd
 
 # Round 2+ fast path: an existing run dir's meta.json already pins this PR.
 META=""

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -23,10 +23,10 @@ command -v jq >/dev/null 2>&1 || { echo "preflight: missing jq" >&2; exit 1; }
 # Anchor state to the main checkout's `.foundry/runs/`, not cwd. When
 # invoked from a linked worktree (e.g. via foundry pipeline HANDOFF),
 # `--show-toplevel` returns the worktree path; using it would scatter
-# resolve state across worktrees. `git worktree list --porcelain`
+# resolve state across worktrees. `git worktree list --porcelain 2>/dev/null`
 # always emits the main worktree first, so its leading entry is the
 # main checkout regardless of which worktree we run from.
-REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
+REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
   || { echo "preflight: not in a git repo" >&2; exit 1; }
 
 # Round 2+ fast path: an existing run dir's meta.json already pins this PR.

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -23,13 +23,11 @@ command -v jq >/dev/null 2>&1 || { echo "preflight: missing jq" >&2; exit 1; }
 # Anchor state to the main checkout's `.foundry/runs/`, not cwd. When
 # invoked from a linked worktree (e.g. via foundry pipeline HANDOFF),
 # `--show-toplevel` returns the worktree path; using it would scatter
-# resolve state across worktrees. The shared `.git`'s parent is the
+# resolve state across worktrees. `git worktree list --porcelain`
+# always emits the main worktree first, so its leading entry is the
 # main checkout regardless of which worktree we run from.
-_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
+REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
   || { echo "preflight: not in a git repo" >&2; exit 1; }
-[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
-REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
-unset _gcd
 
 # Round 2+ fast path: an existing run dir's meta.json already pins this PR.
 META=""

--- a/.claude/skills/resolve-tileops/round-post.sh
+++ b/.claude/skills/resolve-tileops/round-post.sh
@@ -19,11 +19,8 @@ command -v jq >/dev/null 2>&1 || { echo "round-post: missing jq" >&2; exit 1; }
 
 REPO="tile-ai/TileOPs"
 # Anchor state lookup to the main checkout (see preflight.sh).
-_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
+REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
   || { echo "round-post: not in a git repo" >&2; exit 1; }
-[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
-REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
-unset _gcd
 
 META=""
 for m in "$REPO_PATH/.foundry/runs"/*/resolve/meta.json; do

--- a/.claude/skills/resolve-tileops/round-post.sh
+++ b/.claude/skills/resolve-tileops/round-post.sh
@@ -18,8 +18,12 @@ command -v gh >/dev/null 2>&1 || { echo "round-post: missing gh" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "round-post: missing jq" >&2; exit 1; }
 
 REPO="tile-ai/TileOPs"
-REPO_PATH="$(git rev-parse --show-toplevel 2>/dev/null)" \
+# Anchor state lookup to the main checkout (see preflight.sh).
+_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "round-post: not in a git repo" >&2; exit 1; }
+[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
+REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
+unset _gcd
 
 META=""
 for m in "$REPO_PATH/.foundry/runs"/*/resolve/meta.json; do

--- a/.claude/skills/resolve-tileops/round-post.sh
+++ b/.claude/skills/resolve-tileops/round-post.sh
@@ -19,7 +19,7 @@ command -v jq >/dev/null 2>&1 || { echo "round-post: missing jq" >&2; exit 1; }
 
 REPO="tile-ai/TileOPs"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
+REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
   || { echo "round-post: not in a git repo" >&2; exit 1; }
 
 META=""

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -24,7 +24,7 @@ command -v jq >/dev/null 2>&1 || { echo "round-pre: missing jq" >&2; exit 1; }
 REPO="tile-ai/TileOPs"
 REVIEWER_LOGIN="${RESOLVE_REVIEWER_LOGIN:-Ibuki-wind}"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
+REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
   || { echo "round-pre: not in a git repo" >&2; exit 1; }
 
 # Locate state. preflight.sh must have created it.

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -24,11 +24,8 @@ command -v jq >/dev/null 2>&1 || { echo "round-pre: missing jq" >&2; exit 1; }
 REPO="tile-ai/TileOPs"
 REVIEWER_LOGIN="${RESOLVE_REVIEWER_LOGIN:-Ibuki-wind}"
 # Anchor state lookup to the main checkout (see preflight.sh).
-_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
+REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
   || { echo "round-pre: not in a git repo" >&2; exit 1; }
-[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
-REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
-unset _gcd
 
 # Locate state. preflight.sh must have created it.
 META=""

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -23,8 +23,12 @@ command -v jq >/dev/null 2>&1 || { echo "round-pre: missing jq" >&2; exit 1; }
 
 REPO="tile-ai/TileOPs"
 REVIEWER_LOGIN="${RESOLVE_REVIEWER_LOGIN:-Ibuki-wind}"
-REPO_PATH="$(git rev-parse --show-toplevel 2>/dev/null)" \
+# Anchor state lookup to the main checkout (see preflight.sh).
+_gcd="$(git rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "round-pre: not in a git repo" >&2; exit 1; }
+[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
+REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
+unset _gcd
 
 # Locate state. preflight.sh must have created it.
 META=""

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -43,7 +43,7 @@ LOOP_START_EPOCH=$(date +%s)
 #
 # - REPO_PATH is the *state root* — main checkout. Used for `.foundry/
 #   runs/`, fetches, refs, and managed worktrees so state is shared
-#   across all worktrees of one repo. `git worktree list --porcelain`
+#   across all worktrees of one repo. `git worktree list --porcelain 2>/dev/null`
 #   always lists the main worktree first.
 # - SOURCE_ROOT is the *source/policy root* — the repo that contains
 #   this script. Used for `loading.yaml`, `criteria.md`, `procedure.md`,
@@ -52,7 +52,7 @@ LOOP_START_EPOCH=$(date +%s)
 #   a loop launched from a linked worktree would mix policy files
 #   (criteria/procedure/loading from worktree branch via SKILL_DIR,
 #   checklists from main branch via REPO_PATH).
-REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
+REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
   || { echo "loop.sh: not in a git repo" >&2; exit 1; }
 SOURCE_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -39,7 +39,15 @@ MAX_IDLE=20
 # lifetime (hours), low enough that a runaway is bounded to a day.
 MAX_WALL_CLOCK_HOURS=24
 LOOP_START_EPOCH=$(date +%s)
-REPO_PATH="$(git rev-parse --show-toplevel)"
+# Anchor state to the main checkout, not cwd. When invoked from a
+# linked worktree (e.g. via foundry pipeline HANDOFF), `--show-toplevel`
+# returns the worktree path; using it would scatter `.foundry/runs/`
+# state across worktrees. The shared `.git`'s parent is the main
+# checkout regardless of which worktree we run from.
+_gcd="$(git rev-parse --git-common-dir)"
+[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
+REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
+unset _gcd
 
 CRITERIA_PATH="$SKILL_DIR/criteria.md"
 PROCEDURE_PATH="$SKILL_DIR/procedure.md"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -39,20 +39,27 @@ MAX_IDLE=20
 # lifetime (hours), low enough that a runaway is bounded to a day.
 MAX_WALL_CLOCK_HOURS=24
 LOOP_START_EPOCH=$(date +%s)
-# Anchor state to the main checkout, not cwd. When invoked from a
-# linked worktree (e.g. via foundry pipeline HANDOFF), `--show-toplevel`
-# returns the worktree path; using it would scatter `.foundry/runs/`
-# state across worktrees. The shared `.git`'s parent is the main
-# checkout regardless of which worktree we run from.
-_gcd="$(git rev-parse --git-common-dir)"
-[[ "$_gcd" = /* ]] || _gcd="$(pwd)/$_gcd"
-REPO_PATH="$(cd "$(dirname "$_gcd")" && pwd)"
-unset _gcd
+# State root vs source root are distinct (Ibuki review on PR #1139):
+#
+# - REPO_PATH is the *state root* — main checkout. Used for `.foundry/
+#   runs/`, fetches, refs, and managed worktrees so state is shared
+#   across all worktrees of one repo. `git worktree list --porcelain`
+#   always lists the main worktree first.
+# - SOURCE_ROOT is the *source/policy root* — the repo that contains
+#   this script. Used for `loading.yaml`, `criteria.md`, `procedure.md`,
+#   and `.claude/review-checklists/` so the loop reads policy files
+#   from the same branch that ships this script. Without the split,
+#   a loop launched from a linked worktree would mix policy files
+#   (criteria/procedure/loading from worktree branch via SKILL_DIR,
+#   checklists from main branch via REPO_PATH).
+REPO_PATH="$(git worktree list --porcelain | head -n 1 | sed 's/^worktree //')" \
+  || { echo "loop.sh: not in a git repo" >&2; exit 1; }
+SOURCE_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
 
 CRITERIA_PATH="$SKILL_DIR/criteria.md"
 PROCEDURE_PATH="$SKILL_DIR/procedure.md"
 LOADING_YAML="$SKILL_DIR/loading.yaml"
-CHECKLISTS_DIR="$REPO_PATH/.claude/review-checklists"
+CHECKLISTS_DIR="$SOURCE_ROOT/.claude/review-checklists"
 
 # Discover the local remote that points at tile-ai/TileOPs. Different clones
 # use different remote names (origin in clones, upstream in forks, anything

--- a/.claude/skills/review-tileops/procedure.md
+++ b/.claude/skills/review-tileops/procedure.md
@@ -4,7 +4,7 @@
 1. **Free-form review (primary).** Flag: logic errors, edge cases, API misuse, races, resource leaks, broken invariants, error-handling gaps, perf regressions, dead code, unclear names, missing tests. This is where the bulk of your reasoning belongs.
 1. **Triage unresolved review threads.** For each thread, judge whether the developer's latest change resolves the concern. If unresolved, surface as an inline comment.
 1. **Apply each loaded project-specific guard (last, supplement).** Walk its bullets against the diff. Add anything new to the step-2 findings.
-1. **Approval-gate decision.** If the diff touches `tests/` AND your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every check. Downgrade to `REQUEST_CHANGES` if any fail.
+1. **Approval-gate decision.** If your draft event is `APPROVE`: read `.claude/review-checklists/approval-gate.md` and run every applicable check (each item self-scopes to the diff per the file's preamble). Downgrade to `REQUEST_CHANGES` if any fail.
 1. **Compose inline comments** per `criteria.md` §2 — one per issue, format `<what is wrong and why> → <what to change>`. Name the function, variable, or pattern.
 1. **Compose the summary** per `criteria.md` §3. Omit empty sections. A clean PR gets a single line: `Clean — no issues.`
 1. **Submit one atomic review** per `criteria.md` §1, with the inline comments in the `comments=[…]` array. Follow `criteria.md` §4 hard rules.


### PR DESCRIPTION
## Summary

Anchor `.foundry/runs/` state to the main checkout via `git worktree list --porcelain | head -n 1`. Without this, foundry-pipeline HANDOFF runs leave review/resolve state under `.claude/worktrees/<task>/` instead of the main checkout where every standalone run already writes.

`loop.sh` additionally splits state root from source/policy root: `criteria.md` / `procedure.md` / `loading.yaml` / `.claude/review-checklists/` read from `SKILL_DIR`'s repo (so a worktree-launched loop reads consistent policy from its own branch).

Bundled cleanups in `.claude/`:
- approval-gate.md regrouped (Tests / Authoring / Review process / Scope-specific) + `**Replies**` rule.
- procedure.md step 5: gate runs before every APPROVE (not just `tests/` diffs).

## Test plan

- [x] mdformat / codespell / pre-commit pass
- [x] From main checkout and from a linked worktree, the new resolver returns the main checkout