### PR TITLE
[Feat][Ops] align elementwise_unary_activation impl + scaffolding to manifest spec

### DIFF
--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -119,8 +119,16 @@ class UnaryBenchmark(BenchmarkBase[_UnaryWorkload]):
         if self._op is not None:
             eval_fn = getattr(self._op, "eval_roofline", None)
             if eval_fn is not None:
-                flops, _ = eval_fn()
-                return float(flops)
+                # The base ``Op.eval_roofline`` raises ``NotImplementedError``
+                # so subclasses must opt in. Fall through to the per-elem
+                # path when the op inherits the unimplemented stub rather
+                # than crashing the bench.
+                try:
+                    flops, _ = eval_fn()
+                except NotImplementedError:
+                    pass
+                else:
+                    return float(flops)
             per_elem = getattr(self._op, "FLOPS_PER_ELEM", None)
             if per_elem is not None:
                 return float(per_elem) * self.workload.n_total

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -25,6 +25,7 @@ from tileops.kernels.elementwise import (
     ReluFwdKernel,
     _make_unary_explicit,
 )
+from tileops.manifest import load_manifest
 from tileops.ops.elementwise import (
     ErfFwdOp,
     GeluFwdOp,
@@ -383,13 +384,44 @@ _R6_KERNEL_OPS = [
     ("mish", MishFwdKernel),
 ]
 
-# Per-op FLOP coefficients drawn from the manifest roofline column. Used
-# by the kernel-direct benches (R6 / R7) where there is no Op instance
-# from which to read ``eval_roofline()``.
+
+def _flops_per_elem_from_manifest(op_key: str) -> int:
+    """Read ``roofline.flops`` for *op_key* and return the per-element coefficient.
+
+    The kernel-direct benches (R6 / R7) build kernels without an Op
+    instance, so they cannot call ``op.eval_roofline()``. Reading the
+    coefficient from the manifest at import time keeps the bench column
+    aligned with the manifest contract and prevents drift from a
+    hand-maintained mirror table.
+
+    Supports the simple shapes used by the unary activation manifest:
+    ``"N"`` (-> 1) and ``"<int> * N"`` (-> the integer). Raises if the
+    expression uses a form this helper does not recognize so that any
+    future manifest extension fails loudly here rather than silently
+    drifting again.
+    """
+    flops_expr = load_manifest()[op_key]["roofline"]["flops"]
+    expr = flops_expr.replace(" ", "")
+    if expr == "N":
+        return 1
+    if expr.endswith("*N"):
+        coeff = expr[:-2]
+        if coeff.isdigit():
+            return int(coeff)
+    raise ValueError(
+        f"unsupported manifest roofline.flops form for {op_key!r}: "
+        f"{flops_expr!r}; extend _flops_per_elem_from_manifest to "
+        f"handle this shape."
+    )
+
+
+# Per-op FLOP coefficients derived from the manifest roofline column at
+# import time. Used by the kernel-direct benches (R6 / R7) where there
+# is no Op instance from which to read ``eval_roofline()``.
 _MANIFEST_FLOPS_PER_ELEM = {
-    "relu": 2,
-    "erf": 8,
-    "mish": 7,
+    "relu": _flops_per_elem_from_manifest("ReluFwdOp"),
+    "erf": _flops_per_elem_from_manifest("ErfFwdOp"),
+    "mish": _flops_per_elem_from_manifest("MishFwdOp"),
 }
 
 _R6_THREADS = [128, 256]

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -93,9 +93,39 @@ class UnaryBenchCase:
 
 
 class UnaryBenchmark(BenchmarkBase[_UnaryWorkload]):
-    """Bandwidth-oriented benchmark for unary elementwise ops."""
+    """Bandwidth-oriented benchmark for unary elementwise ops.
+
+    The default FLOP count is ``n_total`` (one fp op per element) which
+    matches the simplest manifest entries (``flops: "N"`` for ``neg``,
+    ``abs``, etc.). Activations and other transcendental ops declare
+    higher manifest coefficients (``sigmoid: 4*N``, ``mish: 7*N``) and
+    must construct the bench with ``flops_per_elem=`` (or pass
+    ``op=`` and let the bench read the op's ``eval_roofline()``) so the
+    TFLOPs column reflects the manifest contract.
+    """
+
+    def __init__(
+        self,
+        workload: _UnaryWorkload,
+        *,
+        flops_per_elem: Optional[int] = None,
+        op: Optional[object] = None,
+    ):
+        super().__init__(workload)
+        self._flops_per_elem = flops_per_elem
+        self._op = op
 
     def calculate_flops(self) -> Optional[float]:
+        if self._op is not None:
+            eval_fn = getattr(self._op, "eval_roofline", None)
+            if eval_fn is not None:
+                flops, _ = eval_fn()
+                return float(flops)
+            per_elem = getattr(self._op, "FLOPS_PER_ELEM", None)
+            if per_elem is not None:
+                return float(per_elem) * self.workload.n_total
+        if self._flops_per_elem is not None:
+            return float(self._flops_per_elem) * self.workload.n_total
         return self.workload.n_total
 
     def calculate_memory(self) -> Optional[float]:
@@ -121,11 +151,11 @@ class R2SmallTensorFixture(FixtureBase):
 def test_r2_small_tensor_unary(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     """R2: Benchmark divmod overhead on small tensors (unary relu, 4K)."""
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
     op = ReluFwdOp(N_total=n_total, dtype=dtype)
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -181,7 +211,7 @@ def test_r3_jit_compilation_cost(shape: tuple[int, ...]) -> None:
 
     # Warm: profile subsequent calls
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
+    bm = UnaryBenchmark(test, op=op)
     warm_result = bm.profile(op, x)
 
     BenchmarkReport.record(
@@ -229,11 +259,11 @@ def test_r4_default_strategy_unary(
 ) -> None:
     """R4: Benchmark all 3 unary strategies to confirm DEFAULT_STRATEGY."""
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
     op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_strategy_unary",
@@ -273,11 +303,11 @@ def test_r4_default_strategy_gelu(
 ) -> None:
     """R4: Benchmark gelu strategies (transcendental op) to confirm DEFAULT_STRATEGY."""
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
     op = GeluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_strategy_gelu",
@@ -320,11 +350,11 @@ def test_r5_boundary_guard(shape: tuple[int, ...], align_label: str) -> None:
     """
     dtype = torch.float16
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
     op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy="explicit_parallel")
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r5_boundary",
@@ -344,6 +374,15 @@ _R6_KERNEL_OPS = [
     ("erf", ErfFwdKernel),
     ("mish", MishFwdKernel),
 ]
+
+# Per-op FLOP coefficients drawn from the manifest roofline column. Used
+# by the kernel-direct benches (R6 / R7) where there is no Op instance
+# from which to read ``eval_roofline()``.
+_MANIFEST_FLOPS_PER_ELEM = {
+    "relu": 2,
+    "erf": 8,
+    "mish": 7,
+}
 
 _R6_THREADS = [128, 256]
 
@@ -391,7 +430,9 @@ def test_r6_threads_comparison(
     dtype = torch.float16
     dtype_str = "float16"
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
+    bm = UnaryBenchmark(
+        test, flops_per_elem=_MANIFEST_FLOPS_PER_ELEM[op_name],
+    )
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
@@ -461,7 +502,9 @@ def test_r7_dtype_npt(
     threads = 256
     dtype_str = "float32" if dtype == torch.float32 else "float16"
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
+    bm = UnaryBenchmark(
+        test, flops_per_elem=_MANIFEST_FLOPS_PER_ELEM["relu"],
+    )
     inputs = test.gen_inputs()
 
     # Build kernel directly with the desired threads/npt so block_size is correct
@@ -498,10 +541,10 @@ def test_relu_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     # ``ReluTest`` (workloads) accepts a flat element count; the bench
     # harness still records the original shape tuple via ``record(...)``.
     test = ReluTest(n_total, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     op = ReluFwdOp(N_total=n_total, dtype=dtype)
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -550,10 +593,15 @@ def test_param_free_unary_bench(
     shape = _SHAPES_2D[1]  # (1024, 4096), LLaMA hidden dim
     n_total = prod(shape)
     test = UnaryBenchCase(shape, dtype)
-    bm = UnaryBenchmark(test)
     inputs = test.gen_inputs()
 
     op = op_cls(N_total=n_total, dtype=dtype)
+    # Pass ``op=`` so UnaryBenchmark reads ``op.eval_roofline()`` /
+    # ``FLOPS_PER_ELEM`` and reports manifest-aligned TFLOPs (e.g. SiLU
+    # 4*N, Mish 7*N, SELU 5*N) rather than the bandwidth-only 1*N
+    # default. The torch baseline is profiled with the same harness so
+    # both rows share the same FLOP normalization.
+    bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -521,22 +521,31 @@ def test_relu_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
 
 
 _PARAM_FREE_ACTIVATION_OPS = [
-    pytest.param(SiluFwdOp, "silu", id="silu"),
-    pytest.param(HardswishFwdOp, "hardswish", id="hardswish"),
-    pytest.param(HardsigmoidFwdOp, "hardsigmoid", id="hardsigmoid"),
-    pytest.param(MishFwdOp, "mish", id="mish"),
-    pytest.param(SeluFwdOp, "selu", id="selu"),
+    pytest.param(SiluFwdOp, "silu", torch.nn.functional.silu, id="silu"),
+    pytest.param(
+        HardswishFwdOp, "hardswish", torch.nn.functional.hardswish, id="hardswish",
+    ),
+    pytest.param(
+        HardsigmoidFwdOp, "hardsigmoid", torch.nn.functional.hardsigmoid,
+        id="hardsigmoid",
+    ),
+    pytest.param(MishFwdOp, "mish", torch.nn.functional.mish, id="mish"),
+    pytest.param(SeluFwdOp, "selu", torch.nn.functional.selu, id="selu"),
 ]
 
 
-@pytest.mark.parametrize("op_cls, op_label", _PARAM_FREE_ACTIVATION_OPS)
+@pytest.mark.parametrize("op_cls, op_label, torch_ref", _PARAM_FREE_ACTIVATION_OPS)
 @pytest.mark.parametrize("dtype", [torch.float16])
-def test_param_free_unary_bench(op_cls, op_label: str, dtype: torch.dtype) -> None:
+def test_param_free_unary_bench(
+    op_cls, op_label: str, torch_ref, dtype: torch.dtype,
+) -> None:
     """Throughput bench for param-free unary activations (manifest-aligned).
 
     One representative shape × fp16 keeps each op covered for AC-5
     ("each touched bench file produces numbers; no correctness
-    assertions") without expanding the matrix.
+    assertions") without expanding the matrix. Records both the TileOps
+    op and the matching ``torch.nn.functional`` reference so each row
+    has an external baseline per the benchmark contract.
     """
     shape = _SHAPES_2D[1]  # (1024, 4096), LLaMA hidden dim
     n_total = prod(shape)
@@ -547,6 +556,12 @@ def test_param_free_unary_bench(op_cls, op_label: str, dtype: torch.dtype) -> No
     op = op_cls(N_total=n_total, dtype=dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch_ref(x)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -25,7 +25,16 @@ from tileops.kernels.elementwise import (
     ReluFwdKernel,
     _make_unary_explicit,
 )
-from tileops.ops.elementwise import ErfFwdOp, GeluFwdOp, MishFwdOp, ReluFwdOp
+from tileops.ops.elementwise import (
+    ErfFwdOp,
+    GeluFwdOp,
+    HardsigmoidFwdOp,
+    HardswishFwdOp,
+    MishFwdOp,
+    ReluFwdOp,
+    SeluFwdOp,
+    SiluFwdOp,
+)
 from workloads.activation import ReluTest
 from workloads.workload_base import FixtureBase
 
@@ -501,6 +510,43 @@ def test_relu_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
 
     result_bl = bm.profile(baseline_fn, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ---------------------------------------------------------------------------
+# Throughput coverage for the param-free unary activations declared in
+# tileops/manifest/elementwise_unary_activation.yaml. Each op gets a single
+# fp16 case at the LLaMA hidden-dim shape so the bench file produces a
+# number for downstream perf tracking without inflating CI runtime.
+# ---------------------------------------------------------------------------
+
+
+_PARAM_FREE_ACTIVATION_OPS = [
+    pytest.param(SiluFwdOp, "silu", id="silu"),
+    pytest.param(HardswishFwdOp, "hardswish", id="hardswish"),
+    pytest.param(HardsigmoidFwdOp, "hardsigmoid", id="hardsigmoid"),
+    pytest.param(MishFwdOp, "mish", id="mish"),
+    pytest.param(SeluFwdOp, "selu", id="selu"),
+]
+
+
+@pytest.mark.parametrize("op_cls, op_label", _PARAM_FREE_ACTIVATION_OPS)
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_param_free_unary_bench(op_cls, op_label: str, dtype: torch.dtype) -> None:
+    """Throughput bench for param-free unary activations (manifest-aligned).
+
+    One representative shape × fp16 keeps each op covered for AC-5
+    ("each touched bench file produces numbers; no correctness
+    assertions") without expanding the matrix.
+    """
+    shape = _SHAPES_2D[1]  # (1024, 4096), LLaMA hidden dim
+    n_total = prod(shape)
+    test = UnaryBenchCase(shape, dtype)
+    bm = UnaryBenchmark(test)
+    inputs = test.gen_inputs()
+
+    op = op_cls(N_total=n_total, dtype=dtype)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -298,6 +298,33 @@ def test_nan_to_num_e5m2_overflow_scalar_params_rejected():
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(torch.float8_e4m3fn, id="e4m3fn"),
+        pytest.param(torch.float8_e5m2, id="e5m2"),
+    ],
+)
+def test_nan_to_num_fp8_default_ctor_accepts_dtype_sentinels(dtype):
+    """NanToNumFwdOp default ctor must succeed for fp8 dtypes.
+
+    Regression guard: when ``posinf`` / ``neginf`` are left at their
+    manifest default ``None``, the op must NOT validate the legacy
+    fp16-shaped sentinels (1e4 / -1e4) against the narrow fp8 range.
+    Instead, it forwards +/-inf to the kernel, which clamps to the
+    effective output dtype's finite range.
+    """
+    from tileops.ops.elementwise import NanToNumFwdOp
+
+    op = NanToNumFwdOp(N_total=8, dtype=dtype)
+    assert op.posinf is None
+    assert op.neginf is None
+    out_finfo = torch.finfo(op.kernel.output_dtype)
+    assert op.kernel.posinf_val == out_finfo.max
+    assert op.kernel.neginf_val == out_finfo.min
+
+
+@pytest.mark.smoke
 def test_leaky_relu_e5m2_overflow_negative_slope_rejected():
     """LeakyReLU rejects negative_slope that exceeds effective kernel dtype range."""
     from tileops.ops.elementwise import LeakyReluFwdOp

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -286,7 +286,7 @@ def test_masked_fill_e5m2_overflow_fill_value():
 
 @pytest.mark.smoke
 def test_nan_to_num_e5m2_overflow_scalar_params_rejected():
-    """NanToNum rejects replacement values that exceed effective kernel dtype range."""
+    """NanToNum rejects replacement values that exceed user-facing dtype range."""
     from tileops.ops.elementwise import NanToNumFwdOp
 
     n = 1024
@@ -297,6 +297,34 @@ def test_nan_to_num_e5m2_overflow_scalar_params_rejected():
         NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1e5, neginf_val=-1.0)
     with pytest.raises(ValueError, match=r"neginf=.*not representable"):
         NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1.0, neginf_val=-1e5)
+
+
+@pytest.mark.smoke
+def test_nan_to_num_e5m2_rejects_value_above_fp8_max_but_within_fp16():
+    """fp8 explicit replacements must validate against the user-facing dtype.
+
+    ``torch.finfo(torch.float8_e5m2).max`` is 57344.0 while
+    ``torch.finfo(torch.float16).max`` is 65504.0. A replacement like
+    60000.0 fits in the kernel's intermediate fp16 buffer but overflows
+    on the fp8 post-cast and surfaces as ``+Inf``. Validation must
+    therefore target the *user-facing* dtype, not the intermediate, so
+    callers learn at construction time that the value is unsafe.
+    """
+    from tileops.ops.elementwise import NanToNumFwdOp
+
+    n = 1024
+    dtype = torch.float8_e5m2
+    fp8_max = torch.finfo(dtype).max  # 57344.0
+    fp16_max = torch.finfo(torch.float16).max  # 65504.0
+    above_fp8 = 60000.0
+    assert fp8_max < above_fp8 < fp16_max, (
+        "Test premise: 60000 must lie strictly between fp8_e5m2 max "
+        f"({fp8_max}) and fp16 max ({fp16_max})"
+    )
+    with pytest.raises(ValueError, match=r"posinf=.*not representable"):
+        NanToNumFwdOp(N_total=n, dtype=dtype, posinf=above_fp8)
+    with pytest.raises(ValueError, match=r"neginf=.*not representable"):
+        NanToNumFwdOp(N_total=n, dtype=dtype, neginf=-above_fp8)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -291,9 +291,11 @@ def test_nan_to_num_e5m2_overflow_scalar_params_rejected():
 
     n = 1024
     dtype = torch.float8_e5m2
-    with pytest.raises(ValueError, match="posinf_val=.*not representable"):
+    # Validation messages use the canonical manifest-aligned names
+    # (``posinf`` / ``neginf``) regardless of which alias the user passes.
+    with pytest.raises(ValueError, match=r"posinf=.*not representable"):
         NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1e5, neginf_val=-1.0)
-    with pytest.raises(ValueError, match="neginf_val=.*not representable"):
+    with pytest.raises(ValueError, match=r"neginf=.*not representable"):
         NanToNumFwdOp(N_total=n, dtype=dtype, nan_val=0.0, posinf_val=1.0, neginf_val=-1e5)
 
 
@@ -312,16 +314,64 @@ def test_nan_to_num_fp8_default_ctor_accepts_dtype_sentinels(dtype):
     manifest default ``None``, the op must NOT validate the legacy
     fp16-shaped sentinels (1e4 / -1e4) against the narrow fp8 range.
     Instead, it forwards +/-inf to the kernel, which clamps to the
-    effective output dtype's finite range.
+    *final* user-facing dtype's finite range — i.e. the dtype the caller
+    actually sees after the Op-layer post-cast, not the kernel's fp16
+    intermediate. For e5m2 that is 57344.0; clamping to fp16's 65504.0
+    would round to +Inf on the cast back to e5m2.
     """
     from tileops.ops.elementwise import NanToNumFwdOp
 
     op = NanToNumFwdOp(N_total=8, dtype=dtype)
     assert op.posinf is None
     assert op.neginf is None
-    out_finfo = torch.finfo(op.kernel.output_dtype)
-    assert op.kernel.posinf_val == out_finfo.max
-    assert op.kernel.neginf_val == out_finfo.min
+    # The clamp targets the final user-facing dtype.
+    final_dtype = op.kernel._fp8_output_dtype or op.kernel.output_dtype
+    assert final_dtype == dtype
+    final_finfo = torch.finfo(final_dtype)
+    assert op.kernel.posinf_val == final_finfo.max
+    assert op.kernel.neginf_val == final_finfo.min
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(torch.float8_e4m3fn, id="e4m3fn"),
+        pytest.param(torch.float8_e5m2, id="e5m2"),
+    ],
+)
+def test_nan_to_num_fp8_default_replaces_inf_with_finite(dtype):
+    """End-to-end: default ``+/-inf`` sentinels produce finite outputs.
+
+    Constructs the op with the manifest default (``posinf=None`` /
+    ``neginf=None``), feeds an input containing ``+/-inf`` and ``NaN``,
+    and asserts the *final* op output is entirely finite. This catches
+    the regression where the e5m2 path round-tripped through fp16's
+    65504.0 sentinel and then overflowed to ``Inf`` on the cast back to
+    e5m2 (whose max is 57344.0).
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from tileops.ops.elementwise import NanToNumFwdOp
+
+    n = 1024
+    op = NanToNumFwdOp(N_total=n, dtype=dtype)
+    x_fp16 = torch.empty(n, dtype=torch.float16, device="cuda")
+    x_fp16.fill_(0.0)
+    x_fp16[0] = float("inf")
+    x_fp16[1] = float("-inf")
+    x_fp16[2] = float("nan")
+    x = x_fp16.to(dtype)
+
+    out = op(x)
+    assert out.dtype == dtype
+    # Every replaced position must be finite in the final dtype.
+    finite_mask = torch.isfinite(out.to(torch.float32))
+    assert finite_mask.all(), (
+        f"NanToNum default sentinels surfaced non-finite output for {dtype}: "
+        f"out[0]={out[0].item()}, out[1]={out[1].item()}, out[2]={out[2].item()}"
+    )
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_elementwise_independent_fp8.py
+++ b/tests/ops/test_elementwise_independent_fp8.py
@@ -341,11 +341,13 @@ def test_nan_to_num_fp8_default_ctor_accepts_dtype_sentinels(dtype):
     Regression guard: when ``posinf`` / ``neginf`` are left at their
     manifest default ``None``, the op must NOT validate the legacy
     fp16-shaped sentinels (1e4 / -1e4) against the narrow fp8 range.
-    Instead, it forwards +/-inf to the kernel, which clamps to the
-    *final* user-facing dtype's finite range — i.e. the dtype the caller
-    actually sees after the Op-layer post-cast, not the kernel's fp16
-    intermediate. For e5m2 that is 57344.0; clamping to fp16's 65504.0
-    would round to +Inf on the cast back to e5m2.
+    Instead, the Op layer resolves ``None`` to the *final* user-facing
+    dtype's finite extrema (``torch.finfo(dtype).max`` / ``.min``) and
+    passes those finite values to the kernel — i.e. clamping targets
+    the dtype the caller actually sees after the Op-layer post-cast,
+    not the kernel's fp16 intermediate. For e5m2 that is 57344.0;
+    clamping to fp16's 65504.0 would round to +Inf on the cast back to
+    e5m2.
     """
     from tileops.ops.elementwise import NanToNumFwdOp
 

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -292,6 +292,28 @@ def test_unary_activation_inplace_true_aliases_input(op_name: str) -> None:
     )
 
 
+@pytest.mark.smoke
+def test_apply_inplace_numel_mismatch_raises_value_error() -> None:
+    """``_InplaceMixin._apply_inplace`` rejects numel mismatches with a ValueError.
+
+    Locks the docstring contract: broadcasting is not supported on the
+    inplace path, and the failure surface is ``ValueError`` (not the
+    ``RuntimeError`` that would bubble up from a bare ``Tensor.reshape``
+    call).
+    """
+    import tileops.ops.elementwise as mod
+
+    apply_inplace = mod._InplaceMixin._apply_inplace
+    a = torch.empty(8, dtype=torch.float32)
+    b = torch.empty(7, dtype=torch.float32)
+    with pytest.raises(ValueError, match="numel"):
+        apply_inplace(True, a, b)
+    # dtype mismatch path (already a ValueError) — guard against regression.
+    c = torch.empty(8, dtype=torch.float16)
+    with pytest.raises(ValueError, match="dtype"):
+        apply_inplace(True, a, c)
+
+
 def _torch_reference(op_name: str):
     """Map an activation op class to its ``torch.nn.functional`` reference."""
     refs = {

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -171,6 +171,14 @@ def test_gelu_approximate_modes_accepted() -> None:
     with pytest.raises(ValueError, match="approximate"):
         mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="invalid")
 
+    # The manifest-allowed ``'tanh'`` value must be accepted by the
+    # constructor rather than rejected. The tanh path skips kernel
+    # construction (no CUDA build) and routes through a torch fallback in
+    # ``_eager_forward``, so this assertion is safe on CPU-only hosts.
+    op_tanh = mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="tanh")
+    assert op_tanh.approximate == "tanh"
+    assert op_tanh.kernel is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -128,6 +128,71 @@ def test_clamp_family_accepts_canonical_kwargs(op_name: str) -> None:
     )
 
 
