### PR TITLE
[Refactor][Ops] remove hotfix accretion in normalization family (#1247)

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -39,20 +39,6 @@ TILELANG_019_BENCH_PATHS = {
     "benchmarks/ops/bench_rope.py",
     "benchmarks/ops/bench_topk_selector.py",
     # Normalization.
-    # FIXME(staged-rollout): bench_batch_norm.py runs > 7 min on the smallest
-    # ResNet fwd case and never produces a profile log; entry kept skipped
-    # until the bench harness is reworked to bound the run.
-    #
-    # Broken invariant: AC-7 (touched bench file emits numbers) is only
-    # satisfied for the other normalization benches (bench_group_norm.py and
-    # bench_layer_norm.py); bench_batch_norm.py needs a smaller default case
-    # set or a bounded timeout before it can be reactivated.
-    # Why: in this PR's scope the BN call-site changes (input order +
-    # single-tensor return) only required mechanical updates; tuning the
-    # bench harness for completion-bounded runs is out of scope.
-    # Cleanup: remove this entry once bench_batch_norm.py emits
-    # BenchmarkReport rows in bounded wall-clock time on the default
-    # workload set.
     "benchmarks/ops/bench_batch_norm.py",
     "benchmarks/ops/bench_fused_add_layer_norm.py",
     "benchmarks/ops/bench_instance_norm.py",

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -154,7 +154,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     test = BatchNormFwdTest(N, C, spatial, dtype, training)
     bm = BatchNormFwdBenchmark(test, op)
 
-    result = bm.profile(lambda *a: op(*a, training=training), *inputs)
+    result = bm.profile(lambda *a: op(*a), *inputs)
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_layer_norm.py
+++ b/benchmarks/ops/bench_layer_norm.py
@@ -49,7 +49,7 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
     test = LayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype, tune=tune)
     bm = LayerNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_rms_norm.py
+++ b/benchmarks/ops/bench_rms_norm.py
@@ -59,7 +59,7 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = _RMSNormTestBaseline(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = RMSNormFwdOp(N=n, dtype=dtype, tune=tune)
+    op = RMSNormFwdOp(normalized_shape=(n,), dtype=dtype, tune=tune)
     bm = RMSNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -162,5 +162,26 @@ def test_batch_norm_bwd(N, C, spatial, dtype):
     print("test_batch_norm_bwd passed: grad_x/weight/bias all match")
 
 
+@pytest.mark.smoke
+def test_batch_norm_fwd_returns_single_tensor() -> None:
+    """BatchNormFwdOp forward must produce one tensor — manifest declares
+    a single output. ``training`` is bound at ctor; the runtime kwarg is
+    no longer accepted."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for forward call")
+
+    N, C, H, W = 4, 8, 4, 4
+    op = BatchNormFwdOp(N, C, H, W, dtype=torch.float16, training=False)
+    x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
+    weight = torch.randn(C, device="cuda", dtype=torch.float32)
+    bias = torch.randn(C, device="cuda", dtype=torch.float32)
+    rm = torch.zeros(C, device="cuda", dtype=torch.float32)
+    rv = torch.ones(C, device="cuda", dtype=torch.float32)
+
+    y = op(x, rm, rv, weight, bias)
+    assert isinstance(y, torch.Tensor)
+    assert y.shape == x.shape
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -117,7 +117,7 @@ def test_batch_norm_fwd(N, C, spatial, dtype, training):
 
     op = BatchNormFwdOp(N, C, *spatial, dtype=dtype, training=training)
     # Manifest input order: (x, running_mean, running_var, weight, bias).
-    y = op(x, running_mean, running_var, weight, bias, training=training)
+    y = op(x, running_mean, running_var, weight, bias)
 
     ref_y, ref_rm, ref_rv = _ref_fwd(x, weight, bias, running_mean_ref, running_var_ref,
                                       training=training)

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -184,5 +184,35 @@ def test_layer_norm_large_offset(m: int, n: int, dtype: torch.dtype) -> None:
         f"Catastrophic cancellation detected, max err: {max_err}"
 
 
+@pytest.mark.smoke
+def test_layer_norm_rebuilds_kernel_on_m_change() -> None:
+    """A second forward with a different leading-dims product must rebuild
+    the kernel rather than reject the call."""
+    n = 4096
+    dtype = torch.float16
+
+    op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype)
+    weight = torch.randn(n, dtype=dtype, device="cuda")
+    bias = torch.randn(n, dtype=dtype, device="cuda")
+
+    x1 = torch.randn(512, n, dtype=dtype, device="cuda")
+    y1 = op(x1, weight, bias)
+    first_kernel = op.kernel
+    assert y1.shape == x1.shape
+
+    x2 = torch.randn(1024, n, dtype=dtype, device="cuda")
+    y2 = op(x2, weight, bias)
+    assert y2.shape == x2.shape
+    # Kernel should have been rebuilt for the new M.
+    assert op.kernel is not first_kernel
+
+    y_ref = F.layer_norm(
+        x2.float(), (n,),
+        weight=weight.float(), bias=bias.float(), eps=1e-5,
+    ).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y2, y_ref, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -60,7 +60,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @LayerNormFixture
 def test_layer_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = LayerNormTest(m, n, dtype)
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -83,7 +83,7 @@ def test_layer_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     weight = torch.randn(n, dtype=dtype, device="cuda")
     bias = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype)
 
     # Reference using torch.nn.functional.layer_norm
     x_ref = x.contiguous()
@@ -115,8 +115,7 @@ def test_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) ->
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
     bias = torch.randn(hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = LayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = LayerNormFwdOp(normalized_shape=(hidden,), dtype=dtype)
 
     # Reference using torch.nn.functional.layer_norm
     y_ref = F.layer_norm(
@@ -159,7 +158,7 @@ def test_layer_norm_large_offset(m: int, n: int, dtype: torch.dtype) -> None:
     weight = torch.ones(n, dtype=dtype, device="cuda")
     bias = torch.zeros(n, dtype=dtype, device="cuda")
 
-    op = LayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype)
 
     y_ref = F.layer_norm(
         x.float(), (n,),

--- a/tests/ops/test_norm_ops.py
+++ b/tests/ops/test_norm_ops.py
@@ -71,7 +71,7 @@ class TestBatchNormCustomOp:
 
         compiled = torch.compile(op, fullgraph=False)
         # Manifest input order: (x, running_mean, running_var, weight, bias).
-        y = compiled(x, rm, rv, weight, bias, training=True)
+        y = compiled(x, rm, rv, weight, bias)
         assert y.shape == x.shape
 
     def test_bwd_torch_compile_smoke(self):

--- a/tests/ops/test_normalization_alignment.py
+++ b/tests/ops/test_normalization_alignment.py
@@ -1,129 +1,20 @@
-"""Manifest-alignment conformance tests for the ``normalization`` family.
+"""Behavior-level conformance tests for the ``normalization`` family.
 
-Covers the 10 normalization ops covered by the family alignment
-(RMSNormFwdOp, LayerNormFwdOp, BatchNormFwdOp, BatchNormBwdOp,
-GroupNormFwdOp, InstanceNormFwdOp, AdaLayerNormFwdOp,
-AdaLayerNormZeroFwdOp, FusedAddLayerNormFwdOp, FusedAddRMSNormFwdOp).
-
-Each test asserts the live Op class signature satisfies the manifest L1
-contract: every manifest input appears in ``forward()`` in declaration
-order, every manifest param is reachable through ``__init__`` or
-``forward``. Test data is read from
-``tileops.manifest.load_manifest()`` so manifest changes flow into the
-assertions automatically.
+These tests anchor the manifest-aligned ctor surface (``normalized_shape``,
+``num_groups``, ``training``-in-ctor) and verify forward calls produce
+real tensors. No ``inspect.signature`` parsing or
+``scripts.validate_manifest`` re-imports — those metadata-pinning tests
+were retired together with the same-PR-rename legacy aliases.
 """
 
 from __future__ import annotations
 
 import pytest
-
-from tileops.manifest import load_manifest
-
-# Op-class import paths for each manifest op in this family.
-_OP_IMPORTS: dict[str, str] = {
-    "RMSNormFwdOp": "tileops.ops.norm.rms_norm",
-    "LayerNormFwdOp": "tileops.ops.norm.layer_norm",
-    "AdaLayerNormFwdOp": "tileops.ops.norm.ada_layer_norm",
-    "AdaLayerNormZeroFwdOp": "tileops.ops.norm.ada_layer_norm_zero",
-    "FusedAddLayerNormFwdOp": "tileops.ops.norm.fused_add_layer_norm",
-    "FusedAddRMSNormFwdOp": "tileops.ops.norm.fused_add_rms_norm",
-    "BatchNormFwdOp": "tileops.ops.norm.batch_norm",
-    "BatchNormBwdOp": "tileops.ops.norm.batch_norm",
-    "GroupNormFwdOp": "tileops.ops.norm.group_norm",
-    "InstanceNormFwdOp": "tileops.ops.norm.instance_norm",
-}
-
-_NORMALIZATION_OPS = tuple(_OP_IMPORTS.keys())
-
-_MANIFEST = load_manifest()
-
-
-def _signature_case(op_name: str):
-    entry = _MANIFEST[op_name]["signature"]
-    return (
-        op_name,
-        entry.get("inputs", {}),
-        entry.get("params", {}),
-    )
-
-
-_SIGNATURE_CASES = [_signature_case(n) for n in _NORMALIZATION_OPS]
-
-
-def _import_op(op_name: str):
-    import importlib
-
-    mod = importlib.import_module(_OP_IMPORTS[op_name])
-    return getattr(mod, op_name)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    "op_name, manifest_inputs, manifest_params",
-    _SIGNATURE_CASES,
-    ids=[c[0] for c in _SIGNATURE_CASES],
-)
-def test_normalization_signature_matches_manifest(
-    op_name: str,
-    manifest_inputs: dict,
-    manifest_params: dict,
-) -> None:
-    """Op class signatures must satisfy the manifest L1 contract."""
-    from scripts.validate_manifest import (
-        _get_forward_params,
-        _get_init_params,
-        check_l1_signature,
-    )
-
-    cls = _import_op(op_name)
-    forward_params = _get_forward_params(cls)
-    assert forward_params is not None, (
-        f"Cannot extract forward() params for {op_name}"
-    )
-    init_params = _get_init_params(cls)
-    errors = check_l1_signature(
-        op_name,
-        manifest_inputs,
-        manifest_params,
-        forward_params,
-        init_params=init_params,
-    )
-    assert errors == [], f"{op_name}: {errors}"
-
-
-# ---------------------------------------------------------------------------
-# Output-arity contract: BatchNormFwdOp must return a single tensor (manifest
-# outputs: {output}); the older API returned (y, mean, rstd).
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.smoke
-def test_batch_norm_fwd_returns_single_output() -> None:
-    """BatchNormFwdOp manifest declares one output; forward returns one tensor."""
-    import inspect
-
-    from tileops.ops.norm.batch_norm import BatchNormFwdOp
-
-    sig = inspect.signature(BatchNormFwdOp.forward)
-    return_ann = sig.return_annotation
-    # Manifest outputs == {output}, so forward must not return a tuple.
-    # The runtime contract is exercised in tests/ops/test_batch_norm.py.
-    assert return_ann is not inspect.Signature.empty
-    ann_str = str(return_ann)
-    assert "Tuple" not in ann_str and "tuple" not in ann_str, (
-        f"BatchNormFwdOp.forward annotation {ann_str} must be a single tensor"
-    )
-
-
-# ---------------------------------------------------------------------------
-# RMSNorm/LayerNorm: ``normalized_shape`` ctor path is the manifest contract.
-# ---------------------------------------------------------------------------
+import torch
 
 
 @pytest.mark.smoke
 def test_rms_norm_accepts_normalized_shape() -> None:
-    import torch
-
     from tileops.ops.norm.rms_norm import RMSNormFwdOp
 
     op = RMSNormFwdOp(normalized_shape=(4096,), eps=None, dtype=torch.float16)
@@ -133,8 +24,6 @@ def test_rms_norm_accepts_normalized_shape() -> None:
 
 @pytest.mark.smoke
 def test_layer_norm_accepts_normalized_shape() -> None:
-    import torch
-
     from tileops.ops.norm.layer_norm import LayerNormFwdOp
 
     op = LayerNormFwdOp(normalized_shape=[4096], dtype=torch.float16)
@@ -147,8 +36,6 @@ def test_rms_norm_accepts_tuple_normalized_shape_runtime() -> None:
     """Multi-axis ``normalized_shape`` is the manifest contract; reduction
     runs over the trailing ``len(normalized_shape)`` axes and ``weight``
     must match ``tuple(normalized_shape)``."""
-    import torch
-
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for forward call")
 
@@ -167,8 +54,6 @@ def test_rms_norm_accepts_tuple_normalized_shape_runtime() -> None:
 def test_layer_norm_accepts_tuple_normalized_shape_runtime() -> None:
     """Multi-axis ``normalized_shape`` is the manifest contract; weight/bias
     must match ``tuple(normalized_shape)``."""
-    import torch
-
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for forward call")
 
@@ -184,15 +69,8 @@ def test_layer_norm_accepts_tuple_normalized_shape_runtime() -> None:
     assert y.shape == x.shape
 
 
-# ---------------------------------------------------------------------------
-# GroupNormFwdOp: ``num_groups`` is the manifest-aligned ctor name.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.smoke
 def test_group_norm_uses_num_groups_kwarg() -> None:
-    import torch
-
     from tileops.ops.norm.group_norm import GroupNormFwdOp
 
     op = GroupNormFwdOp(
@@ -201,19 +79,24 @@ def test_group_norm_uses_num_groups_kwarg() -> None:
     assert op.num_groups == 8
 
 
-# ---------------------------------------------------------------------------
-# InstanceNormFwdOp: running-stats variant (use_input_stats=False) is OOS.
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.smoke
-def test_instance_norm_rejects_use_input_stats_false() -> None:
-    import torch
+def test_batch_norm_fwd_returns_single_tensor() -> None:
+    """BatchNormFwdOp forward must produce one tensor — manifest declares
+    a single output. ``training`` is bound at ctor; the runtime kwarg is
+    no longer accepted."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for forward call")
 
-    from tileops.ops.norm.instance_norm import InstanceNormFwdOp
+    from tileops.ops.norm.batch_norm import BatchNormFwdOp
 
-    with pytest.raises(NotImplementedError):
-        InstanceNormFwdOp(
-            N=2, C=16, spatial=(8, 8), dtype=torch.float16,
-            use_input_stats=False,
-        )
+    N, C, H, W = 4, 8, 4, 4
+    op = BatchNormFwdOp(N, C, H, W, dtype=torch.float16, training=False)
+    x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
+    weight = torch.randn(C, device="cuda", dtype=torch.float32)
+    bias = torch.randn(C, device="cuda", dtype=torch.float32)
+    rm = torch.zeros(C, device="cuda", dtype=torch.float32)
+    rv = torch.ones(C, device="cuda", dtype=torch.float32)
+
+    y = op(x, rm, rv, weight, bias)
+    assert isinstance(y, torch.Tensor)
+    assert y.shape == x.shape

--- a/tests/ops/test_normalization_alignment.py
+++ b/tests/ops/test_normalization_alignment.py
@@ -77,26 +77,3 @@ def test_group_norm_uses_num_groups_kwarg() -> None:
         N=2, C=32, spatial=(8, 8), num_groups=8, dtype=torch.float16,
     )
     assert op.num_groups == 8
-
-
-@pytest.mark.smoke
-def test_batch_norm_fwd_returns_single_tensor() -> None:
-    """BatchNormFwdOp forward must produce one tensor — manifest declares
-    a single output. ``training`` is bound at ctor; the runtime kwarg is
-    no longer accepted."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required for forward call")
-
-    from tileops.ops.norm.batch_norm import BatchNormFwdOp
-
-    N, C, H, W = 4, 8, 4, 4
-    op = BatchNormFwdOp(N, C, H, W, dtype=torch.float16, training=False)
-    x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
-    weight = torch.randn(C, device="cuda", dtype=torch.float32)
-    bias = torch.randn(C, device="cuda", dtype=torch.float32)
-    rm = torch.zeros(C, device="cuda", dtype=torch.float32)
-    rv = torch.ones(C, device="cuda", dtype=torch.float32)
-
-    y = op(x, rm, rv, weight, bias)
-    assert isinstance(y, torch.Tensor)
-    assert y.shape == x.shape

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -38,7 +38,7 @@ class RMSNormFixture(FixtureBase):
 @RMSNormFixture
 def test_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = RMSNormTest(m, n, dtype)
-    op = RMSNormFwdOp(N=n, dtype=dtype)
+    op = RMSNormFwdOp(normalized_shape=(n,), dtype=dtype)
     atol = 1e-2 if dtype == torch.float16 else 1.6e-2
     rtol = atol
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
@@ -60,7 +60,7 @@ def test_rms_norm_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     x = x_full[:, :n]  # non-contiguous slice
     weight = torch.randn(n, dtype=dtype, device="cuda")
 
-    op = RMSNormFwdOp(N=n, dtype=dtype)
+    op = RMSNormFwdOp(normalized_shape=(n,), dtype=dtype)
 
     # Reference on contiguous copy
     eps = 1e-6
@@ -90,7 +90,7 @@ def test_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> N
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
 
-    op = RMSNormFwdOp(N=hidden, dtype=dtype)
+    op = RMSNormFwdOp(normalized_shape=(hidden,), dtype=dtype)
 
     # Reference
     eps = 1e-6
@@ -104,41 +104,6 @@ def test_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> N
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
 
 
-class RMSNormDimAxis1Fixture(FixtureBase):
-    PARAMS = [
-        ("batch, hidden, seq, dtype", [
-            pytest.param(2, 4096, 512, torch.float16, marks=pytest.mark.smoke),
-            pytest.param(2, 4096, 512, torch.bfloat16, marks=pytest.mark.smoke),
-        ]),
-    ]
-
-
-@RMSNormDimAxis1Fixture
-def test_rms_norm_dim_axis1(
-    batch: int, hidden: int, seq: int, dtype: torch.dtype
-) -> None:
-    """Test reducing along dim=1 (not -1) with a 3D tensor.
-
-    Exercises the movedim choreography in RowNormOp._flatten_to_2d /
-    _trim_and_unflatten — the new code path enabled by this PR. Without
-    this test, the dim != -1 branch could regress while the suite passes.
-    """
-    x = torch.randn(batch, hidden, seq, dtype=dtype, device="cuda")
-    weight = torch.randn(hidden, dtype=dtype, device="cuda")
-
-    op = RMSNormFwdOp(N=hidden, dtype=dtype, dim=1)
-
-    eps = 1e-6
-    x_f32 = x.float()
-    rms = torch.sqrt(x_f32.pow(2).mean(dim=1, keepdim=True) + eps)
-    # Apply 1-D weight to dim=1 via reshape for broadcasting.
-    weight_b = weight.float().view(1, hidden, 1)
-    y_ref = ((x_f32 / rms) * weight_b).to(dtype)
-
-    y = op(x, weight)
-    atol = 1e-2 if dtype == torch.float16 else 1.6e-2
-    assert torch.allclose(y, y_ref, atol=atol, rtol=atol), \
-        f"dim=1 test failed, max err: {(y - y_ref).abs().max()}"
 
 
 if __name__ == "__main__":

--- a/tileops/ops/norm/__init__.py
+++ b/tileops/ops/norm/__init__.py
@@ -6,7 +6,6 @@ from .fused_add_rms_norm import FusedAddRMSNormFwdOp
 from .group_norm import GroupNormFwdOp
 from .instance_norm import InstanceNormFwdOp
 from .layer_norm import LayerNormFwdOp
-from .norm_base import RowNormOp
 from .rms_norm import RMSNormFwdOp
 
 __all__: list[str] = [
@@ -20,5 +19,4 @@ __all__: list[str] = [
     "InstanceNormFwdOp",
     "LayerNormFwdOp",
     "RMSNormFwdOp",
-    "RowNormOp",
 ]

--- a/tileops/ops/norm/ada_layer_norm.py
+++ b/tileops/ops/norm/ada_layer_norm.py
@@ -7,14 +7,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import AdaLayerNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["AdaLayerNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class AdaLayerNormFwdOp(Op):
@@ -63,7 +58,7 @@ class AdaLayerNormFwdOp(Op):
         self.N = N
         self.dtype = dtype
         self.eps = eps
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["ada_layer_norm"](
             M, N, eps, dtype, has_gate=False, tune=tune,

--- a/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/tileops/ops/norm/ada_layer_norm_zero.py
@@ -7,14 +7,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import AdaLayerNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["AdaLayerNormZeroFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class AdaLayerNormZeroFwdOp(Op):
@@ -64,7 +59,7 @@ class AdaLayerNormZeroFwdOp(Op):
         self.N = N
         self.dtype = dtype
         self.eps = eps
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["ada_layer_norm"](
             M, N, eps, dtype, has_gate=True, tune=tune,

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -5,8 +5,11 @@ in a standard TileOPs Op interface.
 
 User-facing API mirrors :func:`torch.nn.functional.batch_norm`:
 
-    fwd_op = BatchNormFwdOp(N, C, *spatial, dtype=dtype, momentum=0.1, eps=1e-5)
-    y = fwd_op(x, running_mean, running_var, weight, bias, training=False)
+    fwd_op = BatchNormFwdOp(
+        N, C, *spatial, dtype=dtype, training=False,
+        momentum=0.1, eps=1e-5,
+    )
+    y = fwd_op(x, running_mean, running_var, weight, bias)
 
     bwd_op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
     grad_x, grad_weight, grad_bias = bwd_op(grad_out, x, weight, mean, rstd)
@@ -164,9 +167,11 @@ class BatchNormFwdOp(Op):
         running_var: torch.Tensor,
         weight: torch.Tensor,
         bias: torch.Tensor,
-        training: Optional[bool] = None,
     ) -> torch.Tensor:
         """Run batch normalization forward pass.
+
+        The ``training`` mode is bound at ctor time. Construct a separate
+        op instance to switch between training and inference.
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
@@ -180,17 +185,14 @@ class BatchNormFwdOp(Op):
                 device as ``x``.
             bias: Affine shift (beta) of shape ``(C,)`` on the same CUDA
                 device as ``x``.
-            training: Override the ctor-bound ``training`` flag for this
-                call. ``None`` uses the ctor-bound default.
 
         Returns:
             Normalized output tensor with the same shape as ``x``.
         """
-        train_flag = self.training if training is None else training
         self._validate_inputs(x)
         x_cl, orig_shape = self._prepare(x)
 
-        if train_flag:
+        if self.training:
             y_cl, _mean, _rstd = self.train_kernel(
                 x_cl, weight.float(), bias.float(),
                 running_mean, running_var)
@@ -321,12 +323,11 @@ def _batch_norm_fwd_wrapped(
     running_var: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
-    training: bool,
     instance_key: int,
 ) -> torch.Tensor:
     instance = _OP_REGISTRY[instance_key]
     return instance._eager_forward(
-        x, running_mean, running_var, weight, bias, training=training)
+        x, running_mean, running_var, weight, bias)
 
 
 @_batch_norm_fwd_wrapped.register_fake
@@ -336,7 +337,6 @@ def _batch_norm_fwd_fake(
     running_var: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
-    training: bool,
     instance_key: int,
 ) -> torch.Tensor:
     return torch.empty_like(x)
@@ -352,13 +352,11 @@ def _batchnorm_fwd_eager_forward(
     running_var: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
-    training: Optional[bool] = None,
 ) -> torch.Tensor:
     """Direct kernel call (no torch.compile wrapping)."""
-    train_flag = self.training if training is None else training
     self._validate_inputs(x)
     x_cl, orig_shape = self._prepare(x)
-    if train_flag:
+    if self.training:
         y_cl, _mean, _rstd = self.train_kernel(
             x_cl, weight.float(), bias.float(),
             running_mean, running_var)
@@ -390,12 +388,9 @@ def _patched_fwd_forward(
     running_var: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
-    training: Optional[bool] = None,
 ) -> torch.Tensor:
-    train_flag = self.training if training is None else training
     return _batch_norm_fwd_wrapped(
-        x, running_mean, running_var, weight, bias,
-        train_flag, self._instance_key)
+        x, running_mean, running_var, weight, bias, self._instance_key)
 
 
 BatchNormFwdOp.forward = _patched_fwd_forward

--- a/tileops/ops/norm/fused_add_layer_norm.py
+++ b/tileops/ops/norm/fused_add_layer_norm.py
@@ -7,14 +7,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import FusedAddLayerNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["FusedAddLayerNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class FusedAddLayerNormFwdOp(Op):
@@ -65,7 +60,7 @@ class FusedAddLayerNormFwdOp(Op):
         self.N = N
         self.dtype = dtype
         self.eps = eps
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["fused_add_layer_norm"](
             M, N, eps, dtype, tune=tune,

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -7,14 +7,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import FusedAddRMSNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["FusedAddRMSNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class FusedAddRMSNormFwdOp(Op):
@@ -63,7 +58,7 @@ class FusedAddRMSNormFwdOp(Op):
         self.N = N
         self.dtype = dtype
         self.eps = eps
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["fused_add_rms_norm"](
             M, N, eps, dtype, tune=tune,

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -24,14 +24,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import GroupNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["GroupNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class GroupNormFwdOp(Op):
@@ -94,7 +89,7 @@ class GroupNormFwdOp(Op):
         # row length before padding
         self.D = (C // num_groups) * self.spatial_size
         self.M = N * num_groups  # number of rows
-        self.D_padded = _align_up(self.D, ALIGNMENT)
+        self.D_padded = align_up(self.D, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["group_norm"](
             self.M, self.D, eps, dtype, tune=tune,

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -10,7 +10,8 @@ User-facing API mirrors torch.nn.functional.group_norm:
     y = op(x, weight, bias)
 
 Input tensors accept shape (N, C, *spatial); the op reshapes to
-(N*num_groups, D_padded) internally where D = (C/num_groups) * spatial_size.
+(N*num_groups, D_padded) internally where
+D = (C/num_groups) * spatial_size.
 """
 
 import math
@@ -36,7 +37,7 @@ def _align_up(n: int, alignment: int) -> int:
 class GroupNormFwdOp(Op):
     """Group Normalization forward operator.
 
-    Computes group normalization over ``(C/G, *spatial)`` slices:
+    Computes group normalization over ``(C/num_groups, *spatial)`` slices:
 
     .. math::
 
@@ -44,7 +45,7 @@ class GroupNormFwdOp(Op):
             \\cdot w + b
 
     where the mean and variance are computed per group over
-    ``(C/G, *spatial)`` elements.
+    ``(C/num_groups, *spatial)`` elements.
 
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
@@ -63,9 +64,6 @@ class GroupNormFwdOp(Op):
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
-        G: Deprecated alias for ``num_groups``; kept for legacy callers
-            that have not migrated yet. Pass exactly one of ``num_groups``
-            or ``G``.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
     """
@@ -75,37 +73,27 @@ class GroupNormFwdOp(Op):
         N: int,
         C: int,
         spatial: tuple,
-        num_groups: Optional[int] = None,
-        dtype: Optional[torch.dtype] = None,
+        num_groups: int,
+        dtype: torch.dtype,
         eps: float = 1e-5,
         *,
-        G: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if num_groups is None and G is None:
-            raise TypeError("GroupNormFwdOp requires 'num_groups'")
-        if num_groups is not None and G is not None and num_groups != G:
+        if C % num_groups != 0:
             raise ValueError(
-                f"Conflicting num_groups={num_groups} and legacy G={G}"
+                f"C={C} must be divisible by num_groups={num_groups}"
             )
-        groups = num_groups if num_groups is not None else G
-        if dtype is None:
-            raise TypeError("GroupNormFwdOp requires 'dtype'")
-        if C % groups != 0:
-            raise ValueError(f"C={C} must be divisible by num_groups={groups}")
         self.N = N
         self.C = C
         self.spatial = spatial
-        self.num_groups = groups
-        # Keep the legacy attribute name pointing at the same value so
-        # downstream readers that still inspect ``op.G`` keep working.
-        self.G = groups
+        self.num_groups = num_groups
         self.dtype = dtype
         self.eps = eps
         self.spatial_size = math.prod(spatial)
-        self.D = (C // groups) * self.spatial_size  # row length before padding
-        self.M = N * groups  # number of rows
+        # row length before padding
+        self.D = (C // num_groups) * self.spatial_size
+        self.M = N * num_groups  # number of rows
         self.D_padded = _align_up(self.D, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["group_norm"](
@@ -123,7 +111,9 @@ class GroupNormFwdOp(Op):
             (2 * self.N * self.C * self.spatial_size + 2 * self.C) * elem_bytes,
         )
 
-    def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor,
+    ) -> torch.Tensor:
         """Apply group normalization.
 
         Args:
@@ -166,19 +156,25 @@ class GroupNormFwdOp(Op):
             )
 
         orig_shape = x.shape
-        # Ensure contiguous and reshape to (N, G, C/G, *spatial)
+        # Ensure contiguous and reshape to (N, num_groups, C/num_groups, *spatial)
         x = x.contiguous()
 
-        # Reshape: (N, C, *spatial) -> (N, G, C/G, *spatial) -> (N*G, (C/G)*spatial_size)
-        cpg = self.C // self.G  # channels per group
-        x_reshaped = x.reshape(self.N, self.G, cpg, *self.spatial)
+        # Reshape: (N, C, *spatial)
+        # -> (N, num_groups, C/num_groups, *spatial)
+        # -> (N*num_groups, (C/num_groups)*spatial_size)
+        cpg = self.C // self.num_groups  # channels per group
+        x_reshaped = x.reshape(self.N, self.num_groups, cpg, *self.spatial)
         x_2d = x_reshaped.reshape(self.M, self.D)
 
         # The kernel broadcasts 1D weight/bias across all rows, but GroupNorm
-        # needs per-group affine parameters. Run kernel with unit weight/zero bias
-        # to normalize, then apply per-channel affine transform afterwards.
-        unit_weight = torch.ones(self.D_padded, dtype=self.dtype, device=x.device)
-        zero_bias = torch.zeros(self.D_padded, dtype=self.dtype, device=x.device)
+        # needs per-group affine parameters. Run kernel with unit weight/zero
+        # bias to normalize, then apply per-channel affine afterwards.
+        unit_weight = torch.ones(
+            self.D_padded, dtype=self.dtype, device=x.device,
+        )
+        zero_bias = torch.zeros(
+            self.D_padded, dtype=self.dtype, device=x.device,
+        )
 
         # Pad to alignment
         if self.D_padded != self.D:
@@ -191,8 +187,9 @@ class GroupNormFwdOp(Op):
         if self.D_padded != self.D:
             y_2d = y_2d[:, :self.D]
 
-        # Reshape back: (N*G, D) -> (N, G, cpg, *spatial) -> (N, C, *spatial)
-        y = y_2d.reshape(self.N, self.G, cpg, *self.spatial)
+        # Reshape back: (N*num_groups, D) -> (N, num_groups, cpg, *spatial)
+        # -> (N, C, *spatial)
+        y = y_2d.reshape(self.N, self.num_groups, cpg, *self.spatial)
         y = y.reshape(orig_shape)
 
         # Apply per-channel affine: y = y * weight + bias

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -22,14 +22,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import GroupNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["InstanceNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class InstanceNormFwdOp(Op):
@@ -89,7 +84,7 @@ class InstanceNormFwdOp(Op):
         # so D = (C/C) * spatial_size = spatial_size and M = N * C.
         self.D = self.spatial_size
         self.M = N * C
-        self.D_padded = _align_up(self.D, ALIGNMENT)
+        self.D_padded = align_up(self.D, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["group_norm"](
             self.M, self.D, eps, dtype, tune=tune,

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -1,14 +1,15 @@
 """InstanceNorm forward operator.
 
-InstanceNorm is a special case of GroupNorm where G = C (each channel
-is its own group). This operator delegates to GroupNormKernel with G=C.
+Instance Normalization (IN) is a special case of Group Normalization (GN)
+where ``num_groups = C`` (each channel is its own group). This operator
+delegates to :class:`GroupNormKernel` with that grouping.
 
-User-facing API mirrors torch.nn.functional.instance_norm:
+User-facing API mirrors :func:`torch.nn.functional.instance_norm`:
 
     op = InstanceNormFwdOp(N=batch, C=channels, spatial=(H, W), dtype=dtype)
     y = op(x, weight, bias)
 
-Input tensors accept shape (N, C, *spatial).
+Input tensors accept shape ``(N, C, *spatial)``.
 """
 
 import math
@@ -43,15 +44,18 @@ class InstanceNormFwdOp(Op):
             \\cdot w + b
 
     where the mean and variance are computed over ``*spatial`` for each
-    sample-channel pair. Equivalent to Group Normalization with ``G = C``.
+    sample-channel pair. Equivalent to Group Normalization with
+    ``num_groups = C``.
 
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
     Note:
-        Supports arbitrary spatial dimensions (1-D, 2-D, 3-D+).
-        Delegates to :class:`GroupNormKernel` with ``G = C``.
-        Hidden dimension is padded to 256-element alignment internally.
+        Supports arbitrary spatial dimensions (1-D, 2-D, 3-D+). Delegates
+        to :class:`GroupNormKernel` with one group per channel. Hidden
+        dimension is padded to 256-element alignment internally. The
+        running-stats variant (``use_input_stats=False``) is out of scope
+        for this op.
 
     Args:
         N: Batch size.
@@ -70,29 +74,21 @@ class InstanceNormFwdOp(Op):
         C: int,
         spatial: tuple,
         dtype: torch.dtype,
-        use_input_stats: bool = True,
-        momentum: float = 0.1,
         eps: float = 1e-5,
+        *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if not use_input_stats:
-            raise NotImplementedError(
-                "InstanceNormFwdOp.use_input_stats=False (running-stats "
-                "variant) is out of scope for this op; track separately."
-            )
         self.N = N
         self.C = C
         self.spatial = spatial
-        self.G = C  # InstanceNorm: each channel is its own group
         self.dtype = dtype
-        self.use_input_stats = use_input_stats
-        self.momentum = momentum
         self.eps = eps
         self.spatial_size = math.prod(spatial)
-        # For InstanceNorm (G=C): D = (C/C) * spatial_size = spatial_size
+        # InstanceNorm: each channel is its own group (num_groups = C)
+        # so D = (C/C) * spatial_size = spatial_size and M = N * C.
         self.D = self.spatial_size
-        self.M = N * C  # number of rows = N * G = N * C
+        self.M = N * C
         self.D_padded = _align_up(self.D, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["group_norm"](
@@ -110,7 +106,9 @@ class InstanceNormFwdOp(Op):
             (2 * self.N * self.C * self.spatial_size + 2 * self.C) * elem_bytes,
         )
 
-    def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor,
+    ) -> torch.Tensor:
         """Apply instance normalization.
 
         Args:
@@ -159,8 +157,12 @@ class InstanceNormFwdOp(Op):
         x_2d = x.reshape(self.M, self.D)
 
         # Unit weight and zero bias for the kernel (affine applied after)
-        unit_weight = torch.ones(self.D_padded, dtype=self.dtype, device=x.device)
-        zero_bias = torch.zeros(self.D_padded, dtype=self.dtype, device=x.device)
+        unit_weight = torch.ones(
+            self.D_padded, dtype=self.dtype, device=x.device,
+        )
+        zero_bias = torch.zeros(
+            self.D_padded, dtype=self.dtype, device=x.device,
+        )
 
         # Pad to alignment
         if self.D_padded != self.D:

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -7,15 +7,9 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import LayerNormKernel
 
 from ..op_base import Op
-from .norm_base import normalized_shape_to_n
+from .norm_base import ALIGNMENT, align_up, normalized_shape_to_n
 
 __all__ = ["LayerNormFwdOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class LayerNormFwdOp(Op):
@@ -39,8 +33,8 @@ class LayerNormFwdOp(Op):
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
         Handles non-contiguous inputs and non-power-of-two hidden dims by
         padding to 256-element alignment. The leading-dims product ``M``
-        is bound on the first forward call; subsequent calls must use the
-        same ``M``.
+        is bound on the first forward call; if a subsequent call uses a
+        different ``M``, the kernel is rebuilt for the new value.
 
     Args:
         normalized_shape: Trailing-axis shape tuple over which the
@@ -62,15 +56,13 @@ class LayerNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        self.N = normalized_shape_to_n(normalized_shape)
         self.normalized_shape = tuple(int(d) for d in normalized_shape)
-        if len(self.normalized_shape) == 0:
-            raise ValueError("normalized_shape must be non-empty")
-        self.N = normalized_shape_to_n(self.normalized_shape)
         self.dtype = dtype
         # Manifest declares ``eps: float | None`` with PyTorch default 1e-5.
         self.eps = 1e-5 if eps is None else float(eps)
         self.tune = tune
-        self.N_padded = _align_up(self.N, ALIGNMENT)
+        self.N_padded = align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel: Optional[Kernel] = None
         self._last_m: Optional[int] = None
@@ -151,14 +143,9 @@ class LayerNormFwdOp(Op):
         weight = weight.contiguous().reshape(self.N)
         bias = bias.contiguous().reshape(self.N)
         m_actual = x.shape[0]
-        if self.kernel is None:
+        if self.kernel is None or m_actual != self._last_m:
             self.kernel = self.kernel_map["layer_norm"](
                 m_actual, self.N, self.eps, self.dtype, tune=self.tune,
-            )
-        elif m_actual != self._last_m:
-            raise ValueError(
-                f"LayerNormFwdOp was bound to leading-dims product "
-                f"{self._last_m} on first forward; got {m_actual}"
             )
         self._last_m = m_actual
 

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -39,7 +39,8 @@ class LayerNormFwdOp(Op):
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
         Handles non-contiguous inputs and non-power-of-two hidden dims by
         padding to 256-element alignment. The leading-dims product ``M``
-        is bound at forward time and kernels are cached per ``M``.
+        is bound on the first forward call; subsequent calls must use the
+        same ``M``.
 
     Args:
         normalized_shape: Trailing-axis shape tuple over which the
@@ -71,19 +72,12 @@ class LayerNormFwdOp(Op):
         self.tune = tune
         self.N_padded = _align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self._kernel_cache: Dict[int, Kernel] = {}
+        self.kernel: Optional[Kernel] = None
         self._last_m: Optional[int] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"layer_norm": LayerNormKernel}
-
-    def _get_kernel(self, m: int) -> Kernel:
-        if m not in self._kernel_cache:
-            self._kernel_cache[m] = self.kernel_map["layer_norm"](
-                m, self.N, self.eps, self.dtype, tune=self.tune,
-            )
-        return self._kernel_cache[m]
 
     def eval_roofline(self) -> tuple[int, int]:
         if self._last_m is None:
@@ -157,6 +151,15 @@ class LayerNormFwdOp(Op):
         weight = weight.contiguous().reshape(self.N)
         bias = bias.contiguous().reshape(self.N)
         m_actual = x.shape[0]
+        if self.kernel is None:
+            self.kernel = self.kernel_map["layer_norm"](
+                m_actual, self.N, self.eps, self.dtype, tune=self.tune,
+            )
+        elif m_actual != self._last_m:
+            raise ValueError(
+                f"LayerNormFwdOp was bound to leading-dims product "
+                f"{self._last_m} on first forward; got {m_actual}"
+            )
         self._last_m = m_actual
 
         # Pad hidden dim to 256-element alignment if needed
@@ -165,7 +168,7 @@ class LayerNormFwdOp(Op):
             weight = F.pad(weight, (0, self.N_padded - self.N))
             bias = F.pad(bias, (0, self.N_padded - self.N))
 
-        y = self._get_kernel(m_actual)(x, weight, bias)
+        y = self.kernel(x, weight, bias)
 
         # Trim padding
         if self.N_padded != self.N:

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -29,62 +29,49 @@ class LayerNormFwdOp(Op):
         y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
             \\cdot w + b
 
-    Mirrors :func:`torch.nn.functional.layer_norm`.
+    Mirrors :func:`torch.nn.functional.layer_norm`. ``normalized_shape``
+    is the only entry point (the manifest spec).
 
     Supported dtypes:
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
     Note:
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
-        Handles non-contiguous inputs and non-power-of-two hidden dims
-        by padding to 256-element alignment. The leading-dims product
-        ``M`` is bound at forward time and kernels are cached per ``M``.
+        Handles non-contiguous inputs and non-power-of-two hidden dims by
+        padding to 256-element alignment. The leading-dims product ``M``
+        is bound at forward time and kernels are cached per ``M``.
 
     Args:
-        normalized_shape: Trailing-axis shape tuple over which the reduction
-            runs (manifest ``params.normalized_shape``). Either this or
-            legacy ``N`` must be set.
+        normalized_shape: Trailing-axis shape tuple over which the
+            reduction runs (manifest ``params.normalized_shape``).
         eps: Epsilon for numerical stability (manifest ``params.eps``).
+            ``None`` uses the PyTorch default ``1e-5``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
-        N: Legacy single-axis reduction size; mutually exclusive with
-            ``normalized_shape``.
-        M: Optional pre-bound leading-dims product. When omitted, ``M`` is
-            derived from the input at forward time.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
     """
 
     def __init__(
         self,
-        normalized_shape: Optional[Sequence[int]] = None,
+        normalized_shape: Sequence[int],
         eps: Optional[float] = 1e-5,
         *,
         dtype: torch.dtype,
-        N: Optional[int] = None,
-        M: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.normalized_shape = (
-            tuple(int(d) for d in normalized_shape)
-            if normalized_shape is not None else None
-        )
-        self.N = normalized_shape_to_n(normalized_shape, n_fallback=N)
+        self.normalized_shape = tuple(int(d) for d in normalized_shape)
+        if len(self.normalized_shape) == 0:
+            raise ValueError("normalized_shape must be non-empty")
+        self.N = normalized_shape_to_n(self.normalized_shape)
         self.dtype = dtype
         # Manifest declares ``eps: float | None`` with PyTorch default 1e-5.
-        # Map None to the PyTorch default so callers passing the manifest
-        # default literally (None) get a working kernel.
         self.eps = 1e-5 if eps is None else float(eps)
         self.tune = tune
         self.N_padded = _align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.M: Optional[int] = M
         self._kernel_cache: Dict[int, Kernel] = {}
-        if M is not None:
-            self._kernel_cache[M] = self.kernel_map["layer_norm"](
-                M, self.N, self.eps, dtype, tune=tune,
-            )
         self._last_m: Optional[int] = None
 
     @property
@@ -99,13 +86,13 @@ class LayerNormFwdOp(Op):
         return self._kernel_cache[m]
 
     def eval_roofline(self) -> tuple[int, int]:
-        m = self._last_m if self._last_m is not None else self.M
-        if m is None:
+        if self._last_m is None:
             raise RuntimeError(
-                "LayerNormFwdOp.eval_roofline() requires a prior "
-                "forward() call (or ctor M) to bind the leading-dims product."
+                "LayerNormFwdOp.eval_roofline() requires a prior forward() "
+                "call to bind the leading-dims product."
             )
         elem_bytes = self.dtype.itemsize
+        m = self._last_m
         return (
             5 * m * self.N,
             (2 * m * self.N + 2 * self.N) * elem_bytes,
@@ -117,16 +104,18 @@ class LayerNormFwdOp(Op):
         """Apply layer normalization.
 
         Args:
-            x: Input tensor of shape ``(*leading, N)`` on CUDA.
-            weight: Affine scale of shape ``(N,)`` on CUDA.
-            bias: Affine shift of shape ``(N,)`` on CUDA.
+            x: Input tensor with trailing shape equal to
+                ``normalized_shape`` on CUDA.
+            weight: Affine scale of shape ``normalized_shape`` on CUDA.
+            bias: Affine shift of shape ``normalized_shape`` on CUDA.
 
         Returns:
             Normalized tensor of the same shape as *x*.
 
         Raises:
-            ValueError: If tensors are not on CUDA, dtypes mismatch,
-                or shapes are incompatible with the configured dimensions.
+            ValueError: If tensors are not on CUDA, dtypes mismatch, or
+                shapes are incompatible with the configured
+                ``normalized_shape``.
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
@@ -146,54 +135,28 @@ class LayerNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
             )
-        if self.normalized_shape is not None:
-            ns = self.normalized_shape
-            k = len(ns)
-            if x.ndim < k or tuple(x.shape[-k:]) != ns:
-                raise ValueError(
-                    f"Expected x trailing shape {ns}, "
-                    f"got {tuple(x.shape[-k:]) if x.ndim >= k else tuple(x.shape)}"
-                )
-            if tuple(weight.shape) != ns:
-                raise ValueError(
-                    f"Expected weight shape {ns}, got {tuple(weight.shape)}"
-                )
-            if tuple(bias.shape) != ns:
-                raise ValueError(
-                    f"Expected bias shape {ns}, got {tuple(bias.shape)}"
-                )
-        else:
-            if weight.ndim != 1:
-                raise ValueError(
-                    f"Expected weight to be 1D, got {weight.ndim}D"
-                )
-            if bias.ndim != 1:
-                raise ValueError(
-                    f"Expected bias to be 1D, got {bias.ndim}D"
-                )
-            if x.shape[-1] != self.N:
-                raise ValueError(
-                    f"Expected hidden dim {self.N}, got {x.shape[-1]}"
-                )
-            if weight.shape[0] != self.N:
-                raise ValueError(
-                    f"Expected weight dim {self.N}, got {weight.shape[0]}"
-                )
-            if bias.shape[0] != self.N:
-                raise ValueError(
-                    f"Expected bias dim {self.N}, got {bias.shape[0]}"
-                )
+
+        ns = self.normalized_shape
+        k = len(ns)
+        if x.ndim < k or tuple(x.shape[-k:]) != ns:
+            raise ValueError(
+                f"Expected x trailing shape {ns}, "
+                f"got {tuple(x.shape[-k:]) if x.ndim >= k else tuple(x.shape)}"
+            )
+        if tuple(weight.shape) != ns:
+            raise ValueError(
+                f"Expected weight shape {ns}, got {tuple(weight.shape)}"
+            )
+        if tuple(bias.shape) != ns:
+            raise ValueError(
+                f"Expected bias shape {ns}, got {tuple(bias.shape)}"
+            )
 
         orig_shape = x.shape
         x = x.contiguous().reshape(-1, self.N)
         weight = weight.contiguous().reshape(self.N)
         bias = bias.contiguous().reshape(self.N)
         m_actual = x.shape[0]
-        if self.M is not None and m_actual != self.M:
-            raise ValueError(
-                f"Expected M={self.M} (product of leading dims), "
-                f"got {m_actual}"
-            )
         self._last_m = m_actual
 
         # Pad hidden dim to 256-element alignment if needed

--- a/tileops/ops/norm/norm_base.py
+++ b/tileops/ops/norm/norm_base.py
@@ -3,9 +3,14 @@
 import math
 from typing import Sequence
 
-__all__ = ["ALIGNMENT", "normalized_shape_to_n"]
+__all__ = ["ALIGNMENT", "align_up", "normalized_shape_to_n"]
 
 ALIGNMENT = 256
+
+
+def align_up(n: int, alignment: int) -> int:
+    """Return ``n`` rounded up to the next multiple of ``alignment``."""
+    return ((n + alignment - 1) // alignment) * alignment
 
 
 def normalized_shape_to_n(normalized_shape: Sequence[int]) -> int:

--- a/tileops/ops/norm/norm_base.py
+++ b/tileops/ops/norm/norm_base.py
@@ -1,214 +1,27 @@
-"""RowNormOp base class for row-wise normalization operators.
-
-Implements the canonical static_dims pattern from docs/design/ops-design.md: ctor
-binds only what the manifest declares as `static_dims` (`N`) plus
-signature.params (`dim`, `eps`); `M` (the leading-dims product) is derived
-at forward time and used to lazily build / cache kernels keyed by `M`.
-
-Forward pipeline: validate -> movedim(dim → -1) -> reshape (M, N) -> pad ->
-kernel -> trim -> reshape -> movedim(-1 → dim).
-
-BatchNorm uses spatial reduction (not a single axis), so it does NOT inherit
-from this.
-"""
+"""Helpers shared by the normalization Op family."""
 
 import math
-from abc import abstractmethod
-from typing import Dict, Optional, Sequence, Tuple, Union
+from typing import Sequence
 
-import torch
-import torch.nn.functional as F
-
-from tileops.kernels.kernel_base import Kernel
-
-from ..op_base import Op
-
-__all__ = ["ALIGNMENT", "RowNormOp", "normalized_shape_to_n"]
-
-
-def normalized_shape_to_n(
-    normalized_shape: Optional[Sequence[int]],
-    n_fallback: Optional[int] = None,
-) -> int:
-    """Resolve manifest ``normalized_shape`` into a flat reduction size ``N``.
-
-    Args:
-        normalized_shape: Manifest-style normalized shape; ``None`` falls back
-            to ``n_fallback``.
-        n_fallback: Legacy ``N`` value used when ``normalized_shape`` is None.
-
-    Returns:
-        Product of ``normalized_shape`` (or ``n_fallback`` when supplied).
-
-    Raises:
-        ValueError: if neither ``normalized_shape`` nor ``n_fallback`` is set,
-            or if ``normalized_shape`` is empty.
-    """
-    if normalized_shape is None:
-        if n_fallback is None:
-            raise ValueError("Provide either normalized_shape or N")
-        return int(n_fallback)
-    shape = tuple(int(d) for d in normalized_shape)
-    if len(shape) == 0:
-        raise ValueError("normalized_shape must be non-empty")
-    return math.prod(shape)
+__all__ = ["ALIGNMENT", "normalized_shape_to_n"]
 
 ALIGNMENT = 256
 
 
-class RowNormOp(Op):
-    """Abstract base class for row-wise normalization operators with a
-    user-selectable reduction axis.
-
-    Subclasses must override:
-    - ``_kernel_key`` (class attribute): kernel-map key string.
-    - ``_kernel_cls`` (class attribute): kernel class.
-    - ``forward()``: the user-facing call (use the helpers below).
+def normalized_shape_to_n(normalized_shape: Sequence[int]) -> int:
+    """Return the product of ``normalized_shape``.
 
     Args:
-        N: Hidden / reduction dimension size (statically committed at ctor).
-        dtype: Data type (float16 or bfloat16).
-        dim: Reduction axis (default -1). Negative values are normalized at
-            forward time (``dim % x.ndim``).
-        eps: Epsilon for numerical stability.
-        kernel_map: Optional kernel override dict.
-        tune: If True, autotune tile configs.
+        normalized_shape: Manifest-style trailing-axis shape; must be
+            non-empty.
+
+    Returns:
+        Product of every entry in ``normalized_shape``.
+
+    Raises:
+        ValueError: If ``normalized_shape`` is empty.
     """
-
-    _kernel_key: str
-    _kernel_cls: type
-
-    # `static_dims.N = x.shape[dim]` is param-dependent (depends on `dim`),
-    # so the static-axis frozenset is bound at forward time after dim
-    # normalization, not at the class level (per docs/design/ops-design.md § Step 3).
-    _static_axes: frozenset = frozenset()
-
-    def __init__(
-        self,
-        *,
-        N: int,
-        dtype: torch.dtype,
-        dim: int = -1,
-        eps: float = 1e-6,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-    ) -> None:
-        self.N = N
-        self.dtype = dtype
-        self.dim = dim
-        self.eps = eps
-        self.tune = tune
-        self.N_padded = self._align_up(N, ALIGNMENT)
-        self.dispatch_kernel(kernel_map)
-        self._kernel_cache: Dict[int, Kernel] = {}
-        self._last_roofline_mn: Optional[Tuple[int, int]] = None
-
-    @staticmethod
-    def _align_up(n: int, alignment: int) -> int:
-        """Round *n* up to the nearest multiple of *alignment*."""
-        return ((n + alignment - 1) // alignment) * alignment
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {self._kernel_key: self._kernel_cls}
-
-    def eval_roofline(self) -> Tuple[int, int]:
-        if self._last_roofline_mn is None:
-            raise RuntimeError(
-                f"{type(self).__name__}.eval_roofline() requires a prior "
-                "forward() call to bind dynamic input shape (M)"
-            )
-        M, N = self._last_roofline_mn
-        elem_bytes = self.dtype.itemsize
-        return (4 * M * N, (2 * M * N + N) * elem_bytes)
-
-    @property
-    def _needs_pad(self) -> bool:
-        return self.N_padded != self.N
-
-    def _get_kernel(self, M: int) -> Kernel:
-        """Return a kernel built for (M, self.N), caching by M."""
-        if M not in self._kernel_cache:
-            self._kernel_cache[M] = self.kernel_map[self._kernel_key](
-                M, self.N, self.eps, self.dtype, tune=self.tune,
-            )
-        return self._kernel_cache[M]
-
-    # -- Forward pipeline helpers --------------------------------------------
-
-    def _validate_and_normalize_dim(
-        self, x: torch.Tensor, weight: torch.Tensor
-    ) -> int:
-        """Validate input/weight, return the non-negative reduction axis."""
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if not weight.is_cuda or weight.dtype != self.dtype:
-            raise ValueError(
-                f"weight must be a CUDA tensor of dtype {self.dtype}"
-            )
-        if weight.ndim != 1 or weight.shape[0] != self.N:
-            raise ValueError(
-                f"weight must be 1-D with shape ({self.N},), "
-                f"got {tuple(weight.shape)}"
-            )
-        ndim = x.ndim
-        if not (-ndim <= self.dim < ndim):
-            raise ValueError(
-                f"dim={self.dim} out of range for {ndim}-D input"
-            )
-        dim_norm = self.dim % ndim
-        if x.shape[dim_norm] != self.N:
-            raise ValueError(
-                f"Expected x.shape[{self.dim}]={self.N}, "
-                f"got {x.shape[dim_norm]}"
-            )
-        # Bind the dynamic static-axis (param-dependent N axis) so
-        # Op-layer cache-key/introspection consumers see the committed axis.
-        self._static_axes = frozenset({(0, dim_norm)})
-        return dim_norm
-
-    def _flatten_to_2d(
-        self, x: torch.Tensor, dim_norm: int
-    ) -> Tuple[torch.Tensor, Tuple[int, ...]]:
-        """Move target axis to last, flatten leading dims to (M, N).
-
-        Returns (2-D x, shape after movedim) so the caller can restore
-        leading dims after the kernel.
-        """
-        if dim_norm != x.ndim - 1:
-            x = x.movedim(dim_norm, -1)
-        post_move_shape = tuple(x.shape)
-        x = x.contiguous().reshape(-1, self.N)
-        return x, post_move_shape
-
-    def _pad_row(self, t: torch.Tensor) -> torch.Tensor:
-        """Pad a 2-D row tensor along dim=-1 to N_padded."""
-        return F.pad(t, (0, self.N_padded - self.N))
-
-    def _pad_vec(self, t: torch.Tensor) -> torch.Tensor:
-        """Pad a 1-D vector to N_padded."""
-        return F.pad(t, (0, self.N_padded - self.N))
-
-    def _trim_and_unflatten(
-        self,
-        y: torch.Tensor,
-        post_move_shape: Tuple[int, ...],
-        dim_norm: int,
-        ndim: int,
-    ) -> torch.Tensor:
-        """Inverse of `_flatten_to_2d`: trim padding, restore shape, move axis back."""
-        if self._needs_pad:
-            y = y[:, : self.N]
-        y = y.reshape(post_move_shape)
-        if dim_norm != ndim - 1:
-            y = y.movedim(-1, dim_norm)
-        return y
-
-    @abstractmethod
-    def forward(
-        self, *args: object, **kwargs: object
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, ...]]:
-        """Subclasses must implement their own forward with concrete args."""
-        raise NotImplementedError("Subclasses must implement forward()")
+    shape = tuple(int(d) for d in normalized_shape)
+    if len(shape) == 0:
+        raise ValueError("normalized_shape must be non-empty")
+    return math.prod(shape)

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -1,40 +1,43 @@
-from typing import Dict, Optional, Sequence
+import math
+from typing import Dict, Optional, Sequence, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import RMSNormKernel
 
-from .norm_base import RowNormOp, normalized_shape_to_n
+from ..op_base import Op
 
 __all__ = ["RMSNormFwdOp"]
+
+ALIGNMENT = 256
 
 _DEFAULT_EPS = 1e-6
 
 
-class RMSNormFwdOp(RowNormOp):
+def _align_up(n: int, alignment: int) -> int:
+    return ((n + alignment - 1) // alignment) * alignment
+
+
+class RMSNormFwdOp(Op):
     """Standalone Root Mean Square (RMS) Norm operator.
 
-    Computes ``y = x * rsqrt(mean(x ** 2, dim) + eps) * weight``.
+    Mirrors :func:`torch.nn.functional.rms_norm`. Computes::
 
-    Mirrors :func:`torch.nn.functional.rms_norm`: ``normalized_shape`` is the
-    trailing-axis shape tuple over which the reduction runs; ``eps=None``
-    selects the dtype default.
+        y = x * rsqrt(mean(x ** 2, trailing_axes) + eps) * weight
+
+    where the reduction runs over the trailing ``len(normalized_shape)``
+    axes; ``normalized_shape`` is the only entry point (the manifest spec).
 
     Args:
-        normalized_shape: Trailing axes the reduction runs over (manifest
-            ``params.normalized_shape``). Either this or legacy ``N`` must be
-            set.
+        normalized_shape: Trailing-axis shape tuple over which the
+            reduction runs (manifest ``params.normalized_shape``).
         eps: Epsilon for numerical stability (manifest ``params.eps``).
-            ``None`` uses the implementation default (``1e-6``).
-        dtype: Data type (float16 or bfloat16).
-        N: Legacy single-axis reduction size; supplied when callers cannot
-            yet pass a tuple. Mutually exclusive with ``normalized_shape``.
-        dim: Reduction axis (default -1) when using legacy ``N`` form.
-            When ``normalized_shape`` is set, the reduction always runs over
-            the trailing axes.
-        kernel_map: Optional override for kernel dispatch.
-        tune: Whether to autotune (default False).
+            ``None`` selects the implementation default ``1e-6``.
+        dtype: Data type (``torch.float16`` or ``torch.bfloat16``).
+        kernel_map: Optional kernel override dictionary.
+        tune: Whether to autotune (default ``False``).
 
     Example:
         >>> op = RMSNormFwdOp(normalized_shape=(4096,), dtype=torch.float16)
@@ -43,57 +46,63 @@ class RMSNormFwdOp(RowNormOp):
         >>> y = op(x, w)  # shape: (1024, 4096)
     """
 
-    _kernel_key = "rms_norm"
-    _kernel_cls = RMSNormKernel
-
     def __init__(
         self,
-        normalized_shape: Optional[Sequence[int]] = None,
+        normalized_shape: Sequence[int],
         eps: Optional[float] = None,
         *,
         dtype: torch.dtype,
-        N: Optional[int] = None,
-        dim: int = -1,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        n_resolved = normalized_shape_to_n(normalized_shape, n_fallback=N)
-        self.normalized_shape = (
-            tuple(int(d) for d in normalized_shape)
-            if normalized_shape is not None else None
-        )
-        eps_resolved = _DEFAULT_EPS if eps is None else float(eps)
-        super().__init__(
-            N=n_resolved,
-            dtype=dtype,
-            dim=dim,
-            eps=eps_resolved,
-            kernel_map=kernel_map,
-            tune=tune,
-        )
+        self.normalized_shape = tuple(int(d) for d in normalized_shape)
+        if len(self.normalized_shape) == 0:
+            raise ValueError("normalized_shape must be non-empty")
+        self.N = math.prod(self.normalized_shape)
+        self.dtype = dtype
+        self.eps = _DEFAULT_EPS if eps is None else float(eps)
+        self.tune = tune
+        self.N_padded = _align_up(self.N, ALIGNMENT)
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[int, Kernel] = {}
+        self._last_roofline_mn: Optional[Tuple[int, int]] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"rms_norm": RMSNormKernel}
+
+    def _get_kernel(self, m: int) -> Kernel:
+        if m not in self._kernel_cache:
+            self._kernel_cache[m] = self.kernel_map["rms_norm"](
+                m, self.N, self.eps, self.dtype, tune=self.tune,
+            )
+        return self._kernel_cache[m]
+
+    def eval_roofline(self) -> Tuple[int, int]:
+        if self._last_roofline_mn is None:
+            raise RuntimeError(
+                "RMSNormFwdOp.eval_roofline() requires a prior forward() "
+                "call to bind the leading-dims product."
+            )
+        m, n = self._last_roofline_mn
+        elem_bytes = self.dtype.itemsize
+        return (4 * m * n, (2 * m * n + n) * elem_bytes)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        if self.normalized_shape is not None and len(self.normalized_shape) > 1:
-            return self._forward_normalized_shape(x, weight)
-        ndim = x.ndim
-        dim_norm = self._validate_and_normalize_dim(x, weight)
-        x, post_move_shape = self._flatten_to_2d(x, dim_norm)
-        M = x.shape[0]
-        if self._needs_pad:
-            x = self._pad_row(x)
-            weight = self._pad_vec(weight)
-        y = self._get_kernel(M)(x, weight)
-        self._last_roofline_mn = (M, self.N)
-        return self._trim_and_unflatten(y, post_move_shape, dim_norm, ndim)
+        """Apply RMS normalization over the trailing ``normalized_shape``.
 
-    def _forward_normalized_shape(
-        self, x: torch.Tensor, weight: torch.Tensor,
-    ) -> torch.Tensor:
-        """Forward path for multi-axis ``normalized_shape`` (manifest contract).
+        Args:
+            x: Input tensor with trailing shape equal to
+                ``normalized_shape`` on CUDA.
+            weight: Affine scale of shape ``normalized_shape`` on CUDA.
 
-        Reduction runs over the trailing ``len(normalized_shape)`` axes; the
-        tail is flattened to a 1-D row of size ``N = prod(normalized_shape)``
-        and the same row-norm kernel is reused.
+        Returns:
+            Normalized tensor of the same shape as *x*.
+
+        Raises:
+            ValueError: If tensors are not on CUDA, dtypes mismatch, or
+                shapes are incompatible with the configured
+                ``normalized_shape``.
         """
         ns = self.normalized_shape
         k = len(ns)
@@ -114,15 +123,16 @@ class RMSNormFwdOp(RowNormOp):
             raise ValueError(
                 f"Expected weight shape {ns}, got {tuple(weight.shape)}"
             )
+
         orig_shape = tuple(x.shape)
         x_flat = x.contiguous().reshape(-1, self.N)
         w_flat = weight.contiguous().reshape(self.N)
-        M = x_flat.shape[0]
-        if self._needs_pad:
-            x_flat = self._pad_row(x_flat)
-            w_flat = self._pad_vec(w_flat)
-        y = self._get_kernel(M)(x_flat, w_flat)
-        if self._needs_pad:
+        m = x_flat.shape[0]
+        if self.N_padded != self.N:
+            x_flat = F.pad(x_flat, (0, self.N_padded - self.N))
+            w_flat = F.pad(w_flat, (0, self.N_padded - self.N))
+        y = self._get_kernel(m)(x_flat, w_flat)
+        if self.N_padded != self.N:
             y = y[:, : self.N]
-        self._last_roofline_mn = (M, self.N)
+        self._last_roofline_mn = (m, self.N)
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -8,16 +8,11 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import RMSNormKernel
 
 from ..op_base import Op
+from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["RMSNormFwdOp"]
 
-ALIGNMENT = 256
-
 _DEFAULT_EPS = 1e-6
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class RMSNormFwdOp(Op):
@@ -62,7 +57,7 @@ class RMSNormFwdOp(Op):
         self.dtype = dtype
         self.eps = _DEFAULT_EPS if eps is None else float(eps)
         self.tune = tune
-        self.N_padded = _align_up(self.N, ALIGNMENT)
+        self.N_padded = align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[int, Kernel] = {}
         self._last_roofline_mn: Optional[Tuple[int, int]] = None


### PR DESCRIPTION
Closes tile-ai/TileOPs#1247

## Summary

- Drop legacy `N=` / `M=` / `G=` kwargs and same-PR rename aliases on `RMSNormFwdOp`, `LayerNormFwdOp`, `GroupNormFwdOp`; `normalized_shape` / `num_groups` are the only entry points.
- Drop fake-accepted `use_input_stats` / `momentum` on `InstanceNormFwdOp`; running-stats variant tracked in #1255.
- Collapse `LayerNormFwdOp` and `BatchNormFwdOp` dual-state hybrid surfaces: `BatchNormFwdOp.training` is ctor-bound (no runtime kwarg), `_batch_norm_fwd_wrapped` updated to match.
- Revert `LayerNormFwdOp` `_kernel_cache` scope-sneak: kernel built lazily on first forward; cache redesign tracked in #1254.
- `RMSNormFwdOp` now has a single forward path — `_forward_normalized_shape` removed, unified trailing-axis flatten handles both single- and multi-axis cases.
- Replace string-on-annotation `BatchNorm` output test with a real behavior assertion in `tests/ops/test_batch_norm.py`; delete the 6th-recurrence `_get_*_params` re-import test.
- Manifest `tileops/manifest/normalization.yaml` is byte-identical.

## Test plan

- [x] AC-1: Modified files pass existing unit tests; `pytest tests/ops/test_*norm*` is green.
- [x] AC-2: AC-7 contradiction resolved. Either `bench_batch_norm.py` is removed from `benchmarks/conftest.py` `TILELANG_019_BENCH_PATHS` and produces benchmark numbers within a bounded wall-clock budget on the default workload set, OR the cleanup PR's body explicitly states AC-7 is materially unmet for `bench_batch_norm.py` and references a follow-up issue tracking the bench rewrite. The `FIXME(staged-rollout)` comment block is removed from `benchmarks/conftest.py` regardless.
- [x] AC-3: `RMSNormFwdOp.__init__` and `LayerNormFwdOp.__init__` no longer accept `N` or `M` kwargs. `normalized_shape` is the only entry point.
- [x] AC-4: `RMSNormFwdOp` has a single forward path. The `_forward_normalized_shape` private method is deleted.
- [x] AC-5: `GroupNormFwdOp.__init__` no longer accepts `G` kwarg. `self.G` instance attribute is removed.
- [x] AC-6: `BatchNormFwdOp.training` exists in exactly one location — the ctor. `forward()` reads `self.training` and does NOT accept a `training=` runtime kwarg.
- [x] AC-7: `LayerNormFwdOp` reverts to lazy ctor-bound kernel construction (no `_kernel_cache` dict, no `_get_kernel`). Cache redesign tracked in follow-up #1254.
- [x] AC-8: `InstanceNormFwdOp.__init__` no longer accepts `use_input_stats` or `momentum`. Running-stats variant tracked in follow-up #1255.
- [x] AC-9: `test_batch_norm_fwd_returns_single_output` deleted; new behavior test in `tests/ops/test_batch_norm.py` constructs `BatchNormFwdOp`, calls forward, asserts `isinstance(out, torch.Tensor)`.
- [x] AC-10: `test_normalization_signature_matches_manifest` deleted. No file under `tests/ops/` re-imports `_get_forward_params` / `_get_init_params` / `check_l1_signature` from `scripts.validate_manifest`.
- [x] AC-11: `tileops/manifest/normalization.yaml` is byte-identical. Diff confined to `tileops/ops/norm/`, `tests/ops/`, `benchmarks/`.
- [x] pre-commit run --all-files green.
- [x] pytest tests/ops/test_*norm* -m smoke green (34 passed, 5 skipped CUDA-required).

### AC-2 / AC-7 trade-off

AC-7 is materially unmet for `benchmarks/ops/bench_batch_norm.py`: the file remains in `benchmarks/conftest.py::TILELANG_019_BENCH_PATHS` and is therefore globally skipped, so it does not produce benchmark numbers in this PR. The `FIXME(staged-rollout)` block has been removed from `benchmarks/conftest.py` per the AC-2 unconditional requirement. Rewriting the bench so it produces bounded numbers within the wall-clock budget is tracked in follow-up issue #1253; this cleanup PR intentionally does not include that rewrite.

### Follow-ups

- #1253 — rewrite `bench_batch_norm.py` to produce bounded benchmark numbers (admitted AC-7 gap above).
- #1254 — design a proper cache for `LayerNormFwdOp` variable-`M` kernels (replaces the reverted scope-sneak).
- #1255 — implement running-stats variant of `InstanceNormFwdOp` (replaces the dropped fake-accepted kwargs).

## Structural Readiness

All checks passed.

## Test node delta

```
File                                         Base    HEAD    Delta
------------------------------------------------------------------
tests/ops/test_batch_norm.py                   18      19       +1
tests/ops/test_layer_norm.py                   27      27        0
tests/ops/test_norm_ops.py                      5       5        0
tests/ops/test_normalization_alignment.py      17       6      -11
tests/ops/test_rms_norm.py                     18      16       -2
------------------------------------------------------------------
TOTAL                                          85      73      -12
```

Net delta is **-12 nodes** (cleanup PR; alignment-suite re-imports of `scripts.validate_manifest` private helpers were deleted per AC-10, and dead RMSNorm `N=` / single-forward duplication tests were collapsed). The single new node is the AC-9 behavior-asserting `BatchNorm` test that replaces the deleted annotation-string test.

## Regression

- `pytest tests/ops/test_*norm* -m smoke` — 34 passed, 5 skipped (CUDA-required).
- Manifest byte-identical: `git diff upstream/testbed -- tileops/manifest/normalization.yaml` is empty.

