### PR TITLE
[Refactor][Ops] de-duplicate unary activation forward/inplace dispatch (#1220)

### DIFF
--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -7,6 +7,8 @@ identity, ``approximate`` validation, kernel_map override
 dispatch, and end-to-end correctness against the PyTorch reference.
 """
 
+import inspect
+
 import pytest
 import torch
 
@@ -183,6 +185,96 @@ def test_gelu_approximate_none_runs_through_forward() -> None:
     expected = torch.nn.functional.gelu(x, approximate="none")
     assert y.shape == x.shape
     assert torch.allclose(y, expected, rtol=1e-2, atol=1e-2)
+
+
+# Frozen ``__init__`` signatures for every unary activation Op. The
+# refactor pulling shared ``__init__`` / ``forward`` / ``_eager_forward``
+# logic up into a base or mixin must keep these byte-identical, because
+# downstream code (tests, benches, codegen) relies on them.
+_FROZEN_UNARY_ACTIVATION_SIGNATURES = {
+    "ReluFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SiluFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardswishFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardsigmoidFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "MishFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SeluFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, *, "
+        "strategy: Optional[str] = None, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "LeakyReluFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, "
+        "negative_slope: float = 0.01, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "EluFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, "
+        "alpha: float = 1.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "HardtanhFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, "
+        "min_val: float = -1.0, max_val: float = 1.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False, inplace: bool = False)"
+    ),
+    "SoftplusFwdOp": (
+        "(self, N_total: int, dtype: torch.dtype, "
+        "beta: float = 1.0, threshold: float = 20.0, *, "
+        "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
+        "tune: bool = False)"
+    ),
+}
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "op_name", sorted(_FROZEN_UNARY_ACTIVATION_SIGNATURES.keys()),
+)
+def test_unary_activation_init_signature_is_frozen(op_name: str) -> None:
+    """All ten unary activation Ops keep their ``__init__`` signature.
+
+    The shared base/mixin refactor must not alter the constructor
+    contract (parameter names, defaults, keyword-only-ness) of any
+    leaf Op; downstream code (codegen, tests, benches) depends on
+    these exact signatures.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = getattr(mod, op_name)
+    sig = inspect.signature(cls.__init__)
+    assert str(sig) == _FROZEN_UNARY_ACTIVATION_SIGNATURES[op_name], (
+        f"{op_name}.__init__ signature drifted: "
+        f"got {sig!s}, expected {_FROZEN_UNARY_ACTIVATION_SIGNATURES[op_name]}"
+    )
 
 
 if __name__ == "__main__":

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1023,40 +1023,33 @@ class FusedGatedOp(Op):
 # ---------------------------------------------------------------------------
 
 
-class _ParamFreeActivationOp(UnaryOp):
-    """Shared base for the param-free activation Op group.
+class _UnaryActivationMixin:
+    """Shared ``forward`` / inplace dispatch for unary activation Ops.
 
-    Centralizes the canonical constructor and ``forward`` flow used by
-    activations whose only manifest-declared parameter is ``inplace``
-    (ReLU, SiLU, HardSwish, HardSigmoid, Mish, SELU). Each leaf only
-    declares its op-specific class fields (``_op_name``, ``kernel_cls``,
-    ``FLOPS_PER_ELEM``, docstring); behavior is otherwise inherited.
+    The ten unary activation Ops (six param-free: ReLU, SiLU, HardSwish,
+    HardSigmoid, Mish, SELU; four parametric: LeakyReLU, ELU, Hardtanh,
+    Softplus) share an identical ``forward`` template:
 
-    ``inplace=True`` dispatches through a separate ``_wrapped_inplace``
-    custom op registered with ``mutates_args=("x",)`` so ``torch.compile``
-    traces the mutation correctly; the returned tensor is the original
-    input (``y is x``).
+    1. validate ``input`` against the op's ``dtype`` / ``N_total`` contract,
+    2. when ``self.inplace`` is true, dispatch through ``_wrapped_inplace``
+       (registered with ``mutates_args=("x",)`` so ``torch.compile`` traces
+       the mutation correctly) and return the original ``input`` so callers
+       see ``y is x``,
+    3. otherwise dispatch through the standard ``_wrapped`` custom op or
+       fall back to ``_eager_forward``.
+
+    Concrete classes provide ``_validate_input`` and ``_eager_forward``
+    (both inherited from ``UnaryOp``) plus ``self.inplace`` /
+    ``self._instance_key`` state. Leaves that do not expose ``inplace``
+    in their signature (e.g. Softplus) simply default ``self.inplace`` to
+    ``False`` via ``_finalize_init``.
     """
 
     # Set by ``_register_unary_inplace_custom_op`` for leaves that
     # declare ``inplace`` in their manifest signature. Stays ``None``
-    # when the leaf does not support inplace.
+    # when the leaf does not support inplace (e.g. Softplus, or a
+    # test-only subclass that skipped registration).
     _wrapped_inplace = None
-
-    def __init__(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        *,
-        strategy: Optional[str] = None,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-        tune: bool = False,
-        inplace: bool = False,
-    ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
-        self.inplace = inplace
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
         self._validate_input(input)
@@ -1076,28 +1069,49 @@ class _ParamFreeActivationOp(UnaryOp):
         return self._eager_forward(input)
 
 
-class _ParametricActivationOp(Op):
+class _ParamFreeActivationOp(_UnaryActivationMixin, UnaryOp):
+    """Shared base for the param-free activation Op group.
+
+    Centralizes the canonical constructor used by activations whose only
+    manifest-declared parameter is ``inplace`` (ReLU, SiLU, HardSwish,
+    HardSigmoid, Mish, SELU). Each leaf only declares its op-specific
+    class fields (``_op_name``, ``kernel_cls``, ``FLOPS_PER_ELEM``,
+    docstring); ``forward``/``_eager_forward`` come from
+    ``_UnaryActivationMixin`` / ``UnaryOp``.
+    """
+
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        *,
+        strategy: Optional[str] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+        inplace: bool = False,
+    ):
+        super().__init__(
+            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        )
+        self.inplace = inplace
+
+
+class _ParametricActivationOp(_UnaryActivationMixin, UnaryOp):
     """Shared base for the parametric activation Op group.
 
-    Centralizes the ``_eager_forward`` and ``forward`` flows for
-    activations that take one or more scalar construction-time
+    Used by activations that take one or more scalar construction-time
     parameters (LeakyReLU, ELU, Hardtanh, Softplus). Leaves own their
     ``__init__`` (scalar parameter names and defaults vary per leaf):
     each leaf validates its scalars, populates ``self.<param>`` for
     introspection, instantiates ``self.kernel`` with typed kwargs, and
     registers itself with ``_OP_REGISTRY`` via the
-    ``_finalize_init`` helper.
+    ``_finalize_init`` helper. ``UnaryOp.__init__`` is intentionally
+    bypassed; ``_finalize_init`` performs the equivalent state setup.
 
     Leaves that declare ``inplace`` in the manifest signature accept it
-    in ``__init__`` and pass it to ``_finalize_init``. ``inplace=True``
-    dispatches through ``_wrapped_inplace`` (registered with
-    ``mutates_args=("x",)``); the returned tensor is the original input.
+    in ``__init__`` and pass it to ``_finalize_init``. ``forward`` and
+    ``_eager_forward`` are inherited from the mixin and ``UnaryOp``.
     """
-
-    # Set by ``_register_unary_inplace_custom_op`` for leaves that
-    # declare ``inplace`` in their manifest signature. Stays ``None``
-    # when the leaf does not support inplace (e.g. Softplus).
-    _wrapped_inplace = None
 
     def _finalize_init(
         self,
@@ -1118,33 +1132,14 @@ class _ParametricActivationOp(Op):
         self.dtype = dtype
         self.inplace = inplace
         self.kernel = kernel
+        # Mirror ``UnaryOp.__init__``: surface ``output_dtype`` so callers
+        # and ``total_memory`` can reason about FP8 post-casts. Parametric
+        # activations do not currently declare an FP8 path, so the common
+        # branch returns ``self.dtype``; the lookup is kept for parity.
+        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
+        self.output_dtype = fp8_out or getattr(self.kernel, "output_dtype", dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
-
-    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
-        if not input.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if input.dtype != self.dtype:
-            raise ValueError(f"Expected input.dtype {self.dtype}, got {input.dtype}")
-        if input.numel() != self.N_total:
-            raise ValueError(f"Expected {self.N_total} elements, got {input.numel()}")
-        if self.inplace:
-            wrapped_inplace = type(self)._wrapped_inplace
-            if wrapped_inplace is not None:
-                wrapped_inplace(input, self._instance_key)
-                return input
-            result = self._eager_forward(input)
-            input.copy_(result.reshape(input.shape))
-            return input
-        wrapped = type(self)._wrapped
-        if wrapped is not None:
-            return wrapped(input, self._instance_key)
-        return self._eager_forward(input)
 
 
 class ReluFwdOp(_ParamFreeActivationOp):


### PR DESCRIPTION
## Summary

Closes #1220.

Extract the identical `forward` template and `_wrapped_inplace` state used by the ten unary activation Ops into a single shared mixin under `tileops/ops/elementwise.py`:

- Six param-free leaves: `ReluFwdOp`, `SiluFwdOp`, `HardswishFwdOp`, `HardsigmoidFwdOp`, `MishFwdOp`, `SeluFwdOp`.
- Four parametric leaves: `LeakyReluFwdOp`, `EluFwdOp`, `HardtanhFwdOp`, `SoftplusFwdOp`.

Before, `_ParamFreeActivationOp` and `_ParametricActivationOp` each carried their own copy of the inplace-vs-eager dispatch ladder (and the parametric base inlined a copy of `_validate_input` and `_eager_forward` that was byte-identical to `UnaryOp`'s versions). Now both bases extend `(_UnaryActivationMixin, UnaryOp)`:

- The mixin owns `forward()` and the `_wrapped_inplace` class slot.
- `UnaryOp` provides `_validate_input` and `_eager_forward`, which the parametric base picks up by inheritance instead of redefining.
- `_finalize_init` in the parametric base now also records `self.output_dtype` mirroring `UnaryOp.__init__`, so both groups expose the same surface.

## Design choice: single mixin vs. two bases

Picked **a single mixin (`_UnaryActivationMixin`) plus the existing two bases** rather than collapsing everything into one class. Reasons:

1. Constructor signatures genuinely differ between the two groups. Param-free leaves take `(N_total, dtype, *, strategy, kernel_map, tune, inplace)`; the four parametric leaves each take their own scalar params (`negative_slope`, `alpha`, `min_val/max_val`, `beta/threshold`) and Softplus drops `inplace`. Forcing one base would require either `**kwargs` indirection or a hard-coded scalar-param mechanism, neither of which is bit-identical to today's signatures (which AC-3 freezes).
2. The truly duplicated code is the `forward` body and the `_wrapped_inplace` slot — a thin mixin captures exactly that without changing how leaves construct their kernels.
3. Keeping `_ParamFreeActivationOp` and `_ParametricActivationOp` as the inheritance anchors preserves their docstring narratives and the existing `_register_unary_inplace_custom_op` wiring.

The mixin is `_`-prefixed so it is not part of the public surface.

## Test plan

- [x] `pre-commit run --all-files` — passes.
- [x] `pytest tests/ops/test_elementwise_unary_activation_alignment.py tests/ops/test_activation.py tests/ops/test_elementwise_independent_fp8.py` — 151 passed (141 pre-existing + 10 new constructor-signature freeze cases).
- [x] `validate_manifest.py --check-op` clean for relu / silu / hardswish / hardsigmoid / mish / selu / leaky_relu / elu / hardtanh / softplus.
- [x] `benchmarks/ops/bench_activation.py` runs to completion and emits rows for all touched ops (10 unrelated `erf` / `mish` failures are an environment-only `/tmp/tvm-debug-mode-tempdirs` permission collision, present on `testbed` HEAD as well).
- [x] `git diff --name-only testbed..HEAD` confined to `tileops/ops/elementwise.py` and `tests/ops/test_elementwise_unary_activation_alignment.py` — no `tileops/manifest/` or `tileops/kernels/` changes.

## Behavior preservation

- Constructor signatures of all ten leaves are byte-identical (frozen by `test_unary_activation_init_signature_is_frozen`).
- `inplace=True` still aliases `input` and dispatches through `_wrapped_inplace`; `inplace=False` returns a fresh tensor.
- `_validate_input` raises the same `ValueError` on non-CUDA / dtype mismatch / numel mismatch (the parametric path now uses `UnaryOp._validate_input` whose error messages and conditions match the previous inline checks).
- Manifest-derived `FLOPS_PER_ELEM` and `eval_roofline` unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>