### PR TITLE
[Fix] nightshift run: review-loop trigger + benchmark-template layout

### DIFF
--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -662,12 +662,21 @@ while true; do
   # Idle path: HEAD unchanged AND no inbox prompt. Absorb any comment-id
   # advances and sleep. ROUND==0 (first poll, never reviewed) always
   # falls through to a fresh round.
+  #
+  # Comment activity does NOT count toward the stall counter — an active
+  # discussion (replies flowing back and forth without a push) is engaged
+  # work, not a dead PR. The stall counter is meant to catch a truly
+  # quiet counterpart, so reset it whenever comments advance even though
+  # we're not running codex this poll.
   if [[ "$ROUND" -gt 0 && "$HEAD_UNCHANGED" -eq 1 && "$INBOX_PRESENT" -eq 0 ]]; then
     if [[ "$COMMENTS_CHANGED" -eq 1 ]]; then
       jq --argjson iid "$LATEST_ISSUE_ID" --argjson rid "$LATEST_REVIEW_ID" \
-         '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
+         '.last_issue_comment_id=$iid | .last_review_comment_id=$rid
+          | .consecutive_idle=0' \
          "$META" > "$META.tmp" && mv "$META.tmp" "$META"
       log "comment-only update on unchanged HEAD ${HEAD_SHA:0:7} — absorbed; not re-reviewing (write inbox.md to force a round)"
+      sleep "$POLL_INTERVAL"
+      continue
     fi
     CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
     NEW_IDLE=$((CONSECUTIVE_IDLE + 1))
@@ -797,7 +806,8 @@ while true; do
       POST_REVIEW_ID=$(latest_review_comment_id)
       if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" \
             && "$POST_ISSUE_ID" == "$LATEST_ISSUE_ID" \
-            && "$POST_REVIEW_ID" == "$LATEST_REVIEW_ID" ]]; then
+            && "$POST_REVIEW_ID" == "$LATEST_REVIEW_ID" \
+            && ! -s "$RUN_DIR/inbox.md" ]]; then
         converge_and_exit
       fi
     fi

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -609,33 +609,66 @@ while true; do
   LATEST_ISSUE_ID=$(latest_issue_comment_id)
   LATEST_REVIEW_ID=$(latest_review_comment_id)
 
+  # Trigger policy: a fresh codex round fires only on a HEAD change or an
+  # explicit human prompt in inbox.md. Comment-only deltas (replies,
+  # discussion on a previous blocker) are absorbed — the tracked comment
+  # ids advance so the loop stops re-firing, but no new review runs.
+  #
+  # Why not re-review on comment changes: when a human pushes back on a
+  # blocker without changing code, re-running the full review on the same
+  # SHA tends to mine *new* nits the prior round didn't flag, drifting
+  # away from the original disagreement and looking to the developer like
+  # the bot is hunting for something to complain about. If the human
+  # genuinely wants a fresh pass on unchanged code, they write to
+  # inbox.md (the existing per-round guidance channel).
+  INBOX_PRESENT=0
+  [[ -s "$RUN_DIR/inbox.md" ]] && INBOX_PRESENT=1
+  HEAD_UNCHANGED=0
+  [[ "$HEAD_SHA" == "$LAST_SHA" ]] && HEAD_UNCHANGED=1
+  COMMENTS_CHANGED=0
+  if [[ "$LATEST_ISSUE_ID" != "$LAST_ISSUE_ID_PREV" \
+        || "$LATEST_REVIEW_ID" != "$LAST_REVIEW_ID_PREV" ]]; then
+    COMMENTS_CHANGED=1
+  fi
+
   # Resume / restart: if local meta says we approved last time, converge
