### PR TITLE
[Test][Kernels] audit fp8/None SUPPORTED_DTYPES + per-family rejection sentinels

### DIFF
--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -85,6 +85,7 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
     roots = (ew.Kernel,)
     none_offenders = []
     type_offenders = []
+    empty_offenders = []
     fp8_offenders = []
     for _name, cls in inspect.getmembers(ew, inspect.isclass):
         if cls in abstract:
@@ -98,6 +99,9 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
         if not isinstance(supported, tuple):
             type_offenders.append((cls.__name__, type(supported).__name__))
             continue
+        if len(supported) == 0:
+            empty_offenders.append(cls.__name__)
+            continue
         leaked = [dt for dt in supported if dt in fp8_dtypes]
         if leaked:
             fp8_offenders.append((cls.__name__, leaked))
@@ -106,6 +110,9 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
     )
     assert not type_offenders, (
         f"Concrete kernels with non-tuple SUPPORTED_DTYPES: {type_offenders}"
+    )
+    assert not empty_offenders, (
+        f"Concrete kernels with empty SUPPORTED_DTYPES tuple: {empty_offenders}"
     )
     assert not fp8_offenders, (
         f"Concrete kernels admitting fp8 in SUPPORTED_DTYPES: {fp8_offenders}"

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -226,13 +226,19 @@ def test_lerp_kernel_rejects_int():
 
 @pytest.mark.smoke
 def test_division_family_kernel_rejects_bool_and_int():
-    """Division family (float-only ``_FLOAT_DTYPES``) rejects bool and int."""
-    from tileops.kernels.elementwise import DivFwdKernel
+    """Division family (Div/FloorDivide/Remainder, float-only ``_FLOAT_DTYPES``)
+    rejects bool and int at the kernel layer."""
+    from tileops.kernels.elementwise import (
+        DivFwdKernel,
+        FloorDivideFwdKernel,
+        RemainderFwdKernel,
+    )
 
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        DivFwdKernel(**_binary_kwargs(torch.bool))
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        DivFwdKernel(**_binary_kwargs(torch.int32))
+    for cls in (DivFwdKernel, FloorDivideFwdKernel, RemainderFwdKernel):
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.bool))
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.int32))
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -62,8 +62,8 @@ def test_binary_arith_kernel_rejects_fp8():
 
 @pytest.mark.smoke
 def test_no_concrete_kernel_inherits_none_supported_dtypes():
-    """AC-1 guard: every concrete BinaryKernel / UnaryKernel subclass must
-    declare SUPPORTED_DTYPES (directly or via a non-None base). Inheriting the
+    """AC-1 guard: every concrete ``Kernel`` subclass must declare
+    SUPPORTED_DTYPES (directly or via a non-None base). Inheriting the
     ``None`` default from the abstract ``Kernel`` base hides the rejection
     contract and lets fp8 slip through silently.
     """
@@ -72,12 +72,12 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
     import tileops.kernels.elementwise as ew
 
     abstract = {
-        ew.BinaryKernel, ew.UnaryKernel, ew.FloatUnaryKernel,
+        ew.Kernel, ew.BinaryKernel, ew.UnaryKernel, ew.FloatUnaryKernel,
         ew.LogicalUnaryKernel, ew.FloatPredicateKernel,
         ew.FusedGatedKernel, ew.ParametricUnaryKernel,
         ew._AlphaScaledBinaryKernel,
     }
-    roots = (ew.BinaryKernel, ew.UnaryKernel)
+    roots = (ew.Kernel,)
     offenders = []
     for _name, cls in inspect.getmembers(ew, inspect.isclass):
         if cls in abstract:

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -75,22 +75,20 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
 
     import tileops.kernels.elementwise as ew
 
-    abstract = {
-        ew.Kernel, ew.BinaryKernel, ew.UnaryKernel, ew.FloatUnaryKernel,
-        ew.LogicalUnaryKernel, ew.FloatPredicateKernel,
-        ew.FusedGatedKernel, ew.ParametricUnaryKernel,
-        ew._AlphaScaledBinaryKernel,
-    }
     fp8_dtypes = set(ew._FP8_DTYPES)
-    roots = (ew.Kernel,)
     none_offenders = []
     type_offenders = []
     empty_offenders = []
     fp8_offenders = []
-    for _name, cls in inspect.getmembers(ew, inspect.isclass):
-        if cls in abstract:
+    # Audit every concrete kernel reachable from the elementwise module.
+    # Concrete kernels follow the ``<Op>FwdKernel`` / ``<Op>BwdKernel`` naming
+    # convention; abstract template bases (BinaryKernel, FloatUnaryKernel, etc.)
+    # do not. Filtering by suffix keeps this guard stable when new templates are
+    # introduced — no manual allowlist to maintain.
+    for cls_name, cls in inspect.getmembers(ew, inspect.isclass):
+        if not issubclass(cls, ew.Kernel):
             continue
-        if not any(issubclass(cls, b) for b in roots):
+        if not (cls_name.endswith("FwdKernel") or cls_name.endswith("BwdKernel")):
             continue
         supported = getattr(cls, "SUPPORTED_DTYPES", None)
         if supported is None:
@@ -203,16 +201,18 @@ def test_logical_unary_kernel_rejects_fp8():
 
 
 @pytest.mark.smoke
-def test_pow_kernel_rejects_bool():
-    """PowFwdKernel (float-only family) rejects bool inputs.
+def test_pow_kernel_rejects_bool_and_int():
+    """PowFwdKernel (float-only family) rejects both bool and int inputs.
 
     Companion sentinel to fp8 rejection: ``PowFwdKernel.SUPPORTED_DTYPES``
-    is ``_FLOAT_DTYPES``, so int/bool must also raise at the kernel layer.
+    is ``_FLOAT_DTYPES``, so int and bool must also raise at the kernel layer.
     """
     from tileops.kernels.elementwise import PowFwdKernel
 
     with pytest.raises(ValueError, match="only supports dtypes"):
         PowFwdKernel(**_binary_kwargs(torch.bool))
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        PowFwdKernel(**_binary_kwargs(torch.int32))
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -62,10 +62,14 @@ def test_binary_arith_kernel_rejects_fp8():
 
 @pytest.mark.smoke
 def test_no_concrete_kernel_inherits_none_supported_dtypes():
