### PR TITLE
[Feat][Kernels] int / bool kernel coverage for elementwise_binary

### DIFF
--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -1325,5 +1325,47 @@ def test_sub_rejects_bool_dtype() -> None:
         SubFwdOp(a_shape=shape, b_shape=shape, dtype=torch.bool)
 
 
+class FullUnionFp8RejectFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, dtype", [
+            pytest.param(AddFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
+            pytest.param(SubFwdOp, torch.float8_e5m2, marks=pytest.mark.smoke),
+            pytest.param(MulFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
+            pytest.param(MaximumFwdOp, torch.float8_e5m2, marks=pytest.mark.smoke),
+            pytest.param(MinimumFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
+        ]),
+    ]
+
+
+@FullUnionFp8RejectFixture
+def test_full_union_binary_ops_reject_fp8_dtype(
+    op_cls, dtype: torch.dtype,
+) -> None:
+    """Add/Sub/Mul/Maximum/Minimum reject fp8 at the public op layer.
+
+    Pins the manifest dtype union: even though the kernel templates can
+    compile for fp8, the elementwise_binary manifest stops at float32,
+    so the public ops must refuse fp8 at construction time.
+    """
+    shape = (16,)
+    with pytest.raises(ValueError, match="does not support dtype"):
+        op_cls(a_shape=shape, b_shape=shape, dtype=dtype)
+
+
+@pytest.mark.smoke
+def test_add_bool_broadcast() -> None:
+    """AddFwdOp(bool) with broadcast inputs lowers via the forced 'direct'
+    strategy and still matches torch.logical_or semantics."""
+    a_shape = (8, 16)
+    b_shape = (1, 16)
+    a = torch.randint(0, 2, a_shape, device="cuda").to(torch.bool)
+    b = torch.randint(0, 2, b_shape, device="cuda").to(torch.bool)
+    op = AddFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=torch.bool)
+    ref = torch.logical_or(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _exact_compare(out, ref)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -858,8 +858,6 @@ class FloatOnlyBinaryRejectFixture(FixtureBase):
             pytest.param(PowFwdOp, torch.int32, marks=pytest.mark.smoke),
             pytest.param(FloorDivideFwdOp, torch.int64, marks=pytest.mark.smoke),
             pytest.param(LerpFwdOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MaximumFwdOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(MinimumFwdOp, torch.int64, marks=pytest.mark.smoke),
         ]),
     ]
 
