### PR TITLE
[BugFix][ROPE] fix non-neox 2d compile failure

### DIFF
--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -437,7 +437,6 @@ def test_rope_non_neox_2d(batch: int, seq_len: int, num_heads: int,
                           head_dim: int, dtype: torch.dtype) -> None:
     from tileops.ops.rope import RopeNonNeoxOp
 
-    pytest.skip("Temporarily skipping known non-neox 2D RoPE failures under TileLang 0.1.9 (#1039).")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)
@@ -586,7 +585,6 @@ def test_rope_non_neox_edge(batch: int, seq_len: int, num_heads: int,
     """Edge cases: seq_len=1 and longer sequences."""
     from tileops.ops.rope import RopeNonNeoxOp
 
-    pytest.skip("Temporarily skipping known non-neox edge RoPE failures under TileLang 0.1.9 (#1039).")
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
     op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
                        batch=batch, num_heads=num_heads)

--- a/tileops/kernels/rope.py
+++ b/tileops/kernels/rope.py
@@ -266,14 +266,14 @@ def _make_rope_non_neox_2d(batch: int, seq_len: int, num_heads: int, head_dim: i
                     s = sin_table[s_idx, freq_idx]
                     val = x[flat_idx]
 
-                    # Adjacent pair: even pairs with next, odd pairs with prev
-                    is_even = (col % 2) == 0
-                    paired_col = T.if_then_else(is_even, col + 1, col - 1)
-                    head_base = flat_idx - col
-                    paired_idx = head_base + paired_col
+                    # Adjacent pair: even pairs with next, odd pairs with previous.
+                    # Compute the same pair as a +/-1 flat offset to avoid a
+                    # TileLang 0.1.9 lowering bug for if_then_else-derived indices.
+                    col_parity = col % 2
+                    paired_idx = flat_idx + 1 - 2 * col_parity
                     paired_val = x[paired_idx]
 
-                    rotated = T.if_then_else(is_even, -paired_val, paired_val)
+                    rotated = T.if_then_else(col_parity == 0, -paired_val, paired_val)
                     y[flat_idx] = val * c + rotated * s
 
         return main


### PR DESCRIPTION
Closes #1269

## Summary

- Fix RoPE non-neox 2D TileLang 0.1.9 compilation by expressing adjacent-pair lookup as an equivalent flat +/-1 offset.
- Remove the temporary skips from the previously failing non-neox 2D and edge RoPE tests.

## Test plan

- [x] `TMPDIR=/home/lyc/Project/TileOPs/.tmp/tvm_tmp python -m pytest tests/ops/test_rope.py::test_rope_non_neox_2d tests/ops/test_rope.py::test_rope_non_neox_edge -q`
- [x] `TMPDIR=/home/lyc/Project/TileOPs/.tmp/tvm_tmp python -m pytest tests/ops/test_rope.py -q`
- [x] pre-commit hooks passed during `git commit`

## Regression

- Exact previously skipped nodeids now pass under `tilelang 0.1.9`: `7 passed`.
- Full RoPE test file passes under `tilelang 0.1.9`: `52 passed`.
