### PR TITLE
[Maintain][Manifest] flip reduction LogSoftmax/LogSumExp/Prod to implemented

### DIFF
--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -55,7 +55,7 @@ SoftmaxFwdOp:
 LogSoftmaxFwdOp:
   ref_api: "torch.nn.functional.log_softmax"
   family: reduction
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -107,7 +107,7 @@ LogSoftmaxFwdOp:
 LogSumExpFwdOp:
   ref_api: "torch.logsumexp"
   family: reduction
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -347,7 +347,7 @@ AminFwdOp:
 ProdFwdOp:
   ref_api: "torch.prod"
   family: reduction
-  status: spec-only
+  status: implemented
   # NOTE: torch.prod has two overloads -- prod(input) for full reduction (no
   # dim arg) and prod(input, dim, keepdim=False) where dim is a required int.
   # Unlike torch.sum, torch.prod's dim overload rejects dim=None at runtime


### PR DESCRIPTION
## Summary

Flip `status: spec-only → implemented` for the 3 fully-aligned reduction ops in `tileops/manifest/reduction.yaml`:

- `LogSoftmaxFwdOp` (restore from spec-only — FLOP path fixed in impl PR #1235; manifest's `5 * M * N` matches code)
- `LogSumExpFwdOp`
- `ProdFwdOp`

### Scope reduction vs issue body

Issue #1199 listed 13 target ops. The remaining 10 (`SumFwdOp`, `MeanFwdOp`, `AmaxFwdOp`, `AminFwdOp`, `VarFwdOp`, `StdFwdOp`, `VarMeanFwdOp`, `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`) carry an inline `# dim=None not yet implemented; update when impl lands` comment in the manifest — their implementations do not yet support the `dim=None` case the PyTorch-aligned manifest signature declares. Those ops remain `spec-only` until the `dim=None` impl lands; flipping them now would create a real spec-vs-code divergence.

This PR therefore flips only the 3 ops with no outstanding `dim=None` blocker.

## Test plan

- [x] `python scripts/validate_manifest.py` exits 0
- [x] `git diff` shows only `status:` line changes on the 3 ops
- [x] Ops with `# dim=None not yet implemented` comment remain `spec-only`

Partial closure of #1199 — issue should be updated (or kept open until `dim=None` impl lands and the remaining 10 can flip).