@@ -1164,6 +1162,167 @@ def test_div_rounding_mode_dispatch() -> None:
             a_shape=shape, b_shape=shape, dtype=torch.float16,
             rounding_mode="invalid",
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-dtype int / bool correctness for arithmetic ops with manifest int union
+# ---------------------------------------------------------------------------
+
+_BINARY_INT_DTYPES = [
+    torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
+]
+# Add / Mul / Maximum / Minimum accept the full union including bool;
+# Sub mirrors PyTorch and excludes bool (bool subtraction is undefined).
+_FULL_UNION_OPS = [
+    (AddFwdOp, torch.add),
+    (MulFwdOp, torch.mul),
+    (MaximumFwdOp, torch.maximum),
+    (MinimumFwdOp, torch.minimum),
+]
+
+
+def _gen_int_pair(n: int, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    if dtype == torch.uint8:
+        lo, hi = 0, 32
+    elif dtype == torch.int8:
+        lo, hi = -16, 16
+    else:
+        lo, hi = -64, 64
+    a = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    b = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    return a, b
+
+
+def _exact_compare(out: torch.Tensor, ref: torch.Tensor) -> None:
+    assert out.dtype == ref.dtype, f"dtype mismatch: {out.dtype} vs {ref.dtype}"
+    assert torch.equal(out, ref), (
+        f"Mismatch: {(out != ref).sum().item()} elements differ"
+    )
+
+
+# Dtype-coverage axis: exercise every manifest-declared int dtype on a
+# single representative op (AddFwdOp). The op-coverage axis below fixes
+# dtype = int32 and varies op_cls. Decoupling the axes avoids the
+# dtype x op cross product.
+class BinaryArithIntDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("dtype", [
+            pytest.param(dt, marks=pytest.mark.smoke)
+            for dt in _BINARY_INT_DTYPES
+        ]),
+    ]
+
+
+@BinaryArithIntDtypeFixture
+def test_binary_arith_integer_dtype_add(dtype: torch.dtype) -> None:
+    """AddFwdOp matches torch.add on every manifest-declared int dtype."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_pair(n, dtype)
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    ref = torch.add(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _exact_compare(out, ref)
+
+
+# Op-coverage axis: at fixed dtype = int32, every full-union arithmetic
+# op (plus SubFwdOp) matches its torch reference.
+_INT_OP_CASES = _FULL_UNION_OPS + [(SubFwdOp, torch.sub)]
+
+
+class BinaryArithOpIntFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _INT_OP_CASES
+        ]),
+    ]
+
+
+@BinaryArithOpIntFixture
+def test_binary_arith_op_int32(op_cls, ref_fn) -> None:
+    """Each arithmetic op matches its torch reference on int32 inputs."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_pair(n, torch.int32)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _exact_compare(out, ref)
+
+
+# Bool-axis reference mapping. The kernel implements:
+#   AddFwdOp(bool, bool) := a | b   (logical OR — kernel uses ``a + b``,
+#                                    which lowers to OR for bool operands;
+#                                    must NOT be XOR)
+#   MulFwdOp(bool, bool) := a & b   (logical AND — kernel uses ``a * b``)
+#   MaximumFwdOp(bool, bool) := a | b   (T.max on bool == OR)
+#   MinimumFwdOp(bool, bool) := a & b   (T.min on bool == AND)
+# torch.add / torch.mul on bool tensors happen to coincide with OR/AND,
+# but we use torch.logical_or / torch.logical_and as the explicit
+# reference so the contract — and any future divergence in PyTorch's
+# bool arithmetic semantics — is documented at the call site.
+_FULL_UNION_BOOL_REFS = [
+    (AddFwdOp, torch.logical_or),
+    (MulFwdOp, torch.logical_and),
+    (MaximumFwdOp, torch.logical_or),
+    (MinimumFwdOp, torch.logical_and),
+]
+
+
+class BinaryArithBoolDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _FULL_UNION_BOOL_REFS
+        ]),
+    ]
+
+
+@BinaryArithBoolDtypeFixture
+def test_binary_arith_bool_dtype(op_cls, ref_fn) -> None:
+    """Add/Mul/Maximum/Minimum match logical OR/AND on torch.bool inputs.
+
+    SubFwdOp is excluded because torch.sub raises on bool inputs.
+    """
+    n = 4_096
+    shape = (n,)
+    a = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    b = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _exact_compare(out, ref)
+
+
+@pytest.mark.smoke
+def test_add_bool_is_or_not_xor() -> None:
+    """AddFwdOp(bool) must lower to OR (True+True=True), not XOR.
+
+    Sentinel guard: if a future TileLang change lowers ``+`` on bool as
+    XOR, this test fails on the (True, True) lane (XOR would give False,
+    OR gives True). Random-bool tests cover both lanes statistically;
+    this test pins the contract on a deterministic input.
+    """
+    shape = (4,)
+    a = torch.tensor([True, True, False, False], device="cuda")
+    b = torch.tensor([True, False, True, False], device="cuda")
+    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    expected = torch.tensor([True, True, True, False], device="cuda")
+    with torch.no_grad():
+        out = op(a, b)
+    _exact_compare(out, expected)
+
+
+@pytest.mark.smoke
+def test_sub_rejects_bool_dtype() -> None:
+    """torch.sub raises on bool; SubFwdOp must reject it at construction time."""
+    shape = (16,)
+    with pytest.raises(ValueError, match="does not support dtype"):
+        SubFwdOp(a_shape=shape, b_shape=shape, dtype=torch.bool)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -363,18 +363,16 @@ def test_comparison_bool_dtype(op_cls, ref_fn) -> None:
 
 
 class ComparisonRejectFixture(FixtureBase):
