### PR TITLE
[Chore][Manifest] flip 7 elementwise ops to spec-only

### DIFF
--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -60,7 +60,7 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -100,7 +100,7 @@ MaskedFillScalarFwdOp:
   # Per the "No Optional[Tensor]" manifest rule, this is split from the
   # 0-dim-Tensor-value primary entry above.
   family: elementwise
-  status: implemented
+  status: spec-only
   variant_of: MaskedFillFwdOp
 
   signature:

--- a/tileops/manifest/elementwise_multi_input.yaml
+++ b/tileops/manifest/elementwise_multi_input.yaml
@@ -13,7 +13,7 @@ WhereFwdOp:
   # constrains them to ``same_as(input)``; once the kernel grows an input
   # cast path, relax ``other`` to the full float union and document the
   # promotion contract here.
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -400,7 +400,7 @@ ClampFwdOp:
   # single-bound min-only form, and the single-bound max-only form each
   # land as their own variant_of entries below.
   family: elementwise
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -438,7 +438,7 @@ ClampScalarFwdOp:
   # with Number (or None) bounds. Per the "No Optional[Tensor]" manifest
   # rule, this is split from the Tensor-bound primary entry above.
   family: elementwise
-  status: implemented
+  status: spec-only
   variant_of: ClampFwdOp
 
   signature:
@@ -477,7 +477,7 @@ ClampMinFwdOp:
   # Single-bound Tensor variant: torch.clamp_min(input, min: Tensor) —
   # equivalent to torch.clamp with only the lower bound provided.
   family: elementwise
-  status: implemented
+  status: spec-only
   variant_of: ClampFwdOp
 
   signature:
@@ -512,7 +512,7 @@ ClampMaxFwdOp:
   # Single-bound Tensor variant: torch.clamp_max(input, max: Tensor) —
   # equivalent to torch.clamp with only the upper bound provided.
   family: elementwise
-  status: implemented
+  status: spec-only
   variant_of: ClampFwdOp
 
   signature:


### PR DESCRIPTION
Closes #1153

## Summary

- Flip `status: implemented → spec-only` for 7 elementwise ops across 3 manifest shards: `ClampFwdOp`, `ClampScalarFwdOp`, `ClampMinFwdOp`, `ClampMaxFwdOp` (`elementwise_unary_activation.yaml`); `MaskedFillFwdOp`, `MaskedFillScalarFwdOp` (`elementwise_binary.yaml`); `WhereFwdOp` (`elementwise_multi_input.yaml`).
- Manifest-only change. No edits under `tileops/ops/`, `tileops/kernels/`, `tests/`, `benchmarks/`, or `docs/`. Round-trip parser preserved comments and key order.

## Test plan

- [x] AC-1: Modified files pass unit tests. (`python -m pytest -q tests/test_validate_manifest.py tests/test_ops_manifest.py tests/test_workloads_to_params.py` → 217 passed)
- [x] AC-2: All 7 ops report `status: spec-only` via `load_manifest()` lookup.
- [x] AC-3: `git diff main -- tileops/` is non-empty only for `tileops/manifest/elementwise_*.yaml`; no other path under `tileops/` is touched.
- [x] AC-4: `python scripts/validate_manifest.py` exits 0 (`All manifest checks passed.`).
- [x] AC-5: `git diff main -- tileops/manifest/ | grep -E '^[+-][[:space:]]*status:' | sort -u` shows only `- status: implemented` and `+ status: spec-only`, applied to the 7 entries only.

## Additional context

Manifest-trust-model rule: an implementation does not yet conform to spec → flip `status` to `spec-only`. Code/tests will be re-aligned in follow-up PRs.