-  # only if GitHub still shows APPROVED *and* nothing has changed since
-  # the approval. New commits auto-dismiss approvals (state goes
-  # DISMISSED), but new issue/review comments do not — so a comments-
-  # changed check is still required to avoid silently skipping unread
-  # human feedback. Any miss → fall through to a fresh round on the
-  # current head.
+  # only if GitHub still shows APPROVED *and* HEAD has not moved. New
+  # commits auto-dismiss approvals (state goes DISMISSED). Comment-only
+  # changes do not warrant retracting an APPROVE — see policy above; a
+  # human who wants the bot to re-engage on unchanged code writes to
+  # inbox.md.
   if [[ "$LAST_EVENT" == "APPROVE" ]]; then
     GH_REVIEW_STATE=$(latest_reviewer_review_state)
     if [[ "$GH_REVIEW_STATE" == "APPROVED" \
-          && "$HEAD_SHA" == "$LAST_SHA" \
-          && "$LATEST_ISSUE_ID" == "$LAST_ISSUE_ID_PREV" \
-          && "$LATEST_REVIEW_ID" == "$LAST_REVIEW_ID_PREV" ]]; then
+          && "$HEAD_UNCHANGED" -eq 1 \
+          && "$INBOX_PRESENT" -eq 0 ]]; then
+      # Absorb any new comment ids so we don't keep re-querying GitHub
+      # for the same comments on every poll.
+      if [[ "$COMMENTS_CHANGED" -eq 1 ]]; then
+        jq --argjson iid "$LATEST_ISSUE_ID" --argjson rid "$LATEST_REVIEW_ID" \
+           '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
+           "$META" > "$META.tmp" && mv "$META.tmp" "$META"
+      fi
       converge_and_exit
     fi
-    log "prior APPROVE no longer current (gh=$GH_REVIEW_STATE, head_changed=$([[ "$HEAD_SHA" != "$LAST_SHA" ]] && echo y || echo n), issue_comments_changed=$([[ "$LATEST_ISSUE_ID" != "$LAST_ISSUE_ID_PREV" ]] && echo y || echo n), review_comments_changed=$([[ "$LATEST_REVIEW_ID" != "$LAST_REVIEW_ID_PREV" ]] && echo y || echo n)) — re-reviewing current head"
+    log "prior APPROVE no longer current (gh=$GH_REVIEW_STATE, head_changed=$([[ "$HEAD_UNCHANGED" -eq 0 ]] && echo y || echo n), inbox=$([[ "$INBOX_PRESENT" -eq 1 ]] && echo y || echo n)) — re-reviewing current head"
     jq '.last_codex_event="DISMISSED" | .last_reviewed_sha=null' \
       "$META" > "$META.tmp" && mv "$META.tmp" "$META"
     LAST_EVENT="DISMISSED"
     LAST_SHA="null"
+    HEAD_UNCHANGED=0
   fi
 
-  # Anything new since last round?
-  if [[ "$ROUND" -gt 0 \
-        && "$HEAD_SHA" == "$LAST_SHA" \
-        && "$LATEST_ISSUE_ID" == "$LAST_ISSUE_ID_PREV" \
-        && "$LATEST_REVIEW_ID" == "$LAST_REVIEW_ID_PREV" ]]; then
+  # Idle path: HEAD unchanged AND no inbox prompt. Absorb any comment-id
+  # advances and sleep. ROUND==0 (first poll, never reviewed) always
+  # falls through to a fresh round.
+  if [[ "$ROUND" -gt 0 && "$HEAD_UNCHANGED" -eq 1 && "$INBOX_PRESENT" -eq 0 ]]; then
+    if [[ "$COMMENTS_CHANGED" -eq 1 ]]; then
+      jq --argjson iid "$LATEST_ISSUE_ID" --argjson rid "$LATEST_REVIEW_ID" \
+         '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
+         "$META" > "$META.tmp" && mv "$META.tmp" "$META"
+      log "comment-only update on unchanged HEAD ${HEAD_SHA:0:7} — absorbed; not re-reviewing (write inbox.md to force a round)"
+    fi
     CONSECUTIVE_IDLE=$(jq -r '.consecutive_idle // 0' "$META")
     NEW_IDLE=$((CONSECUTIVE_IDLE + 1))
     jq --argjson n "$NEW_IDLE" '.consecutive_idle=$n' "$META" \
@@ -645,7 +678,7 @@ while true; do
       set_meta_status "stalled"
       exit 5
     fi
