### PR TITLE
[BugFix][Attention] fix MHA decode lse layout inference

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -31,8 +31,6 @@ TILELANG_019_BENCH_PATHS = {
     "benchmarks/ops/attention/bench_gqa_sliding_window.py",
     "benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py",
     "benchmarks/ops/attention/bench_mha.py",
-    "benchmarks/ops/attention/bench_mha_decode.py",
-    "benchmarks/ops/attention/bench_mha_decode_paged.py",
     # Other operators.
     "benchmarks/ops/bench_fft.py",
     "benchmarks/ops/bench_mhc_post.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ TILELANG_019_SKIP_REASON = (
 
 TILELANG_019_KNOWN_FAILING_PATH_SUFFIXES = (
     "tests/ops/test_batch_norm.py",
-    "tests/ops/attention/test_mha_decode_paged.py",
 )
 
 TILELANG_019_KNOWN_FAILING_NODEIDS = {

--- a/tests/ops/attention/test_mha_decode.py
+++ b/tests/ops/attention/test_mha_decode.py
@@ -33,8 +33,6 @@ class MhaDecodeFixture(FixtureBase):
 @MhaDecodeFixture
 def test_mha_decode(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: torch.dtype,
                     tune: bool) -> None:
-    if s_kv == 8192:
-        pytest.skip("Long-context MHA decode fails under tilelang 0.1.9; re-enable when decode produces numerically correct results.")
     test = MhaDecodeTest(b, h, s_q, s_kv, d, dtype)
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=2e-3, rtol=1e-5)

--- a/tests/ops/attention/test_mha_decode_paged.py
+++ b/tests/ops/attention/test_mha_decode_paged.py
@@ -94,7 +94,6 @@ def test_mha_decode_paged_op(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    pytest.skip("Paged MHA decode fails under tilelang 0.1.9; re-enable when decode produces numerically correct results.")
     test = MhaDecodePagedTest(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch=batch,

--- a/tileops/kernels/attention/mha_decode.py
+++ b/tileops/kernels/attention/mha_decode.py
@@ -281,7 +281,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                     by,
                     :,
                     bx * block_M:(bx + 1) * block_M,
-                ], lse_shared)
+                ], lse_shared, disable_tma=True)
                 T.copy(lse_shared, lse_local)
                 T.reduce_max(lse_local, lse_max_local, dim=0, clear=False)
                 for k in T.Pipelined(num_split):

--- a/tileops/kernels/attention/mha_decode.py
+++ b/tileops/kernels/attention/mha_decode.py
@@ -256,6 +256,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                 po_shared = T.alloc_shared([block_M, dim], dtype)
                 o_accum_local = T.alloc_fragment([block_M, dim], accum_dtype)
                 o_shared = T.alloc_shared([block_M, dim], dtype)
+                lse_shared = T.alloc_shared([num_split, block_M], dtype)
                 lse_local = T.alloc_fragment([num_split, block_M], dtype)
                 lse_local_split = T.alloc_fragment([block_M], accum_dtype)
                 lse_logsum_local = T.alloc_fragment([block_M], accum_dtype)
@@ -269,6 +270,8 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                         tilelang.layout.make_swizzled_layout(o_shared),
                     po_shared:
                         tilelang.layout.make_swizzled_layout(po_shared),
+                    lse_local:
+                        T.Fragment(lse_local.shape, forward_thread_fn=lambda _k, i: i),
                 })
 
                 T.clear(lse_logsum_local)
@@ -278,10 +281,11 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                     by,
                     :,
                     bx * block_M:(bx + 1) * block_M,
-                ], lse_local)
+                ], lse_shared)
+                T.copy(lse_shared, lse_local)
                 T.reduce_max(lse_local, lse_max_local, dim=0, clear=False)
                 for k in T.Pipelined(num_split):
-                    T.copy(lse_local[k, :], lse_local_split)
+                    T.copy(lse_shared[k, :], lse_local_split)
                     for i in T.Parallel(block_M):
                         lse_logsum_local[i] += T.exp2(lse_local_split[i] - lse_max_local[i])
                 for i in T.Parallel(block_M):
@@ -292,8 +296,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, 
                         po_shared,
                         disable_tma=True)
                     T.copy(po_shared, po_local)
-                    for i in T.Parallel(block_M):
-                        lse_local_split[i] = lse_local[k, i]
+                    T.copy(lse_shared[k, :], lse_local_split)
                     for i in T.Parallel(block_M):
                         scale_local[i] = T.exp2(lse_local_split[i] - lse_logsum_local[i])
                     for i, j in T.Parallel(block_M, dim):

--- a/tileops/kernels/attention/mha_decode_paged.py
+++ b/tileops/kernels/attention/mha_decode_paged.py
@@ -313,6 +313,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
                 po_shared = T.alloc_shared([block_M, dim], dtype)
                 o_accum_local = T.alloc_fragment([block_M, dim], accum_dtype)
                 o_shared = T.alloc_shared([block_M, dim], dtype)