+def _clamp_construct_kwargs(op_name: str) -> tuple[tuple, dict]:
+    """Return ``(positional, keyword)`` args needed to construct ``op_name``.
+
+    Each Clamp variant has a distinct positional signature:
+
+    +----------------------+--------------------------------------------------+
+    | ``ClampFwdOp``       | ``(input_shape, min_shape, max_shape, dtype)``.  |
+    +----------------------+--------------------------------------------------+
+    | ``ClampScalarFwdOp`` | ``(input_shape,)`` + ``min``/``max`` kwargs.     |
+    +----------------------+--------------------------------------------------+
+    | ``ClampMinFwdOp``    | ``(input_shape, min_shape, dtype)``.             |
+    +----------------------+--------------------------------------------------+
+    | ``ClampMaxFwdOp``    | ``(input_shape, max_shape, dtype)``.             |
+    +----------------------+--------------------------------------------------+
+    """
+    shape = (2, 4)
+    if op_name == "ClampFwdOp":
+        return ((shape, shape, shape, torch.float16), {})
+    if op_name == "ClampScalarFwdOp":
+        return ((shape,), {"min": -1.0, "max": 1.0, "dtype": torch.float16})
+    # ClampMin / ClampMax
+    return ((shape, shape, torch.float16), {})
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("op_name", [op[0] for op in _CLAMP_OPS])
+def test_clamp_family_kernel_map_override_is_dispatched(op_name: str) -> None:
+    """A user-supplied ``kernel_map`` value must reach the kernel build.
+
+    A regression that accepts ``kernel_map=`` in the constructor but
+    silently ignores the override would still pass the signature
+    metadata check above. Construct each Clamp op with a ``kernel_map``
+    whose value is a *subclass* of the default kernel and assert the
+    constructed ``self.kernel`` is an instance of that subclass —
+    ``dispatch_kernel`` always rebuilds the dict, so identity checks
+    on the dict itself are not load-bearing; the load-bearing
+    invariant is that the override class is the one actually used to
+    build ``self.kernel``. Skipped without CUDA because constructors
+    JIT-compile the kernel.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    pos, kw = _clamp_construct_kwargs(op_name)
+    # Read ``default_kernel_map`` from a baseline instance so we know
+    # which key/class pair to override with a marker subclass.
+    inst = cls(*pos, **kw)
+    (key, default_kernel_cls), = inst.default_kernel_map.items()
+
+    class MarkerKernel(default_kernel_cls):  # type: ignore[misc, valid-type]
+        """Subclass marker; identical behavior, distinct identity."""
+
+    override = {key: MarkerKernel}
+    inst2 = cls(*pos, **kw, kernel_map=override)
+    assert inst2.kernel_map[key] is MarkerKernel, (
+        f"{op_name}: kernel_map override entry was not stored on "
+        f"self.kernel_map (got {inst2.kernel_map[key]!r})"
+    )
+    assert isinstance(inst2.kernel, MarkerKernel), (
+        f"{op_name}: kernel_map override class was not used to build "
+        f"self.kernel (kernel type: {type(inst2.kernel).__name__})"
+    )
+
+
 @pytest.mark.smoke
 def test_nan_to_num_param_aliases_back_compat() -> None:
     """NanToNumFwdOp must keep ``nan_val`` / ``posinf_val`` / ``neginf_val``
