### PR TITLE
[Maintain][Manifest] flip reduction Sum/Mean/Amax/Amin to implemented

### DIFF
--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -159,7 +159,7 @@ LogSumExpFwdOp:
 SumFwdOp:
   ref_api: "torch.sum"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -211,7 +211,7 @@ SumFwdOp:
 MeanFwdOp:
   ref_api: "torch.mean"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -259,7 +259,7 @@ MeanFwdOp:
 AmaxFwdOp:
   ref_api: "torch.amax"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -303,7 +303,7 @@ AmaxFwdOp:
 AminFwdOp:
   ref_api: "torch.amin"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
Closes #1399

## Summary

- Flip `SumFwdOp`, `MeanFwdOp`, `AmaxFwdOp`, `AminFwdOp` in `tileops/manifest/reduction.yaml` from `status: spec-only` to `status: implemented`.
- No changes to `signature`, `shape_rules`, `dtype_combos`, `roofline`, or `workloads` on the flipped entries.
- Implementation already landed via #1396; this PR closes the spec/impl trust-boundary handoff.

## Test plan

- [x] AC-1: `tileops/manifest/reduction.yaml` shows `status: implemented` for SumFwdOp, MeanFwdOp, AmaxFwdOp, AminFwdOp.
- [x] AC-2: `python scripts/validate_manifest.py` exits 0.
- [x] AC-3: `pytest tests/test_validate_manifest.py` passes (218 passed).
- [x] AC-4: PR diff touches only `tileops/manifest/reduction.yaml`.
