### PR TITLE
[Refactor][Benchmark] route ada_layer_norm and cumulative benches through manifest

### DIFF
--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -55,9 +55,9 @@ class AdaLayerNormZeroBenchmark(BenchmarkBase[AdaLayerNormZeroTest]):
         return self._get_roofline()[1]
 
 
-def _manifest_params(op_name):
+def _to_params(workloads):
     params = []
-    for w in load_workloads(op_name):
+    for w in workloads:
         m, n = w["x_shape"]
         label = w.get("label", f"{m}x{n}")
         for dtype_str in w["dtypes"]:
@@ -67,7 +67,7 @@ def _manifest_params(op_name):
     return params
 
 
-@pytest.mark.parametrize("m, n, dtype", _manifest_params(_ADA_OP_NAME))
+@pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_OP_NAME)))
 def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
@@ -86,7 +86,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-@pytest.mark.parametrize("m, n, dtype", _manifest_params(_ADA_ZERO_OP_NAME))
+@pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
 def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroTest(m, n, dtype)
     inputs = test.gen_inputs()

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -24,9 +24,11 @@ class AdaLayerNormBenchmark(BenchmarkBase[AdaLayerNormTest]):
         self._op = op
 
     def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = self._op.eval_roofline()
-        return self._roofline_cache
+        cache = self._roofline_cache
+        if cache is None:
+            cache = self._op.eval_roofline()
+            self._roofline_cache = cache
+        return cache
 
     def calculate_flops(self) -> Optional[float]:
         return self._get_roofline()[0]
@@ -44,9 +46,11 @@ class AdaLayerNormZeroBenchmark(BenchmarkBase[AdaLayerNormZeroTest]):
         self._op = op
 
     def _get_roofline(self) -> tuple[float, float]:
-        if self._roofline_cache is None:
-            self._roofline_cache = self._op.eval_roofline()
-        return self._roofline_cache
+        cache = self._roofline_cache
+        if cache is None:
+            cache = self._op.eval_roofline()
+            self._roofline_cache = cache
+        return cache
 
     def calculate_flops(self) -> Optional[float]:
         return self._get_roofline()[0]

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -1,34 +1,26 @@
-"""Benchmarks for cumulative ops (cumsum, cumprod)."""
+"""Benchmarks for cumulative ops (cumsum, cumprod).
 
-from typing import Optional
+Workload shapes and roofline formulas are loaded from the ops manifest
+(``tileops/manifest/scan.yaml``).
+"""
 
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from workloads.workload_base import FixtureBase, WorkloadBase
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from tileops.ops.reduction.cumprod import CumprodFwdOp
+from tileops.ops.reduction.cumsum import CumsumFwdOp
+from workloads.workload_base import WorkloadBase
+
+_CUMSUM_OP = "CumsumFwdOp"
+_CUMPROD_OP = "CumprodFwdOp"
 
 
-class CumulativeBenchFixture(FixtureBase):
-    PARAMS = [
-        (
-            "m, n, dtype, op_kind",
-            [
-                pytest.param(1024, 4096, torch.float16, "cumsum"),
-                pytest.param(1024, 4096, torch.bfloat16, "cumsum"),
-                pytest.param(4096, 4096, torch.float16, "cumsum"),
-                pytest.param(1024, 4096, torch.float16, "cumprod"),
-                pytest.param(1024, 4096, torch.bfloat16, "cumprod"),
-                pytest.param(4096, 4096, torch.float16, "cumprod"),
-            ],
-        ),
-    ]
-
-
-class CumulativeBenchTest(WorkloadBase):
+class _CumulativeWorkload(WorkloadBase):
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
         self.m = m
         self.n = n
+        self.shape = (m, n)
         self.dtype = dtype
         self.op_kind = op_kind
 
@@ -43,45 +35,43 @@ class CumulativeBenchTest(WorkloadBase):
         x_f32 = x.float()
         if self.op_kind == "cumsum":
             return x_f32.cumsum(dim=-1).to(x.dtype)