@@ -143,29 +208,104 @@ def test_nan_to_num_param_aliases_back_compat() -> None:
         assert name in keys, f"NanToNumFwdOp.__init__ missing '{name}'; got {keys}"
 
 
-@pytest.mark.smoke
-def test_unary_activation_inplace_default_false() -> None:
-    """Param-free unary activations expose ``inplace=False`` per the manifest.
+_INPLACE_PARAM_FREE_OPS = (
+    "ReluFwdOp", "SiluFwdOp", "HardswishFwdOp",
+    "HardsigmoidFwdOp", "MishFwdOp", "SeluFwdOp",
+)
+_INPLACE_PARAMETRIC_OPS = (
+    "LeakyReluFwdOp", "EluFwdOp", "HardtanhFwdOp",
+)
 
-    The op layer does not implement in-place execution; the kwarg is
-    accepted purely to satisfy the manifest signature contract. Calling
-    with ``inplace=True`` must therefore raise rather than silently
-    return out-of-place output.
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name", _INPLACE_PARAM_FREE_OPS + _INPLACE_PARAMETRIC_OPS,
+)
+def test_unary_activation_inplace_default_false(op_name: str) -> None:
+    """Activations declaring ``inplace`` expose ``inplace=False`` by default.
+
+    Covers every unary activation whose manifest entry declares an
+    ``inplace`` param (param-free ReLU/SiLU/HardSwish/HardSigmoid/Mish/SELU
+    plus the parametric LeakyReLU/ELU/Hardtanh). The op-level
+    ``inplace=True`` semantics are exercised by
+    ``test_unary_activation_inplace_true_aliases_input`` below; this
+    test covers the signature contract and is safe on CPU-only hosts
+    because it only inspects metadata.
     """
     import tileops.ops.elementwise as mod
 
-    for op_name in (
-        "ReluFwdOp", "SiluFwdOp", "HardswishFwdOp",
-        "HardsigmoidFwdOp", "MishFwdOp", "SeluFwdOp",
-    ):
-        cls = getattr(mod, op_name)
-        init_sig = inspect.signature(cls.__init__)
-        assert "inplace" in init_sig.parameters
-        assert init_sig.parameters["inplace"].default is False
-        # Constructing with inplace=True is rejected (not silently ignored)
-        # because the kernels do not support in-place writes.
-        with pytest.raises(NotImplementedError, match="in-place"):
-            cls(N_total=8, dtype=torch.float16, inplace=True)
+    cls = getattr(mod, op_name)
+    init_sig = inspect.signature(cls.__init__)
+    assert "inplace" in init_sig.parameters, (
+        f"{op_name}.__init__ missing 'inplace' kwarg; got {list(init_sig.parameters)}"
+    )
+    inplace_param = init_sig.parameters["inplace"]
+    assert inplace_param.default is False
+    assert inplace_param.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{op_name}.__init__ 'inplace' must be keyword-only, "
+        f"got kind={inplace_param.kind}"
+    )
+
+
+def _construct_inplace_op(mod, op_name: str, n_total: int, dtype: torch.dtype, inplace: bool):
+    """Build an instance with the manifest-spec construction signature."""
+    cls = getattr(mod, op_name)
+    if op_name in _INPLACE_PARAM_FREE_OPS:
+        return cls(N_total=n_total, dtype=dtype, inplace=inplace)
+    if op_name == "LeakyReluFwdOp":
+        return cls(n_total, dtype, inplace=inplace)
+    if op_name == "EluFwdOp":
+        return cls(n_total, dtype, inplace=inplace)
+    if op_name == "HardtanhFwdOp":
+        return cls(n_total, dtype, inplace=inplace)
+    raise AssertionError(f"unexpected op_name {op_name!r}")
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "op_name", _INPLACE_PARAM_FREE_OPS + _INPLACE_PARAMETRIC_OPS,
+)
+def test_unary_activation_inplace_true_aliases_input(op_name: str) -> None:
+    """``inplace=True`` must mutate ``input`` and return the same tensor.
+
+    PyTorch's contract for ``functional.relu(x, inplace=True)`` (and the
+    other activations declaring ``inplace`` in their manifest entry) is
+    that the returned tensor *is* ``x`` and that ``x`` now holds the
+    activation output. Verify both invariants for every activation
+    covered by ``_InplaceMixin``.
+    """
+    import tileops.ops.elementwise as mod
+
+    n_total = 64
+    dtype = torch.float16
+    op = _construct_inplace_op(mod, op_name, n_total, dtype, inplace=True)
+    x = torch.randn(n_total, dtype=dtype, device="cuda")
+    expected = _torch_reference(op_name)(x.clone())
+    y = op(x)
+    assert y is x, (
+        f"{op_name}: inplace=True must return the input tensor (identity); "
+        f"got id(y)={id(y)} id(x)={id(x)}"
+    )
+    assert torch.allclose(x, expected, rtol=1e-2, atol=1e-2), (
+        f"{op_name}: inplace=True did not mutate input to the activation output"
+    )
+
+
+def _torch_reference(op_name: str):
+    """Map an activation op class to its ``torch.nn.functional`` reference."""
+    refs = {
+        "ReluFwdOp": torch.nn.functional.relu,
+        "SiluFwdOp": torch.nn.functional.silu,
+        "HardswishFwdOp": torch.nn.functional.hardswish,
+        "HardsigmoidFwdOp": torch.nn.functional.hardsigmoid,
+        "MishFwdOp": torch.nn.functional.mish,
+        "SeluFwdOp": torch.nn.functional.selu,
+        "LeakyReluFwdOp": torch.nn.functional.leaky_relu,
+        "EluFwdOp": torch.nn.functional.elu,
+        "HardtanhFwdOp": torch.nn.functional.hardtanh,
+    }
+    return refs[op_name]
 
 
 @pytest.mark.smoke
@@ -205,6 +345,33 @@ def test_gelu_approximate_modes_accepted() -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_gelu_approximate_tanh_runs_through_forward() -> None:
+    """GeluFwdOp(approximate='tanh') must dispatch through ``forward()``.
+
+    The earlier signature/metadata check covers ``__init__``; this test
+    closes the gap by exercising the public forward path on CUDA so a
+    regression that breaks ``forward()`` (e.g. routes the tanh op
+    through a kernel that doesn't exist) is caught instead of only
+    surfacing in eager-only callers.
+    """
+    import tileops.ops.elementwise as mod
+
+    n_total = 128
+    dtype = torch.float16
+    op = mod.GeluFwdOp(N_total=n_total, dtype=dtype, approximate="tanh")
+    x = torch.randn(n_total, dtype=dtype, device="cuda")
+    y = op(x)
+    expected = torch.nn.functional.gelu(x, approximate="tanh")
+    assert y.shape == x.shape
+    assert y.dtype == x.dtype
+    assert torch.allclose(y, expected, rtol=1e-2, atol=1e-2), (
+        "GeluFwdOp(approximate='tanh').forward must match "
+        "torch.nn.functional.gelu(approximate='tanh') on CUDA"
+    )
+
+
+@pytest.mark.smoke
 def test_gelu_tanh_rejects_unsupported_dtype() -> None:
     """tanh fallback must enforce the same dtype gate as the kernel path.
 
@@ -217,6 +384,43 @@ def test_gelu_tanh_rejects_unsupported_dtype() -> None:
 
     with pytest.raises(ValueError, match=r"gelu does not support dtype"):
         mod.GeluFwdOp(N_total=8, dtype=torch.int32, approximate="tanh")
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name, expected_per_elem",
+    [
+        ("ReluFwdOp", 2),
+        ("SiluFwdOp", 4),
+        ("HardswishFwdOp", 7),
+        ("HardsigmoidFwdOp", 6),
+        ("MishFwdOp", 7),
+        ("SeluFwdOp", 5),
+    ],
+)
+def test_activation_flops_per_elem_matches_manifest(
+    op_name: str, expected_per_elem: int,
+) -> None:
+    """Activation ``FLOPS_PER_ELEM`` must match the manifest roofline coefficient.
+
+    The bench reads ``op.eval_roofline()`` (or ``FLOPS_PER_ELEM`` as a
+    fallback) to report manifest-aligned TFLOPs. This test pins the
+    per-element FLOP coefficient against the manifest's
+    ``roofline.flops`` column for each unary activation, so a regression
+    that silently reverts to the bandwidth-only ``1*N`` default surfaces
+    here instead of producing under-reported TFLOPs in the bench.
+
+    The ``eval_roofline`` return is only inspected for the FLOPs slot
+    (first element); the ``bytes`` slot is covered by the existing
+    elementwise total_memory tests.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    assert getattr(cls, "FLOPS_PER_ELEM", None) == expected_per_elem, (
+        f"{op_name}.FLOPS_PER_ELEM = {getattr(cls, 'FLOPS_PER_ELEM', None)!r}, "
+        f"expected {expected_per_elem} per the manifest roofline.flops"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -1,0 +1,176 @@
+"""Manifest-alignment conformance tests for `elementwise_unary_activation`.
+
+Covers the 16 ops in
+``tileops/manifest/elementwise_unary_activation.yaml`` (12 unary
+activations + 4 Clamp variants). Each test asserts that the live Op
+class signatures match the manifest declaration, mirroring the L1
+signature check in ``scripts.validate_manifest``.
+
+The conformance gate has three parts:
+
+1. Every manifest input must appear (in order) as a ``forward()``
+   parameter.
+2. Every manifest param must appear in either ``__init__()`` or
+   ``forward()``.
+3. The Clamp family (``ClampFwdOp``, ``ClampScalarFwdOp``,
+   ``ClampMinFwdOp``, ``ClampMaxFwdOp``) must accept ``kernel_map=`` and
+   ``tune=`` keyword arguments per the canonical UnaryOp pattern.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+# 12 spec-only ops + 4 Clamp ops = 16 ops in scope.
+_ACTIVATION_OPS = [
+    # (op_class_name, manifest_inputs (forward order), manifest_params)
+    ("ReluFwdOp", ["input"], ["inplace"]),
+    ("GeluFwdOp", ["input"], ["approximate"]),
+    ("SiluFwdOp", ["input"], ["inplace"]),
+    ("HardswishFwdOp", ["input"], ["inplace"]),
+    ("HardsigmoidFwdOp", ["input"], ["inplace"]),
+    ("MishFwdOp", ["input"], ["inplace"]),
+    ("SeluFwdOp", ["input"], ["inplace"]),
+    ("LeakyReluFwdOp", ["input"], ["negative_slope", "inplace"]),
+    ("EluFwdOp", ["input"], ["alpha", "inplace"]),
+    ("HardtanhFwdOp", ["input"], ["min_val", "max_val", "inplace"]),
+    ("SoftplusFwdOp", ["input"], ["beta", "threshold"]),
+    ("NanToNumFwdOp", ["input"], ["nan", "posinf", "neginf"]),
+]
+
+_CLAMP_OPS = [
+    ("ClampFwdOp", ["input", "min", "max"], []),
+    ("ClampScalarFwdOp", ["input"], ["min", "max"]),
+    ("ClampMinFwdOp", ["input", "min"], []),
+    ("ClampMaxFwdOp", ["input", "max"], []),
+]
+
+
+def _explicit_param_names(func) -> list[str]:
+    """Return positional / keyword param names of ``func`` (no *args / **kwargs)."""
+    sig = inspect.signature(func)
+    return [
+        name for name, p in sig.parameters.items()
+        if name != "self"
+        and p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    ]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name, manifest_inputs, manifest_params",
+    _ACTIVATION_OPS + _CLAMP_OPS,
+    ids=lambda v: v if isinstance(v, str) else None,
+)
+def test_activation_signature_matches_manifest(
+    op_name: str, manifest_inputs: list[str], manifest_params: list[str],
+) -> None:
+    """Op class signatures must satisfy the manifest L1 contract."""
+    import tileops.ops.elementwise as mod
+    from scripts.validate_manifest import (
+        _get_forward_params,
+        _get_init_params,
+        check_l1_signature,
+    )
+
+    cls = getattr(mod, op_name)
+    forward_params = _get_forward_params(cls)
+    assert forward_params is not None, (
+        f"Cannot extract forward() params for {op_name}"
+    )
+    init_params = _get_init_params(cls)
+    inputs_dict = {n: {} for n in manifest_inputs}
+    params_dict = {n: {} for n in manifest_params}
+    errors = check_l1_signature(
+        op_name, inputs_dict, params_dict, forward_params,
+        init_params=init_params,
+    )
+    assert errors == [], f"{op_name}: {errors}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_name", [op[0] for op in _CLAMP_OPS])
+def test_clamp_family_accepts_canonical_kwargs(op_name: str) -> None:
+    """Clamp ops must accept canonical ``kernel_map`` and ``tune`` kwargs.
+
+    AC-3: ``(M_or_shape, dtype, *, kernel_map=None, tune=False, **op_specific)``.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    init_sig = inspect.signature(cls.__init__)
+    init_keys = list(init_sig.parameters.keys())
+    assert "kernel_map" in init_keys, (
+        f"{op_name}.__init__ missing canonical 'kernel_map' kwarg; got {init_keys}"
+    )
+    assert "tune" in init_keys, (
+        f"{op_name}.__init__ missing canonical 'tune' kwarg; got {init_keys}"
+    )
+    # Both must be keyword-only with the canonical defaults.
+    assert init_sig.parameters["kernel_map"].default is None
+    assert init_sig.parameters["tune"].default is False
+
+
+@pytest.mark.smoke
+def test_nan_to_num_param_aliases_back_compat() -> None:
+    """NanToNumFwdOp must keep ``nan_val`` / ``posinf_val`` / ``neginf_val``
+    accepted as aliases for the manifest-aligned ``nan`` / ``posinf`` /
+    ``neginf`` so existing call sites keep working during the migration.
+    """
+    import tileops.ops.elementwise as mod
+
+    init_sig = inspect.signature(mod.NanToNumFwdOp.__init__)
+    keys = list(init_sig.parameters.keys())
+    # Manifest-aligned names are the canonical entry points.
+    for name in ("nan", "posinf", "neginf"):
+        assert name in keys, f"NanToNumFwdOp.__init__ missing '{name}'; got {keys}"
+
+
+@pytest.mark.smoke
+def test_unary_activation_inplace_default_false() -> None:
+    """Param-free unary activations expose ``inplace=False`` per the manifest.
+
+    The op layer does not implement in-place execution; the kwarg is
+    accepted purely to satisfy the manifest signature contract. Calling
+    with ``inplace=True`` must therefore raise rather than silently
+    return out-of-place output.
+    """
+    import tileops.ops.elementwise as mod
+
+    for op_name in (
+        "ReluFwdOp", "SiluFwdOp", "HardswishFwdOp",
+        "HardsigmoidFwdOp", "MishFwdOp", "SeluFwdOp",
+    ):
+        cls = getattr(mod, op_name)
+        init_sig = inspect.signature(cls.__init__)
+        assert "inplace" in init_sig.parameters
+        assert init_sig.parameters["inplace"].default is False
+        # Constructing with inplace=True is rejected (not silently ignored)
+        # because the kernels do not support in-place writes.
+        with pytest.raises(NotImplementedError, match="in-place"):
+            cls(N_total=8, dtype=torch.float16, inplace=True)
+
+
+@pytest.mark.smoke
+def test_gelu_approximate_modes_accepted() -> None:
+    """GeluFwdOp must accept ``approximate='none'`` and ``'tanh'`` per manifest."""
+    import tileops.ops.elementwise as mod
+
+    init_sig = inspect.signature(mod.GeluFwdOp.__init__)
+    assert "approximate" in init_sig.parameters
+    assert init_sig.parameters["approximate"].default == "none"
+
+    # Constructor must reject values outside ``{'none', 'tanh'}`` (manifest
+    # shape_rule constraint). We check on CPU via attribute introspection
+    # because the kernel build requires CUDA.
+    with pytest.raises(ValueError, match="approximate"):
+        mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="invalid")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -111,9 +111,21 @@ def test_clamp_family_accepts_canonical_kwargs(op_name: str) -> None:
     assert "tune" in init_keys, (
         f"{op_name}.__init__ missing canonical 'tune' kwarg; got {init_keys}"
     )
-    # Both must be keyword-only with the canonical defaults.
-    assert init_sig.parameters["kernel_map"].default is None
-    assert init_sig.parameters["tune"].default is False
+    # Both must be keyword-only with the canonical defaults. Assert
+    # ``Parameter.kind`` so a positional-or-keyword regression also
+    # fails the gate, not just a renamed-default regression.
+    kernel_map_param = init_sig.parameters["kernel_map"]
+    tune_param = init_sig.parameters["tune"]
+    assert kernel_map_param.default is None
+    assert tune_param.default is False
+    assert kernel_map_param.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{op_name}.__init__ 'kernel_map' must be keyword-only, "
+        f"got kind={kernel_map_param.kind}"
+    )
+    assert tune_param.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{op_name}.__init__ 'tune' must be keyword-only, "
+        f"got kind={tune_param.kind}"
+    )
 
 
 @pytest.mark.smoke
@@ -175,9 +187,36 @@ def test_gelu_approximate_modes_accepted() -> None:
     # constructor rather than rejected. The tanh path skips kernel
     # construction (no CUDA build) and routes through a torch fallback in
     # ``_eager_forward``, so this assertion is safe on CPU-only hosts.
-    op_tanh = mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="tanh")
+    op_tanh = mod.GeluFwdOp(N_total=8, dtype=torch.float32, approximate="tanh")
     assert op_tanh.approximate == "tanh"
     assert op_tanh.kernel is None
+
+    # Exercise the fallback path end-to-end via _eager_forward so a
+    # regression in the tanh routing is actually caught (not just a
+    # constructor smoke check). _eager_forward bypasses the .is_cuda
+    # input gate in forward(), letting this run on CPU-only hosts.
+    x = torch.randn(8, dtype=torch.float32)
+    out = op_tanh._eager_forward(x)
+    expected = torch.nn.functional.gelu(x, approximate="tanh")
+    assert out.shape == x.shape
+    assert torch.allclose(out, expected, rtol=0, atol=0), (
+        "GeluFwdOp tanh fallback must match torch.nn.functional.gelu(approximate='tanh')"
+    )
+
+
+@pytest.mark.smoke
+def test_gelu_tanh_rejects_unsupported_dtype() -> None:
+    """tanh fallback must enforce the same dtype gate as the kernel path.
+
+    The 'none' branch rejects unsupported dtypes via GeluFwdKernel's
+    SUPPORTED_DTYPES check inside ``super().__init__``. The tanh branch
+    must mirror that contract so a caller doesn't construct a broken op
+    and only learn at forward() time that the dtype is unsupported.
+    """
+    import tileops.ops.elementwise as mod
+
+    with pytest.raises(ValueError, match=r"gelu does not support dtype"):
+        mod.GeluFwdOp(N_total=8, dtype=torch.int32, approximate="tanh")
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -3061,9 +3061,17 @@ class NanToNumFwdKernel(ParametricUnaryKernel):
         super().__init__(N_total, dtype, config=config, tune=tune)
 
     def _post_init_params(self):
-        self.nan_val = _clamp_to_dtype_range(self._raw_nan_val, self.output_dtype)
-        self.posinf_val = _clamp_to_dtype_range(self._raw_posinf_val, self.output_dtype)
-        self.neginf_val = _clamp_to_dtype_range(self._raw_neginf_val, self.output_dtype)
+        # Clamp to the *final* user-facing dtype, not the kernel's
+        # intermediate output_dtype. For e5m2 the kernel writes fp16 and
+        # the Op layer post-casts to e5m2; clamping to fp16's max
+        # (65504.0) would round up to +Inf in e5m2 (max 57344.0), so the
+        # default ``+/-inf`` sentinels would surface as Inf instead of
+        # finite max/min. Using ``_fp8_output_dtype or output_dtype``
+        # picks the dtype the caller actually sees.
+        final_dtype = self._fp8_output_dtype or self.output_dtype
+        self.nan_val = _clamp_to_dtype_range(self._raw_nan_val, final_dtype)
+        self.posinf_val = _clamp_to_dtype_range(self._raw_posinf_val, final_dtype)
+        self.neginf_val = _clamp_to_dtype_range(self._raw_neginf_val, final_dtype)
 
     @staticmethod
     def _builder_fn():

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -3061,17 +3061,9 @@ class NanToNumFwdKernel(ParametricUnaryKernel):
         super().__init__(N_total, dtype, config=config, tune=tune)
 
     def _post_init_params(self):
-        # Clamp to the *final* user-facing dtype, not the kernel's
-        # intermediate output_dtype. For e5m2 the kernel writes fp16 and
-        # the Op layer post-casts to e5m2; clamping to fp16's max
-        # (65504.0) would round up to +Inf in e5m2 (max 57344.0), so the
-        # default ``+/-inf`` sentinels would surface as Inf instead of
-        # finite max/min. Using ``_fp8_output_dtype or output_dtype``
-        # picks the dtype the caller actually sees.
-        final_dtype = self._fp8_output_dtype or self.output_dtype
-        self.nan_val = _clamp_to_dtype_range(self._raw_nan_val, final_dtype)
-        self.posinf_val = _clamp_to_dtype_range(self._raw_posinf_val, final_dtype)
-        self.neginf_val = _clamp_to_dtype_range(self._raw_neginf_val, final_dtype)
+        self.nan_val = _clamp_to_dtype_range(self._raw_nan_val, self.output_dtype)
+        self.posinf_val = _clamp_to_dtype_range(self._raw_posinf_val, self.output_dtype)
+        self.neginf_val = _clamp_to_dtype_range(self._raw_neginf_val, self.output_dtype)
 
     @staticmethod
     def _builder_fn():

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -989,11 +989,20 @@ class _InplaceMixin:
         Returns ``input_tensor`` (preserving identity) if ``inplace`` is
         True, otherwise returns ``output`` unchanged.
 
+        The kernel path frequently flattens the input before launch, so
+        ``output`` may differ from ``input_tensor`` in *layout* while
+        carrying the same number of elements. A ``reshape`` followed by
+        ``copy_`` recovers the caller's layout without broadcasting; any
+        true element-count mismatch is rejected up front with a
+        ``ValueError`` rather than letting ``reshape`` raise a downstream
+        ``RuntimeError``.
+
         Raises:
-            ValueError: if ``output.shape`` is not broadcast-compatible
-                with ``input_tensor.shape`` or if ``output.dtype`` does
-                not match ``input_tensor.dtype`` (an inplace write must
-                not change the storage dtype).
+            ValueError: if ``output.dtype`` does not match
+                ``input_tensor.dtype`` (an inplace write must not change
+                the storage dtype), or if ``output.numel()`` does not
+                equal ``input_tensor.numel()`` (broadcasting is not
+                supported here).
         """
         if not inplace:
             return output
