### PR TITLE
[Fix][Skills] make review-tileops / resolve-tileops scripts cwd-independent

### DIFF
--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -20,14 +20,15 @@ REPO="tile-ai/TileOPs"
 command -v gh >/dev/null 2>&1 || { echo "preflight: missing gh" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "preflight: missing jq" >&2; exit 1; }
 
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state to the main checkout's `.foundry/runs/`, not cwd. When
 # invoked from a linked worktree (e.g. via foundry pipeline HANDOFF),
 # `--show-toplevel` returns the worktree path; using it would scatter
 # resolve state across worktrees. `git worktree list --porcelain 2>/dev/null`
 # always emits the main worktree first, so its leading entry is the
 # main checkout regardless of which worktree we run from.
-REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
-  || { echo "preflight: not in a git repo" >&2; exit 1; }
+REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+  || { echo "preflight: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
 
 # Round 2+ fast path: an existing run dir's meta.json already pins this PR.
 META=""

--- a/.claude/skills/resolve-tileops/preflight.sh
+++ b/.claude/skills/resolve-tileops/preflight.sh
@@ -24,11 +24,17 @@ SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state to the main checkout's `.foundry/runs/`, not cwd. When
 # invoked from a linked worktree (e.g. via foundry pipeline HANDOFF),
 # `--show-toplevel` returns the worktree path; using it would scatter
-# resolve state across worktrees. `git worktree list --porcelain 2>/dev/null`
-# always emits the main worktree first, so its leading entry is the
-# main checkout regardless of which worktree we run from.
-REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+# resolve state across worktrees. `git rev-parse --git-common-dir`
+# returns the main worktree's `.git` directory regardless of which
+# worktree we run from; its parent is the main checkout. Single
+# command, no pipe — avoids SIGPIPE under `set -o pipefail`.
+GIT_COMMON_DIR="$(git -C "$SKILL_DIR" rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "preflight: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
+# --git-common-dir is relative to the invoking worktree when that
+# worktree is the main one, absolute when invoked from a linked
+# worktree. Normalize to absolute, then take parent.
+[[ "$GIT_COMMON_DIR" != /* ]] && GIT_COMMON_DIR="$SKILL_DIR/$GIT_COMMON_DIR"
+REPO_PATH="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 
 # Round 2+ fast path: an existing run dir's meta.json already pins this PR.
 META=""

--- a/.claude/skills/resolve-tileops/round-post.sh
+++ b/.claude/skills/resolve-tileops/round-post.sh
@@ -18,9 +18,10 @@ command -v gh >/dev/null 2>&1 || { echo "round-post: missing gh" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "round-post: missing jq" >&2; exit 1; }
 
 REPO="tile-ai/TileOPs"
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
-  || { echo "round-post: not in a git repo" >&2; exit 1; }
+REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+  || { echo "round-post: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
 
 META=""
 for m in "$REPO_PATH/.foundry/runs"/*/resolve/meta.json; do

--- a/.claude/skills/resolve-tileops/round-post.sh
+++ b/.claude/skills/resolve-tileops/round-post.sh
@@ -20,8 +20,10 @@ command -v jq >/dev/null 2>&1 || { echo "round-post: missing jq" >&2; exit 1; }
 REPO="tile-ai/TileOPs"
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+GIT_COMMON_DIR="$(git -C "$SKILL_DIR" rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "round-post: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
+[[ "$GIT_COMMON_DIR" != /* ]] && GIT_COMMON_DIR="$SKILL_DIR/$GIT_COMMON_DIR"
+REPO_PATH="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 
 META=""
 for m in "$REPO_PATH/.foundry/runs"/*/resolve/meta.json; do

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -24,8 +24,8 @@ command -v jq >/dev/null 2>&1 || { echo "round-pre: missing jq" >&2; exit 1; }
 REVIEWER_LOGIN="${RESOLVE_REVIEWER_LOGIN:-Ibuki-wind}"
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
-  || { echo "round-pre: not in a git repo" >&2; exit 1; }
+REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+  || { echo "round-pre: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
 
 # Locate state. preflight.sh must have created it.
 META=""

--- a/.claude/skills/resolve-tileops/round-pre.sh
+++ b/.claude/skills/resolve-tileops/round-pre.sh
@@ -24,8 +24,10 @@ command -v jq >/dev/null 2>&1 || { echo "round-pre: missing jq" >&2; exit 1; }
 REVIEWER_LOGIN="${RESOLVE_REVIEWER_LOGIN:-Ibuki-wind}"
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Anchor state lookup to the main checkout (see preflight.sh).
-REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+GIT_COMMON_DIR="$(git -C "$SKILL_DIR" rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "round-pre: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
+[[ "$GIT_COMMON_DIR" != /* ]] && GIT_COMMON_DIR="$SKILL_DIR/$GIT_COMMON_DIR"
+REPO_PATH="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 
 # Locate state. preflight.sh must have created it.
 META=""

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -52,8 +52,8 @@ LOOP_START_EPOCH=$(date +%s)
 #   a loop launched from a linked worktree would mix policy files
 #   (criteria/procedure/loading from worktree branch via SKILL_DIR,
 #   checklists from main branch via REPO_PATH).
-REPO_PATH="$(git worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
-  || { echo "loop.sh: not in a git repo" >&2; exit 1; }
+REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+  || { echo "loop.sh: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
 SOURCE_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
 
 CRITERIA_PATH="$SKILL_DIR/criteria.md"

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -43,8 +43,11 @@ LOOP_START_EPOCH=$(date +%s)
 #
 # - REPO_PATH is the *state root* — main checkout. Used for `.foundry/
 #   runs/`, fetches, refs, and managed worktrees so state is shared
-#   across all worktrees of one repo. `git worktree list --porcelain 2>/dev/null`
-#   always lists the main worktree first.
+#   across all worktrees of one repo. Resolved via
+#   `git rev-parse --git-common-dir`, whose parent is the main
+#   worktree regardless of which worktree we launch from. Single
+#   command — no pipe — so `set -o pipefail` cannot misfire on
+#   SIGPIPE when the repo has many linked worktrees.
 # - SOURCE_ROOT is the *source/policy root* — the repo that contains
 #   this script. Used for `loading.yaml`, `criteria.md`, `procedure.md`,
 #   and `.claude/review-checklists/` so the loop reads policy files
@@ -52,8 +55,10 @@ LOOP_START_EPOCH=$(date +%s)
 #   a loop launched from a linked worktree would mix policy files
 #   (criteria/procedure/loading from worktree branch via SKILL_DIR,
 #   checklists from main branch via REPO_PATH).
-REPO_PATH="$(git -C "$SKILL_DIR" worktree list --porcelain 2>/dev/null | head -n 1 | sed 's/^worktree //')" \
+GIT_COMMON_DIR="$(git -C "$SKILL_DIR" rev-parse --git-common-dir 2>/dev/null)" \
   || { echo "loop.sh: cannot resolve repo root from \$SKILL_DIR=$SKILL_DIR" >&2; exit 1; }
+[[ "$GIT_COMMON_DIR" != /* ]] && GIT_COMMON_DIR="$SKILL_DIR/$GIT_COMMON_DIR"
+REPO_PATH="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 SOURCE_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
 
 CRITERIA_PATH="$SKILL_DIR/criteria.md"


### PR DESCRIPTION
## Summary

Four skill scripts (review-tileops/loop.sh, resolve-tileops/preflight.sh, round-pre.sh, round-post.sh) computed REPO_PATH via `git worktree list --porcelain | head -n 1 | sed ...`. Two latent bugs converged in this pattern:

1. **cwd-dependence**: `git worktree list` operates on the git repo of cwd. If the script was invoked via absolute path from outside the repo, the command had no repo to inspect and exited 128.
2. **SIGPIPE under `set -o pipefail`**: in a checkout with multiple worktrees, `head -n 1` closes the pipe after one line. Upstream `git worktree list` then receives SIGPIPE and exits 141. `pipefail` propagates that exit code, so the `||` branch fired "not in a git repo" even when called from a valid worktree.

The shipped fix replaces the pipe entirely with `git rev-parse --git-common-dir`, which returns the `.git` directory of the main worktree as a single value (no pipe, no SIGPIPE risk, no multi-line parse). The main worktree path is its parent directory. `git -C "$SKILL_DIR"` anchors the command to the repo containing the script, removing the cwd dependence in the same step.

The error message is retuned to `cannot resolve repo root from $SKILL_DIR=...` so the next debugger sees the actual resolution target rather than the misleading "not in a git repo" hint.

## Test plan

- [x] `bash .claude/skills/review-tileops/loop.sh non-numeric` from inside the main checkout — passes REPO_PATH resolution, stops at PR-arg validation.
- [x] Same call via absolute path from `/tmp` (outside any repo) — also passes REPO_PATH resolution.
- [x] Same call from inside a linked worktree — REPO_PATH resolves to the main checkout, not the worktree.
- [x] Same three checks applied to resolve-tileops/preflight.sh, round-pre.sh, round-post.sh.