### PR TITLE
[Feat][Skill] add --nightshift flag to /follow-up

### DIFF
--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -27,14 +27,23 @@ description: Introspect a development session and generate follow-up issues for 
 
 `<PR_NUMBER>` is required. If missing, terminate immediately: `Missing PR number. Usage: /follow-up <PR_NUMBER>`.
 
-Resolve PR:
+Parse arguments and resolve PR:
 
 ```bash
-gh pr view <PR_NUMBER> --json number,title,url,body
+# Parse positional + flag arguments. Set NIGHTSHIFT=1 iff --nightshift is present; 0 otherwise.
+NIGHTSHIFT=0
+for arg in "$@"; do
+  case "$arg" in
+    --nightshift) NIGHTSHIFT=1 ;;
+    *) PR_NUMBER="${PR_NUMBER:-$arg}" ;;
+  esac
+done
+
+gh pr view "$PR_NUMBER" --json number,title,url,body
 OWNER_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 ```
 
-Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `OWNER_REPO`.
+Extract: `PR_NUMBER`, `PR_TITLE`, `PR_URL`, `PR_BODY`, `OWNER_REPO`. `NIGHTSHIFT` is now bound (`0` or `1`) and gates step 5 mode selection, the step 6 label guard, and the step 6 frontmatter template.
 
 **Fail** (PR not found) → terminate: `PR #<PR_NUMBER> not found in $OWNER_REPO.`
 
@@ -137,10 +146,10 @@ gh label list --search "follow-up" --json name --jq '.[].name' | grep -qx "follo
 
 **Nightshift label guard** — only when `--nightshift` was passed. The `nightshift` label is human-curated in the canonical setup (specific color and description); do not auto-create it with arbitrary metadata. Instead, fail fast with a clear error if it is missing:
 
-Set `NIGHTSHIFT=1` when the flag is parsed in step 1; leave it unset (or `0`) otherwise. The guard below is a no-op in default mode:
+`NIGHTSHIFT` was bound in Step 1 (`1` if `--nightshift` was passed, else `0`). The guard below is a no-op in default mode:
 
 ```bash
-if [[ "${NIGHTSHIFT:-0}" == "1" ]]; then
+if [[ "$NIGHTSHIFT" == "1" ]]; then
   gh label list --search "nightshift" --json name --jq '.[].name' | grep -qx "nightshift" \
     || { echo "nightshift label missing in $OWNER_REPO — see foundry nightshift docs" >&2; exit 1; }
 fi

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -95,6 +95,10 @@ Reduce to **max 3 issues**:
 
 **`--nightshift` mode**: skip the candidate presentation and the `Actions: confirm all / drop by number / edit / move <item> to out-of-scope` interaction entirely. Treat every candidate (and every in-scope suggestion) as confirmed — equivalent to the user typing `confirm all` — and proceed straight to Step 6. The auto-accept branch is conditional on the flag; default-mode behavior is unchanged when the flag is absent.
 
+#### Default mode (no `--nightshift`)
+
+The presentation template below applies only to default mode. Render it to stdout and wait on the `Actions:` line.
+
 ```
 Follow-up candidates from PR #<number>: <title>
 ──────────────────────────────────────────────────
@@ -118,6 +122,10 @@ Out-of-scope suggestions (deferred — printed in step 8, not committed):
 Actions: confirm all / drop by number / edit / move <item> to out-of-scope
 ```
 
+#### `--nightshift` mode (auto-accept)
+
+Do not render the template above. Auto-accept all candidates and proceed directly to Step 6.
+
 ### 6. CREATE
 
 Ensure label exists:
@@ -127,26 +135,21 @@ gh label list --search "follow-up" --json name --jq '.[].name' | grep -qx "follo
   || gh label create "follow-up" --description "Generated from dev session introspection" --color "c5def5"
 ```
 
+**Nightshift label guard** — only when `--nightshift` was passed. The `nightshift` label is human-curated in the canonical setup (specific color and description); do not auto-create it with arbitrary metadata. Instead, fail fast with a clear error if it is missing:
+
+```bash
+# Only when --nightshift was passed:
+gh label list --search "nightshift" --json name --jq '.[].name' | grep -qx "nightshift" \
+  || { echo "nightshift label missing in $OWNER_REPO — see foundry nightshift docs" >&2; exit 1; }
+```
+
+If `--nightshift` was passed and the `nightshift` label does not exist, terminate with: `nightshift label missing in $OWNER_REPO — see foundry nightshift docs`. Do not create the label automatically.
+
 For each confirmed item, invoke `foundry:creating-issue` with `--from-draft <tmpfile>`.
 
