### PR TITLE
[Maintain][Manifest] flip All/Any/CountNonzero reduction ops to implemented

### DIFF
--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -636,7 +636,7 @@ ArgminFwdOp:
 AllFwdOp:
   ref_api: "torch.all"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -682,7 +682,7 @@ AllFwdOp:
 AnyFwdOp:
   ref_api: "torch.any"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:
@@ -728,7 +728,7 @@ AnyFwdOp:
 CountNonzeroFwdOp:
   ref_api: "torch.count_nonzero"
   family: reduction
-  status: spec-only  # dim=None not yet implemented; update when impl lands
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
Closes #1401

## Summary

- Flip `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp` from `status: spec-only` to `status: implemented` in `tileops/manifest/reduction.yaml`.
- Single-file manifest-only change; no signature/roofline/workloads/shape_rules edits.

## Context

Third of a sibling set:

- #1428 — issue #1399, Sum/Mean/Amax/Amin.
- #1430 — issue #1400, Var/Std/VarMean.
- This PR — issue #1401, All/Any/CountNonzero.

After all three merge, the remaining 7 spec-only reduction ops flip to `implemented`, bringing the reduction family to 19/19 `status: implemented`.

## Note on AC-5

AC-5 in the linked issue says "All 13 reduction.yaml ops are status: implemented after merge." The literal count is stale — `reduction.yaml` currently holds 19 ops (12 already `implemented` on `upstream/main`, 7 `spec-only` before this sibling set). The substantive intent — "reduction family fully implemented after merge" — is satisfied once #1428, #1430, and this PR all land.

## Test plan

- [x] AC-1: `tileops/manifest/reduction.yaml` shows `status: implemented` for AllFwdOp, AnyFwdOp, CountNonzeroFwdOp.
- [x] AC-2: `python scripts/validate_manifest.py` exits 0.
- [x] AC-3: `pytest tests/test_validate_manifest.py` passes.
- [x] AC-4: PR diff touches only `tileops/manifest/reduction.yaml` (3 lines changed).
- [x] AC-5: Reduction family fully `implemented` after the three sibling PRs merge (literal "13" is a stale count; see note above).