### PR TITLE
[Maintain][Manifest] flip elementwise_multi_input WhereFwdOp to implemented

### DIFF
--- a/tileops/manifest/elementwise_multi_input.yaml
+++ b/tileops/manifest/elementwise_multi_input.yaml
@@ -8,7 +8,7 @@
 WhereFwdOp:
   ref_api: "torch.where"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
## Summary

Flip `status: spec-only → implemented` for `WhereFwdOp` in `tileops/manifest/elementwise_multi_input.yaml`.

`LerpTensorFwdOp` was already flipped to `implemented` by follow-up #1264 (real implementation), so it is not touched here.

Sibling impl PR #1229 has merged. Refactor #1250 also on main.

## Test plan

- [x] `python scripts/validate_manifest.py` exits 0
- [x] `git diff` shows only `status:` line change for `WhereFwdOp`

Closes #1197.