-        elif self.op_kind == "cumprod":
-            return x_f32.cumprod(dim=-1).to(x.dtype)
-        raise ValueError(f"Unknown op_kind: {self.op_kind}")
+        return x_f32.cumprod(dim=-1).to(x.dtype)
 
 
-class CumulativeBenchmark(BenchmarkBase[CumulativeBenchTest]):
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        # Approximate: inclusive scan performs N-1 ops per row, rounded up to M*N
-        return t.m * t.n
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read x (M*N) + write output (M*N)
-        return 2 * t.m * t.n * elem_bytes
-
-
-def _make_op(m: int, n: int, dtype: torch.dtype, op_kind: str):
-    """Create the appropriate Op for the given op_kind."""
-    from tileops.ops.reduction.cumprod import CumprodFwdOp
-    from tileops.ops.reduction.cumsum import CumsumFwdOp
-
-    op_map = {
-        "cumsum": CumsumFwdOp,
-        "cumprod": CumprodFwdOp,
-    }
-    cls = op_map[op_kind]
-    return cls(N=n, dtype=dtype)
-
-
-@CumulativeBenchFixture
-def test_cumulative_bench(m: int, n: int, dtype: torch.dtype, op_kind: str) -> None:
-    test = CumulativeBenchTest(m, n, dtype, op_kind)
-    bm = CumulativeBenchmark(test)
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))
+def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
+    m, n = shape
+    test = _CumulativeWorkload(m, n, dtype, "cumsum")
     inputs = test.gen_inputs()
 
-    op = _make_op(m, n, dtype, op_kind)
-    result = bm.profile(op, *inputs)
+    op = CumsumFwdOp(N=n, dtype=dtype)
+    bm = ManifestBenchmark(_CUMSUM_OP, op, test)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+
+
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
+def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
+    m, n = shape
+    test = _CumulativeWorkload(m, n, dtype, "cumprod")
+    inputs = test.gen_inputs()
+
+    op = CumprodFwdOp(N=n, dtype=dtype)
+    bm = ManifestBenchmark(_CUMPROD_OP, op, test)
+    try:
+        result = bm.profile(op, *inputs)
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -41,7 +41,8 @@ class _CumulativeWorkload(WorkloadBase):
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))
 def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     m, n = shape
-    test = _CumulativeWorkload(m, n, dtype, "cumsum")
+    op_kind = "cumsum"
+    test = _CumulativeWorkload(m, n, dtype, op_kind)
     inputs = test.gen_inputs()
 
     op = CumsumFwdOp(N=n, dtype=dtype)
@@ -52,16 +53,19 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    # Preserve legacy report column order: m, n, dtype, op_kind.
+    report_params = {"m": m, "n": n, "dtype": dtype, "op_kind": op_kind}
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
 def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     m, n = shape
-    test = _CumulativeWorkload(m, n, dtype, "cumprod")
+    op_kind = "cumprod"
+    test = _CumulativeWorkload(m, n, dtype, op_kind)
     inputs = test.gen_inputs()
 
     op = CumprodFwdOp(N=n, dtype=dtype)
@@ -72,10 +76,12 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    # Preserve legacy report column order: m, n, dtype, op_kind.
+    report_params = {"m": m, "n": n, "dtype": dtype, "op_kind": op_kind}
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -1,26 +1,34 @@
-"""Benchmarks for cumulative ops (cumsum, cumprod).
+"""Benchmarks for cumulative ops (cumsum, cumprod)."""
 
-Workload shapes and roofline formulas are loaded from the ops manifest
-(``tileops/manifest/scan.yaml``).
-"""
+from typing import Optional
 
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
-from tileops.ops.reduction.cumprod import CumprodFwdOp
-from tileops.ops.reduction.cumsum import CumsumFwdOp
-from workloads.workload_base import WorkloadBase
-
-_CUMSUM_OP = "CumsumFwdOp"
-_CUMPROD_OP = "CumprodFwdOp"
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from workloads.workload_base import FixtureBase, WorkloadBase
 
 
-class _CumulativeWorkload(WorkloadBase):
+class CumulativeBenchFixture(FixtureBase):
+    PARAMS = [
+        (
+            "m, n, dtype, op_kind",
+            [
+                pytest.param(1024, 4096, torch.float16, "cumsum"),
+                pytest.param(1024, 4096, torch.bfloat16, "cumsum"),
+                pytest.param(4096, 4096, torch.float16, "cumsum"),
+                pytest.param(1024, 4096, torch.float16, "cumprod"),
+                pytest.param(1024, 4096, torch.bfloat16, "cumprod"),
+                pytest.param(4096, 4096, torch.float16, "cumprod"),
+            ],
+        ),
+    ]
+
+
+class CumulativeBenchTest(WorkloadBase):
     def __init__(self, m: int, n: int, dtype: torch.dtype, op_kind: str):
         self.m = m
         self.n = n
