### PR TITLE
[Feat][Ops] align elementwise_binary impl + tests to manifest spec

### DIFF
--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -848,6 +848,10 @@ def test_binary_arith_edge_cases(op_cls, ref_fn, gen_fn) -> None:
 
 
 class FloatOnlyBinaryRejectFixture(FixtureBase):
+    # ``MaximumFwdOp`` and ``MinimumFwdOp`` are intentionally absent: their
+    # manifests declare the full bool / integer / float dtype union and the
+    # op layer routes integer dtypes through a torch fallback so the
+    # manifest contract is honored end-to-end.
     PARAMS = [
         ("op_cls, dtype", [
             pytest.param(DivFwdOp, torch.int32, marks=pytest.mark.smoke),
@@ -855,8 +859,6 @@ class FloatOnlyBinaryRejectFixture(FixtureBase):
             pytest.param(PowFwdOp, torch.int32, marks=pytest.mark.smoke),
             pytest.param(FloorDivideFwdOp, torch.int64, marks=pytest.mark.smoke),
             pytest.param(LerpFwdOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MaximumFwdOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MinimumFwdOp, torch.int64, marks=pytest.mark.smoke),
         ]),
     ]
 

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -875,7 +875,7 @@ def test_binary_op_rejects_runtime_dtype_mismatch() -> None:
     op = SubFwdOp(a_shape=(16,), b_shape=(16,), dtype=torch.float16)
     a = torch.randn(16, device="cuda", dtype=torch.float32)
     b = torch.randn(16, device="cuda", dtype=torch.float16)
-    with pytest.raises(ValueError, match="Expected a.dtype"):
+    with pytest.raises(ValueError, match="Expected input.dtype"):
         op(a, b)
 
 

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -254,11 +254,18 @@ def test_eq_edge_case(n_total: int, dtype: torch.dtype) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Dtype rejection tests
+# Manifest dtype-union acceptance tests
 # ---------------------------------------------------------------------------
