### PR TITLE
[BugFix][GQA] Replace deprecated T.gemm(..., wg_wait=...) with T.wgmma_gemm() + T.wait_wgmma()

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -49,7 +49,6 @@ TILELANG_019_BENCH_PATHS = {
 }
 
 TILELANG_019_BENCH_PREFIXES = (
-    "benchmarks/ops/attention/bench_gqa.py::test_gqa_bwd_bench",
     "benchmarks/ops/bench_convolution.py::test_conv2d_bench",
     "benchmarks/ops/bench_convolution.py::test_conv3d_bench",
 )

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -816,7 +816,6 @@ def test_gqa_prefill_with_kv_cache_rejects_bad_contract_inputs() -> None:
 @GroupedQueryAttentionBwdFixture
 def test_gqa_bwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
-    pytest.skip("GQA backward fails under tilelang 0.1.9 due to autodiff lowering regression; re-enable when backward produces numerically correct grads.")
     test = GroupedQueryAttentionBwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -232,9 +232,9 @@ def _sparse_mla_kernel(batch: int,
                         for h_i, bi_i in T.Parallel(h_per_block, i_block):
                             acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0,
                                                               -T.infinity(acc_s.dtype))
-                        T.gemm(q_shared_l, kv_shared_0_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(q_shared_r, kv_shared_0_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(q_tail_shared, k_tail_shared_0, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(q_shared_l, kv_shared_0_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(q_shared_r, kv_shared_0_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(q_tail_shared, k_tail_shared_0, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 
@@ -268,9 +268,9 @@ def _sparse_mla_kernel(batch: int,
                         for h_i, bi_i in T.Parallel(h_per_block, i_block):
                             acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0,
                                                               -T.infinity(acc_s.dtype))
-                        T.gemm(q_shared_l, kv_shared_1_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(q_shared_r, kv_shared_1_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(q_tail_shared, k_tail_shared_1, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(q_shared_l, kv_shared_1_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(q_shared_r, kv_shared_1_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(q_tail_shared, k_tail_shared_1, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 

--- a/tileops/kernels/attention/deepseek_mla_decode.py
+++ b/tileops/kernels/attention/deepseek_mla_decode.py
@@ -435,9 +435,9 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
-                        T.gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 
@@ -469,9 +469,9 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
-                        T.gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 
@@ -660,9 +660,9 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
-                        T.gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 
@@ -694,9 +694,9 @@ def _mla_decode_ws_kernel(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, dty
                         T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
 
                         T.clear(acc_s)
-                        T.gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True, wg_wait=-1)
-                        T.gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True, wg_wait=-1)
+                        T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True)
 
                         T.wait_wgmma(0)
 

--- a/tileops/kernels/attention/gqa_bwd.py
+++ b/tileops/kernels/attention/gqa_bwd.py
@@ -362,22 +362,20 @@ def _mha_bwd_wgmma_pipelined_kernel(batch: int,
                 for k_idx in T.Pipelined(loop_st, loop_ed, num_stages=num_stages):
                     T.copy(q[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], q_frag)
                     T.clear(qkt)
-                    T.gemm(
+                    T.wgmma_gemm(
                         k_shared,
                         q_frag,
                         qkt,
                         transpose_B=True,
-                        policy=T.GemmWarpPolicy.FullRow,
-                        wg_wait=-1)
+                        policy=T.GemmWarpPolicy.FullRow)
                     T.copy(do[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], do_shared)
                     T.clear(dst)
-                    T.gemm(
+                    T.wgmma_gemm(
                         v_shared,
                         do_shared,
                         dst,
                         transpose_B=True,
-                        policy=T.GemmWarpPolicy.FullRow,
-                        wg_wait=-1)
+                        policy=T.GemmWarpPolicy.FullRow)
 
                     T.copy(lse[bz, bx, k_idx * block_n:(k_idx + 1) * block_n], lse_shared)
                     T.wait_wgmma(1)
@@ -389,18 +387,20 @@ def _mha_bwd_wgmma_pipelined_kernel(batch: int,
                                                        qkt[i, j], 0)
                     T.wait_wgmma(0)
                     T.copy(qkt, qkt_cast)
-                    T.gemm(
-                        qkt_cast, do_shared, dv_frag, policy=T.GemmWarpPolicy.FullRow, wg_wait=-1)
+                    T.wgmma_gemm(
+                        qkt_cast, do_shared, dv_frag, policy=T.GemmWarpPolicy.FullRow)
 
                     T.copy(delta[bz, bx, k_idx * block_n:(k_idx + 1) * block_n], delta_shared)
 
                     for i, j in T.Parallel(block_m, block_n):
                         dst_cast[i, j] = qkt[i, j] * (dst[i, j] - delta_shared[j]) * sm_scale
-                    T.gemm(dst_cast, q_frag, dk_frag, policy=T.GemmWarpPolicy.FullRow, wg_wait=1)
+                    T.wgmma_gemm(dst_cast, q_frag, dk_frag, policy=T.GemmWarpPolicy.FullRow)
+                    T.wait_wgmma(1)
 
                     T.copy(dst_cast, dst_shared)
                     T.clear(dq_frag)
-                    T.gemm(dst_shared, k_shared, dq_frag, transpose_A=True, wg_wait=1)
+                    T.wgmma_gemm(dst_shared, k_shared, dq_frag, transpose_A=True)
+                    T.wait_wgmma(1)
                     T.wait_wgmma(0)
                     T.copy(dq_frag, dq_shared)
                     T.atomic_add(dq[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], dq_shared)
@@ -444,15 +444,15 @@ class MHABwdWgmmaPipelinedKernel(Kernel):
     def default_config(self) -> dict:
         return {
             "block_m": 128,
-            "block_n": 128 if self.dim <= 64 else 32,
+            "block_n": 64,
             "num_stages": 2,
             "threads": 256
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
+        block_m = [64, 128]
+        block_n = [64, 128]
         num_stages = [1, 2, 3]
         threads = [128, 256]
         _configs = list(itertools.product(block_m, block_n, num_stages, threads))
@@ -710,13 +710,12 @@ def _gqa_bwd_wgmma_pipelined_kernel(batch: int,
                 for k_idx in T.Pipelined(loop_st, loop_ed, num_stages=num_stages):
                     T.copy(q[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], q_frag)
                     T.clear(qkt)
-                    T.gemm(
+                    T.wgmma_gemm(
                         k_shared,
                         q_frag,
                         qkt,
                         transpose_B=True,
-                        policy=T.GemmWarpPolicy.FullRow,
-                        wg_wait=-1)
+                        policy=T.GemmWarpPolicy.FullRow)
                     T.copy(lse[bz, bx, k_idx * block_n:(k_idx + 1) * block_n], lse_shared)
                     for i, j in T.Parallel(block_m, block_n):
                         qkt[i, j] = T.exp2(qkt[i, j] * scale - lse_shared[j])
@@ -726,28 +725,29 @@ def _gqa_bwd_wgmma_pipelined_kernel(batch: int,
                                                        qkt[i, j], 0)
                     T.copy(do[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], do_shared)
                     T.clear(dst)
-                    T.gemm(
+                    T.wgmma_gemm(
                         v_shared,
                         do_shared,
                         dst,
                         transpose_B=True,
-                        policy=T.GemmWarpPolicy.FullRow,
-                        wg_wait=-1)
+                        policy=T.GemmWarpPolicy.FullRow)
                     T.wait_wgmma(1)
                     T.copy(qkt, qkt_cast)
-                    T.gemm(
-                        qkt_cast, do_shared, dv_frag, policy=T.GemmWarpPolicy.FullRow, wg_wait=-1)
+                    T.wgmma_gemm(
+                        qkt_cast, do_shared, dv_frag, policy=T.GemmWarpPolicy.FullRow)
 
                     T.copy(delta[bz, bx, k_idx * block_n:(k_idx + 1) * block_n], delta_shared)
 
                     for i, j in T.Parallel(block_m, block_n):
                         dst_cast[i, j] = qkt[i, j] * (dst[i, j] - delta_shared[j]) * sm_scale
                     T.wait_wgmma(0)
-                    T.gemm(dst_cast, q_frag, dk_frag, policy=T.GemmWarpPolicy.FullRow, wg_wait=1)
+                    T.wgmma_gemm(dst_cast, q_frag, dk_frag, policy=T.GemmWarpPolicy.FullRow)
+                    T.wait_wgmma(1)
 
                     T.copy(dst_cast, dst_shared)
                     T.clear(dq_frag)
-                    T.gemm(dst_shared, k_shared, dq_frag, transpose_A=True, wg_wait=1)
+                    T.wgmma_gemm(dst_shared, k_shared, dq_frag, transpose_A=True)
+                    T.wait_wgmma(1)
                     T.wait_wgmma(0)
                     T.copy(dq_frag, dq_shared)
                     T.atomic_add(dq[bz, k_idx * block_n:(k_idx + 1) * block_n, bx, :], dq_shared)
@@ -793,15 +793,15 @@ class GQABwdWgmmaPipelinedKernel(Kernel):
     def default_config(self) -> dict:
         return {
             "block_m": 128,
-            "block_n": 128 if self.dim <= 64 else 32,
+            "block_n": 64,
             "num_stages": 2,
             "threads": 256
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
+        block_m = [64, 128]
+        block_n = [64, 128]
         num_stages = [1, 2, 3]
         threads = [128, 256]
         _configs = list(itertools.product(block_m, block_n, num_stages, threads))

--- a/tileops/ops/attention/deepseek_dsa.py
+++ b/tileops/ops/attention/deepseek_dsa.py
@@ -4,6 +4,7 @@ import torch
 
 from tileops.kernels.attention import SparseMlaKernel
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import is_hopper
 
 from ..op_base import Op
 
@@ -106,6 +107,11 @@ class DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(Op):
             Dict[str, Kernel]: A dictionary mapping kernel names to kernel functions.
             The default map includes the "sparse_mla_kernel".
         """
+        if not is_hopper():
+            raise RuntimeError(
+                "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp requires a Hopper GPU "
+                "(SM90) because the underlying SparseMlaKernel uses WGMMA instructions."
+            )
         return {"sparse_mla_kernel": SparseMlaKernel}
 
     def forward(self, q: torch.Tensor, kv: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Closes #1423

## Summary

- Replace deprecated `T.gemm(..., wg_wait=...)` calls with public `T.wgmma_gemm()` + explicit `T.wait_wgmma()` in attention kernels that used manual WGMMA wait scheduling.
- `gqa_bwd.py`: migrate the WGMMA-pipelined backward path and constrain autotune/default configs to `block_n >= 64` where needed for WGMMA-compatible shapes.
- Re-enable `tests/ops/attention/test_gqa.py::test_gqa_bwd` under TileLang 0.1.9.
- Re-enable `benchmarks/ops/attention/bench_gqa.py::test_gqa_bwd_bench` under TileLang 0.1.9.

Related: #1436

## Remaining MLA/DSA status

- DeepSeek MLA/DSA decode are **not fully fixed by this PR**.
- The original public API incompatibility (`T.gemm(..., wg_wait=...)` rejected by TileLang 0.1.9) is removed, but both kernels still fail during TileLang layout inference when compiled through the explicit `T.wgmma_gemm()` path.
- Observed failure: `InternalError: Check failed: (min_reg_num < INT64_MAX) is false: no available layout found`.
- Because of that, the MLA/DSA test and benchmark skips remain in place and should be handled separately.

## Benchmarks

GPU: NVIDIA H200, `CUDA_VISIBLE_DEVICES=1`.

Compared `benchmarks/ops/attention/bench_gqa.py::test_gqa_bwd_bench` between:

- current branch + TileLang 0.1.9 / Torch 2.9.0+cu128
- `main` + `tileops-release` / TileLang 0.1.8 / Torch 2.10.0+cu128

| case | current 0.1.9 latency_ms | main 0.1.8 latency_ms | delta |
| --- | ---: | ---: | ---: |
| batch=2, seq_len=4096, heads=32, heads_kv=8, dim=128 | 4.3396 | 3.9586 | +9.6% slower |
| batch=1, seq_len=8192, heads=32, heads_kv=8, dim=128 | 8.4947 | 7.4557 | +13.9% slower |
| batch=1, seq_len=4096, heads=64, heads_kv=8, dim=128 | 4.4330 | 4.0044 | +10.7% slower |
| batch=1, seq_len=4096, heads=128, heads_kv=8, dim=128 | 10.1638 | 8.4853 | +19.8% slower |
| batch=2, seq_len=2048, heads=32, heads_kv=8, dim=128 | 1.1371 | 1.0957 | +3.8% slower |

Impact: the compatibility fix unblocks GQA backward on TileLang 0.1.9, but the current explicit WGMMA path is slower than the old TileLang 0.1.8 `T.gemm(..., wg_wait=...)` path on these benchmark cases.

## Test plan

- [x] `CUDA_VISIBLE_DEVICES=1 TMPDIR=/home/lyc/Project/TileOps-workspace2/.tmp/tvm_tmp python -m pytest tests/ops/attention/test_gqa.py::test_gqa_bwd -vvs` -> 4 passed
- [x] `CUDA_VISIBLE_DEVICES=1 TMPDIR=/home/lyc/Project/TileOps-workspace2/.tmp/tvm_tmp python -m pytest benchmarks/ops/attention/bench_gqa.py::test_gqa_bwd_bench -vvs` -> 5 passed
- [x] `main` + `conda tileops-release` + TileLang 0.1.8 baseline benchmark -> 5 passed
- [x] pre-commit hook passed on commit and push

## Artifacts

Local benchmark artifacts are under `output_mid/wg_wait_api_incompatibility_gqa_bwd_20260511/`:

- `current_tilelang_019/profile_run.log`
- `current_tilelang_019/pytest.log`
- `main_tilelang_018/profile_run.log`
- `main_tilelang_018/pytest.log`
- `comparison.md`

