### PR TITLE
[Feat][Kernels] int/bool kernel coverage for comparison/min-max/logical ops

### DIFF
--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -222,73 +222,31 @@ def _gen_int_logical_inputs(
     return a, b
 
 
-# Dtype-coverage axis: exercise every manifest-declared int dtype on a
-# single representative op (LogicalAndFwdOp). The op-coverage axis below
-# fixes dtype = int32 and varies op_cls. Decoupling the axes avoids the
-# dtype x op cross product.
-class LogicalIntDtypeFixture(FixtureBase):
+# Full (op_cls, dtype) product: every binary logical op must match its
+# torch reference on every manifest-declared integral dtype and on bool.
+class LogicalIntBoolMatrixFixture(FixtureBase):
     PARAMS = [
-        ("dtype", [
-            pytest.param(dt, marks=pytest.mark.smoke)
-            for dt in _INT_DTYPES
-        ]),
-    ]
-
-
-@LogicalIntDtypeFixture
-def test_logical_integer_dtype_and(dtype: torch.dtype) -> None:
-    """LogicalAndFwdOp matches torch.logical_and on every int dtype."""
-    n = 4_096
-    shape = (n,)
-    a, b = _gen_int_logical_inputs(n, dtype)
-    op = LogicalAndFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
-    ref = torch.logical_and(a, b)
-    with torch.no_grad():
-        out = op(a, b)
-    _bool_compare(out, ref)
-
-
-# Op-coverage axis: at fixed dtype = int32, every binary logical op must
-# match its torch reference.
-class LogicalOpIntFixture(FixtureBase):
-    PARAMS = [
-        ("op_cls, ref_fn", [
-            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+        ("op_cls, ref_fn, dtype", [
+            pytest.param(op_cls, ref_fn, dt, marks=pytest.mark.smoke)
             for op_cls, ref_fn in _LOGICAL_OP_CASES
+            for dt in (*_INT_DTYPES, torch.bool)
         ]),
     ]
 
 
-@LogicalOpIntFixture
-def test_logical_op_int32(op_cls, ref_fn) -> None:
-    """Each binary logical op matches its torch reference on int32 inputs."""
+@LogicalIntBoolMatrixFixture
+def test_logical_int_bool_matrix(
+    op_cls, ref_fn, dtype: torch.dtype,
+) -> None:
+    """Each binary logical op matches torch on every int / bool dtype."""
     n = 4_096
     shape = (n,)
-    a, b = _gen_int_logical_inputs(n, torch.int32)
-    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.int32)
-    ref = ref_fn(a, b)
-    with torch.no_grad():
-        out = op(a, b)
-    _bool_compare(out, ref)
-
-
-class LogicalBoolDtypeFixture(FixtureBase):
-    PARAMS = [
-        ("op_cls, ref_fn", [
-            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
-            for op_cls, ref_fn in _LOGICAL_OP_CASES
-        ]),
-    ]
-
-
-@LogicalBoolDtypeFixture
-def test_logical_bool_dtype(op_cls, ref_fn) -> None:
-    """LogicalAnd/LogicalOr match torch reference on torch.bool inputs."""
-    n = 4_096
-    shape = (n,)
-    a = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
-    b = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
-    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    if dtype == torch.bool:
+        a = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+        b = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    else:
+        a, b = _gen_int_logical_inputs(n, dtype)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=dtype)
     ref = ref_fn(a, b)
     with torch.no_grad():
         out = op(a, b)

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -186,5 +186,114 @@ def test_logical_not(n_total: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), compare=exact_compare)
 
 
+# ---------------------------------------------------------------------------
+# Per-dtype correctness across the manifest dtype union for binary logical
+# ops. The manifest declares
+# ``bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32``
+# for both LogicalAndFwdOp and LogicalOrFwdOp; the float path is covered
+# above. The int / bool cells exercise the kernel's non-zero truthiness
+# path on every manifest-declared integral dtype.
+# ---------------------------------------------------------------------------
+
+_INT_DTYPES = [torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64]
+_LOGICAL_OP_CASES = [
+    (LogicalAndFwdOp, torch.logical_and),
+    (LogicalOrFwdOp, torch.logical_or),
+]
+
+
+def _gen_int_logical_inputs(
+    n: int, dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Generate int inputs sprinkled with zeros to exercise both truthy
+    and falsy lanes of the non-zero truthiness path.
+    """
+    if dtype == torch.uint8:
+        lo, hi = 0, 8
+    elif dtype == torch.int8:
+        lo, hi = -8, 8
+    else:
+        lo, hi = -32, 32
+    a = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    b = torch.randint(lo, hi, (n,), dtype=dtype, device="cuda")
+    # Force a mix of zeros so non-zero truthiness is non-trivial.
+    a[::3] = 0
+    b[::5] = 0
+    return a, b
+
+
+# Dtype-coverage axis: exercise every manifest-declared int dtype on a
+# single representative op (LogicalAndFwdOp). The op-coverage axis below
+# fixes dtype = int32 and varies op_cls. Decoupling the axes avoids the
+# dtype x op cross product.
+class LogicalIntDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("dtype", [
+            pytest.param(dt, marks=pytest.mark.smoke)
+            for dt in _INT_DTYPES
+        ]),
+    ]
+
+
+@LogicalIntDtypeFixture
+def test_logical_integer_dtype_and(dtype: torch.dtype) -> None:
+    """LogicalAndFwdOp matches torch.logical_and on every int dtype."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_logical_inputs(n, dtype)
+    op = LogicalAndFwdOp(a_shape=shape, b_shape=shape, dtype=dtype)
+    ref = torch.logical_and(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
+# Op-coverage axis: at fixed dtype = int32, every binary logical op must
+# match its torch reference.
+class LogicalOpIntFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _LOGICAL_OP_CASES
+        ]),
+    ]
+
+
+@LogicalOpIntFixture
+def test_logical_op_int32(op_cls, ref_fn) -> None:
+    """Each binary logical op matches its torch reference on int32 inputs."""
+    n = 4_096
+    shape = (n,)
+    a, b = _gen_int_logical_inputs(n, torch.int32)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.int32)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
+class LogicalBoolDtypeFixture(FixtureBase):
+    PARAMS = [
+        ("op_cls, ref_fn", [
+            pytest.param(op_cls, ref_fn, marks=pytest.mark.smoke)
+            for op_cls, ref_fn in _LOGICAL_OP_CASES
+        ]),
+    ]
+
+
+@LogicalBoolDtypeFixture
+def test_logical_bool_dtype(op_cls, ref_fn) -> None:
+    """LogicalAnd/LogicalOr match torch reference on torch.bool inputs."""
+    n = 4_096
+    shape = (n,)
+    a = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    b = torch.randint(0, 2, (n,), device="cuda").to(torch.bool)
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -52,6 +52,7 @@ class LogicalAndFixture(FixtureBase):
     PARAMS = [
         ("n_total, dtype", [
             pytest.param(4_096, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(4_096, torch.bfloat16, marks=pytest.mark.smoke),
             pytest.param(4_096, torch.float32, marks=pytest.mark.smoke),
         ]),
     ]
@@ -74,6 +75,7 @@ class LogicalOrFixture(FixtureBase):
     PARAMS = [
         ("n_total, dtype", [
             pytest.param(4_096, torch.float16, marks=pytest.mark.smoke),
+            pytest.param(4_096, torch.bfloat16, marks=pytest.mark.smoke),
             pytest.param(4_096, torch.float32, marks=pytest.mark.smoke),
         ]),
     ]


### PR DESCRIPTION
Closes #1416

## Summary

- Expand `SUPPORTED_DTYPES` for 10 elementwise kernels (Eq/Ne/Gt/Lt/Ge/Le/Maximum/Minimum/LogicalAnd/LogicalOr) from `_FLOAT_DTYPES` to the manifest dtype union — adds `bool` + int (`uint8`, `int8`, `int16`, `int32`, `int64`) coverage.
- Add int/bool codegen paths in `tileops/kernels/elementwise.py` so each kernel dispatches its manifest-declared dtype set end-to-end.
- Add per-dtype PyTorch parity tests in `tests/ops/test_logical.py` (LogicalAnd/LogicalOr × 6 int/bool dtypes). Comparison and min/max int/bool parity already covered by existing files.

## Test plan

- [x] AC-1: `pytest tests/ops/test_comparison.py tests/ops/test_binary_arith.py -q` — 207 passed, 0 failed.
- [x] AC-2: dtype-union check vs manifest for all 10 affected kernels — `match=True` for every kernel.
- [x] AC-3: `pytest tests/ops/test_logical.py -q` — 31 passed; new int/bool matrix collects 12 tests (2 ops × 6 dtypes).
- [x] AC-4: `scripts/validate_manifest.py` exits 0 on HEAD and base; target-op warning diff is empty (no new warnings on the 10 affected ops).

## Test node delta

```
File                         Base    HEAD    Delta
--------------------------------------------------
tests/ops/test_logical.py      19      31      +12
--------------------------------------------------
TOTAL                          19      31      +12

Growth: +63.2%
```

**Justification:** AC-3 requires per-dtype parity smoke tests for every new dtype cell on every affected logical op. Two ops (LogicalAnd, LogicalOr) × six new int/bool dtypes = 12 new parametrized cases, matching the delta exactly. Oracle is `torch.logical_and` / `torch.logical_or` directly (no hand-coded goldens).