### PR TITLE
[Doc][Process] sweep agent-loaded rules/ + domain-rules/ for brevity

### DIFF
--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -8,7 +8,7 @@
 
 ______________________________________________________________________
 
-- Every benchmark must record ≥1 non-`"tileops"` baseline. If external baseline is conditional, add a local torch fallback.
-- Tag names: lowercase, hyphen-separated. Tags starting with `"tileops"` = TileOPs entries; all others = baselines.
-- `calculate_flops()` / `calculate_memory()` return `None` to omit the metric from the report.
-- Benchmark shapes must reflect real DNN workloads. Use LLaMA-family dimensions as defaults. Annotate shape constants with the model/scenario they represent. Do not use arbitrary flat numbers (262K, 1M, 4M).
+- Every benchmark records ≥1 non-`tileops` baseline. If the external baseline is conditional, add a local torch fallback.
+- Tag names: lowercase, hyphen-separated. Tags starting with `tileops` are TileOPs entries; everything else is a baseline.
+- `calculate_flops()` / `calculate_memory()` return `None` to omit the metric.
+- Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never use arbitrary flat numbers (262K, 1M, 4M).

--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -8,42 +8,42 @@
 
 ______________________________________________________________________
 
-- Manifest key must equal the corresponding Op `cls.__name__` exactly. Class-naming convention is in `ops-design.md`.
+- Manifest key must equal the Op `cls.__name__` exactly.
 
-- `ref_api` (required) — declares the external API the signature follows (e.g., `torch.nn.functional.rms_norm`). Set to `"none"` if no direct external counterpart exists. Informational only; does not affect validation.
+- `ref_api` (required): the external API the signature mirrors (e.g. `torch.nn.functional.rms_norm`); `"none"` if none. Informational, not validated.
 
-- `inputs`, `outputs`, `params` are ordered dicts. Key order = function signature position. Do not reorder.
+- `inputs`, `outputs`, `params` are ordered dicts — key order is signature position. Don't reorder.
 