-    log "no new commits / comments — idle $NEW_IDLE/$MAX_IDLE, sleeping ${POLL_INTERVAL}s"
+    log "no new commits — idle $NEW_IDLE/$MAX_IDLE, sleeping ${POLL_INTERVAL}s"
     sleep "$POLL_INTERVAL"
     continue
   fi
@@ -846,21 +879,27 @@ while true; do
 
   log "round $NEXT_ROUND done — event=$EVENT blockers=$BLOCKERS sha=${HEAD_SHA:0:7}"
 
-  # APPROVE this round → exit, but re-check stability first. HEAD_SHA
-  # and the comment ids were snapshotted before Codex ran (potentially
-  # minutes ago); a push or non-reviewer comment arriving during the
-  # review must not be silently skipped. If anything moved, fall
-  # through to sleep + next iteration, which will pick up the change.
+  # APPROVE this round → exit, but re-check stability first. HEAD_SHA was
+  # snapshotted before Codex ran (potentially minutes ago); a push that
+  # arrived during the review must not be silently skipped. Comment-only
+  # changes during the review do NOT retract the APPROVE — same rationale
+  # as the top-of-loop trigger policy: a human who wants the bot to
+  # re-engage on unchanged code uses inbox.md.
   if [[ "$EVENT" == "APPROVE" ]]; then
     POST_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
     POST_ISSUE_ID=$(latest_issue_comment_id)
     POST_REVIEW_ID=$(latest_review_comment_id)
-    if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" \
-          && "$POST_ISSUE_ID" == "$LATEST_ISSUE_ID" \
-          && "$POST_REVIEW_ID" == "$LATEST_REVIEW_ID" ]]; then
+    if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" && ! -s "$RUN_DIR/inbox.md" ]]; then
+      # Absorb any comment-id advances that landed during the round so
+      # the next idle iteration doesn't see a stale prev-id mismatch.
+      if [[ "$POST_ISSUE_ID" != "$LATEST_ISSUE_ID" || "$POST_REVIEW_ID" != "$LATEST_REVIEW_ID" ]]; then
+        jq --argjson iid "$POST_ISSUE_ID" --argjson rid "$POST_REVIEW_ID" \
+           '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
+           "$META" > "$META.tmp" && mv "$META.tmp" "$META"
+      fi
       converge_and_exit
     fi
-    log "APPROVE produced but state moved during review (head_changed=$([[ "$POST_HEAD_SHA" != "$HEAD_SHA" ]] && echo y || echo n), issue_comments_changed=$([[ "$POST_ISSUE_ID" != "$LATEST_ISSUE_ID" ]] && echo y || echo n), review_comments_changed=$([[ "$POST_REVIEW_ID" != "$LATEST_REVIEW_ID" ]] && echo y || echo n)) — falling through"
+    log "APPROVE produced but state moved during review (head_changed=$([[ "$POST_HEAD_SHA" != "$HEAD_SHA" ]] && echo y || echo n), inbox=$([[ -s "$RUN_DIR/inbox.md" ]] && echo y || echo n)) — falling through"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -632,26 +632,26 @@ while true; do
   fi
 
   # Resume / restart: if local meta says we approved last time, converge
-  # only if GitHub still shows APPROVED *and* HEAD has not moved. New
-  # commits auto-dismiss approvals (state goes DISMISSED). Comment-only
-  # changes do not warrant retracting an APPROVE — see policy above; a
-  # human who wants the bot to re-engage on unchanged code writes to
-  # inbox.md.
+  # only if GitHub still shows APPROVED, HEAD has not moved, *and* no new
+  # human comments have arrived since the approval. New commits auto-
+  # dismiss approvals (state goes DISMISSED), but comments do not — and
+  # at the convergence boundary the loop is about to exit, so a comment
+  # that landed during the prior round's codex window would be silently
+  # lost forever if we converged without checking. The trigger policy in
+  # the idle path (HEAD-only, no comment trigger) does NOT apply here:
+  # idle keeps the loop alive so a future commit can still be reviewed,
+  # whereas convergence is terminal. Falling through on comment changes
+  # gives the human's late-arriving feedback exactly one re-review pass
+  # before the loop exits.
   if [[ "$LAST_EVENT" == "APPROVE" ]]; then
     GH_REVIEW_STATE=$(latest_reviewer_review_state)
     if [[ "$GH_REVIEW_STATE" == "APPROVED" \
           && "$HEAD_UNCHANGED" -eq 1 \
+          && "$COMMENTS_CHANGED" -eq 0 \
           && "$INBOX_PRESENT" -eq 0 ]]; then