-The `labels:` block in the frontmatter depends on whether `--nightshift` was passed:
+Pick exactly one of the two frontmatter + body templates below based on whether `--nightshift` was passed. The body sections after the frontmatter are byte-identical between the two; only the `labels:` block differs.
 
-- **Default mode** — single `follow-up` label:
-
-  ```yaml
-  labels:
-    - follow-up
-  ```
-
-- **`--nightshift` mode** — both labels, `nightshift` appended:
-
-  ```yaml
-  labels:
-    - follow-up
-    - nightshift
-  ```
-
-Full frontmatter + body template (use the appropriate `labels:` block above):
+**Default invocation** (no `--nightshift`) — emits only the `follow-up` label. Use this template verbatim:
 
 ```markdown
 ---
@@ -154,7 +157,44 @@ type: <FEAT|BUG|PERF|REFACTOR|DOCS|TEST>
 component: <affected module>
 labels:
   - follow-up
-  # - nightshift   # add this line only when invoked with --nightshift
+target_repo: <OWNER_REPO>
+---
+
+# Description
+## Symptom / Motivation
+Discovered during PR #<PR_NUMBER> (<PR_TITLE>).
+<what was observed, why it matters>
+
+## Root Cause Analysis
+<why not addressed in source PR — scope, complexity, risk>
+
+## Related Files
+- <paths from diff or session>
+
+# Goal
+<one sentence>
+
+# Plan
+<!-- type: proposal -->
+1. <step>
+2. <step>
+
+# Constraints
+- Must not regress PR #<PR_NUMBER>
+
+# Acceptance Criteria
+- [ ] AC-1: Modified files pass unit tests
+```
+
+**With `--nightshift`** — emits both `follow-up` and `nightshift` labels. Use this template verbatim:
+
+```markdown
+---
+type: <FEAT|BUG|PERF|REFACTOR|DOCS|TEST>
+component: <affected module>
+labels:
+  - follow-up
+  - nightshift
 target_repo: <OWNER_REPO>
 ---
 

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -5,9 +5,10 @@ description: Introspect a development session and generate follow-up issues for 
 
 ## Arguments
 
-| Argument      | Required | Description                      |
-| ------------- | -------- | -------------------------------- |
-| `<PR_NUMBER>` | Yes      | TileOPs PR number (e.g. `1131`). |
+| Argument       | Required | Description                                                                                                                                                 |
+| -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<PR_NUMBER>`  | Yes      | TileOPs PR number (e.g. `1131`).                                                                                                                            |
+| `--nightshift` | No       | Boolean flag. Skip the interactive presentation gate (auto-accept all candidates) and inject the `nightshift` label into every created issue's frontmatter. |
 
 ## Contract
 
@@ -90,7 +91,9 @@ Reduce to **max 3 issues**:
 
 ### 5. PRESENT
 
-Show candidates in **dependency order** (prerequisites first). Wait for user confirmation.
+**Default mode** (no `--nightshift`): show candidates in **dependency order** (prerequisites first). Wait for user confirmation via the `Actions:` line below.
+
+**`--nightshift` mode**: skip the candidate presentation and the `Actions: confirm all / drop by number / edit / move <item> to out-of-scope` interaction entirely. Treat every candidate (and every in-scope suggestion) as confirmed — equivalent to the user typing `confirm all` — and proceed straight to Step 6. The auto-accept branch is conditional on the flag; default-mode behavior is unchanged when the flag is absent.
 
 ```
 Follow-up candidates from PR #<number>: <title>
@@ -124,7 +127,26 @@ gh label list --search "follow-up" --json name --jq '.[].name' | grep -qx "follo
   || gh label create "follow-up" --description "Generated from dev session introspection" --color "c5def5"
 ```
 