-        self.shape = (m, n)
         self.dtype = dtype
         self.op_kind = op_kind
 
@@ -37,53 +45,47 @@ class _CumulativeWorkload(WorkloadBase):
             return x_f32.cumsum(dim=-1).to(x.dtype)
         elif self.op_kind == "cumprod":
             return x_f32.cumprod(dim=-1).to(x.dtype)
-        raise ValueError(f"Unknown op_kind: {self.op_kind!r}")
+        raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-@pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))
-def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
-    m, n = shape
-    op_kind = "cumsum"
-    test = _CumulativeWorkload(m, n, dtype, op_kind)
+class CumulativeBenchmark(BenchmarkBase[CumulativeBenchTest]):
+    def calculate_flops(self) -> Optional[float]:
+        t = self.workload
+        # Approximate: inclusive scan performs N-1 ops per row, rounded up to M*N
+        return t.m * t.n
+
+    def calculate_memory(self) -> Optional[float]:
+        t = self.workload
+        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
+        # Read x (M*N) + write output (M*N)
+        return 2 * t.m * t.n * elem_bytes
+
+
+def _make_op(m: int, n: int, dtype: torch.dtype, op_kind: str):
+    """Create the appropriate Op for the given op_kind."""
+    from tileops.ops.reduction.cumprod import CumprodFwdOp
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    op_map = {
+        "cumsum": CumsumFwdOp,
+        "cumprod": CumprodFwdOp,
+    }
+    cls = op_map[op_kind]
+    return cls(N=n, dtype=dtype)
+
+
+@CumulativeBenchFixture
+def test_cumulative_bench(m: int, n: int, dtype: torch.dtype, op_kind: str) -> None:
+    test = CumulativeBenchTest(m, n, dtype, op_kind)
+    bm = CumulativeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = CumsumFwdOp(N=n, dtype=dtype)
-    bm = ManifestBenchmark(_CUMSUM_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    # Preserve legacy report column order: m, n, dtype, op_kind.
-    report_params = {"m": m, "n": n, "dtype": dtype, "op_kind": op_kind}
-    BenchmarkReport.record(op, report_params, result, tag="tileops")
+    op = _make_op(m, n, dtype, op_kind)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
-
-
-@pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
-def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
-    m, n = shape
-    op_kind = "cumprod"
-    test = _CumulativeWorkload(m, n, dtype, op_kind)
-    inputs = test.gen_inputs()
-
-    op = CumprodFwdOp(N=n, dtype=dtype)
-    bm = ManifestBenchmark(_CUMPROD_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    # Preserve legacy report column order: m, n, dtype, op_kind.
-    report_params = {"m": m, "n": n, "dtype": dtype, "op_kind": op_kind}
-    BenchmarkReport.record(op, report_params, result, tag="tileops")
-
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -35,7 +35,9 @@ class _CumulativeWorkload(WorkloadBase):
         x_f32 = x.float()
         if self.op_kind == "cumsum":
             return x_f32.cumsum(dim=-1).to(x.dtype)
-        return x_f32.cumprod(dim=-1).to(x.dtype)
+        elif self.op_kind == "cumprod":
+            return x_f32.cumprod(dim=-1).to(x.dtype)
+        raise ValueError(f"Unknown op_kind: {self.op_kind!r}")
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))

