### PR TITLE
[Fix][NORM] enforce required weight/bias on GroupNorm/InstanceNorm forward

### DIFF
--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -6,10 +6,14 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import load_workloads
-from tileops.ops.norm.group_norm import GroupNormFwdOp
+from tileops.ops.norm.group_norm import (
+    GroupNormFwdOp,
+    GroupNormFwdOpNoAffine,
+)
 from workloads.group_norm import GroupNormTest
 
 _OP_NAME = "GroupNormFwdOp"
+_OP_NAME_NO_AFFINE = "GroupNormFwdOpNoAffine"
 
 
 class GroupNormBenchmark(BenchmarkBase[GroupNormTest]):
@@ -32,15 +36,15 @@ class GroupNormBenchmark(BenchmarkBase[GroupNormTest]):
         return self._get_roofline()[1]
 
 
-def _manifest_params():
+def _build_params(workloads):
     params = []
-    for w in load_workloads(_OP_NAME):
+    for w in workloads:
         shape = w["x_shape"]
         n, c, spatial = shape[0], shape[1], tuple(shape[2:])
         num_groups = w.get("num_groups")
         if num_groups is None:
             raise KeyError(
-                f"Workload manifest for {_OP_NAME} must contain 'num_groups'"
+                "Workload manifest must contain 'num_groups'"
             )
         label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
         for dtype_str in w["dtypes"]:
@@ -50,7 +54,12 @@ def _manifest_params():
     return params
 
 
-@pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune", _manifest_params())
+_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME))
+_NO_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME_NO_AFFINE))
+
+
+@pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune",
+                         _AFFINE_PARAMS)
 def test_group_norm_bench(n: int, c: int, spatial: tuple, num_groups: int,
                           dtype: torch.dtype, tune: bool) -> None:
     test = GroupNormTest(n, c, spatial, num_groups, dtype)
@@ -64,11 +73,6 @@ def test_group_norm_bench(n: int, c: int, spatial: tuple, num_groups: int,
     result = bm.profile(op, x, weight, bias)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    # Affine-free path (weight=None, bias=None) exercises the cached
-    # unit_weight / zero_bias allocation reuse on the op instance.
-    result_no_affine = bm.profile(op, x, None, None)
-    BenchmarkReport.record(op, locals(), result_no_affine, tag="tileops-no-affine")
-
     # Baseline: torch.nn.functional.group_norm
     def baseline_fn(x, weight, bias):
         return F.group_norm(x, num_groups, weight=weight, bias=bias, eps=1e-5)
@@ -76,11 +80,28 @@ def test_group_norm_bench(n: int, c: int, spatial: tuple, num_groups: int,
     result_bl = bm.profile(baseline_fn, x, weight, bias)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
+
+@pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune",
+                         _NO_AFFINE_PARAMS)
+def test_group_norm_no_affine_bench(n: int, c: int, spatial: tuple,
+                                    num_groups: int, dtype: torch.dtype,
+                                    tune: bool) -> None:
+    test = GroupNormTest(n, c, spatial, num_groups, dtype)
+    x, _, _ = test.gen_inputs()
+
+    op = GroupNormFwdOpNoAffine(
+        N=n, C=c, spatial=spatial, num_groups=num_groups,
+        dtype=dtype, tune=tune,
+    )
+    bm = GroupNormBenchmark(test, op)
+    result = bm.profile(op, x)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
     def baseline_no_affine(x):
         return F.group_norm(x, num_groups, weight=None, bias=None, eps=1e-5)
 
-    result_bl_no_affine = bm.profile(baseline_no_affine, x)
-    BenchmarkReport.record(op, locals(), result_bl_no_affine, tag="torch-no-affine")
+    result_bl = bm.profile(baseline_no_affine, x)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -6,10 +6,14 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import load_workloads
-from tileops.ops.norm.instance_norm import InstanceNormFwdOp
+from tileops.ops.norm.instance_norm import (
+    InstanceNormFwdOp,
+    InstanceNormFwdOpNoAffine,
+)
 from workloads.instance_norm import InstanceNormTest
 
 _OP_NAME = "InstanceNormFwdOp"
+_OP_NAME_NO_AFFINE = "InstanceNormFwdOpNoAffine"
 
 
 class InstanceNormBenchmark(BenchmarkBase[InstanceNormTest]):
@@ -32,9 +36,9 @@ class InstanceNormBenchmark(BenchmarkBase[InstanceNormTest]):
         return self._get_roofline()[1]
 
 
-def _manifest_params():
+def _build_params(workloads):
     params = []
-    for w in load_workloads(_OP_NAME):
+    for w in workloads:
         shape = w["x_shape"]
         n, c, spatial = shape[0], shape[1], tuple(shape[2:])
         label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
@@ -45,7 +49,11 @@ def _manifest_params():
     return params
 
 
-@pytest.mark.parametrize("n, c, spatial, dtype, tune", _manifest_params())
+_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME))
+_NO_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME_NO_AFFINE))
+
+
+@pytest.mark.parametrize("n, c, spatial, dtype, tune", _AFFINE_PARAMS)
 def test_instance_norm_bench(n: int, c: int, spatial: tuple,
                              dtype: torch.dtype, tune: bool) -> None:
     test = InstanceNormTest(n, c, spatial, dtype)