+#
+# Comparison ops declare the full ``bool | uint8 | int8 | int16 | int32 |
+# int64 | float16 | bfloat16 | float32`` union in the manifest. The
+# underlying TileLang kernel only supports float dtypes, so the op layer
+# routes integer / bool inputs through a torch eager fallback. These
+# tests pin the op-level acceptance and replace the previous "rejects
+# integer dtype" tests, which contradicted the manifest contract.
 
 
-class ComparisonRejectFixture(FixtureBase):
+class ComparisonAcceptFixture(FixtureBase):
     PARAMS = [
         ("op_cls, dtype", [
             pytest.param(EqFwdOp, torch.int32, marks=pytest.mark.smoke),
@@ -272,12 +279,12 @@ class ComparisonRejectFixture(FixtureBase):
     ]
 
 
-@ComparisonRejectFixture
-def test_comparison_rejects_integer_dtype(op_cls, dtype: torch.dtype) -> None:
-    """Comparison ops only support float dtypes; integers must be rejected."""
+@ComparisonAcceptFixture
+def test_comparison_accepts_integer_dtype(op_cls, dtype: torch.dtype) -> None:
+    """Comparison ops must accept the manifest-declared integer dtypes."""
     shape = (16,)
-    with pytest.raises(ValueError, match="does not support dtype"):
-        op_cls(a_shape=shape, b_shape=shape, dtype=dtype)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=dtype)
+    assert op.dtype is dtype
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_binary_alignment.py
+++ b/tests/ops/test_elementwise_binary_alignment.py
@@ -1,0 +1,372 @@
+"""Manifest-alignment conformance tests for ``elementwise_binary``.
+
+Covers the 24 ops in ``tileops/manifest/elementwise_binary.yaml``:
+
+- ``PreluFwdOp`` (channel-broadcast PReLU)
+- ``MaskedFillFwdOp`` / ``MaskedFillScalarFwdOp``
+- 9 binary arithmetic ops (Add/Sub/Mul/Div/Remainder/Pow/FloorDivide/Lerp/
+  Maximum/Minimum)
+- 6 binary comparison ops (Eq/Ne/Gt/Lt/Ge/Le)
+- 2 binary logical ops (LogicalAnd/LogicalOr)
+- 3 binary bitwise ops (BitwiseAnd/BitwiseOr/BitwiseXor)
+
+Each test asserts the live Op class signature satisfies the manifest L1
+contract: every manifest input appears in ``forward()`` in declaration
+order, and every manifest param is reachable through either
+``__init__()`` or ``forward()``.
+
+A separate group of tests exercises bidirectional broadcast: every
+broadcast-capable op must accept ``input.shape != other.shape`` and
+produce the bidirectional broadcast output shape. The ``MaskedFillScalar``
+dtype-widening contract (bool / uint8 / int8 / int16 / int32 / int64 /
+float16 / bfloat16 / float32) is also covered here.
+"""
+
+import inspect
+
+import pytest
+import torch
+
+# 24 ops in scope. (op_class_name, manifest_inputs (forward order),
+# manifest_params (any field that lives on __init__ or forward).)
+_BINARY_OPS = [
+    # PReLU and MaskedFill are independent custom-signature ops.
+    ("PreluFwdOp", ["input", "weight"], []),
+    ("MaskedFillFwdOp", ["input", "mask", "value"], []),
+    ("MaskedFillScalarFwdOp", ["input", "mask"], ["value"]),
+    # Binary arithmetic ops.
+    ("AddFwdOp", ["input", "other"], ["alpha"]),
+    ("SubFwdOp", ["input", "other"], ["alpha"]),
+    ("MulFwdOp", ["input", "other"], []),
+    ("DivFwdOp", ["input", "other"], ["rounding_mode"]),
+    ("RemainderFwdOp", ["input", "other"], []),
+    ("PowFwdOp", ["input", "exponent"], []),
+    ("FloorDivideFwdOp", ["input", "other"], []),
+    ("LerpFwdOp", ["input", "end"], ["weight"]),
+    ("MaximumFwdOp", ["input", "other"], []),
+    ("MinimumFwdOp", ["input", "other"], []),
+    # Binary comparison ops (output bool).
+    ("EqFwdOp", ["input", "other"], []),
+    ("NeFwdOp", ["input", "other"], []),
+    ("GtFwdOp", ["input", "other"], []),
+    ("LtFwdOp", ["input", "other"], []),
+    ("GeFwdOp", ["input", "other"], []),
+    ("LeFwdOp", ["input", "other"], []),
+    # Binary logical ops (output bool).
+    ("LogicalAndFwdOp", ["input", "other"], []),
+    ("LogicalOrFwdOp", ["input", "other"], []),
+    # Binary bitwise ops.
+    ("BitwiseAndFwdOp", ["input", "other"], []),
+    ("BitwiseOrFwdOp", ["input", "other"], []),
+    ("BitwiseXorFwdOp", ["input", "other"], []),
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name, manifest_inputs, manifest_params",
+    _BINARY_OPS,
+    ids=lambda v: v if isinstance(v, str) else None,
+)
+def test_binary_signature_matches_manifest(
+    op_name: str, manifest_inputs: list[str], manifest_params: list[str],
+) -> None:
+    """Op class signatures must satisfy the manifest L1 contract."""
+    import tileops.ops.elementwise as mod
+    from scripts.validate_manifest import (
+        _get_forward_params,
+        _get_init_params,
+        check_l1_signature,
+    )
+
+    cls = getattr(mod, op_name)
+    forward_params = _get_forward_params(cls)
+    assert forward_params is not None, (
+        f"Cannot extract forward() params for {op_name}"
+    )
+    init_params = _get_init_params(cls)
+    inputs_dict = {n: {} for n in manifest_inputs}
+    params_dict = {n: {} for n in manifest_params}
+    errors = check_l1_signature(
+        op_name, inputs_dict, params_dict, forward_params,
+        init_params=init_params,
+    )
+    assert errors == [], f"{op_name}: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Bidirectional broadcast coverage (AC-5)
+# ---------------------------------------------------------------------------
+#
+# Every broadcast-capable binary op must accept input.shape != other.shape.
+# A representative bidirectional case ((3,1) x (1,4) -> (3,4)) exercises
+# both directions: input contributes the leading axis, other contributes
+# the trailing axis, neither operand alone is the output shape.
+
+# (op_name, dtype, gen_a, gen_b, ref_fn)
+_BROADCAST_FLOAT_OPS = [
+    ("AddFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a + b),
+    ("SubFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a - b),
+    ("MulFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a * b),
+    ("DivFwdOp",
+     torch.float16,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda a, b: a / b),
+    ("RemainderFwdOp",
+     torch.float16,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda a, b: torch.remainder(a, b)),
+    ("PowFwdOp",
+     torch.float16,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.5,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") * 2.0,
+     lambda a, b: torch.pow(a, b)),
+    ("FloorDivideFwdOp",
+     torch.float16,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda s, d: torch.rand(*s, dtype=d, device="cuda") + 0.1,
+     lambda a, b: torch.floor_divide(a, b)),
+    ("LerpFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: torch.lerp(a, b, 0.5)),
+    ("MaximumFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: torch.maximum(a, b)),
+    ("MinimumFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: torch.minimum(a, b)),
+    ("EqFwdOp",
+     torch.float16,
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda a, b: a == b),
+    ("NeFwdOp",
+     torch.float16,
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda a, b: a != b),
+    ("GtFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a > b),
+    ("LtFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a < b),
+    ("GeFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a >= b),
+    ("LeFwdOp",
+     torch.float16,
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda s, d: torch.randn(*s, dtype=d, device="cuda"),
+     lambda a, b: a <= b),
+    ("LogicalAndFwdOp",
+     torch.float16,
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda a, b: torch.logical_and(a, b)),
+    ("LogicalOrFwdOp",
+     torch.float16,
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda s, d: (torch.randn(*s, dtype=d, device="cuda") > 0).to(d),
+     lambda a, b: torch.logical_or(a, b)),
+]
+
+_BROADCAST_INT_OPS = [
+    ("BitwiseAndFwdOp",
+     torch.int32,
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda a, b: torch.bitwise_and(a, b)),
+    ("BitwiseOrFwdOp",
+     torch.int32,
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda a, b: torch.bitwise_or(a, b)),
+    ("BitwiseXorFwdOp",
+     torch.int32,
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda s, d: torch.randint(-1000, 1000, s, dtype=d, device="cuda"),
+     lambda a, b: torch.bitwise_xor(a, b)),
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "op_name, dtype, gen_a, gen_b, ref_fn",
+    _BROADCAST_FLOAT_OPS + _BROADCAST_INT_OPS,
+    ids=lambda v: v if isinstance(v, str) else None,
+)
+def test_binary_op_bidirectional_broadcast(
+    op_name: str, dtype: torch.dtype, gen_a, gen_b, ref_fn,
+) -> None:
+    """Bidirectional broadcast: (3,1) x (1,4) -> (3,4)."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    a_shape = (3, 1)
+    b_shape = (1, 4)
+    a = gen_a(a_shape, dtype)
+    b = gen_b(b_shape, dtype)
+    op = cls(a_shape=a_shape, b_shape=b_shape, dtype=dtype)
+    out = op(a, b)
+    ref = ref_fn(a, b)
+    assert tuple(out.shape) == (3, 4), (
+        f"{op_name}: expected output shape (3, 4), got {tuple(out.shape)}"
+    )
+    if out.dtype.is_floating_point:
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+    else:
+        torch.testing.assert_close(out, ref.to(out.dtype))
+
+
+# ---------------------------------------------------------------------------
+# MaskedFillScalar dtype widening (AC-4)
+# ---------------------------------------------------------------------------
+
+# Manifest declares: bool | uint8 | int8 | int16 | int32 | int64 |
+# float16 | bfloat16 | float32. Construction must succeed for every dtype
+# at the impl level even when the underlying float-only kernel cannot run
+# integer dtypes — the op layer routes integer inputs through a torch
+# fallback so the manifest contract is honored end-to-end.
+_MASKED_FILL_DTYPE_UNION = [
+    torch.bool,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _MASKED_FILL_DTYPE_UNION)
+def test_masked_fill_scalar_accepts_manifest_dtype_union(
+    dtype: torch.dtype,
+) -> None:
+    """MaskedFillScalarFwdOp must accept the full manifest dtype union."""
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+
+    # Construction must succeed for every manifest-declared dtype.
+    op = MaskedFillScalarFwdOp(
+        input=(8,), mask=(8,), value=0, dtype=dtype,
+    )
+    assert op.dtype is dtype
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.bool,
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    ],
+)
+def test_masked_fill_scalar_int_fallback_matches_torch(
+    dtype: torch.dtype,
+) -> None:
+    """Integer-dtype MaskedFillScalar must match torch.masked_fill."""
+    from tileops.ops.elementwise import MaskedFillScalarFwdOp
+
+    n = 16
+    if dtype is torch.bool:
+        x = torch.zeros(n, dtype=dtype, device="cuda")
+        x[::2] = True
+        fill_value = True
+    else:
+        x = torch.arange(n, dtype=dtype, device="cuda")
+        fill_value = 7
+    mask = torch.zeros(n, dtype=torch.bool, device="cuda")
+    mask[1::2] = True
+    op = MaskedFillScalarFwdOp(
+        input=(n,), mask=(n,), value=fill_value, dtype=dtype,
+    )
+    out = op(x, mask)
+    ref = x.masked_fill(mask, fill_value)
+    assert out.dtype == dtype
+    torch.testing.assert_close(out, ref)
+
+
+# ---------------------------------------------------------------------------
+# Param plumbing for ops with extra manifest params
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_add_alpha_param_plumbed() -> None:
+    """AddFwdOp must accept manifest-declared ``alpha`` param.
+
+    PyTorch ``torch.add(input, other, *, alpha=1)`` defaults alpha to 1.
+    """
+    from tileops.ops.elementwise import AddFwdOp
+
+    init_sig = inspect.signature(AddFwdOp.__init__)
+    forward_sig = inspect.signature(AddFwdOp.forward)
+    keys = set(init_sig.parameters) | set(forward_sig.parameters)
+    assert "alpha" in keys, (
+        f"AddFwdOp missing manifest 'alpha' param; init keys "
+        f"{list(init_sig.parameters)}, forward keys "
+        f"{list(forward_sig.parameters)}"
+    )
+
+
+@pytest.mark.smoke
+def test_sub_alpha_param_plumbed() -> None:
+    """SubFwdOp must accept manifest-declared ``alpha`` param."""
+    from tileops.ops.elementwise import SubFwdOp
+
+    init_sig = inspect.signature(SubFwdOp.__init__)
+    forward_sig = inspect.signature(SubFwdOp.forward)
+    keys = set(init_sig.parameters) | set(forward_sig.parameters)
+    assert "alpha" in keys, f"SubFwdOp missing 'alpha'; got {keys}"
+
+
+@pytest.mark.smoke
+def test_div_rounding_mode_param_plumbed() -> None:
+    """DivFwdOp must accept manifest-declared ``rounding_mode`` param."""
+    from tileops.ops.elementwise import DivFwdOp
+
+    init_sig = inspect.signature(DivFwdOp.__init__)
+    forward_sig = inspect.signature(DivFwdOp.forward)
+    keys = set(init_sig.parameters) | set(forward_sig.parameters)
+    assert "rounding_mode" in keys, (
+        f"DivFwdOp missing 'rounding_mode'; got {keys}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_elementwise_binary_alignment.py
+++ b/tests/ops/test_elementwise_binary_alignment.py
@@ -95,7 +95,7 @@ def test_binary_signature_matches_manifest(
 
 
 # ---------------------------------------------------------------------------
-# Bidirectional broadcast coverage (AC-5)
+# Bidirectional broadcast coverage
 # ---------------------------------------------------------------------------
 #
 # Every broadcast-capable binary op must accept input.shape != other.shape.
@@ -247,7 +247,7 @@ def test_binary_op_bidirectional_broadcast(
 
 
 # ---------------------------------------------------------------------------
-# MaskedFillScalar dtype widening (AC-4)
+# MaskedFillScalar dtype widening
 # ---------------------------------------------------------------------------
 
 # Manifest declares: bool | uint8 | int8 | int16 | int32 | int64 |

--- a/tests/ops/test_elementwise_binary_alignment.py
+++ b/tests/ops/test_elementwise_binary_alignment.py
@@ -4,7 +4,7 @@ Covers the 24 ops in ``tileops/manifest/elementwise_binary.yaml``:
 
 - ``PreluFwdOp`` (channel-broadcast PReLU)
 - ``MaskedFillFwdOp`` / ``MaskedFillScalarFwdOp``
-- 9 binary arithmetic ops (Add/Sub/Mul/Div/Remainder/Pow/FloorDivide/Lerp/
+- 10 binary arithmetic ops (Add/Sub/Mul/Div/Remainder/Pow/FloorDivide/Lerp/
   Maximum/Minimum)
 - 6 binary comparison ops (Eq/Ne/Gt/Lt/Ge/Le)
 - 2 binary logical ops (LogicalAnd/LogicalOr)
@@ -366,6 +366,226 @@ def test_div_rounding_mode_param_plumbed() -> None:
     assert "rounding_mode" in keys, (
         f"DivFwdOp missing 'rounding_mode'; got {keys}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Functional correctness for non-default alpha / rounding_mode
+# ---------------------------------------------------------------------------
+#
+# The Op layer routes non-default ``alpha`` / ``rounding_mode`` through a
+# torch eager fallback (the kernel does not bake these in). These tests
+# guard the runtime semantics on the fallback path so the manifest
+# contract for non-default values is honored end-to-end, not just at the
+# signature level.
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_add_alpha_nondefault_matches_torch() -> None:
+    """``AddFwdOp(alpha=2)`` must agree with ``torch.add(..., alpha=2)``."""
+    from tileops.ops.elementwise import AddFwdOp
+
+    a = torch.randn(8, dtype=torch.float16, device="cuda")
+    b = torch.randn(8, dtype=torch.float16, device="cuda")
+    op = AddFwdOp(a_shape=(8,), b_shape=(8,), dtype=torch.float16, alpha=2)
+    out = op(a, b)
+    ref = torch.add(a, b, alpha=2)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_sub_alpha_nondefault_matches_torch() -> None:
+    """``SubFwdOp(alpha=3)`` must agree with ``torch.sub(..., alpha=3)``."""
+    from tileops.ops.elementwise import SubFwdOp
+
+    a = torch.randn(8, dtype=torch.float16, device="cuda")
+    b = torch.randn(8, dtype=torch.float16, device="cuda")
+    op = SubFwdOp(a_shape=(8,), b_shape=(8,), dtype=torch.float16, alpha=3)
+    out = op(a, b)
+    ref = torch.sub(a, b, alpha=3)
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("rounding_mode", ["floor", "trunc"])
+def test_div_rounding_mode_nondefault_matches_torch(rounding_mode: str) -> None:
+    """``DivFwdOp(rounding_mode=...)`` must agree with ``torch.div``."""
+    from tileops.ops.elementwise import DivFwdOp
+
+    a = torch.randn(8, dtype=torch.float32, device="cuda") * 4.0
+    b = torch.rand(8, dtype=torch.float32, device="cuda") + 0.5
+    op = DivFwdOp(
+        a_shape=(8,), b_shape=(8,), dtype=torch.float32,
+        rounding_mode=rounding_mode,
+    )
+    out = op(a, b)
+    ref = torch.div(a, b, rounding_mode=rounding_mode)
+    torch.testing.assert_close(out, ref)
+
+
+@pytest.mark.smoke
+def test_alpha_and_rounding_mode_are_keyword_only() -> None:
+    """``alpha`` / ``rounding_mode`` must be keyword-only.
+
+    Inserting them positionally before ``strategy/kernel_map/tune`` would
+    silently re-bind any existing positional ``strategy`` arguments to
+    the new param.
+    """
+    from tileops.ops.elementwise import AddFwdOp, DivFwdOp, SubFwdOp
+
+    for cls, name in [(AddFwdOp, "alpha"), (SubFwdOp, "alpha"), (DivFwdOp, "rounding_mode")]:
+        sig = inspect.signature(cls.__init__)
+        param = sig.parameters[name]
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"{cls.__name__}.__init__({name}) must be keyword-only, "
+            f"got kind={param.kind}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest dtype-union coverage
+# ---------------------------------------------------------------------------
+#
+# The manifest declares the full
+# ``bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 |
+# float32`` dtype union for arithmetic Add/Sub/Mul/Maximum/Minimum and
+# every comparison op (Eq/Ne/Gt/Lt/Ge/Le). The underlying TileLang
+# kernel only supports float dtypes, so the op layer routes integer /
+# bool inputs through a torch eager fallback. These tests:
+#
+#   1. ``test_*_construction_*`` -- construction must succeed for every
+#      manifest dtype (was previously ``ValueError`` for non-float).
+#   2. ``test_*_int_fallback_matches_torch`` -- the fallback path must
+#      match ``torch`` runtime semantics.
+
+_BINARY_FULL_UNION = [
+    torch.bool,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+]
+
+# Bool is excluded for ops where torch itself rejects bool-in-bool-out
+# arithmetic (sub does not accept bool).
+_ARITH_DTYPES_NO_BOOL = [d for d in _BINARY_FULL_UNION if d is not torch.bool]
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name", ["AddFwdOp", "MulFwdOp", "MaximumFwdOp", "MinimumFwdOp"],
+)
+@pytest.mark.parametrize("dtype", _BINARY_FULL_UNION)
+def test_arith_construction_accepts_manifest_dtype_union(
+    op_name: str, dtype: torch.dtype,
+) -> None:
+    """Add/Mul/Maximum/Minimum must construct for every manifest dtype."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    op = cls(a_shape=(8,), b_shape=(8,), dtype=dtype)
+    assert op.dtype is dtype
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", _ARITH_DTYPES_NO_BOOL)
+def test_sub_construction_accepts_manifest_dtype_union(
+    dtype: torch.dtype,
+) -> None:
+    """SubFwdOp must construct for every manifest dtype except bool."""
+    from tileops.ops.elementwise import SubFwdOp
+
+    op = SubFwdOp(a_shape=(8,), b_shape=(8,), dtype=dtype)
+    assert op.dtype is dtype
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name",
+    ["EqFwdOp", "NeFwdOp", "GtFwdOp", "LtFwdOp", "GeFwdOp", "LeFwdOp"],
+)
+@pytest.mark.parametrize("dtype", _BINARY_FULL_UNION)
+def test_compare_construction_accepts_manifest_dtype_union(
+    op_name: str, dtype: torch.dtype,
+) -> None:
+    """Comparison ops must construct for every manifest dtype."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    op = cls(a_shape=(8,), b_shape=(8,), dtype=dtype)
+    assert op.dtype is dtype
+
+
+# (op_name, torch ref) for arithmetic ops that share the full union.
+_ARITH_INT_FALLBACK = [
+    ("AddFwdOp", lambda a, b: a + b),
+    ("MulFwdOp", lambda a, b: a * b),
+    ("MaximumFwdOp", torch.maximum),
+    ("MinimumFwdOp", torch.minimum),
+]
+
+_COMPARE_INT_FALLBACK = [
+    ("EqFwdOp", torch.eq),
+    ("NeFwdOp", torch.ne),
+    ("GtFwdOp", torch.gt),
+    ("LtFwdOp", torch.lt),
+    ("GeFwdOp", torch.ge),
+    ("LeFwdOp", torch.le),
+]
+
+_INT_DTYPES = [
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("op_name, ref_fn", _ARITH_INT_FALLBACK)
+@pytest.mark.parametrize("dtype", _INT_DTYPES)
+def test_arith_int_fallback_matches_torch(
+    op_name: str, ref_fn, dtype: torch.dtype,
+) -> None:
+    """Integer arithmetic ops must match torch via the op-layer fallback."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    a = torch.randint(0, 8, (8,), dtype=dtype, device="cuda")
+    b = torch.randint(1, 8, (8,), dtype=dtype, device="cuda")
+    op = cls(a_shape=(8,), b_shape=(8,), dtype=dtype)
+    out = op(a, b)
+    ref = ref_fn(a, b)
+    assert out.dtype == ref.dtype
+    torch.testing.assert_close(out, ref)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("op_name, ref_fn", _COMPARE_INT_FALLBACK)
+@pytest.mark.parametrize("dtype", _INT_DTYPES)
+def test_compare_int_fallback_matches_torch(
+    op_name: str, ref_fn, dtype: torch.dtype,
+) -> None:
+    """Integer comparison ops must match torch via the op-layer fallback."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    a = torch.randint(0, 4, (8,), dtype=dtype, device="cuda")
+    b = torch.randint(0, 4, (8,), dtype=dtype, device="cuda")
+    op = cls(a_shape=(8,), b_shape=(8,), dtype=dtype)
+    out = op(a, b)
+    ref = ref_fn(a, b)
+    assert out.dtype == torch.bool
+    torch.testing.assert_close(out, ref)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_binary_alignment.py
+++ b/tests/ops/test_elementwise_binary_alignment.py
@@ -588,5 +588,32 @@ def test_compare_int_fallback_matches_torch(
     torch.testing.assert_close(out, ref)
 
 
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "op_name, ref_fn",
+    [
+        ("AddFwdOp", torch.add),
+        ("MulFwdOp", torch.mul),
+        ("MaximumFwdOp", torch.maximum),
+        ("MinimumFwdOp", torch.minimum),
+    ],
+)
+def test_arith_bool_fallback_matches_torch(op_name: str, ref_fn) -> None:
+    """Bool arithmetic ops in the manifest dtype union must match torch."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    a = torch.tensor([True, False, True, False, True, False, True, False],
+                     dtype=torch.bool, device="cuda")
+    b = torch.tensor([True, True, False, False, True, True, False, False],
+                     dtype=torch.bool, device="cuda")
+    op = cls(a_shape=(8,), b_shape=(8,), dtype=torch.bool)
+    out = op(a, b)
+    ref = ref_fn(a, b)
+    assert out.dtype == ref.dtype
+    torch.testing.assert_close(out, ref)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1169,8 +1169,10 @@ class _AlphaScaledBinaryOp(BinaryOp):
     Non-default ``alpha`` values are routed through a ``torch.add`` /
     ``torch.sub`` eager fallback after the same input validation as the
     kernel path runs, so the manifest contract is honored without a
-    kernel rewrite. ``alpha`` is keyword-only to keep the existing
-    positional ``(a_shape, b_shape, dtype, strategy, ...)`` call pattern.
+    kernel rewrite. The leading ``*`` makes ``alpha`` and the existing
+    ``strategy`` / ``kernel_map`` / ``tune`` parameters keyword-only;
+    only the positional triplet ``(a_shape, b_shape, dtype)`` is shared
+    with ``BinaryOp``.
     """
 
     def __init__(
@@ -1210,8 +1212,11 @@ class AddFwdOp(_AlphaScaledBinaryOp):
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
-        self._validate_binary_inputs(input, other)
         if self.alpha != 1:
+            # Fallback path bypasses ``BinaryOp.forward`` so we run the
+            # shared validator here. The ``alpha == 1`` path delegates to
+            # ``super().forward()``, which already validates.
+            self._validate_binary_inputs(input, other)
             return torch.add(input, other, alpha=self.alpha)
         return super().forward(input, other)
 
@@ -1234,8 +1239,10 @@ class SubFwdOp(_AlphaScaledBinaryOp):
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
-        self._validate_binary_inputs(input, other)
         if self.alpha != 1:
+            # Fallback path bypasses ``BinaryOp.forward``; validate here.
+            # The ``alpha == 1`` path delegates to ``super().forward()``.
+            self._validate_binary_inputs(input, other)
             return torch.sub(input, other, alpha=self.alpha)
         return super().forward(input, other)
 
@@ -1256,9 +1263,10 @@ class DivFwdOp(BinaryOp):
     ``rounding_mode`` accepts ``None`` (true division), ``"trunc"``
     (truncation toward zero), or ``"floor"`` (floor division). Non-None
     rounding modes run through a ``torch.div`` eager fallback after the
-    standard ``BinaryOp`` device / dtype / numel checks. ``rounding_mode``
-    is keyword-only to preserve the existing positional
-    ``(a_shape, b_shape, dtype, strategy, ...)`` call pattern.
+    standard ``BinaryOp`` device / dtype / numel checks. The leading ``*``
+    makes ``rounding_mode`` and the existing ``strategy`` / ``kernel_map``
+    / ``tune`` parameters keyword-only; only the positional triplet
+    ``(a_shape, b_shape, dtype)`` is shared with ``BinaryOp``.
     """
 
     _op_name = "div"
@@ -1291,8 +1299,10 @@ class DivFwdOp(BinaryOp):
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
-        self._validate_binary_inputs(input, other)
         if self.rounding_mode is not None:
+            # Fallback path bypasses ``BinaryOp.forward``; validate here.
+            # The default path delegates to ``super().forward()``.
+            self._validate_binary_inputs(input, other)
             return torch.div(input, other, rounding_mode=self.rounding_mode)
         return super().forward(input, other)
 
@@ -3038,7 +3048,9 @@ class MaskedFillScalarFwdOp(Op):
     Args:
         input: Shape of the input tensor.
         mask: Shape of the mask tensor (bool).
-        value: Scalar fill value.
+        value: Scalar fill value (bool / int / float; range-validated
+            against ``dtype`` for the float vectorized path; passed
+            through verbatim on the integer / bool fallback path).
         dtype: Torch dtype.
     """
 
@@ -3049,7 +3061,7 @@ class MaskedFillScalarFwdOp(Op):
         self,
         input: tuple,  # noqa: A002
         mask: tuple,
-        value: float = 0.0,
+        value: bool | int | float = 0,
         dtype: torch.dtype = torch.float32,
     ):
         self.input_shape = tuple(input)

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -842,32 +842,40 @@ class BinaryOp(Op):
         out_elem = fp8_out.itemsize if fp8_out is not None else in_elem
         return (self.a_numel + self.b_numel) * in_elem + self.N_total * out_elem
 
-    def _eager_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: torch.Tensor,
+    ) -> torch.Tensor:
         """Direct kernel call for use inside custom_op implementation."""
         result = self.kernel(
-            a.contiguous().view(-1), b.contiguous().view(-1),
+            input.contiguous().view(-1), other.contiguous().view(-1),
         ).reshape(self.out_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        if not a.is_cuda or not b.is_cuda:
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        if not input.is_cuda or not other.is_cuda:
             raise ValueError("Inputs must be CUDA tensors")
-        if a.dtype != self.dtype:
-            raise ValueError(f"Expected a.dtype {self.dtype}, got {a.dtype}")
-        if b.dtype != self.dtype:
-            raise ValueError(f"Expected b.dtype {self.dtype}, got {b.dtype}")
-        if a.numel() != self.a_numel:
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if other.dtype != self.dtype:
+            raise ValueError(f"Expected other.dtype {self.dtype}, got {other.dtype}")
+        if input.numel() != self.a_numel:
             raise ValueError(
-                f"Expected a to have {self.a_numel} elements, got {a.numel()}"
+                f"Expected input to have {self.a_numel} elements, got {input.numel()}"
             )
-        if b.numel() != self.b_numel:
+        if other.numel() != self.b_numel:
             raise ValueError(
-                f"Expected b to have {self.b_numel} elements, got {b.numel()}"
+                f"Expected other to have {self.b_numel} elements, got {other.numel()}"
             )
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(a, b, self._out_shape_list, self._instance_key)
-        return self._eager_forward(a, b)
+            return wrapped(input, other, self._out_shape_list, self._instance_key)
+        return self._eager_forward(input, other)
 
 
 class FusedGatedOp(Op):
@@ -1068,32 +1076,126 @@ class ReluFwdOp(UnaryOp, _InplaceMixin):
         return self._inplace_aware_forward(input)
 
 
-class AddFwdOp(BinaryOp):
-    """Element-wise addition with broadcast: y = a + b."""
+class _AlphaScaledBinaryOp(BinaryOp):
+    """Shared base for ops that take a scalar ``alpha`` multiplier on ``other``.
+
+    PyTorch ``torch.add(input, other, alpha=1)`` and ``torch.sub(input,
+    other, alpha=1)`` scale ``other`` by ``alpha`` before the binary op.
+    The kernel does not bake ``alpha`` in, so ``alpha != 1`` is enforced
+    at the op layer by pre-scaling ``other`` before kernel dispatch.
+    Only the manifest-declared default (``alpha=1``) is wired through the
+    fast kernel path; non-default values fall through to a torch eager
+    op so the manifest contract is honored without a kernel rewrite.
+    """
+
+    _alpha_default: int | float = 1
+
+    def __init__(
+        self,
+        a_shape: tuple,
+        b_shape: tuple,
+        dtype: torch.dtype,
+        alpha: int | float = 1,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        super().__init__(
+            a_shape, b_shape, dtype, strategy=strategy,
+            kernel_map=kernel_map, tune=tune,
+        )
+        self.alpha = alpha
+
+
+class AddFwdOp(_AlphaScaledBinaryOp):
+    """Element-wise addition with broadcast: y = input + alpha * other.
+
+    Conforms to ``torch.add(input, other, *, alpha=1)``. ``alpha`` defaults
+    to ``1``; non-default values fall through to a torch fallback so the
+    manifest contract is honored end-to-end.
+    """
 
     _op_name = "add"
     kernel_cls = AddFwdKernel
 
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.alpha != 1:
+            return torch.add(input, other, alpha=self.alpha)
+        return super().forward(input, other)
 
-class SubFwdOp(BinaryOp):
-    """Element-wise subtraction with broadcast: y = a - b."""
+
+class SubFwdOp(_AlphaScaledBinaryOp):
+    """Element-wise subtraction with broadcast: y = input - alpha * other.
+
+    Conforms to ``torch.sub(input, other, *, alpha=1)``.
+    """
 
     _op_name = "sub"
     kernel_cls = SubFwdKernel
 
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.alpha != 1:
+            return torch.sub(input, other, alpha=self.alpha)
+        return super().forward(input, other)
+
 
 class MulFwdOp(BinaryOp):
-    """Element-wise multiplication with broadcast: y = a * b."""
+    """Element-wise multiplication with broadcast: y = input * other."""
 
     _op_name = "mul"
     kernel_cls = MulFwdKernel
 
 
 class DivFwdOp(BinaryOp):
-    """Element-wise division with broadcast: y = a / b."""
+    """Element-wise division with broadcast: y = input / other.
+
+    Conforms to ``torch.div(input, other, *, rounding_mode=None)``.
+    ``rounding_mode`` accepts ``None`` (true division), ``"trunc"``
+    (truncation toward zero), or ``"floor"`` (floor division). Non-None
+    rounding modes route through a torch fallback rather than a kernel
+    rewrite, honoring the manifest contract end-to-end.
+    """
 
     _op_name = "div"
     kernel_cls = DivFwdKernel
+
+    def __init__(
+        self,
+        a_shape: tuple,
+        b_shape: tuple,
+        dtype: torch.dtype,
+        rounding_mode: Optional[str] = None,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        if rounding_mode is not None and rounding_mode not in ("trunc", "floor"):
+            raise ValueError(
+                f"DivFwdOp received rounding_mode={rounding_mode!r}; "
+                "manifest allows None, 'trunc', or 'floor'"
+            )
+        super().__init__(
+            a_shape, b_shape, dtype, strategy=strategy,
+            kernel_map=kernel_map, tune=tune,
+        )
+        self.rounding_mode = rounding_mode
+
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.rounding_mode is not None:
+            return torch.div(input, other, rounding_mode=self.rounding_mode)
+        return super().forward(input, other)
 
 
 class RemainderFwdOp(BinaryOp):
@@ -1104,10 +1206,29 @@ class RemainderFwdOp(BinaryOp):
 
 
 class PowFwdOp(BinaryOp):
-    """Element-wise power with broadcast: y = a ** b."""
+    """Element-wise power with broadcast: y = input ** exponent.
+
+    Conforms to ``torch.pow(input, exponent)``: the second operand carries
+    the manifest-declared name ``exponent`` rather than the generic
+    ``other`` so the L1 signature check matches the manifest.
+    """
 
     _op_name = "pow"
     kernel_cls = PowFwdKernel
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        exponent: torch.Tensor,
+    ) -> torch.Tensor:
+        return super()._eager_forward(input, exponent)
+
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        exponent: torch.Tensor,
+    ) -> torch.Tensor:
+        return super().forward(input, exponent)
 
 
 class FloorDivideFwdOp(BinaryOp):
@@ -1137,6 +1258,20 @@ class LerpFwdOp(BinaryOp):
 
     _op_name = "lerp"
     kernel_cls = LerpFwdKernel
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        end: torch.Tensor,
+    ) -> torch.Tensor:
+        return BinaryOp._eager_forward(self, input, end)
+
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        end: torch.Tensor,
+    ) -> torch.Tensor:
+        return BinaryOp.forward(self, input, end)
 
     def __init__(
         self,
@@ -1211,8 +1346,12 @@ class _BoolOutputBinaryOp(BinaryOp):
     _eager_forward (eager) or _wrapped (compile, where register_fake is correct).
     """
 
-    def _eager_forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        result = super()._eager_forward(a, b)
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        result = super()._eager_forward(input, other)
         return result.to(torch.bool)
 
 
@@ -2188,24 +2327,32 @@ class PreluFwdOp(Op):
     def default_kernel_map(self):
         return {"prelu": PreluFwdKernel}
 
-    def _eager_forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        orig_shape = x.shape
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        orig_shape = input.shape
         result = self.kernel(
-            x.contiguous().reshape(-1), weight.contiguous().reshape(-1),
+            input.contiguous().reshape(-1), weight.contiguous().reshape(-1),
         ).reshape(orig_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        weight: torch.Tensor,
+    ) -> torch.Tensor:
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {x.numel()}")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, weight, self._instance_key)
-        return self._eager_forward(x, weight)
+            return wrapped(input, weight, self._instance_key)
+        return self._eager_forward(input, weight)
 
 
 class WhereFwdOp(Op):
@@ -2734,11 +2881,27 @@ class MaskedFillFwdOp(Op):
         return self._eager_forward(input, mask, value)
 
 
+_MASKED_FILL_INT_DTYPES = (
+    torch.bool,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+)
+
+
 class MaskedFillScalarFwdOp(Op):
     """MaskedFill with Number (scalar) value.
 
     Conforms to ``torch.Tensor.masked_fill(mask, value: Number)``. Output
     shape follows the bidirectional broadcast of ``input`` and ``mask``.
+
+    The manifest declares the full PyTorch dtype union (``bool | uint8 |
+    int8 | int16 | int32 | int64 | float16 | bfloat16 | float32``). The
+    underlying TileLang kernel only supports float dtypes; integer and
+    bool dtypes route through a torch eager fallback at the op layer so
+    the manifest contract is honored end-to-end without a kernel rewrite.
 
     Args:
         input: Shape of the input tensor.
@@ -2757,7 +2920,6 @@ class MaskedFillScalarFwdOp(Op):
         value: float = 0.0,
         dtype: torch.dtype = torch.float32,
     ):
-        _validate_scalar_param_repr("value", value, dtype, self._op_name)
         self.input_shape = tuple(input)
         self.mask_shape = tuple(mask)
         self.dtype = dtype
@@ -2772,7 +2934,17 @@ class MaskedFillScalarFwdOp(Op):
         self._needs_broadcast = (
             self.input_shape != self.out_shape or self.mask_shape != self.out_shape
         )
-        self.kernel = MaskedFillFwdKernel(self.N_total, dtype, value)
+        # Integer / bool dtypes route through a torch fallback because the
+        # underlying float-only kernel cannot run them. Float dtypes go
+        # through the fast vectorized kernel as before, with the scalar
+        # representability validator gating against silent overflow into
+        # the user-facing dtype.
+        self._use_torch_fallback = dtype in _MASKED_FILL_INT_DTYPES
+        if self._use_torch_fallback:
+            self.kernel = None
+        else:
+            _validate_scalar_param_repr("value", value, dtype, self._op_name)
+            self.kernel = MaskedFillFwdKernel(self.N_total, dtype, value)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -2787,6 +2959,8 @@ class MaskedFillScalarFwdOp(Op):
         return t.contiguous().view(-1)
 
     def _eager_forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if self._use_torch_fallback:
+            return input.masked_fill(mask, self.value)
         out_shape = self.out_shape if self.out_shape else (1,)
         x_flat = self._expand_flat(input, out_shape)
         mask_b = mask if mask.dtype == torch.bool else mask.bool()
@@ -2812,7 +2986,7 @@ class MaskedFillScalarFwdOp(Op):
                 f"Expected mask.shape {self.mask_shape}, got {tuple(mask.shape)}"
             )
         wrapped = type(self)._wrapped
-        if wrapped is not None:
+        if wrapped is not None and not self._use_torch_fallback:
             return wrapped(input, mask, self._instance_key)
         return self._eager_forward(input, mask)
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1363,14 +1363,14 @@ class LerpFwdOp(BinaryOp):
         input: torch.Tensor,  # noqa: A002
         end: torch.Tensor,
     ) -> torch.Tensor:
-        return BinaryOp._eager_forward(self, input, end)
+        return super()._eager_forward(input, end)
 
     def forward(
         self,
         input: torch.Tensor,  # noqa: A002
         end: torch.Tensor,
     ) -> torch.Tensor:
-        return BinaryOp.forward(self, input, end)
+        return super().forward(input, end)
 
     def __init__(
         self,

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -930,19 +930,21 @@ class BinaryOp(Op):
         ``torch.add(..., alpha=2)``) so that error types and messages stay
         consistent regardless of which branch ``forward`` takes.
         """
+        a_name = getattr(self, "_input_name", "input")
+        b_name = getattr(self, "_other_name", "other")
         if not input.is_cuda or not other.is_cuda:
             raise ValueError("Inputs must be CUDA tensors")
         if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+            raise ValueError(f"Expected {a_name}.dtype {self.dtype}, got {input.dtype}")
         if other.dtype != self.dtype:
-            raise ValueError(f"Expected other.dtype {self.dtype}, got {other.dtype}")
+            raise ValueError(f"Expected {b_name}.dtype {self.dtype}, got {other.dtype}")
         if input.numel() != self.a_numel:
             raise ValueError(
-                f"Expected input to have {self.a_numel} elements, got {input.numel()}"
+                f"Expected {a_name} to have {self.a_numel} elements, got {input.numel()}"
             )
         if other.numel() != self.b_numel:
             raise ValueError(
-                f"Expected other to have {self.b_numel} elements, got {other.numel()}"
+                f"Expected {b_name} to have {self.b_numel} elements, got {other.numel()}"
             )
 
     def forward(
@@ -1324,6 +1326,7 @@ class PowFwdOp(BinaryOp):
 
     _op_name = "pow"
     kernel_cls = PowFwdKernel
+    _other_name = "exponent"
 
     def _eager_forward(
         self,
@@ -1367,6 +1370,7 @@ class LerpFwdOp(BinaryOp):
 
     _op_name = "lerp"
     kernel_cls = LerpFwdKernel
+    _other_name = "end"
 
     def _eager_forward(
         self,

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -112,6 +112,25 @@ _FP8_NONSAT_OUTPUT_DTYPES = {
     torch.float8_e5m2: torch.float16,
 }
 
+# Manifest-declared dtypes for binary arithmetic / comparison ops that
+# the underlying float-only TileLang kernels cannot compile. The op
+# layer routes these through a torch eager fallback (see
+# ``BinaryOp._TORCH_FALLBACK_DTYPES``) so the manifest contract is
+# honored end-to-end. ``_BINARY_FALLBACK_INT_DTYPES`` includes
+# ``torch.bool`` for ops where the manifest signature accepts bool
+# input (e.g. ``torch.add``); the ``_no_bool`` variant excludes it for
+# ``torch.sub``, which mirrors PyTorch's rejection of bool arithmetic
+# for sub.
+_BINARY_FALLBACK_INT_DTYPES = (
+    torch.bool,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+)
+_BINARY_FALLBACK_INT_DTYPES_NO_BOOL = _BINARY_FALLBACK_INT_DTYPES[1:]
+
 
 def _effective_scalar_kernel_dtype(dtype: torch.dtype) -> torch.dtype:
     """Return the dtype used when scalar literals are materialized in kernels."""
@@ -792,6 +811,25 @@ class BinaryOp(Op):
     kernel_cls: type
     _op_name: str
     _wrapped = None  # Set by _register_binary_custom_op at class definition
+    # Subclasses set this to a torch reference (e.g. ``torch.add``) when the
+    # manifest dtype union extends beyond the underlying kernel's runtime
+    # support. ``None`` means "kernel-only"; passing a dtype in
+    # ``_TORCH_FALLBACK_DTYPES`` then raises.
+    _torch_fallback_fn: Optional[Callable] = None
+    # Manifest-declared dtypes that the kernel cannot compile and that
+    # must route through ``_torch_fallback_fn`` instead. The subclass
+    # owns this list because the kernel's ``SUPPORTED_DTYPES`` is
+    # frequently ``None`` (i.e. "no static check") even when the
+    # underlying TileLang codegen still rejects bool / integer
+    # arithmetic. Empty tuple means "every manifest dtype goes through
+    # the kernel path".
+    _TORCH_FALLBACK_DTYPES: tuple = ()
+    # Default for subclasses (e.g. ``LerpFwdOp``) that override
+    # ``__init__`` and do not exercise the dtype-fallback branch. Such
+    # subclasses leave ``_torch_fallback_fn = None`` and rely on the
+    # base class dtype check inline; the instance-level attribute may
+    # never be assigned, so ``forward`` consults the class-level default.
+    _use_torch_fallback = False
 
     def __init__(
         self,
@@ -802,9 +840,24 @@ class BinaryOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        supported = self.kernel_cls.SUPPORTED_DTYPES
-        if supported is not None and dtype not in supported:
-            names = ", ".join(str(dt) for dt in supported)
+        # Two-stage dtype gate:
+        #   1. The kernel may declare its own ``SUPPORTED_DTYPES``; honor
+        #      that as the kernel-path filter.
+        #   2. The op subclass owns ``_TORCH_FALLBACK_DTYPES`` -- dtypes
+        #      that are inside the manifest contract but outside what the
+        #      kernel can compile (e.g. bool / integer for the
+        #      float-only Add / Mul / Maximum kernels). For those, route
+        #      through ``_torch_fallback_fn`` instead.
+        kernel_supported = self.kernel_cls.SUPPORTED_DTYPES
+        is_fallback_dtype = (
+            self._torch_fallback_fn is not None
+            and dtype in self._TORCH_FALLBACK_DTYPES
+        )
+        kernel_supports = (
+            kernel_supported is None or dtype in kernel_supported
+        )
+        if not kernel_supports and not is_fallback_dtype:
+            names = ", ".join(str(dt) for dt in kernel_supported)
             raise ValueError(
                 f"{self._op_name} does not support dtype {dtype}. "
                 f"Supported: [{names}]"
@@ -821,11 +874,19 @@ class BinaryOp(Op):
         self.N_total = prod(out_shape)
         self.a_numel = prod(a_shape)
         self.b_numel = prod(b_shape)
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            self.N_total, dtype, coalesced_shape, a_strides, b_strides,
-            self.a_numel, self.b_numel, strategy=strategy, tune=tune,
-        )
+        # When the manifest dtype is outside kernel support, take the torch
+        # eager fallback path: skip kernel construction (it would raise) and
+        # mark the instance so forward() routes through ``_torch_fallback_fn``.
+        self._use_torch_fallback = is_fallback_dtype
+        if self._use_torch_fallback:
+            self.kernel_map = self.default_kernel_map
+            self.kernel = None
+        else:
+            self.dispatch_kernel(kernel_map)
+            self.kernel = self.kernel_map[self._op_name](
+                self.N_total, dtype, coalesced_shape, a_strides, b_strides,
+                self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            )
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -848,16 +909,27 @@ class BinaryOp(Op):
         other: torch.Tensor,
     ) -> torch.Tensor:
         """Direct kernel call for use inside custom_op implementation."""
+        if self._use_torch_fallback:
+            # Manifest-declared dtype outside kernel support: defer to the
+            # registered torch reference so the manifest contract is honored
+            # without a kernel rewrite. Broadcasting is handled by torch.
+            return type(self)._torch_fallback_fn(input, other)
         result = self.kernel(
             input.contiguous().view(-1), other.contiguous().view(-1),
         ).reshape(self.out_shape)
         return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(
+    def _validate_binary_inputs(
         self,
         input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
         other: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> None:
+        """Validate device / dtype / numel against the op's declared contract.
+
+        Shared by the kernel path and any subclass torch fallback (e.g.
+        ``torch.add(..., alpha=2)``) so that error types and messages stay
+        consistent regardless of which branch ``forward`` takes.
+        """
         if not input.is_cuda or not other.is_cuda:
             raise ValueError("Inputs must be CUDA tensors")
         if input.dtype != self.dtype:
@@ -872,8 +944,19 @@ class BinaryOp(Op):
             raise ValueError(
                 f"Expected other to have {self.b_numel} elements, got {other.numel()}"
             )
+
+    def forward(
+        self,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_binary_inputs(input, other)
         wrapped = type(self)._wrapped
-        if wrapped is not None:
+        # ``register_fake`` declares the kernel output dtype, so the
+        # ``_wrapped`` path cannot model the torch fallback faithfully.
+        # Route fallback dtypes through eager so the result dtype matches
+        # the manifest contract.
+        if wrapped is not None and not self._use_torch_fallback:
             return wrapped(input, other, self._out_shape_list, self._instance_key)
         return self._eager_forward(input, other)
 
@@ -1081,20 +1164,21 @@ class _AlphaScaledBinaryOp(BinaryOp):
 
     PyTorch ``torch.add(input, other, alpha=1)`` and ``torch.sub(input,
     other, alpha=1)`` scale ``other`` by ``alpha`` before the binary op.
-    The kernel does not bake ``alpha`` in, so ``alpha != 1`` is enforced
-    at the op layer by pre-scaling ``other`` before kernel dispatch.
-    Only the manifest-declared default (``alpha=1``) is wired through the
-    fast kernel path; non-default values fall through to a torch eager
-    op so the manifest contract is honored without a kernel rewrite.
+    The kernel does not bake ``alpha`` in: only the manifest-declared
+    default (``alpha=1``) is wired through the fast kernel path.
+    Non-default ``alpha`` values are routed through a ``torch.add`` /
+    ``torch.sub`` eager fallback after the same input validation as the
+    kernel path runs, so the manifest contract is honored without a
+    kernel rewrite. ``alpha`` is keyword-only to keep the existing
+    positional ``(a_shape, b_shape, dtype, strategy, ...)`` call pattern.
     """
-
-    _alpha_default: int | float = 1
 
     def __init__(
         self,
         a_shape: tuple,
         b_shape: tuple,
         dtype: torch.dtype,
+        *,
         alpha: int | float = 1,
         strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -1111,18 +1195,22 @@ class AddFwdOp(_AlphaScaledBinaryOp):
     """Element-wise addition with broadcast: y = input + alpha * other.
 
     Conforms to ``torch.add(input, other, *, alpha=1)``. ``alpha`` defaults
-    to ``1``; non-default values fall through to a torch fallback so the
-    manifest contract is honored end-to-end.
+    to ``1``; non-default values run through a ``torch.add`` eager
+    fallback after the standard ``BinaryOp`` device / dtype / numel
+    checks so the manifest contract is honored end-to-end.
     """
 
     _op_name = "add"
     kernel_cls = AddFwdKernel
+    _torch_fallback_fn = staticmethod(torch.add)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
     def forward(
         self,
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
+        self._validate_binary_inputs(input, other)
         if self.alpha != 1:
             return torch.add(input, other, alpha=self.alpha)
         return super().forward(input, other)
@@ -1131,17 +1219,22 @@ class AddFwdOp(_AlphaScaledBinaryOp):
 class SubFwdOp(_AlphaScaledBinaryOp):
     """Element-wise subtraction with broadcast: y = input - alpha * other.
 
-    Conforms to ``torch.sub(input, other, *, alpha=1)``.
+    Conforms to ``torch.sub(input, other, *, alpha=1)``. Non-default
+    ``alpha`` values run through a ``torch.sub`` eager fallback after the
+    standard ``BinaryOp`` device / dtype / numel checks.
     """
 
     _op_name = "sub"
     kernel_cls = SubFwdKernel
+    _torch_fallback_fn = staticmethod(torch.sub)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES_NO_BOOL
 
     def forward(
         self,
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
+        self._validate_binary_inputs(input, other)
         if self.alpha != 1:
             return torch.sub(input, other, alpha=self.alpha)
         return super().forward(input, other)
@@ -1152,6 +1245,8 @@ class MulFwdOp(BinaryOp):
 
     _op_name = "mul"
     kernel_cls = MulFwdKernel
+    _torch_fallback_fn = staticmethod(torch.mul)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class DivFwdOp(BinaryOp):
@@ -1160,8 +1255,10 @@ class DivFwdOp(BinaryOp):
     Conforms to ``torch.div(input, other, *, rounding_mode=None)``.
     ``rounding_mode`` accepts ``None`` (true division), ``"trunc"``
     (truncation toward zero), or ``"floor"`` (floor division). Non-None
-    rounding modes route through a torch fallback rather than a kernel
-    rewrite, honoring the manifest contract end-to-end.
+    rounding modes run through a ``torch.div`` eager fallback after the
+    standard ``BinaryOp`` device / dtype / numel checks. ``rounding_mode``
+    is keyword-only to preserve the existing positional
+    ``(a_shape, b_shape, dtype, strategy, ...)`` call pattern.
     """
 
     _op_name = "div"
@@ -1172,6 +1269,7 @@ class DivFwdOp(BinaryOp):
         a_shape: tuple,
         b_shape: tuple,
         dtype: torch.dtype,
+        *,
         rounding_mode: Optional[str] = None,
         strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -1193,6 +1291,7 @@ class DivFwdOp(BinaryOp):
         input: torch.Tensor,  # noqa: A002
         other: torch.Tensor,
     ) -> torch.Tensor:
+        self._validate_binary_inputs(input, other)
         if self.rounding_mode is not None:
             return torch.div(input, other, rounding_mode=self.rounding_mode)
         return super().forward(input, other)
@@ -1319,6 +1418,8 @@ class MaximumFwdOp(BinaryOp):
 
     _op_name = "maximum"
     kernel_cls = MaximumFwdKernel
+    _torch_fallback_fn = staticmethod(torch.maximum)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class MinimumFwdOp(BinaryOp):
@@ -1326,6 +1427,8 @@ class MinimumFwdOp(BinaryOp):
 
     _op_name = "minimum"
     kernel_cls = MinimumFwdKernel
+    _torch_fallback_fn = staticmethod(torch.minimum)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 # ---------------------------------------------------------------------------
@@ -1339,11 +1442,14 @@ class MinimumFwdOp(BinaryOp):
 class _BoolOutputBinaryOp(BinaryOp):
     """Mixin that casts kernel int8 output to torch.bool.
 
-    _eager_forward casts the int8 kernel output to bool.  In the torch.compile
-    path, register_fake already declares torch.bool as the output dtype, and
-    the actual execution goes through _eager_forward which handles the cast.
-    No forward override is needed because BinaryOp.forward delegates to
-    _eager_forward (eager) or _wrapped (compile, where register_fake is correct).
+    ``_eager_forward`` casts the int8 kernel output to bool.  In the
+    ``torch.compile`` path, ``register_fake`` already declares
+    ``torch.bool`` as the output dtype, and the actual execution goes
+    through ``_eager_forward`` which handles the cast.  When the manifest
+    dtype falls outside the underlying float kernel's support set, the
+    base ``BinaryOp._eager_forward`` returns the torch reference's
+    output directly (already ``torch.bool``), so the post-cast in this
+    branch is a no-op rather than a double-cast.
     """
 
     def _eager_forward(
@@ -1360,6 +1466,8 @@ class EqFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "eq"
     kernel_cls = EqFwdKernel
+    _torch_fallback_fn = staticmethod(torch.eq)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class NeFwdOp(_BoolOutputBinaryOp):
@@ -1367,6 +1475,8 @@ class NeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "ne"
     kernel_cls = NeFwdKernel
+    _torch_fallback_fn = staticmethod(torch.ne)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class GtFwdOp(_BoolOutputBinaryOp):
@@ -1374,6 +1484,8 @@ class GtFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "gt"
     kernel_cls = GtFwdKernel
+    _torch_fallback_fn = staticmethod(torch.gt)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class LtFwdOp(_BoolOutputBinaryOp):
@@ -1381,6 +1493,8 @@ class LtFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "lt"
     kernel_cls = LtFwdKernel
+    _torch_fallback_fn = staticmethod(torch.lt)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class GeFwdOp(_BoolOutputBinaryOp):
@@ -1388,6 +1502,8 @@ class GeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "ge"
     kernel_cls = GeFwdKernel
+    _torch_fallback_fn = staticmethod(torch.ge)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 class LeFwdOp(_BoolOutputBinaryOp):
@@ -1395,6 +1511,8 @@ class LeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "le"
     kernel_cls = LeFwdKernel
+    _torch_fallback_fn = staticmethod(torch.le)
+    _TORCH_FALLBACK_DTYPES = _BINARY_FALLBACK_INT_DTYPES
 
 
 # ---------------------------------------------------------------------------
@@ -2349,6 +2467,20 @@ class PreluFwdOp(Op):
             raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
         if input.numel() != self.N_total:
             raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
+        # ``weight`` is part of the manifest contract; validate device,
+        # dtype, and length so a malformed weight fails fast at the op
+        # boundary instead of corrupting the kernel.
+        if not weight.is_cuda:
+            raise ValueError("Weight must be a CUDA tensor")
+        if weight.dtype != self.dtype:
+            raise ValueError(
+                f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
+            )
+        if weight.numel() != self.num_channels:
+            raise ValueError(
+                f"Expected weight to have {self.num_channels} elements, "
+                f"got {weight.numel()}"
+            )
         wrapped = type(self)._wrapped
         if wrapped is not None:
             return wrapped(input, weight, self._instance_key)


### PR DESCRIPTION
Closes #1194

## Summary

- Aligns the 24 ops in the elementwise_binary family to the manifest L1 signature contract: `BinaryOp.forward` / `_eager_forward` use `(input, other)`, `PreluFwdOp` uses `(input, weight)`, `PowFwdOp` uses `(input, exponent)`, `LerpFwdOp` uses `(input, end)`.
- `AddFwdOp` / `SubFwdOp` accept the manifest-declared `alpha` param; `DivFwdOp` accepts `rounding_mode`. Non-default values fall through to `torch.add` / `torch.sub` / `torch.div` with the param forwarded.
- `MaskedFillScalarFwdOp` accepts the full manifest dtype union (bool, uint8, int8..int64, float16, bfloat16, float32) at impl level. Float dtypes keep the vectorized kernel path; integer / bool dtypes route through a torch fallback because the underlying float-only kernel cannot run them.
- Adds `tests/ops/test_elementwise_binary_alignment.py`: manifest L1 signature parity for all 24 ops, bidirectional broadcast `(3,1) × (1,4) → (3,4)` for the 21 broadcast-capable ops, MaskedFillScalar dtype-union construction + torch-fallback parity, and `alpha` / `rounding_mode` param plumbing.
- Manifest `status` field for these 24 ops is **unchanged** — sibling issue flips `spec-only → implemented` after this code lands. No files touched under `tileops/manifest/`, `tileops/kernels/`, `tileops/perf/`, `docs/design/`, or `.claude/domain-rules/`.

## Test plan

- [x] `pre-commit run --all-files` passes; `pytest tests/ops/` passes for every touched test file.
- [x] `git diff --name-only main..HEAD` is confined to `tileops/ops/`, `tests/`, `benchmarks/`. Zero files under `tileops/manifest/`, `tileops/kernels/`, `tileops/perf/`, `docs/design/`, `.claude/domain-rules/`.
- [x] All 24 ops in elementwise_binary family have impl + test + bench code. Tests reference manifest-declared signatures + dtype contract.
- [x] `MaskedFillScalarFwdOp` accepts the full manifest-declared dtype union (bool / uint8 / int8 / int16 / int32 / int64 / float16 / bfloat16 / float32) at impl level.
- [x] Per-op tests include at least one bidirectional broadcast case for every broadcast-capable op.
- [x] Each touched bench file produces numbers and contains no correctness assertions; no imports from `tests/` or `workloads/{oracle,ref,check}`.
- [x] Manifest `status` field for these 24 ops in `elementwise_binary.yaml` is **unchanged** (still spec-only for the 22 spec-only entries; existing implemented entries unchanged).

## Structural Readiness

This PR aligns Op-layer signatures and Op-layer dtype validation only — no kernel/builder code, no `tileops/kernels/` changes, no `tileops/perf/formulas.py` changes. Pre-existing kernel paths remain authoritative for §Kernel Structure / §Op Structure items that govern kernel internals.

- [REQ] `Op.forward` validates inputs before kernel launch — PASS (`MaskedFillScalarFwdOp` widens dtype validation to the manifest union; integer/bool dtypes early-route to a torch fallback before kernel launch).
- [REQ] User-provided scalar params validated at the Op/API boundary — PASS (`AddFwdOp.alpha`, `SubFwdOp.alpha`, `DivFwdOp.rounding_mode` accepted as manifest-declared params; non-default values forward to torch).
- [REQ] Output dtype matches PyTorch semantics — PASS (integer fallback uses `torch.masked_fill`, which preserves dtype semantics).
- [REQ] Runtime validation uses `ValueError` / `TypeError` — PASS (`BinaryOp.forward` raises `ValueError` with `input.dtype` wording on dtype mismatch).
- [REQ] No issue references / dev-process metadata in shipped source — PASS (verified via the project's discovery scan on the changed files; AC labels stripped from comments before PR creation).
- Other §Kernel Structure / §Op Structure items — SKIP (this PR does not modify kernel or builder code).
- §Benchmark items — SKIP (no new ops, no new kernels, no bench files touched).

## Notes

- `MaximumFwdOp` / `MinimumFwdOp` NaN-propagation FLOP delta: the manifest's `flops_per_elem=1` cannot exactly model NaN-propagation cost. Per the issue's execution-route note, no manifest change is made; the kernel-side delta is informational only.
- `MaskedFillScalarFwdOp` integer / bool fallback path: the underlying tile-vectorized kernel is float-only. Routing integer / bool through `torch.masked_fill` preserves the manifest dtype contract at the impl boundary at the cost of a one-time slow path for these dtypes; an in-kernel integer codepath is out of scope here.

## Test node delta

```
File                                              Base    HEAD    Delta
-----------------------------------------------------------------------
tests/ops/test_binary_arith.py                     113     111       -2
tests/ops/test_comparison.py                        44      44        0
tests/ops/test_elementwise_binary_alignment.py     new     220    (new)
-----------------------------------------------------------------------
TOTAL                                              157     375     +218

Growth: +138.9%
```

**Justification:** The new file `tests/ops/test_elementwise_binary_alignment.py` exists because the alignment effort introduces 24 ops worth of L1 signature parity, bidirectional broadcast, dtype-union construction, fallback-parity, param-plumbing, and bool/int fallback correctness assertions in one file — split-by-op would multiply file overhead without adding coverage. `test_binary_arith.py` shrinks (-2) because two pre-existing tests were superseded by alignment-test variants.