-    """AC-1 guard: every concrete ``Kernel`` subclass must declare
-    SUPPORTED_DTYPES (directly or via a non-None base). Inheriting the
-    ``None`` default from the abstract ``Kernel`` base hides the rejection
-    contract and lets fp8 slip through silently.
+    """Every concrete ``Kernel`` subclass must declare SUPPORTED_DTYPES as a
+    non-empty tuple that excludes every fp8 dtype.
+
+    The ``None`` default lives on the elementwise template bases
+    (``UnaryKernel`` / ``BinaryKernel`` and their float / logical / predicate
+    siblings), not on the abstract ``Kernel`` root. Inheriting that default
+    silently hides the rejection contract; admitting an fp8 entry would let
+    fp8 reach codegen paths that PR-time guards no longer cover.
     """
     import inspect
 
@@ -77,17 +81,34 @@ def test_no_concrete_kernel_inherits_none_supported_dtypes():
         ew.FusedGatedKernel, ew.ParametricUnaryKernel,
         ew._AlphaScaledBinaryKernel,
     }
+    fp8_dtypes = set(ew._FP8_DTYPES)
     roots = (ew.Kernel,)
-    offenders = []
+    none_offenders = []
+    type_offenders = []
+    fp8_offenders = []
     for _name, cls in inspect.getmembers(ew, inspect.isclass):
         if cls in abstract:
             continue
         if not any(issubclass(cls, b) for b in roots):
             continue
-        if getattr(cls, "SUPPORTED_DTYPES", None) is None:
-            offenders.append(cls.__name__)
-    assert not offenders, (
-        f"Concrete kernels with SUPPORTED_DTYPES=None: {offenders}"
+        supported = getattr(cls, "SUPPORTED_DTYPES", None)
+        if supported is None:
+            none_offenders.append(cls.__name__)
+            continue
+        if not isinstance(supported, tuple):
+            type_offenders.append((cls.__name__, type(supported).__name__))
+            continue
+        leaked = [dt for dt in supported if dt in fp8_dtypes]
+        if leaked:
+            fp8_offenders.append((cls.__name__, leaked))
+    assert not none_offenders, (
+        f"Concrete kernels with SUPPORTED_DTYPES=None: {none_offenders}"
+    )
+    assert not type_offenders, (
+        f"Concrete kernels with non-tuple SUPPORTED_DTYPES: {type_offenders}"
+    )
+    assert not fp8_offenders, (
+        f"Concrete kernels admitting fp8 in SUPPORTED_DTYPES: {fp8_offenders}"
     )
 
 
@@ -100,12 +121,17 @@ def _binary_kwargs(dtype):
 
 
 @pytest.mark.smoke
-def test_comparison_kernel_rejects_fp8():
-    """Comparison family (Eq/Ne/Gt/Lt/Ge/Le) rejects fp8 at the kernel layer."""
-    from tileops.kernels.elementwise import EqFwdKernel
+def test_comparison_family_kernel_rejects_fp8():
+    """Comparison family (Eq/Lt/Ge representatives) rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import (
+        EqFwdKernel,
+        GeFwdKernel,
+        LtFwdKernel,
+    )
 
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        EqFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+    for cls in (EqFwdKernel, LtFwdKernel, GeFwdKernel):
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.float8_e4m3fn))
 
 
 @pytest.mark.smoke
