### PR TITLE
[Refactor][Ops] align W0 ops with manifest parity check

### DIFF
--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -60,7 +60,7 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -97,7 +97,7 @@ MaskedFillScalarFwdOp:
   # Per the "No Optional[Tensor]" manifest rule, this is split from the
   # 0-dim-Tensor-value primary entry above.
   family: elementwise
-  status: implemented
+  status: spec-only
   variant_of: MaskedFillFwdOp
 
   signature:

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -60,6 +60,7 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
+  # spec-only: kernel only supports float dtypes; manifest declares int/bool union
   status: spec-only
 
   signature:
@@ -97,6 +98,7 @@ MaskedFillScalarFwdOp:
   # Per the "No Optional[Tensor]" manifest rule, this is split from the
   # 0-dim-Tensor-value primary entry above.
   family: elementwise
+  # spec-only: kernel only supports float dtypes; manifest declares int/bool union
   status: spec-only
   variant_of: MaskedFillFwdOp
 

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -7,7 +7,7 @@
 RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -7,6 +7,7 @@
 RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
+  # spec-only: shape_rules reference runtime-bound normalized_shape param without manifest default
   status: spec-only
 
   signature:

--- a/tileops/ops/elementwise/where.py
+++ b/tileops/ops/elementwise/where.py
@@ -71,6 +71,42 @@ class WhereFwdOp(Op):
     def default_kernel_map(self):
         return {"where": WhereFwdKernel}
 
+    def _infer_output_shapes(
+        self,
+        condition_shape: tuple,
+        input_shape: tuple,
+        other_shape: tuple,
+    ) -> Dict[str, tuple]:
+        out = tuple(
+            torch.broadcast_shapes(
+                tuple(condition_shape),
+                tuple(input_shape),
+                tuple(other_shape),
+            )
+        )
+        return {"output": out}
+
+    def _validate_dtypes(
+        self,
+        condition: torch.Tensor,
+        input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
+        other: torch.Tensor,
+    ) -> None:
+        if condition.dtype != torch.bool:
+            raise ValueError(
+                f"Expected condition.dtype torch.bool, got {condition.dtype}"
+            )
+        if input.dtype not in self._SUPPORTED_DTYPES:
+            names = ", ".join(str(dt) for dt in self._SUPPORTED_DTYPES)
+            raise ValueError(
+                f"Expected input.dtype in [{names}], got {input.dtype}"
+            )
+        if other.dtype != input.dtype:
+            raise ValueError(
+                f"Expected other.dtype == input.dtype ({input.dtype}), "
+                f"got {other.dtype}"
+            )
+
     @staticmethod
     def _expand_flat(t: torch.Tensor, target_shape: tuple) -> torch.Tensor:
         """Expand ``t`` to ``target_shape`` and return a contiguous flat view."""


### PR DESCRIPTION
Closes #1376

## Summary

- Align 8 W0 ops with the manifest parity check (default `validate_manifest.py` mode reports zero `[shape]/[dtype]` warnings for all 8).
- `WhereFwdOp`: add mechanical `_infer_output_shapes` and `_validate_dtypes` overrides matching the manifest broadcast/dtype contract.
- Demote `MaskedFillFwdOp`, `MaskedFillScalarFwdOp`, and `RMSNormFwdOp` to `status: spec-only` with documented per-op reasons in their manifest entries.
- Clamp family (`ClampFwdOp`, `ClampScalarFwdOp`, `ClampMinFwdOp`, `ClampMaxFwdOp`) was already aligned — no code change needed.

## Per-op approach

| Op | Approach | Notes |
| --- | --- | --- |
| `ClampFwdOp` | already aligned | overrides match manifest; no change |
| `ClampScalarFwdOp` | already aligned | overrides match manifest; no change |
| `ClampMinFwdOp` | already aligned | overrides match manifest; no change |
| `ClampMaxFwdOp` | already aligned | overrides match manifest; no change |
| `WhereFwdOp` | mechanical override added | `_infer_output_shapes` + `_validate_dtypes` aligned with manifest broadcast/dtype contract |
| `MaskedFillFwdOp` | demoted to `spec-only` | implementation deviates from spec; flip in follow-up impl PR |
| `MaskedFillScalarFwdOp` | demoted to `spec-only` | implementation deviates from spec; flip in follow-up impl PR |
| `RMSNormFwdOp` | demoted to `spec-only` | implementation deviates from spec; flip in follow-up impl PR |

## Test plan

- [x] Modified files pass unit tests (pytest tests/ops/) — 318 passed across the changed-op test files (`test_elementwise_compile.py`, `test_special_elementwise.py`, `test_special_elementwise_conformance.py`, `test_elementwise_independent_fp8.py`, `test_elementwise_unary_activation_alignment.py`, `test_rms_norm.py`, `test_normalization_alignment.py`).
- [x] `python scripts/validate_manifest.py` emits zero parity warnings for the 8 W0 ops (default mode).
- [x] `tests/test_validate_manifest.py` passes — 218 passed.
- [x] Each op is either covered by both overrides aligned with manifest, or demoted to `status: spec-only` with reason in this description.
- [x] All 8 W0 ops are explicitly addressed in the per-op approach table above.
