### PR TITLE
[BugFix][GQA] Fix varlen sliding-window WGMMA output race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,8 +44,6 @@ TILELANG_019_KNOWN_FAILING_NODEIDS = {
     "tests/ops/test_engram.py::test_engram_decode[4-1024-512-20-4-5-dtype2-False]",
     "tests/ops/test_engram.py::test_engram_decode[8-512-256-18-4-3-dtype3-False]",
     "tests/ops/test_engram.py::test_engram_decode_multi_step",
-    "tests/ops/attention/test_gqa_sliding_window_varlen.py::test_gqa_sliding_window_varlen_fwd_op[2-seqlens_q8-seqlens_k8-8-2-64-False-64-64-dtype8-False]",
-    "tests/ops/attention/test_gqa_sliding_window_varlen.py::test_gqa_sliding_window_varlen_fwd_op[2-seqlens_q13-seqlens_k13-8-2-64-True-0--1-dtype13-False]",
     "tests/ops/test_deltanet_recurrence.py::test_deltanet_decode[1-4-64-64-dtype1-False]",
     "tests/ops/test_deltanet_recurrence.py::test_deltanet_decode[1-4-64-64-dtype2-False]",
     "tests/ops/test_deltanet_recurrence.py::test_deltanet_decode[2-8-64-64-dtype5-False]",

--- a/tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
+++ b/tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
@@ -514,7 +514,9 @@ def _gqa_sw_fwd_varlen_wgmma_pipelined_kernel(
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] = T.if_then_else(
                         logsum[i] > 0, acc_o[i, j] / logsum[i], 0.0)
+                T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
+                T.sync_threads(3, threads)
                 for i, j in T.Parallel(block_m, dim):
                     if bx * block_m + i < q_len:
                         output[q_start + bx * block_m + i, by,


### PR DESCRIPTION
Closes #1404

## Summary

- Add explicit partial shared-memory synchronization around the WGMMA varlen sliding-window output staging copy.
- Remove the two fixed GQA sliding-window varlen TileLang 0.1.9 skip nodeids.

## Test plan

- [x] pre-commit passed during `git commit`
- [x] `TMPDIR=/home/lyc/Project/TileOPs/.tmp/tvm_tmp python -m pytest tests/ops/attention/test_gqa_sliding_window_varlen.py -vvs`

## Regression

The two previously skipped nodeids from #1074 now run and pass locally on H200 with the default WGMMA `threads=256` configuration. The exported CUDA root cause was a missing shared-memory producer/consumer sync around the `acc_o` to `o_shared` staging copy.

## Additional context

Related to #1071 and #1074.