### PR TITLE
[Refactor][Ops] factor activation Op duplication into shared bases

### DIFF
--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -27,14 +27,18 @@ from tileops.kernels.elementwise import (
 )
 from tileops.manifest import load_manifest
 from tileops.ops.elementwise import (
+    EluFwdOp,
     ErfFwdOp,
     GeluFwdOp,
     HardsigmoidFwdOp,
     HardswishFwdOp,
+    HardtanhFwdOp,
+    LeakyReluFwdOp,
     MishFwdOp,
     ReluFwdOp,
     SeluFwdOp,
     SiluFwdOp,
+    SoftplusFwdOp,
 )
 from workloads.activation import ReluTest
 from workloads.workload_base import FixtureBase
@@ -624,11 +628,10 @@ def test_param_free_unary_bench(
 ) -> None:
     """Throughput bench for param-free unary activations (manifest-aligned).
 
-    One representative shape × fp16 keeps each op covered for AC-5
-    ("each touched bench file produces numbers; no correctness
-    assertions") without expanding the matrix. Records both the TileOps
-    op and the matching ``torch.nn.functional`` reference so each row
-    has an external baseline per the benchmark contract.
+    One representative shape x fp16 keeps each op covered without
+    expanding the matrix. Records both the TileOps op and the matching
+    ``torch.nn.functional`` reference so each row has an external
+    baseline per the benchmark contract.
     """
     shape = _SHAPES_2D[1]  # (1024, 4096), LLaMA hidden dim
     n_total = prod(shape)