-      # Absorb any new comment ids so we don't keep re-querying GitHub
-      # for the same comments on every poll.
-      if [[ "$COMMENTS_CHANGED" -eq 1 ]]; then
-        jq --argjson iid "$LATEST_ISSUE_ID" --argjson rid "$LATEST_REVIEW_ID" \
-           '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
-           "$META" > "$META.tmp" && mv "$META.tmp" "$META"
-      fi
       converge_and_exit
     fi
-    log "prior APPROVE no longer current (gh=$GH_REVIEW_STATE, head_changed=$([[ "$HEAD_UNCHANGED" -eq 0 ]] && echo y || echo n), inbox=$([[ "$INBOX_PRESENT" -eq 1 ]] && echo y || echo n)) — re-reviewing current head"
+    log "prior APPROVE no longer current (gh=$GH_REVIEW_STATE, head_changed=$([[ "$HEAD_UNCHANGED" -eq 0 ]] && echo y || echo n), comments_changed=$([[ "$COMMENTS_CHANGED" -eq 1 ]] && echo y || echo n), inbox=$([[ "$INBOX_PRESENT" -eq 1 ]] && echo y || echo n)) — re-reviewing current head"
     jq '.last_codex_event="DISMISSED" | .last_reviewed_sha=null' \
       "$META" > "$META.tmp" && mv "$META.tmp" "$META"
     LAST_EVENT="DISMISSED"
@@ -879,27 +879,25 @@ while true; do
 
   log "round $NEXT_ROUND done — event=$EVENT blockers=$BLOCKERS sha=${HEAD_SHA:0:7}"
 
-  # APPROVE this round → exit, but re-check stability first. HEAD_SHA was
-  # snapshotted before Codex ran (potentially minutes ago); a push that
-  # arrived during the review must not be silently skipped. Comment-only
-  # changes during the review do NOT retract the APPROVE — same rationale
-  # as the top-of-loop trigger policy: a human who wants the bot to
-  # re-engage on unchanged code uses inbox.md.
+  # APPROVE this round → exit, but re-check stability first. HEAD_SHA and
+  # the comment ids were snapshotted before Codex ran (potentially
+  # minutes ago). A push or non-reviewer comment arriving during the
+  # review must not be silently skipped: at convergence the loop is
+  # about to exit, so a late-arriving human reply that we drop here is
+  # lost forever. The asymmetry vs. the idle path is intentional — idle
+  # keeps the loop alive (a future commit will trigger), convergence is
+  # terminal (one re-review pass to absorb late feedback before exit).
   if [[ "$EVENT" == "APPROVE" ]]; then
     POST_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid --jq .headRefOid)
     POST_ISSUE_ID=$(latest_issue_comment_id)
     POST_REVIEW_ID=$(latest_review_comment_id)
-    if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" && ! -s "$RUN_DIR/inbox.md" ]]; then
-      # Absorb any comment-id advances that landed during the round so
-      # the next idle iteration doesn't see a stale prev-id mismatch.
-      if [[ "$POST_ISSUE_ID" != "$LATEST_ISSUE_ID" || "$POST_REVIEW_ID" != "$LATEST_REVIEW_ID" ]]; then
-        jq --argjson iid "$POST_ISSUE_ID" --argjson rid "$POST_REVIEW_ID" \
-           '.last_issue_comment_id=$iid | .last_review_comment_id=$rid' \
-           "$META" > "$META.tmp" && mv "$META.tmp" "$META"
-      fi
+    if [[ "$POST_HEAD_SHA" == "$HEAD_SHA" \
+          && "$POST_ISSUE_ID" == "$LATEST_ISSUE_ID" \
+          && "$POST_REVIEW_ID" == "$LATEST_REVIEW_ID" \
+          && ! -s "$RUN_DIR/inbox.md" ]]; then
       converge_and_exit
     fi