@@ -1002,9 +1011,16 @@ class _InplaceMixin:
                 f"inplace=True requires output.dtype ({output.dtype}) to "
                 f"match input.dtype ({input_tensor.dtype}); they differ"
             )
-        # ``copy_`` broadcasts as needed; reshape to the input layout
-        # to handle the contiguous/flatten round-trip used by the kernel
-        # path without forcing the caller to think about it.
+        if output.numel() != input_tensor.numel():
+            raise ValueError(
+                f"inplace=True requires output.numel() ({output.numel()}) "
+                f"to match input.numel() ({input_tensor.numel()}); "
+                f"broadcasting is not supported on the inplace path"
+            )
+        # Reshape to the input layout to handle the contiguous/flatten
+        # round-trip used by the kernel path without forcing the caller
+        # to think about it. The numel guard above ensures reshape never
+        # raises here.
         input_tensor.copy_(output.reshape(input_tensor.shape))
         return input_tensor
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -2707,12 +2707,12 @@ class NanToNumFwdOp(Op):
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
         nan: Replacement for NaN (default 0.0). Manifest-aligned name.
-        posinf: Replacement for +Inf. Manifest default ``None`` maps to
-            the kernel sentinel (``1e4``); pass an explicit float to
-            override.
-        neginf: Replacement for -Inf. Manifest default ``None`` maps to
-            the kernel sentinel (``-1e4``); pass an explicit float to
-            override.
+        posinf: Replacement for +Inf. Manifest default ``None`` resolves
+            to the largest finite value representable in the kernel's
+            effective output dtype (matches ``torch.nan_to_num``).
+        neginf: Replacement for -Inf. Manifest default ``None`` resolves
+            to the smallest (most negative) finite value representable
+            in the kernel's effective output dtype.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
 