@@ -120,10 +146,15 @@ def test_pow_kernel_rejects_fp8():
 @pytest.mark.smoke
 def test_division_family_kernel_rejects_fp8():
     """Division family (Div/FloorDivide/Remainder) rejects fp8 at the kernel layer."""
-    from tileops.kernels.elementwise import DivFwdKernel
+    from tileops.kernels.elementwise import (
+        DivFwdKernel,
+        FloorDivideFwdKernel,
+        RemainderFwdKernel,
+    )
 
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        DivFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+    for cls in (DivFwdKernel, FloorDivideFwdKernel, RemainderFwdKernel):
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.float8_e4m3fn))
 
 
 @pytest.mark.smoke
@@ -136,21 +167,23 @@ def test_lerp_kernel_rejects_fp8():
 
 
 @pytest.mark.smoke
-def test_maximum_minimum_kernel_rejects_fp8():
+def test_maximum_minimum_family_kernel_rejects_fp8():
     """Maximum/Minimum family rejects fp8 at the kernel layer."""
-    from tileops.kernels.elementwise import MaximumFwdKernel
+    from tileops.kernels.elementwise import MaximumFwdKernel, MinimumFwdKernel
 
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        MaximumFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+    for cls in (MaximumFwdKernel, MinimumFwdKernel):
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.float8_e4m3fn))
 
 
 @pytest.mark.smoke
-def test_logical_binary_kernel_rejects_fp8():
-    """LogicalAnd/Or family rejects fp8 at the kernel layer."""
-    from tileops.kernels.elementwise import LogicalAndFwdKernel
+def test_logical_binary_family_kernel_rejects_fp8():
+    """LogicalAnd/LogicalOr family rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import LogicalAndFwdKernel, LogicalOrFwdKernel
 
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        LogicalAndFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+    for cls in (LogicalAndFwdKernel, LogicalOrFwdKernel):
+        with pytest.raises(ValueError, match="only supports dtypes"):
+            cls(**_binary_kwargs(torch.float8_e4m3fn))
 
 
 @pytest.mark.smoke
@@ -160,6 +193,39 @@ def test_logical_unary_kernel_rejects_fp8():
 
     with pytest.raises(ValueError, match="only supports dtypes"):
         LogicalNotFwdKernel(N_total=_N, dtype=torch.float8_e4m3fn)
+
+
+@pytest.mark.smoke
+def test_pow_kernel_rejects_bool():
+    """PowFwdKernel (float-only family) rejects bool inputs.
+
+    Companion sentinel to fp8 rejection: ``PowFwdKernel.SUPPORTED_DTYPES``
+    is ``_FLOAT_DTYPES``, so int/bool must also raise at the kernel layer.
+    """
+    from tileops.kernels.elementwise import PowFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        PowFwdKernel(**_binary_kwargs(torch.bool))
+
+
+@pytest.mark.smoke
+def test_lerp_kernel_rejects_int():
+    """LerpFwdKernel (float-only family) rejects int32 inputs."""
+    from tileops.kernels.elementwise import LerpFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        LerpFwdKernel(**_binary_kwargs(torch.int32))
+
+
+@pytest.mark.smoke
+def test_division_family_kernel_rejects_bool_and_int():
+    """Division family (float-only ``_FLOAT_DTYPES``) rejects bool and int."""
+    from tileops.kernels.elementwise import DivFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        DivFwdKernel(**_binary_kwargs(torch.bool))
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        DivFwdKernel(**_binary_kwargs(torch.int32))
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_elementwise_fp8.py
+++ b/tests/ops/test_elementwise_fp8.py
@@ -60,5 +60,107 @@ def test_binary_arith_kernel_rejects_fp8():
         )
 
 
+@pytest.mark.smoke
+def test_no_concrete_kernel_inherits_none_supported_dtypes():
+    """AC-1 guard: every concrete BinaryKernel / UnaryKernel subclass must
+    declare SUPPORTED_DTYPES (directly or via a non-None base). Inheriting the
+    ``None`` default from the abstract ``Kernel`` base hides the rejection
+    contract and lets fp8 slip through silently.
+    """
+    import inspect
+
+    import tileops.kernels.elementwise as ew
+
+    abstract = {
+        ew.BinaryKernel, ew.UnaryKernel, ew.FloatUnaryKernel,
+        ew.LogicalUnaryKernel, ew.FloatPredicateKernel,
+        ew.FusedGatedKernel, ew.ParametricUnaryKernel,
+        ew._AlphaScaledBinaryKernel,
+    }
+    roots = (ew.BinaryKernel, ew.UnaryKernel)
+    offenders = []
+    for _name, cls in inspect.getmembers(ew, inspect.isclass):
+        if cls in abstract:
+            continue
+        if not any(issubclass(cls, b) for b in roots):
+            continue
+        if getattr(cls, "SUPPORTED_DTYPES", None) is None:
+            offenders.append(cls.__name__)
+    assert not offenders, (
+        f"Concrete kernels with SUPPORTED_DTYPES=None: {offenders}"
+    )
+
+
+def _binary_kwargs(dtype):
+    return dict(
+        N_total=_N, dtype=dtype,
+        coalesced_shape=(_N,), a_strides=(1,), b_strides=(1,),
+        a_numel=_N, b_numel=_N,
+    )
+
+
+@pytest.mark.smoke
+def test_comparison_kernel_rejects_fp8():
+    """Comparison family (Eq/Ne/Gt/Lt/Ge/Le) rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import EqFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        EqFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_pow_kernel_rejects_fp8():
+    """PowFwdKernel rejects fp8 (narrowed _FLOAT_DTYPES)."""
+    from tileops.kernels.elementwise import PowFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        PowFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_division_family_kernel_rejects_fp8():
+    """Division family (Div/FloorDivide/Remainder) rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import DivFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        DivFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_lerp_kernel_rejects_fp8():
+    """LerpFwdKernel rejects fp8 (narrowed _FLOAT_DTYPES)."""
+    from tileops.kernels.elementwise import LerpFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        LerpFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_maximum_minimum_kernel_rejects_fp8():
+    """Maximum/Minimum family rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import MaximumFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        MaximumFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_logical_binary_kernel_rejects_fp8():
+    """LogicalAnd/Or family rejects fp8 at the kernel layer."""
+    from tileops.kernels.elementwise import LogicalAndFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        LogicalAndFwdKernel(**_binary_kwargs(torch.float8_e4m3fn))
+
+
+@pytest.mark.smoke
+def test_logical_unary_kernel_rejects_fp8():
+    """LogicalNotFwdKernel (LogicalUnaryKernel base) rejects fp8."""
+    from tileops.kernels.elementwise import LogicalNotFwdKernel
+
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        LogicalNotFwdKernel(N_total=_N, dtype=torch.float8_e4m3fn)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])


