### PR TITLE
[Feat][Kernels] rounding-mode div kernel path for trunc/floor

### DIFF
--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.elementwise import DivTruncFwdKernel, FloorDivideFwdKernel
 from tileops.ops.elementwise import (
     AddFwdOp,
     DivFwdOp,
@@ -23,6 +24,7 @@ from tileops.ops.elementwise import (
     SubFwdOp,
     coalesce_broadcast_dims,
 )
+from tileops.ops.elementwise.arithmetic import _DIV_KERNEL_BY_ROUNDING_MODE
 from workloads.binary_arith import AddSameShapeTest as _AddSameShapeTestWorkload
 
 
@@ -1113,6 +1115,55 @@ def test_lerp_tensor_dtype_mismatch_rejected() -> None:
     w_bad = torch.rand(shape, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="weight.dtype"):
         op(a, b, w_bad)
+
+
+# ---------------------------------------------------------------------------
+# DivFwdOp rounding_mode trunc/floor coverage
+# ---------------------------------------------------------------------------
+
+
+_DIV_ROUNDING_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+_DIV_ROUNDING_MODES = ["trunc", "floor"]
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("rounding_mode", _DIV_ROUNDING_MODES)
+@pytest.mark.parametrize("dtype", _DIV_ROUNDING_DTYPES)
+def test_div_rounding_mode_eager(rounding_mode: str, dtype: torch.dtype) -> None:
+    """DivFwdOp(rounding_mode=...) matches torch.div for trunc and floor."""
+    shape = (64, 256)
+    # Both positive and negative quotients naturally arise from randn inputs;
+    # clamp ``b`` away from zero so division is well-defined.
+    a = torch.randn(*shape, dtype=dtype, device="cuda") * 5.0
+    b = torch.randn(*shape, dtype=dtype, device="cuda") * 2.0 + 1.0
+    b = torch.where(b.abs() < 0.5, torch.full_like(b, 1.0), b)
+    op = DivFwdOp(
+        a_shape=shape, b_shape=shape, dtype=dtype, rounding_mode=rounding_mode,
+    )
+    with torch.no_grad():
+        out = op(a, b)
+    ref = torch.div(a.float(), b.float(), rounding_mode=rounding_mode).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    # rounding-mode divergence in reduced precision can flip by 1 unit at
+    # quotient boundaries; mirror the floor_divide convention.
+    if dtype != torch.float32:
+        atol = 1.0
+        rtol = 0.0
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_div_rounding_mode_dispatch() -> None:
+    """DivFwdOp wires rounding_mode to the right kernel class and rejects unknown modes."""
+    assert _DIV_KERNEL_BY_ROUNDING_MODE["trunc"] is DivTruncFwdKernel
+    assert _DIV_KERNEL_BY_ROUNDING_MODE["floor"] is FloorDivideFwdKernel
+    shape = (16,)
+    with pytest.raises(ValueError, match="rounding_mode"):
+        DivFwdOp(
+            a_shape=shape, b_shape=shape, dtype=torch.float16,
+            rounding_mode="invalid",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -844,5 +844,37 @@ def test_masked_fill_scalar_compile_broadcast():
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
+# --- DivFwdOp rounding_mode trunc/floor compile coverage ---
+
+
+_DIV_ROUNDING_COMPILE_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+_DIV_ROUNDING_COMPILE_MODES = ["trunc", "floor"]
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("rounding_mode", _DIV_ROUNDING_COMPILE_MODES)
+@pytest.mark.parametrize("dtype", _DIV_ROUNDING_COMPILE_DTYPES)
+def test_div_rounding_mode_compile(rounding_mode: str, dtype: torch.dtype) -> None:
+    """torch.compile path matches torch.div for trunc and floor rounding modes."""
+    shape = _SMALL
+    a = torch.randn(shape, dtype=dtype, device="cuda") * 5.0
+    b = torch.randn(shape, dtype=dtype, device="cuda") * 2.0 + 1.0
+    b = torch.where(b.abs() < 0.5, torch.full_like(b, 1.0), b)
+    op = DivFwdOp(
+        a_shape=shape, b_shape=shape, dtype=dtype, rounding_mode=rounding_mode,
+    )
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(a, b)
+    ref = torch.div(a.float(), b.float(), rounding_mode=rounding_mode).to(dtype)
+    # rounding-mode divergence in reduced precision can flip by 1 unit at
+    # quotient boundaries; loosen tolerance for fp16/bf16 accordingly.
+    if dtype == torch.float32:
+        atol, rtol = 1e-5, 1e-5
+    else:
+        atol, rtol = 1.0, 0.0
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -87,6 +87,8 @@ __all__ = [
     "SubFwdKernel",
     "MulFwdKernel",
     "DivFwdKernel",
+    "DivTruncFwdKernel",
+    "DivFloorFwdKernel",
     "RemainderFwdKernel",
     "PowFwdKernel",
     "FloorDivideFwdKernel",
@@ -1288,6 +1290,44 @@ class DivFwdKernel(BinaryKernel):
     @staticmethod
     def op_func(a, b):
         return a / b
+
+
+class DivTruncFwdKernel(BinaryKernel):
+    """Element-wise truncated division: y = trunc(a / b).
+
+    Matches ``torch.div(a, b, rounding_mode="trunc")`` semantics: rounds
+    the quotient toward zero. Division and ``trunc`` are computed in fp32
+    to avoid two sources of error: (1) ``htrunc`` is not available for
+    ``cutlass::half_t`` in CUDA, and (2) fp16 division rounds the
+    quotient before ``trunc`` sees it.
+    """
+
+    SUPPORTED_DTYPES = _FLOAT_DTYPES
+
+    @staticmethod
+    def op_func(a, b):
+        a_f32 = T.cast(a, "float32")
+        b_f32 = T.cast(b, "float32")
+        return T.Cast(a.dtype, T.trunc(a_f32 / b_f32))
+
+
+class DivFloorFwdKernel(BinaryKernel):
+    """Element-wise floor division: y = floor(a / b).
+
+    Matches ``torch.div(a, b, rounding_mode="floor")`` semantics: rounds
+    the quotient toward negative infinity. Division and ``floor`` are
+    computed in fp32 to avoid two sources of error: (1) ``hfloor`` is
+    not available for ``cutlass::half_t`` in CUDA, and (2) fp16 division
+    rounds the quotient before ``floor`` sees it.
+    """
+
+    SUPPORTED_DTYPES = _FLOAT_DTYPES
+
+    @staticmethod
+    def op_func(a, b):
+        a_f32 = T.cast(a, "float32")
+        b_f32 = T.cast(b, "float32")
+        return T.Cast(a.dtype, T.floor(a_f32 / b_f32))
 
 
 class RemainderFwdKernel(BinaryKernel):

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -88,7 +88,6 @@ __all__ = [
     "MulFwdKernel",
     "DivFwdKernel",
     "DivTruncFwdKernel",
-    "DivFloorFwdKernel",
     "RemainderFwdKernel",
     "PowFwdKernel",
     "FloorDivideFwdKernel",
@@ -1309,25 +1308,6 @@ class DivTruncFwdKernel(BinaryKernel):
         a_f32 = T.cast(a, "float32")
         b_f32 = T.cast(b, "float32")
         return T.Cast(a.dtype, T.trunc(a_f32 / b_f32))
-
-
-class DivFloorFwdKernel(BinaryKernel):
-    """Element-wise floor division: y = floor(a / b).
-
-    Matches ``torch.div(a, b, rounding_mode="floor")`` semantics: rounds
-    the quotient toward negative infinity. Division and ``floor`` are
-    computed in fp32 to avoid two sources of error: (1) ``hfloor`` is
-    not available for ``cutlass::half_t`` in CUDA, and (2) fp16 division
-    rounds the quotient before ``floor`` sees it.
-    """
-
-    SUPPORTED_DTYPES = _FLOAT_DTYPES
-
-    @staticmethod
-    def op_func(a, b):
-        a_f32 = T.cast(a, "float32")
-        b_f32 = T.cast(b, "float32")
-        return T.Cast(a.dtype, T.floor(a_f32 / b_f32))
 
 
 class RemainderFwdKernel(BinaryKernel):

--- a/tileops/ops/elementwise/arithmetic.py
+++ b/tileops/ops/elementwise/arithmetic.py
@@ -7,7 +7,9 @@ import torch
 
 from tileops.kernels.elementwise import (
     AddFwdKernel,
+    DivFloorFwdKernel,
     DivFwdKernel,
+    DivTruncFwdKernel,
     FloorDivideFwdKernel,
     LerpFwdKernel,
     LerpTensorFwdKernel,
@@ -60,15 +62,20 @@ class MulFwdOp(BinaryOp):
     kernel_cls = MulFwdKernel
 
 
+_DIV_KERNEL_BY_ROUNDING_MODE = {
+    None: DivFwdKernel,
+    "trunc": DivTruncFwdKernel,
+    "floor": DivFloorFwdKernel,
+}
+
+
 class DivFwdOp(BinaryOp):
     """Element-wise division with broadcast: y = input / other.
 
     Conforms to ``torch.div(input, other, *, rounding_mode=None)``.
     ``rounding_mode`` accepts ``None`` (true division), ``"trunc"``
-    (truncation toward zero), or ``"floor"`` (floor division). Only
-    ``rounding_mode is None`` dispatches to the kernel; the trunc /
-    floor variants raise ``NotImplementedError`` until a rounded-divide
-    kernel lands (tracked in a follow-up issue). The leading ``*``
+    (truncation toward zero), or ``"floor"`` (floor division); each
+    value selects a dedicated kernel specialization. The leading ``*``
     makes ``rounding_mode`` and the existing ``strategy`` /
     ``kernel_map`` / ``tune`` parameters keyword-only; only the
     positional triplet ``(a_shape, b_shape, dtype)`` is shared with
@@ -89,29 +96,21 @@ class DivFwdOp(BinaryOp):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if rounding_mode is not None and rounding_mode not in ("trunc", "floor"):
+        if rounding_mode not in _DIV_KERNEL_BY_ROUNDING_MODE:
             raise ValueError(
                 f"DivFwdOp received rounding_mode={rounding_mode!r}; "
                 "manifest allows None, 'trunc', or 'floor'"
             )
+        self.rounding_mode = rounding_mode
+        # ``self.kernel_cls`` becomes an instance attribute that shadows the
+        # class attribute so ``BinaryOp.default_kernel_map`` (and the
+        # SUPPORTED_DTYPES check in ``BinaryOp.__init__``) pick the variant
+        # matching ``rounding_mode``.
+        self.kernel_cls = _DIV_KERNEL_BY_ROUNDING_MODE[rounding_mode]
         super().__init__(
             a_shape, b_shape, dtype, strategy=strategy,
             kernel_map=kernel_map, tune=tune,
         )
-        self.rounding_mode = rounding_mode
-
-    def forward(
-        self,
-        input: torch.Tensor,  # noqa: A002
-        other: torch.Tensor,
-    ) -> torch.Tensor:
-        if self.rounding_mode is not None:
-            raise NotImplementedError(
-                f"DivFwdOp(rounding_mode={self.rounding_mode!r}) is not yet "
-                "implemented; the current kernel only honors rounding_mode is "
-                "None. A follow-up issue tracks the kernel work."
-            )
-        return super().forward(input, other)
 
 
 class RemainderFwdOp(BinaryOp):

--- a/tileops/ops/elementwise/arithmetic.py
+++ b/tileops/ops/elementwise/arithmetic.py
@@ -7,7 +7,6 @@ import torch
 
 from tileops.kernels.elementwise import (
     AddFwdKernel,
-    DivFloorFwdKernel,
     DivFwdKernel,
     DivTruncFwdKernel,
     FloorDivideFwdKernel,
@@ -65,7 +64,7 @@ class MulFwdOp(BinaryOp):
 _DIV_KERNEL_BY_ROUNDING_MODE = {
     None: DivFwdKernel,
     "trunc": DivTruncFwdKernel,
-    "floor": DivFloorFwdKernel,
+    "floor": FloorDivideFwdKernel,
 }
 
 


### PR DESCRIPTION
Closes #1245

## Summary

Adds `rounding_mode='trunc' | 'floor'` support to `DivFwdOp`. Previously only `rounding_mode=None` (true division) worked; non-None raised `NotImplementedError`.

- `tileops/kernels/elementwise.py`: new `DivTruncFwdKernel` (fp32 promotion → divide → `T.trunc` → cast back). `'floor'` reuses existing `FloorDivideFwdKernel` (byte-identical to what an early draft `DivFloorFwdKernel` would have been; that draft class was removed during review).
- `tileops/ops/elementwise/arithmetic.py`: `_DIV_KERNEL_BY_ROUNDING_MODE` dispatch (`None → DivFwdKernel`, `'trunc' → DivTruncFwdKernel`, `'floor' → FloorDivideFwdKernel`). Forward-time `NotImplementedError` guard removed; invalid modes raise `ValueError` at construction.
- `tests/ops/test_binary_arith.py`: `test_div_rounding_mode_eager` (6 cells: trunc/floor × fp16/bf16/fp32, mixed-sign quotients vs `torch.div`) + `test_div_rounding_mode_dispatch` (CPU-only dispatch table + invalid-mode rejection).
- `tests/ops/test_elementwise_compile.py`: `test_div_rounding_mode_compile` (6 cells under `torch.compile(fullgraph=True)`, same oracle).

## Test plan

- [x] `pytest tests/ops/test_binary_arith.py tests/ops/test_elementwise_compile.py -m smoke` — 89 passed.
- [x] Manual parity vs `torch.div(..., rounding_mode=...)` on fp16/bf16/fp32; tolerances follow the existing `FloorDivideFwdKernel` convention (`atol=1.0, rtol=0` for half precision rounding-mode kernels, `1e-5` for fp32).
- [x] `scripts/validate_manifest.py` clean on `DivFwdOp`.