+                lse_shared = T.alloc_shared([num_split, block_M], dtype)
                 lse_local = T.alloc_fragment([num_split, block_M], dtype)
                 lse_local_split = T.alloc_fragment([block_M], accum_dtype)
                 lse_logsum_local = T.alloc_fragment([block_M], accum_dtype)
@@ -326,6 +327,8 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
                         tilelang.layout.make_swizzled_layout(o_shared),
                     po_shared:
                         tilelang.layout.make_swizzled_layout(po_shared),
+                    lse_local:
+                        T.Fragment(lse_local.shape, forward_thread_fn=lambda _k, i: i),
                 })
 
                 T.clear(lse_logsum_local)
@@ -335,10 +338,11 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
                     by,
                     :,
                     bx * block_M:(bx + 1) * block_M,
-                ], lse_local)
+                ], lse_shared)
+                T.copy(lse_shared, lse_local)
                 T.reduce_max(lse_local, lse_max_local, dim=0, clear=False)
                 for k in T.Pipelined(num_split):
-                    T.copy(lse_local[k, :], lse_local_split)
+                    T.copy(lse_shared[k, :], lse_local_split)
                     for i in T.Parallel(block_M):
                         lse_logsum_local[i] += T.exp2(lse_local_split[i] - lse_max_local[i])
                 for i in T.Parallel(block_M):
@@ -349,8 +353,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
                         po_shared,
                         disable_tma=True)
                     T.copy(po_shared, po_local)
-                    for i in T.Parallel(block_M):
-                        lse_local_split[i] = lse_local[k, i]
+                    T.copy(lse_shared[k, :], lse_local_split)
                     for i in T.Parallel(block_M):
                         scale_local[i] = T.exp2(lse_local_split[i] - lse_logsum_local[i])
                     for i, j in T.Parallel(block_M, dim):

--- a/tileops/kernels/attention/mha_decode_paged.py
+++ b/tileops/kernels/attention/mha_decode_paged.py
@@ -338,7 +338,7 @@ def _mha_decode_split_kernel(batch, heads, seqlen_q, seqlen_kv, dim, page_size, 
                     by,
                     :,
                     bx * block_M:(bx + 1) * block_M,
-                ], lse_shared)
+                ], lse_shared, disable_tma=True)
                 T.copy(lse_shared, lse_local)
                 T.reduce_max(lse_local, lse_max_local, dim=0, clear=False)
                 for k in T.Pipelined(num_split):


### PR DESCRIPTION
## Summary

Closes #1074.

- Stage MHA decode split LSE values through shared memory before per-split reads, while keeping `lse_local` as a fragment for `T.reduce_max`.
- Apply the same layout-inference fix to dense and paged MHA decode kernels.
- Re-enable the TileLang 0.1.9 MHA decode tests and benchmarks that were skipped for this failure.

## Test plan

- `python -m pytest tests/ops/attention/test_mha_decode.py tests/ops/attention/test_mha_decode_paged.py -q -rs`
  - Result: `7 passed`
- Direct representative validation under `tilelang==0.1.9` was also run during triage for:
  - dense MHA decode fp16/bf16 long-context cases
  - paged MHA decode smoke cases
  - explicit `num_split=2` and `num_split=8` kernel construction paths

## Benchmark

Benchmarks were run on GPU 1, confirmed at 1830 MHz SM clock before execution.

- Modified branch, `tilelang==0.1.9`:
  - `CUDA_VISIBLE_DEVICES=1 python -m pytest benchmarks/ops/attention/bench_mha_decode.py benchmarks/ops/attention/bench_mha_decode_paged.py -q -s -rs`
  - Result: `7 passed`
- Baseline `main`, `conda tileops-release`, `tilelang==0.1.8`, same GPU:
  - `CUDA_VISIBLE_DEVICES=1 /home/lyc/miniconda3/envs/tileops-release/bin/python -m pytest benchmarks/ops/attention/bench_mha_decode.py benchmarks/ops/attention/bench_mha_decode_paged.py -q -rs`
  - Result: `7 passed`

TileOps latency comparison, ms:

| Case | Modified 0.1.9 | main 0.1.8 | Impact |
| --- | ---: | ---: | --- |
| MHA decode fp16 long cache | 0.0515 | 0.0539 | no regression, ~4.5% faster |
| MHA decode bf16 long cache | 0.0512 | 0.0542 | no regression, ~5.5% faster |
| MHA decode short kv tail | 0.0049 | 0.0048 | effectively flat, +0.0001 ms |
| Paged decode single-token page128 | 0.0230 | 0.0232 | no regression |
| Paged decode batch2-page256 | 0.0211 | 0.0216 | no regression |
| Paged decode longer-cache | 0.0221 | 0.0221 | flat |
| Paged decode shorter-cache | 0.0208 | 0.0221 | no regression, ~5.9% faster |

Conclusion: no material benchmark regression was observed from this change.

## Regression

This fixes the TileLang 0.1.9 fragment access layout inference failure triggered by reading `lse_local[k, i]` inside a `T.Parallel` loop. The updated path avoids non-zero fragment indexing inside the parallel loop by copying the per-split LSE row from shared memory into a fragment before use.