@@ -641,6 +644,94 @@ def test_param_free_unary_bench(
     # 4*N, Mish 7*N, SELU 5*N) rather than the bandwidth-only 1*N
     # default. The torch baseline is profiled with the same harness so
     # both rows share the same FLOP normalization.
+    bm = UnaryBenchmark(test, op=op)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def baseline_fn(x):
+        return torch_ref(x)
+
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+# ---------------------------------------------------------------------------
+# Throughput coverage for the parametric unary activations (leaky_relu, elu,
+# hardtanh, softplus). These ops take scalar constructor params and need
+# matching kwargs on the torch baseline so the two rows compute the same
+# function. Layout mirrors the param-free block: one fp16 case at the
+# LLaMA hidden-dim shape per op.
+# ---------------------------------------------------------------------------
+
+
+def _leaky_relu_baseline(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.leaky_relu(x, negative_slope=0.01)
+
+
+def _elu_baseline(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.elu(x, alpha=1.0)
+
+
+def _hardtanh_baseline(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.hardtanh(x, min_val=-1.0, max_val=1.0)
+
+
+def _softplus_baseline(x: torch.Tensor) -> torch.Tensor:
+    return torch.nn.functional.softplus(x, beta=1.0, threshold=20.0)
+
+
+_PARAMETRIC_ACTIVATION_OPS = [
+    pytest.param(
+        LeakyReluFwdOp, "leaky_relu",
+        {"negative_slope": 0.01},
+        _leaky_relu_baseline,
+        id="leaky_relu",
+    ),
+    pytest.param(
+        EluFwdOp, "elu",
+        {"alpha": 1.0},
+        _elu_baseline,
+        id="elu",
+    ),
+    pytest.param(
+        HardtanhFwdOp, "hardtanh",
+        {"min_val": -1.0, "max_val": 1.0},
+        _hardtanh_baseline,
+        id="hardtanh",
+    ),
+    pytest.param(
+        SoftplusFwdOp, "softplus",
+        {"beta": 1.0, "threshold": 20.0},
+        _softplus_baseline,
+        id="softplus",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "op_cls, op_label, op_kwargs, torch_ref", _PARAMETRIC_ACTIVATION_OPS,
+)
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_parametric_unary_bench(
+    op_cls,
+    op_label: str,
+    op_kwargs: dict,
+    torch_ref,
+    dtype: torch.dtype,
+) -> None:
+    """Throughput bench for parametric unary activations (manifest-aligned).
+
+    Each op is constructed with its default scalar params and the torch
+    baseline is wrapped with the same kwargs so both rows compute the
+    same function. One representative shape x fp16 keeps the matrix
+    small while still producing a number per touched op.
+    """
+    shape = _SHAPES_2D[1]  # (1024, 4096), LLaMA hidden dim
+    n_total = prod(shape)
+    test = UnaryBenchCase(shape, dtype)
+    inputs = test.gen_inputs()
+
+    op = op_cls(N_total=n_total, dtype=dtype, **op_kwargs)
     bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/tests/ops/test_activation_op_signature_snapshot.py
+++ b/tests/ops/test_activation_op_signature_snapshot.py
@@ -1,0 +1,143 @@
+"""Inspect-based signature snapshot for the activation Op family.
+
+Pins the exact ``__init__`` and ``forward`` signatures (parameter
+names, kinds, defaults, type annotations) for the ten activation Ops
+covered by the shared base/mixin refactor. Any change here means a
+public-API change for these Ops; review must be deliberate.
+
+The snapshot is the canonical pre-refactor surface captured against
+the live classes; it doubles as the AC-3 regression gate.
+"""
+
+import inspect
+
+import pytest
+
+# Snapshot of the constructor signature ``str`` (excluding ``self``)
+# for each activation Op class, captured against the pre-refactor
+# implementation. Both keys and ordering are load-bearing.
+_INIT_SIGNATURES = {
+    "ReluFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SiluFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardswishFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardsigmoidFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "MishFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SeluFwdOp": (
+        "(N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "LeakyReluFwdOp": (
+        "(N_total: int, dtype: torch.dtype, "
+        "negative_slope: float = 0.01, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "EluFwdOp": (
+        "(N_total: int, dtype: torch.dtype, alpha: float = 1.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardtanhFwdOp": (
+        "(N_total: int, dtype: torch.dtype, "
+        "min_val: float = -1.0, max_val: float = 1.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SoftplusFwdOp": (
+        "(N_total: int, dtype: torch.dtype, "
+        "beta: float = 1.0, threshold: float = 20.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False)"
+    ),
+}
+
+
+_FORWARD_SIGNATURE = "(input: torch.Tensor) -> torch.Tensor"
+
+
+def _stringify_init(cls: type) -> str:
+    sig = inspect.signature(cls.__init__)
+    params = [p for name, p in sig.parameters.items() if name != "self"]
+    return str(sig.replace(parameters=params))
+
+
+def _stringify_forward(cls: type) -> str:
+    sig = inspect.signature(cls.forward)
+    params = [p for name, p in sig.parameters.items() if name != "self"]
+    return str(sig.replace(parameters=params))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_name, expected_sig", list(_INIT_SIGNATURES.items()))
+def test_init_signature_matches_snapshot(op_name: str, expected_sig: str) -> None:
+    """Constructor signature must remain bit-identical across the refactor."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    actual = _stringify_init(cls)
+    assert actual == expected_sig, (
+        f"{op_name}.__init__ drift:\n  expected: {expected_sig}\n  actual:   {actual}"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_name", list(_INIT_SIGNATURES.keys()))
+def test_forward_signature_matches_snapshot(op_name: str) -> None:
+    """Forward signature must remain ``(input: Tensor) -> Tensor``."""
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    actual = _stringify_forward(cls)
+    assert actual == _FORWARD_SIGNATURE, (
+        f"{op_name}.forward drift:\n  expected: {_FORWARD_SIGNATURE}\n  actual:   {actual}"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_name", list(_INIT_SIGNATURES.keys()))
+def test_kwarg_kinds_keyword_only(op_name: str) -> None:
+    """``kernel_map``, ``tune``, ``inplace`` must be keyword-only on each Op.
+
+    Catches accidental promotion to positional-or-keyword (which would
+    silently widen the public API).
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    params = inspect.signature(cls.__init__).parameters
+    kw_only_required = ["kernel_map", "tune"]
+    if op_name != "SoftplusFwdOp":
+        kw_only_required.append("inplace")
+    for kw in kw_only_required:
+        assert kw in params, f"{op_name}.__init__ missing {kw!r}"
+        assert params[kw].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{op_name}.__init__ {kw!r} kind is "
+            f"{params[kw].kind!r}, expected KEYWORD_ONLY"
+        )

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -293,6 +293,45 @@ def test_unary_activation_inplace_true_aliases_input(op_name: str) -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_softplus_ignores_post_construction_inplace() -> None:
+    """Softplus must not honor ``op.inplace = True`` set after construction.
+
+    Softplus's manifest signature does not declare ``inplace``; the
+    parametric activation base shares an inplace path with siblings
+    (LeakyReLU/ELU/Hardtanh) that *do* declare it, so the leaf opts out
+    via ``_SUPPORTS_INPLACE = False``. Verify the opt-out: flipping
+    ``self.inplace`` post-construction must not change tensor identity
+    or mutate the input in place.
+    """
+    import tileops.ops.elementwise as mod
+
+    n_total = 64
+    dtype = torch.float16
+    op = mod.SoftplusFwdOp(N_total=n_total, dtype=dtype)
+    x = torch.randn(n_total, dtype=dtype, device="cuda")
+    x_before = x.clone()
+
+    # Baseline: default ``inplace=False`` returns a fresh tensor.
+    y_default = op(x)
+    assert y_default is not x
+    assert torch.allclose(x, x_before), "default path must not mutate input"
+
+    # Force the flag on; with ``_SUPPORTS_INPLACE = False`` the forward
+    # flow ignores it and behavior matches the default path.
+    op.inplace = True
+    y_forced = op(x)
+    assert y_forced is not x, (
+        "SoftplusFwdOp.inplace = True must not alias the input "
+        "(manifest does not declare inplace)"
+    )
+    assert torch.allclose(x, x_before), (
+        "SoftplusFwdOp.inplace = True must not mutate the input "
+        "(manifest does not declare inplace)"
+    )
+
+
+@pytest.mark.smoke
 def test_apply_inplace_numel_mismatch_raises_value_error() -> None:
     """``_InplaceMixin._apply_inplace`` rejects numel mismatches with a ValueError.
 

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -293,45 +293,6 @@ def test_unary_activation_inplace_true_aliases_input(op_name: str) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_softplus_ignores_post_construction_inplace() -> None:
-    """Softplus must not honor ``op.inplace = True`` set after construction.
-
-    Softplus's manifest signature does not declare ``inplace``; the
-    parametric activation base shares an inplace path with siblings
-    (LeakyReLU/ELU/Hardtanh) that *do* declare it, so the leaf opts out
-    via ``_SUPPORTS_INPLACE = False``. Verify the opt-out: flipping
-    ``self.inplace`` post-construction must not change tensor identity
-    or mutate the input in place.
-    """
-    import tileops.ops.elementwise as mod
-
-    n_total = 64
-    dtype = torch.float16
-    op = mod.SoftplusFwdOp(N_total=n_total, dtype=dtype)
-    x = torch.randn(n_total, dtype=dtype, device="cuda")
-    x_before = x.clone()
-
-    # Baseline: default ``inplace=False`` returns a fresh tensor.
-    y_default = op(x)
-    assert y_default is not x
-    assert torch.allclose(x, x_before), "default path must not mutate input"
-
-    # Force the flag on; with ``_SUPPORTS_INPLACE = False`` the forward
-    # flow ignores it and behavior matches the default path.
-    op.inplace = True
-    y_forced = op(x)
-    assert y_forced is not x, (
-        "SoftplusFwdOp.inplace = True must not alias the input "
-        "(manifest does not declare inplace)"
-    )
-    assert torch.allclose(x, x_before), (
-        "SoftplusFwdOp.inplace = True must not mutate the input "
-        "(manifest does not declare inplace)"
-    )
-
-
-@pytest.mark.smoke
 def test_apply_inplace_numel_mismatch_raises_value_error() -> None:
     """``_InplaceMixin._apply_inplace`` rejects numel mismatches with a ValueError.
 

--- a/tests/ops/test_softplus_inplace_regression.py
+++ b/tests/ops/test_softplus_inplace_regression.py
@@ -1,0 +1,43 @@
+"""Regression: ``SoftplusFwdOp`` opts out of the shared inplace path.
+
+The parametric activation base shares an inplace path with siblings
+(LeakyReLU/ELU/Hardtanh) that declare ``inplace`` in the manifest.
+Softplus's manifest signature does not declare ``inplace``, so the
+leaf opts out via ``_SUPPORTS_INPLACE = False``. Pin the opt-out:
+flipping ``self.inplace`` after construction must not change tensor
+identity or mutate the input.
+"""
+
+import pytest
+import torch
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_softplus_ignores_post_construction_inplace() -> None:
+    """Softplus must not honor ``op.inplace = True`` set after construction."""
+    import tileops.ops.elementwise as mod
+
+    n_total = 64
+    dtype = torch.float16
+    op = mod.SoftplusFwdOp(N_total=n_total, dtype=dtype)
+    x = torch.randn(n_total, dtype=dtype, device="cuda")
+    x_before = x.clone()
+
+    # Baseline: default ``inplace=False`` returns a fresh tensor.
+    y_default = op(x)
+    assert y_default is not x
+    assert torch.allclose(x, x_before), "default path must not mutate input"
+
+    # Force the flag on; with ``_SUPPORTS_INPLACE = False`` the forward
+    # flow ignores it and behavior matches the default path.
+    op.inplace = True
+    y_forced = op(x)
+    assert y_forced is not x, (
+        "SoftplusFwdOp.inplace = True must not alias the input "
+        "(manifest does not declare inplace)"
+    )
+    assert torch.allclose(x, x_before), (
+        "SoftplusFwdOp.inplace = True must not mutate the input "
+        "(manifest does not declare inplace)"
+    )

--- a/tests/ops/test_softplus_inplace_regression.py
+++ b/tests/ops/test_softplus_inplace_regression.py
@@ -27,7 +27,7 @@ def test_softplus_ignores_post_construction_inplace() -> None:
     # Baseline: default ``inplace=False`` returns a fresh tensor.
     y_default = op(x)
     assert y_default is not x
-    assert torch.allclose(x, x_before), "default path must not mutate input"
+    assert torch.equal(x, x_before), "default path must not mutate input"
 
     # Force the flag on; with ``_SUPPORTS_INPLACE = False`` the forward
     # flow ignores it and behavior matches the default path.
@@ -37,7 +37,7 @@ def test_softplus_ignores_post_construction_inplace() -> None:
         "SoftplusFwdOp.inplace = True must not alias the input "
         "(manifest does not declare inplace)"
     )
-    assert torch.allclose(x, x_before), (
+    assert torch.equal(x, x_before), (
         "SoftplusFwdOp.inplace = True must not mutate the input "
         "(manifest does not declare inplace)"
     )

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1172,13 +1172,20 @@ class _InplaceMixin:
         return self._apply_inplace(self.inplace, input, result)
 
 
-class ReluFwdOp(UnaryOp, _InplaceMixin):
-    """ReLU activation: y = max(x, 0)."""
+class _ParamFreeActivationOp(UnaryOp, _InplaceMixin):
+    """Shared base for the param-free activation Op group.
 
-    _op_name = "relu"
-    kernel_cls = ReluFwdKernel
-    # Manifest: flops = "2 * N" (compare + select per element).
-    FLOPS_PER_ELEM = 2
+    Centralizes the canonical constructor and ``forward`` flow used by
+    activations whose only manifest-declared parameter is ``inplace``
+    (ReLU, SiLU, HardSwish, HardSigmoid, Mish, SELU). Each leaf only
+    declares its op-specific class fields (``_op_name``, ``kernel_cls``,
+    ``FLOPS_PER_ELEM``, docstring); behavior is otherwise inherited.
+
+    The constructor signature is preserved as
+    ``(N_total, dtype, *, strategy=None, kernel_map=None, tune=False,
+    inplace=False)`` so leaves remain bit-identical to the pre-refactor
+    public API.
+    """
 
     def __init__(
         self,
@@ -1197,6 +1204,95 @@ class ReluFwdOp(UnaryOp, _InplaceMixin):
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
         return self._inplace_aware_forward(input)
+
+
+class _ParametricActivationOp(Op, _InplaceMixin):
+    """Shared base for the parametric activation Op group.
+
+    Centralizes the kernel-construction, ``_eager_forward``, and
+    ``forward`` flows for activations that take one or more scalar
+    construction-time parameters (LeakyReLU, ELU, Hardtanh, Softplus).
+    Leaves keep authority over their constructor signature -- each
+    declares the scalar params with op-specific defaults explicitly --
+    but delegate the post-validation init body to ``_init_common`` and
+    inherit the shared ``forward`` flow.
+
+    The base class does not implement ``__init__`` itself: scalar
+    parameter names and defaults vary per leaf, and pinning them in
+    one place would either force a positional ``**params`` (drifts the
+    public API) or push validation onto the leaves (defeats the
+    refactor). Leaves must call ``self._init_common(...)`` after
+    populating their op-specific scalar attributes.
+
+    The optional ``inplace`` param is honored by ``forward``: leaves
+    that do not declare ``inplace`` must set ``self.inplace = False``
+    via ``_init_common``'s default so the dispatch logic remains
+    well-defined.
+    """
+
+    def _init_common(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        kernel_kwargs: Dict[str, object],
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ) -> None:
+        """Populate Op-base state and instantiate the kernel.
+
+        Args:
+            N_total: Total number of elements (flattened).
+            dtype: Torch dtype.
+            kernel_kwargs: Op-specific scalar kwargs forwarded to the
+                kernel constructor (e.g. ``{"alpha": alpha}``).
+            kernel_map: Optional kernel dispatch override.
+            tune: Whether to autotune the kernel.
+            inplace: Whether ``forward`` should materialize the result
+                back into ``input``. Ignored if the leaf does not
+                expose ``inplace`` to callers (the leaf simply omits
+                the kwarg from its constructor and relies on the
+                default).
+        """
+        self.N_total = N_total
+        self.dtype = dtype
+        self.inplace = inplace
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map[self._op_name](
+            N_total, dtype, tune=tune, **kernel_kwargs,
+        )
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        orig_shape = input.shape
+        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
+        return _apply_fp8_post_cast(result, self.kernel)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
+            raise ValueError("Input must be a CUDA tensor")
+        if input.dtype != self.dtype:
+            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
+        if input.numel() != self.N_total:
+            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
+        wrapped = type(self)._wrapped
+        # inplace=True bypasses the torch.compile route; the custom_op
+        # is registered with mutates_args=() and would mis-trace.
+        if wrapped is not None and not self.inplace:
+            return wrapped(input, self._instance_key)
+        result = self._eager_forward(input)
+        return self._apply_inplace(self.inplace, input, result)
+
+
+class ReluFwdOp(_ParamFreeActivationOp):
+    """ReLU activation: y = max(x, 0)."""
+
+    _op_name = "relu"
+    kernel_cls = ReluFwdKernel
+    # Manifest: flops = "2 * N" (compare + select per element).
+    FLOPS_PER_ELEM = 2
 
 
 class _AlphaScaledBinaryOp(BinaryOp):
@@ -1970,31 +2066,13 @@ class GeluFwdOp(UnaryOp):
         return super()._eager_forward(input)
 
 
-class SiluFwdOp(UnaryOp, _InplaceMixin):
+class SiluFwdOp(_ParamFreeActivationOp):
     """Element-wise SiLU (Swish): y = x * sigmoid(x)."""
 
     _op_name = "silu"
     kernel_cls = SiluFwdKernel
     # Manifest: flops = "4 * N" (sigmoid + multiply).
     FLOPS_PER_ELEM = 4
-
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        return self._inplace_aware_forward(input)
 
 
 class SigmoidFwdOp(UnaryOp):
@@ -2015,7 +2093,7 @@ class TanhFwdOp(UnaryOp):
     FLOPS_PER_ELEM = 5
 
 
-class HardswishFwdOp(UnaryOp, _InplaceMixin):
+class HardswishFwdOp(_ParamFreeActivationOp):
     """Element-wise HardSwish: y = x * clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardswish"
@@ -2023,26 +2101,8 @@ class HardswishFwdOp(UnaryOp, _InplaceMixin):
     # Manifest: flops = "7 * N" (add + clamp(2 cmp+2 sel) + mul + div).
     FLOPS_PER_ELEM = 7
 
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        return self._inplace_aware_forward(input)
-
-
-class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
+class HardsigmoidFwdOp(_ParamFreeActivationOp):
     """Element-wise HardSigmoid: y = clamp(x + 3, 0, 6) / 6."""
 
     _op_name = "hardsigmoid"
@@ -2050,26 +2110,8 @@ class HardsigmoidFwdOp(UnaryOp, _InplaceMixin):
     # Manifest: flops = "6 * N" (add + clamp(2 cmp+2 sel) + div).
     FLOPS_PER_ELEM = 6
 
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        return self._inplace_aware_forward(input)
-
-
-class MishFwdOp(UnaryOp, _InplaceMixin):
+class MishFwdOp(_ParamFreeActivationOp):
     """Element-wise Mish: y = x * tanh(softplus(x))."""
 
     _op_name = "mish"
@@ -2077,50 +2119,14 @@ class MishFwdOp(UnaryOp, _InplaceMixin):
     # Manifest: flops = "7 * N" (softplus + tanh + mul).
     FLOPS_PER_ELEM = 7
 
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        return self._inplace_aware_forward(input)
-
-
-class SeluFwdOp(UnaryOp, _InplaceMixin):
+class SeluFwdOp(_ParamFreeActivationOp):
     """Element-wise SELU activation."""
 
     _op_name = "selu"
     kernel_cls = SeluFwdKernel
     # Manifest: flops = "5 * N" (branch + exp/sub/mul + lambda mul).
     FLOPS_PER_ELEM = 5
-
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        return self._inplace_aware_forward(input)
 
 
 # ---------------------------------------------------------------------------
@@ -2210,7 +2216,7 @@ class IsfiniteFwdOp(_IntIdentityUnaryOp):
 # ---------------------------------------------------------------------------
 
 
-class LeakyReluFwdOp(Op, _InplaceMixin):
+class LeakyReluFwdOp(_ParametricActivationOp):
     """Leaky ReLU: y = x if x > 0 else negative_slope * x.
 
     Args:
@@ -2241,43 +2247,18 @@ class LeakyReluFwdOp(Op, _InplaceMixin):
         inplace: bool = False,
     ):
         _validate_scalar_param_repr("negative_slope", negative_slope, dtype, self._op_name)
-        self.N_total = N_total
-        self.dtype = dtype
         self.negative_slope = negative_slope
-        self.inplace = inplace
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["leaky_relu"](
-            N_total, dtype, negative_slope=negative_slope, tune=tune,
+        self._init_common(
+            N_total, dtype, {"negative_slope": negative_slope},
+            kernel_map=kernel_map, tune=tune, inplace=inplace,
         )
-        self._instance_key = id(self)
-        _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
         return {"leaky_relu": LeakyReluFwdKernel}
 
-    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if not input.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
-        wrapped = type(self)._wrapped
-        # inplace=True bypasses the torch.compile route; the custom_op
-        # is registered with mutates_args=() and would mis-trace.
-        if wrapped is not None and not self.inplace:
-            return wrapped(input, self._instance_key)
-        result = self._eager_forward(input)
-        return self._apply_inplace(self.inplace, input, result)
-
-
-class EluFwdOp(Op, _InplaceMixin):
+class EluFwdOp(_ParametricActivationOp):
     """ELU: y = x if x > 0 else alpha * (exp(x) - 1).
 
     Args:
@@ -2306,39 +2287,18 @@ class EluFwdOp(Op, _InplaceMixin):
         inplace: bool = False,
     ):
         _validate_scalar_param_repr("alpha", alpha, dtype, self._op_name)
-        self.N_total = N_total
-        self.dtype = dtype
         self.alpha = alpha
-        self.inplace = inplace
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["elu"](N_total, dtype, alpha=alpha, tune=tune)
-        self._instance_key = id(self)
-        _OP_REGISTRY[self._instance_key] = self
+        self._init_common(
+            N_total, dtype, {"alpha": alpha},
+            kernel_map=kernel_map, tune=tune, inplace=inplace,
+        )
 
     @property
     def default_kernel_map(self):
         return {"elu": EluFwdKernel}
 
-    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if not input.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
-        wrapped = type(self)._wrapped
-        if wrapped is not None and not self.inplace:
-            return wrapped(input, self._instance_key)
-        result = self._eager_forward(input)
-        return self._apply_inplace(self.inplace, input, result)
-
-
-class HardtanhFwdOp(Op, _InplaceMixin):
+class HardtanhFwdOp(_ParametricActivationOp):
     """Hardtanh: y = clamp(x, min_val, max_val).
 
     Args:
@@ -2370,42 +2330,19 @@ class HardtanhFwdOp(Op, _InplaceMixin):
     ):
         _validate_scalar_param_repr("min_val", min_val, dtype, self._op_name)
         _validate_scalar_param_repr("max_val", max_val, dtype, self._op_name)
-        self.N_total = N_total
-        self.dtype = dtype
         self.min_val = min_val
         self.max_val = max_val
-        self.inplace = inplace
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["hardtanh"](
-            N_total, dtype, min_val=min_val, max_val=max_val, tune=tune,
+        self._init_common(
+            N_total, dtype, {"min_val": min_val, "max_val": max_val},
+            kernel_map=kernel_map, tune=tune, inplace=inplace,
         )
-        self._instance_key = id(self)
-        _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
         return {"hardtanh": HardtanhFwdKernel}
 
-    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if not input.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
-        wrapped = type(self)._wrapped
-        if wrapped is not None and not self.inplace:
-            return wrapped(input, self._instance_key)
-        result = self._eager_forward(input)
-        return self._apply_inplace(self.inplace, input, result)
-
-
-class SoftplusFwdOp(Op):
+class SoftplusFwdOp(_ParametricActivationOp):
     """Softplus: y = log(1 + exp(x*beta))/beta if x*beta <= threshold else x.
 
     Args:
@@ -2432,37 +2369,19 @@ class SoftplusFwdOp(Op):
     ):
         _validate_scalar_param_repr("beta", beta, dtype, self._op_name)
         _validate_scalar_param_repr("threshold", threshold, dtype, self._op_name)
-        self.N_total = N_total
-        self.dtype = dtype
         self.beta = beta
         self.threshold = threshold
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["softplus"](
-            N_total, dtype, beta=beta, threshold=threshold, tune=tune,
+        # Softplus does not expose ``inplace`` to callers; the parametric
+        # base defaults ``self.inplace = False`` so ``forward`` skips the
+        # mutate-back path entirely.
+        self._init_common(
+            N_total, dtype, {"beta": beta, "threshold": threshold},
+            kernel_map=kernel_map, tune=tune,
         )
-        self._instance_key = id(self)
-        _OP_REGISTRY[self._instance_key] = self
 
     @property
     def default_kernel_map(self):
         return {"softplus": SoftplusFwdKernel}
-
-    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if not input.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
-        wrapped = type(self)._wrapped
-        if wrapped is not None:
-            return wrapped(input, self._instance_key)
-        return self._eager_forward(input)
 
 
 class PreluFwdOp(Op):

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1224,11 +1224,19 @@ class _ParametricActivationOp(Op, _InplaceMixin):
     refactor). Leaves must call ``self._init_common(...)`` after
     populating their op-specific scalar attributes.
 
-    The optional ``inplace`` param is honored by ``forward``: leaves
-    that do not declare ``inplace`` must set ``self.inplace = False``
-    via ``_init_common``'s default so the dispatch logic remains
-    well-defined.
+    The optional ``inplace`` param is honored by ``forward`` only on
+    leaves whose manifest entry declares ``inplace``. Leaves that omit
+    ``inplace`` from their manifest signature must set
+    ``_SUPPORTS_INPLACE = False`` so ``forward`` ignores any
+    post-construction mutation of ``self.inplace`` and behavior matches
+    the manifest contract.
     """
+
+    # Default: leaves that expose ``inplace`` in their constructor honor
+    # it. Set False on a leaf whose manifest signature does not declare
+    # ``inplace`` (e.g. ``softplus``) so ``forward`` short-circuits the
+    # mutate-back path even if a caller flips ``op.inplace = True``.
+    _SUPPORTS_INPLACE: bool = True
 
     def _init_common(
         self,
@@ -1278,12 +1286,17 @@ class _ParametricActivationOp(Op, _InplaceMixin):
         if input.numel() != self.N_total:
             raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
         wrapped = type(self)._wrapped
+        # Leaves that do not declare ``inplace`` in their manifest entry
+        # set ``_SUPPORTS_INPLACE = False``; force the inplace flag off
+        # so ``forward`` ignores any post-construction mutation of
+        # ``self.inplace`` and matches the manifest signature.
+        inplace = self.inplace and self._SUPPORTS_INPLACE
         # inplace=True bypasses the torch.compile route; the custom_op
         # is registered with mutates_args=() and would mis-trace.
-        if wrapped is not None and not self.inplace:
+        if wrapped is not None and not inplace:
             return wrapped(input, self._instance_key)
         result = self._eager_forward(input)
-        return self._apply_inplace(self.inplace, input, result)
+        return self._apply_inplace(inplace, input, result)
 
 
 class ReluFwdOp(_ParamFreeActivationOp):
@@ -2356,6 +2369,12 @@ class SoftplusFwdOp(_ParametricActivationOp):
 
     _op_name = "softplus"
     _wrapped = None
+    # Softplus's manifest signature does not declare ``inplace``; opt
+    # out of the parametric base's inplace path so a caller flipping
+    # ``op.inplace = True`` post-construction cannot change behavior.
+    _SUPPORTS_INPLACE = False
+    # Manifest: flops = "7 * N" (mul + exp + add + log + div + compare + select).
+    FLOPS_PER_ELEM = 7
 
     def __init__(
         self,

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -284,10 +284,11 @@ def _register_lerp_tensor_custom_op(op_cls):
 
     The fake function computes the broadcast output shape from ``input`` /
     ``end`` / ``weight`` so that ``torch.compile(fullgraph=True)`` works
-    for both same-shape and broadcasting inputs. Registered under a
-    distinct ``_tensor`` namespace to avoid colliding with the scalar
-    ``LerpFwdOp`` (which bakes ``weight`` at construction time and uses
-    the binary registration path).
+    for both same-shape and broadcasting inputs. The op is registered
+    as ``top::elementwise_{op_name}`` (e.g. ``top::elementwise_lerp_tensor``
+    when ``op_cls._op_name == 'lerp_tensor'``), giving it a distinct name
+    from the scalar ``LerpFwdOp`` (registered as ``top::elementwise_lerp``
+    via the binary path) so the two overloads cannot collide.
     """
     op_name = op_cls._op_name
 
@@ -1097,8 +1098,11 @@ class _InplaceMixin:
     Used by activation ops whose manifest entry declares ``inplace:
     bool = False`` (e.g. ReLU, SiLU, HardSwish, HardSigmoid, Mish, SELU,
     LeakyReLU, ELU, Hardtanh). Activations whose manifest does not
-    declare ``inplace`` (e.g. GELU, Softplus) intentionally do not mix
-    this in.
+    declare ``inplace`` opt out in one of two ways: standalone unary
+    ops (e.g. GELU) simply do not mix this in, while parametric ops
+    that share ``_ParametricActivationOp`` as their base (e.g. Softplus)
+    inherit the mixin transparently and set ``_SUPPORTS_INPLACE = False``
+    so ``forward()`` ignores any post-construction ``inplace`` toggle.
 
     The underlying kernels always write to a fresh output buffer, but
     PyTorch's activation contract for ``inplace=True`` requires the

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -625,7 +625,6 @@ __all__ = [
     "ClampMaxFwdOp",
     "MaskedFillFwdOp",
     "MaskedFillScalarFwdOp",
-    "LerpTensorFwdOp",
     "NanToNumFwdOp",
     "AlibiFwdOp",
     "SinusoidalFwdOp",

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -287,8 +287,8 @@ def _register_lerp_tensor_custom_op(op_cls):
     for both same-shape and broadcasting inputs. The op is registered
     as ``top::elementwise_{op_name}`` (e.g. ``top::elementwise_lerp_tensor``
     when ``op_cls._op_name == 'lerp_tensor'``), giving it a distinct name
-    from the scalar ``LerpFwdOp`` (registered as ``top::elementwise_lerp``
-    via the binary path) so the two overloads cannot collide.
+    from the scalar ``LerpFwdOp`` (registered as ``top::elementwise_binary_lerp``
+    via the binary factory) so the two overloads cannot collide.
     """
     op_name = op_cls._op_name
 
@@ -3503,7 +3503,7 @@ _register_masked_fill_tensor_value_custom_op(MaskedFillFwdOp)
 
 # --- Tensor-weight lerp (1 op: input, end, weight -> out) ---
 # Registered under ``top::elementwise_lerp_tensor`` to avoid colliding with
-# the scalar ``LerpFwdOp``'s ``top::elementwise_lerp`` namespace. The fake
+# the scalar ``LerpFwdOp``'s ``top::elementwise_binary_lerp`` namespace. The fake
 # function is broadcast-aware so torch.compile(fullgraph=True) traces
 # correctly for both same-shape and broadcasting inputs.
 _register_lerp_tensor_custom_op(LerpTensorFwdOp)

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -624,6 +624,7 @@ __all__ = [
     "ClampMaxFwdOp",
     "MaskedFillFwdOp",
     "MaskedFillScalarFwdOp",
+    "LerpTensorFwdOp",
     "NanToNumFwdOp",
     "AlibiFwdOp",
     "SinusoidalFwdOp",


### PR DESCRIPTION
Closes #1220

## Summary

- Factor the `__init__` / `_eager_forward` / `forward` boilerplate shared across the ten elementwise unary activation Ops into two thin internal base classes in `tileops/ops/elementwise.py`.
- Param-free group (`Relu`, `Silu`, `Hardswish`, `Hardsigmoid`, `Mish`, `Selu`) now inherits `_ParamFreeActivationOp`, reusing `UnaryOp.__init__` for the dispatch/validate plumbing it already supplies.
- Parametric group (`LeakyRelu`, `Elu`, `Hardtanh`, `Softplus`) inherits `_ParametricActivationOp`, which threads scalar kwargs (`negative_slope`, `alpha`, `min_val`/`max_val`, `beta`/`threshold`) into the kernel constructor.
- Public surface unchanged: same constructor signatures, kwarg ordering, keyword-only-ness, `kernel_map=None` / `tune=False` defaults, and `_apply_inplace` numel-mismatch `ValueError` semantics. No changes under `tileops/manifest/` or `tileops/kernels/`.
- Adds throughput rows for the four parametric activations to `benchmarks/ops/bench_activation.py` and an `inspect`-based snapshot test (`tests/ops/test_activation_op_signature_snapshot.py`) so any future drift in the ten constructor signatures fails loudly.

## Design rationale

Two thin base classes, not a single mixin. The param-free group only needs to share `__init__` + `forward` on top of `UnaryOp`'s existing dispatch/validate plumbing. The parametric group must inherit from `Op` directly because each leaf takes op-specific scalar kernel kwargs that `UnaryOp.__init__` does not forward. A single mixin would have to re-derive the `UnaryOp` vs `Op` distinction at runtime via attribute sniffing, which is harder to read than two named bases. The split also keeps `Softplus` (no `inplace`) a plain leaf of `_ParametricActivationOp`: its constructor omits `inplace` and inherits `self.inplace=False` from the shared init default instead of needing a third base.

## Test plan

- [x] AC-1: `pre-commit run --all-files` passes; `pytest tests/ops/test_elementwise_unary_activation_alignment.py tests/ops/test_activation.py tests/ops/test_elementwise_independent_fp8.py` passes (164 passed, same count as PR #1211 HEAD).
- [x] AC-2: `git diff --name-only upstream/testbed...HEAD` is confined to `tileops/ops/`, `tests/`, `benchmarks/`; no changes under `tileops/manifest/` or `tileops/kernels/`.
- [x] AC-3: All ten activation Ops expose the same constructor signature (parameters, defaults, keyword-only-ness) as on PR #1211 HEAD; verified by the new `inspect`-based snapshot test (30 cases).
- [x] AC-4: `validate_manifest --check-op` reports zero new errors for the touched ops (only pre-existing warnings).
- [x] AC-5: `python -m pytest benchmarks/ops/bench_activation.py` runs to completion (102 passed) and `profile_run.log` contains rows for all ten refactored ops; no correctness assertions added.
- [x] AC-6: design rationale documented above.

## Structural Readiness

All checks passed.

## Benchmark

`python -m pytest -q benchmarks/ops/bench_activation.py` → 102 passed; `profile_run.log` written with rows for `ReluFwdOp`, `SiluFwdOp`, `HardswishFwdOp`, `HardsigmoidFwdOp`, `MishFwdOp`, `SeluFwdOp`, `LeakyReluFwdOp`, `EluFwdOp`, `HardtanhFwdOp`, `SoftplusFwdOp`. This PR is a behavior-preserving refactor of `forward` plumbing only; no kernel changes, so throughput is unchanged versus PR #1211 HEAD beyond noise.

**Command:** `PYTHONPATH="$PWD" python -m pytest -q benchmarks/ops/bench_activation.py`

## Regression

The new `tests/ops/test_activation_op_signature_snapshot.py` pins the constructor signatures (parameters, defaults, keyword-only-ness) of all ten activation Ops via `inspect.signature`, so any future change to a base class that would alter a leaf Op's public signature fails the snapshot test instead of silently shipping.

## Test node delta

```
File                                                  Base    HEAD    Delta
---------------------------------------------------------------------------
tests/ops/test_activation_op_signature_snapshot.py     new      30    (new)
tests/ops/test_softplus_inplace_regression.py          new       1    (new)
---------------------------------------------------------------------------
TOTAL                                                    0      31      +31

All 31 nodes are from new files.
```

**Justification:** The two new test files are scoped tightly to this PR's correctness contracts. `test_activation_op_signature_snapshot.py` (30 cases) pins the public constructor signature of every refactored activation Op via `inspect.signature` so a future base-class edit that would silently change a leaf Op's public surface fails this snapshot instead of shipping. `test_softplus_inplace_regression.py` (1 case) pins the Softplus opt-out from the shared inplace path (`_SUPPORTS_INPLACE = False`) so a future regression that re-exposes the post-construction `op.inplace = True` mutation path is caught at test time.