### PR TITLE
[Doc] introduce docs/known-issues.md with logical reduction perf entry

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,63 +1,42 @@
 # Known Issues
 
-Tracks issues where the spec / manifest is correct but the current
-implementation has a non-trivial gap (performance, precision, missing
-specialization). Each entry should name the affected op(s), the gap, the
-root cause, and a pointer to where a fix would land.
+Acknowledged gaps where the spec is correct but the implementation has a
+non-trivial perf / precision / specialization deficit and we're choosing
+not to fix it now. Bugs go to GitHub issues; this file is the register.
 
-Entries here are not bugs against the spec — those go to GitHub issues
-with the `bug` label. Entries here are *acknowledged* deviations that
-the project chooses not to fix immediately.
+Each entry: affected ops, the gap, costs, and where a fix lands.
 
 ______________________________________________________________________
 
 ## Logical reductions — input dtype pre-conversion overhead
 
-**Affected ops**: `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`
+**Ops**: `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`
 (`tileops/manifest/reduction.yaml`, `tileops/kernels/reduction/logical_reduce.py`)
 
-**Spec status**: aligned with PyTorch as of #1451 — signatures accept
-`bool | float16 | bfloat16 | float32 | int32 | int64 | complex64 | complex128`.
+**Gap**: manifest accepts `bool | int32 | int64 | complex64 | complex128`
+(aligned with PyTorch in #1451), but the TileLang kernel only ingests
+`float16 | bfloat16 | float32`. The op layer bridges via
+`to_logical_float32` (`logical_reduce.py:51`), materializing a
+full-sized `float32` intermediate before dispatch.
 
-**Gap**: the TileLang kernel only supports `float16 | bfloat16 | float32`
-inputs. The op layer bridges the gap by calling
-`to_logical_float32(x)` (`logical_reduce.py:51`) before kernel dispatch
-for any input whose dtype is in `_UNSUPPORTED_STORAGE_DTYPES = {bool, int32, int64, complex64, complex128}`. This produces a full-sized
-`float32` intermediate tensor and reads the source tensor end-to-end in
-PyTorch before the kernel ever runs.
+**Per-dtype cost of the materialization**:
 
-**Concrete costs**:
+| Input dtype  | Cost                                                       |
+| ------------ | ---------------------------------------------------------- |
+| `bool`       | 1 B → 4 B, 4× DRAM traffic; reduce was bandwidth-bound     |
+| `int32`      | extra full-tensor read + write, not fused                  |
+| `int64`      | 8 B → 4 B; bits wasted (only `!= 0` is needed)             |
+| `complex64`  | 8 B read twice (`.real`, `.imag`) → 4 B write; ≥1.25× DRAM |
+| `complex128` | 16 B read twice → 4 B write; worst case                    |
 
-| Input dtype  | Pre-conversion cost                                                        | Notes                                                                                 |
-| ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `bool`       | 1 B → 4 B write amplification (4× DRAM traffic on the materialized tensor) | logical reduce on bool is bandwidth-bound; the predicate dominates the actual reduce. |
-| `int32`      | one extra full-tensor read + float32 write                                 | Bandwidth-neutral on the *write* side, but the materialize is not fused.              |
-| `int64`      | 8 B → 4 B; cast loses precision for \|x\| > 2²⁴                            | Semantically safe (we only need `!= 0`), but the lost bits are wasted bandwidth.      |
-| `complex64`  | 8 B input read twice (`.real`, `.imag`), then 4 B float32 write            | At least 1.25× DRAM traffic vs. a fused kernel.                                       |
-| `complex128` | 16 B input read twice, then 4 B float32 write                              | Worst case; biggest opportunity if specialized.                                       |
+**Also**:
 
-Additionally:
+- Kernel has a redundant `T.if_then_else(x_f32 != 0.0, ...)`
+  (`logical_reduce.py:131`, `:210`) — no-op on the pre-converted path,
+  needed on the raw float path; kernel can't tell them apart.
+- `source.kernel_map` is not dtype-specialized; future specialization
+  must extend both kernel and manifest map shape.
 
-- The kernel itself contains a redundant `T.if_then_else(x_f32 != 0.0, 1.0, 0.0)` (`logical_reduce.py:131`, `:210`). For tensors that came
-  through `to_logical_float32` the input is already `{0.0, 1.0}` and
-  this predicate is a no-op; the kernel cannot distinguish the two
-  paths so the instruction stays.
-- `source.kernel_map` in `reduction.yaml` is not dtype-specialized.
-  Adding integer/complex kernels later will require expanding both the
-  kernel side and the manifest's `kernel_map` shape.
-
-**Why not fixed now**: PR #1451 was scoped to manifest alignment per the
-trust-model carve-out (manifest-only PR). The fix needs new TileLang
-kernels that take `int{32,64}`, `bool`, and `complex{64,128}` directly
-and do the `!= 0` predicate on the first load — separate work.
-
-**Pointer for a fix**:
-
-- Add dtype-specialized entries to
-  `tileops/kernels/reduction/logical_reduce.py` so the kernel ingests
-  the source dtype and writes 0/1 into shared memory at first load.
-- Drop the op-layer `to_logical_float32` call for dtypes the kernel can
-  now consume directly.
-- Expand `reduction.yaml`'s `source.kernel_map` accordingly.
-- Remove the redundant `!= 0` predicate on the post-conversion path
-  (or split the kernel into pre-converted vs. raw entry points).
+**Fix sketch**: dtype-specialized kernels that consume the source dtype
+directly and predicate on first load; drop `to_logical_float32` for
+those dtypes; extend `kernel_map`; split or DCE the redundant predicate.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,63 @@
+# Known Issues
+
+Tracks issues where the spec / manifest is correct but the current
+implementation has a non-trivial gap (performance, precision, missing
+specialization). Each entry should name the affected op(s), the gap, the
+root cause, and a pointer to where a fix would land.
+
+Entries here are not bugs against the spec — those go to GitHub issues
+with the `bug` label. Entries here are *acknowledged* deviations that
+the project chooses not to fix immediately.
+
+______________________________________________________________________
+
+## Logical reductions — input dtype pre-conversion overhead
+
+**Affected ops**: `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`
+(`tileops/manifest/reduction.yaml`, `tileops/kernels/reduction/logical_reduce.py`)
+
+**Spec status**: aligned with PyTorch as of #1451 — signatures accept
+`bool | float16 | bfloat16 | float32 | int32 | int64 | complex64 | complex128`.
+
+**Gap**: the TileLang kernel only supports `float16 | bfloat16 | float32`
+inputs. The op layer bridges the gap by calling
+`to_logical_float32(x)` (`logical_reduce.py:51`) before kernel dispatch
+for any input whose dtype is in `_UNSUPPORTED_STORAGE_DTYPES = {bool, int32, int64, complex64, complex128}`. This produces a full-sized
+`float32` intermediate tensor and reads the source tensor end-to-end in
+PyTorch before the kernel ever runs.
+
+**Concrete costs**:
+
+| Input dtype  | Pre-conversion cost                                                        | Notes                                                                                 |
+| ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `bool`       | 1 B → 4 B write amplification (4× DRAM traffic on the materialized tensor) | logical reduce on bool is bandwidth-bound; the predicate dominates the actual reduce. |
+| `int32`      | one extra full-tensor read + float32 write                                 | Bandwidth-neutral on the *write* side, but the materialize is not fused.              |
+| `int64`      | 8 B → 4 B; cast loses precision for \|x\| > 2²⁴                            | Semantically safe (we only need `!= 0`), but the lost bits are wasted bandwidth.      |
+| `complex64`  | 8 B input read twice (`.real`, `.imag`), then 4 B float32 write            | At least 1.25× DRAM traffic vs. a fused kernel.                                       |
+| `complex128` | 16 B input read twice, then 4 B float32 write                              | Worst case; biggest opportunity if specialized.                                       |
+
+Additionally:
+
+- The kernel itself contains a redundant `T.if_then_else(x_f32 != 0.0, 1.0, 0.0)` (`logical_reduce.py:131`, `:210`). For tensors that came
+  through `to_logical_float32` the input is already `{0.0, 1.0}` and
+  this predicate is a no-op; the kernel cannot distinguish the two
+  paths so the instruction stays.
+- `source.kernel_map` in `reduction.yaml` is not dtype-specialized.
+  Adding integer/complex kernels later will require expanding both the
+  kernel side and the manifest's `kernel_map` shape.
+
+**Why not fixed now**: PR #1451 was scoped to manifest alignment per the
+trust-model carve-out (manifest-only PR). The fix needs new TileLang
+kernels that take `int{32,64}`, `bool`, and `complex{64,128}` directly
+and do the `!= 0` predicate on the first load — separate work.
+
+**Pointer for a fix**:
+
+- Add dtype-specialized entries to
+  `tileops/kernels/reduction/logical_reduce.py` so the kernel ingests
+  the source dtype and writes 0/1 into shared memory at first load.
+- Drop the op-layer `to_logical_float32` call for dtypes the kernel can
+  now consume directly.
+- Expand `reduction.yaml`'s `source.kernel_map` accordingly.
+- Remove the redundant `!= 0` predicate on the post-conversion path
+  (or split the kernel into pre-converted vs. raw entry points).

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -13,11 +13,16 @@ ______________________________________________________________________
 **Ops**: `AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`
 (`tileops/manifest/reduction.yaml`, `tileops/kernels/reduction/logical_reduce.py`)
 
-**Gap**: manifest accepts `bool | int32 | int64 | complex64 | complex128`
-(aligned with PyTorch in #1451), but the TileLang kernel only ingests
-`float16 | bfloat16 | float32`. The op layer bridges via
-`to_logical_float32` (`logical_reduce.py:51`), materializing a
-full-sized `float32` intermediate before dispatch.
+**Gap**: PyTorch's `torch.all` / `torch.any` / `torch.count_nonzero`
+accept `bool | int32 | int64 | complex64 | complex128` in addition to
+the floating dtypes; the manifest currently lists only
+`float16 | bfloat16 | float32 | bool` (`AllFwdOp` / `AnyFwdOp`) and
+`float16 | bfloat16 | float32` (`CountNonzeroFwdOp`). Once the
+manifest is expanded to match the PyTorch surface (tracked in #1451),
+the int / complex inputs will be admissible but the TileLang kernel
+still only ingests `float16 | bfloat16 | float32`. The op layer
+bridges via `to_logical_float32` (`logical_reduce.py:51`),
+materializing a full-sized `float32` intermediate before dispatch.
 
 **Per-dtype cost of the materialization**:
 


### PR DESCRIPTION
## Summary

- Add `docs/known-issues.md` as a project-level register of acknowledged gaps where the spec/manifest is correct but the implementation has a non-trivial performance, precision, or specialization deficit.
- First entry: logical reductions (`AllFwdOp`, `AnyFwdOp`, `CountNonzeroFwdOp`) — after #1451 aligned manifest signatures with PyTorch (`int32`, `int64`, `bool`, `complex64`, `complex128`), the TileLang kernel still only ingests `float16/bfloat16/float32`; the op layer bridges via `to_logical_float32`, materializing a full-sized `float32` intermediate before dispatch.
- Entry tabulates per-dtype DRAM costs, notes the redundant in-kernel `!= 0` predicate on the pre-converted path, and the non-dtype-specialized `source.kernel_map`.
- Points at where a future fix lands: dtype-specialized TileLang kernels that consume `int{32,64}`, `bool`, `complex{64,128}` directly and predicate on first load.

## Test plan

- [x] pre-commit passed (mdformat applied)
- [x] no code changes — docs-only

## Additional context

This is a register, not a bug tracker. Entries here are *acknowledged* deviations the project chooses not to fix immediately. Per-issue tracking still goes through GitHub issues.

Future entries should follow the same template: affected ops, spec status, gap, concrete costs, why not fixed now, pointer for a fix.