### PR TITLE
[Feat][Ops] add fused tanh-GELU unary kernel (#1241)

### DIFF
--- a/benchmarks/ops/bench_activation.py
+++ b/benchmarks/ops/bench_activation.py
@@ -281,23 +281,26 @@ def test_r4_default_strategy_unary(
     )
 
 
-# Also benchmark gelu to verify strategy choice holds for transcendental ops
+# Also benchmark gelu to verify strategy choice holds for transcendental ops.
+# Both ``approximate`` modes (``none`` -> erf-based; ``tanh`` -> tanh
+# approximation) are exercised so the bench captures kernel selection.
 _R4_GELU_PARAMS = []
 for size_label, _shape in _SHAPE_BY_LABEL.items():
     for dt in _DTYPES:
         for strategy in _UNARY_STRATEGIES:
-            _R4_GELU_PARAMS.append(
-                pytest.param(
-                    _shape, size_label, dt, strategy,
-                    id=f"gelu-{size_label}-{dt}-{strategy}",
-                    marks=pytest.mark.full,
+            for approximate in ("none", "tanh"):
+                _R4_GELU_PARAMS.append(
+                    pytest.param(
+                        _shape, size_label, dt, strategy, approximate,
+                        id=f"gelu-{approximate}-{size_label}-{dt}-{strategy}",
+                        marks=pytest.mark.full,
+                    )
                 )
-            )
 
 
 class R4GeluStrategyFixture(FixtureBase):
     PARAMS = [
-        ("shape, size_label, dtype, strategy", _R4_GELU_PARAMS),
+        ("shape, size_label, dtype, strategy, approximate", _R4_GELU_PARAMS),
     ]
 
 
@@ -307,21 +310,25 @@ def test_r4_default_strategy_gelu(
     size_label: str,
     dtype: torch.dtype,
     strategy: str,
+    approximate: str,
 ) -> None:
     """R4: Benchmark gelu strategies (transcendental op) to confirm DEFAULT_STRATEGY."""
     test = UnaryBenchCase(shape, dtype)
     inputs = test.gen_inputs()
 
     n_total = prod(shape)
-    op = GeluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    op = GeluFwdOp(
+        N_total=n_total, dtype=dtype, strategy=strategy,
+        approximate=approximate,
+    )
     bm = UnaryBenchmark(test, op=op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(
         "r4_strategy_gelu",
         {"shape": shape, "size_label": size_label,
-         "dtype": dtype, "strategy": strategy},
+         "dtype": dtype, "strategy": strategy, "approximate": approximate},
         result,
-        tag=f"gelu_{strategy}",
+        tag=f"gelu_{approximate}_{strategy}",
     )
 
 

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -114,10 +114,10 @@ def _randn(n: int, dtype: torch.dtype) -> torch.Tensor:
     return torch.randn(n, device="cuda", dtype=dtype)
 
 
-def _make_activation_test(n_total, dtype, gen_fn, ref_fn, op_cls):
+def _make_activation_test(n_total, dtype, gen_fn, ref_fn, op_cls, **op_kwargs):
     """Build test, instantiate op, and run check."""
     test = UnaryActivationTest(n_total, dtype, gen_fn=gen_fn, ref_fn=ref_fn)
-    op = op_cls(N_total=n_total, dtype=dtype)
+    op = op_cls(N_total=n_total, dtype=dtype, **op_kwargs)
     if dtype == torch.float16:
         tol = {"atol": 1e-3, "rtol": 1e-3}
     elif dtype == torch.bfloat16:
@@ -128,10 +128,16 @@ def _make_activation_test(n_total, dtype, gen_fn, ref_fn, op_cls):
 
 
 @ActivationFixture
-def test_gelu(n_total: int, dtype: torch.dtype) -> None:
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu(n_total: int, dtype: torch.dtype, approximate: str) -> None:
     from tileops.ops.elementwise import GeluFwdOp
-    _make_activation_test(n_total, dtype, _randn,
-                          F.gelu, GeluFwdOp)
+
+    def _ref(x: torch.Tensor) -> torch.Tensor:
+        return F.gelu(x, approximate=approximate)
+
+    _make_activation_test(
+        n_total, dtype, _randn, _ref, GeluFwdOp, approximate=approximate,
+    )
 
 
 @ActivationFixture

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -157,32 +157,31 @@ def test_unary_activation_inplace_false_returns_fresh_tensor(op_name: str) -> No
 
 @pytest.mark.smoke
 def test_gelu_approximate_validation() -> None:
-    """GeluFwdOp must accept ``approximate='none'`` and reject invalid values.
-
-    ``approximate='tanh'`` is a manifest-allowed value but no fused
-    tanh-GELU unary kernel is implemented yet (see follow-up issue
-    referenced in the ``NotImplementedError`` message).
-    """
+    """GeluFwdOp must reject ``approximate`` values outside the manifest set."""
     import tileops.ops.elementwise as mod
 
     with pytest.raises(ValueError, match="approximate"):
         mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="invalid")
-    with pytest.raises(NotImplementedError, match=r"tanh"):
-        mod.GeluFwdOp(N_total=8, dtype=torch.float16, approximate="tanh")
 
 
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_gelu_approximate_none_runs_through_forward() -> None:
-    """GeluFwdOp(approximate='none') must dispatch through ``forward()``."""
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu_approximate_runs_through_forward(approximate: str) -> None:
+    """Both ``approximate='none'`` and ``'tanh'`` must dispatch end-to-end.
+
+    Each mode is checked against ``torch.nn.functional.gelu`` with the
+    matching ``approximate`` argument so the kernel selection is
+    observable from the op layer.
+    """
     import tileops.ops.elementwise as mod
 
     n_total = 128
     dtype = torch.float16
-    op = mod.GeluFwdOp(N_total=n_total, dtype=dtype)
+    op = mod.GeluFwdOp(N_total=n_total, dtype=dtype, approximate=approximate)
     x = torch.randn(n_total, dtype=dtype, device="cuda")
     y = op(x)
-    expected = torch.nn.functional.gelu(x, approximate="none")
+    expected = torch.nn.functional.gelu(x, approximate=approximate)
     assert y.shape == x.shape
     assert torch.allclose(y, expected, rtol=1e-2, atol=1e-2)
 

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -1737,7 +1737,7 @@ class Expm1FwdKernel(FloatUnaryKernel):
 
 
 # ---------------------------------------------------------------------------
-# Concrete unary kernel subclasses -- activations (8)
+# Concrete unary kernel subclasses -- activations (9)
 # ---------------------------------------------------------------------------
 
 
@@ -1766,7 +1766,7 @@ class GeluTanhFwdKernel(FloatUnaryKernel):
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
         x_f32 = T.cast(x, "float32")
-        inner = sqrt_2_over_pi * x_f32 * (one + coeff * x_f32 * x_f32)
+        inner = sqrt_2_over_pi * (x_f32 + coeff * x_f32 * x_f32 * x_f32)
         return half * x_f32 * (one + T.tanh(inner))
 
 

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -67,6 +67,7 @@ __all__ = [
     "TruncFwdKernel",
     # --- unary: activations (8) ---
     "GeluFwdKernel",
+    "GeluTanhFwdKernel",
     "HardsigmoidFwdKernel",
     "HardswishFwdKernel",
     "MishFwdKernel",
@@ -1749,6 +1750,24 @@ class GeluFwdKernel(FloatUnaryKernel):
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
         return half * x * (one + T.erf(T.cast(x, "float32") * inv_sqrt_2))
+
+
+class GeluTanhFwdKernel(FloatUnaryKernel):
+    """Element-wise GELU using the tanh approximation.
+
+    Computes ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))``,
+    matching ``torch.nn.functional.gelu(x, approximate='tanh')``.
+    """
+
+    @staticmethod
+    def op_func(x):
+        sqrt_2_over_pi = T.cast(0.7978845608028654, "float32")
+        coeff = T.cast(0.044715, "float32")
+        half = T.cast(0.5, "float32")
+        one = T.cast(1.0, "float32")
+        x_f32 = T.cast(x, "float32")
+        inner = sqrt_2_over_pi * (x_f32 + coeff * x_f32 * x_f32 * x_f32)
+        return half * x_f32 * (one + T.tanh(inner))
 
 
 class SiluFwdKernel(FloatUnaryKernel):

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -65,7 +65,7 @@ __all__ = [
     "SinFwdKernel",
     "SqrtFwdKernel",
     "TruncFwdKernel",
-    # --- unary: activations (8) ---
+    # --- unary: activations (9) ---
     "GeluFwdKernel",
     "GeluTanhFwdKernel",
     "HardsigmoidFwdKernel",

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -1766,7 +1766,7 @@ class GeluTanhFwdKernel(FloatUnaryKernel):
         half = T.cast(0.5, "float32")
         one = T.cast(1.0, "float32")
         x_f32 = T.cast(x, "float32")
-        inner = sqrt_2_over_pi * (x_f32 + coeff * x_f32 * x_f32 * x_f32)
+        inner = sqrt_2_over_pi * x_f32 * (one + coeff * x_f32 * x_f32)
         return half * x_f32 * (one + T.tanh(inner))
 
 

--- a/tileops/ops/elementwise.py
+++ b/tileops/ops/elementwise.py
@@ -47,6 +47,7 @@ from tileops.kernels.elementwise import (
     GeluAndMulFwdKernel,
     GeluFwdKernel,
     GeluTanhAndMulFwdKernel,
+    GeluTanhFwdKernel,
     GtFwdKernel,
     HardsigmoidFwdKernel,
     HardswishFwdKernel,
@@ -1837,10 +1838,9 @@ class _GeluApproximateBase(UnaryOp):
 
     Validates the ``approximate`` argument against the manifest's allowed
     values (``'none'`` / ``'tanh'``), records it on ``self.approximate``
-    for introspection, and then delegates to ``UnaryOp.__init__``.
-    ``approximate='tanh'`` is rejected with ``NotImplementedError`` until
-    a fused tanh-GELU unary kernel is exposed to the Op layer (tracked
-    in a follow-up issue).
+    for introspection, and then delegates to ``UnaryOp.__init__``. The
+    ``default_kernel_map`` of the leaf op picks the kernel implementation
+    from ``self.approximate``.
     """
 
     def __init__(
@@ -1858,13 +1858,6 @@ class _GeluApproximateBase(UnaryOp):
                 f"{type(self).__name__}: approximate must be 'none' or "
                 f"'tanh', got {approximate!r}"
             )
-        if approximate == "tanh":
-            raise NotImplementedError(
-                f"{type(self).__name__}(approximate='tanh') is not "
-                "implemented: no fused tanh-GELU unary kernel is exposed "
-                "to the Op layer yet. A follow-up issue "
-                "tracks the kernel work.",
-            )
         self.approximate = approximate
         super().__init__(
             N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
@@ -1878,10 +1871,9 @@ class GeluFwdOp(_GeluApproximateBase):
         N_total: Number of elements (flattened input).
         dtype: Torch dtype.
         approximate: Approximation mode. ``'none'`` (default) routes to
-            the erf-based ``GeluFwdKernel``. ``'tanh'`` is accepted by
-            the manifest signature but raises ``NotImplementedError``
-            because no fused tanh-GELU unary kernel is implemented yet
-            (tracked in a follow-up issue).
+            the erf-based ``GeluFwdKernel``. ``'tanh'`` routes to
+            ``GeluTanhFwdKernel`` (the fused tanh approximation
+            ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))``).
         strategy: Optional kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
@@ -1889,11 +1881,19 @@ class GeluFwdOp(_GeluApproximateBase):
 
     _op_name = "gelu"
     kernel_cls = GeluFwdKernel
-    # Manifest: flops = "8 * N" (erf-based: mul + erf + add + mul + mul ≈ 8).
+    # Manifest: flops = "8 * N" (erf-based: mul + erf + add + mul + mul ≈ 8;
+    # tanh approximation is similar order, see manifest comment).
     FLOPS_PER_ELEM = 8
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        kernel_cls = (
+            GeluTanhFwdKernel if self.approximate == "tanh" else GeluFwdKernel
+        )
+        return {self._op_name: kernel_cls}
 
 
 class SiluFwdOp(_ParamFreeActivationOp):


### PR DESCRIPTION
Closes tile-ai/TileOPs#1241

## Summary

- Add `GeluTanhFwdKernel` (new) in `tileops/kernels/elementwise.py`, the fused tanh approximation `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))` with fp32 promotion for the cubic/tanh path.
- `GeluFwdOp.default_kernel_map` now dispatches on `self.approximate`: `'none'` → `GeluFwdKernel`, `'tanh'` → `GeluTanhFwdKernel`. `_GeluApproximateBase` validates `approximate ∈ {none, tanh}` and stores it; `NotImplementedError` is removed.
- Tests in `tests/ops/test_activation.py` and `tests/ops/test_elementwise_unary_activation_alignment.py` parametrize both modes end-to-end and assert `torch.nn.functional.gelu` agreement.
- `benchmarks/ops/bench_activation.py` exercises both `approximate` modes.
- Manifest unchanged; `roofline.flops = 8*N` remains valid for both modes.

## Test plan

- [x] AC-1: `GeluFwdOp(approximate='tanh').forward(x)` matches `torch.nn.functional.gelu(x, approximate='tanh')` within standard activation tolerances.
- [x] AC-2: A new behavior test exercises both `approximate='none'` and `'tanh'` end-to-end.
- [x] AC-3: `NotImplementedError` is removed from `GeluFwdOp`.
- [x] AC-4: Bench numbers for the tanh path are recorded in the PR body.
- [x] pre-commit passed
- [x] pytest passed (11 targeted checks, 50 total in dev round)

## Structural Readiness

All checks passed.

## Benchmark

**Environment**: NVIDIA H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.9

### GeluFwdOp (1024, 4096) — fp16, register_copy strategy

| approximate | TileOPs (ms) | TFLOPS | BW (TB/s) |
| ----------- | ------------ | ------ | --------- |
| none        | 0.017        | 1.98   | 0.99      |
| tanh        | 0.015        | 2.23   | 1.12      |

**Takeaways:** The fused tanh path is memory-bound at this shape and runs ~12% faster than the `'none'` path because it avoids an erf call while still vectorizing the cubic in fp32. Both paths share the same `register_copy` strategy and dispatch through `default_kernel_map`.

**Command:** `PYTHONPATH="$PWD" python -m pytest benchmarks/ops/bench_activation.py -v`

## Test node delta

```
File                                                        Base    HEAD    Delta
---------------------------------------------------------------------------------
tests/ops/test_activation.py                                  52      55       +3
tests/ops/test_elementwise_unary_activation_alignment.py      35      36       +1
---------------------------------------------------------------------------------
TOTAL                                                         87      91       +4
```

**Justification:** +3 nodes in `test_activation.py` parametrize the new `approximate='tanh'` path across fp16/bf16/fp32 alongside the existing `'none'` cases (AC-2). +1 node in the alignment test covers `approximate='tanh'` reaching `forward()` without raising. Both additions are minimum coverage for the new dispatch branch.