@@ -56,11 +64,6 @@ def test_instance_norm_bench(n: int, c: int, spatial: tuple,
     result = bm.profile(op, x, weight, bias)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    # Affine-free path (weight=None, bias=None) exercises the cached
-    # unit_weight / zero_bias allocation reuse on the op instance.
-    result_no_affine = bm.profile(op, x, None, None)
-    BenchmarkReport.record(op, locals(), result_no_affine, tag="tileops-no-affine")
-
     # Baseline: torch.nn.functional.instance_norm
     def baseline_fn(x, weight, bias):
         return F.instance_norm(x, weight=weight, bias=bias, eps=1e-5)
@@ -68,11 +71,29 @@ def test_instance_norm_bench(n: int, c: int, spatial: tuple,
     result_bl = bm.profile(baseline_fn, x, weight, bias)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
+
+@pytest.mark.parametrize("n, c, spatial, dtype, tune", _NO_AFFINE_PARAMS)
+def test_instance_norm_no_affine_bench(n: int, c: int, spatial: tuple,
+                                       dtype: torch.dtype, tune: bool) -> None:
+    test = InstanceNormTest(n, c, spatial, dtype)
+    x, _, _ = test.gen_inputs()
+
+    op = InstanceNormFwdOpNoAffine(
+        N=n, C=c, spatial=spatial, dtype=dtype, tune=tune,
+    )
+    bm = InstanceNormBenchmark(test, op)
+    # Running stats are required positional args (R16) but ignored on the
+    # use_input_stats=True path; pass placeholders.
+    rm = torch.zeros(c, dtype=torch.float32, device="cuda")
+    rv = torch.ones(c, dtype=torch.float32, device="cuda")
+    result = bm.profile(op, x, rm, rv)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
     def baseline_no_affine(x):
         return F.instance_norm(x, weight=None, bias=None, eps=1e-5)
 
-    result_bl_no_affine = bm.profile(baseline_no_affine, x)
-    BenchmarkReport.record(op, locals(), result_bl_no_affine, tag="torch-no-affine")
+    result_bl = bm.profile(baseline_no_affine, x)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -99,80 +99,31 @@ def test_group_norm_non_contiguous(n: int, c: int, spatial: tuple, g: int,
 
 
 @pytest.mark.smoke
-def test_group_norm_optional_weight_bias_cache_stable() -> None:
-    """When weight/bias are None, repeated forwards reuse cached affine tensors."""
-    n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    op = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
-    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-
-    y1 = op(x, None, None)
-    cached_weight_id = id(op._cached_unit_weight)
-    cached_bias_id = id(op._cached_zero_bias)
-
-    y2 = op(x, None, None)
-    assert id(op._cached_unit_weight) == cached_weight_id, \
-        "unit_weight cache should be reused across forward calls"
-    assert id(op._cached_zero_bias) == cached_bias_id, \
-        "zero_bias cache should be reused across forward calls"
-
-    # Correctness: matches torch reference (weight=None / bias=None).
-    y_ref = F.group_norm(x.float(), g, weight=None, bias=None, eps=1e-5).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y1, y_ref, atol=atol, rtol=rtol)
-    assert torch.allclose(y2, y_ref, atol=atol, rtol=rtol)
-
-
-@pytest.mark.smoke
-def test_group_norm_cache_rebuilds_on_dtype_change() -> None:
-    """Cache rebuilds when input dtype changes; cached tensors track input dtype."""
-    n, c, spatial, g = 2, 32, (8, 8), 8
-
-    # First combo: float16
-    op16 = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g,
-                          dtype=torch.float16)
-    x16 = torch.randn((n, c, *spatial), dtype=torch.float16, device="cuda")
-    op16(x16, None, None)
-    assert op16._cached_unit_weight.dtype == torch.float16
-    assert op16._cached_unit_weight.device == x16.device
-
-    # Second combo: bfloat16 (different dtype, same device class)
-    op_bf = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g,
-                           dtype=torch.bfloat16)
-    x_bf = torch.randn((n, c, *spatial), dtype=torch.bfloat16, device="cuda")
-    op_bf(x_bf, None, None)
-    assert op_bf._cached_unit_weight.dtype == torch.bfloat16
-    assert op_bf._cached_zero_bias.dtype == torch.bfloat16
-
-
-@pytest.mark.smoke
-def test_group_norm_supplied_affine_does_not_consult_cache() -> None:
-    """When weight and bias are both supplied, the cache must not be consulted."""
+def test_group_norm_rejects_none_weight_or_bias() -> None:
+    """Affine op rejects ``weight=None`` / ``bias=None``; affine-free path lives on NoAffine."""
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
     op = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     weight = torch.randn((c,), dtype=dtype, device="cuda")
     bias = torch.randn((c,), dtype=dtype, device="cuda")
 
