### PR TITLE
[Fix][Manifest] align logical reduction signatures with implemented dtypes

### DIFF
--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -640,7 +640,7 @@ AllFwdOp:
 
   signature:
     inputs:
-      x: {dtype: "float16 | bfloat16 | float32 | bool"}
+      x: {dtype: "float16 | bfloat16 | float32 | bool | int32 | int64 | complex64 | complex128"}
     outputs:
       output: {dtype: "bool"}
     params:
@@ -686,7 +686,7 @@ AnyFwdOp:
 
   signature:
     inputs:
-      x: {dtype: "float16 | bfloat16 | float32 | bool"}
+      x: {dtype: "float16 | bfloat16 | float32 | bool | int32 | int64 | complex64 | complex128"}
     outputs:
       output: {dtype: "bool"}
     params:
@@ -732,7 +732,7 @@ CountNonzeroFwdOp:
 
   signature:
     inputs:
-      x: {dtype: "float16 | bfloat16 | float32"}
+      x: {dtype: "float16 | bfloat16 | float32 | bool | int32 | int64 | complex64 | complex128"}
     outputs:
       output: {dtype: "int64"}
     params:


### PR DESCRIPTION
Closes #1449

## Summary

- Add `int32`, `int64`, `complex64`, `complex128` to `AllFwdOp` and `AnyFwdOp` signature dtypes.
- Add `bool`, `int32`, `int64`, `complex64`, `complex128` to `CountNonzeroFwdOp` signature dtypes.
- Manifest-only change in `tileops/manifest/reduction.yaml`; aligns spec with PyTorch's logical reduction input dtype support and existing implementation.

## Test plan

- [x] Modified files pass unit tests
- [x] AllFwdOp and AnyFwdOp signatures include int32, int64, complex64, and complex128 in addition to their currently declared dtypes.
- [x] CountNonzeroFwdOp signature includes bool, int32, int64, complex64, and complex128 in addition to its currently declared floating dtypes.
- [x] python scripts/validate_manifest.py passes.
- [x] Logical reduction conformance tests still match PyTorch for the declared dtype set.
