### PR TITLE
[Maintain][Manifest] flip Var/Std/VarMean fwd ops to status: implemented

### DIFF
--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -404,7 +404,7 @@ ProdFwdOp:
 VarFwdOp:
   ref_api: "torch.var"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -449,7 +449,7 @@ VarFwdOp:
 StdFwdOp:
   ref_api: "torch.std"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -494,7 +494,7 @@ StdFwdOp:
 VarMeanFwdOp:
   ref_api: "torch.var_mean"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
Closes #1400

## Summary

- Flip `VarFwdOp`, `StdFwdOp`, `VarMeanFwdOp` from `status: spec-only` to `status: implemented` in `tileops/manifest/reduction.yaml`.
- Diff is YAML-only; no signature/roofline/workloads/shape-rule edits (status flip carve-out).

## Context

The issue body references impl PR `#1397`, which does not exist. The actual implementation already landed on `main`:

- `dim=None` support via #834.
- Cross-`dim` × `correction` conformance coverage via #1406.

This PR is the spec-side flip aligning manifest status with the already-merged implementation and conformance tests.

## Test plan

- [x] AC-1: `tileops/manifest/reduction.yaml` shows `status: implemented` for `VarFwdOp`, `StdFwdOp`, `VarMeanFwdOp`.
- [x] AC-2: `python scripts/validate_manifest.py` exits 0 (`All manifest checks passed.`).
- [x] AC-3: `pytest tests/test_validate_manifest.py` passes (218 passed, 3 warnings).
- [x] AC-4: PR diff touches only `tileops/manifest/reduction.yaml` (+3 / -3).
