### PR TITLE
[Maintain][Manifest] flip normalization status to implemented

### DIFF
--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -7,7 +7,7 @@
 RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -55,7 +55,7 @@ RMSNormFwdOp:
 LayerNormFwdOp:
   ref_api: "torch.nn.functional.layer_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -105,7 +105,7 @@ LayerNormFwdOp:
 AdaLayerNormFwdOp:
   ref_api: "none"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -150,7 +150,7 @@ AdaLayerNormFwdOp:
 AdaLayerNormZeroFwdOp:
   ref_api: "none"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -197,7 +197,7 @@ AdaLayerNormZeroFwdOp:
 FusedAddLayerNormFwdOp:
   ref_api: "none"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -247,7 +247,7 @@ FusedAddLayerNormFwdOp:
 FusedAddRMSNormFwdOp:
   ref_api: "none"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -302,7 +302,7 @@ FusedAddRMSNormFwdOp:
 BatchNormFwdOp:
   ref_api: "torch.nn.functional.batch_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -356,7 +356,7 @@ BatchNormFwdOp:
 BatchNormBwdOp:
   ref_api: "torch.nn.functional.batch_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -410,7 +410,7 @@ BatchNormBwdOp:
 GroupNormFwdOp:
   ref_api: "torch.nn.functional.group_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -508,7 +508,7 @@ GroupNormFwdOpNoAffine:
 InstanceNormFwdOp:
   ref_api: "torch.nn.functional.instance_norm"
   family: normalization
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
## Summary

Flip `status: spec-only → implemented` for the 10 normalization ops in `tileops/manifest/normalization.yaml`:

`RMSNormFwdOp`, `LayerNormFwdOp`, `BatchNormFwdOp`, `BatchNormBwdOp`, `GroupNormFwdOp`, `InstanceNormFwdOp`, `AdaLayerNormFwdOp`, `AdaLayerNormZeroFwdOp`, `FusedAddLayerNormFwdOp`, `FusedAddRMSNormFwdOp`.

The two no-affine variants (`GroupNormFwdOpNoAffine`, `InstanceNormFwdOpNoAffine`) are already `implemented` (added in #1284) and not touched here.

Sibling impl PR #1240 has merged. Refactor #1256 and follow-ups #1266 / #1274 / #1284 all on main. testbed→main promotion (#1380) brought #1373 (InstanceNormFwdOp ctor `use_input_stats` / `momentum` alignment) onto main, so InstanceNorm now matches its manifest contract.

This is the last flip in W2. With this merged, all of W2 (#1142) is on `implemented` for the elementwise / reduction (partial — see #1199) / normalization families.

## Test plan

- [x] `python scripts/validate_manifest.py` exits 0
- [x] `git diff` shows only `status:` line changes
- [x] All 10 target ops carry `status: implemented` post-flip
- [x] No-affine variants remain unchanged

Closes #1201.