-    def _raise(*args, **kwargs):
-        raise AssertionError(
-            "_get_affine_identity must not be called on the supplied-affine path"
-        )
+    with pytest.raises((ValueError, TypeError)):
+        op(x, None, bias)
+    with pytest.raises((ValueError, TypeError)):
+        op(x, weight, None)
+    with pytest.raises((ValueError, TypeError)):
+        op(x, None, None)
 
-    op._get_affine_identity = _raise  # type: ignore[method-assign]
 
-    y = op(x, weight, bias)
-
-    # Correctness sanity check: matches torch reference.
-    y_ref = F.group_norm(
-        x.float(), g, weight=weight.float(), bias=bias.float(), eps=1e-5,
-    ).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
-
-    # Cache state must remain untouched.
-    assert op._cached_unit_weight is None
-    assert op._cached_zero_bias is None
-    assert op._cached_affine_key is None
+@pytest.mark.smoke
+def test_group_norm_forward_required_signature() -> None:
+    """`forward` declares weight and bias as required (no Optional, no default)."""
+    import inspect
+    sig = inspect.signature(GroupNormFwdOp.forward)
+    weight_param = sig.parameters["weight"]
+    bias_param = sig.parameters["bias"]
+    assert weight_param.default is inspect.Parameter.empty
+    assert bias_param.default is inspect.Parameter.empty
 
 
 @pytest.mark.smoke
@@ -195,8 +146,14 @@ def test_group_norm_rejects_device_mismatch() -> None:
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
+    weight_other = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 1),
+    )
+    bias_other = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 1),
+    )
     with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other, None, None)
+        op(x_other, weight_other, bias_other)
 
 
 @pytest.mark.smoke
@@ -220,10 +177,13 @@ def test_group_norm_rejects_affine_device_mismatch() -> None:
     bias_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
     bias_same = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 0))
 
+    weight_same = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 0),
+    )
     with pytest.raises(ValueError, match="weight on"):
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
-        op(x, None, bias_other)
+        op(x, weight_same, bias_other)
 
 
 class GroupNormNoAffineFixture(FixtureBase):

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -155,75 +155,30 @@ def test_instance_norm_no_affine_running_stats(
 
 
 @pytest.mark.smoke
-def test_instance_norm_optional_weight_bias_cache_stable() -> None:
-    """When weight/bias are None, repeated forwards reuse cached affine tensors."""
+def test_instance_norm_rejects_none_weight_or_bias() -> None:
+    """Affine op rejects ``weight=None`` / ``bias=None``; affine-free path lives on NoAffine."""
     n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
-    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-
-    y1 = op(x, None, None)
-    cached_weight_id = id(op._cached_unit_weight)
-    cached_bias_id = id(op._cached_zero_bias)
-
-    y2 = op(x, None, None)
-    assert id(op._cached_unit_weight) == cached_weight_id, \
-        "unit_weight cache should be reused across forward calls"
-    assert id(op._cached_zero_bias) == cached_bias_id, \
-        "zero_bias cache should be reused across forward calls"
-
-    y_ref = F.instance_norm(x.float(), weight=None, bias=None, eps=1e-5).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y1, y_ref, atol=atol, rtol=rtol)
-    assert torch.allclose(y2, y_ref, atol=atol, rtol=rtol)
-
-
-@pytest.mark.smoke
-def test_instance_norm_cache_rebuilds_on_dtype_change() -> None:
-    """Cache rebuilds when input dtype changes; cached tensors track input dtype."""
-    n, c, spatial = 2, 16, (8, 8)
-
-    op16 = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=torch.float16)
-    x16 = torch.randn((n, c, *spatial), dtype=torch.float16, device="cuda")
-    op16(x16, None, None)
-    assert op16._cached_unit_weight.dtype == torch.float16
-    assert op16._cached_unit_weight.device == x16.device
-
-    op_bf = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=torch.bfloat16)
-    x_bf = torch.randn((n, c, *spatial), dtype=torch.bfloat16, device="cuda")
-    op_bf(x_bf, None, None)
-    assert op_bf._cached_unit_weight.dtype == torch.bfloat16
-    assert op_bf._cached_zero_bias.dtype == torch.bfloat16
-
-
-@pytest.mark.smoke
-def test_instance_norm_supplied_affine_does_not_consult_cache() -> None:
-    """When weight and bias are both supplied, the cache must not be consulted."""
-    n, c, spatial, dtype = 2, 32, (8, 8), torch.float16
     op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     weight = torch.randn((c,), dtype=dtype, device="cuda")
     bias = torch.randn((c,), dtype=dtype, device="cuda")
 
-    def _raise(*args, **kwargs):
-        raise AssertionError(
-            "_get_affine_identity must not be called on the supplied-affine path"
-        )
+    with pytest.raises((ValueError, TypeError)):
+        op(x, None, bias)
+    with pytest.raises((ValueError, TypeError)):
+        op(x, weight, None)
+    with pytest.raises((ValueError, TypeError)):
+        op(x, None, None)
 
-    op._get_affine_identity = _raise  # type: ignore[method-assign]
 
