### PR TITLE
[Doc][Process] permit workloads addition on spec-only -> implemented promotion

### DIFF
--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -5,22 +5,12 @@
 
 ## Status flip carve-out
 
-An implementation PR (the one that aligns op code with the manifest) MAY touch the manifest entry of the op being aligned, but ONLY within the metadata fields enumerated below. Contractual fields stay frozen and require a separate manifest-only PR with human review.
+An implementation PR may edit the aligned op's manifest entry only at:
 
-**Allowed in an implementation PR** (metadata only — no human re-review of the spec needed):
+- `status` (any direction).
+- `source.kernel_map` entries.
+- `workloads` — **only** when the same PR flips `status: spec-only → implemented` on that op (promotion forces non-empty workloads to satisfy `test_every_op_has_at_least_two_workloads`).
 
-- Flip `status: spec-only` ↔ `status: implemented`.
-- Add or remove entries in `source.kernel_map` (the dispatch registration table).
-- Add entries to `workloads`, ONLY when this PR also flips `status` from `spec-only` to `implemented` for the same op. A `spec-only` entry has empty `workloads` by definition, and `test_every_op_has_at_least_two_workloads` requires ≥2 entries on `implemented` ops, so promotion forces this addition. Other status transitions (including `implemented` → `spec-only`) and ops already at `implemented` MUST NOT change `workloads` in an implementation PR; route those edits through a separate manifest-only PR.
+Every other field — `signature`, `roofline.*`, `params`, output-dtype, shape rules, and any other `workloads` edit — needs a separate manifest-only PR with human review.
 
-Except for the `workloads` allowance above, these edits are permitted ONLY on op entries whose `signature`, `workloads`, `roofline`, and `params` blocks are byte-identical between the PR's base and head.
-
-**Not allowed in an implementation PR** (contractual — require a manifest-only PR with human review):
-
-- Any change to `signature` (parameter names, order, default values, `dtype`, `ref_api`, `ref_dtype`).
-- Any change to `workloads` (shape entries, axis names, named-tile sets), except the `spec-only` → `implemented` promotion case enumerated in the "Allowed" list above.
-- Any change to `roofline.*` (`vars`, formulas, `flops`, `bytes`, `peak_*`, per-consumer fields).
-- Any change to `params` (declared static or dynamic parameters, defaults).
-- Any change to output-dtype rules or shape rules (e.g. `output_dtype`, `shape_rules`).
-
-This carve-out narrows the prohibition; it does not relax the trust boundary. If an implementation PR needs any change in the "not allowed" list, stop, open a manifest-only PR for that change first, and resume the implementation PR against the merged manifest.
+The carve-out narrows the prohibition; it does not relax the trust boundary.

--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -11,13 +11,14 @@ An implementation PR (the one that aligns op code with the manifest) MAY touch t
 
 - Flip `status: spec-only` ↔ `status: implemented`.
 - Add or remove entries in `source.kernel_map` (the dispatch registration table).
+- Add entries to `workloads`, ONLY when this PR also flips `status` from `spec-only` to `implemented` for the same op. A `spec-only` entry has empty `workloads` by definition, and `test_every_op_has_at_least_two_workloads` requires ≥2 entries on `implemented` ops, so promotion forces this addition. Other status transitions (including `implemented` → `spec-only`) and ops already at `implemented` MUST NOT change `workloads` in an implementation PR; route those edits through a separate manifest-only PR.
 
-These edits are permitted ONLY on op entries whose `signature`, `workloads`, `roofline`, and `params` blocks are byte-identical between the PR's base and head.
+Except for the `workloads` allowance above, these edits are permitted ONLY on op entries whose `signature`, `workloads`, `roofline`, and `params` blocks are byte-identical between the PR's base and head.
 
 **Not allowed in an implementation PR** (contractual — require a manifest-only PR with human review):
 
 - Any change to `signature` (parameter names, order, default values, `dtype`, `ref_api`, `ref_dtype`).
-- Any change to `workloads` (shape entries, axis names, named-tile sets).
+- Any change to `workloads` (shape entries, axis names, named-tile sets), except the `spec-only` → `implemented` promotion case enumerated in the "Allowed" list above.
 - Any change to `roofline.*` (`vars`, formulas, `flops`, `bytes`, `peak_*`, per-consumer fields).
 - Any change to `params` (declared static or dynamic parameters, defaults).
 - Any change to output-dtype rules or shape rules (e.g. `output_dtype`, `shape_rules`).

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -25,7 +25,7 @@ Source of truth for op interfaces. Human-reviewed, separate PR.
 
 ### Status flip carve-out
 
-An implementation PR MAY flip `status:` and edit `source.kernel_map` on the op it aligns; contractual fields (`signature`, `workloads`, `roofline.*`, `params`, output-dtype / shape rules) stay frozen and require a separate manifest-only PR with human review.
+An implementation PR MAY flip `status:` and edit `source.kernel_map` on the op it aligns, and MAY add `workloads` entries on that op when the same PR promotes it from `spec-only` to `implemented` (a `spec-only` entry has empty workloads, but `implemented` ops must satisfy the ≥2-workloads test). All other contractual fields (`signature`, `roofline.*`, `params`, output-dtype / shape rules, plus `workloads` edits to already-implemented ops or to ops not changing status) stay frozen and require a separate manifest-only PR with human review.
 
 Authoritative enumeration of allowed vs forbidden mutations: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
 

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -25,9 +25,9 @@ Source of truth for op interfaces. Human-reviewed, separate PR.
 
 ### Status flip carve-out
 
-An implementation PR MAY flip `status:` and edit `source.kernel_map` on the op it aligns, and MAY add `workloads` entries on that op when the same PR promotes it from `spec-only` to `implemented` (a `spec-only` entry has empty workloads, but `implemented` ops must satisfy the ≥2-workloads test). All other contractual fields (`signature`, `roofline.*`, `params`, output-dtype / shape rules, plus `workloads` edits to already-implemented ops or to ops not changing status) stay frozen and require a separate manifest-only PR with human review.
+An implementation PR may edit only `status`, `source.kernel_map`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
 
-Authoritative enumeration of allowed vs forbidden mutations: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
+Full enumeration: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
 
 → Rules: [manifest-spec.md](../../.claude/domain-rules/manifest-spec.md) | Guide: [manifest.md](manifest.md)
 


### PR DESCRIPTION
Closes tile-ai/TileOPs#1265

## Summary

- Amend `.claude/rules/manifest-trust-model.md` to enumerate `workloads` as an allowed field when a single PR flips an op's `status` from `spec-only` to `implemented`.
- Make explicit that the carve-out does NOT extend to `implemented -> spec-only` transitions or to ops already at `implemented`; `workloads` edits remain forbidden in those cases.
- Cross-reference the carve-out from `docs/design/trust-model.md` so the design summary stays consistent with the authoritative rules file.

## Test plan

- [x] Carve-out section explicitly lists `workloads` as an allowed field when promoting `spec-only` to `implemented`.
- [x] Wording makes clear this exception does not extend to other status transitions or to ops already at `implemented`.
- [x] Cross-referenced from `docs/design/trust-model.md`.
- [x] `make lint` (pre-commit run --all-files) passed.