@@ -2747,15 +2747,23 @@ class NanToNumFwdOp(Op):
             posinf = posinf_val  # type: ignore[assignment]
         if neginf_val is not _NAN_TO_NUM_SENTINEL:
             neginf = neginf_val  # type: ignore[assignment]
-        # Default-None mapping mirrors torch.nan_to_num: when posinf /
-        # neginf are not supplied, fall back to the kernel's stable
-        # finite sentinels so this constructor is a drop-in for the
-        # legacy positional / keyword call sites.
-        kernel_posinf = 1e4 if posinf is None else posinf
-        kernel_neginf = -1e4 if neginf is None else neginf
+        # User-supplied scalars must be representable in the effective
+        # kernel dtype. ``None`` is the manifest default and resolves to
+        # +/-inf below so that the kernel's _clamp_to_dtype_range maps
+        # them to the dtype's finite max / min — that path keeps
+        # narrow-range dtypes (e.g. float8_e4m3fn whose max is 448) from
+        # rejecting their own defaults before the kernel can clamp them.
         _validate_scalar_param_repr("nan_val", nan, dtype, self._op_name)
-        _validate_scalar_param_repr("posinf_val", kernel_posinf, dtype, self._op_name)
-        _validate_scalar_param_repr("neginf_val", kernel_neginf, dtype, self._op_name)
+        if posinf is None:
+            kernel_posinf = math.inf
+        else:
+            _validate_scalar_param_repr("posinf_val", posinf, dtype, self._op_name)
+            kernel_posinf = posinf
+        if neginf is None:
+            kernel_neginf = -math.inf
+        else:
+            _validate_scalar_param_repr("neginf_val", neginf, dtype, self._op_name)
+            kernel_neginf = neginf
         self.N_total = N_total
         self.dtype = dtype
         self.nan = nan

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -121,24 +121,31 @@ def _effective_scalar_kernel_dtype(dtype: torch.dtype) -> torch.dtype:
 def _validate_scalar_param_repr(
     param_name: str, value: float, dtype: torch.dtype, op_name: str,
 ) -> None:
-    """Reject scalar params that cannot be represented in the kernel dtype."""
+    """Reject scalar params that cannot be represented in the user dtype.
+
+    Validation targets the *user-facing* ``dtype`` rather than the
+    intermediate ``_effective_scalar_kernel_dtype(dtype)``.  For fp8
+    dtypes the kernel runs in fp16 to preserve Inf/NaN, but a value that
+    only fits in fp16 would surface as ``+/-Inf`` after the final fp8
+    post-cast. Validating against the user dtype keeps explicit
+    replacements finite end-to-end.
+    """
     if not isinstance(value, (int, float)):
         raise TypeError(f"{op_name} expected scalar {param_name} to be int/float, got {type(value)}")
 
-    kernel_dtype = _effective_scalar_kernel_dtype(dtype)
-    finfo = torch.finfo(kernel_dtype)
+    finfo = torch.finfo(dtype)
     value_f64 = float(value)
     if math.isnan(value_f64):
         return
     if math.isinf(value_f64):
         raise ValueError(
             f"{op_name} received {param_name}={value!r}, but {param_name} must be finite and "
-            f"representable in effective kernel dtype {kernel_dtype}"
+            f"representable in dtype {dtype}"
         )
     if not (finfo.min <= value_f64 <= finfo.max):
         raise ValueError(
             f"{op_name} received {param_name}={value!r}, which is not representable in "
-            f"effective kernel dtype {kernel_dtype} (valid finite range: "
+            f"dtype {dtype} (valid finite range: "
             f"[{finfo.min}, {finfo.max}])"
         )
 
@@ -953,23 +960,53 @@ class FusedGatedOp(Op):
 
 
 class _InplaceMixin:
-    """Reject ``inplace=True`` for activation ops that don't support it.
+    """Implement out-of-kernel ``inplace=True`` for activation ops.
 
     Used by activation ops whose manifest entry declares ``inplace:
     bool = False`` (e.g. ReLU, SiLU, HardSwish, HardSigmoid, Mish, SELU,
     LeakyReLU, ELU, Hardtanh). Activations whose manifest does not
     declare ``inplace`` (e.g. GELU, Softplus) intentionally do not mix
-    this in. The kwarg is accepted purely to satisfy the L1 signature
-    contract; the underlying kernels write to a fresh output buffer, so
-    a non-default value is rejected rather than silently ignored.
+    this in.
+
+    The underlying kernels always write to a fresh output buffer, but
+    PyTorch's activation contract for ``inplace=True`` requires the
+    *user-visible* tensor identity to be preserved (``y is x``).  We
+    honor the manifest contract by computing into a fresh buffer and
+    then copying the result back into the input tensor when
+    ``inplace=True``; the returned tensor is the original input. The
+    op-level ``inplace`` mutation is intentionally only honored on the
+    eager ``forward()`` path: the ``torch.compile`` ``_wrapped`` route
+    is registered with ``mutates_args=()`` and would mis-trace under
+    aliasing, so we route inplace=True around the custom-op dispatch.
     """
 
     @staticmethod
-    def _reject_inplace(inplace: bool, op_name: str) -> None:
-        if inplace:
-            raise NotImplementedError(
-                f"{op_name}: in-place execution is not supported; pass inplace=False"
+    def _apply_inplace(
+        inplace: bool, input_tensor: torch.Tensor, output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Materialize ``output`` back into ``input_tensor`` when inplace=True.
+
+        Returns ``input_tensor`` (preserving identity) if ``inplace`` is
+        True, otherwise returns ``output`` unchanged.
+
+        Raises:
+            ValueError: if ``output.shape`` is not broadcast-compatible
+                with ``input_tensor.shape`` or if ``output.dtype`` does
+                not match ``input_tensor.dtype`` (an inplace write must
+                not change the storage dtype).
+        """
+        if not inplace:
+            return output
+        if output.dtype != input_tensor.dtype:
+            raise ValueError(
+                f"inplace=True requires output.dtype ({output.dtype}) to "
+                f"match input.dtype ({input_tensor.dtype}); they differ"
             )
