### PR TITLE
[Docs][Meta] add skill-doc-style pointer to Domain Rules table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,13 @@ The manifest lives at `tileops/manifest/`, one or more YAML files per op family 
 
 Read the relevant context file **before** modifying files in that domain. Do not load them if your task does not touch that domain.
 
-| When you modify                                                   | Read first                                                                               |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `tests/`                                                          | [.claude/domain-rules/testing-budget.md](.claude/domain-rules/testing-budget.md)         |
-| `tileops/manifest/`                                               | [.claude/domain-rules/manifest-spec.md](.claude/domain-rules/manifest-spec.md)           |
-| `scripts/validate_manifest.py`, `tests/test_validate_manifest.py` | [.claude/domain-rules/manifest-validator.md](.claude/domain-rules/manifest-validator.md) |
-| `tileops/ops/`, `tileops/kernels/`                                | [.claude/domain-rules/ops-design.md](.claude/domain-rules/ops-design.md)                 |
-| `benchmarks/`                                                     | [.claude/domain-rules/benchmark.md](.claude/domain-rules/benchmark.md)                   |
-| `workloads/`                                                      | [docs/design/trust-model.md](docs/design/trust-model.md)                                 |
-| `docs/design/`                                                    | [.claude/domain-rules/design-docs.md](.claude/domain-rules/design-docs.md)               |
+| When you modify                                                   | Read first                                                                                |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `tests/`                                                          | [.claude/domain-rules/testing-budget.md](.claude/domain-rules/testing-budget.md)          |
+| `tileops/manifest/`                                               | [.claude/domain-rules/manifest-spec.md](.claude/domain-rules/manifest-spec.md)            |
+| `scripts/validate_manifest.py`, `tests/test_validate_manifest.py` | [.claude/domain-rules/manifest-validator.md](.claude/domain-rules/manifest-validator.md)  |
+| `tileops/ops/`, `tileops/kernels/`                                | [.claude/domain-rules/ops-design.md](.claude/domain-rules/ops-design.md)                  |
+| `benchmarks/`                                                     | [.claude/domain-rules/benchmark.md](.claude/domain-rules/benchmark.md)                    |
+| `workloads/`                                                      | [docs/design/trust-model.md](docs/design/trust-model.md)                                  |
+| `docs/design/`                                                    | [.claude/domain-rules/design-docs.md](.claude/domain-rules/design-docs.md)                |
+| `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`                | `~/.claude/rules/skill-doc-style.md` (user-level) — imperative, concise, no stale anchors |


### PR DESCRIPTION
## Summary

Adds one row to the Domain Rules table in CLAUDE.md pointing editors of \`.claude/skills/*/SKILL.md\` and \`.claude/agents/*.md\` to \`~/.claude/rules/skill-doc-style.md\` — a user-level, project-agnostic style guide for Claude-facing documentation.

## Why user-level

The style is about how to write LLM-readable docs (imperative, concise, no stale anchors), not about TileOPs business logic. Living at \`~/.claude/rules/\` lets the same guide cover other projects on the same machine without each repo copying it. External contributors won't have the file at the literal path; the row exists primarily to remind the primary maintainer to apply it when editing TileOPs skills.

## Test plan

- [x] CLAUDE.md renders correctly (mdformat applied during pre-commit).
- [x] Existing Domain Rules rows untouched.