### PR DESCRIPTION
Closes #1421

## Summary

- Add static audit guard `test_no_concrete_kernel_inherits_none_supported_dtypes` that walks every concrete `Kernel` subclass reachable from `tileops.kernels.elementwise` (filtered by `FwdKernel` / `BwdKernel` suffix), asserts `SUPPORTED_DTYPES` is a non-empty tuple, and asserts no entry is a member of `ew._FP8_DTYPES`.
- Add per-family kernel-layer fp8 (and where applicable bool/int) rejection sentinels covering: float unary (`Relu`), bitwise unary, binary bitwise, binary arithmetic (`Add`/`Sub`/`Mul`), comparison family (`Eq`/`Lt`/`Ge`), `Pow` (+ bool/int reject), division family (`Div`/`FloorDivide`/`Remainder`, + bool/int reject), `Lerp` (+ int reject), max/min family (`Maximum`/`Minimum`), logical binary (`LogicalAnd`/`LogicalOr`), logical unary (`LogicalNot`).
- Tests only; no kernel implementation, no manifest edits.

## Test plan

- [x] AC-1: static audit reports zero concrete `FwdKernel`/`BwdKernel` subclass with `SUPPORTED_DTYPES is None` (71 concrete subclasses audited under `ew.Kernel`, 0 offenders).
- [x] AC-2: each affected `SUPPORTED_DTYPES` matches its manifest signature or is a strict subset (Maximum/Minimum/Eq/Ne/Gt/Lt/Ge/Le strict subset; rest match).
- [x] AC-3: fp8 dtypes (`torch.float8_e4m3fn`, `torch.float8_e5m2`) absent from every audited `SUPPORTED_DTYPES` tuple (0 fp8 offenders).
- [x] AC-4: per-family kernel-layer fp8/bool/int rejection sentinel exists per affected kernel family (15 sentinels in `tests/ops/test_elementwise_fp8.py`).
- [x] AC-5: `pytest tests/ops/test_elementwise_fp8.py` — 15 passed at HEAD `5c6244c`.
- [x] pre-commit passed

## Test node delta

```
File                                 Base    HEAD    Delta
----------------------------------------------------------
tests/ops/test_elementwise_fp8.py       4      15      +11
----------------------------------------------------------
TOTAL                                   4      15      +11

Growth: +275.0%
```

**Justification:** +11 nodes against `upstream/testbed`. New nodes implement AC-1 (one static audit guard walking all 71 concrete `Kernel` subclasses — replaces what would otherwise be per-op parametric cases) and AC-4 (per-family kernel-layer rejection sentinels: fp8 across all affected families, plus bool/int negative cases for `Pow`, division family, and `Lerp`). Growth is concentrated in one file because the audit guard is single-node by design.
