### PR TITLE
[Fix][Skills] cap codex subprocess + reap children in review-tileops loop

### DIFF
--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -87,9 +87,18 @@ log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 # to init and keep running after the loop (or its tmux pane / SSH) exits.
 cleanup_and_exit() {
   trap - TERM INT HUP EXIT
-  kill -TERM 0 2>/dev/null || true
-  sleep 1
-  kill -KILL 0 2>/dev/null || true
+  # Kill direct children only. `kill 0` (pgroup) would also hit the
+  # user's interactive shell — foreground `review-loop` shares a pgroup
+  # with the calling tmux pane, and `nohup … &` does not create one.
+  # `timeout` forwards SIGTERM to codex, so one level is enough.
+  local pids
+  pids=$(pgrep -P $$ 2>/dev/null) || true
+  if [[ -n "$pids" ]]; then
+    kill -TERM $pids 2>/dev/null || true
+    sleep 1
+    kill -KILL $pids 2>/dev/null || true
+  fi
+  exit 130
 }
 trap cleanup_and_exit TERM INT HUP
 

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -25,10 +25,10 @@ REPO="tile-ai/TileOPs"
 MAX_ROUNDS=15
 POLL_INTERVAL=180
 CODEX_RETRY=3
-# Per-round hard cap on the codex subprocess. Codex can wedge on MCP
-# transport failures (endless "Reconnecting 1/5 → 5/5" with no exit),
-# blocking the loop on `wait`; this bounds the round so CODEX_RETRY=3
-# stays reachable.
+# Per-round hard cap on the synchronous codex invocation. Codex can wedge
+# on MCP transport failures (endless "Reconnecting 1/5 → 5/5" with no
+# exit); without this cap bash sits in waitpid forever and CODEX_RETRY=3
+# is unreachable. Worst case: 3 × 1800s ≈ 90 min before status=error.
 CODEX_TIMEOUT_SEC=1800
 # Stall safety: terminate after this many consecutive idle polls (no new
 # commits / comments). MAX_IDLE * POLL_INTERVAL must comfortably exceed
