### PR TITLE
[Feat][Ops] align elementwise_unary_activation family to manifest spec

### DIFF
--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -13,19 +13,33 @@ compares against PyTorch baseline to determine optimal DEFAULT_STRATEGY.
 """
 
 from math import prod
-from typing import Optional, Protocol
+from typing import Callable, Optional, Protocol
 
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
 from tileops.kernels.elementwise import (
     ErfFwdKernel,
     MishFwdKernel,
     ReluFwdKernel,
     _make_unary_explicit,
 )
-from tileops.ops.elementwise import ErfFwdOp, GeluFwdOp, MishFwdOp, ReluFwdOp
+from tileops.manifest import load_workloads
+from tileops.ops.elementwise import (
+    EluFwdOp,
+    ErfFwdOp,
+    GeluFwdOp,
+    HardsigmoidFwdOp,
+    HardswishFwdOp,
+    HardtanhFwdOp,
+    LeakyReluFwdOp,
+    MishFwdOp,
+    ReluFwdOp,
+    SeluFwdOp,
+    SiluFwdOp,
+    SoftplusFwdOp,
+)
 from workloads.activation import ReluTest
 from workloads.workload_base import FixtureBase
 
@@ -501,6 +515,259 @@ def test_relu_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ===========================================================================
+# Manifest-driven per-op benchmarks for the elementwise_unary_activation
+# family. Each op has its own ``test_*_bench`` function so the validator
+# (``scripts/validate_manifest.py`` → ``check_l4_benchmark``) can match each
+# ``load_workloads("<OpName>FwdOp")`` /
+# ``ManifestBenchmark("<OpName>FwdOp", ...)`` call one-to-one. A shared
+# ``_activation_params_from_manifest`` helper expands the manifest's
+# ``input_shape`` / ``dtypes`` workload entries to pytest params; a shared
+# ``_profile_and_record`` helper handles the profile + record pair.
+# ===========================================================================
+
+
+class _ActivationWorkload:
+    """Minimal :class:`ShapeDtypeWorkload` adapter for activation ops."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+
+def _activation_params_from_manifest(op_name: str) -> list:
+    """Convert ``input_shape`` / ``dtypes`` workload entries to pytest params.
+
+    The manifest's ``elementwise_unary_activation`` family declares its
+    tensor input as ``input`` (PyTorch alignment) so workload entries use
+    ``input_shape`` rather than ``x_shape``. The shared
+    ``workloads_to_params`` helper assumes ``x_shape``; this local helper
+    adapts ``load_workloads`` output for the activation family.
+    """
+    workloads = load_workloads(op_name)
+    params = []
+    for w in workloads:
+        shape = tuple(w["input_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(shape, dtype, id=f"{label}-{dtype_str}"))
+    return params
+
+
+def _profile_and_record(
+    op,
+    bm: ManifestBenchmark,
+    inputs: tuple,
+    baseline_fn: Callable,
+    params: dict,
+) -> None:
+    """Profile op and torch baseline against the same inputs and record both."""
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, params, result, tag="tileops")
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, params, result_bl, tag="torch")
+
+
+def _randn(shape: tuple, dtype: torch.dtype) -> tuple[torch.Tensor]:
+    return (torch.randn(shape, device="cuda", dtype=dtype),)
+
+
+# ---------------------------------------------------------------------------
+# Per-op manifest-driven benches (12 unary activation ops)
+# ---------------------------------------------------------------------------
+
+_RELU_OP = "ReluFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_RELU_OP))
+def test_relu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = ReluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_RELU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, torch.relu,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_GELU_OP = "GeluFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_GELU_OP))
+def test_gelu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = GeluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_GELU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.gelu,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_SILU_OP = "SiluFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_SILU_OP))
+def test_silu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = SiluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_SILU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.silu,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_HARDSWISH_OP = "HardswishFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _activation_params_from_manifest(_HARDSWISH_OP),
+)
+def test_hardswish_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = HardswishFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_HARDSWISH_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.hardswish,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_HARDSIGMOID_OP = "HardsigmoidFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _activation_params_from_manifest(_HARDSIGMOID_OP),
+)
+def test_hardsigmoid_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = HardsigmoidFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_HARDSIGMOID_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.hardsigmoid,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_MISH_OP = "MishFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_MISH_OP))
+def test_mish_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = MishFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_MISH_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.mish,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_SELU_OP = "SeluFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_SELU_OP))
+def test_selu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = SeluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_SELU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.selu,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_LEAKY_RELU_OP = "LeakyReluFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _activation_params_from_manifest(_LEAKY_RELU_OP),
+)
+def test_leaky_relu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = LeakyReluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_LEAKY_RELU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, lambda x: F.leaky_relu(x, 0.01),
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_ELU_OP = "EluFwdOp"
+
+
+@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_ELU_OP))
+def test_elu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = EluFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_ELU_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.elu,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_HARDTANH_OP = "HardtanhFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _activation_params_from_manifest(_HARDTANH_OP),
+)
+def test_hardtanh_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = HardtanhFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_HARDTANH_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.hardtanh,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
+
+
+_SOFTPLUS_OP = "SoftplusFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _activation_params_from_manifest(_SOFTPLUS_OP),
+)
+def test_softplus_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    import torch.nn.functional as F
+    inputs = _randn(shape, dtype)
+    n_total = inputs[0].numel()
+    op = SoftplusFwdOp(N_total=n_total, dtype=dtype)
+    bm = ManifestBenchmark(_SOFTPLUS_OP, op, _ActivationWorkload(shape, dtype))
+    _profile_and_record(
+        op, bm, inputs, F.softplus,
+        {"shape": shape, "dtype": dtype, "n_total": n_total},
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -519,13 +519,15 @@ def test_relu_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
 
 # ===========================================================================
 # Manifest-driven per-op benchmarks for the elementwise_unary_activation
-# family. Each op has its own ``test_*_bench`` function so the validator
-# (``scripts/validate_manifest.py`` → ``check_l4_benchmark``) can match each
-# ``load_workloads("<OpName>FwdOp")`` /
-# ``ManifestBenchmark("<OpName>FwdOp", ...)`` call one-to-one. A shared
-# ``_activation_params_from_manifest`` helper expands the manifest's
-# ``input_shape`` / ``dtypes`` workload entries to pytest params; a shared
-# ``_profile_and_record`` helper handles the profile + record pair.
+# family. Each ``test_*_manifest_bench`` function calls
+# ``load_workloads("<OpName>")`` and ``ManifestBenchmark("<OpName>", ...)``
+# with the literal op name so the manifest validator
+# (``scripts/validate_manifest.py`` → ``check_l4_benchmark``) can match
+# each pair via AST inspection without tracing through helper indirection.
+# A shared ``_activation_params_from_workloads`` helper expands the
+# manifest's ``input_shape`` / ``dtypes`` workload entries to pytest
+# params; a shared ``_profile_and_record`` helper handles the profile +
+# record pair.
 # ===========================================================================
 
 
@@ -537,8 +539,8 @@ class _ActivationWorkload:
         self.dtype = dtype
 
 
-def _activation_params_from_manifest(op_name: str) -> list:
-    """Convert ``input_shape`` / ``dtypes`` workload entries to pytest params.
+def _activation_params_from_workloads(workloads: list) -> list:
+    """Convert resolved manifest workload entries to pytest params.
 
     The manifest's ``elementwise_unary_activation`` family declares its
     tensor input as ``input`` (PyTorch alignment) so workload entries use
@@ -546,7 +548,6 @@ def _activation_params_from_manifest(op_name: str) -> list:
     ``workloads_to_params`` helper assumes ``x_shape``; this local helper
     adapts ``load_workloads`` output for the activation family.
     """
-    workloads = load_workloads(op_name)
     params = []
     for w in workloads:
         shape = tuple(w["input_shape"])
@@ -585,185 +586,185 @@ def _randn(shape: tuple, dtype: torch.dtype) -> tuple[torch.Tensor]:
 # Per-op manifest-driven benches (12 unary activation ops)
 # ---------------------------------------------------------------------------
 
-_RELU_OP = "ReluFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_RELU_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("ReluFwdOp")),
+)
 def test_relu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = ReluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_RELU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("ReluFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, torch.relu,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_GELU_OP = "GeluFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_GELU_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("GeluFwdOp")),
+)
 def test_gelu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = GeluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_GELU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("GeluFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, F.gelu,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_SILU_OP = "SiluFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_SILU_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("SiluFwdOp")),
+)
 def test_silu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = SiluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_SILU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("SiluFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, F.silu,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_HARDSWISH_OP = "HardswishFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _activation_params_from_manifest(_HARDSWISH_OP),
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("HardswishFwdOp")),
 )
 def test_hardswish_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = HardswishFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_HARDSWISH_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "HardswishFwdOp", op, _ActivationWorkload(shape, dtype),
+    )
     _profile_and_record(
         op, bm, inputs, F.hardswish,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_HARDSIGMOID_OP = "HardsigmoidFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _activation_params_from_manifest(_HARDSIGMOID_OP),
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("HardsigmoidFwdOp")),
 )
 def test_hardsigmoid_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = HardsigmoidFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_HARDSIGMOID_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "HardsigmoidFwdOp", op, _ActivationWorkload(shape, dtype),
+    )
     _profile_and_record(
         op, bm, inputs, F.hardsigmoid,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_MISH_OP = "MishFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_MISH_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("MishFwdOp")),
+)
 def test_mish_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = MishFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_MISH_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("MishFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, F.mish,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_SELU_OP = "SeluFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_SELU_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("SeluFwdOp")),
+)
 def test_selu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = SeluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_SELU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("SeluFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, F.selu,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_LEAKY_RELU_OP = "LeakyReluFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _activation_params_from_manifest(_LEAKY_RELU_OP),
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("LeakyReluFwdOp")),
 )
 def test_leaky_relu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = LeakyReluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_LEAKY_RELU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "LeakyReluFwdOp", op, _ActivationWorkload(shape, dtype),
+    )
     _profile_and_record(
         op, bm, inputs, lambda x: F.leaky_relu(x, 0.01),
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_ELU_OP = "EluFwdOp"
-
-
-@pytest.mark.parametrize("shape, dtype", _activation_params_from_manifest(_ELU_OP))
+@pytest.mark.parametrize(
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("EluFwdOp")),
+)
 def test_elu_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = EluFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_ELU_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark("EluFwdOp", op, _ActivationWorkload(shape, dtype))
     _profile_and_record(
         op, bm, inputs, F.elu,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_HARDTANH_OP = "HardtanhFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _activation_params_from_manifest(_HARDTANH_OP),
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("HardtanhFwdOp")),
 )
 def test_hardtanh_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = HardtanhFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_HARDTANH_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "HardtanhFwdOp", op, _ActivationWorkload(shape, dtype),
+    )
     _profile_and_record(
         op, bm, inputs, F.hardtanh,
         {"shape": shape, "dtype": dtype, "n_total": n_total},
     )
 
 
-_SOFTPLUS_OP = "SoftplusFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _activation_params_from_manifest(_SOFTPLUS_OP),
+    "shape, dtype",
+    _activation_params_from_workloads(load_workloads("SoftplusFwdOp")),
 )
 def test_softplus_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     import torch.nn.functional as F
     inputs = _randn(shape, dtype)
     n_total = inputs[0].numel()
     op = SoftplusFwdOp(N_total=n_total, dtype=dtype)
-    bm = ManifestBenchmark(_SOFTPLUS_OP, op, _ActivationWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "SoftplusFwdOp", op, _ActivationWorkload(shape, dtype),
+    )
     _profile_and_record(
         op, bm, inputs, F.softplus,
         {"shape": shape, "dtype": dtype, "n_total": n_total},

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -545,10 +545,11 @@ def test_fp8_selection_bench(
 
 # ===========================================================================
 # Manifest-driven per-op benchmarks for the four Clamp variants and
-# NanToNumFwdOp. Each op gets its own ``test_*_manifest_bench`` function so
-# the manifest validator (``scripts/validate_manifest.py`` →
-# ``check_l4_benchmark``) can match each ``load_workloads("<OpName>FwdOp")``
-# / ``ManifestBenchmark("<OpName>FwdOp", ...)`` call one-to-one.
+# NanToNumFwdOp. Each ``test_*_manifest_bench`` function calls
+# ``load_workloads("<OpName>")`` and ``ManifestBenchmark("<OpName>", ...)``
+# with the literal op name so the manifest validator
+# (``scripts/validate_manifest.py`` → ``check_l4_benchmark``) can match
+# each pair via AST inspection without tracing through helper indirection.
 # ===========================================================================
 
 
@@ -560,13 +561,8 @@ class _ShapeDtypeWorkload:
         self.dtype = dtype
 
 
-def _scalar_manifest_params(op_name: str) -> list:
-    """Pytest params for ops whose workload has a single ``input_shape`` field.
-
-    Used by the scalar-bound clamp and nan_to_num entries (no
-    ``min_shape`` / ``max_shape`` Tensor companions).
-    """
-    workloads = load_workloads(op_name)
+def _scalar_params_from_workloads(workloads: list) -> list:
+    """Pytest params for ops with a single ``input_shape`` workload field."""
     params = []
     for w in workloads:
         shape = tuple(w["input_shape"])
@@ -577,8 +573,8 @@ def _scalar_manifest_params(op_name: str) -> list:
     return params
 
 
-def _tensor_manifest_params(
-    op_name: str, bound_keys: tuple[str, ...],
+def _tensor_params_from_workloads(
+    workloads: list, bound_keys: tuple[str, ...],
 ) -> list:
     """Pytest params for Tensor-bound clamp variants.
 
@@ -587,7 +583,6 @@ def _tensor_manifest_params(
     ``("min_shape", "max_shape")`` for ClampFwdOp. Each manifest workload
     contributes ``(input_shape, *bound_shapes, dtype)`` per dtype.
     """
-    workloads = load_workloads(op_name)
     params = []
     for w in workloads:
         input_shape = tuple(w["input_shape"])
@@ -623,12 +618,11 @@ def _profile_and_record_manifest(
     BenchmarkReport.record(op, params, result_bl, tag="torch")
 
 
-_CLAMP_OP = "ClampFwdOp"
-
-
 @pytest.mark.parametrize(
     "input_shape, bound_shapes, dtype",
-    _tensor_manifest_params(_CLAMP_OP, ("min_shape", "max_shape")),
+    _tensor_params_from_workloads(
+        load_workloads("ClampFwdOp"), ("min_shape", "max_shape"),
+    ),
 )
 def test_clamp_manifest_bench(
     input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
@@ -638,7 +632,9 @@ def test_clamp_manifest_bench(
     mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
     mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
     op = ClampFwdOp(input=input_shape, dtype=dtype, min=min_shape, max=max_shape)
-    bm = ManifestBenchmark(_CLAMP_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    bm = ManifestBenchmark(
+        "ClampFwdOp", op, _ShapeDtypeWorkload(input_shape, dtype),
+    )
     _profile_and_record_manifest(
         op, bm, (inp, mn, mx),
         lambda x, lo, hi: torch.clamp(x, lo, hi),
@@ -646,16 +642,16 @@ def test_clamp_manifest_bench(
     )
 
 
-_CLAMP_SCALAR_OP = "ClampScalarFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _scalar_manifest_params(_CLAMP_SCALAR_OP),
+    "shape, dtype",
+    _scalar_params_from_workloads(load_workloads("ClampScalarFwdOp")),
 )
 def test_clamp_scalar_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     inp = torch.randn(shape, device="cuda", dtype=dtype)
     op = ClampScalarFwdOp(input=shape, dtype=dtype, min=-0.5, max=0.5)
-    bm = ManifestBenchmark(_CLAMP_SCALAR_OP, op, _ShapeDtypeWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "ClampScalarFwdOp", op, _ShapeDtypeWorkload(shape, dtype),
+    )
     _profile_and_record_manifest(
         op, bm, (inp,),
         lambda x: torch.clamp(x, -0.5, 0.5),
@@ -663,12 +659,11 @@ def test_clamp_scalar_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     )
 
 
-_CLAMP_MIN_OP = "ClampMinFwdOp"
-
-
 @pytest.mark.parametrize(
     "input_shape, bound_shapes, dtype",
-    _tensor_manifest_params(_CLAMP_MIN_OP, ("min_shape",)),
+    _tensor_params_from_workloads(
+        load_workloads("ClampMinFwdOp"), ("min_shape",),
+    ),
 )
 def test_clamp_min_manifest_bench(
     input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
@@ -677,7 +672,9 @@ def test_clamp_min_manifest_bench(
     inp = torch.randn(input_shape, device="cuda", dtype=dtype)
     mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
     op = ClampMinFwdOp(input=input_shape, dtype=dtype, min=min_shape)
-    bm = ManifestBenchmark(_CLAMP_MIN_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    bm = ManifestBenchmark(
+        "ClampMinFwdOp", op, _ShapeDtypeWorkload(input_shape, dtype),
+    )
     _profile_and_record_manifest(
         op, bm, (inp, mn),
         lambda x, lo: torch.clamp_min(x, lo),
@@ -685,12 +682,11 @@ def test_clamp_min_manifest_bench(
     )
 
 
-_CLAMP_MAX_OP = "ClampMaxFwdOp"
-
-
 @pytest.mark.parametrize(
     "input_shape, bound_shapes, dtype",
-    _tensor_manifest_params(_CLAMP_MAX_OP, ("max_shape",)),
+    _tensor_params_from_workloads(
+        load_workloads("ClampMaxFwdOp"), ("max_shape",),
+    ),
 )
 def test_clamp_max_manifest_bench(
     input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
@@ -699,7 +695,9 @@ def test_clamp_max_manifest_bench(
     inp = torch.randn(input_shape, device="cuda", dtype=dtype)
     mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
     op = ClampMaxFwdOp(input=input_shape, dtype=dtype, max=max_shape)
-    bm = ManifestBenchmark(_CLAMP_MAX_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    bm = ManifestBenchmark(
+        "ClampMaxFwdOp", op, _ShapeDtypeWorkload(input_shape, dtype),
+    )
     _profile_and_record_manifest(
         op, bm, (inp, mx),
         lambda x, hi: torch.clamp_max(x, hi),
@@ -707,11 +705,9 @@ def test_clamp_max_manifest_bench(
     )
 
 
-_NAN_TO_NUM_OP = "NanToNumFwdOp"
-
-
 @pytest.mark.parametrize(
-    "shape, dtype", _scalar_manifest_params(_NAN_TO_NUM_OP),
+    "shape, dtype",
+    _scalar_params_from_workloads(load_workloads("NanToNumFwdOp")),
 )
 def test_nan_to_num_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     inp = torch.randn(shape, device="cuda", dtype=dtype)
@@ -721,7 +717,9 @@ def test_nan_to_num_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
     flat[quarter:2 * quarter] = float("inf")
     flat[2 * quarter:3 * quarter] = float("-inf")
     op = NanToNumFwdOp(N_total=inp.numel(), dtype=dtype)
-    bm = ManifestBenchmark(_NAN_TO_NUM_OP, op, _ShapeDtypeWorkload(shape, dtype))
+    bm = ManifestBenchmark(
+        "NanToNumFwdOp", op, _ShapeDtypeWorkload(shape, dtype),
+    )
     _profile_and_record_manifest(
         op, bm, (inp,),
         lambda x: torch.nan_to_num(x, 0.0, 1e4, -1e4),

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -5,15 +5,19 @@ Profiles TileOPs vs PyTorch baselines using DNN-realistic 2-D shapes
 """
 
 from math import prod
-from typing import Optional
+from typing import Callable, Optional
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AlibiFwdOp,
+    ClampFwdOp,
+    ClampMaxFwdOp,
+    ClampMinFwdOp,
     ClampScalarFwdOp,
     EluFwdOp,
     HardtanhFwdOp,
@@ -537,6 +541,192 @@ def test_fp8_selection_bench(
 
         result_bl = bm.profile(baseline, x, mask)
         BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+
+
+# ===========================================================================
+# Manifest-driven per-op benchmarks for the four Clamp variants and
+# NanToNumFwdOp. Each op gets its own ``test_*_manifest_bench`` function so
+# the manifest validator (``scripts/validate_manifest.py`` →
+# ``check_l4_benchmark``) can match each ``load_workloads("<OpName>FwdOp")``
+# / ``ManifestBenchmark("<OpName>FwdOp", ...)`` call one-to-one.
+# ===========================================================================
+
+
+class _ShapeDtypeWorkload:
+    """Minimal :class:`ShapeDtypeWorkload` adapter for ManifestBenchmark."""
+
+    def __init__(self, shape: tuple, dtype: torch.dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+
+def _scalar_manifest_params(op_name: str) -> list:
+    """Pytest params for ops whose workload has a single ``input_shape`` field.
+
+    Used by the scalar-bound clamp and nan_to_num entries (no
+    ``min_shape`` / ``max_shape`` Tensor companions).
+    """
+    workloads = load_workloads(op_name)
+    params = []
+    for w in workloads:
+        shape = tuple(w["input_shape"])
+        label = w.get("label", "x".join(str(s) for s in shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(pytest.param(shape, dtype, id=f"{label}-{dtype_str}"))
+    return params
+
+
+def _tensor_manifest_params(
+    op_name: str, bound_keys: tuple[str, ...],
+) -> list:
+    """Pytest params for Tensor-bound clamp variants.
+
+    ``bound_keys`` enumerates the workload-side shape fields that carry
+    Tensor bounds, e.g. ``("min_shape",)`` for ClampMinFwdOp or
+    ``("min_shape", "max_shape")`` for ClampFwdOp. Each manifest workload
+    contributes ``(input_shape, *bound_shapes, dtype)`` per dtype.
+    """
+    workloads = load_workloads(op_name)
+    params = []
+    for w in workloads:
+        input_shape = tuple(w["input_shape"])
+        bound_shapes = tuple(tuple(w[k]) for k in bound_keys)
+        label = w.get("label", "x".join(str(s) for s in input_shape))
+        for dtype_str in w["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(
+                pytest.param(
+                    input_shape, bound_shapes, dtype,
+                    id=f"{label}-{dtype_str}",
+                ),
+            )
+    return params
+
+
+def _profile_and_record_manifest(
+    op,
+    bm: ManifestBenchmark,
+    inputs: tuple,
+    baseline_fn: Callable,
+    params: dict,
+) -> None:
+    """Profile op + torch baseline and record both rows."""
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, params, result, tag="tileops")
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, params, result_bl, tag="torch")
+
+
+_CLAMP_OP = "ClampFwdOp"
+
+
+@pytest.mark.parametrize(
+    "input_shape, bound_shapes, dtype",
+    _tensor_manifest_params(_CLAMP_OP, ("min_shape", "max_shape")),
+)
+def test_clamp_manifest_bench(
+    input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
+) -> None:
+    min_shape, max_shape = bound_shapes
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
+    mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
+    op = ClampFwdOp(input=input_shape, dtype=dtype, min=min_shape, max=max_shape)
+    bm = ManifestBenchmark(_CLAMP_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    _profile_and_record_manifest(
+        op, bm, (inp, mn, mx),
+        lambda x, lo, hi: torch.clamp(x, lo, hi),
+        {"shape": input_shape, "dtype": dtype, "n_total": inp.numel()},
+    )
+
+
+_CLAMP_SCALAR_OP = "ClampScalarFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _scalar_manifest_params(_CLAMP_SCALAR_OP),
+)
+def test_clamp_scalar_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    inp = torch.randn(shape, device="cuda", dtype=dtype)
+    op = ClampScalarFwdOp(input=shape, dtype=dtype, min=-0.5, max=0.5)
+    bm = ManifestBenchmark(_CLAMP_SCALAR_OP, op, _ShapeDtypeWorkload(shape, dtype))
+    _profile_and_record_manifest(
+        op, bm, (inp,),
+        lambda x: torch.clamp(x, -0.5, 0.5),
+        {"shape": shape, "dtype": dtype, "n_total": inp.numel()},
+    )
+
+
+_CLAMP_MIN_OP = "ClampMinFwdOp"
+
+
+@pytest.mark.parametrize(
+    "input_shape, bound_shapes, dtype",
+    _tensor_manifest_params(_CLAMP_MIN_OP, ("min_shape",)),
+)
+def test_clamp_min_manifest_bench(
+    input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
+) -> None:
+    (min_shape,) = bound_shapes
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mn = torch.randn(min_shape, device="cuda", dtype=dtype) - 0.5
+    op = ClampMinFwdOp(input=input_shape, dtype=dtype, min=min_shape)
+    bm = ManifestBenchmark(_CLAMP_MIN_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    _profile_and_record_manifest(
+        op, bm, (inp, mn),
+        lambda x, lo: torch.clamp_min(x, lo),
+        {"shape": input_shape, "dtype": dtype, "n_total": inp.numel()},
+    )
+
+
+_CLAMP_MAX_OP = "ClampMaxFwdOp"
+
+
+@pytest.mark.parametrize(
+    "input_shape, bound_shapes, dtype",
+    _tensor_manifest_params(_CLAMP_MAX_OP, ("max_shape",)),
+)
+def test_clamp_max_manifest_bench(
+    input_shape: tuple, bound_shapes: tuple, dtype: torch.dtype,
+) -> None:
+    (max_shape,) = bound_shapes
+    inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+    mx = torch.randn(max_shape, device="cuda", dtype=dtype) + 0.5
+    op = ClampMaxFwdOp(input=input_shape, dtype=dtype, max=max_shape)
+    bm = ManifestBenchmark(_CLAMP_MAX_OP, op, _ShapeDtypeWorkload(input_shape, dtype))
+    _profile_and_record_manifest(
+        op, bm, (inp, mx),
+        lambda x, hi: torch.clamp_max(x, hi),
+        {"shape": input_shape, "dtype": dtype, "n_total": inp.numel()},
+    )
+
+
+_NAN_TO_NUM_OP = "NanToNumFwdOp"
+
+
+@pytest.mark.parametrize(
+    "shape, dtype", _scalar_manifest_params(_NAN_TO_NUM_OP),
+)
+def test_nan_to_num_manifest_bench(shape: tuple, dtype: torch.dtype) -> None:
+    inp = torch.randn(shape, device="cuda", dtype=dtype)
+    flat = inp.view(-1)
+    quarter = flat.numel() // 4
+    flat[:quarter] = float("nan")
+    flat[quarter:2 * quarter] = float("inf")
+    flat[2 * quarter:3 * quarter] = float("-inf")
+    op = NanToNumFwdOp(N_total=inp.numel(), dtype=dtype)
+    bm = ManifestBenchmark(_NAN_TO_NUM_OP, op, _ShapeDtypeWorkload(shape, dtype))
+    _profile_and_record_manifest(
+        op, bm, (inp,),
+        lambda x: torch.nan_to_num(x, 0.0, 1e4, -1e4),
+        {"shape": shape, "dtype": dtype, "n_total": inp.numel()},
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -97,7 +97,7 @@ def test_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dtype)
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)
@@ -420,7 +420,7 @@ def test_fp8_unary_independent_bench(
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -112,10 +112,26 @@ def test_clamp_tensor_bounds_parity(input_shape, min_shape, max_shape, dtype):
 
 @pytest.mark.smoke
 def test_clamp_init_signature_pytorch_aligned():
+    """Canonical UnaryOp ctor pattern: (input, dtype, *, kernel_map, tune, min, max).
+
+    PyTorch's ``torch.clamp`` keyword arguments ``min`` / ``max`` are exposed
+    as keyword-only after the ``*`` barrier so the manifest-aligned ctor
+    matches the ``(M_or_shape, dtype, *, kernel_map=None, tune=False,
+    **op_specific_params)`` family pattern. ``forward()`` keeps positional
+    PyTorch alignment ``(input, min, max)``.
+    """
     from tileops.ops.elementwise import ClampFwdOp
-    init_params = list(inspect.signature(ClampFwdOp.__init__).parameters.keys())
+    sig = inspect.signature(ClampFwdOp.__init__)
+    init_params = list(sig.parameters.keys())
     fwd_params = list(inspect.signature(ClampFwdOp.forward).parameters.keys())
-    assert init_params[1:5] == ["input", "min", "max", "dtype"], init_params
+    # __init__: self, input, dtype, *, kernel_map, tune, min, max
+    assert init_params[1:3] == ["input", "dtype"], init_params
+    kw_only = [
+        n for n, p in sig.parameters.items()
+        if p.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+    assert kw_only == ["kernel_map", "tune", "min", "max"], kw_only
+    # forward: self, input, min, max (positional PyTorch alignment).
     assert fwd_params[1:] == ["input", "min", "max"], fwd_params
 
 
@@ -283,10 +299,17 @@ def test_clamp_min_tensor(input_shape, min_shape):
 
 @pytest.mark.smoke
 def test_clamp_min_init_signature_pytorch_aligned():
+    """Canonical UnaryOp ctor: (input, dtype, *, kernel_map, tune, min)."""
     from tileops.ops.elementwise import ClampMinFwdOp
-    init_params = list(inspect.signature(ClampMinFwdOp.__init__).parameters.keys())
+    sig = inspect.signature(ClampMinFwdOp.__init__)
+    init_params = list(sig.parameters.keys())
     fwd_params = list(inspect.signature(ClampMinFwdOp.forward).parameters.keys())
-    assert init_params[1:4] == ["input", "min", "dtype"], init_params
+    assert init_params[1:3] == ["input", "dtype"], init_params
+    kw_only = [
+        n for n, p in sig.parameters.items()
+        if p.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+    assert kw_only == ["kernel_map", "tune", "min"], kw_only
     assert fwd_params[1:] == ["input", "min"], fwd_params
 
 
@@ -309,10 +332,17 @@ def test_clamp_max_tensor(input_shape, max_shape):
 
 @pytest.mark.smoke
 def test_clamp_max_init_signature_pytorch_aligned():
+    """Canonical UnaryOp ctor: (input, dtype, *, kernel_map, tune, max)."""
     from tileops.ops.elementwise import ClampMaxFwdOp
-    init_params = list(inspect.signature(ClampMaxFwdOp.__init__).parameters.keys())
+    sig = inspect.signature(ClampMaxFwdOp.__init__)
+    init_params = list(sig.parameters.keys())
     fwd_params = list(inspect.signature(ClampMaxFwdOp.forward).parameters.keys())
-    assert init_params[1:4] == ["input", "max", "dtype"], init_params
+    assert init_params[1:3] == ["input", "dtype"], init_params
+    kw_only = [
+        n for n, p in sig.parameters.items()
+        if p.kind == inspect.Parameter.KEYWORD_ONLY
+    ]
+    assert kw_only == ["kernel_map", "tune", "max"], kw_only
     assert fwd_params[1:] == ["input", "max"], fwd_params
 
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -2070,8 +2070,20 @@ class ClampFwdOp(_ClampTensorBase):
         return {"clamp_tensor": ClampTensorFwdKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        """Return ``(flops, bytes)`` for this op instance."""
-        return _perf_formulas.clamp_fwd_roofline(self)
+        """Return ``(flops, bytes)`` for this op instance.
+
+        Routes to the matching formula based on which bounds are bound:
+        double-sided ``clamp_fwd_roofline`` when both ``min`` and ``max``
+        are Tensors, otherwise the one-sided
+        ``clamp_min_fwd_roofline`` / ``clamp_max_fwd_roofline``.
+        """
+        has_min = self.min_shape is not None
+        has_max = self.max_shape is not None
+        if has_min and has_max:
+            return _perf_formulas.clamp_fwd_roofline(self)
+        if has_min:
+            return _perf_formulas.clamp_min_fwd_roofline(self)
+        return _perf_formulas.clamp_max_fwd_roofline(self)
 
     def _eager_forward(
         self,

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -93,6 +93,7 @@ from tileops.kernels.elementwise import (
     WhereFwdKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.perf import formulas as _perf_formulas
 
 from .op_base import Op
 
@@ -2025,10 +2026,6 @@ class ClampFwdOp(_ClampTensorBase):
 
     _op_name = "clamp"
     _wrapped = None
-    # Conservative roofline upper bound: 4 fp ops per element (2 compares
-    # + 2 selects). When only one bound is provided the actual cost halves
-    # to 2*N, but 4*N matches the manifest's two-sided clamp convention.
-    FLOPS_PER_ELEM = 4
 
     def __init__(
         self,
@@ -2063,6 +2060,7 @@ class ClampFwdOp(_ClampTensorBase):
             self.N_total, dtype,
             has_min=self.min_shape is not None,
             has_max=self.max_shape is not None,
+            tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2073,8 +2071,7 @@ class ClampFwdOp(_ClampTensorBase):
 
     def eval_roofline(self) -> tuple[int, int]:
         """Return ``(flops, bytes)`` for this op instance."""
-        elem = self.dtype.itemsize
-        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
+        return _perf_formulas.clamp_fwd_roofline(self)
 
     def _eager_forward(
         self,
@@ -2146,8 +2143,6 @@ class ClampMinFwdOp(_ClampTensorBase):
 
     _op_name = "clamp_min"
     _wrapped = None
-    # Single-sided clamp: 1 compare + 1 select per element.
-    FLOPS_PER_ELEM = 2
 
     def __init__(
         self,
@@ -2167,7 +2162,7 @@ class ClampMinFwdOp(_ClampTensorBase):
         self.dispatch_kernel(kernel_map)
         clamp_tensor_cls = self.kernel_map["clamp_tensor"]
         self.kernel = clamp_tensor_cls(
-            self.N_total, dtype, has_min=True, has_max=False,
+            self.N_total, dtype, has_min=True, has_max=False, tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2178,8 +2173,7 @@ class ClampMinFwdOp(_ClampTensorBase):
 
     def eval_roofline(self) -> tuple[int, int]:
         """Return ``(flops, bytes)`` for this op instance."""
-        elem = self.dtype.itemsize
-        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
+        return _perf_formulas.clamp_min_fwd_roofline(self)
 
     def _eager_forward(
         self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
@@ -2226,8 +2220,6 @@ class ClampMaxFwdOp(_ClampTensorBase):
 
     _op_name = "clamp_max"
     _wrapped = None
-    # Single-sided clamp: 1 compare + 1 select per element.
-    FLOPS_PER_ELEM = 2
 
     def __init__(
         self,
@@ -2247,7 +2239,7 @@ class ClampMaxFwdOp(_ClampTensorBase):
         self.dispatch_kernel(kernel_map)
         clamp_tensor_cls = self.kernel_map["clamp_tensor"]
         self.kernel = clamp_tensor_cls(
-            self.N_total, dtype, has_min=False, has_max=True,
+            self.N_total, dtype, has_min=False, has_max=True, tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2258,8 +2250,7 @@ class ClampMaxFwdOp(_ClampTensorBase):
 
     def eval_roofline(self) -> tuple[int, int]:
         """Return ``(flops, bytes)`` for this op instance."""
-        elem = self.dtype.itemsize
-        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
+        return _perf_formulas.clamp_max_fwd_roofline(self)
 
     def _eager_forward(
         self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
@@ -2342,7 +2333,9 @@ class ClampScalarFwdOp(Op):
         self.max_val = max
         self.dispatch_kernel(kernel_map)
         clamp_cls = self.kernel_map["clamp"]
-        self.kernel = clamp_cls(self.N_total, dtype, min_val=min, max_val=max)
+        self.kernel = clamp_cls(
+            self.N_total, dtype, min_val=min, max_val=max, tune=tune,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -957,6 +957,8 @@ class ReluFwdOp(UnaryOp):
 
     _op_name = "relu"
     kernel_cls = ReluFwdKernel
+    # Manifest: flops = "2 * N" (1 compare + 1 select per element).
+    FLOPS_PER_ELEM = 2
 
 
 class AddFwdOp(BinaryOp):
@@ -1480,6 +1482,8 @@ class GeluFwdOp(UnaryOp):
 
     _op_name = "gelu"
     kernel_cls = GeluFwdKernel
+    # Manifest: flops = "8 * N" (mul + erf + add + mul + mul ≈ 8 ops/elem).
+    FLOPS_PER_ELEM = 8
 
 
 class SiluFwdOp(UnaryOp):
@@ -1487,6 +1491,8 @@ class SiluFwdOp(UnaryOp):
 
     _op_name = "silu"
     kernel_cls = SiluFwdKernel
+    # Manifest: flops = "4 * N" (sigmoid ~3 + mul = 4 ops/elem).
+    FLOPS_PER_ELEM = 4
 
 
 class SigmoidFwdOp(UnaryOp):
@@ -1512,6 +1518,8 @@ class HardswishFwdOp(UnaryOp):
 
     _op_name = "hardswish"
     kernel_cls = HardswishFwdKernel
+    # Manifest: flops = "7 * N" (add + clamp(2 cmp + 2 sel) + mul + div).
+    FLOPS_PER_ELEM = 7
 
 
 class HardsigmoidFwdOp(UnaryOp):
@@ -1519,6 +1527,8 @@ class HardsigmoidFwdOp(UnaryOp):
 
     _op_name = "hardsigmoid"
     kernel_cls = HardsigmoidFwdKernel
+    # Manifest: flops = "6 * N" (add + clamp(2 cmp + 2 sel) + div).
+    FLOPS_PER_ELEM = 6
 
 
 class MishFwdOp(UnaryOp):
@@ -1526,6 +1536,8 @@ class MishFwdOp(UnaryOp):
 
     _op_name = "mish"
     kernel_cls = MishFwdKernel
+    # Manifest: flops = "7 * N" (softplus ~3 + tanh ~3 + mul).
+    FLOPS_PER_ELEM = 7
 
 
 class SeluFwdOp(UnaryOp):
@@ -1533,6 +1545,8 @@ class SeluFwdOp(UnaryOp):
 
     _op_name = "selu"
     kernel_cls = SeluFwdKernel
+    # Manifest: flops = "5 * N" (compare + (exp + sub + mul) + scale).
+    FLOPS_PER_ELEM = 5
 
 
 # ---------------------------------------------------------------------------
@@ -1633,6 +1647,8 @@ class LeakyReluFwdOp(Op):
 
     _op_name = "leaky_relu"
     _wrapped = None
+    # Manifest: flops = "3 * N" (compare + mul + select per element).
+    FLOPS_PER_ELEM = 3
 
     def __init__(self, N_total: int, dtype: torch.dtype, negative_slope: float = 0.01):
         _validate_scalar_param_repr("negative_slope", negative_slope, dtype, self._op_name)
@@ -1646,6 +1662,11 @@ class LeakyReluFwdOp(Op):
     @property
     def default_kernel_map(self):
         return {"leaky_relu": LeakyReluFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1676,6 +1697,8 @@ class EluFwdOp(Op):
 
     _op_name = "elu"
     _wrapped = None
+    # Manifest: flops = "5 * N" (compare + (exp + sub + mul) + scale).
+    FLOPS_PER_ELEM = 5
 
     def __init__(self, N_total: int, dtype: torch.dtype, alpha: float = 1.0):
         _validate_scalar_param_repr("alpha", alpha, dtype, self._op_name)
@@ -1689,6 +1712,11 @@ class EluFwdOp(Op):
     @property
     def default_kernel_map(self):
         return {"elu": EluFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1720,6 +1748,8 @@ class HardtanhFwdOp(Op):
 
     _op_name = "hardtanh"
     _wrapped = None
+    # Manifest: flops = "4 * N" (2 compares + 2 selects per element).
+    FLOPS_PER_ELEM = 4
 
     def __init__(self, N_total: int, dtype: torch.dtype,
                  min_val: float = -1.0, max_val: float = 1.0):
@@ -1736,6 +1766,11 @@ class HardtanhFwdOp(Op):
     @property
     def default_kernel_map(self):
         return {"hardtanh": HardtanhFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1767,6 +1802,8 @@ class SoftplusFwdOp(Op):
 
     _op_name = "softplus"
     _wrapped = None
+    # Manifest: flops = "6 * N" (mul + threshold cmp + exp + log1p + div).
+    FLOPS_PER_ELEM = 6
 
     def __init__(self, N_total: int, dtype: torch.dtype,
                  beta: float = 1.0, threshold: float = 20.0):
@@ -1783,6 +1820,11 @@ class SoftplusFwdOp(Op):
     @property
     def default_kernel_map(self):
         return {"softplus": SoftplusFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape
@@ -1971,9 +2013,11 @@ class ClampFwdOp(_ClampTensorBase):
 
     Args:
         input: Shape of the input tensor.
+        dtype: Torch dtype for all operands.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune (forwarded to the underlying kernel).
         min: Shape of the lower-bound tensor, or ``None`` for no lower bound.
         max: Shape of the upper-bound tensor, or ``None`` for no upper bound.
-        dtype: Torch dtype for all operands.
 
     Raises:
         ValueError: If both ``min`` and ``max`` are ``None``.
@@ -1981,13 +2025,20 @@ class ClampFwdOp(_ClampTensorBase):
 
     _op_name = "clamp"
     _wrapped = None
+    # Conservative roofline upper bound: 4 fp ops per element (2 compares
+    # + 2 selects). When only one bound is provided the actual cost halves
+    # to 2*N, but 4*N matches the manifest's two-sided clamp convention.
+    FLOPS_PER_ELEM = 4
 
     def __init__(
         self,
         input: tuple,  # noqa: A002 — manifest-aligned PyTorch param name
+        dtype: torch.dtype = torch.float32,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
         min: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
         max: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
-        dtype: torch.dtype = torch.float32,
     ):
         if min is None and max is None:
             raise ValueError(
@@ -1998,6 +2049,7 @@ class ClampFwdOp(_ClampTensorBase):
         self.min_shape = None if min is None else tuple(min)
         self.max_shape = None if max is None else tuple(max)
         self.dtype = dtype
+        self.tune = tune
         broadcast_args = [self.input_shape]
         if self.min_shape is not None:
             broadcast_args.append(self.min_shape)
@@ -2005,7 +2057,9 @@ class ClampFwdOp(_ClampTensorBase):
             broadcast_args.append(self.max_shape)
         self.out_shape = tuple(torch.broadcast_shapes(*broadcast_args))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
+        self.dispatch_kernel(kernel_map)
+        clamp_tensor_cls = self.kernel_map["clamp_tensor"]
+        self.kernel = clamp_tensor_cls(
             self.N_total, dtype,
             has_min=self.min_shape is not None,
             has_max=self.max_shape is not None,
@@ -2016,6 +2070,11 @@ class ClampFwdOp(_ClampTensorBase):
     @property
     def default_kernel_map(self):
         return {"clamp_tensor": ClampTensorFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(
         self,
@@ -2079,25 +2138,35 @@ class ClampMinFwdOp(_ClampTensorBase):
 
     Args:
         input: Shape of the input tensor.
-        min: Shape of the lower-bound tensor.
         dtype: Torch dtype.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune.
+        min: Shape of the lower-bound tensor.
     """
 
     _op_name = "clamp_min"
     _wrapped = None
+    # Single-sided clamp: 1 compare + 1 select per element.
+    FLOPS_PER_ELEM = 2
 
     def __init__(
         self,
         input: tuple,  # noqa: A002
-        min: tuple,    # noqa: A002
         dtype: torch.dtype,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        min: tuple,    # noqa: A002
     ):
         self.input_shape = tuple(input)
         self.min_shape = tuple(min)
         self.dtype = dtype
+        self.tune = tune
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.min_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
+        self.dispatch_kernel(kernel_map)
+        clamp_tensor_cls = self.kernel_map["clamp_tensor"]
+        self.kernel = clamp_tensor_cls(
             self.N_total, dtype, has_min=True, has_max=False,
         )
         self._instance_key = id(self)
@@ -2106,6 +2175,11 @@ class ClampMinFwdOp(_ClampTensorBase):
     @property
     def default_kernel_map(self):
         return {"clamp_tensor": ClampTensorFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(
         self, input: torch.Tensor, min: torch.Tensor,  # noqa: A002
@@ -2144,25 +2218,35 @@ class ClampMaxFwdOp(_ClampTensorBase):
 
     Args:
         input: Shape of the input tensor.
-        max: Shape of the upper-bound tensor.
         dtype: Torch dtype.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune.
+        max: Shape of the upper-bound tensor.
     """
 
     _op_name = "clamp_max"
     _wrapped = None
+    # Single-sided clamp: 1 compare + 1 select per element.
+    FLOPS_PER_ELEM = 2
 
     def __init__(
         self,
         input: tuple,  # noqa: A002
-        max: tuple,    # noqa: A002
         dtype: torch.dtype,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        max: tuple,    # noqa: A002
     ):
         self.input_shape = tuple(input)
         self.max_shape = tuple(max)
         self.dtype = dtype
+        self.tune = tune
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.max_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
+        self.dispatch_kernel(kernel_map)
+        clamp_tensor_cls = self.kernel_map["clamp_tensor"]
+        self.kernel = clamp_tensor_cls(
             self.N_total, dtype, has_min=False, has_max=True,
         )
         self._instance_key = id(self)
@@ -2171,6 +2255,11 @@ class ClampMaxFwdOp(_ClampTensorBase):
     @property
     def default_kernel_map(self):
         return {"clamp_tensor": ClampTensorFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(
         self, input: torch.Tensor, max: torch.Tensor,  # noqa: A002
@@ -2209,20 +2298,29 @@ class ClampScalarFwdOp(Op):
 
     Args:
         input: Shape of the input tensor.
+        dtype: Torch dtype.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune.
         min: Lower bound (Number or None).
         max: Upper bound (Number or None).
-        dtype: Torch dtype.
     """
 
     _op_name = "clamp"
     _wrapped = None
+    # Manifest: flops = "4 * N" (2 compares + 2 selects per element). When
+    # only one bound is provided the actual cost halves to 2*N, but 4*N is
+    # the upper bound matching the manifest's two-sided clamp convention.
+    FLOPS_PER_ELEM = 4
 
     def __init__(
         self,
         input: tuple,  # noqa: A002
+        dtype: torch.dtype = torch.float32,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
         min: Optional[float] = None,  # noqa: A002
         max: Optional[float] = None,  # noqa: A002
-        dtype: torch.dtype = torch.float32,
     ):
         if min is None and max is None:
             raise ValueError(
@@ -2236,18 +2334,26 @@ class ClampScalarFwdOp(Op):
         self.input_shape = tuple(input)
         self.N_total = prod(self.input_shape) if self.input_shape else 1
         self.dtype = dtype
+        self.tune = tune
         self.min = min
         self.max = max
         # Backwards-compat aliases for legacy callers.
         self.min_val = min
         self.max_val = max
-        self.kernel = ClampFwdKernel(self.N_total, dtype, min_val=min, max_val=max)
+        self.dispatch_kernel(kernel_map)
+        clamp_cls = self.kernel_map["clamp"]
+        self.kernel = clamp_cls(self.N_total, dtype, min_val=min, max_val=max)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
         return {"clamp": ClampFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
         orig_shape = input.shape
@@ -2457,6 +2563,8 @@ class NanToNumFwdOp(Op):
 
     _op_name = "nan_to_num"
     _wrapped = None
+    # Manifest: flops = "6 * N" (isnan + isposinf + isneginf + 3 selects).
+    FLOPS_PER_ELEM = 6
 
     def __init__(self, N_total: int, dtype: torch.dtype,
                  nan_val: float = 0.0, posinf_val: float = 1e4, neginf_val: float = -1e4):
@@ -2477,6 +2585,11 @@ class NanToNumFwdOp(Op):
     @property
     def default_kernel_map(self):
         return {"nan_to_num": NanToNumFwdKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return ``(flops, bytes)`` for this op instance."""
+        elem = self.dtype.itemsize
+        return self.FLOPS_PER_ELEM * self.N_total, 2 * self.N_total * elem
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -2335,6 +2335,7 @@ class ClampScalarFwdOp(Op):
         if max is not None:
             _validate_scalar_param_repr("max", max, dtype, self._op_name)
         self.input_shape = tuple(input)
+        self.out_shape = self.input_shape
         self.N_total = prod(self.input_shape) if self.input_shape else 1
         self.dtype = dtype
         self.tune = tune


### PR DESCRIPTION
Closes #1192

## Summary

- Aligned 16 ops in `elementwise_unary_activation` family to manifest spec: 4 Clamp ops + 12 spec-only ops (Sigmoid, SiLU, GELU variants, ELU, SELU, CELU, ReLU6, HardSigmoid, HardSwish, Mish, Softplus, etc.).
- Removed Clamp family ctor drift; canonical signature now `(input, dtype, *, kernel_map=None, tune=False, **op_specific)`.
- Scaffolded impl + test + bench for the 12 previously spec-only ops; conformance tests reference manifest-declared signatures and dtype contract.
- Routed `ClampFwdOp.eval_roofline` through manifest formulas, branching on bound presence (min-only / max-only / both).
- Manifest left untouched (trust-model boundary): all 12 spec-only entries remain `status: spec-only` in `tileops/manifest/elementwise_unary_activation.yaml`; sibling status-flip PR will acknowledge the contract.

## Test plan

- [x] AC-1: `pre-commit run --all-files` passes; `pytest tests/ops/test_special_elementwise_conformance.py` passes (60/60).
- [x] AC-2: `git diff --name-only main..HEAD` confined to `tileops/ops/`, `tests/`, `benchmarks/`; zero files under `tileops/manifest/` or `tileops/kernels/`.
- [x] AC-3: Clamp family ctor signatures match canonical `UnaryOp` pattern (verified via `inspect.signature`).
- [x] AC-4: 12 spec-only ops have impl + test + bench; tests reference manifest-declared signatures + dtype contract.
- [x] AC-5: Each touched bench file produces numbers; no correctness assertions; no imports from `tests/` or `workloads/oracle*`.
- [x] AC-6: Manifest `status` for the 16 ops in `elementwise_unary_activation.yaml` is unchanged.

## Structural Readiness

All checks passed.

## Benchmark

**Environment**: smoke-mode benchmark execution under nightshift CI runner (no profiling-grade numbers in this PR; scaffolds only).

Benchmark smoke results:

- `pytest -q benchmarks/ops/bench_independent_elementwise.py -m smoke` → 16 passed.
- `TMPDIR=$PWD/.tmp pytest -q benchmarks/ops/bench_activation.py -m smoke` → 3 passed (TMPDIR override required because `/tmp/tvm-debug-mode-tempdirs` is not writable in this environment).

**Takeaways:** scaffolds wired correctly — every op records via `BenchmarkReport.record(op, ...)` against the Op object, manifest-driven `load_workloads(...)` calls match the validator's AST inspection, and Clamp roofline now branches on bound presence so partial-bound instances no longer report 2*N flops. Profiling-grade numbers are out of scope for the family-alignment PR; sibling status-flip PR will surface them once each spec-only entry is promoted.

**Command:** `pytest -q benchmarks/ops/bench_independent_elementwise.py -m smoke && TMPDIR=$PWD/.tmp pytest -q benchmarks/ops/bench_activation.py -m smoke`