--- a/benchmarks/ops/bench_reduce_multidim.py
+++ b/benchmarks/ops/bench_reduce_multidim.py
@@ -17,14 +17,17 @@ These two groups cannot provide true multi-dim reduction cases.
 Shape conventions use LLaMA-family dimensions:
   - (batch=4, seq=128, hidden=4096): 7B inference context
   - (batch=2, seq=512, hidden=4096): 7B longer-context inference
-"""
 
-from typing import Optional
+Roofline metadata (FLOPs, bytes) comes from each op's ``eval_roofline()``
+via ``ManifestBenchmark``; the 3D multi-dim shapes themselves are declared
+inline because the manifest workload set for these ops only covers 2D
+last-axis reductions, which is a different test scenario.
+"""
 
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from workloads.workload_base import FixtureBase, WorkloadBase
 
 # ===================================================================
@@ -102,26 +105,7 @@ class ReduceMultidimTest(WorkloadBase):
         return ops[self.op_kind](x_f32).to(x.dtype)
 
 
-class ReduceMultidimBenchmark(BenchmarkBase[ReduceMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        return total_elems
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        # Output elements: product of kept dims
-        out_elems = 1
-        for i, s in enumerate(t.shape):
-            if i not in t.dim:
-                out_elems *= s
-        return (total_elems + out_elems) * elem_bytes
+_REDUCE_OP_NAMES = {"sum": "SumFwdOp", "mean": "MeanFwdOp", "amax": "AmaxFwdOp"}
 
 
 def _make_reduce_op(dtype, op_kind, dim, keepdim):
@@ -141,15 +125,21 @@ def test_reduce_multidim_bench(
     op_kind: str,
 ) -> None:
     test = ReduceMultidimTest(shape, dim, keepdim, dtype, op_kind)
-    bm = ReduceMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_reduce_op(dtype, op_kind, dim, keepdim)
+    bm = ManifestBenchmark(_REDUCE_OP_NAMES[op_kind], op, test)
+    # Preserve legacy report column order: shape, keepdim, dtype, op_kind
+    # (dim is a list and was already silently dropped by the pre-PR
+    # serializability filter, so we omit it here too).
+    report_params = {
+        "shape": shape, "keepdim": keepdim, "dtype": dtype, "op_kind": op_kind,
+    }
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 # ===================================================================
@@ -221,22 +211,7 @@ class ArgreduceMultidimTest(WorkloadBase):
         return x.argmin(dim=self.dim, keepdim=self.keepdim)
 
 
-class ArgreduceMultidimBenchmark(BenchmarkBase[ArgreduceMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        total_elems = 1
-        for s in self.workload.shape:
-            total_elems *= s
-        return total_elems
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        # Output: int64 (8 bytes) for each position
-        out_elems = total_elems // t.shape[t.dim]
-        return total_elems * elem_bytes + out_elems * 8
+_ARGREDUCE_OP_NAMES = {"argmax": "ArgmaxFwdOp", "argmin": "ArgminFwdOp"}
 
 
 def _make_argreduce_op(dtype, op_kind, dim, keepdim):
@@ -256,15 +231,21 @@ def test_argreduce_multidim_bench(
     op_kind: str,
 ) -> None:
     test = ArgreduceMultidimTest(shape, dim, keepdim, dtype, op_kind)
-    bm = ArgreduceMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_argreduce_op(dtype, op_kind, dim, keepdim)
+    bm = ManifestBenchmark(_ARGREDUCE_OP_NAMES[op_kind], op, test)
+    # Preserve legacy report column order: shape, dim, keepdim, dtype, op_kind
+    # (dim is int here and was kept by the pre-PR filter).
+    report_params = {
+        "shape": shape, "dim": dim, "keepdim": keepdim,
+        "dtype": dtype, "op_kind": op_kind,
+    }
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 # ===================================================================
@@ -336,26 +317,9 @@ class LogicalReduceMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class LogicalReduceMultidimBenchmark(BenchmarkBase[LogicalReduceMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        total_elems = 1
-        for s in self.workload.shape:
-            total_elems *= s
-        return total_elems
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        out_elems = 1
-        dims = set(d % len(t.shape) for d in t.dim)
-        for i, s in enumerate(t.shape):
-            if i not in dims:
-                out_elems *= s
-        out_elem_bytes = 8 if t.op_kind == "count_nonzero" else 1
-        return total_elems * elem_bytes + out_elems * out_elem_bytes
+_LOGICAL_OP_NAMES = {
+    "any": "AnyFwdOp", "all": "AllFwdOp", "count_nonzero": "CountNonzeroFwdOp",
+}
 
 
 def _make_logical_op(dtype, op_kind, dim, keepdim):
@@ -380,15 +344,20 @@ def test_logical_reduce_multidim_bench(
     op_kind: str,
 ) -> None:
     test = LogicalReduceMultidimTest(shape, dim, keepdim, dtype, op_kind)
-    bm = LogicalReduceMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_logical_op(dtype, op_kind, dim, keepdim)
+    bm = ManifestBenchmark(_LOGICAL_OP_NAMES[op_kind], op, test)
+    # Preserve legacy report column order: shape, keepdim, dtype, op_kind
+    # (dim list dropped by pre-PR filter).
+    report_params = {
+        "shape": shape, "keepdim": keepdim, "dtype": dtype, "op_kind": op_kind,
+    }
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 # ===================================================================
@@ -455,25 +424,9 @@ class VectorNormMultidimTest(WorkloadBase):
         )
 
 
-class VectorNormMultidimBenchmark(BenchmarkBase[VectorNormMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        total_elems = 1
-        for s in self.workload.shape:
-            total_elems *= s
-        return total_elems
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        out_elems = 1
-        dims = set(d % len(t.shape) for d in t.dim)
-        for i, s in enumerate(t.shape):
-            if i not in dims:
-                out_elems *= s
-        return (total_elems + out_elems) * elem_bytes
+_VECTOR_NORM_OP_NAMES = {
+    "l1": "L1NormFwdOp", "l2": "L2NormFwdOp", "inf": "InfNormFwdOp",
+}
 
 
 def _make_norm_op(dtype, op_kind, dim, keepdim):
@@ -495,15 +448,20 @@ def test_vector_norm_multidim_bench(
     op_kind: str,
 ) -> None:
     test = VectorNormMultidimTest(shape, dim, keepdim, dtype, op_kind)
-    bm = VectorNormMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_norm_op(dtype, op_kind, dim, keepdim)
+    bm = ManifestBenchmark(_VECTOR_NORM_OP_NAMES[op_kind], op, test)
+    # Preserve legacy report column order: shape, keepdim, dtype, op_kind
+    # (dim list dropped by pre-PR filter).
+    report_params = {
+        "shape": shape, "keepdim": keepdim, "dtype": dtype, "op_kind": op_kind,
+    }
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 # ===================================================================
@@ -567,16 +525,7 @@ class CumulativeMultidimTest(WorkloadBase):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
-class CumulativeMultidimBenchmark(BenchmarkBase[CumulativeMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        return t.M * t.N
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        # Read + write: 2 * M * N
-        return 2 * t.M * t.N * elem_bytes
+_CUMULATIVE_OP_NAMES = {"cumsum": "CumsumFwdOp", "cumprod": "CumprodFwdOp"}
 
 
 def _make_cumulative_op(M, N, dtype, op_kind):
@@ -599,15 +548,17 @@ def test_cumulative_multidim_bench(
     op_kind: str,
 ) -> None:
     test = CumulativeMultidimTest(shape, dtype, op_kind)
-    bm = CumulativeMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_cumulative_op(test.M, test.N, dtype, op_kind)
+    bm = ManifestBenchmark(_CUMULATIVE_OP_NAMES[op_kind], op, test)
+    # Preserve legacy report column order: shape, dtype, op_kind.
+    report_params = {"shape": shape, "dtype": dtype, "op_kind": op_kind}
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 # ===================================================================
@@ -680,26 +631,7 @@ class LogSumExpMultidimTest(WorkloadBase):
         )
 
 
-class LogSumExpMultidimBenchmark(BenchmarkBase[LogSumExpMultidimTest]):
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        return total_elems
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem_bytes = torch.tensor([], dtype=t.dtype).element_size()
-        total_elems = 1
-        for s in t.shape:
-            total_elems *= s
-        out_elems = 1
-        dims = set(d % len(t.shape) for d in t.dim)
-        for i, s in enumerate(t.shape):
-            if i not in dims:
-                out_elems *= s
-        return (total_elems + out_elems) * elem_bytes
+_LOGSUMEXP_OP_NAME = "LogSumExpFwdOp"
 
 
 def _make_logsumexp_op(dtype, dim, keepdim):
@@ -716,15 +648,18 @@ def test_logsumexp_multidim_bench(
     dtype: torch.dtype,
 ) -> None:
     test = LogSumExpMultidimTest(shape, dim, keepdim, dtype)
-    bm = LogSumExpMultidimBenchmark(test)
     inputs = test.gen_inputs()
 
     op = _make_logsumexp_op(dtype, dim, keepdim)
+    bm = ManifestBenchmark(_LOGSUMEXP_OP_NAME, op, test)
+    # Preserve legacy report column order: shape, keepdim, dtype
+    # (dim list dropped by pre-PR filter).
+    report_params = {"shape": shape, "keepdim": keepdim, "dtype": dtype}
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, report_params, result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, report_params, result_bl, tag="torch")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1377

## Summary

- Route `benchmarks/ops/bench_ada_layer_norm.py` workloads through `tileops.manifest.load_workloads`; eval roofline through op instance.
- Route `benchmarks/ops/bench_reduce_multidim.py` through `ManifestBenchmark` (FLOP/byte counts now come from `op.eval_roofline()` instead of six hand-rolled `BenchmarkBase` subclasses); 3D multi-dim workload shapes remain declared inline because manifest workloads for these ops only cover 2D last-axis reductions, which is a different test scenario from this file's 3D non-last-axis purpose.
- Output column schema unchanged: `m,n,dtype` for `AdaLayerNorm{Fwd,ZeroFwd}Op`; per-fixture columns preserved for `bench_reduce_multidim.py` (verified with locals()-filter probe — `dim` lists were already silently dropped pre-PR by `BenchmarkReport`'s serializability filter).

## Scope

Converted: `bench_ada_layer_norm.py`, `bench_reduce_multidim.py`.

**Deferred with explicit technical blockers** (not "needs GPU"):

| File | Blocker |
| --- | --- |
| `bench_cumulative.py` | scan.yaml manifest workloads for `CumsumFwdOp` / `CumprodFwdOp` do not match the legacy hand-rolled `WORKLOADS` table (base rows `(1024,4096)` and `(4096,4096)` vs manifest rows `(2048,4096)` and `(64,32768)`). Routing through `load_workloads` would change the benchmark row set and violate AC-4 row-set parity. Defer to a manifest-only PR that aligns scan.yaml workloads first. |
| `bench_binary_elementwise.py` | All 17 binary/comparison/logical/bitwise ops have **zero manifest workloads** (`load_workloads('SubFwdOp')` etc. return `[]`); the 3 fused gated ops (`SiluAndMulFwdOp`, `GeluAndMulFwdOp`, `GeluTanhAndMulFwdOp`) are **absent from the ops manifest entirely**. Additionally, `BinaryOp` and `FusedGatedOp` base classes do **not implement `eval_roofline()`** — they inherit the L1 base stub that raises `NotImplementedError`. Both `load_workloads()` and `ManifestBenchmark` paths are blocked. Conversion would require adding workloads to manifest YAML and implementing `eval_roofline` on the op base classes, both prohibited by this PR's constraints (MUST NOT modify manifest yaml; MUST NOT modify ops or kernels). |
| `bench_activation.py` | File's purpose is sweeping internal kernel-tuning axes (R2-R7 risk points: strategy ∈ {direct, explicit_parallel, register_copy}, `num_per_thread`, threads=128/256, aligned/unaligned tail sizes) that are not manifest workloads. Manifest workloads for the activation ops exist (2 each) but cover only the model-shape geometry sweep; routing the kernel-tuning sweeps through `load_workloads` would discard the file's R2-R7 coverage. The two model-shape tests (e.g. `test_relu_bench`) could be partially converted in a follow-up; the strategy/thread/npt sweeps cannot. |
| `bench_binary_arith.py` | Same `BinaryOp` `eval_roofline` blocker as `bench_binary_elementwise.py` for `AddFwdOp`, `LerpTensorFwdOp`, `WhereFwdOp`. `AddFwdOp` does have manifest workloads (`x_shape`/`y_shape` keyed) but the harness `workloads_to_params` only supports single-input `x_shape`-keyed entries by design (see `_WORKLOAD_META_KEYS` contract). |
| `bench_independent_elementwise.py` | Mixed: some sub-tests (unary activations like `LeakyReluFwdOp`, `EluFwdOp`) inherit `UnaryOp.eval_roofline` and have manifest workloads, but `WhereFwdOp` / `MaskedFillScalarFwdOp` / `PreluFwdOp` / `AlibiFwdOp` / `SinusoidalFwdOp` need either multi-input harness support (out of scope per `workloads_to_params` contract) or `eval_roofline` impls on their op classes. |
| `bench_instance_norm.py` (NoAffine variants) / `bench_group_norm.py` (NoAffine variants) | The default-affine variants are already routed through `load_workloads` in this PR's branch. The NoAffine sub-fixtures use the same op class with `affine=False`; they aren't separately listed in the manifest workload set, so converting them would require either adding NoAffine workload entries (manifest edit, prohibited) or co-locating them with the affine workloads via a flag column. Leaving as-is preserves coverage; no functional regression. |

A simple `input_shape → x_shape` rename helper is **not** what these files need: the actual blockers are missing manifest workload entries, missing op-level `eval_roofline()` implementations, and multi-input signatures that exceed the current single-input harness contract — all of which are out of scope under the trust-model constraints (MUST NOT modify manifest yaml; MUST NOT modify ops or kernels).

The two landed files establish the conversion pattern. Remaining files require manifest-only PRs (to add/align workloads / extend harness contract) or op-PRs (to implement `eval_roofline` on `BinaryOp` / `FusedGatedOp`) before they can land.

## Test plan

- [x] AC-1: `pytest benchmarks/tests/test_roofline_workload_protocol.py -q` → 8 passed; `pytest benchmarks/ops/bench_ada_layer_norm.py benchmarks/ops/bench_cumulative.py benchmarks/ops/bench_reduce_multidim.py -q` → 45 passed.
- [x] AC-2 (scoped to converted files): `grep -nE 'WORKLOADS\s*=\s*\[' benchmarks/ops/bench_ada_layer_norm.py benchmarks/ops/bench_reduce_multidim.py` → no matches.
- [x] AC-3: `bench_ada_layer_norm.py` imports `load_workloads`; `bench_reduce_multidim.py` uses `ManifestBenchmark` for all six fixtures.
- [x] AC-4: row-set parity verified via base-vs-head profile_run.log row-key compare on the two converted files (identical row keys); bench_cumulative reverted to upstream/testbed so its row set is unchanged from base by construction.
- [x] AC-5: PR diff scoped to the two bench files; no tracker edits.

## Regression

Schema check on `profile_run.log`:

| file | columns kept |
| --- | --- |
| `bench_ada_layer_norm.py` | `m,n,dtype,latency_ms,tflops,bandwidth_tbs,config` |
| `bench_reduce_multidim.py` | per-fixture (matches pre-PR after locals() filter): `shape,keepdim,dtype,op_kind` (reduce/logical/vector_norm); `shape,dim,keepdim,dtype,op_kind` (argreduce); `shape,dtype,op_kind` (cumulative); `shape,keepdim,dtype` (logsumexp) |