-    y = op(x, weight, bias)
-
-    # Correctness sanity check: matches torch reference.
-    y_ref = F.instance_norm(
-        x.float(), weight=weight.float(), bias=bias.float(), eps=1e-5,
-    ).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
-
-    # Cache state must remain untouched.
-    assert op._cached_unit_weight is None
-    assert op._cached_zero_bias is None
-    assert op._cached_affine_key is None
+@pytest.mark.smoke
+def test_instance_norm_forward_required_signature() -> None:
+    """`forward` declares weight and bias as required (no Optional, no default)."""
+    sig = inspect.signature(InstanceNormFwdOp.forward)
+    weight_param = sig.parameters["weight"]
+    bias_param = sig.parameters["bias"]
+    assert weight_param.default is inspect.Parameter.empty
+    assert bias_param.default is inspect.Parameter.empty
 
 
 @pytest.mark.smoke
@@ -244,8 +199,14 @@ def test_instance_norm_rejects_device_mismatch() -> None:
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
+    weight_other = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 1),
+    )
+    bias_other = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 1),
+    )
     with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other, None, None)
+        op(x_other, weight_other, bias_other)
 
 
 @pytest.mark.smoke
@@ -267,10 +228,13 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
     bias_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
     bias_same = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 0))
 
+    weight_same = torch.randn(
+        (c,), dtype=dtype, device=torch.device("cuda", 0),
+    )
     with pytest.raises(ValueError, match="weight on"):
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
-        op(x, None, bias_other)
+        op(x, weight_same, bias_other)
 
 
 _OP_CLASSES = [
@@ -366,8 +330,10 @@ def test_instance_norm_default_momentum_does_not_change_output() -> None:
     assert op_default.momentum == pytest.approx(0.1)
     assert op_other.momentum == pytest.approx(0.5)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-    y1 = op_default(x, None, None)
-    y2 = op_other(x, None, None)
+    weight = torch.randn((c,), dtype=dtype, device="cuda")
+    bias = torch.randn((c,), dtype=dtype, device="cuda")
+    y1 = op_default(x, weight, bias)
+    y2 = op_other(x, weight, bias)
     atol, rtol = _get_tolerances(dtype)
     assert torch.allclose(y1, y2, atol=atol, rtol=rtol)
 

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -105,6 +105,19 @@ class GroupNormFwdOp(Op):
         # rather than letting the kernel layer surface an opaque
         # device-mismatch failure.
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+        # Pre-allocate forward-time constants. The kernel binds 1D weight/bias
+        # row-broadcast inputs; GroupNorm needs per-group affine, so the kernel
+        # call uses identity (unit/zero) buffers and the per-channel affine is
+        # applied after. These tensors are immutable for the op's lifetime.
+        self._unit_weight = torch.ones(
+            self.D_padded, dtype=dtype, device=self._kernel_device,
+        )
+        self._zero_bias = torch.zeros(
+            self.D_padded, dtype=dtype, device=self._kernel_device,
+        )
+        self._expected_shape = (self.N, self.C, *self.spatial)
+        self._cpg = self.C // self.num_groups
+        self._affine_shape = (1, self.C) + (1,) * len(self.spatial)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -151,6 +164,10 @@ class GroupNormFwdOp(Op):
             raise ValueError(
                 f"Expected x.dtype {self.dtype}, got {x.dtype}"
             )
+        if tuple(x.shape) != self._expected_shape:
+            raise ValueError(
+                f"Expected x shape {self._expected_shape}, got {tuple(x.shape)}"
+            )
         if not isinstance(weight, torch.Tensor):
             raise ValueError(
                 "weight is required; use GroupNormFwdOpNoAffine for the "
@@ -191,46 +208,27 @@ class GroupNormFwdOp(Op):
             )
 
         orig_shape = x.shape
-        # Ensure contiguous and reshape to (N, num_groups, C/num_groups, *spatial)
         x = x.contiguous()
-
-        # Reshape: (N, C, *spatial)
-        # -> (N, num_groups, C/num_groups, *spatial)
-        # -> (N*num_groups, (C/num_groups)*spatial_size)
-        cpg = self.C // self.num_groups  # channels per group
-        x_reshaped = x.reshape(self.N, self.num_groups, cpg, *self.spatial)
+        x_reshaped = x.reshape(
+            self.N, self.num_groups, self._cpg, *self.spatial,
+        )
         x_2d = x_reshaped.reshape(self.M, self.D)
 
-        # The kernel broadcasts 1D weight/bias across all rows, but GroupNorm
-        # needs per-group affine parameters. Run kernel with unit weight/zero
-        # bias to normalize, then apply per-channel affine afterwards.
-        unit_weight = torch.ones(
-            self.D_padded, dtype=x.dtype, device=x.device,
-        )
-        zero_bias = torch.zeros(
-            self.D_padded, dtype=x.dtype, device=x.device,
-        )
-
-        # Pad to alignment
         if self.D_padded != self.D:
             x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
 
-        # Run kernel: produces (x - mean) / sqrt(var + eps)
-        y_2d = self.kernel(x_2d, unit_weight, zero_bias)
+        # Kernel broadcasts 1D weight/bias row-wise; GroupNorm's per-group
+        # affine doesn't fit that layout, so run the kernel with identity
+        # (unit/zero) and apply per-channel affine after.
+        y_2d = self.kernel(x_2d, self._unit_weight, self._zero_bias)
 
-        # Trim padding
         if self.D_padded != self.D:
             y_2d = y_2d[:, :self.D]
 
-        # Reshape back: (N*num_groups, D) -> (N, num_groups, cpg, *spatial)
-        # -> (N, C, *spatial)
-        y = y_2d.reshape(self.N, self.num_groups, cpg, *self.spatial)
+        y = y_2d.reshape(self.N, self.num_groups, self._cpg, *self.spatial)
         y = y.reshape(orig_shape)
 
-        # Apply per-channel affine: y = y * weight + bias.
-        affine_shape = [1, self.C] + [1] * len(self.spatial)
-        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-
+        y = y * weight.reshape(self._affine_shape) + bias.reshape(self._affine_shape)
         return y
 
 

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -105,27 +105,6 @@ class GroupNormFwdOp(Op):
         # rather than letting the kernel layer surface an opaque
         # device-mismatch failure.
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
-        # Affine-identity tensors are reused across forward calls when the
-        # caller passes weight=None / bias=None. Cached on the op instance
-        # and invalidated on (dtype, device) change of the input.
-        self._cached_unit_weight: Optional[torch.Tensor] = None
-        self._cached_zero_bias: Optional[torch.Tensor] = None
-        self._cached_affine_key: Optional[tuple] = None
-
-    def _get_affine_identity(
-        self, dtype: torch.dtype, device: torch.device,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return cached unit_weight / zero_bias for the given (dtype, device)."""
-        key = (dtype, device)
-        if self._cached_affine_key != key:
-            self._cached_unit_weight = torch.ones(
-                self.D_padded, dtype=dtype, device=device,
-            )
-            self._cached_zero_bias = torch.zeros(
-                self.D_padded, dtype=dtype, device=device,
-            )
-            self._cached_affine_key = key
-        return self._cached_unit_weight, self._cached_zero_bias
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -141,24 +120,24 @@ class GroupNormFwdOp(Op):
     def forward(
         self,
         x: torch.Tensor,
-        weight: Optional[torch.Tensor] = None,
-        bias: Optional[torch.Tensor] = None,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
     ) -> torch.Tensor:
         """Apply group normalization.
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
-            weight: Optional affine scale of shape ``(C,)`` on CUDA. When
-                ``None``, the affine scale defaults to all-ones (no scaling).
-            bias: Optional affine shift of shape ``(C,)`` on CUDA. When
-                ``None``, the affine shift defaults to all-zeros (no shift).
+            weight: Affine scale of shape ``(C,)`` on CUDA. Required; the
+                affine-free path is :class:`GroupNormFwdOpNoAffine`.
+            bias: Affine shift of shape ``(C,)`` on CUDA. Required; the
+                affine-free path is :class:`GroupNormFwdOpNoAffine`.
 
         Returns:
             Normalized tensor of the same shape as *x*.
 
         Raises:
-            ValueError: If tensors are not on CUDA, dtypes mismatch,
-                or shapes are incompatible with the configured dimensions.
+            ValueError: If any tensor is not on CUDA, dtypes mismatch, or
+                shapes are incompatible with the configured dimensions.
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
@@ -172,36 +151,44 @@ class GroupNormFwdOp(Op):
             raise ValueError(
                 f"Expected x.dtype {self.dtype}, got {x.dtype}"
             )
-        if weight is not None:
-            if not weight.is_cuda:
-                raise ValueError("weight must be a CUDA tensor")
-            if weight.device != x.device:
-                raise ValueError(
-                    f"Expected weight on {x.device}, got {weight.device}"
-                )
-            if weight.dtype != self.dtype:
-                raise ValueError(
-                    f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
-                )
-            if weight.ndim != 1 or weight.shape[0] != self.C:
-                raise ValueError(
-                    f"Expected weight shape ({self.C},), got {weight.shape}"
-                )
-        if bias is not None:
-            if not bias.is_cuda:
-                raise ValueError("bias must be a CUDA tensor")
-            if bias.device != x.device:
-                raise ValueError(
-                    f"Expected bias on {x.device}, got {bias.device}"
-                )
-            if bias.dtype != self.dtype:
-                raise ValueError(
-                    f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
-                )
-            if bias.ndim != 1 or bias.shape[0] != self.C:
-                raise ValueError(
-                    f"Expected bias shape ({self.C},), got {bias.shape}"
-                )
+        if not isinstance(weight, torch.Tensor):
+            raise ValueError(
+                "weight is required; use GroupNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        if not isinstance(bias, torch.Tensor):
+            raise ValueError(
+                "bias is required; use GroupNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        if not weight.is_cuda:
+            raise ValueError("weight must be a CUDA tensor")
+        if weight.device != x.device:
+            raise ValueError(
+                f"Expected weight on {x.device}, got {weight.device}"
+            )
+        if weight.dtype != self.dtype:
+            raise ValueError(
+                f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
+            )
+        if weight.ndim != 1 or weight.shape[0] != self.C:
+            raise ValueError(
+                f"Expected weight shape ({self.C},), got {weight.shape}"
+            )
+        if not bias.is_cuda:
+            raise ValueError("bias must be a CUDA tensor")
+        if bias.device != x.device:
+            raise ValueError(
+                f"Expected bias on {x.device}, got {bias.device}"
+            )
+        if bias.dtype != self.dtype:
+            raise ValueError(
+                f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
+            )
+        if bias.ndim != 1 or bias.shape[0] != self.C:
+            raise ValueError(
+                f"Expected bias shape ({self.C},), got {bias.shape}"
+            )
 
         orig_shape = x.shape
         # Ensure contiguous and reshape to (N, num_groups, C/num_groups, *spatial)
@@ -217,20 +204,12 @@ class GroupNormFwdOp(Op):
         # The kernel broadcasts 1D weight/bias across all rows, but GroupNorm
         # needs per-group affine parameters. Run kernel with unit weight/zero
         # bias to normalize, then apply per-channel affine afterwards.
-        # Reuse cached identity tensors only on the affine-free path
-        # (weight is None or bias is None); the user-supplied path allocates
-        # fresh tensors to preserve byte-identical behavior.
-        if weight is None or bias is None:
-            unit_weight, zero_bias = self._get_affine_identity(
-                x.dtype, x.device,
-            )
-        else:
-            unit_weight = torch.ones(
-                self.D_padded, dtype=x.dtype, device=x.device,
-            )
-            zero_bias = torch.zeros(
-                self.D_padded, dtype=x.dtype, device=x.device,
-            )
+        unit_weight = torch.ones(
+            self.D_padded, dtype=x.dtype, device=x.device,
+        )
+        zero_bias = torch.zeros(
+            self.D_padded, dtype=x.dtype, device=x.device,
+        )
 
         # Pad to alignment
         if self.D_padded != self.D:
@@ -248,16 +227,9 @@ class GroupNormFwdOp(Op):
         y = y_2d.reshape(self.N, self.num_groups, cpg, *self.spatial)
         y = y.reshape(orig_shape)
 
-        # Apply per-channel affine: y = y * weight + bias when supplied.
-        # Both args default to identity (no-op) when None. The combined
-        # expression matches the user-supplied path bit-for-bit.
+        # Apply per-channel affine: y = y * weight + bias.
         affine_shape = [1, self.C] + [1] * len(self.spatial)
-        if weight is not None and bias is not None:
-            y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-        elif weight is not None:
-            y = y * weight.reshape(affine_shape)
-        elif bias is not None:
-            y = y + bias.reshape(affine_shape)
+        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
 
         return y
 

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -125,6 +125,18 @@ class InstanceNormFwdOp(Op):
         # rather than letting the kernel layer surface an opaque
         # device-mismatch failure.
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+        # Pre-allocate forward-time constants. The kernel binds 1D weight/bias
+        # row-broadcast inputs; per-channel affine doesn't fit that layout, so
+        # the kernel call uses identity (unit/zero) buffers and the affine is
+        # applied after. These tensors are immutable for the op's lifetime.
+        self._unit_weight = torch.ones(
+            self.D_padded, dtype=dtype, device=self._kernel_device,
+        )
+        self._zero_bias = torch.zeros(
+            self.D_padded, dtype=dtype, device=self._kernel_device,
+        )
+        self._expected_shape = (self.N, self.C, *self.spatial)
+        self._affine_shape = (1, self.C) + (1,) * len(self.spatial)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -196,6 +208,10 @@ class InstanceNormFwdOp(Op):
                 f"but x is on {x.device}. Construct a separate op instance per "
                 f"CUDA device."
             )
+        if tuple(x.shape) != self._expected_shape:
+            raise ValueError(
+                f"Expected x shape {self._expected_shape}, got {tuple(x.shape)}"
+            )
         if not isinstance(weight, torch.Tensor):
             raise ValueError(
                 "weight is required; use InstanceNormFwdOpNoAffine for the "
@@ -237,25 +253,14 @@ class InstanceNormFwdOp(Op):
 
         orig_shape = x.shape
         x = x.contiguous()
-
-        # Reshape: (N, C, *spatial) -> (N*C, spatial_size)
         x_2d = x.reshape(self.M, self.D)
 
-        # Unit weight and zero bias for the kernel (per-channel affine
-        # applied after the shared kernel call).
-        unit_weight = torch.ones(
-            self.D_padded, dtype=x.dtype, device=x.device,
-        )
-        zero_bias = torch.zeros(
-            self.D_padded, dtype=x.dtype, device=x.device,
-        )
-
-        # Pad to alignment
         if self.D_padded != self.D:
             x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
 
-        # Run kernel: produces (x - mean) / sqrt(var + eps)
-        y_2d = self.kernel(x_2d, unit_weight, zero_bias)
+        # Kernel broadcasts 1D weight/bias row-wise; per-channel affine is
+        # applied after, so run the kernel with identity (unit/zero) buffers.
+        y_2d = self.kernel(x_2d, self._unit_weight, self._zero_bias)
 
         # Trim padding
         if self.D_padded != self.D:
@@ -264,10 +269,7 @@ class InstanceNormFwdOp(Op):
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)
 
-        # Apply per-channel affine: y = y * weight + bias.
-        affine_shape = [1, self.C] + [1] * len(self.spatial)
-        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-
+        y = y * weight.reshape(self._affine_shape) + bias.reshape(self._affine_shape)
         return y
 
 

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -125,27 +125,6 @@ class InstanceNormFwdOp(Op):
         # rather than letting the kernel layer surface an opaque
         # device-mismatch failure.
         self._kernel_device = torch.device("cuda", torch.cuda.current_device())
-        # Affine-identity tensors are reused across forward calls when the
-        # caller passes weight=None / bias=None. Cached on the op instance
-        # and invalidated on (dtype, device) change of the input.
-        self._cached_unit_weight: Optional[torch.Tensor] = None
-        self._cached_zero_bias: Optional[torch.Tensor] = None
-        self._cached_affine_key: Optional[tuple] = None
-
-    def _get_affine_identity(
-        self, dtype: torch.dtype, device: torch.device,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return cached unit_weight / zero_bias for the given (dtype, device)."""
-        key = (dtype, device)
-        if self._cached_affine_key != key:
-            self._cached_unit_weight = torch.ones(
-                self.D_padded, dtype=dtype, device=device,
-            )
-            self._cached_zero_bias = torch.zeros(
-                self.D_padded, dtype=dtype, device=device,
-            )
-            self._cached_affine_key = key
-        return self._cached_unit_weight, self._cached_zero_bias
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -189,24 +168,24 @@ class InstanceNormFwdOp(Op):
     def forward(
         self,
         x: torch.Tensor,
-        weight: Optional[torch.Tensor] = None,
-        bias: Optional[torch.Tensor] = None,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
     ) -> torch.Tensor:
         """Apply instance normalization.
 
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
-            weight: Optional affine scale of shape ``(C,)`` on CUDA. When
-                ``None``, the affine scale defaults to all-ones (no scaling).
-            bias: Optional affine shift of shape ``(C,)`` on CUDA. When
-                ``None``, the affine shift defaults to all-zeros (no shift).
+            weight: Affine scale of shape ``(C,)`` on CUDA. Required; the
+                affine-free path is :class:`InstanceNormFwdOpNoAffine`.
+            bias: Affine shift of shape ``(C,)`` on CUDA. Required; the
+                affine-free path is :class:`InstanceNormFwdOpNoAffine`.
 
         Returns:
             Normalized tensor of the same shape as *x*.
 
         Raises:
-            ValueError: If tensors are not on CUDA, dtypes mismatch,
-                or shapes are incompatible with the configured dimensions.
+            ValueError: If any tensor is not on CUDA, dtypes mismatch, or
+                shapes are incompatible with the configured dimensions.
         """
         self._validate_dtypes(x)
         if not x.is_cuda:
@@ -217,36 +196,44 @@ class InstanceNormFwdOp(Op):
                 f"but x is on {x.device}. Construct a separate op instance per "
                 f"CUDA device."
             )
-        if weight is not None:
-            if not weight.is_cuda:
-                raise ValueError("weight must be a CUDA tensor")
-            if weight.device != x.device:
-                raise ValueError(
-                    f"Expected weight on {x.device}, got {weight.device}"
-                )
-            if weight.dtype != self.dtype:
-                raise ValueError(
-                    f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
-                )
-            if weight.ndim != 1 or weight.shape[0] != self.C:
-                raise ValueError(
-                    f"Expected weight shape ({self.C},), got {weight.shape}"
-                )
-        if bias is not None:
-            if not bias.is_cuda:
-                raise ValueError("bias must be a CUDA tensor")
-            if bias.device != x.device:
-                raise ValueError(
-                    f"Expected bias on {x.device}, got {bias.device}"
-                )
-            if bias.dtype != self.dtype:
-                raise ValueError(
-                    f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
-                )
-            if bias.ndim != 1 or bias.shape[0] != self.C:
-                raise ValueError(
-                    f"Expected bias shape ({self.C},), got {bias.shape}"
-                )
+        if not isinstance(weight, torch.Tensor):
+            raise ValueError(
+                "weight is required; use InstanceNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        if not isinstance(bias, torch.Tensor):
+            raise ValueError(
+                "bias is required; use InstanceNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        if not weight.is_cuda:
+            raise ValueError("weight must be a CUDA tensor")
+        if weight.device != x.device:
+            raise ValueError(
+                f"Expected weight on {x.device}, got {weight.device}"
+            )
+        if weight.dtype != self.dtype:
+            raise ValueError(
+                f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
+            )
+        if weight.ndim != 1 or weight.shape[0] != self.C:
+            raise ValueError(
+                f"Expected weight shape ({self.C},), got {weight.shape}"
+            )
+        if not bias.is_cuda:
+            raise ValueError("bias must be a CUDA tensor")
+        if bias.device != x.device:
+            raise ValueError(
+                f"Expected bias on {x.device}, got {bias.device}"
+            )
+        if bias.dtype != self.dtype:
+            raise ValueError(
+                f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
+            )
+        if bias.ndim != 1 or bias.shape[0] != self.C:
+            raise ValueError(
+                f"Expected bias shape ({self.C},), got {bias.shape}"
+            )
 
         orig_shape = x.shape
         x = x.contiguous()
@@ -254,21 +241,14 @@ class InstanceNormFwdOp(Op):
         # Reshape: (N, C, *spatial) -> (N*C, spatial_size)
         x_2d = x.reshape(self.M, self.D)
 
-        # Unit weight and zero bias for the kernel (affine applied after).
-        # Reuse cached identity tensors only on the affine-free path
-        # (weight is None or bias is None); the user-supplied path allocates
-        # fresh tensors to preserve byte-identical behavior.
-        if weight is None or bias is None:
-            unit_weight, zero_bias = self._get_affine_identity(
-                x.dtype, x.device,
-            )
-        else:
-            unit_weight = torch.ones(
-                self.D_padded, dtype=x.dtype, device=x.device,
-            )
-            zero_bias = torch.zeros(
-                self.D_padded, dtype=x.dtype, device=x.device,
-            )
+        # Unit weight and zero bias for the kernel (per-channel affine
+        # applied after the shared kernel call).
+        unit_weight = torch.ones(
+            self.D_padded, dtype=x.dtype, device=x.device,
+        )
+        zero_bias = torch.zeros(
+            self.D_padded, dtype=x.dtype, device=x.device,
+        )
 
         # Pad to alignment
         if self.D_padded != self.D:
@@ -284,16 +264,9 @@ class InstanceNormFwdOp(Op):
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)
 
-        # Apply per-channel affine: y = y * weight + bias when supplied.
-        # Both args default to identity (no-op) when None. The combined
-        # expression matches the user-supplied path bit-for-bit.
+        # Apply per-channel affine: y = y * weight + bias.
         affine_shape = [1, self.C] + [1] * len(self.spatial)
-        if weight is not None and bias is not None:
-            y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-        elif weight is not None:
-            y = y * weight.reshape(affine_shape)
-        elif bias is not None:
-            y = y + bias.reshape(affine_shape)
+        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
 
         return y
 


### PR DESCRIPTION
Closes #1381

## Summary

- Make `weight` and `bias` required tensors on `GroupNormFwdOp.forward` and `InstanceNormFwdOp.forward` (no `Optional`, no default `None`); reject `None`/non-Tensor with `ValueError`.
- Remove `_cached_unit_weight`, `_cached_zero_bias`, `_cached_affine_key`, and `_get_or_create_affine_identity` from `tileops/ops/norm/group_norm.py` and `tileops/ops/norm/instance_norm.py`.
- Migrate affine-free test paths and benchmark rows onto the existing `GroupNormFwdOpNoAffine` / `InstanceNormFwdOpNoAffine` variants.
- Add `pytest.raises` cases asserting the required-tensor contract on the affine ops.
- Manifest (`tileops/manifest/normalization.yaml`) is unchanged.

## Test plan

- [x] AC-1: Modified files pass unit tests (`pytest tests/ops/test_group_norm.py tests/ops/test_instance_norm.py` — 71 passed).
- [x] AC-2: `forward` signatures declare `weight`/`bias` as required (no Optional, no default); passing `None` raises.
- [x] AC-3: `_cached_unit_weight` / `_cached_zero_bias` / `_cached_affine_key` / `_get_or_create_affine_identity` removed (`grep -rn _cached_unit_weight tileops/ops/norm/` returns no hits).
- [x] AC-4: `weight=None`/`bias=None` test paths moved to `*FwdOpNoAffine` or deleted; affine tests include `pytest.raises` for the required-tensor contract.
- [x] AC-5: `benchmarks/ops/bench_group_norm.py` and `bench_instance_norm.py` route affine-free rows through the NoAffine variant; affine op no longer instantiated with `None`.
- [x] AC-6: `python scripts/validate_manifest.py --check-op GroupNormFwdOp` and `--check-op InstanceNormFwdOp` pass (L0–L4).
- [x] AC-7: `tileops/manifest/normalization.yaml` unchanged in this PR.

## Test node delta

Net delta: 73 → 71 (-2). Tests were never expanded; the count moved because cache-related cases were replaced one-for-one (or by a single contract-raise test).

Group norm: 13 → 12 (net −1)
- Removed: `test_group_norm_no_affine` (call site `forward(x, None, None)` no longer reachable on the affine op)
- Removed: `test_group_norm_caches_affine_identity` (cache hack itself is gone)
- Removed: `test_group_norm_separate_affine_caches_per_dtype` (same)
- Added: `test_group_norm_rejects_none_weight_or_bias` — covers AC-4 contract-raise for both arguments in one `pytest.raises` table
- Added: `test_group_norm_forward_required_signature` — structural check that `weight`/`bias` carry no default and no `Optional`

Instance norm: 14 → 13 (net −1)
- Same pattern as group norm (3 cache-tied cases out, 2 contract cases in)

No keep/duplicate cells: each removed case was strictly tied to a deleted code path (the `None`-cache branch); each added case maps to AC-4. Existing dtype/shape sweep is untouched, so no row duplicates dtype coverage that another already covers.

## Regression

- Affine path keeps the same kernel; only the `None` branch is removed. No perf regression expected.