@@ -83,17 +83,24 @@ fi
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 
-# Reap the process group on signal; otherwise codex/gh/git get reparented
-# to init and keep running after the loop (or its tmux pane / SSH) exits.
+# Reap descendant subprocesses on signal. The full chain is
+# `loop.sh → timeout → node(codex) → codex-rust`, and node does not
+# always forward TERM to its rust child, so a one-level kill orphans
+# codex. We can't use `kill 0` (pgroup) either: foreground `review-loop`
+# shares a pgroup with the calling tmux pane, and `nohup … &` does not
+# create one — pgroup-wide TERM would kill the user's shell.
+_collect_descendants() {
+  local p=$1 c
+  for c in $(pgrep -P "$p" 2>/dev/null); do
+    printf '%s\n' "$c"
+    _collect_descendants "$c"
+  done
+}
 cleanup_and_exit() {
   trap - TERM INT HUP EXIT
-  # Kill direct children only. `kill 0` (pgroup) would also hit the
-  # user's interactive shell — foreground `review-loop` shares a pgroup
-  # with the calling tmux pane, and `nohup … &` does not create one.
-  # `timeout` forwards SIGTERM to codex, so one level is enough.
   local pids
-  pids=$(pgrep -P $$ 2>/dev/null) || true
-  if [[ -n "$pids" ]]; then
+  pids=$(_collect_descendants $$ | tr '\n' ' ')
+  if [[ -n "${pids// }" ]]; then
     kill -TERM $pids 2>/dev/null || true
     sleep 1
     kill -KILL $pids 2>/dev/null || true

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -25,12 +25,10 @@ REPO="tile-ai/TileOPs"
 MAX_ROUNDS=15
 POLL_INTERVAL=180
 CODEX_RETRY=3
-# Per-round hard cap on the codex subprocess. Codex has been seen to wedge
-# indefinitely on MCP transport failures (endless "Reconnecting 1/5 → 5/5"
-# loop with no exit), which without this cap blocks the whole review loop
-# on a `wait` that never returns. 1800s comfortably exceeds a slow review
-# round on a large PR, low enough that a wedged codex falls back into the
-# existing CODEX_RETRY=3 path within an hour.
+# Per-round hard cap on the codex subprocess. Codex can wedge on MCP
+# transport failures (endless "Reconnecting 1/5 → 5/5" with no exit),
+# blocking the loop on `wait`; this bounds the round so CODEX_RETRY=3
+# stays reachable.
 CODEX_TIMEOUT_SEC=1800
 # Stall safety: terminate after this many consecutive idle polls (no new
 # commits / comments). MAX_IDLE * POLL_INTERVAL must comfortably exceed
@@ -85,12 +83,8 @@ fi
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 
-# Signal trap: kill the entire process group on Ctrl-C / SIGTERM / SIGHUP so
-# in-flight codex / gh / git subprocesses are reaped instead of being
-# reparented to init and quietly burning tokens after the loop exits.
-# Without this, terminating the loop (or its terminal/tmux pane) leaves
-# orphaned codex processes that keep retrying upstream APIs in the
-# background.
+# Reap the process group on signal; otherwise codex/gh/git get reparented
+# to init and keep running after the loop (or its tmux pane / SSH) exits.
 cleanup_and_exit() {
   trap - TERM INT HUP EXIT
   kill -TERM 0 2>/dev/null || true
@@ -462,12 +456,7 @@ run_codex_round() {
 
   local attempt=0
   while (( attempt < CODEX_RETRY )); do
-    # `timeout --kill-after=30` sends KILL 30s after the initial TERM so
-    # codex cannot ignore the deadline — observed during the MCP wedge
-    # ("timeout waiting for child process to exit"), the codex parent does
-    # not always drop its own children on TERM alone. rc=124 → TERM
-    # honored; rc=137 → KILL fired. Either route falls through to the
-    # existing empty-$lastmsg retry path.
+    # --kill-after: codex doesn't always honor TERM under the MCP wedge.
     local rc=0
     if [[ "$sid" == "null" || -z "$sid" ]]; then
       timeout --kill-after=30 "$CODEX_TIMEOUT_SEC" \

--- a/.claude/skills/review-tileops/loop.sh
+++ b/.claude/skills/review-tileops/loop.sh
@@ -25,6 +25,13 @@ REPO="tile-ai/TileOPs"
 MAX_ROUNDS=15
 POLL_INTERVAL=180
 CODEX_RETRY=3
+# Per-round hard cap on the codex subprocess. Codex has been seen to wedge
+# indefinitely on MCP transport failures (endless "Reconnecting 1/5 → 5/5"
+# loop with no exit), which without this cap blocks the whole review loop
+# on a `wait` that never returns. 1800s comfortably exceeds a slow review
+# round on a large PR, low enough that a wedged codex falls back into the
+# existing CODEX_RETRY=3 path within an hour.
+CODEX_TIMEOUT_SEC=1800
 # Stall safety: terminate after this many consecutive idle polls (no new
 # commits / comments). MAX_IDLE * POLL_INTERVAL must comfortably exceed
 # the longest legitimate in-progress counterpart round (codex review on a
@@ -77,6 +84,20 @@ if [[ -z "$TILEOPS_REMOTE" ]]; then
 fi
 
 log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+# Signal trap: kill the entire process group on Ctrl-C / SIGTERM / SIGHUP so
+# in-flight codex / gh / git subprocesses are reaped instead of being
+# reparented to init and quietly burning tokens after the loop exits.
+# Without this, terminating the loop (or its terminal/tmux pane) leaves
+# orphaned codex processes that keep retrying upstream APIs in the
+# background.
+cleanup_and_exit() {
+  trap - TERM INT HUP EXIT
+  kill -TERM 0 2>/dev/null || true
+  sleep 1
+  kill -KILL 0 2>/dev/null || true
+}
+trap cleanup_and_exit TERM INT HUP
 
 # ---------------------------------------------------------------------------
 # Step A: preflight (once per loop start)
@@ -441,18 +462,32 @@ run_codex_round() {
 
   local attempt=0
   while (( attempt < CODEX_RETRY )); do
+    # `timeout --kill-after=30` sends KILL 30s after the initial TERM so
+    # codex cannot ignore the deadline — observed during the MCP wedge
+    # ("timeout waiting for child process to exit"), the codex parent does
+    # not always drop its own children on TERM alone. rc=124 → TERM
+    # honored; rc=137 → KILL fired. Either route falls through to the
+    # existing empty-$lastmsg retry path.
+    local rc=0
     if [[ "$sid" == "null" || -z "$sid" ]]; then
-      codex --dangerously-bypass-approvals-and-sandbox exec \
-        --json --output-last-message "$lastmsg" --cd "$WORKTREE_DIR" \
-        "$(cat "$prompt_file")" > "$events" 2>&1 || true
+      timeout --kill-after=30 "$CODEX_TIMEOUT_SEC" \
+        codex --dangerously-bypass-approvals-and-sandbox exec \
+          --json --output-last-message "$lastmsg" --cd "$WORKTREE_DIR" \
+          "$(cat "$prompt_file")" > "$events" 2>&1 || rc=$?
     else
       # `codex exec resume` does not accept --cd; the session already
       # remembers its cwd from the initial `exec`, but cd anyway as a
       # belt-and-suspenders for source-file lookups.
       ( cd "$WORKTREE_DIR" && \
-        codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
-          --json --output-last-message "$lastmsg" \
-          "$(cat "$prompt_file")" ) > "$events" 2>&1 || true
+        timeout --kill-after=30 "$CODEX_TIMEOUT_SEC" \
+          codex --dangerously-bypass-approvals-and-sandbox exec resume "$sid" \
+            --json --output-last-message "$lastmsg" \
+            "$(cat "$prompt_file")" ) > "$events" 2>&1 || rc=$?
+    fi
+    if [[ $rc -eq 124 || $rc -eq 137 ]]; then
+      log "codex attempt $((attempt+1)) exceeded ${CODEX_TIMEOUT_SEC}s (rc=$rc) — killed"
+    elif [[ $rc -ne 0 ]]; then
+      log "codex attempt $((attempt+1)) exited rc=$rc"
     fi
 
     if [[ -s "$lastmsg" ]]; then


### PR DESCRIPTION
## Changes

`.claude/skills/review-tileops/loop.sh`:

- Wrap both `codex exec` / `codex exec resume` invocations in `timeout --kill-after=30 1800`. Timeout (rc=124/137) falls through to the existing `CODEX_RETRY=3` retry path; worst case 3 × 1800s ≈ 90 min before `status=error`.
- Add `trap cleanup_and_exit TERM INT HUP`. Handler walks the descendant tree via recursive `pgrep -P`, TERMs every descendant, then KILLs after 1s. Avoids `kill 0` so the user's interactive shell / tmux pane (which shares the loop's pgroup) is not taken down.

## Test plan

- [x] `bash -n loop.sh`; `shellcheck -S warning loop.sh` clean.
- [x] Trap smoke test on a 3-level descendant chain: all descendants collected, TERM delivered, KILL fallback reached, exit 130, no orphans.
- [ ] Re-run `review-loop 1410 --bg` against the MCP wedge — expect `codex attempt N exceeded 1800s (rc=124) — killed` and exit within ~90 min instead of hanging.