### PR TITLE
[Refactor][Bench] redirect fp8-where case off WhereFwdOp (#1231)

### DIFF
--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -522,7 +522,7 @@ def test_fp8_selection_bench(
             return torch.where(cond, x, y)
 
         result_bl = bm.profile(baseline, cond, x, y)
-        BenchmarkReport.record("where_fp8", locals(), result_bl, tag="torch-where-baseline-only")
+        BenchmarkReport.record("where_fp8", locals(), result_bl, tag="torch-ref")
     else:
         test = Fp8MaskedFillBenchCase(shape, dtype)
         bm = Fp8MaskedFillBenchmark(test)

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -509,20 +509,20 @@ def test_fp8_selection_bench(
     n_total = prod(shape)
 
     if op_name == "where":
+        # WhereFwdOp manifest does not declare fp8 dtype support, so this
+        # branch records only the torch.where baseline. Instantiating
+        # WhereFwdOp with an fp8 dtype here would violate the manifest
+        # contract; the manifest is the spec, not the code.
         test = Fp8WhereBenchCase(shape, dtype)
         bm = Fp8WhereBenchmark(test)
         cond, x, y = test.gen_inputs()
-
-        op = WhereFwdOp(condition=tuple(shape), input=tuple(shape), other=tuple(shape), dtype=dtype)
-        result = bm.profile(op, cond, x, y)
-        BenchmarkReport.record(op, locals(), result, tag="tileops")
 
         # torch.where supports fp8 natively (pure selection, no arithmetic)
         def baseline(cond, x, y):
             return torch.where(cond, x, y)
 
         result_bl = bm.profile(baseline, cond, x, y)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        BenchmarkReport.record("where_fp8", locals(), result_bl, tag="torch-where-baseline-only")
     else:
         test = Fp8MaskedFillBenchCase(shape, dtype)
         bm = Fp8MaskedFillBenchmark(test)


### PR DESCRIPTION
Closes tile-ai/TileOPs#1231

## Summary

- Drop `WhereFwdOp` instantiation from the fp8 branch of `test_fp8_selection_bench` — `WhereFwdOp`'s manifest does not declare fp8 dtype support, so building it for fp8 violated the manifest contract.
- Keep the `where` parametrization (matrix unchanged) and record only the `torch.where` baseline for fp8, tagged `torch-where-baseline-only` to make the baseline-only intent explicit.
- Inline comment at the rerouted call site references the manifest-spec rationale.
- `MaskedFillScalarFwdOp` fp8 path is untouched — it still measures both `tileops` and `torch` tags.

## Test plan

- [x] AC-1: `pytest benchmarks/ops/bench_independent_elementwise.py::test_fp8_selection_bench -m smoke` passes locally on H200 (2 passed, 10 deselected)
- [x] AC-2: `pytest benchmarks/ops/bench_independent_elementwise.py::test_fp8_selection_bench -m full` passes locally on H200 (10 passed, 2 deselected)
- [x] AC-3: `git grep -n "WhereFwdOp(.*float8" benchmarks/` returns zero hits
- [x] AC-4: `pre-commit run --all-files` passes

## Regression

Single-file scope: `benchmarks/ops/bench_independent_elementwise.py` (+5/-5). No tileops library code, manifest, or test files touched — change is confined to the benchmark harness for one parametrized case.
