### PR TITLE
[Maintain][Manifest] add at least 2 workloads to 21 binary elementwise ops

### DIFF
--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -151,9 +151,8 @@ AddFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.add_fwd_roofline"
 
@@ -181,9 +180,8 @@ SubFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.sub_fwd_roofline"
 
@@ -209,9 +207,8 @@ MulFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.mul_fwd_roofline"
 
@@ -240,9 +237,8 @@ DivFwdOp:
       - "rounding_mode is None or rounding_mode in ('trunc', 'floor')"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.div_fwd_roofline"
 
@@ -268,9 +264,8 @@ RemainderFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.remainder_fwd_roofline"
 
@@ -296,9 +291,8 @@ PowFwdOp:
       - "output.shape == broadcast_shapes(input.shape, exponent.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], exponent_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], exponent_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.pow_fwd_roofline"
 
@@ -324,9 +318,8 @@ FloorDivideFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.floor_divide_fwd_roofline"
 
@@ -357,9 +350,8 @@ LerpFwdOp:
       - "output.shape == broadcast_shapes(input.shape, end.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], end_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], end_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.lerp_fwd_roofline"
 
@@ -385,9 +377,8 @@ MaximumFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.maximum_fwd_roofline"
 
@@ -413,9 +404,8 @@ MinimumFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.minimum_fwd_roofline"
 
@@ -445,9 +435,8 @@ EqFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.eq_fwd_roofline"
 
@@ -473,9 +462,8 @@ NeFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.ne_fwd_roofline"
 
@@ -501,9 +489,8 @@ GtFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.gt_fwd_roofline"
 
@@ -529,9 +516,8 @@ LtFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.lt_fwd_roofline"
 
@@ -557,9 +543,8 @@ GeFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.ge_fwd_roofline"
 
@@ -585,9 +570,8 @@ LeFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.le_fwd_roofline"
 
@@ -617,9 +601,8 @@ LogicalAndFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool, float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool, float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.logical_and_fwd_roofline"
 
@@ -645,9 +628,8 @@ LogicalOrFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool, float16, bfloat16, float32], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool, float16, bfloat16, float32], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.logical_or_fwd_roofline"
 
@@ -677,9 +659,8 @@ BitwiseAndFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool, int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool, int32, int64], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.bitwise_and_fwd_roofline"
 
@@ -705,9 +686,8 @@ BitwiseOrFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool, int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool, int32, int64], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.bitwise_or_fwd_roofline"
 
@@ -733,9 +713,8 @@ BitwiseXorFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
   workloads:
-    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
-    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
-
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool, int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool, int32, int64], label: cnn-feat-broadcast}
   roofline:
     func: "tileops.perf.formulas.bitwise_xor_fwd_roofline"
 

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -150,7 +150,9 @@ AddFwdOp:
       # Output follows PyTorch broadcasting; numel uses the broadcast shape.
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.add_fwd_roofline"
@@ -178,7 +180,9 @@ SubFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.sub_fwd_roofline"
@@ -204,7 +208,9 @@ MulFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.mul_fwd_roofline"
@@ -233,7 +239,9 @@ DivFwdOp:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
       - "rounding_mode is None or rounding_mode in ('trunc', 'floor')"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.div_fwd_roofline"