+        # ``copy_`` broadcasts as needed; reshape to the input layout
+        # to handle the contiguous/flatten round-trip used by the kernel
+        # path without forcing the caller to think about it.
+        input_tensor.copy_(output.reshape(input_tensor.shape))
+        return input_tensor
 
 
 class ReluFwdOp(UnaryOp, _InplaceMixin):
@@ -977,6 +1014,8 @@ class ReluFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "relu"
     kernel_cls = ReluFwdKernel
+    # Manifest: flops = "2 * N" (compare + select per element).
+    FLOPS_PER_ELEM = 2
 
     def __init__(
         self,
@@ -988,11 +1027,14 @@ class ReluFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class AddFwdOp(BinaryOp):
@@ -1529,6 +1571,8 @@ class GeluFwdOp(UnaryOp):
 
     _op_name = "gelu"
     kernel_cls = GeluFwdKernel
+    # Manifest: flops = "8 * N" (erf-based: mul + erf + add + mul + mul ≈ 8).
+    FLOPS_PER_ELEM = 8
 
     def __init__(
         self,
@@ -1591,6 +1635,8 @@ class SiluFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "silu"
     kernel_cls = SiluFwdKernel
+    # Manifest: flops = "4 * N" (sigmoid + multiply).
+    FLOPS_PER_ELEM = 4
 
     def __init__(
         self,
@@ -1602,11 +1648,14 @@ class SiluFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class SigmoidFwdOp(UnaryOp):
@@ -1632,6 +1681,8 @@ class HardswishFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "hardswish"
     kernel_cls = HardswishFwdKernel
+    # Manifest: flops = "7 * N" (add + clamp(2 cmp+2 sel) + mul + div).
+    FLOPS_PER_ELEM = 7
 
     def __init__(
         self,
@@ -1643,11 +1694,14 @@ class HardswishFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
@@ -1655,6 +1709,8 @@ class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "hardsigmoid"
     kernel_cls = HardsigmoidFwdKernel
+    # Manifest: flops = "6 * N" (add + clamp(2 cmp+2 sel) + div).
+    FLOPS_PER_ELEM = 6
 
     def __init__(
         self,
@@ -1666,11 +1722,14 @@ class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class MishFwdOp(UnaryOp, _InplaceMixin):
@@ -1678,6 +1737,8 @@ class MishFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "mish"
     kernel_cls = MishFwdKernel
+    # Manifest: flops = "7 * N" (softplus + tanh + mul).
+    FLOPS_PER_ELEM = 7
 
     def __init__(
         self,
@@ -1689,11 +1750,14 @@ class MishFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class SeluFwdOp(UnaryOp, _InplaceMixin):
@@ -1701,6 +1765,8 @@ class SeluFwdOp(UnaryOp, _InplaceMixin):
 
     _op_name = "selu"
     kernel_cls = SeluFwdKernel
+    # Manifest: flops = "5 * N" (branch + exp/sub/mul + lambda mul).
+    FLOPS_PER_ELEM = 5
 
     def __init__(
         self,
@@ -1712,11 +1778,14 @@ class SeluFwdOp(UnaryOp, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
         self.inplace = inplace
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        result = super().forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 # ---------------------------------------------------------------------------
@@ -1813,15 +1882,18 @@ class LeakyReluFwdOp(Op, _InplaceMixin):
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
         negative_slope: Slope for negative inputs (default 0.01).
-        inplace: Manifest-declared kwarg; in-place execution is not
-            supported by the kernel and ``inplace=True`` raises
-            ``NotImplementedError``.
+        inplace: When True, copy the result back into ``input`` and
+            return ``input`` (preserving tensor identity). The kernel
+            still computes into a fresh buffer; only the user-visible
+            tensor is mutated, mirroring ``torch.nn.functional.leaky_relu``.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
     """
 
     _op_name = "leaky_relu"
     _wrapped = None
+    # Manifest: flops = "3 * N" (compare + mul + select).
+    FLOPS_PER_ELEM = 3
 
     def __init__(
         self,
@@ -1833,7 +1905,6 @@ class LeakyReluFwdOp(Op, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("negative_slope", negative_slope, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
@@ -1863,9 +1934,12 @@ class LeakyReluFwdOp(Op, _InplaceMixin):
         if input.numel() != self.N_total:
             raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
-        if wrapped is not None:
+        # inplace=True bypasses the torch.compile route; the custom_op
+        # is registered with mutates_args=() and would mis-trace.
+        if wrapped is not None and not self.inplace:
             return wrapped(input, self._instance_key)
-        return self._eager_forward(input)
+        result = self._eager_forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class EluFwdOp(Op, _InplaceMixin):
@@ -1875,14 +1949,16 @@ class EluFwdOp(Op, _InplaceMixin):
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
         alpha: Scale for the negative part (default 1.0).
-        inplace: Manifest-declared kwarg; in-place execution is not
-            supported and ``inplace=True`` raises ``NotImplementedError``.
+        inplace: When True, copy the result back into ``input`` and
+            return ``input`` (preserving tensor identity).
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
     """
 
     _op_name = "elu"
     _wrapped = None
+    # Manifest: flops = "5 * N" (compare + (exp + sub + mul) + branch select).
+    FLOPS_PER_ELEM = 5
 
     def __init__(
         self,
@@ -1894,7 +1970,6 @@ class EluFwdOp(Op, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("alpha", alpha, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
@@ -1922,9 +1997,10 @@ class EluFwdOp(Op, _InplaceMixin):
         if input.numel() != self.N_total:
             raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
-        if wrapped is not None:
+        if wrapped is not None and not self.inplace:
             return wrapped(input, self._instance_key)
-        return self._eager_forward(input)
+        result = self._eager_forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class HardtanhFwdOp(Op, _InplaceMixin):
@@ -1935,14 +2011,16 @@ class HardtanhFwdOp(Op, _InplaceMixin):
         dtype: Torch dtype.
         min_val: Lower bound (default -1.0).
         max_val: Upper bound (default 1.0).
-        inplace: Manifest-declared kwarg; in-place execution is not
-            supported and ``inplace=True`` raises ``NotImplementedError``.
+        inplace: When True, copy the result back into ``input`` and
+            return ``input`` (preserving tensor identity).
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
     """
 
     _op_name = "hardtanh"
     _wrapped = None
+    # Manifest: flops = "4 * N" (2 compares + 2 selects per element).
+    FLOPS_PER_ELEM = 4
 
     def __init__(
         self,
@@ -1955,7 +2033,6 @@ class HardtanhFwdOp(Op, _InplaceMixin):
         tune: bool = False,
         inplace: bool = False,
     ):
-        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("min_val", min_val, dtype, self._op_name)
         _validate_scalar_param_repr("max_val", max_val, dtype, self._op_name)
         self.N_total = N_total
@@ -1987,9 +2064,10 @@ class HardtanhFwdOp(Op, _InplaceMixin):
         if input.numel() != self.N_total:
             raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
-        if wrapped is not None:
+        if wrapped is not None and not self.inplace:
             return wrapped(input, self._instance_key)
-        return self._eager_forward(input)
+        result = self._eager_forward(input)
+        return self._apply_inplace(self.inplace, input, result)
 
 
 class SoftplusFwdOp(Op):
@@ -2724,11 +2802,15 @@ class NanToNumFwdOp(Op):
         dtype: Torch dtype.
         nan: Replacement for NaN (default 0.0). Manifest-aligned name.
         posinf: Replacement for +Inf. Manifest default ``None`` resolves
-            to the largest finite value representable in the kernel's
-            effective output dtype (matches ``torch.nan_to_num``).
+            to the largest finite value representable in the user-facing
+            ``dtype`` (matches ``torch.nan_to_num``). Explicit values
+            must also be representable in ``dtype`` end-to-end; values
+            that fit only in the kernel's intermediate dtype (e.g. fp16
+            for fp8_e5m2) are rejected so the post-cast cannot resurface
+            them as Inf.
         neginf: Replacement for -Inf. Manifest default ``None`` resolves
             to the smallest (most negative) finite value representable
-            in the kernel's effective output dtype.
+            in the user-facing ``dtype``.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -2763,20 +2763,25 @@ class NanToNumFwdOp(Op):
             posinf = posinf_val  # type: ignore[assignment]
         if neginf_val is not _NAN_TO_NUM_SENTINEL:
             neginf = neginf_val  # type: ignore[assignment]
-        # User-supplied scalars must be representable in the effective
-        # kernel dtype. ``None`` is the manifest default and resolves to
-        # +/-inf below so that the kernel's _clamp_to_dtype_range maps
-        # them to the dtype's finite max / min — that path keeps
-        # narrow-range dtypes (e.g. float8_e4m3fn whose max is 448) from
-        # rejecting their own defaults before the kernel can clamp them.
+        # User-supplied scalars must be representable in the user-facing
+        # dtype, so they go through the standard validation path below.
+        # The manifest default ``None`` resolves to the *final*
+        # user-facing dtype's max / min, not ``+/-inf``: the kernel runs
+        # in ``output_dtype`` (fp16 for e5m2 to preserve Inf/NaN) and
+        # _clamp_to_dtype_range targets that intermediate, so forwarding
+        # ``+inf`` would resolve to fp16's 65504.0 and then surface as
+        # ``+Inf`` after the e5m2 post-cast (e5m2 max is 57344.0).
+        # Picking ``torch.finfo(dtype).max`` here keeps the replacement
+        # value finite end-to-end and matches ``torch.nan_to_num``
+        # semantics (replace Inf with the dtype's max finite value).
         _validate_scalar_param_repr("nan", nan, dtype, self._op_name)
         if posinf is None:
-            kernel_posinf = math.inf
+            kernel_posinf = torch.finfo(dtype).max
         else:
             _validate_scalar_param_repr("posinf", posinf, dtype, self._op_name)
             kernel_posinf = posinf
         if neginf is None:
-            kernel_neginf = -math.inf
+            kernel_neginf = torch.finfo(dtype).min
         else:
             _validate_scalar_param_repr("neginf", neginf, dtype, self._op_name)
             kernel_neginf = neginf

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -952,11 +952,44 @@ class FusedGatedOp(Op):
 # ---------------------------------------------------------------------------
 
 
-class ReluFwdOp(UnaryOp):
+class _InplaceMixin:
+    """Reject ``inplace=True`` for activation ops that don't support it.
+
+    The manifest declares ``inplace: bool = False`` on every PyTorch
+    activation, so we accept the kwarg to satisfy the L1 signature
+    contract; the underlying kernels write to a fresh output buffer, so
+    a non-default value is rejected rather than silently ignored.
+    """
+
+    @staticmethod
+    def _reject_inplace(inplace: bool, op_name: str) -> None:
+        if inplace:
+            raise NotImplementedError(
+                f"{op_name}: in-place execution is not supported; pass inplace=False"
+            )
+
+
+class ReluFwdOp(UnaryOp, _InplaceMixin):
     """ReLU activation: y = max(x, 0)."""
 
     _op_name = "relu"
     kernel_cls = ReluFwdKernel
+
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
 
 class AddFwdOp(BinaryOp):
@@ -1476,17 +1509,69 @@ class Expm1FwdOp(UnaryOp):
 
 
 class GeluFwdOp(UnaryOp):
-    """Element-wise GELU using the standard erf formulation."""
+    """Element-wise GELU using the standard erf formulation.
+
+    Args:
+        N_total: Number of elements (flattened input).
+        dtype: Torch dtype.
+        approximate: Approximation mode, ``'none'`` (default) for the exact
+            erf-based formulation. Only ``'none'`` is currently implemented;
+            ``'tanh'`` is accepted by the manifest spec but not yet routed
+            to a kernel and will raise ``NotImplementedError``.
+        strategy: Optional kernel strategy override.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
+    """
 
     _op_name = "gelu"
     kernel_cls = GeluFwdKernel
 
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        approximate: str = "none",
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        if approximate not in ("none", "tanh"):
+            raise ValueError(
+                f"GeluFwdOp: approximate must be 'none' or 'tanh', got {approximate!r}"
+            )
+        if approximate == "tanh":
+            raise NotImplementedError(
+                "GeluFwdOp: approximate='tanh' is declared by the manifest "
+                "but not yet routed to a kernel; only 'none' is supported."
+            )
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.approximate = approximate
 
-class SiluFwdOp(UnaryOp):
-    """Element-wise SiLU (Swish): x * sigmoid(x)."""
+
+class SiluFwdOp(UnaryOp, _InplaceMixin):
+    """Element-wise SiLU (Swish): y = x * sigmoid(x)."""
 
     _op_name = "silu"
     kernel_cls = SiluFwdKernel
+
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
 
 class SigmoidFwdOp(UnaryOp):
@@ -1507,32 +1592,96 @@ class TanhFwdOp(UnaryOp):
     FLOPS_PER_ELEM = 5
 
 
-class HardswishFwdOp(UnaryOp):
-    """Element-wise HardSwish: x * clamp(x + 3, 0, 6) / 6."""
+class HardswishFwdOp(UnaryOp, _InplaceMixin):
+    """Element-wise HardSwish: y = x * clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardswish"
     kernel_cls = HardswishFwdKernel
 
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
-class HardsigmoidFwdOp(UnaryOp):
-    """Element-wise HardSigmoid: clamp(x + 3, 0, 6) / 6."""
+
+class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
+    """Element-wise HardSigmoid: y = clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardsigmoid"
     kernel_cls = HardsigmoidFwdKernel
 
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
-class MishFwdOp(UnaryOp):
-    """Element-wise Mish: x * tanh(softplus(x))."""
+
+class MishFwdOp(UnaryOp, _InplaceMixin):
+    """Element-wise Mish: y = x * tanh(softplus(x))."""
 
     _op_name = "mish"
     kernel_cls = MishFwdKernel
 
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
-class SeluFwdOp(UnaryOp):
-    """Element-wise SELU."""
+
+class SeluFwdOp(UnaryOp, _InplaceMixin):
+    """Element-wise SELU activation."""
 
     _op_name = "selu"
     kernel_cls = SeluFwdKernel
+
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
 
 
 # ---------------------------------------------------------------------------
@@ -1622,24 +1771,43 @@ class IsfiniteFwdOp(_IntIdentityUnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class LeakyReluFwdOp(Op):
+class LeakyReluFwdOp(Op, _InplaceMixin):
     """Leaky ReLU: y = x if x > 0 else negative_slope * x.
 
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
         negative_slope: Slope for negative inputs (default 0.01).
+        inplace: Manifest-declared kwarg; in-place execution is not
+            supported by the kernel and ``inplace=True`` raises
+            ``NotImplementedError``.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
     """
 
     _op_name = "leaky_relu"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype, negative_slope: float = 0.01):
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        negative_slope: float = 0.01,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("negative_slope", negative_slope, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
         self.negative_slope = negative_slope
-        self.kernel = LeakyReluFwdKernel(N_total, dtype, negative_slope=negative_slope)
+        self.inplace = inplace
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["leaky_relu"](
+            N_total, dtype, negative_slope=negative_slope, tune=tune,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1647,42 +1815,58 @@ class LeakyReluFwdOp(Op):
     def default_kernel_map(self):
         return {"leaky_relu": LeakyReluFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
-class EluFwdOp(Op):
+class EluFwdOp(Op, _InplaceMixin):
     """ELU: y = x if x > 0 else alpha * (exp(x) - 1).
 
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
         alpha: Scale for the negative part (default 1.0).
+        inplace: Manifest-declared kwarg; in-place execution is not
+            supported and ``inplace=True`` raises ``NotImplementedError``.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
     """
 
     _op_name = "elu"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype, alpha: float = 1.0):
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        alpha: float = 1.0,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("alpha", alpha, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
         self.alpha = alpha
-        self.kernel = EluFwdKernel(N_total, dtype, alpha=alpha)
+        self.inplace = inplace
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["elu"](N_total, dtype, alpha=alpha, tune=tune)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1690,25 +1874,25 @@ class EluFwdOp(Op):
     def default_kernel_map(self):
         return {"elu": EluFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
-class HardtanhFwdOp(Op):
+class HardtanhFwdOp(Op, _InplaceMixin):
     """Hardtanh: y = clamp(x, min_val, max_val).
 
     Args:
@@ -1716,20 +1900,38 @@ class HardtanhFwdOp(Op):
         dtype: Torch dtype.
         min_val: Lower bound (default -1.0).
         max_val: Upper bound (default 1.0).
+        inplace: Manifest-declared kwarg; in-place execution is not
+            supported and ``inplace=True`` raises ``NotImplementedError``.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
     """
 
     _op_name = "hardtanh"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype,
-                 min_val: float = -1.0, max_val: float = 1.0):
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        min_val: float = -1.0,
+        max_val: float = 1.0,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        self._reject_inplace(inplace, self._op_name)
         _validate_scalar_param_repr("min_val", min_val, dtype, self._op_name)
         _validate_scalar_param_repr("max_val", max_val, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
         self.min_val = min_val
         self.max_val = max_val
-        self.kernel = HardtanhFwdKernel(N_total, dtype, min_val=min_val, max_val=max_val)
+        self.inplace = inplace
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["hardtanh"](
+            N_total, dtype, min_val=min_val, max_val=max_val, tune=tune,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1737,22 +1939,22 @@ class HardtanhFwdOp(Op):
     def default_kernel_map(self):
         return {"hardtanh": HardtanhFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
 class SoftplusFwdOp(Op):
@@ -1763,20 +1965,33 @@ class SoftplusFwdOp(Op):
         dtype: Torch dtype.
         beta: Scaling factor (default 1.0).
         threshold: Linear regime threshold (default 20.0).
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
     """
 
     _op_name = "softplus"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype,
-                 beta: float = 1.0, threshold: float = 20.0):
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        beta: float = 1.0,
+        threshold: float = 20.0,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
         _validate_scalar_param_repr("beta", beta, dtype, self._op_name)
         _validate_scalar_param_repr("threshold", threshold, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
         self.beta = beta
         self.threshold = threshold
-        self.kernel = SoftplusFwdKernel(N_total, dtype, beta=beta, threshold=threshold)
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["softplus"](
+            N_total, dtype, beta=beta, threshold=threshold, tune=tune,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -1784,22 +1999,22 @@ class SoftplusFwdOp(Op):
     def default_kernel_map(self):
         return {"softplus": SoftplusFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
 class PreluFwdOp(Op):
@@ -1988,6 +2203,9 @@ class ClampFwdOp(_ClampTensorBase):
         min: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
         max: Optional[tuple] = None,  # noqa: A002 — manifest-aligned PyTorch param name
         dtype: torch.dtype = torch.float32,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
     ):
         if min is None and max is None:
             raise ValueError(
@@ -2005,10 +2223,12 @@ class ClampFwdOp(_ClampTensorBase):
             broadcast_args.append(self.max_shape)
         self.out_shape = tuple(torch.broadcast_shapes(*broadcast_args))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["clamp_tensor"](
             self.N_total, dtype,
             has_min=self.min_shape is not None,
             has_max=self.max_shape is not None,
+            tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2091,14 +2311,18 @@ class ClampMinFwdOp(_ClampTensorBase):
         input: tuple,  # noqa: A002
         min: tuple,    # noqa: A002
         dtype: torch.dtype,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
     ):
         self.input_shape = tuple(input)
         self.min_shape = tuple(min)
         self.dtype = dtype
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.min_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
-            self.N_total, dtype, has_min=True, has_max=False,
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["clamp_tensor"](
+            self.N_total, dtype, has_min=True, has_max=False, tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2156,14 +2380,18 @@ class ClampMaxFwdOp(_ClampTensorBase):
         input: tuple,  # noqa: A002
         max: tuple,    # noqa: A002
         dtype: torch.dtype,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
     ):
         self.input_shape = tuple(input)
         self.max_shape = tuple(max)
         self.dtype = dtype
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.max_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
-        self.kernel = ClampTensorFwdKernel(
-            self.N_total, dtype, has_min=False, has_max=True,
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["clamp_tensor"](
+            self.N_total, dtype, has_min=False, has_max=True, tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2223,6 +2451,9 @@ class ClampScalarFwdOp(Op):
         min: Optional[float] = None,  # noqa: A002
         max: Optional[float] = None,  # noqa: A002
         dtype: torch.dtype = torch.float32,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
     ):
         if min is None and max is None:
             raise ValueError(
@@ -2241,7 +2472,10 @@ class ClampScalarFwdOp(Op):
         # Backwards-compat aliases for legacy callers.
         self.min_val = min
         self.max_val = max
-        self.kernel = ClampFwdKernel(self.N_total, dtype, min_val=min, max_val=max)
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["clamp"](
+            self.N_total, dtype, min_val=min, max_val=max, tune=tune,
+        )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -2444,32 +2678,79 @@ class MaskedFillScalarFwdOp(Op):
         return self._eager_forward(input, mask)
 
 
+_NAN_TO_NUM_SENTINEL = object()
+
+
 class NanToNumFwdOp(Op):
     """NanToNum: replace NaN, +Inf, -Inf with specified values.
 
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
-        nan_val: Replacement for NaN (default 0.0).
-        posinf_val: Replacement for +Inf (default 1e4).
-        neginf_val: Replacement for -Inf (default -1e4).
+        nan: Replacement for NaN (default 0.0). Manifest-aligned name.
+        posinf: Replacement for +Inf. Manifest default ``None`` maps to
+            the kernel sentinel (``1e4``); pass an explicit float to
+            override.
+        neginf: Replacement for -Inf. Manifest default ``None`` maps to
+            the kernel sentinel (``-1e4``); pass an explicit float to
+            override.
+        kernel_map: Optional kernel dispatch override.
+        tune: Whether to autotune the kernel.
+
+    Note:
+        ``nan_val`` / ``posinf_val`` / ``neginf_val`` remain accepted as
+        legacy aliases for ``nan`` / ``posinf`` / ``neginf`` to keep
+        existing call sites working during the manifest-alignment
+        migration.
     """
 
     _op_name = "nan_to_num"
     _wrapped = None
 
-    def __init__(self, N_total: int, dtype: torch.dtype,
-                 nan_val: float = 0.0, posinf_val: float = 1e4, neginf_val: float = -1e4):
-        _validate_scalar_param_repr("nan_val", nan_val, dtype, self._op_name)
-        _validate_scalar_param_repr("posinf_val", posinf_val, dtype, self._op_name)
-        _validate_scalar_param_repr("neginf_val", neginf_val, dtype, self._op_name)
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        nan: float = 0.0,
+        posinf: Optional[float] = None,
+        neginf: Optional[float] = None,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        # Legacy aliases kept for back-compat with existing tests / benches.
+        nan_val: object = _NAN_TO_NUM_SENTINEL,
+        posinf_val: object = _NAN_TO_NUM_SENTINEL,
+        neginf_val: object = _NAN_TO_NUM_SENTINEL,
+    ):
+        if nan_val is not _NAN_TO_NUM_SENTINEL:
+            nan = nan_val  # type: ignore[assignment]
+        if posinf_val is not _NAN_TO_NUM_SENTINEL:
+            posinf = posinf_val  # type: ignore[assignment]
+        if neginf_val is not _NAN_TO_NUM_SENTINEL:
+            neginf = neginf_val  # type: ignore[assignment]
+        # Default-None mapping mirrors torch.nan_to_num: when posinf /
+        # neginf are not supplied, fall back to the kernel's stable
+        # finite sentinels so this constructor is a drop-in for the
+        # legacy positional / keyword call sites.
+        kernel_posinf = 1e4 if posinf is None else posinf
+        kernel_neginf = -1e4 if neginf is None else neginf
+        _validate_scalar_param_repr("nan_val", nan, dtype, self._op_name)
+        _validate_scalar_param_repr("posinf_val", kernel_posinf, dtype, self._op_name)
+        _validate_scalar_param_repr("neginf_val", kernel_neginf, dtype, self._op_name)
         self.N_total = N_total
         self.dtype = dtype
-        self.nan_val = nan_val
-        self.posinf_val = posinf_val
-        self.neginf_val = neginf_val
-        self.kernel = NanToNumFwdKernel(
-            N_total, dtype, nan_val=nan_val, posinf_val=posinf_val, neginf_val=neginf_val,
+        self.nan = nan
+        self.posinf = posinf
+        self.neginf = neginf
+        # Legacy attribute aliases retained so callers reading the
+        # original names keep working.
+        self.nan_val = nan
+        self.posinf_val = kernel_posinf
+        self.neginf_val = kernel_neginf
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["nan_to_num"](
+            N_total, dtype, nan_val=nan, posinf_val=kernel_posinf,
+            neginf_val=kernel_neginf, tune=tune,
         )
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -2478,22 +2759,22 @@ class NanToNumFwdOp(Op):
     def default_kernel_map(self):
         return {"nan_to_num": NanToNumFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
-        result = self.kernel(x.contiguous().reshape(-1)).reshape(orig_shape)
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
 
 class AlibiFwdOp(Op):

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1008,6 +1008,22 @@ class _InplaceMixin:
         input_tensor.copy_(output.reshape(input_tensor.shape))
         return input_tensor
 
+    def _inplace_aware_forward(
+        self, input: torch.Tensor,  # noqa: A002
+    ) -> torch.Tensor:
+        """Run validate + dispatch + ``_apply_inplace`` for unary activations.
+
+        Routes ``inplace=True`` around the ``_wrapped`` custom-op so the
+        functional torch.compile path never sees a mutation it cannot
+        model (the custom op is registered with ``mutates_args=()``).
+        """
+        self._validate_input(input)
+        wrapped = type(self)._wrapped
+        if wrapped is not None and not self.inplace:
+            return wrapped(input, self._instance_key)
+        result = self._eager_forward(input)
+        return self._apply_inplace(self.inplace, input, result)
+
 
 class ReluFwdOp(UnaryOp, _InplaceMixin):
     """ReLU activation: y = max(x, 0)."""
@@ -1033,8 +1049,7 @@ class ReluFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 class AddFwdOp(BinaryOp):
@@ -1654,8 +1669,7 @@ class SiluFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 class SigmoidFwdOp(UnaryOp):
@@ -1700,8 +1714,7 @@ class HardswishFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
@@ -1728,8 +1741,7 @@ class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 class MishFwdOp(UnaryOp, _InplaceMixin):
@@ -1756,8 +1768,7 @@ class MishFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 class SeluFwdOp(UnaryOp, _InplaceMixin):
@@ -1784,8 +1795,7 @@ class SeluFwdOp(UnaryOp, _InplaceMixin):
         self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        result = super().forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._inplace_aware_forward(input)
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1509,15 +1509,16 @@ class Expm1FwdOp(UnaryOp):
 
 
 class GeluFwdOp(UnaryOp):
-    """Element-wise GELU using the standard erf formulation.
+    """Element-wise GELU honoring the manifest ``approximate`` contract.
 
     Args:
         N_total: Number of elements (flattened input).
         dtype: Torch dtype.
-        approximate: Approximation mode, ``'none'`` (default) for the exact
-            erf-based formulation. Only ``'none'`` is currently implemented;
-            ``'tanh'`` is accepted by the manifest spec but not yet routed
-            to a kernel and will raise ``NotImplementedError``.
+        approximate: Approximation mode. ``'none'`` (default) routes to the
+            erf-based ``GeluFwdKernel``; ``'tanh'`` routes through a torch
+            reference path (``torch.nn.functional.gelu(..., approximate='tanh')``)
+            because no fused tanh-GELU kernel is exposed for the unary op
+            yet. Both values are honored end-to-end.
         strategy: Optional kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
@@ -1540,15 +1541,33 @@ class GeluFwdOp(UnaryOp):
             raise ValueError(
                 f"GeluFwdOp: approximate must be 'none' or 'tanh', got {approximate!r}"
             )
+        self.approximate = approximate
         if approximate == "tanh":
-            raise NotImplementedError(
-                "GeluFwdOp: approximate='tanh' is declared by the manifest "
-                "but not yet routed to a kernel; only 'none' is supported."
-            )
+            # No fused tanh-GELU unary kernel is exposed to the op layer
+            # yet; honor the manifest contract by routing through torch
+            # so callers passing the manifest-allowed value still get a
+            # correct result rather than an error.
+            self.N_total = N_total
+            self.dtype = dtype
+            self.strategy = strategy
+            self.kernel_map = kernel_map or self.default_kernel_map
+            self.kernel = None
+            self.output_dtype = dtype
+            self._instance_key = id(self)
+            _OP_REGISTRY[self._instance_key] = self
+            return
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
         )
-        self.approximate = approximate
+
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if self.kernel is None:
+            # approximate='tanh' fallback path — see __init__.
+            orig_shape = input.shape
+            flat = input.contiguous().reshape(-1)
+            out = torch.nn.functional.gelu(flat, approximate="tanh")
+            return out.reshape(orig_shape)
+        return super()._eager_forward(input)
 
 
 class SiluFwdOp(UnaryOp, _InplaceMixin):

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -955,8 +955,11 @@ class FusedGatedOp(Op):
 class _InplaceMixin:
     """Reject ``inplace=True`` for activation ops that don't support it.
 
-    The manifest declares ``inplace: bool = False`` on every PyTorch
-    activation, so we accept the kwarg to satisfy the L1 signature
+    Used by activation ops whose manifest entry declares ``inplace:
+    bool = False`` (e.g. ReLU, SiLU, HardSwish, HardSigmoid, Mish, SELU,
+    LeakyReLU, ELU, Hardtanh). Activations whose manifest does not
+    declare ``inplace`` (e.g. GELU, Softplus) intentionally do not mix
+    this in. The kwarg is accepted purely to satisfy the L1 signature
     contract; the underlying kernels write to a fresh output buffer, so
     a non-default value is rejected rather than silently ignored.
     """
@@ -1540,6 +1543,19 @@ class GeluFwdOp(UnaryOp):
         if approximate not in ("none", "tanh"):
             raise ValueError(
                 f"GeluFwdOp: approximate must be 'none' or 'tanh', got {approximate!r}"
+            )
+        # Apply the same dtype gate both branches share so the tanh
+        # fallback rejects unsupported dtypes (e.g. integer / fp8) up
+        # front instead of deferring the failure to forward(). The
+        # ``approximate='none'`` branch enforces this implicitly via
+        # GeluFwdKernel's SUPPORTED_DTYPES check inside super().__init__;
+        # mirror that contract here so both branches behave consistently.
+        supported = self.kernel_cls.SUPPORTED_DTYPES
+        if supported is not None and dtype not in supported:
+            names = ", ".join(str(dt) for dt in supported)
+            raise ValueError(
+                f"{self._op_name} does not support dtype {dtype}. "
+                f"Supported: [{names}]"
             )
         self.approximate = approximate
         if approximate == "tanh":
@@ -2753,16 +2769,16 @@ class NanToNumFwdOp(Op):
         # them to the dtype's finite max / min — that path keeps
         # narrow-range dtypes (e.g. float8_e4m3fn whose max is 448) from
         # rejecting their own defaults before the kernel can clamp them.
-        _validate_scalar_param_repr("nan_val", nan, dtype, self._op_name)
+        _validate_scalar_param_repr("nan", nan, dtype, self._op_name)
         if posinf is None:
             kernel_posinf = math.inf
         else:
-            _validate_scalar_param_repr("posinf_val", posinf, dtype, self._op_name)
+            _validate_scalar_param_repr("posinf", posinf, dtype, self._op_name)
             kernel_posinf = posinf
         if neginf is None:
             kernel_neginf = -math.inf
         else:
-            _validate_scalar_param_repr("neginf_val", neginf, dtype, self._op_name)
+            _validate_scalar_param_repr("neginf", neginf, dtype, self._op_name)
             kernel_neginf = neginf
         self.N_total = N_total
         self.dtype = dtype


### PR DESCRIPTION
Closes #1192

## Summary

- Aligned 12 spec-only ops in the `elementwise_unary_activation` family to manifest signatures (impl + test + bench scaffolding).
- Removed Clamp family ctor drift; canonical kernel_map/tune kwargs now accepted.
- Honored manifest tanh-approx GELU; added bench torch baseline for activation.
- Skip op-level validation for `nan_to_num` default sentinels (avoid spurious rejection).
- Manifest `status` field unchanged across all 16 ops (sibling flip handles spec→ready transition).

## Test plan

- [x] pre-commit run --all-files passes; pytest tests/ops passes for every touched test file
- [x] git diff confined to tileops/ops, tests, benchmarks; zero tileops/manifest or tileops/kernels changes
- [x] Clamp family ctor signature accepts canonical kernel_map/tune kwargs
- [x] 12 spec-only ops have impl + test + bench; tests reference manifest-declared signatures + dtype contract
- [x] Each touched bench file produces numbers; no correctness assertions; no imports from tests or oracle workloads
- [x] Manifest status field unchanged for all 16 ops

## Structural Readiness

All checks passed.

## Benchmark

`python -m pytest -q benchmarks/ops/bench_activation.py` with `TMPDIR=$PWD/.tmp`: 98 passed; `profile_run.log` contains tileops/torch latency rows for `silu`, `hardswish`, `hardsigmoid`, `mish`, `selu`.

## Test node delta

```
File                                                        Base    HEAD    Delta
---------------------------------------------------------------------------------
tests/ops/test_elementwise_independent_fp8.py                 54      59       +5
tests/ops/test_elementwise_unary_activation_alignment.py     new      52    (new)
---------------------------------------------------------------------------------
TOTAL                                                         54     111      +57
```

**Justification:** The +5 delta on `test_elementwise_independent_fp8.py` covers newly-aligned independent fp8 activation ops in this family pass (parametrized cases over manifest-declared dtypes, including expanded inplace and round-trip coverage). The new `test_elementwise_unary_activation_alignment.py` carries the per-op alignment matrix for the 12 spec-only activation ops + 4 Clamp ops (signature parity, dtype contract, kernel_map/tune kwarg acceptance, inplace semantics around `torch.compile`) that AC-3/AC-4 require.