-- Params include all PyTorch-supported parameters, even if the current kernel only supports the default. Params default to `__init__` kwargs (architecture-decided, fixed for the Op instance's lifetime); in rare cases a param belongs in `forward()` when PyTorch's reference API requires it or when the value is per-batch — justify the exception in the op's introducing issue.
+- Op signatures must match PyTorch's public API (parameter names, set, semantics). Don't invent parameters.
 
-- `dtype` syntax: `|` for alternatives. `same_as(ref)` is a dtype-only identity constraint: the tensor must have the exact same dtype as `ref` at runtime, does not contribute an independent axis to the Cartesian product in `dtype_combos`, and must not be used for shape.
+- Params include all PyTorch-supported parameters even if the kernel only honors the default. Default to `__init__` kwargs (architecture-decided, lifetime-fixed); a param belongs in `forward()` only when the reference API requires it or the value is per-batch — justify in the introducing issue.
 
-- `dtype_combos` when supported set is a strict subset of the Cartesian product. Omit when all combinations are valid.
+- `dtype` syntax: `|` for alternatives. `same_as(ref)` is dtype-only identity (matches `ref` at runtime, no extra axis in `dtype_combos`, never used for shape).
 
-- Every output tensor's shape must be fully specified via `shape` and/or `shape_rules`. Inputs may omit `shape` (→ arbitrary rank).
+- `dtype_combos` only when the supported set is a strict subset of the Cartesian product. Omit when all combinations are valid.
 
-- `shape` present = fixed rank. Names become roofline variables. `shape` absent = arbitrary rank, use `params` + `shape_rules`.
+- Every output tensor's shape is fully specified by `shape` and/or `shape_rules`. Inputs may omit `shape` (= arbitrary rank).
 
-- Shared dimension names across tensors = sizes must match.
+- `shape` present → fixed rank, names become roofline variables. `shape` absent → arbitrary rank; use `params` + `shape_rules`.
 
-- `shape_rules` are Python expressions for shape relationships. `shape` and `shape_rules` fully specify output shape derivation.
+- Shared dimension names across tensors → sizes must match.
 
-- Reduction-dim validation: do NOT silently wrap out-of-range indices with `% x.ndim`. Canonical predicates and value extractors live in `tileops.manifest.shape_rules` and are exposed as shape_rule builtins (callable by bare name from any rule body, alongside `broadcast_shapes` etc.); new reduction ops MUST reference them, inline string expressions are a transitional fallback only.
+- `shape_rules` are Python expressions describing shape relationships.
 
-- `status` is required: one of `implemented` or `spec-only`.
+- Reduction-dim validation: never silently wrap out-of-range indices with `% x.ndim`. Use the canonical predicates / extractors in `tileops.manifest.shape_rules` (callable by bare name from any rule body); inline string expressions are a transitional fallback only.
 
 - Roofline `vars` maps variable names to Python expressions over tensor shapes and params. Required for arbitrary-rank ops.
 
-- Op signatures must match PyTorch's public API (parameter names, parameter set, semantics). Do not invent parameters.
+- `status` is required: `implemented` or `spec-only`.
 
-- No `Optional[Tensor]` in manifest. Ops with conditional inputs split into variant entries linked by `variant_of`, which is single-level (variant → primary, no chaining). Variants share `source.kernel` and `source.op`; each has its own `signature`, `workloads`, `roofline`.
+- No `Optional[Tensor]` in manifest. Conditional inputs split into variant entries linked by `variant_of` (single-level, no chaining). Variants share `source.kernel` and `source.op`; each carries its own `signature`, `workloads`, `roofline`.
 
-- Tensor layout defaults to contiguous row-major. When an op requires non-default layout (e.g., `channels_last`), add `layout` field to the tensor declaration. `shape` dimension names reflect actual memory order.
+- Tensor layout defaults to contiguous row-major. Non-default needs an explicit `layout` field; `shape` dim names reflect memory order.
 
-- `source.kernel_map` is the Op→Kernel dispatch registration table (`dispatch_key: KernelClassName`). It declares which Kernels an Op uses so agents know what to implement. Does not describe dispatch strategy.
+- `source.kernel_map` is the Op→Kernel dispatch registration table (`dispatch_key: KernelClassName`). It declares what an Op uses, not how dispatch picks.
 
-- Never modify manifest to match non-conforming code. If code doesn't match spec: set `status: spec-only` and fix implementation in a follow-up PR. Never remove params, vars, or shape_rules to silence validator errors.
+- Never modify manifest to match non-conforming code. Code drift → `status: spec-only` and fix code in a follow-up PR. Never remove `params`, roofline `vars`, or `shape_rules` to silence validator errors.
 
-- **Manifest comment policy.** Manifest YAML carries technical content the DSL cannot express structurally (schema clarifications, edge cases, conventions, file-level headers). It does **not** carry development-process metadata — anything bound to a specific issue, PR, commit, or development round. Test: would this comment still be meaningful if every issue / PR had different numbers and every milestone was renamed? Yes → keep. No → move to commit message, PR description, or follow-up issue.
+- **Manifest comment policy.** Comments may carry technical content the DSL can't express (schema clarifications, edge cases, conventions, file headers). They MUST NOT carry development-process metadata bound to a specific issue / PR / commit / round. Test: would the comment still be meaningful if every issue and PR were renumbered? Yes → keep. No → move to commit message, PR description, or follow-up issue.
 
-  Discovery scan (flags candidates, not a hard gate): `grep -rnE '#[0-9]{3,}|[Ff]ollow.?up|AC-[0-9]+' tileops/manifest/*.yaml`
+  Discovery scan: `grep -rnE '#[0-9]{3,}|[Ff]ollow.?up|AC-[0-9]+' tileops/manifest/*.yaml`

--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -8,7 +8,7 @@
 
 ______________________________________________________________________
 
-- Manifest key must equal the Op `cls.__name__` exactly.
+- Manifest key must equal the Op `cls.__name__` exactly. Class-naming convention: see [ops-design.md](ops-design.md).
 
 - `ref_api` (required): the external API the signature mirrors (e.g. `torch.nn.functional.rms_norm`); `"none"` if none. Validator enforces presence + string type only; semantics not checked.
 

--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 
 - Manifest key must equal the Op `cls.__name__` exactly.
 
-- `ref_api` (required): the external API the signature mirrors (e.g. `torch.nn.functional.rms_norm`); `"none"` if none. Informational, not validated.
+- `ref_api` (required): the external API the signature mirrors (e.g. `torch.nn.functional.rms_norm`); `"none"` if none. Validator enforces presence + string type only; semantics not checked.
 
 - `inputs`, `outputs`, `params` are ordered dicts — key order is signature position. Don't reorder.
 

--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -14,23 +14,15 @@ ______________________________________________________________________
 
 - `inputs`, `outputs`, `params` are ordered dicts — key order is signature position. Don't reorder.
 
-- Op signatures must match PyTorch's public API (parameter names, set, semantics). Don't invent parameters.
-
-- Params include all PyTorch-supported parameters even if the kernel only honors the default. Default to `__init__` kwargs (architecture-decided, lifetime-fixed); a param belongs in `forward()` only when the reference API requires it or the value is per-batch — justify in the introducing issue.
+- Op signatures must match PyTorch's public API (names, set, semantics); include every supported parameter even if the kernel only honors the default. Default to `__init__` kwargs (lifetime-fixed); use `forward()` only when the reference API requires it or the value is per-batch — justify in the introducing issue.
 
 - `dtype` syntax: `|` for alternatives. `same_as(ref)` is dtype-only identity (matches `ref` at runtime, no extra axis in `dtype_combos`, never used for shape).
 
 - `dtype_combos` only when the supported set is a strict subset of the Cartesian product. Omit when all combinations are valid.
 
-- Every output tensor's shape is fully specified by `shape` and/or `shape_rules`. Inputs may omit `shape` (= arbitrary rank).
+- Output shapes are fully specified by `shape` and/or `shape_rules`. `shape` present → fixed rank, names become roofline variables; `shape` absent on inputs → arbitrary rank, use `params` + `shape_rules`. Shared dim names across tensors → sizes must match.
 
-- `shape` present → fixed rank, names become roofline variables. `shape` absent → arbitrary rank; use `params` + `shape_rules`.
-
-- Shared dimension names across tensors → sizes must match.
-
-- `shape_rules` are Python expressions describing shape relationships.
-
-- Reduction-dim validation: never silently wrap out-of-range indices with `% x.ndim`. Use the canonical predicates / extractors in `tileops.manifest.shape_rules` (callable by bare name from any rule body); inline string expressions are a transitional fallback only.
+- `shape_rules` are Python expressions describing shape relationships. For reduction-dim validation, use the canonical predicates / extractors in `tileops.manifest.shape_rules` (callable by bare name from any rule body); never silently wrap out-of-range indices with `% x.ndim`. Inline string expressions are a transitional fallback only.
 
 - Roofline `vars` maps variable names to Python expressions over tensor shapes and params. Required for arbitrary-rank ops.
 
@@ -44,6 +36,6 @@ ______________________________________________________________________
 
 - Never modify manifest to match non-conforming code. Code drift → `status: spec-only` and fix code in a follow-up PR. Never remove `params`, roofline `vars`, or `shape_rules` to silence validator errors.
 
-- **Manifest comment policy.** Comments may carry technical content the DSL can't express (schema clarifications, edge cases, conventions, file headers). They MUST NOT carry development-process metadata bound to a specific issue / PR / commit / round. Test: would the comment still be meaningful if every issue and PR were renumbered? Yes → keep. No → move to commit message, PR description, or follow-up issue.
+- **Manifest comment policy.** Comments may carry technical content the DSL can't express (schema clarifications, edge cases, conventions, file headers); they MUST NOT carry process metadata bound to a specific issue, PR, commit, or round. Keep only if meaningful after every issue/PR is renumbered; otherwise move to commit message, PR description, or follow-up issue.
 
   Discovery scan: `grep -rnE '#[0-9]{3,}|[Ff]ollow.?up|AC-[0-9]+' tileops/manifest/*.yaml`

--- a/.claude/domain-rules/ops-design.md
+++ b/.claude/domain-rules/ops-design.md
@@ -7,10 +7,10 @@
 
 ______________________________________________________________________
 
-- Op class names: PascalCase `{Name}{Direction}Op`, direction suffix mandatory. Manifest author chooses `{Name}`; no abbreviation rules.
-- Kernel class names: PascalCase `{Name}{Direction}Kernel`. Builder functions remain snake_case.
-- `kernel_map` is the Op→Kernel dispatch registration table. Keys are snake_case dispatch identifiers, decoupled from class names. Values are Kernel class names. The manifest declares this table; agents implement the listed Kernels. See [ops-design-reference.md § Kernel Dispatch](../../docs/design/ops-design-reference.md#kernel-dispatch-kernel_map).
-- Op `__init__` parameters must be keyword-only (`def __init__(self, *, ...)`). Parameter names come from manifest: `shape` dimension names (fixed-rank), `static_dims` keys (arbitrary-rank), and `params` keys. Information not declared in the manifest must not appear in `__init__`.
-- For arbitrary-rank ops, use `static_dims` in the manifest to declare values the user commits to at construction time. Each entry is a single-axis reference `<tensor>.shape[<const_or_param>]`. Dimensions not in `static_dims` are derived from tensors at forward time. See [manifest.md R20](../../docs/design/manifest.md).
-- When adding or modifying an intermediate base class, changing kernel dispatch patterns, or introducing new class variable protocols, update `docs/design/ops-design.md` to reflect the change.
-- When adding a new op family that inherits `Op` directly, evaluate whether it shares `forward()` flow with an existing family before creating a new base class. Document the decision in the PR.
+- Op class names: PascalCase `{Name}{Direction}Op`, direction suffix mandatory. Manifest author chooses `{Name}`.
+- Kernel class names: PascalCase `{Name}{Direction}Kernel`. Builder functions stay snake_case.
+- `kernel_map` is the Op→Kernel dispatch registration table: snake_case dispatch keys (decoupled from class names) → Kernel class names. Manifest declares it; agents implement the listed Kernels. See [ops-design-reference.md § Kernel Dispatch](../../docs/design/ops-design-reference.md#kernel-dispatch-kernel_map).
+- Op `__init__` is keyword-only (`def __init__(self, *, ...)`). Parameter names come from the manifest: `shape` dim names (fixed-rank), `static_dims` keys (arbitrary-rank), `params` keys. Nothing not in the manifest belongs in `__init__`.
+- Arbitrary-rank ops declare construction-time values via manifest `static_dims`. Each entry is a single-axis reference `<tensor>.shape[<const_or_param>]`; other dims come from tensors at forward time. See [manifest.md R20](../../docs/design/manifest.md).
+- Update `docs/design/ops-design.md` whenever you add/modify an intermediate base class, change a kernel-dispatch pattern, or introduce a new class-variable protocol.
+- A new op family inheriting `Op` directly: first check whether an existing family's `forward()` flow already fits before creating a new base class. Record the decision in the PR.

--- a/.claude/domain-rules/ops-design.md
+++ b/.claude/domain-rules/ops-design.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 - Op class names: PascalCase `{Name}{Direction}Op`, direction suffix mandatory. Manifest author chooses `{Name}`.
 - Kernel class names: PascalCase `{Name}{Direction}Kernel`. Builder functions stay snake_case.
 - `kernel_map` is the Op→Kernel dispatch registration table: snake_case dispatch keys (decoupled from class names) → Kernel class names. Manifest declares it; agents implement the listed Kernels. See [ops-design-reference.md § Kernel Dispatch](../../docs/design/ops-design-reference.md#kernel-dispatch-kernel_map).
-- Op `__init__` is keyword-only (`def __init__(self, *, ...)`). Parameter names come from the manifest: `shape` dim names (fixed-rank), `static_dims` keys (arbitrary-rank), `params` keys. Nothing not in the manifest belongs in `__init__`.
+- Op `__init__` is keyword-only (`def __init__(self, *, ...)`). Parameter names come from the manifest: `shape` dim names (fixed-rank), `static_dims` keys (arbitrary-rank), `params` keys. Only manifest-declared information belongs in `__init__`.
 - Arbitrary-rank ops declare construction-time values via manifest `static_dims`. Each entry is a single-axis reference `<tensor>.shape[<const_or_param>]`; other dims come from tensors at forward time. See [manifest.md R20](../../docs/design/manifest.md).
 - Update `docs/design/ops-design.md` whenever you add/modify an intermediate base class, change a kernel-dispatch pattern, or introduce a new class-variable protocol.
 - A new op family inheriting `Op` directly: first check whether an existing family's `forward()` flow already fits before creating a new base class. Record the decision in the PR.

--- a/.claude/domain-rules/ops-design.md
+++ b/.claude/domain-rules/ops-design.md
@@ -7,8 +7,7 @@
 
 ______________________________________________________________________
 
-- Op class names: PascalCase `{Name}{Direction}Op`, direction suffix mandatory. Manifest author chooses `{Name}`.
-- Kernel class names: PascalCase `{Name}{Direction}Kernel`. Builder functions stay snake_case.
+- Class names: PascalCase `{Name}{Direction}Op` (Op layer) or `{Name}{Direction}Kernel` (Kernel layer); direction suffix mandatory. Manifest author chooses `{Name}`. Builder functions stay snake_case.
 - `kernel_map` is the Op→Kernel dispatch registration table: snake_case dispatch keys (decoupled from class names) → Kernel class names. Manifest declares it; agents implement the listed Kernels. See [ops-design-reference.md § Kernel Dispatch](../../docs/design/ops-design-reference.md#kernel-dispatch-kernel_map).
 - Op `__init__` is keyword-only (`def __init__(self, *, ...)`). Parameter names come from the manifest: `shape` dim names (fixed-rank), `static_dims` keys (arbitrary-rank), `params` keys. Only manifest-declared information belongs in `__init__`.
 - Arbitrary-rank ops declare construction-time values via manifest `static_dims`. Each entry is a single-axis reference `<tensor>.shape[<const_or_param>]`; other dims come from tensors at forward time. See [manifest.md R20](../../docs/design/manifest.md).

--- a/.claude/domain-rules/testing-budget.md
+++ b/.claude/domain-rules/testing-budget.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 - Every test case traces to a specific code path, dtype dispatch, or regression. No cases for combinatorial confidence.
 - Test all supported dtypes. Don't cross dtype and shape coverage unless the combination triggers a distinct code path.
 - Don't generate fixtures from `tileops/manifest/` workloads. Test parameters are a curated correctness subset.
-- Before committing: drop scaffolding tests that guarded intermediate implementation steps but no final code path.
+- Before committing: drop scaffolding tests that guarded intermediate implementation steps and don't guard any final code path.
 - Run `scripts/test_node_delta.py` on PRs touching test files. Growth on existing files → include the script output + a one-line justification in the PR body. New test files only → no delta report.
 - Binary-op tests cover broadcast semantics: bias-add `(B,S,D)+(1,1,D)`, row `(B,S,D)+(B,S,1)`, scalar `(M,N)+(1,1)`. Applies to arithmetic, comparison, logical, bitwise.
 - Skill development tests stay local — never commit anything under `.claude/skills/`.

--- a/.claude/domain-rules/testing-budget.md
+++ b/.claude/domain-rules/testing-budget.md
@@ -7,10 +7,10 @@
 
 ______________________________________________________________________
 
-- Every test case must trace back to a specific code path, dtype dispatch, or regression. Do not add cases for combinatorial confidence.
-- All supported dtypes must be tested. Dtype and shape coverage serve different purposes — do not cross them unless the combination triggers a distinct code path.
-- Do not generate test fixtures from tileops/manifest/ workloads. Test parameters are a curated correctness subset.
-- Before committing, review test cases added during development. Remove scaffolding tests that verified intermediate implementation steps but do not guard a final code path. Keep only tests that remain valuable after the implementation is stable.
-- Run `scripts/test_node_delta.py` before submitting PRs that modify test files. No growth on existing files: nothing to report. Growth on existing files: include script output and one-line justification in PR description. New test files only: no delta report needed.
-- Binary operator tests must cover broadcast semantics: bias-add `(B,S,D)+(1,1,D)`, row `(B,S,D)+(B,S,1)`, scalar `(M,N)+(1,1)`. Applies to arithmetic, comparison, logical, and bitwise binary ops.
-- Skill development tests stay local — do not commit anything under `.claude/skills/`.
+- Every test case traces to a specific code path, dtype dispatch, or regression. No cases for combinatorial confidence.
+- Test all supported dtypes. Don't cross dtype and shape coverage unless the combination triggers a distinct code path.
+- Don't generate fixtures from `tileops/manifest/` workloads. Test parameters are a curated correctness subset.
+- Before committing: drop scaffolding tests that guarded intermediate implementation steps but no final code path.
+- Run `scripts/test_node_delta.py` on PRs touching test files. Growth on existing files → include the script output + a one-line justification in the PR body. New test files only → no delta report.
+- Binary-op tests cover broadcast semantics: bias-add `(B,S,D)+(1,1,D)`, row `(B,S,D)+(B,S,1)`, scalar `(M,N)+(1,1)`. Applies to arithmetic, comparison, logical, bitwise.
+- Skill development tests stay local — never commit anything under `.claude/skills/`.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,14 +1,14 @@
-- Every `tileops/kernels/*` subpackage must have an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
+- Every `tileops/kernels/*` subpackage has an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
 
-- Relative imports for intra-package references (e.g. `from .op import Op`); absolute `tileops.*` imports for cross-package references.
+- Relative imports for intra-package references (`from .op import Op`); absolute `tileops.*` imports for cross-package references.
 
-- Do not use file-level lint suppressions (`# ruff: noqa`, `# flake8: noqa`). Use targeted inline `# noqa: XXXX` only when genuinely needed.
+- No file-level lint suppressions (`# ruff: noqa`, `# flake8: noqa`). Targeted inline `# noqa: XXXX` only when needed.
 
-- Use `T.Tensor(shape, dtype)` for TIR function parameters, not the deprecated `T.Buffer(shape, dtype)`.
+- Use `T.Tensor(shape, dtype)` for TIR function parameters (not deprecated `T.Buffer`).
 
-- Use `T.reinterpret(value, dtype)` (value first), not the deprecated `T.reinterpret(dtype, value)`.
+- Use `T.reinterpret(value, dtype)` (value first; not deprecated dtype-first form).
 
-- When a PR intentionally degrades a test (xfail, skip, weakened assertion) due to a process constraint (e.g. trust model requiring separate manifest and code PRs), mark it with `FIXME(staged-rollout)` using this template:
+- Tests intentionally degraded by a process constraint (e.g. trust model splitting manifest and code PRs) get a `FIXME(staged-rollout)` marker. Cleanup describes the invariant to restore — never references a specific PR. Scan: `grep -rn 'FIXME(staged-rollout)'`.
 
   ```python
   # FIXME(staged-rollout): <one-line summary of what's degraded>
@@ -18,21 +18,16 @@
   # Cleanup: <concrete condition that triggers removal of this marker>
   ```
 
-  Cleanup must describe the invariant to restore, not reference a specific PR. Scan with `grep -rn 'FIXME(staged-rollout)'`.
+- **Abbreviation casing in PascalCase**: standard abbreviations stay fully uppercase — `RMSNormKernel`, `SSDDecodeOp`, `FusedAddRMSNormFwdOp`.
 
-- **Abbreviation casing in PascalCase symbols**: Standard abbreviations must be fully uppercase — `RMS`, not `Rms`; `SSD`, not `Ssd`; `SSM`, not `Ssm`. Examples: `RMSNormKernel`, `SSDDecodeOp`, `FusedAddRMSNormFwdOp`.
+- **Filenames**: all-lowercase with underscores; multi-letter abbreviations stay lowercase — `rms_norm.py`, `ssd_decode.py`. Don't capitalize a single letter.
 
-- **Abbreviation casing in filenames**: Filenames use all-lowercase with underscores. Multi-word abbreviations keep all letters lowercase — `rms_norm.py`, `ssd_decode.py`. Do not capitalize a single letter (e.g. `Ssd_decode.py` is wrong).
+- **Norm filenames**: underscore-separated — `rms_norm`, `layer_norm`, `batch_norm`, `fused_add_rms_norm`. Never contracted (`rmsnorm` etc.).
 
-- **Docstring style: Google**. All Python docstrings (modules, classes, public functions / methods) follow Google style: one-sentence summary on the opening line, blank line, then optional sections `Args:`, `Returns:`, `Raises:`, `Example:`. Internal helpers may use a single-line summary docstring. Do NOT mix Sphinx-style (`:param x:`) or NumPy-style (separate header lines for each param) into the same file.
+- **Docstrings**: Google style. One-sentence summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may have a single-line summary. Never mix Sphinx (`:param x:`) or NumPy headers in the same file.
 
-- **Expand abbreviations on first use in docstrings**: When SSM, SSD, or other domain abbreviations first appear in a module or class docstring, write the full form followed by the abbreviation in parentheses. Subsequent uses in the same file can use the abbreviation alone.
+- **Expand abbreviations on first use in docstrings**: e.g. `State Space Model (SSM)`, `State-Space Dual (SSD)`. Subsequent uses may abbreviate.
 
-  - SSM → State Space Model (SSM)
-  - SSD → State-Space Dual (SSD)
+- **No development-process metadata in shipped source.** Code, docstrings, and manifest YAML must not reference issue/PR numbers, AC labels, round numbers, reviewer names, or `Follow-up: #N` pointers — that context belongs in the commit message, PR description, and the follow-up issue. See [domain-rules/manifest-spec.md](../domain-rules/manifest-spec.md).
 
-- **Underscore-separated naming for norm files**: All norm-related filenames use underscore separation — `rms_norm`, `layer_norm`, `batch_norm`, `fused_add_rms_norm`. Do not contract (e.g. `rmsnorm`, `layernorm`, `batchnorm`).
-
-- **No development-process metadata in shipped source.** Code and docstrings must not reference issue/PR numbers, AC labels (e.g. `AC-4`), round numbers, reviewer names, or `Follow-up: #N` pointers — that context belongs in the commit message, PR description, and the follow-up issue itself. Manifest YAML follows the same principle; see [domain-rules/manifest-spec.md](../domain-rules/manifest-spec.md).
-
-  Discovery scan (flags candidates; new code must not add new matches): `grep -rnE '(^|[^[:alnum:]])#[0-9]{3,}|AC-[0-9]+|round-[0-9]+ review|[Ff]ollow-up:[[:space:]]*#' --exclude-dir=manifest tileops/ tests/ benchmarks/ scripts/`
+  Discovery scan: `grep -rnE '(^|[^[:alnum:]])#[0-9]{3,}|AC-[0-9]+|round-[0-9]+ review|[Ff]ollow-up:[[:space:]]*#' --exclude-dir=manifest tileops/ tests/ benchmarks/ scripts/`

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,4 +1,4 @@
-- Every `tileops/kernels/*` subpackage has an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
+- Every `tileops/kernels/*` subpackage MUST have an `__init__.py` with explicit `__all__` and `from .module import Symbol` re-exports.
 
 - Relative imports for intra-package references (`from .op import Op`); absolute `tileops.*` imports for cross-package references.
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -20,9 +20,7 @@
 
 - **Abbreviation casing in PascalCase**: standard abbreviations stay fully uppercase — `RMSNormKernel`, `SSDDecodeOp`, `FusedAddRMSNormFwdOp`.
 
-- **Filenames**: all-lowercase with underscores; multi-letter abbreviations stay lowercase — `rms_norm.py`, `ssd_decode.py`. Don't capitalize a single letter.
-
-- **Norm filenames**: underscore-separated — `rms_norm`, `layer_norm`, `batch_norm`, `fused_add_rms_norm`. Never contracted (`rmsnorm` etc.).
+- **Filenames**: all-lowercase with underscores; multi-letter abbreviations stay lowercase — `rms_norm.py`, `ssd_decode.py`. Don't capitalize a single letter. Norm filenames specifically must be underscore-separated, never contracted (`rms_norm`, never `rmsnorm`).
 
 - **Docstrings**: Google style. One-sentence summary, blank line, then optional `Args:` / `Returns:` / `Raises:` / `Example:`. Internal helpers may have a single-line summary. Never mix Sphinx (`:param x:`) or NumPy headers in the same file.
 


### PR DESCRIPTION
## Summary

Per `feedback_agent_doc_brevity.md`: agents load these docs on every invocation; verbose phrasing burns context budget and buries the rule. This PR is **Pass 1 + Pass 2** of the brevity sweep tracked in #1277.

- `.claude/rules/code-style.md` — collapse FIXME(staged-rollout) preamble; tighten Google-docstring, abbreviation, and dev-process-metadata bullets.
- `.claude/domain-rules/manifest-spec.md` — merge near-duplicate bullets; collapse comment-policy preamble.
- `.claude/domain-rules/{benchmark,ops-design,testing-budget}.md` — one imperative sentence per directive.

`security.md`, `manifest-trust-model.md`, `manifest-validator.md`, `design-docs.md` left as-is — already at one-bullet-per-rule.

## Test plan

- [x] No rule lost: every removed sentence's directive is still expressed (verified by hand against the pre-sweep diff).
- [x] Cross-references preserved.
- [x] `pre-commit run --files <changed docs>` clean (mdformat round-trip applied).

## Scope notes

Pass 3 (`.claude/skills/*/SKILL.md`) and Pass 4 (`docs/design/*.md`) deferred to separate PRs. SKILL files are operational protocols loaded only on skill invocation (lower context cost), and tightening them risks dropping load-bearing detail sub-skills depend on. Design docs need per-file judgment about which sections are decisions vs implementation snapshots.

Closes tile-ai/TileOPs#1277