-    log "APPROVE produced but state moved during review (head_changed=$([[ "$POST_HEAD_SHA" != "$HEAD_SHA" ]] && echo y || echo n), inbox=$([[ -s "$RUN_DIR/inbox.md" ]] && echo y || echo n)) — falling through"
+    log "APPROVE produced but state moved during review (head_changed=$([[ "$POST_HEAD_SHA" != "$HEAD_SHA" ]] && echo y || echo n), issue_comments_changed=$([[ "$POST_ISSUE_ID" != "$LATEST_ISSUE_ID" ]] && echo y || echo n), review_comments_changed=$([[ "$POST_REVIEW_ID" != "$LATEST_REVIEW_ID" ]] && echo y || echo n), inbox=$([[ -s "$RUN_DIR/inbox.md" ]] && echo y || echo n)) — falling through"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/.foundry/mold/benchmark-template.md
+++ b/.foundry/mold/benchmark-template.md
@@ -18,8 +18,10 @@ Filling in the template below:
   norms). Pure data movement → BW only. Don't list both.
 - Show throughput for TileOPs only; baseline's absolute throughput is
   noise once Speedup is given.
-- Drop the Shape column if the op only varies dtype. Never put autotune
-  config (`block_m`, `threads`) in the table — implementation detail.
+- Drop the Shape column if the op only varies dtype; in that case put
+  the fixed shape in the section header (e.g. `### {OpName} (4096, 4096)`)
+  so the benchmark's scale stays visible. Never put autotune config
+  (`block_m`, `threads`) in the table — implementation detail.
 - **Preserve the original shape tuple — never flatten to a single
   element count.** Write `(4096, 4096)` for a 2D input, `(2, 4096, 128)`
   for a 3D one, and `(4194304,)` (or `(4M,)`) for a genuinely 1D op.

--- a/.foundry/mold/benchmark-template.md
+++ b/.foundry/mold/benchmark-template.md
@@ -1,13 +1,26 @@
 <!--
 INSTRUCTIONS FOR THE AGENT (do not copy into the PR body).
 
+Layout principle: one section per op, one table per section, TileOPs and
+baseline side-by-side on the same row so readers can compare without
+mentally joining two tables.
+
 Filling in the template below:
 
-- One row per measurement (op × shape × dtype). Don't aggregate multiple
-  measurements into a single cell.
-- Don't include the bench file path as a column — it's noise. If multiple
-  bench files contribute, group with sub-headers per bench.
-- TFLOPS not meaningful (pure data movement) → use "—".
+- One row per measurement (shape × dtype) within an op's table.
+- Baseline column header names the baseline (`torch (ms)`, `FA3 (ms)`,
+  `triton (ms)`). Don't write a generic "Baseline". Multiple baselines →
+  add more columns and more Speedup columns (`vs torch`, `vs FA3`).
+- Speedup is always present — it's the first number readers look for.
+  Format `4.96×`, two decimals, computed as baseline_ms / tileops_ms.
+- Throughput column: show ONE — TFLOPS for compute-bound ops (matmul,
+  attention), BW (TB/s) for memory-bound ops (reductions, elementwise,
+  norms). Pure data movement → BW only. Don't list both.
+- Show throughput for TileOPs only; baseline's absolute throughput is
+  noise once Speedup is given.
+- Drop the Shape column if the op only varies dtype. Never put autotune
+  config (`block_m`, `threads`) in the table — implementation detail.
+- Environment block goes once at the top, not per op.
 - Takeaways = conclusions, not data repetition. Wins, losses with a brief
   reason (not blocking), dtype/shape patterns.
 
@@ -32,8 +45,13 @@ copied into the PR body):
 
 **Environment**: \{GPU}, CUDA \{ver}, PyTorch \{ver}, TileLang \{ver}
 
