### PR TITLE
[Refactor][Ops] route kernel_map override through dispatch_kernel (#1221)

### DIFF
--- a/tests/ops/test_kernel_map_install.py
+++ b/tests/ops/test_kernel_map_install.py
@@ -102,6 +102,28 @@ def test_install_kernel_map_compatible_override_forward_bit_identical() -> None:
 
 
 @pytest.mark.smoke
+def test_install_kernel_map_supported_archs_none() -> None:
+    """A kernel with ``supported_archs=None`` installs without raising.
+
+    The base ``Kernel`` class declares ``supported_archs: Optional[list[int]]``
+    defaulting to ``None``. The validate-and-install path must treat ``None``
+    as "no arch restriction" rather than attempting ``in None``, which would
+    raise ``TypeError``.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = mod.ReluFwdOp
+    inst = cls(N_total=8, dtype=torch.float16)
+    (key, default_kernel_cls), = inst.default_kernel_map.items()
+
+    class UnrestrictedKernel(default_kernel_cls):  # type: ignore[misc, valid-type]
+        supported_archs = None
+
+    overridden = cls(N_total=8, dtype=torch.float16, kernel_map={key: UnrestrictedKernel})
+    assert overridden.kernel_map[key] is UnrestrictedKernel
+
+
+@pytest.mark.smoke
 def test_install_kernel_map_is_private_helper_only() -> None:
     """Refactor exposes ``_install_kernel_map`` only — no new public API.
 

--- a/tests/ops/test_kernel_map_install.py
+++ b/tests/ops/test_kernel_map_install.py
@@ -1,0 +1,116 @@
+"""Tests for the shared ``_install_kernel_map`` validation path.
+
+A user-supplied ``kernel_map`` and the auto-discovered ``default_kernel_map``
+must traverse the same validate-and-install path in the Op base, so that
+architecture-compatibility checks fire identically regardless of provenance.
+"""
+
+
+import pytest
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
+
+
+def _make_incompatible_arch_list() -> list[int]:
+    """Return a ``supported_archs`` list that excludes the current device."""
+    current = get_sm_version()
+    candidates = [70, 75, 80, 86, 89, 90, 100]
+    incompatible = [a for a in candidates if a != current]
+    assert incompatible, "no incompatible arch candidate available"
+    return incompatible
+
+
+@pytest.mark.smoke
+def test_install_kernel_map_user_supplied_incompatible_raises_valueerror() -> None:
+    """User-supplied incompatible kernel raises ``ValueError`` (auto-discovery class)."""
+    import tileops.ops.elementwise as mod
+
+    cls = mod.ReluFwdOp
+    inst = cls(N_total=8, dtype=torch.float16)
+    (key, default_kernel_cls), = inst.default_kernel_map.items()
+    incompatible_archs = _make_incompatible_arch_list()
+
+    class IncompatibleKernel(default_kernel_cls):  # type: ignore[misc, valid-type]
+        supported_archs = incompatible_archs
+
+    with pytest.raises(ValueError, match="not supported on architecture"):
+        cls(N_total=8, dtype=torch.float16, kernel_map={key: IncompatibleKernel})
+
+
+@pytest.mark.smoke
+def test_install_kernel_map_auto_discovery_incompatible_raises_same_class() -> None:
+    """Auto-discovery path raises the same ``ValueError`` on identical input.
+
+    Build an Op subclass whose ``default_kernel_map`` already points at an
+    arch-incompatible kernel; constructing it must raise the same class
+    that the user-supplied path produces.
+    """
+    import tileops.ops.elementwise as mod
+
+    base_cls = mod.ReluFwdOp
+    base_inst = base_cls(N_total=8, dtype=torch.float16)
+    (key, default_kernel_cls), = base_inst.default_kernel_map.items()
+    incompatible_archs = _make_incompatible_arch_list()
+
+    class IncompatibleKernel(default_kernel_cls):  # type: ignore[misc, valid-type]
+        supported_archs = incompatible_archs
+
+    class AutoDiscoveredIncompatibleOp(base_cls):  # type: ignore[misc, valid-type]
+        @property
+        def default_kernel_map(self) -> dict[str, Kernel]:
+            return {key: IncompatibleKernel}
+
+    with pytest.raises(ValueError, match="not supported on architecture"):
+        AutoDiscoveredIncompatibleOp(N_total=8, dtype=torch.float16)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.smoke
+def test_install_kernel_map_compatible_override_forward_bit_identical() -> None:
+    """A compatible user-supplied override yields bit-identical forward output.
+
+    Build an op with the default kernel and the same op with a marker
+    subclass override (same kernel logic, distinct identity). Both must
+    produce the exact same forward output on identical input.
+    """
+    import tileops.ops.elementwise as mod
+
+    cls = mod.ReluFwdOp
+    n_total = 128
+    dtype = torch.float16
+
+    baseline = cls(N_total=n_total, dtype=dtype)
+    (key, default_kernel_cls), = baseline.default_kernel_map.items()
+
+    class MarkerKernel(default_kernel_cls):  # type: ignore[misc, valid-type]
+        """Subclass marker; identical behavior, distinct identity."""
+
+    overridden = cls(
+        N_total=n_total, dtype=dtype, kernel_map={key: MarkerKernel},
+    )
+    assert isinstance(overridden.kernel, MarkerKernel)
+
+    torch.manual_seed(0)
+    x = torch.randn(n_total, dtype=dtype, device="cuda")
+    y_baseline = baseline(x.clone())
+    y_overridden = overridden(x.clone())
+    assert torch.equal(y_baseline, y_overridden), (
+        "compatible kernel_map override must yield bit-identical forward output"
+    )
+
+
+@pytest.mark.smoke
+def test_install_kernel_map_is_private_helper_only() -> None:
+    """Refactor exposes ``_install_kernel_map`` only — no new public API.
+
+    Guards AC: the shared path is private (leading underscore); the public
+    surface is unchanged (``dispatch_kernel``, ``kernel_map``, ``tune``).
+    """
+    from tileops.ops.op_base import Op
+
+    assert hasattr(Op, "_install_kernel_map")
+    assert hasattr(Op, "dispatch_kernel")
+    public_names = [n for n in vars(Op) if not n.startswith("_")]
+    assert "install_kernel_map" not in public_names

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -1623,11 +1623,12 @@ class _IntIdentityUnaryOp(UnaryOp):
             self.N_total = N_total
             self.dtype = dtype
             self.strategy = strategy
-            # Skip dispatch_kernel: the float-only kernel cannot be
-            # instantiated for an integer dtype. Expose a kernel_map shape
-            # consistent with the float path for any introspection that
-            # iterates it, but leave the kernel itself unconstructed.
-            self.kernel_map = kernel_map or self.default_kernel_map
+            # The float-only kernel cannot be instantiated for an integer
+            # dtype, so the kernel itself stays unconstructed. The kernel_map
+            # is still installed through the shared validate-and-install path
+            # so a user-supplied override is arch-checked identically to the
+            # auto-discovered map on the float path.
+            self._install_kernel_map(kernel_map)
             self.kernel = None
             self.output_dtype = (
                 type(self)._int_output_dtype

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -135,20 +135,37 @@ class Op(ABC):
             "intentionally does not provide a generic evaluator — see "
             "docs/design/roofline.md §4.4.6 (Evaluator Surface Boundary)")
 
-    def dispatch_kernel(self, kernel_map: Optional[dict[str, Kernel]] = None) -> None:
+    def _install_kernel_map(self, candidate_map: Optional[dict[str, Kernel]] = None) -> None:
+        """Validate and install the resolved kernel map onto ``self.kernel_map``.
+
+        Iterates ``self.default_kernel_map`` and, for each entry, picks the
+        override from ``candidate_map`` when present, falling back to the
+        default. Each resolved kernel is then validated against the current
+        device architecture: if the kernel declares ``supported_archs`` and the
+        current ``sm`` version is not in that list, a ``ValueError`` is raised
+        — the same exception class produced by the auto-discovery path on the
+        same input. Both auto-discovered and user-supplied maps share this
+        single validate-and-install path, so arch-compat checks fire
+        identically regardless of provenance.
+        """
         if self.default_kernel_map is None or len(self.default_kernel_map) == 0:
             raise ValueError("default_kernel_map must be non-empty")
-        self.kernel_map = {}
+        resolved: dict[str, Kernel] = {}
+        current_arch = get_sm_version()
         for name, default_kernel in self.default_kernel_map.items():
-            if kernel_map is not None and name in kernel_map:
-                kernel_type = kernel_map[name]
+            if candidate_map is not None and name in candidate_map:
+                kernel_type = candidate_map[name]
             else:
                 kernel_type = default_kernel
-            current_arch = get_sm_version()
             if kernel_type is not None and current_arch not in kernel_type.supported_archs:
                 raise ValueError(
                     f'{kernel_type.__name__} is not supported on architecture {current_arch}')
-            self.kernel_map[name] = kernel_type
+            resolved[name] = kernel_type
+        self.kernel_map = resolved
+
+    def dispatch_kernel(self, kernel_map: Optional[dict[str, Kernel]] = None) -> None:
+        """Resolve and install the kernel map (auto-discovery entry point)."""
+        self._install_kernel_map(kernel_map)
 
     def autotune(self) -> None:
         """Autotune all kernels of the op"""

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -148,16 +148,21 @@ class Op(ABC):
         single validate-and-install path, so arch-compat checks fire
         identically regardless of provenance.
         """
-        if self.default_kernel_map is None or len(self.default_kernel_map) == 0:
+        default_map = self.default_kernel_map
+        if default_map is None or len(default_map) == 0:
             raise ValueError("default_kernel_map must be non-empty")
         resolved: dict[str, Kernel] = {}
         current_arch = get_sm_version()
-        for name, default_kernel in self.default_kernel_map.items():
+        for name, default_kernel in default_map.items():
             if candidate_map is not None and name in candidate_map:
                 kernel_type = candidate_map[name]
             else:
                 kernel_type = default_kernel
-            if kernel_type is not None and current_arch not in kernel_type.supported_archs:
+            if (
+                kernel_type is not None
+                and kernel_type.supported_archs is not None
+                and current_arch not in kernel_type.supported_archs
+            ):
                 raise ValueError(
                     f'{kernel_type.__name__} is not supported on architecture {current_arch}')
             resolved[name] = kernel_type


### PR DESCRIPTION
Closes tile-ai/TileOPs#1221

## Summary

- Add a private `Op._install_kernel_map(kernel_map)` helper that runs the same arch-compatibility validation `dispatch_kernel` performs on auto-discovered maps, then installs the validated map onto the op.
- Route user-supplied `kernel_map` through `_install_kernel_map` so an arch-incompatible override now raises `ValueError` at construction time, identical to the auto-discovery path.
- `dispatch_kernel` keeps its public signature; it now delegates to `_install_kernel_map` so both provenance paths share one validation site.
- Update `tileops/ops/elementwise.py` to use the shared helper for its template ops; no public API change.

## Test plan

- [x] AC-1 — `pre-commit run --all-files` clean; `pytest tests/ops/` 2339 passed (15 pre-existing failures reproduce on `upstream/testbed` baseline; unrelated MoE/GQA env+dtype issues).
- [x] AC-2 — `tests/ops/test_kernel_map_install.py` exercises both an arch-incompatible user-supplied `kernel_map` and an arch-incompatible auto-discovered map; both raise `ValueError` with matching `…not supported on architecture…` message.
- [x] AC-3 — Bit-identical forward output for an arch-compatible user-supplied override on `ReluFwdOp` (`torch.equal(out_baseline, out_overridden)`).
- [x] AC-4 — `git diff --name-only upstream/testbed...HEAD` confined to `tileops/ops/{op_base.py,elementwise.py}` and `tests/ops/test_kernel_map_install.py`; no edits under `tileops/manifest/`, `tileops/kernels/`, or `benchmarks/`.
- [x] AC-5 — Only new symbol is the private `_install_kernel_map`; `install_kernel_map` (no underscore) is not added to public names — asserted by `test_install_kernel_map_is_private_helper_only`.

## Regression

- Compatible user-supplied `kernel_map` produces forward output bit-identical to the pre-refactor path on `ReluFwdOp` (sm_90 / H200), guarded by `test_install_kernel_map_compatible_override_forward_bit_identical`.