-For each confirmed item, invoke `foundry:creating-issue` with `--from-draft <tmpfile>`:
+For each confirmed item, invoke `foundry:creating-issue` with `--from-draft <tmpfile>`.
+
+The `labels:` block in the frontmatter depends on whether `--nightshift` was passed:
+
+- **Default mode** — single `follow-up` label:
+
+  ```yaml
+  labels:
+    - follow-up
+  ```
+
+- **`--nightshift` mode** — both labels, `nightshift` appended:
+
+  ```yaml
+  labels:
+    - follow-up
+    - nightshift
+  ```
+
+Full frontmatter + body template (use the appropriate `labels:` block above):
 
 ```markdown
 ---
@@ -132,6 +154,7 @@ type: <FEAT|BUG|PERF|REFACTOR|DOCS|TEST>
 component: <affected module>
 labels:
   - follow-up
+  # - nightshift   # add this line only when invoked with --nightshift
 target_repo: <OWNER_REPO>
 ---
 

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -137,10 +137,13 @@ gh label list --search "follow-up" --json name --jq '.[].name' | grep -qx "follo
 
 **Nightshift label guard** — only when `--nightshift` was passed. The `nightshift` label is human-curated in the canonical setup (specific color and description); do not auto-create it with arbitrary metadata. Instead, fail fast with a clear error if it is missing:
 
+Set `NIGHTSHIFT=1` when the flag is parsed in step 1; leave it unset (or `0`) otherwise. The guard below is a no-op in default mode:
+
 ```bash
-# Only when --nightshift was passed:
-gh label list --search "nightshift" --json name --jq '.[].name' | grep -qx "nightshift" \
-  || { echo "nightshift label missing in $OWNER_REPO — see foundry nightshift docs" >&2; exit 1; }
+if [[ "${NIGHTSHIFT:-0}" == "1" ]]; then
+  gh label list --search "nightshift" --json name --jq '.[].name' | grep -qx "nightshift" \
+    || { echo "nightshift label missing in $OWNER_REPO — see foundry nightshift docs" >&2; exit 1; }
+fi
 ```
 
 If `--nightshift` was passed and the `nightshift` label does not exist, terminate with: `nightshift label missing in $OWNER_REPO — see foundry nightshift docs`. Do not create the label automatically.

--- a/.claude/skills/follow-up/SKILL.md
+++ b/.claude/skills/follow-up/SKILL.md
@@ -31,13 +31,20 @@ Parse arguments and resolve PR:
 
 ```bash
 # Parse positional + flag arguments. Set NIGHTSHIFT=1 iff --nightshift is present; 0 otherwise.
+# Reject unknown flags so typos like --nightshfit do not silently fall through to PR_NUMBER.
 NIGHTSHIFT=0
 for arg in "$@"; do
   case "$arg" in
     --nightshift) NIGHTSHIFT=1 ;;
+    -*) echo "Unknown flag: $arg. Usage: /follow-up <PR_NUMBER> [--nightshift]" >&2; exit 1 ;;
     *) PR_NUMBER="${PR_NUMBER:-$arg}" ;;
   esac
 done
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+  echo "Missing PR number. Usage: /follow-up <PR_NUMBER>" >&2
+  exit 1
+fi
 
 gh pr view "$PR_NUMBER" --json number,title,url,body
 OWNER_REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')


### PR DESCRIPTION
Closes #1159

## Summary

- Add `--nightshift` flag to `/follow-up` skill: skip Step 5 interactive confirmation gate (auto-confirm all candidates) and inject `nightshift` label into Step 6 frontmatter alongside `follow-up`.
- Default invocation behavior is byte-identical when the flag is absent (interactive Step 5, single-label frontmatter).

## Test plan

- [x] AC-1: Modified files pass unit tests.
- [x] AC-2: .claude/skills/follow-up/SKILL.md Arguments table contains a row for --nightshift; verifiable by grep.
- [x] AC-3: Step 5 PRESENT documents auto-accept branch under --nightshift.
- [x] AC-4: Step 6 CREATE documents that labels: includes nightshift only when --nightshift is set.
- [x] AC-5: git diff main -- .claude/skills/ non-empty for follow-up/SKILL.md and empty for every other file under .claude/skills/.
- [x] AC-6: No code/test/doc files modified; git diff main --name-only lists only .claude/skills/follow-up/SKILL.md.
