### PR TITLE
[Feat][Norm] implement no-affine GroupNorm/InstanceNorm variants

### DIFF
--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.norm.group_norm import GroupNormFwdOp
+from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormFwdOpNoAffine
 from workloads.group_norm import GroupNormTest as _GroupNormTestWorkload
 
 
@@ -224,6 +224,75 @@ def test_group_norm_rejects_affine_device_mismatch() -> None:
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
         op(x, None, bias_other)
+
+
+class GroupNormNoAffineFixture(FixtureBase):
+    PARAMS = [
+        ("n, c, spatial, g, dtype", [
+            pytest.param(2, 32, (8, 8), 8, torch.float32, marks=pytest.mark.smoke),
+            pytest.param(2, 32, (8, 8), 8, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(2, 32, (8, 8), 8, torch.bfloat16, marks=pytest.mark.smoke),
+            pytest.param(4, 16, (4, 4), 4, torch.float16, marks=pytest.mark.full),
+            # Non-aligned spatial: exercises padding path.
+            pytest.param(2, 32, (7, 7), 8, torch.float16, marks=pytest.mark.full),
+            # 1D spatial.
+            pytest.param(2, 32, (16,), 8, torch.float16, marks=pytest.mark.full),
+            # 3D spatial.
+            pytest.param(2, 16, (4, 4, 4), 4, torch.float16, marks=pytest.mark.full),
+        ]),
+    ]
+
+
+@GroupNormNoAffineFixture
+def test_group_norm_no_affine_op(n: int, c: int, spatial: tuple, g: int,
+                                 dtype: torch.dtype) -> None:
+    """No-affine GroupNorm op matches torch.nn.functional.group_norm with weight=bias=None."""
+    op = GroupNormFwdOpNoAffine(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    y = op(x)
+    y_ref = F.group_norm(x.float(), g, weight=None, bias=None, eps=1e-5).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
+@pytest.mark.smoke
+def test_group_norm_no_affine_forward_signature() -> None:
+    """No-affine forward accepts only x — no weight/bias parameters."""
+    import inspect
+    sig = inspect.signature(GroupNormFwdOpNoAffine.forward)
+    params = [p for p in sig.parameters if p != "self"]
+    assert params == ["x"], f"expected ['x'], got {params}"
+
+
+@pytest.mark.smoke
+def test_group_norm_no_affine_rejects_device_mismatch() -> None:
+    """Forward raises ValueError when input lives on a different CUDA device."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
+
+    n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
+    with torch.cuda.device(0):
+        op = GroupNormFwdOpNoAffine(
+            N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
+        )
+    x_other = torch.randn(
+        (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
+    )
+    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
+        op(x_other)
+
+
+@pytest.mark.smoke
+def test_group_norm_no_affine_rejects_dtype_mismatch() -> None:
+    """Forward raises ValueError when input dtype differs from configured dtype."""
+    n, c, spatial, g = 2, 32, (8, 8), 8
+    op = GroupNormFwdOpNoAffine(
+        N=n, C=c, spatial=spatial, num_groups=g, dtype=torch.float16,
+    )
+    x = torch.randn((n, c, *spatial), dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="dtype"):
+        op(x)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -284,6 +284,18 @@ def test_group_norm_no_affine_rejects_device_mismatch() -> None:
 
 
 @pytest.mark.smoke
+def test_group_norm_no_affine_rejects_shape_mismatch() -> None:
+    """Forward raises ValueError when input shape differs from configured (N, C, *spatial)."""
+    n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
+    op = GroupNormFwdOpNoAffine(
+        N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
+    )
+    x_bad = torch.randn((n, c, 4, 8), dtype=dtype, device="cuda")
+    with pytest.raises(ValueError, match="shape"):
+        op(x_bad)
+
+
+@pytest.mark.smoke
 def test_group_norm_no_affine_rejects_dtype_mismatch() -> None:
     """Forward raises ValueError when input dtype differs from configured dtype."""
     n, c, spatial, g = 2, 32, (8, 8), 8

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -295,5 +295,28 @@ def test_group_norm_no_affine_rejects_dtype_mismatch() -> None:
         op(x)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("n, c, spatial, g", [
+    # M = N * num_groups not divisible by max block_m (16): triggers tail
+    # program reading/writing rows >= M before the M-padding fix.
+    (1, 24, (4, 4), 3),   # M = 3
+    (3, 30, (2, 2), 5),   # M = 15
+    (1, 16, (8, 8), 1),   # M = 1
+])
+def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
+                                         g: int) -> None:
+    """No-affine GroupNorm handles M not divisible by the kernel's block_m."""
+    dtype = torch.float16
+    op = GroupNormFwdOpNoAffine(N=n, C=c, spatial=spatial, num_groups=g,
+                                dtype=dtype)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    y = op(x)
+    y_ref = F.group_norm(x.float(), g, weight=None, bias=None,
+                        eps=1e-5).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -3,7 +3,10 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.norm.instance_norm import InstanceNormFwdOp
+from tileops.ops.norm.instance_norm import (
+    InstanceNormFwdOp,
+    InstanceNormFwdOpNoAffine,
+)
 from workloads.instance_norm import InstanceNormTest as _InstanceNormTestWorkload
 
 
@@ -205,6 +208,71 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
         op(x, None, bias_other)
+
+
+class InstanceNormNoAffineFixture(FixtureBase):
+    PARAMS = [
+        ("n, c, spatial, dtype", [
+            pytest.param(2, 16, (8, 8), torch.float32, marks=pytest.mark.smoke),
+            pytest.param(2, 16, (8, 8), torch.float16, marks=pytest.mark.smoke),
+            pytest.param(2, 16, (8, 8), torch.bfloat16, marks=pytest.mark.smoke),
+            pytest.param(4, 8, (4, 4), torch.float16, marks=pytest.mark.full),
+            # 1D spatial.
+            pytest.param(2, 16, (16,), torch.float16, marks=pytest.mark.full),
+            # 3D spatial.
+            pytest.param(2, 8, (4, 4, 4), torch.float16, marks=pytest.mark.full),
+        ]),
+    ]
+
+
+@InstanceNormNoAffineFixture
+def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
+                                    dtype: torch.dtype) -> None:
+    """No-affine InstanceNorm op matches torch.nn.functional.instance_norm with weight=bias=None."""
+    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    y = op(x)
+    y_ref = F.instance_norm(x.float(), weight=None, bias=None, eps=1e-5).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
+@pytest.mark.smoke
+def test_instance_norm_no_affine_forward_signature() -> None:
+    """No-affine forward accepts only x — no weight/bias parameters."""
+    import inspect
+    sig = inspect.signature(InstanceNormFwdOpNoAffine.forward)
+    params = [p for p in sig.parameters if p != "self"]
+    assert params == ["x"], f"expected ['x'], got {params}"
+
+
+@pytest.mark.smoke
+def test_instance_norm_no_affine_rejects_device_mismatch() -> None:
+    """Forward raises ValueError when input lives on a different CUDA device."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
+
+    n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
+    with torch.cuda.device(0):
+        op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
+    x_other = torch.randn(
+        (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
+    )
+    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
+        op(x_other)
+
+
+@pytest.mark.smoke
+def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
+    """Forward raises ValueError when input dtype differs from configured dtype."""
+    n, c, spatial = 2, 16, (8, 8)
+    op = InstanceNormFwdOpNoAffine(
+        N=n, C=c, spatial=spatial, dtype=torch.float16,
+    )
+    x = torch.randn((n, c, *spatial), dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="dtype"):
+        op(x)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -275,5 +275,27 @@ def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
         op(x)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("n, c, spatial", [
+    # M = N * C not divisible by max block_m (16): triggers tail program
+    # reading/writing rows >= M before the M-padding fix.
+    (1, 3, (4, 4)),    # M = 3
+    (3, 5, (2, 2)),    # M = 15
+    (1, 1, (8, 8)),    # M = 1
+])
+def test_instance_norm_no_affine_tail_block(n: int, c: int,
+                                            spatial: tuple) -> None:
+    """No-affine InstanceNorm handles M not divisible by the kernel's block_m."""
+    dtype = torch.float16
+    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    y = op(x)
+    y_ref = F.instance_norm(x.float(), weight=None, bias=None,
+                            eps=1e-5).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -264,6 +264,26 @@ def test_instance_norm_no_affine_rejects_device_mismatch() -> None:
 
 
 @pytest.mark.smoke
+def test_instance_norm_no_affine_rejects_shape_mismatch() -> None:
+    """Forward raises ValueError when input shape differs from configured (N, C, *spatial)."""
+    n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
+    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
+    x_bad = torch.randn((n, c, 4, 8), dtype=dtype, device="cuda")
+    with pytest.raises(ValueError, match="shape"):
+        op(x_bad)
+
+
+@pytest.mark.smoke
+def test_instance_norm_no_affine_rejects_use_input_stats_false() -> None:
+    """Constructor raises ValueError when use_input_stats=False (unsupported)."""
+    with pytest.raises(ValueError, match="use_input_stats"):
+        InstanceNormFwdOpNoAffine(
+            N=2, C=16, spatial=(8, 8), dtype=torch.float16,
+            use_input_stats=False,
+        )
+
+
+@pytest.mark.smoke
 def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
     """Forward raises ValueError when input dtype differs from configured dtype."""
     n, c, spatial = 2, 16, (8, 8)

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -210,6 +210,23 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
         op(x, None, bias_other)
 
 
+# FIXME(staged-rollout): skip no-affine InstanceNorm tests while the
+# manifest entry is `status: spec-only`.
+#
+# Broken invariant: the manifest declares `use_input_stats` and `momentum`
+# (matching torch.nn.functional.instance_norm), but the current op only
+# implements the `use_input_stats=True` branch and lacks running_mean /
+# running_var arguments — so the implementation does not yet conform to
+# the spec.
+# Why: trust model requires status=spec-only when implementation is
+# incomplete; the running-stats path lands in a follow-up PR.
+# Cleanup: remove this marker once `InstanceNormFwdOpNoAffine` flips back
+# to `status: implemented` with full running-stats support.
+_NO_AFFINE_PENDING_RUNNING_STATS = pytest.mark.skip(
+    reason="InstanceNormFwdOpNoAffine is spec-only pending running-stats path",
+)
+
+
 class InstanceNormNoAffineFixture(FixtureBase):
     PARAMS = [
         ("n, c, spatial, dtype", [
@@ -225,6 +242,7 @@ class InstanceNormNoAffineFixture(FixtureBase):
     ]
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @InstanceNormNoAffineFixture
 def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
                                     dtype: torch.dtype) -> None:
@@ -238,6 +256,7 @@ def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
         f"max err: {(y - y_ref).abs().max()}"
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 def test_instance_norm_no_affine_forward_signature() -> None:
     """No-affine forward accepts only x — no weight/bias parameters."""
@@ -247,6 +266,7 @@ def test_instance_norm_no_affine_forward_signature() -> None:
     assert params == ["x"], f"expected ['x'], got {params}"
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 def test_instance_norm_no_affine_rejects_device_mismatch() -> None:
     """Forward raises ValueError when input lives on a different CUDA device."""
@@ -263,6 +283,7 @@ def test_instance_norm_no_affine_rejects_device_mismatch() -> None:
         op(x_other)
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 def test_instance_norm_no_affine_rejects_shape_mismatch() -> None:
     """Forward raises ValueError when input shape differs from configured (N, C, *spatial)."""
@@ -273,6 +294,7 @@ def test_instance_norm_no_affine_rejects_shape_mismatch() -> None:
         op(x_bad)
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 def test_instance_norm_no_affine_rejects_use_input_stats_false() -> None:
     """Constructor raises ValueError when use_input_stats=False (unsupported)."""
@@ -283,6 +305,7 @@ def test_instance_norm_no_affine_rejects_use_input_stats_false() -> None:
         )
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
     """Forward raises ValueError when input dtype differs from configured dtype."""
@@ -295,6 +318,7 @@ def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
         op(x)
 
 
+@_NO_AFFINE_PENDING_RUNNING_STATS
 @pytest.mark.smoke
 @pytest.mark.parametrize("n, c, spatial", [
     # M = N * C not divisible by max block_m (16): triggers tail program

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -3,10 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.norm.instance_norm import (
-    InstanceNormFwdOp,
-    InstanceNormFwdOpNoAffine,
-)
+from tileops.ops.norm.instance_norm import InstanceNormFwdOp
 from workloads.instance_norm import InstanceNormTest as _InstanceNormTestWorkload
 
 
@@ -208,137 +205,6 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
         op(x, None, bias_other)
-
-
-# FIXME(staged-rollout): skip no-affine InstanceNorm tests while the
-# manifest entry is `status: spec-only`.
-#
-# Broken invariant: the manifest declares `use_input_stats` and `momentum`
-# (matching torch.nn.functional.instance_norm), but the current op only
-# implements the `use_input_stats=True` branch and lacks running_mean /
-# running_var arguments — so the implementation does not yet conform to
-# the spec.
-# Why: trust model requires status=spec-only when implementation is
-# incomplete; the running-stats path lands in a follow-up PR.
-# Cleanup: remove this marker once `InstanceNormFwdOpNoAffine` flips back
-# to `status: implemented` with full running-stats support.
-_NO_AFFINE_PENDING_RUNNING_STATS = pytest.mark.skip(
-    reason="InstanceNormFwdOpNoAffine is spec-only pending running-stats path",
-)
-
-
-class InstanceNormNoAffineFixture(FixtureBase):
-    PARAMS = [
-        ("n, c, spatial, dtype", [
-            pytest.param(2, 16, (8, 8), torch.float32, marks=pytest.mark.smoke),
-            pytest.param(2, 16, (8, 8), torch.float16, marks=pytest.mark.smoke),
-            pytest.param(2, 16, (8, 8), torch.bfloat16, marks=pytest.mark.smoke),
-            pytest.param(4, 8, (4, 4), torch.float16, marks=pytest.mark.full),
-            # 1D spatial.
-            pytest.param(2, 16, (16,), torch.float16, marks=pytest.mark.full),
-            # 3D spatial.
-            pytest.param(2, 8, (4, 4, 4), torch.float16, marks=pytest.mark.full),
-        ]),
-    ]
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@InstanceNormNoAffineFixture
-def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
-                                    dtype: torch.dtype) -> None:
-    """No-affine InstanceNorm op matches torch.nn.functional.instance_norm with weight=bias=None."""
-    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
-    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-    y = op(x)
-    y_ref = F.instance_norm(x.float(), weight=None, bias=None, eps=1e-5).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
-        f"max err: {(y - y_ref).abs().max()}"
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-def test_instance_norm_no_affine_forward_signature() -> None:
-    """No-affine forward accepts only x — no weight/bias parameters."""
-    import inspect
-    sig = inspect.signature(InstanceNormFwdOpNoAffine.forward)
-    params = [p for p in sig.parameters if p != "self"]
-    assert params == ["x"], f"expected ['x'], got {params}"
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-def test_instance_norm_no_affine_rejects_device_mismatch() -> None:
-    """Forward raises ValueError when input lives on a different CUDA device."""
-    if torch.cuda.device_count() < 2:
-        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
-
-    n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    with torch.cuda.device(0):
-        op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
-    x_other = torch.randn(
-        (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
-    )
-    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other)
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-def test_instance_norm_no_affine_rejects_shape_mismatch() -> None:
-    """Forward raises ValueError when input shape differs from configured (N, C, *spatial)."""
-    n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
-    x_bad = torch.randn((n, c, 4, 8), dtype=dtype, device="cuda")
-    with pytest.raises(ValueError, match="shape"):
-        op(x_bad)
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-def test_instance_norm_no_affine_rejects_use_input_stats_false() -> None:
-    """Constructor raises ValueError when use_input_stats=False (unsupported)."""
-    with pytest.raises(ValueError, match="use_input_stats"):
-        InstanceNormFwdOpNoAffine(
-            N=2, C=16, spatial=(8, 8), dtype=torch.float16,
-            use_input_stats=False,
-        )
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-def test_instance_norm_no_affine_rejects_dtype_mismatch() -> None:
-    """Forward raises ValueError when input dtype differs from configured dtype."""
-    n, c, spatial = 2, 16, (8, 8)
-    op = InstanceNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, dtype=torch.float16,
-    )
-    x = torch.randn((n, c, *spatial), dtype=torch.float32, device="cuda")
-    with pytest.raises(ValueError, match="dtype"):
-        op(x)
-
-
-@_NO_AFFINE_PENDING_RUNNING_STATS
-@pytest.mark.smoke
-@pytest.mark.parametrize("n, c, spatial", [
-    # M = N * C not divisible by max block_m (16): triggers tail program
-    # reading/writing rows >= M before the M-padding fix.
-    (1, 3, (4, 4)),    # M = 3
-    (3, 5, (2, 2)),    # M = 15
-    (1, 1, (8, 8)),    # M = 1
-])
-def test_instance_norm_no_affine_tail_block(n: int, c: int,
-                                            spatial: tuple) -> None:
-    """No-affine InstanceNorm handles M not divisible by the kernel's block_m."""
-    dtype = torch.float16
-    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
-    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-    y = op(x)
-    y_ref = F.instance_norm(x.float(), weight=None, bias=None,
-                            eps=1e-5).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
-        f"max err: {(y - y_ref).abs().max()}"
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/norm/__init__.py
+++ b/tileops/kernels/norm/__init__.py
@@ -1,7 +1,7 @@
 from .ada_layer_norm import AdaLayerNormKernel
 from .batch_norm import BatchNormBwdKernel, BatchNormFwdInferKernel, BatchNormFwdTrainKernel
 from .fused_add_norm import FusedAddLayerNormKernel, FusedAddRMSNormKernel
-from .group_norm import GroupNormKernel
+from .group_norm import GroupNormKernel, GroupNormNoAffineKernel
 from .layer_norm import LayerNormKernel
 from .rms_norm import RMSNormKernel
 
@@ -13,6 +13,7 @@ __all__: list[str] = [
     "FusedAddLayerNormKernel",
     "FusedAddRMSNormKernel",
     "GroupNormKernel",
+    "GroupNormNoAffineKernel",
     "LayerNormKernel",
     "RMSNormKernel",
 ]

--- a/tileops/kernels/norm/__init__.py
+++ b/tileops/kernels/norm/__init__.py
@@ -2,6 +2,7 @@ from .ada_layer_norm import AdaLayerNormKernel
 from .batch_norm import BatchNormBwdKernel, BatchNormFwdInferKernel, BatchNormFwdTrainKernel
 from .fused_add_norm import FusedAddLayerNormKernel, FusedAddRMSNormKernel
 from .group_norm import GroupNormKernel, GroupNormNoAffineKernel
+from .instance_norm import InstanceNormKernel, InstanceNormNoAffineKernel
 from .layer_norm import LayerNormKernel
 from .rms_norm import RMSNormKernel
 
@@ -14,6 +15,8 @@ __all__: list[str] = [
     "FusedAddRMSNormKernel",
     "GroupNormKernel",
     "GroupNormNoAffineKernel",
+    "InstanceNormKernel",
+    "InstanceNormNoAffineKernel",
     "LayerNormKernel",
     "RMSNormKernel",
 ]

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -26,7 +26,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-__all__ = ["GroupNormKernel"]
+__all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
 ALIGNMENT = 256
 
@@ -204,4 +204,163 @@ class GroupNormKernel(Kernel):
             x,
             weight,
             bias,
+        )
+
+
+@functools.lru_cache(maxsize=32)
+def _group_norm_no_affine_kernel(M, D, eps, dtype):
+    """Build a row-wise normalization kernel for shape (M, D_padded) without affine.
+
+    Same numerics as :func:`_group_norm_kernel` but omits the trailing
+    weight/bias multiply/add — output is ``(x - mean) * rstd``. Used for the
+    no-affine variants of GroupNorm and InstanceNorm.
+
+    Args:
+        M: Number of rows = N * G.
+        D: Row length = (C / G) * spatial_size (before padding).
+        eps: Epsilon for numerical stability.
+        dtype: TileLang dtype string.
+    """
+    D_padded = _align_up(D, ALIGNMENT)
+    pad_count = D_padded - D
+
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m, threads):
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, D_padded), dtype],
+            y: T.Tensor[(M, D_padded), dtype],
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                shared_buf = T.alloc_shared((block_m, D_padded), dtype)
+                x_local = T.alloc_fragment((block_m, D_padded), dtype)
+                x_f32 = T.alloc_fragment((block_m, D_padded), "float32")
+                acc = T.alloc_fragment((block_m,), "float32")
+                mean_val = T.alloc_fragment((block_m,), "float32")
+                rstd = T.alloc_fragment((block_m,), "float32")
+
+                T.copy(x[pid_m * block_m, 0], shared_buf)
+                T.copy(shared_buf, x_local)
+
+                for i, j in T.Parallel(block_m, D_padded):
+                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+                T.reduce_sum(x_f32, acc, dim=1)
+                for i in T.Parallel(block_m):
+                    mean_val[i] = acc[i] / float(D)
+
+                for i, j in T.Parallel(block_m, D_padded):
+                    x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+
+                T.reduce_sum(x_f32, acc, dim=1)
+                for i in T.Parallel(block_m):
+                    rstd[i] = T.rsqrt(
+                        (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
+                        / float(D)
+                        + eps
+                    )
+
+                # No-affine output: y = (x - mean) * rstd
+                for i, j in T.Parallel(block_m, D_padded):
+                    x_local[i, j] = T.cast(
+                        (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
+                        dtype,
+                    )
+
+                T.copy(x_local, shared_buf)
+                T.copy(shared_buf, y[pid_m * block_m, 0])
+
+        return main
+
+    return _func
+
+
+@torch.library.custom_op("top::group_norm_no_affine_fwd", mutates_args=())
+def _group_norm_no_affine_wrapped(
+    M: int,
+    D: int,
+    eps: float,
+    dtype_str: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _group_norm_no_affine_kernel(M, D, eps, dtype_str)(block_m, threads)(x)
+
+
+@_group_norm_no_affine_wrapped.register_fake
+def _(M, D, eps, dtype_str, block_m, threads, x):
+    D_padded = _align_up(D, ALIGNMENT)
+    return torch.empty((M, D_padded), dtype=x.dtype, device=x.device)
+
+
+class GroupNormNoAffineKernel(Kernel):
+    """GroupNorm forward kernel without affine scale/shift.
+
+    Computes ``y = (x - mean) * rstd`` row-wise for shape ``(M, D)`` reshaped
+    inputs. Shares the build/launch parameters and shared-memory layout of
+    :class:`GroupNormKernel`; only the output stage differs (no weight/bias
+    multiply-add). Used by the no-affine variants of GroupNorm and
+    InstanceNorm.
+
+    Args:
+        M: Number of rows = N * G.
+        D: Row length = (C / G) * spatial_size.
+        eps: Epsilon for numerical stability.
+        dtype: Data type (float32, float16, or bfloat16).
+        config: Optional tile config dict.
+        tune: If True, autotune tile config.
+    """
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        M: int,
+        D: int,
+        eps: float,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        self.M = M
+        self.D = D
+        self.eps = eps
+        self.dtype = dtype
+        self.D_padded = _align_up(D, ALIGNMENT)
+        self.kernel = _group_norm_no_affine_kernel(
+            self.M, self.D, self.eps, self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_m = 1
+        for bm in [1, 2, 4, 8, 16]:
+            if bm <= max_block_m:
+                block_m = bm
+        return {"block_m": block_m, "threads": 256}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
+        max_block_m = (48 * 1024) // smem_per_row
+        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
+        threads_list = [128, 256]
+        configs = list(itertools.product(block_ms, threads_list))
+        return [{"block_m": bm, "threads": t} for bm, t in configs]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _group_norm_no_affine_wrapped(
+            self.M,
+            self.D,
+            self.eps,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
         )

--- a/tileops/kernels/norm/instance_norm.py
+++ b/tileops/kernels/norm/instance_norm.py
@@ -1,4 +1,34 @@
-# InstanceNorm reuses GroupNormKernel with G=C.
-# No dedicated kernel is needed; see tileops/kernels/norm/group_norm.py.
+"""InstanceNorm kernels.
 
-__all__: list[str] = []
+InstanceNorm is the special case of GroupNorm with G = C (each channel is
+its own group). The math reduces exactly to the GroupNorm row-wise kernel
+on a reshape of ``(N, C, *spatial) -> (N*C, spatial_size)``.
+
+This module exposes thin aliases over the GroupNorm kernels so that
+op modules and the manifest can name the InstanceNorm-specific kernel
+without duplicating the TileLang body.
+"""
+
+from .group_norm import GroupNormKernel, GroupNormNoAffineKernel
+
+__all__ = ["InstanceNormKernel", "InstanceNormNoAffineKernel"]
+
+
+class InstanceNormKernel(GroupNormKernel):
+    """InstanceNorm forward kernel with affine scale/shift.
+
+    Alias of :class:`GroupNormKernel` invoked with ``G = C``; the underlying
+    row-wise kernel is identical. Defined here so that
+    :mod:`tileops.ops.norm.instance_norm` and the manifest can refer to an
+    InstanceNorm-specific kernel symbol.
+    """
+
+
+class InstanceNormNoAffineKernel(GroupNormNoAffineKernel):
+    """InstanceNorm forward kernel without affine scale/shift.
+
+    Alias of :class:`GroupNormNoAffineKernel` invoked with ``G = C``; the
+    underlying row-wise kernel is identical. Defined here so that
+    :mod:`tileops.ops.norm.instance_norm` and the manifest can refer to an
+    InstanceNorm-specific kernel symbol.
+    """

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -596,7 +596,7 @@ InstanceNormFwdOpNoAffine:
   source:
     kernel: tileops/kernels/norm/group_norm.py
     kernel_map:
-      group_norm_no_affine: GroupNormNoAffineKernel
+      instance_norm_no_affine: InstanceNormNoAffineKernel
     op: tileops/ops/norm/instance_norm.py
     test: tests/ops/test_instance_norm.py
     bench: benchmarks/ops/bench_instance_norm.py

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -559,7 +559,7 @@ InstanceNormFwdOpNoAffine:
   # default for InstanceNorm. Split from the affine primary per the
   # "No Optional[Tensor]" rule (R16, .claude/domain-rules/manifest-spec.md).
   family: normalization
-  status: implemented
+  status: spec-only
   variant_of: InstanceNormFwdOp
 
   signature:

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -462,7 +462,7 @@ GroupNormFwdOpNoAffine:
   # .claude/domain-rules/manifest-spec.md). torch.nn.GroupNorm toggles
   # weight and bias together via the affine flag.
   family: normalization
-  status: spec-only
+  status: implemented
   variant_of: GroupNormFwdOp
 
   signature:
@@ -500,7 +500,7 @@ GroupNormFwdOpNoAffine:
   source:
     kernel: tileops/kernels/norm/group_norm.py
     kernel_map:
-      group_norm: GroupNormKernel
+      group_norm_no_affine: GroupNormNoAffineKernel
     op: tileops/ops/norm/group_norm.py
     test: tests/ops/test_group_norm.py
     bench: benchmarks/ops/bench_group_norm.py
@@ -559,7 +559,7 @@ InstanceNormFwdOpNoAffine:
   # default for InstanceNorm. Split from the affine primary per the
   # "No Optional[Tensor]" rule (R16, .claude/domain-rules/manifest-spec.md).
   family: normalization
-  status: spec-only
+  status: implemented
   variant_of: InstanceNormFwdOp
 
   signature:
@@ -596,7 +596,7 @@ InstanceNormFwdOpNoAffine:
   source:
     kernel: tileops/kernels/norm/group_norm.py
     kernel_map:
-      group_norm: GroupNormKernel
+      group_norm_no_affine: GroupNormNoAffineKernel
     op: tileops/ops/norm/instance_norm.py
     test: tests/ops/test_instance_norm.py
     bench: benchmarks/ops/bench_instance_norm.py

--- a/tileops/ops/norm/__init__.py
+++ b/tileops/ops/norm/__init__.py
@@ -3,8 +3,8 @@ from .ada_layer_norm_zero import AdaLayerNormZeroFwdOp
 from .batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from .fused_add_layer_norm import FusedAddLayerNormFwdOp
 from .fused_add_rms_norm import FusedAddRMSNormFwdOp
-from .group_norm import GroupNormFwdOp
-from .instance_norm import InstanceNormFwdOp
+from .group_norm import GroupNormFwdOp, GroupNormFwdOpNoAffine
+from .instance_norm import InstanceNormFwdOp, InstanceNormFwdOpNoAffine
 from .layer_norm import LayerNormFwdOp
 from .rms_norm import RMSNormFwdOp
 
@@ -16,7 +16,9 @@ __all__: list[str] = [
     "FusedAddLayerNormFwdOp",
     "FusedAddRMSNormFwdOp",
     "GroupNormFwdOp",
+    "GroupNormFwdOpNoAffine",
     "InstanceNormFwdOp",
+    "InstanceNormFwdOpNoAffine",
     "LayerNormFwdOp",
     "RMSNormFwdOp",
 ]

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -28,6 +28,11 @@ from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["GroupNormFwdOp", "GroupNormFwdOpNoAffine"]
 
+# Largest candidate block_m in GroupNormNoAffineKernel.autotune_configs.
+# The op pads M to a multiple of this value so the kernel's full-tile
+# T.copy never crosses the M boundary regardless of the selected block_m.
+_M_BLOCK_ALIGN = 16
+
 
 class GroupNormFwdOp(Op):
     """Group Normalization forward operator.
@@ -313,9 +318,13 @@ class GroupNormFwdOpNoAffine(Op):
         self.D = (C // num_groups) * self.spatial_size
         self.M = N * num_groups
         self.D_padded = align_up(self.D, ALIGNMENT)
+        # Kernel launches T.ceildiv(M, block_m) programs, each copying a full
+        # block_m-row tile. Pad M to a multiple of the largest candidate
+        # block_m so the tail program never reads/writes past the input.
+        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["group_norm_no_affine"](
-            self.M, self.D, eps, dtype, tune=tune,
+            self.M_padded, self.D, eps, dtype, tune=tune,
         )
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
 
@@ -365,9 +374,14 @@ class GroupNormFwdOpNoAffine(Op):
 
         if self.D_padded != self.D:
             x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+        if self.M_padded != self.M:
+            # Pad along dim 0 (M); padded rows are dropped after the kernel.
+            x_2d = F.pad(x_2d, (0, 0, 0, self.M_padded - self.M))
 
         y_2d = self.kernel(x_2d)
 
+        if self.M_padded != self.M:
+            y_2d = y_2d[:self.M, :]
         if self.D_padded != self.D:
             y_2d = y_2d[:, :self.D]
 

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -365,6 +365,11 @@ class GroupNormFwdOpNoAffine(Op):
             raise ValueError(
                 f"Expected x.dtype {self.dtype}, got {x.dtype}"
             )
+        expected_shape = (self.N, self.C, *self.spatial)
+        if tuple(x.shape) != expected_shape:
+            raise ValueError(
+                f"Expected x shape {expected_shape}, got {tuple(x.shape)}"
+            )
 
         orig_shape = x.shape
         x = x.contiguous()

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -21,12 +21,12 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.norm import GroupNormKernel
+from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 
 from ..op_base import Op
 from .norm_base import ALIGNMENT, align_up
 
-__all__ = ["GroupNormFwdOp"]
+__all__ = ["GroupNormFwdOp", "GroupNormFwdOpNoAffine"]
 
 
 class GroupNormFwdOp(Op):
@@ -255,3 +255,121 @@ class GroupNormFwdOp(Op):
             y = y + bias.reshape(affine_shape)
 
         return y
+
+
+class GroupNormFwdOpNoAffine(Op):
+    """Group Normalization forward without affine scale/shift.
+
+    Computes group normalization without the trailing weight/bias affine:
+
+    .. math::
+
+        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+
+    where the mean and variance are computed per group over
+    ``(C/num_groups, *spatial)`` elements. Mirrors
+    ``torch.nn.functional.group_norm(x, num_groups, weight=None, bias=None)``
+    and ``torch.nn.GroupNorm(affine=False)``.
+
+    Supported dtypes:
+        ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
+
+    Args:
+        N: Batch size.
+        C: Number of channels.
+        spatial: Spatial dimensions tuple ``(H, W, ...)``.
+        num_groups: Number of groups (manifest ``params.num_groups``).
+            Must divide *C* evenly.
+        dtype: Data type (``torch.float32``, ``torch.float16``, or
+            ``torch.bfloat16``).
+        eps: Epsilon for numerical stability.
+        kernel_map: Optional kernel override dictionary.
+        tune: If ``True``, autotune tile configurations.
+    """
+
+    def __init__(
+        self,
+        N: int,
+        C: int,
+        spatial: tuple,
+        num_groups: int,
+        dtype: torch.dtype,
+        eps: float = 1e-5,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        if C % num_groups != 0:
+            raise ValueError(
+                f"C={C} must be divisible by num_groups={num_groups}"
+            )
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.num_groups = num_groups
+        self.dtype = dtype
+        self.eps = eps
+        self.spatial_size = math.prod(spatial)
+        self.D = (C // num_groups) * self.spatial_size
+        self.M = N * num_groups
+        self.D_padded = align_up(self.D, ALIGNMENT)
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["group_norm_no_affine"](
+            self.M, self.D, eps, dtype, tune=tune,
+        )
+        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"group_norm_no_affine": GroupNormNoAffineKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        elem_bytes = self.dtype.itemsize
+        return (
+            3 * self.N * self.C * self.spatial_size,
+            2 * self.N * self.C * self.spatial_size * elem_bytes,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply group normalization without affine.
+
+        Args:
+            x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
+
+        Returns:
+            Normalized tensor of the same shape as *x*.
+
+        Raises:
+            ValueError: If *x* is not a CUDA tensor, lives on a different
+                device than the op was constructed for, or its dtype does
+                not match the configured dtype.
+        """
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.device != self._kernel_device:
+            raise ValueError(
+                f"Device mismatch: op was constructed for {self._kernel_device} "
+                f"but x is on {x.device}. Construct a separate op instance per "
+                f"CUDA device."
+            )
+        if x.dtype != self.dtype:
+            raise ValueError(
+                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+            )
+
+        orig_shape = x.shape
+        x = x.contiguous()
+        cpg = self.C // self.num_groups
+        x_reshaped = x.reshape(self.N, self.num_groups, cpg, *self.spatial)
+        x_2d = x_reshaped.reshape(self.M, self.D)
+
+        if self.D_padded != self.D:
+            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+
+        y_2d = self.kernel(x_2d)
+
+        if self.D_padded != self.D:
+            y_2d = y_2d[:, :self.D]
+
+        y = y_2d.reshape(self.N, self.num_groups, cpg, *self.spatial)
+        return y.reshape(orig_shape)

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -19,7 +19,10 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
+from tileops.kernels.norm import (
+    GroupNormKernel,
+    InstanceNormNoAffineKernel,
+)
 
 from ..op_base import Op
 from .norm_base import ALIGNMENT, align_up
@@ -300,14 +303,14 @@ class InstanceNormFwdOpNoAffine(Op):
         self.M = N * C
         self.D_padded = align_up(self.D, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["group_norm_no_affine"](
+        self.kernel = self.kernel_map["instance_norm_no_affine"](
             self.M, self.D, eps, dtype, tune=tune,
         )
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"group_norm_no_affine": GroupNormNoAffineKernel}
+        return {"instance_norm_no_affine": InstanceNormNoAffineKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
         elem_bytes = self.dtype.itemsize

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -29,6 +29,11 @@ from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["InstanceNormFwdOp", "InstanceNormFwdOpNoAffine"]
 
+# Largest candidate block_m in InstanceNormNoAffineKernel.autotune_configs.
+# The op pads M to a multiple of this value so the kernel's full-tile
+# T.copy never crosses the M boundary regardless of the selected block_m.
+_M_BLOCK_ALIGN = 16
+
 
 class InstanceNormFwdOp(Op):
     """Instance Normalization forward operator.
@@ -302,9 +307,13 @@ class InstanceNormFwdOpNoAffine(Op):
         self.D = self.spatial_size
         self.M = N * C
         self.D_padded = align_up(self.D, ALIGNMENT)
+        # Kernel launches T.ceildiv(M, block_m) programs, each copying a full
+        # block_m-row tile. Pad M to a multiple of the largest candidate
+        # block_m so the tail program never reads/writes past the input.
+        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["instance_norm_no_affine"](
-            self.M, self.D, eps, dtype, tune=tune,
+            self.M_padded, self.D, eps, dtype, tune=tune,
         )
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
 
@@ -352,9 +361,14 @@ class InstanceNormFwdOpNoAffine(Op):
 
         if self.D_padded != self.D:
             x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+        if self.M_padded != self.M:
+            # Pad along dim 0 (M); padded rows are dropped after the kernel.
+            x_2d = F.pad(x_2d, (0, 0, 0, self.M_padded - self.M))
 
         y_2d = self.kernel(x_2d)
 
+        if self.M_padded != self.M:
+            y_2d = y_2d[:self.M, :]
         if self.D_padded != self.D:
             y_2d = y_2d[:, :self.D]
 

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -293,8 +293,10 @@ class InstanceNormFwdOpNoAffine(Op):
         tune: bool = False,
     ):
         if not use_input_stats:
-            raise NotImplementedError(
-                "use_input_stats=False (running-stats path) is out of scope"
+            raise ValueError(
+                "use_input_stats=False (running-stats / eval-mode path) is "
+                "not supported by InstanceNormFwdOpNoAffine; only "
+                "use_input_stats=True (per-batch statistics) is implemented."
             )
         self.N = N
         self.C = C
@@ -353,6 +355,11 @@ class InstanceNormFwdOpNoAffine(Op):
         if x.dtype != self.dtype:
             raise ValueError(
                 f"Expected x.dtype {self.dtype}, got {x.dtype}"
+            )
+        expected_shape = (self.N, self.C, *self.spatial)
+        if tuple(x.shape) != expected_shape:
+            raise ValueError(
+                f"Expected x shape {expected_shape}, got {tuple(x.shape)}"
             )
 
         orig_shape = x.shape

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -19,12 +19,12 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.norm import GroupNormKernel
+from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 
 from ..op_base import Op
 from .norm_base import ALIGNMENT, align_up
 
-__all__ = ["InstanceNormFwdOp"]
+__all__ = ["InstanceNormFwdOp", "InstanceNormFwdOpNoAffine"]
 
 
 class InstanceNormFwdOp(Op):
@@ -241,3 +241,118 @@ class InstanceNormFwdOp(Op):
             y = y + bias.reshape(affine_shape)
 
         return y
+
+
+class InstanceNormFwdOpNoAffine(Op):
+    """Instance Normalization forward without affine scale/shift.
+
+    Computes instance normalization without the trailing weight/bias affine:
+
+    .. math::
+
+        y = \\frac{x - \\mathrm{E}[x]}{\\sqrt{\\mathrm{Var}[x] + \\epsilon}}
+
+    where the mean and variance are computed over ``*spatial`` for each
+    sample-channel pair. Mirrors
+    ``torch.nn.functional.instance_norm(x, weight=None, bias=None, ...)``
+    and ``torch.nn.InstanceNorm*(affine=False)`` (the InstanceNorm default).
+
+    Supported dtypes:
+        ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
+
+    Args:
+        N: Batch size.
+        C: Number of channels.
+        spatial: Spatial dimensions tuple ``(H, W, ...)``.
+        dtype: Data type (``torch.float32``, ``torch.float16``, or
+            ``torch.bfloat16``).
+        eps: Epsilon for numerical stability.
+        kernel_map: Optional kernel override dictionary.
+        tune: If ``True``, autotune tile configurations.
+    """
+
+    def __init__(
+        self,
+        N: int,
+        C: int,
+        spatial: tuple,
+        dtype: torch.dtype,
+        use_input_stats: bool = True,
+        momentum: float = 0.1,
+        eps: float = 1e-5,
+        *,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ):
+        if not use_input_stats:
+            raise NotImplementedError(
+                "use_input_stats=False (running-stats path) is out of scope"
+            )
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.dtype = dtype
+        self.use_input_stats = use_input_stats
+        self.momentum = momentum
+        self.eps = eps
+        self.spatial_size = math.prod(spatial)
+        self.D = self.spatial_size
+        self.M = N * C
+        self.D_padded = align_up(self.D, ALIGNMENT)
+        self.dispatch_kernel(kernel_map)
+        self.kernel = self.kernel_map["group_norm_no_affine"](
+            self.M, self.D, eps, dtype, tune=tune,
+        )
+        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"group_norm_no_affine": GroupNormNoAffineKernel}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        elem_bytes = self.dtype.itemsize
+        return (
+            3 * self.N * self.C * self.spatial_size,
+            2 * self.N * self.C * self.spatial_size * elem_bytes,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply instance normalization without affine.
+
+        Args:
+            x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
+
+        Returns:
+            Normalized tensor of the same shape as *x*.
+
+        Raises:
+            ValueError: If *x* is not a CUDA tensor, lives on a different
+                device than the op was constructed for, or its dtype does
+                not match the configured dtype.
+        """
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.device != self._kernel_device:
+            raise ValueError(
+                f"Device mismatch: op was constructed for {self._kernel_device} "
+                f"but x is on {x.device}. Construct a separate op instance per "
+                f"CUDA device."
+            )
+        if x.dtype != self.dtype:
+            raise ValueError(
+                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+            )
+
+        orig_shape = x.shape
+        x = x.contiguous()
+        x_2d = x.reshape(self.M, self.D)
+
+        if self.D_padded != self.D:
+            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+
+        y_2d = self.kernel(x_2d)
+
+        if self.D_padded != self.D:
+            y_2d = y_2d[:, :self.D]
+
+        return y_2d.reshape(orig_shape)


### PR DESCRIPTION
Closes #1275

## Summary

- Add `GroupNormNoAffineKernel` (real no-affine kernel; no weight/bias multiply-add) in `tileops/kernels/norm/group_norm.py`; alias `InstanceNormNoAffineKernel` re-exported from `tileops/kernels/norm/instance_norm.py`.
- `GroupNormFwdOpNoAffine` and `InstanceNormFwdOpNoAffine` route the no-affine signature directly to the no-affine kernel — `Op.forward(self, x)`, no identity-weight/bias synthesis.
- Op layer pads `M` to a multiple of the largest candidate `block_m` to prevent tail-block OOB on `T.ceildiv(M, block_m)` programs.
- `forward()` validates `x.shape == (self.N, self.C, *self.spatial)` and raises `ValueError` on mismatch.
- **Scope-down**: only `GroupNormFwdOpNoAffine` is promoted to `status: implemented`. `InstanceNormFwdOpNoAffine` remains `spec-only` because PyTorch's `torch.nn.functional.instance_norm` declares `use_input_stats` / `momentum` (so the manifest must too), and this PR only handles `use_input_stats=True`. The running-stats path (`use_input_stats=False`) is tracked in follow-up issue #1289 and will re-promote the variant once landed.

## Test plan

- [x] AC-1: no-affine kernels expose a code path that does not perform a weight/bias affine multiply/add (`tileops/kernels/norm/{group_norm,instance_norm}.py`).
- [x] AC-2: no-affine ops route the no-affine signature directly to the new kernel — no identity-weight/bias synthesis (`tileops/ops/norm/{group_norm,instance_norm}.py`).
- [x] AC-3: `pytest tests/ops/test_group_norm.py tests/ops/test_instance_norm.py -m "smoke or full"` — GroupNorm no-affine tests pass; InstanceNorm no-affine tests will land in #1289 alongside the running-stats implementation. 50 passed on current head.
- [x] AC-4 (partial): `python scripts/validate_manifest.py` and `pytest tests/test_validate_manifest.py` both pass; `GroupNormFwdOpNoAffine.status` flipped to `implemented`. `InstanceNormFwdOpNoAffine.status` stays `spec-only` until #1289.

## Structural Readiness

- `[REC] BenchmarkBase / calculate_flops / calculate_memory / dtype matrix` — SKIP. Issue constraints state: "Each variant gets benchmark coverage as a separate follow-up; this issue is implementation + tests only."
- `[REQ] Dtype support matrix in PR body` — inherited from primary affine entries; the no-affine kernel subclasses the same SUPPORTED_DTYPES surface (fp16, bf16, fp32) and validates via `Kernel.__init__`.
- All other `[REQ]` items: PASS.

## Test node delta

```
tests/ops/test_group_norm.py: 16 -> 32 (+16)
tests/ops/test_instance_norm.py: 10 -> 10 (unchanged)
```

**Justification:** new no-affine GroupNorm variant needs its own coverage matrix (shapes × dtypes); reusing existing affine cases would not exercise the no-affine signature path. InstanceNorm no-affine tests will be authored in follow-up #1289 alongside the running-stats implementation, so this PR adds no skipped scaffolding for the still-spec-only variant.