@@ -259,7 +267,9 @@ RemainderFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.remainder_fwd_roofline"
@@ -285,7 +295,9 @@ PowFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, exponent.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.pow_fwd_roofline"
@@ -311,7 +323,9 @@ FloorDivideFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.floor_divide_fwd_roofline"
@@ -342,7 +356,9 @@ LerpFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, end.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.lerp_fwd_roofline"
@@ -368,7 +384,9 @@ MaximumFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.maximum_fwd_roofline"
@@ -394,7 +412,9 @@ MinimumFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.minimum_fwd_roofline"
@@ -424,7 +444,9 @@ EqFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.eq_fwd_roofline"
@@ -450,7 +472,9 @@ NeFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.ne_fwd_roofline"
@@ -476,7 +500,9 @@ GtFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.gt_fwd_roofline"
@@ -502,7 +528,9 @@ LtFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.lt_fwd_roofline"
@@ -528,7 +556,9 @@ GeFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.ge_fwd_roofline"
@@ -554,7 +584,9 @@ LeFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [float16, bfloat16], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [float16, bfloat16], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.le_fwd_roofline"
@@ -584,7 +616,9 @@ LogicalAndFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.logical_and_fwd_roofline"
@@ -610,7 +644,9 @@ LogicalOrFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [bool], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [bool], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.logical_or_fwd_roofline"
@@ -640,7 +676,9 @@ BitwiseAndFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.bitwise_and_fwd_roofline"
@@ -666,7 +704,9 @@ BitwiseOrFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.bitwise_or_fwd_roofline"
@@ -692,7 +732,9 @@ BitwiseXorFwdOp:
     shape_rules:
       - "output.shape == broadcast_shapes(input.shape, other.shape)"
 
-  workloads: []
+  workloads:
+    - {input_shape: [2048, 4096], other_shape: [2048, 4096], dtypes: [int32, int64], label: hidden-state-prefill}
+    - {input_shape: [16, 256, 56, 56], other_shape: [256, 1, 1], dtypes: [int32, int64], label: cnn-feat-broadcast}
 
   roofline:
     func: "tileops.perf.formulas.bitwise_xor_fwd_roofline"


### PR DESCRIPTION
## Summary

Fix gpu-smoke `test_every_op_has_at_least_two_workloads` failure by populating empty `workloads:` lists on 21 implemented binary elementwise ops (\`AddFwdOp\`, \`SubFwdOp\`, \`MulFwdOp\`, \`DivFwdOp\`, \`RemainderFwdOp\`, \`PowFwdOp\`, \`FloorDivideFwdOp\`, \`LerpFwdOp\`, \`MaximumFwdOp\`, \`MinimumFwdOp\`, \`Eq/Ne/Gt/Lt/Ge/LeFwdOp\`, \`LogicalAnd/OrFwdOp\`, \`BitwiseAnd/Or/XorFwdOp\`).

This pre-existing testbed CI break has been blocking nightshift auto-merge for PRs #1387, #1388, #1389, #1391. Filed as issue #1390 — this PR resolves it.

## Plan executed

Each affected op now declares two representative workloads:
- **LLM hidden-state prefill**: \`input/other [2048, 4096]\` (no broadcast)
- **CNN feature map**: \`input [16, 256, 56, 56]\`, \`other [256, 1, 1]\` (channel-wise broadcast)

Dtype matrix matches each op's signature:
- Float-only ops (\`Div\`, \`Pow\`, \`Lerp\`, \`Remainder\`, \`FloorDivide\`): \`float16, bfloat16\`
- Bitwise ops (\`BitwiseAnd/Or/Xor\`): \`int32, int64\`
- Logical ops (\`LogicalAnd/Or\`): \`bool\`
- Default (other arithmetic + comparison): \`float16, bfloat16\`

## Test plan

- [x] \`pytest tests/test_ops_manifest.py::TestOpSchema::test_every_op_has_at_least_two_workloads\` — passes
- [x] \`pytest tests/test_validate_manifest.py tests/test_ops_manifest.py\` — 239 passed
- [x] \`python scripts/validate_manifest.py\` — \"All manifest checks passed\"
- [x] Pre-commit clean

## Acceptance Criteria

Closes #1390.

- AC-1: ✅ Modified files pass unit tests.
- AC-2: ✅ \`AddFwdOp.workloads\` (and 20 siblings) now have 2 entries each, satisfying signature + broadcasting rules.
- AC-3: ✅ \`scripts/validate_manifest.py\` exits 0 with no new warnings on the affected ops.
- AC-4: To be verified by gpu-smoke on this PR's run.

## Trust model

Manifest-only PR. No \`signature\`, \`roofline\`, \`params\`, \`shape_rules\`, or \`dtype_combos\` edits. Falls within the trust-model rule that workload edits without a status flip require a separate manifest-only PR with human review — this is that PR.