### PR TITLE
[Fix][Bench] accept GroupNorm num_groups workload key

### DIFF
--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -37,7 +37,7 @@ def _manifest_params():
     for w in load_workloads(_OP_NAME):
         shape = w["x_shape"]
         n, c, spatial = shape[0], shape[1], tuple(shape[2:])
-        g = w["groups"]
+        g = w["num_groups"] if "num_groups" in w else w["groups"]
         label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -37,7 +37,11 @@ def _manifest_params():
     for w in load_workloads(_OP_NAME):
         shape = w["x_shape"]
         n, c, spatial = shape[0], shape[1], tuple(shape[2:])
-        g = w["num_groups"] if "num_groups" in w else w["groups"]
+        g = w.get("num_groups", w.get("groups"))
+        if g is None:
+            raise KeyError(
+                f"Workload manifest for {_OP_NAME} must contain 'num_groups' or 'groups'"
+            )
         label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)


### PR DESCRIPTION
## Summary

- update the GroupNorm benchmark manifest adapter to read `num_groups`
- keep a fallback for older manifest snapshots that still use `groups`

Closes #1213

## Why

#1158 renamed the GroupNorm manifest workload key from `groups` to `num_groups`, but `benchmarks/ops/bench_group_norm.py` still read `w["groups"]`. That makes the nightly benchmark job fail during pytest collection before any benchmark cases run.

## Validation

Validated in the local nightly docker image with the shared nightly cache mounted at `/data7/shared/ci-cache`:

```text
python -m pytest --collect-only -q benchmarks/ops/bench_group_norm.py
# 4 tests collected

python -m pytest --collect-only -q benchmarks/ops
# 1213 tests collected

python -m pytest -q benchmarks/ops/bench_group_norm.py
# 3 passed, 1 skipped
```