+    # Smoke cases (first three) cover the three rejected dtypes on three
+    # distinct op_cls so the tier validator's "each dtype needs a smoke"
+    # rule is satisfied while keeping "full cases must not differ from a
+    # smoke case only by dtype" — each smoke op_cls is unique.
     PARAMS = [
         ("op_cls, dtype", [
             pytest.param(EqFwdOp, torch.complex64, marks=pytest.mark.smoke),
-            pytest.param(NeFwdOp, torch.complex64, marks=pytest.mark.full),
-            pytest.param(GtFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(NeFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
+            pytest.param(GtFwdOp, torch.float8_e5m2, marks=pytest.mark.smoke),
             pytest.param(LtFwdOp, torch.complex64, marks=pytest.mark.full),
-            pytest.param(GeFwdOp, torch.complex64, marks=pytest.mark.full),
-            pytest.param(LeFwdOp, torch.complex64, marks=pytest.mark.full),
-            pytest.param(EqFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
-            pytest.param(NeFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
-            pytest.param(GtFwdOp, torch.float8_e4m3fn, marks=pytest.mark.full),
-            pytest.param(LtFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
             pytest.param(GeFwdOp, torch.float8_e4m3fn, marks=pytest.mark.full),
             pytest.param(LeFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
         ]),

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -357,7 +357,8 @@ def test_comparison_bool_dtype(op_cls, ref_fn) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Dtype rejection tests (fp8 is outside the manifest dtype union)
+# Dtype rejection tests (dtypes outside the manifest dtype union: fp8 and
+# complex must raise at construction time).
 # ---------------------------------------------------------------------------
 
 
@@ -370,6 +371,12 @@ class ComparisonRejectFixture(FixtureBase):
             pytest.param(LtFwdOp, torch.complex64, marks=pytest.mark.full),
             pytest.param(GeFwdOp, torch.complex64, marks=pytest.mark.full),
             pytest.param(LeFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(EqFwdOp, torch.float8_e4m3fn, marks=pytest.mark.smoke),
+            pytest.param(NeFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
+            pytest.param(GtFwdOp, torch.float8_e4m3fn, marks=pytest.mark.full),
+            pytest.param(LtFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
+            pytest.param(GeFwdOp, torch.float8_e4m3fn, marks=pytest.mark.full),
+            pytest.param(LeFwdOp, torch.float8_e5m2, marks=pytest.mark.full),
         ]),
     ]
 

--- a/tests/ops/test_comparison.py
+++ b/tests/ops/test_comparison.py
@@ -254,27 +254,131 @@ def test_eq_edge_case(n_total: int, dtype: torch.dtype) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Dtype rejection tests
+# Per-dtype correctness across the manifest dtype union
+# ---------------------------------------------------------------------------
+
+_INT_DTYPES = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]
+_CMP_OP_CASES = [
+    (EqFwdOp, torch.eq),
+    (NeFwdOp, torch.ne),
+    (GtFwdOp, torch.gt),
+    (LtFwdOp, torch.lt),
+    (GeFwdOp, torch.ge),
+    (LeFwdOp, torch.le),
+]
+
+
+def _gen_int_inputs(n: int, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    if dtype == torch.uint8:
+        lo, hi = 0, 16
+    elif dtype == torch.int8:
+        lo, hi = -16, 16
+    else:
+        lo, hi = -64, 64
+    a = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    b = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    # Inject some equal positions so eq/ge/le exercise the True branch.
+    b[: n // 4] = a[: n // 4]
+    return a, b
+
+
+# Dtype-coverage axis: exercise every manifest-declared int dtype on a
+# single representative op (EqFwdOp). The op-coverage axis below uses a
+# fixed dtype and varies op_cls; this avoids the dtype x op cross product.
+class ComparisonIntDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("dtype", [
+            pytest.param(dt, marks=pytest.mark.smoke)
+            for dt in _INT_DTYPES
+        ]),
+    ]
+
+
+@ComparisonIntDtypeFixture
+def test_comparison_integer_dtype_eq(dtype: torch.dtype) -> None:
+    """EqFwdOp matches torch.eq on every manifest-declared int dtype."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_inputs(n, dtype)
+    op = EqFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    ref = torch.eq(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
+# Op-coverage axis: at a fixed integer dtype, every comparison op must
+# match its torch reference. Combined with the dtype-coverage axis above,
+# this gives full per-op-per-dtype coverage in N + M cases instead of
+# N x M.
+class ComparisonOpIntFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _CMP_OP_CASES
+        ]),
+    ]
+
+
+@ComparisonOpIntFixture
+def test_comparison_op_int32(op_cls, ref_fn) -> None:
+    """Each comparison op matches its torch reference on int32 inputs."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_inputs(n, torch.int32)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
+class ComparisonBoolDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _CMP_OP_CASES
+        ]),
+    ]
+
+
+@ComparisonBoolDtypeFixture
+def test_comparison_bool_dtype(op_cls, ref_fn) -> None:
+    """Comparison ops match torch reference on torch.bool inputs."""
+    n = 4_096
+    shape = (n,)
+    a = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    b = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
+# ---------------------------------------------------------------------------
+# Dtype rejection tests (fp8 is outside the manifest dtype union)
 # ---------------------------------------------------------------------------
 
 
 class ComparisonRejectFixture(FixtureBase):
     PARAMS = [
         ("op_cls, dtype", [
-            pytest.param(EqFwdOp, torch.int32, marks=pytest.mark.smoke),
-            pytest.param(EqFwdOp, torch.int64, marks=pytest.mark.smoke),
-            pytest.param(NeFwdOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(GtFwdOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(LtFwdOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(GeFwdOp, torch.int32, marks=pytest.mark.full),
-            pytest.param(LeFwdOp, torch.int32, marks=pytest.mark.full),
+            pytest.param(EqFwdOp, torch.complex64, marks=pytest.mark.smoke),
+            pytest.param(NeFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(GtFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(LtFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(GeFwdOp, torch.complex64, marks=pytest.mark.full),
+            pytest.param(LeFwdOp, torch.complex64, marks=pytest.mark.full),
         ]),
     ]
 
 
 @ComparisonRejectFixture
-def test_comparison_rejects_integer_dtype(op_cls, dtype: torch.dtype) -> None:
-    """Comparison ops only support float dtypes; integers must be rejected."""
+def test_comparison_rejects_unsupported_dtype(
+    op_cls, dtype: torch.dtype,
+) -> None:
+    """Comparison ops reject dtypes outside the supported set (e.g. complex)."""
     shape = (16,)
     with pytest.raises(ValueError, match="does not support dtype"):
         op_cls(a_shape=shape, b_shape=shape, dtype=dtype)

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -33,6 +33,7 @@ fp8 dtype support (e4m3fn, e5m2):
 
 import functools
 import math
+import warnings
 
 import tilelang
 import tilelang.language as T
@@ -833,7 +834,21 @@ class BinaryKernel(Kernel):
         self._same_shape = _is_contiguous_same_shape(
             coalesced_shape, a_strides, b_strides,
         )
-        if strategy is not None:
+        # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads /
+        # stores, which the CUDA codegen cannot lower. Force the scalar
+        # ``direct`` strategy for bool inputs regardless of caller request.
+        bool_input = dtype == torch.bool
+        if bool_input:
+            if strategy is not None and strategy != "direct":
+                warnings.warn(
+                    f"BinaryKernel: dtype=torch.bool requires strategy="
+                    f"'direct' (TileLang cannot lower vectorised boolx<N> "
+                    f"loads); overriding requested strategy={strategy!r}.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            self.strategy = "direct"
+        elif strategy is not None:
             # register_copy requires same-shape contiguous inputs (no
             # broadcast); silently downgrade to explicit_parallel when
             # the caller requests register_copy on broadcast shapes.
@@ -1272,7 +1287,14 @@ class SubFwdKernel(_AlphaScaledBinaryKernel):
 
 
 class MulFwdKernel(BinaryKernel):
-    """Element-wise multiplication: y = a * b."""
+    """Element-wise multiplication: y = a * b.
+
+    Supports the manifest dtype union (bool / unsigned / signed integer /
+    half / single precision floats). Bool multiplication is logical AND
+    (PyTorch semantics).
+    """
+
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
 
@@ -1435,26 +1457,46 @@ class LerpFwdKernel(BinaryKernel):
             raise ValueError(f"Unknown strategy: {strategy}")
 
 
-class MaximumFwdKernel(BinaryKernel):
-    """Element-wise maximum: y = max(a, b) with NaN propagation.
+def _is_float_dtype_str(dtype_str: str) -> bool:
+    """Return True for floating-point TileLang dtype strings.
 
-    Matches torch.maximum semantics:
+    TileLang IR exposes operand dtypes only as strings (``"float16"``,
+    ``"bfloat16"``, ``"float32"``, ``"float8_e4m3fn"`` ...), so prefix
+    matching is the established convention for float detection inside
+    ``op_func`` kernel bodies. All TileLang float dtype names start
+    with ``"float"`` or ``"bfloat"``; integer / bool dtype names
+    (``"int*"``, ``"uint*"``, ``"bool"``) do not.
+    """
+    return dtype_str.startswith(("float", "bfloat"))
+
+
+class MaximumFwdKernel(BinaryKernel):
+    """Element-wise maximum: y = max(a, b).
+
+    For float dtypes, matches torch.maximum semantics:
     - If either operand is NaN, the result is NaN.
     - maximum(+0.0, -0.0) = +0.0 (IEEE 754 signed-zero).
 
-    Performance: uses T.max for the fast path (correct signed-zero on CUDA
-    -- fmaxf returns +0 for max(+0,-0)) plus two isnan guards for NaN
-    propagation. Total IR: 1 max + 2 fp32 casts + 2 isnan + 2 select.
+    For integer / bool dtypes (no NaN representation), uses ``T.max``
+    directly without the NaN guards.
+
+    Performance (float path): uses T.max for the fast path (correct
+    signed-zero on CUDA -- fmaxf returns +0 for max(+0,-0)) plus two
+    isnan guards for NaN propagation. Total IR: 1 max + 2 fp32 casts +
+    2 isnan + 2 select.
     """
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
 
     @staticmethod
     def op_func(a, b):
-        # T.max handles signed-zero correctly (returns +0 for max(+0,-0))
-        # but does NOT propagate NaN -- it returns the non-NaN operand.
         result = T.max(a, b)
-        # NaN propagation: cast to fp32 for isnan (bfloat16 lacks native isnan).
+        if not _is_float_dtype_str(str(a.dtype)):
+            # Integer / bool: no NaN representation, T.max is sufficient.
+            return result
+        # Float path: T.max handles signed-zero correctly but does NOT
+        # propagate NaN -- it returns the non-NaN operand. Cast to fp32
+        # for isnan (bfloat16 lacks native isnan).
         a_is_nan = T.isnan(T.Cast("float32", a))
         b_is_nan = T.isnan(T.Cast("float32", b))
         result = T.if_then_else(b_is_nan, b, result)
@@ -1463,25 +1505,28 @@ class MaximumFwdKernel(BinaryKernel):
 
 
 class MinimumFwdKernel(BinaryKernel):
-    """Element-wise minimum: y = min(a, b) with NaN propagation.
+    """Element-wise minimum: y = min(a, b).
 
-    Matches torch.minimum semantics:
+    For float dtypes, matches torch.minimum semantics:
     - If either operand is NaN, the result is NaN.
     - minimum(-0.0, +0.0) = -0.0 (IEEE 754 signed-zero).
 
-    Performance: uses T.min for the fast path (correct signed-zero on CUDA
-    -- fminf returns -0 for min(-0,+0)) plus two isnan guards for NaN
-    propagation. See MaximumFwdKernel for full rationale.
+    For integer / bool dtypes (no NaN representation), uses ``T.min``
+    directly without the NaN guards.
+
+    Performance (float path): uses T.min for the fast path (correct
+    signed-zero on CUDA -- fminf returns -0 for min(-0,+0)) plus two
+    isnan guards for NaN propagation. See MaximumFwdKernel for full
+    rationale.
     """
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
 
     @staticmethod
     def op_func(a, b):
-        # T.min handles signed-zero correctly (returns -0 for min(+0,-0))
-        # but does NOT propagate NaN -- it returns the non-NaN operand.
         result = T.min(a, b)
-        # NaN propagation: cast to fp32 for isnan (bfloat16 lacks native isnan).
+        if not _is_float_dtype_str(str(a.dtype)):
+            return result
         a_is_nan = T.isnan(T.Cast("float32", a))
         b_is_nan = T.isnan(T.Cast("float32", b))
         result = T.if_then_else(b_is_nan, b, result)
@@ -1497,7 +1542,7 @@ class MinimumFwdKernel(BinaryKernel):
 class EqFwdKernel(BinaryKernel):
     """Element-wise equality: y = (a == b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod
@@ -1510,7 +1555,7 @@ class EqFwdKernel(BinaryKernel):
 class NeFwdKernel(BinaryKernel):
     """Element-wise not-equal: y = (a != b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod
@@ -1523,7 +1568,7 @@ class NeFwdKernel(BinaryKernel):
 class GtFwdKernel(BinaryKernel):
     """Element-wise greater-than: y = (a > b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod
@@ -1536,7 +1581,7 @@ class GtFwdKernel(BinaryKernel):
 class LtFwdKernel(BinaryKernel):
     """Element-wise less-than: y = (a < b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod
@@ -1549,7 +1594,7 @@ class LtFwdKernel(BinaryKernel):
 class GeFwdKernel(BinaryKernel):
     """Element-wise greater-equal: y = (a >= b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod
@@ -1562,7 +1607,7 @@ class GeFwdKernel(BinaryKernel):
 class LeFwdKernel(BinaryKernel):
     """Element-wise less-equal: y = (a <= b), stored as int8 (1/0)."""
 
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
+    SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
     OUTPUT_DTYPE = torch.int8
 
     @staticmethod

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -834,6 +834,13 @@ class BinaryKernel(Kernel):
         self._same_shape = _is_contiguous_same_shape(
             coalesced_shape, a_strides, b_strides,
         )
+        # Validate a caller-provided strategy up front so typos raise the
+        # same ValueError regardless of dtype (the bool override below
+        # otherwise silently accepts an unknown strategy for bool inputs).
+        if strategy is not None and strategy not in self.STRATEGIES:
+            raise ValueError(
+                f"Unknown strategy '{strategy}', expected one of {self.STRATEGIES}"
+            )
         # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads /
         # stores, which the CUDA codegen cannot lower. Force the scalar
         # ``direct`` strategy for bool inputs regardless of caller request.


### PR DESCRIPTION
Closes #1243

## Summary

- Widen `_BINARY_FULL_DTYPES` (bool/uint8/int8/int16/int32/int64/fp16/bf16/fp32) and `_BINARY_NO_BOOL_DTYPES` (Sub) so 11 elementwise_binary ops accept every manifest-declared dtype. Public op layer matches the manifest dtype union exactly; fp8 remains kernel-internal.
- Force `BinaryKernel` to the `direct` strategy when `dtype == torch.bool` (TileLang cannot lower vectorised `bool×N`). `RuntimeWarning` when a non-default caller-provided strategy is overridden.
- Per-dtype correctness tests on three decoupled axes (dtype-axis × representative op, op-axis × int32, bool-axis × every bool-supporting op) per `.claude/domain-rules/testing-budget.md`. References are `torch.*`; bool ops mapped to `torch.logical_or` / `torch.logical_and`. Sentinel `test_add_bool_is_or_not_xor` pins TileLang's bool `+` lowering.
- `tests/ops/test_elementwise_fp8.py` rerouted: fp8 acceptance / forward-dtype onto `DivFwdKernel`, saturation / Inf overflow onto `ExpFwdOp` — `AddFwdOp` is no longer reachable with fp8 at the public layer.
- Manifest byte-identical. `status: spec-only → implemented` flip is a follow-up manifest-only PR per the trust model.

## Test plan

- [x] `pytest tests/ops/test_binary_arith.py tests/ops/test_comparison.py tests/ops/test_elementwise_fp8.py` green (193 nodes)
- [x] `scripts/validate_manifest.py` clean for all 11 ops
- [x] pre-commit, gitleaks, actionlint, ci-gate green