### PR TITLE
[Refactor][Manifest] drop eager ops import from tileops package

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -36,30 +36,11 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_DIR = REPO_ROOT / "tileops" / "manifest"
 
-# Load ``tileops/manifest/shape_rules.py`` directly via importlib so the
-# validator does not pull in the full ``tileops`` package (which eagerly
-# imports ``tileops.ops`` at package init time). Loading the module file
-# in isolation keeps the validator's import surface minimal and avoids
-# coupling validator startup to runtime op infrastructure.
-import importlib.util as _importlib_util  # noqa: E402
-
-_SHAPE_RULES_PATH = REPO_ROOT / "tileops" / "manifest" / "shape_rules.py"
-_shape_rules_spec = _importlib_util.spec_from_file_location(
-    "_tileops_validator_shape_rules", _SHAPE_RULES_PATH,
+from tileops.manifest.shape_rules import (  # noqa: E402
+    dim_range_validity,
+    dim_uniqueness,
+    reduced_axes,
 )
-if _shape_rules_spec is None or _shape_rules_spec.loader is None:
-    raise ImportError(
-        f"could not load shape_rules helpers from {_SHAPE_RULES_PATH}",
-    )
-_shape_rules_module = _importlib_util.module_from_spec(_shape_rules_spec)
-_shape_rules_spec.loader.exec_module(_shape_rules_module)
-# Pull individual helpers off the isolated module by attribute. Keeping
-# the references narrow (no broader registry import) localises any
-# future shape_rules.py rename or removal to a single edit site here.
-_dim_range_validity = _shape_rules_module.dim_range_validity
-_dim_uniqueness = _shape_rules_module.dim_uniqueness
-_reduced_axes = _shape_rules_module.reduced_axes
-del _shape_rules_module
 
 # Valid torch dtype base names (without same_as references)
 _TORCH_DTYPES = {
@@ -1543,9 +1524,9 @@ _SHAPE_RULE_BUILTIN_PAIRS = [
     ("max", max),
     ("broadcast_shapes", _broadcast_shapes),
     ("is_broadcastable_to", _is_broadcastable_to),
-    ("dim_range_validity", _dim_range_validity),
-    ("dim_uniqueness", _dim_uniqueness),
-    ("reduced_axes", _reduced_axes),
+    ("dim_range_validity", dim_range_validity),
+    ("dim_uniqueness", dim_uniqueness),
+    ("reduced_axes", reduced_axes),
 ]
 _SHAPE_RULE_BUILTINS: dict = {}
 for _entry_name, _entry_fn in _SHAPE_RULE_BUILTIN_PAIRS:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -33,14 +33,14 @@ from pathlib import Path
 
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-MANIFEST_DIR = REPO_ROOT / "tileops" / "manifest"
-
-from tileops.manifest.shape_rules import (  # noqa: E402
+from tileops.manifest.shape_rules import (
     dim_range_validity,
     dim_uniqueness,
     reduced_axes,
 )
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_DIR = REPO_ROOT / "tileops" / "manifest"
 
 # Valid torch dtype base names (without same_as references)
 _TORCH_DTYPES = {

--- a/tileops/__init__.py
+++ b/tileops/__init__.py
@@ -1,3 +1,1 @@
-from . import ops
-
-__all__ = ["ops"]
+__all__: list[str] = []


### PR DESCRIPTION
Closes #1216

## Summary

- Drop `from . import ops` (and the matching `__all__` entry) from `tileops/__init__.py`. Importing `tileops` no longer pulls in `tileops.ops` or any `tilelang.*` module as a side effect.
- Replace the `importlib.spec_from_file_location` workaround in `scripts/validate_manifest.py` with a direct `from tileops.manifest.shape_rules import dim_range_validity, dim_uniqueness, reduced_axes`. Drop the `_SHAPE_RULES_PATH` / `_shape_rules_spec` / `_shape_rules_module` plumbing and the underscore-prefixed rebindings.

## Test plan

- [x] AC-1: Modified files pass existing tests.
- [x] AC-2: `import tileops` does not load `tileops.ops` (verified via `sys.modules` snapshot).
- [x] AC-3: `from tileops.manifest import shape_rules` does not load `tileops.ops` or any `tilelang.*` module (verified via `sys.modules` snapshot).
- [x] AC-4: `scripts/validate_manifest.py` uses standard `from tileops.manifest.shape_rules import ...` instead of `importlib.spec_from_file_location`; the `_SHAPE_RULES_PATH` literal is removed.
- [x] AC-5: `python scripts/validate_manifest.py` exit 0 on the checked-in manifest, output bit-identical to pre-change baseline.