-| Op  | Shape | dtype | TileOPs (ms) | Baseline (ms) | Speedup | TFLOPS | BW (TB/s) |
-| --- | ----- | ----- | ------------ | ------------- | ------- | ------ | --------- |
+### \{OpName}
+
+| dtype | TileOPs (ms) | \{baseline} (ms) | Speedup | BW (TB/s) |
+| ----- | ------------ | ---------------- | ------- | --------- |
+
+<!-- Repeat one ### section per op. Add a Shape column on the left when
+the op varies shape. Swap `BW (TB/s)` for `TFLOPS` on compute-bound ops. -->
 
 **Takeaways:** {wins · losses with brief reason · dtype/shape patterns}
 

--- a/.foundry/mold/benchmark-template.md
+++ b/.foundry/mold/benchmark-template.md
@@ -20,6 +20,13 @@ Filling in the template below:
   noise once Speedup is given.
 - Drop the Shape column if the op only varies dtype. Never put autotune
   config (`block_m`, `threads`) in the table — implementation detail.
+- **Preserve the original shape tuple — never flatten to a single
+  element count.** Write `(4096, 4096)` for a 2D input, `(2, 4096, 128)`
+  for a 3D one, and `(4194304,)` (or `(4M,)`) for a genuinely 1D op.
+  A bare `4M` loses dimensionality: readers can't tell `(4M,)` from
+  `(2K, 2K)` from `(64, 64K)`, yet those have very different access
+  patterns. Use `K`/`M` only inside a tuple to keep large numbers
+  readable, never to replace it.
 - Environment block goes once at the top, not per op.
 - Takeaways = conclusions, not data repetition. Wins, losses with a brief
   reason (not blocking), dtype/shape patterns.
@@ -47,11 +54,12 @@ copied into the PR body):
 
 ### \{OpName}
 
-| dtype | TileOPs (ms) | \{baseline} (ms) | Speedup | BW (TB/s) |
-| ----- | ------------ | ---------------- | ------- | --------- |
+| Shape | dtype | TileOPs (ms) | \{baseline} (ms) | Speedup | BW (TB/s) |
+| ----- | ----- | ------------ | ---------------- | ------- | --------- |
 
-<!-- Repeat one ### section per op. Add a Shape column on the left when
-the op varies shape. Swap `BW (TB/s)` for `TFLOPS` on compute-bound ops. -->
+<!-- Repeat one ### section per op. Drop the Shape column if the op only
+varies dtype. Swap `BW (TB/s)` for `TFLOPS` on compute-bound ops.
+Shape values are tuples: `(4096, 4096)`, `(2, 4096, 128)`, `(4M,)`. -->
 
 **Takeaways:** {wins · losses with brief reason · dtype/shape patterns}
 


### PR DESCRIPTION
Bundle of fixes from running nightshift autonomous-mode reviews on #1174.

## Changes

**`.claude/skills/review-tileops/loop.sh`** — trigger policy redesign

- Idle path: only HEAD changes (or `inbox.md`) trigger a fresh codex round. Comment-only deltas are absorbed silently. Original symptom on #1174: a developer reply on unchanged HEAD made the loop re-review and mine new nits.
- APPROVE convergence gates (top-of-loop resume, post-round stability, Rule 1 same-SHA skip): keep the comment-id equality check — at convergence the loop is about to exit, so a late-arriving comment must trigger one more pass. All three gates also honor `inbox.md`.
- Comment activity resets `consecutive_idle` so an active discussion (replies without a push) doesn't hit MAX_IDLE and exit as stalled.

**`.foundry/mold/benchmark-template.md`** — layout redesign

- One section per op, TileOPs and baseline side-by-side on the same row (was: separate sub-tables).
- Mandatory `Speedup` column formatted `4.96×`; baseline column header names the baseline (`torch (ms)` etc.).
- Single throughput column for TileOPs only (BW for memory-bound, TFLOPS for compute-bound).
- Original shape tuple required (e.g. `(4096, 4096)`, `(4M,)`) — no flattening to bare element counts.
- When dropping the Shape column (op only varies dtype), put the fixed shape in the section header.