### PR TITLE
[Perf][GroupedGemm] 3-warpgroup persistent kernel

### DIFF
--- a/benchmarks/ops/bench_grouped_gemm_3wg_vs_2wg.py
+++ b/benchmarks/ops/bench_grouped_gemm_3wg_vs_2wg.py
@@ -1,0 +1,139 @@
+"""Benchmark GroupedGemmPersistent3WGKernel vs torch._grouped_mm (CUTLASS-backed).
+
+torch._grouped_mm (PyTorch 2.10+) dispatches to CUTLASS grouped GEMM kernels
+internally, making it the strongest available baseline for Hopper grouped GEMM.Cases:
+  Qwen3-235B-decode   E=128 T=512
+  Qwen3-235B-prefill  E=128 T=4096
+  DeepSeek-V3-decode  E=256 T=512
+  DeepSeek-V3-prefill E=256 T=4096
+× {uniform, skewed} distribution = 8 cases.
+
+Usage:
+    TILELANG_CLEANUP_TEMP_FILES=1 TMPDIR=/tmp/jieneng_tvm_tmp \\
+    conda run -n tileops-tl9 --no-capture-output \\
+    python benchmarks/ops/bench_grouped_gemm_3wg_vs_2wg.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import torch  # noqa: E402
+from tilelang.profiler import do_bench  # noqa: E402
+
+from tileops.kernels.grouped_gemm import (  # noqa: E402
+    GroupedGemmPersistent3WGKernel,
+)
+
+_DTYPE = torch.bfloat16
+_WARMUP = 25
+_REP = 100
+
+
+def gen_inputs(T, E, K_top, N, K_hidden, distribution):
+    torch.manual_seed(42)
+    dev = "cuda"
+    numel = T * K_top
+
+    if distribution == "uniform":
+        per = numel // E
+        sizes = torch.full((E,), per, dtype=torch.int32, device=dev)
+        sizes[:numel % E] += 1
+    elif distribution == "skewed":
+        top = max(1, E // 5)
+        per_top = (4 * numel) // (5 * top)
+        sizes = torch.full((E,), 1, dtype=torch.int32, device=dev)
+        sizes[:top] = per_top
+        rem = numel - sizes.sum().item()
+        sizes[0] += rem
+    else:
+        raise ValueError(distribution)
+    offsets = torch.zeros(E, dtype=torch.int32, device=dev)
+    offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+
+    A = torch.randn(int(sizes.sum().item()), K_hidden, dtype=_DTYPE, device=dev) * 0.02
+    B = torch.randn(E, N, K_hidden, dtype=_DTYPE, device=dev) * 0.02
+    return A, B, sizes, offsets, numel
+
+
+def pytorch_grouped_gemm(A, B_KN, offs_cumsum, C_buf):
+    """torch._grouped_mm baseline (CUTLASS-backed grouped GEMM in PyTorch 2.10+).
+
+    Args:
+        A: [numel, K] bf16
+        B_KN: [E, K, N] bf16 (pre-transposed from our NT layout [E, N, K])
+        offs_cumsum: [E] int32 cumulative offsets (no leading 0)
+        C_buf: unused, kept for API compat
+    """
+    return torch._grouped_mm(A, B_KN, offs_cumsum)
+
+
+def tflops(ms, numel, N, K):
+    return 2.0 * numel * N * K / ms * 1e-9
+
+
+def run_case(T, E, K_top, N, K, label):
+    numel = T * K_top
+    flops = 2.0 * numel * N * K
+    sm = torch.cuda.get_device_properties(0).multi_processor_count
+
+    print(f"\n{'═' * 88}")
+    print(f"  {label}")
+    print(f"  Grouped GEMM: M_total={numel}, N={N}, K={K}, groups={E}, bf16")
+    print(f"  (from MoE: T={T}, top_k={K_top}, E={E}; sm_count={sm})")
+    print(f"  FLOPs = {flops / 1e12:.3f} TFLOPs")
+    print(f"{'═' * 88}")
+
+    for dist in ("uniform", "skewed"):
+        A, B, sizes, offsets, _ = gen_inputs(T, E, K_top, N, K, dist)
+        sz_summary = (
+            f"M_per_group: min={sizes.min().item()}, "
+            f"max={sizes.max().item()}, "
+            f"mean={sizes.float().mean().item():.0f}")
+        print(f"\n  distribution={dist:<8}  ({sz_summary})")
+        print(f"  {'impl':>18}  {'ms':>8}  {'TFLOPS':>8}  {'vs torch':>10}")
+        print(f"  {'-' * 18}  {'-' * 8}  {'-' * 8}  {'-' * 10}")
+
+        k3 = GroupedGemmPersistent3WGKernel(numel=numel, num_experts=E, N=N, K=K,
+                                            dtype=_DTYPE, sm_count=sm)
+
+        # Prepare inputs for torch._grouped_mm: B must be [E, K, N] (NN layout)
+        # and offs is cumulative sizes without leading 0.
+        B_KN = B.transpose(1, 2).contiguous()
+        offs_cumsum = torch.cumsum(sizes, dim=0).to(torch.int32)
+
+        C_3wg = k3(A, B, sizes, offsets)
+        torch.cuda.synchronize()
+        C_pt = pytorch_grouped_gemm(A, B_KN, offs_cumsum, None)
+        torch.cuda.synchronize()
+        md = (C_pt - C_3wg).abs().max().item()
+
+        t_pt = do_bench(
+            lambda: pytorch_grouped_gemm(A, B_KN, offs_cumsum, None),  # noqa: B023
+            warmup=_WARMUP, rep=_REP)
+        t_3wg = do_bench(lambda: k3(A, B, sizes, offsets), warmup=_WARMUP, rep=_REP)  # noqa: B023
+
+        spd = f"{t_pt / t_3wg:.2f}x"
+        print(f"  {'torch._grouped_mm':>18}  {t_pt:>8.3f}  {tflops(t_pt, numel, N, K):>8.2f}  {'1.00x':>10}")
+        print(f"  {'3-WG':>18}  {t_3wg:>8.3f}  {tflops(t_3wg, numel, N, K):>8.2f}  {spd:>10}")
+        print(f"  max_diff (torch vs 3-WG): {md:.2e}")
+
+
+def main():
+    cases = [
+        # T,    E,   top_k, N,     K,    label
+        (512,  128,  8,  4096, 7168, "Qwen3-235B-decode   E=128 T=512"),
+        (4096, 128,  8,  4096, 7168, "Qwen3-235B-prefill  E=128 T=4096"),
+        (512,  256,  8,  4096, 7168, "DeepSeek-V3-decode  E=256 T=512"),
+        (4096, 256,  8,  4096, 7168, "DeepSeek-V3-prefill E=256 T=4096"),
+    ]
+    for T, E, K_top, N, K, label in cases:
+        run_case(T, E, K_top, N, K, label)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/test_grouped_gemm_persistent_3wg.py
+++ b/tests/kernels/test_grouped_gemm_persistent_3wg.py
@@ -1,0 +1,128 @@
+"""Correctness tests for GroupedGemmPersistent3WGKernel.
+
+Verifies that the 3-WG kernel produces the same output as the 2-WG
+GroupedGemmPersistentKernel across shapes and distributions.
+The 3-WG kernel is K-aligned only, so all test shapes satisfy K % block_k == 0.
+"""
+
+import pytest
+import torch
+
+from tileops.kernels.grouped_gemm import (
+    GroupedGemmPersistent3WGKernel,
+    GroupedGemmPersistentKernel,
+)
+
+
+def make_inputs(T: int, E: int, top_k: int, N: int, K: int,
+                dtype: torch.dtype, distribution: str = "uniform",
+                seed: int = 42):
+    torch.manual_seed(seed)
+    numel = T * top_k
+    dev = "cuda"
+
+    if distribution == "uniform":
+        tokens_per_expert = max(1, numel // E)
+        sizes = torch.zeros(E, dtype=torch.int32, device=dev)
+        sizes[:] = tokens_per_expert
+        sizes[-1] = numel - tokens_per_expert * (E - 1)
+    else:
+        sizes = torch.ones(E, dtype=torch.int32, device=dev)
+        extra = numel - E
+        top_experts = max(1, E // 5)
+        per_top = extra // top_experts
+        sizes[:top_experts] += per_top
+        sizes[0] += extra - per_top * top_experts
+
+    offsets = torch.zeros(E, dtype=torch.int32, device=dev)
+    offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+
+    A = torch.randn(numel, K, dtype=dtype, device=dev) * 0.02
+    B = torch.randn(E, N, K, dtype=dtype, device=dev) * 0.02
+    return A, B, sizes, offsets, numel
+
+
+@pytest.mark.smoke
+def test_import():
+    from tileops.kernels.grouped_gemm import GroupedGemmPersistent3WGKernel  # noqa: F401
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+def test_output_shape(dtype):
+    T, E, top_k, N, K = 32, 4, 2, 256, 64
+    numel = T * top_k
+    A, B, sizes, offsets, _ = make_inputs(T, E, top_k, N, K, dtype)
+    sm = torch.cuda.get_device_properties(0).multi_processor_count
+    kernel = GroupedGemmPersistent3WGKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C = kernel(A, B, sizes, offsets)
+    assert C.shape == (numel, N)
+    assert C.dtype == dtype
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("distribution", ["uniform", "skewed"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("T,E,top_k,N,K", [
+    (32,  4,  2,  256,  64),
+    (64,  8,  4,  256,  128),
+    (128, 16, 4,  512,  256),
+], ids=["small", "medium", "larger"])
+def test_matches_2wg_kernel(T, E, top_k, N, K, dtype, distribution):
+    numel = T * top_k
+    A, B, sizes, offsets, _ = make_inputs(T, E, top_k, N, K, dtype, distribution)
+    sm = torch.cuda.get_device_properties(0).multi_processor_count
+
+    ref = GroupedGemmPersistentKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_ref = ref(A, B, sizes, offsets)
+
+    k3 = GroupedGemmPersistent3WGKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_out = k3(A, B, sizes, offsets)
+
+    torch.testing.assert_close(
+        C_out.float(), C_ref.float(),
+        atol=1e-2, rtol=1e-2,
+        msg=f"Mismatch: T={T} E={E} top_k={top_k} N={N} K={K} {dtype} dist={distribution}")
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("E", [128, 256], ids=["E128", "E256"])
+def test_large_expert_count(E):
+    T, top_k, N, K = 512, 8, 256, 128
+    numel = T * top_k
+    dtype = torch.bfloat16
+    A, B, sizes, offsets, _ = make_inputs(T, E, top_k, N, K, dtype, "uniform")
+    sm = torch.cuda.get_device_properties(0).multi_processor_count
+
+    ref = GroupedGemmPersistentKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_ref = ref(A, B, sizes, offsets)
+
+    k3 = GroupedGemmPersistent3WGKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_out = k3(A, B, sizes, offsets)
+
+    torch.testing.assert_close(C_out.float(), C_ref.float(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_skewed_decode_shape():
+    """Decode-like shape with skewed distribution — the case that previously hung."""
+    T, E, top_k, N, K = 64, 16, 4, 256, 128
+    numel = T * top_k
+    dtype = torch.bfloat16
+    A, B, sizes, offsets, _ = make_inputs(T, E, top_k, N, K, dtype, "skewed")
+    sm = torch.cuda.get_device_properties(0).multi_processor_count
+
+    ref = GroupedGemmPersistentKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_ref = ref(A, B, sizes, offsets)
+
+    k3 = GroupedGemmPersistent3WGKernel(
+        numel=numel, num_experts=E, N=N, K=K, dtype=dtype, sm_count=sm)
+    C_out = k3(A, B, sizes, offsets)
+
+    torch.testing.assert_close(C_out.float(), C_ref.float(), atol=1e-2, rtol=1e-2)

--- a/tileops/kernels/grouped_gemm/__init__.py
+++ b/tileops/kernels/grouped_gemm/__init__.py
@@ -1,8 +1,10 @@
 from .grouped_gemm import _DEFAULT_CONFIGS, GroupedGemmKernel
 from .grouped_gemm_persistent import GroupedGemmPersistentKernel
+from .grouped_gemm_persistent_3wg import GroupedGemmPersistent3WGKernel
 
 __all__ = [
     "_DEFAULT_CONFIGS",
     "GroupedGemmKernel",
+    "GroupedGemmPersistent3WGKernel",
     "GroupedGemmPersistentKernel",
 ]

--- a/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -1,0 +1,655 @@
+"""3-warpgroup persistent grouped GEMM kernel (K-aligned only).
+
+Architecture:
+  threads = 384 (3 warpgroups)
+    Producer WG (tx <  128):           T.dec_max_nreg(24)
+                                       atomic_add(counter, 2) per iter,
+                                       binary search both tiles,
+                                       interleaved TMA loads feeding wg0
+                                       and wg1 SMEM each k.
+    Consumer WG0 (128 ≤ tx < 256):     T.inc_max_nreg(240)
+                                       owns (m_tile_0, n_tile_0).
+    Consumer WG1 (tx ≥ 256):           T.inc_max_nreg(240)
+                                       owns (m_tile_1, n_tile_1).
+
+The two consumer warpgroups process *independent* tiles with their own
+double-buffered SMEM and their own ab_full/ab_empty barrier pairs, so
+epilogues (write-C + bf16 cast) on one WG naturally overlap the other
+WG's mainloop without any inter-WG ordering protocol.
+
+Scope: K-aligned path only.  Callers needing K-unaligned should use
+GroupedGemmPersistentKernel (the 2-WG kernel).  Cluster multicast is
+deferred (TileLang 0.1.9 does not auto-emit multicast TMA on SM90 from
+cluster_dims=(1,2,1); see tileops_md/tilelang_cluster_multicast_investigation.md).
+"""
+
+import functools
+import math
+import os
+
+import tilelang
+import tilelang.language as T
+import torch
+import torch.nn.functional as F
+
+from tileops.kernels.kernel_base import Kernel
+
+_ANCHOR_HELPER_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "_anchor_helper.h")
+)
+
+__all__ = [
+    "GroupedGemmPersistent3WGKernel",
+]
+
+
+_DEFAULT_CONFIG = {
+    "block_m": 64,
+    "block_n": 256,
+    "block_k": 64,
+    "num_stages": 3,
+    "threads": 384,
+    "group_size_m": 1,
+}
+
+
+@functools.lru_cache(maxsize=64)
+def _persistent_grouped_gemm_3wg_kernel(
+    numel: int,
+    num_experts: int,
+    N: int,
+    K: int,
+    dtype: str,
+    sm_count: int,
+    block_k: int,
+):
+    """Build a 3-WG pingpong persistent grouped-GEMM JIT factory.
+
+    Args:
+        numel:       Total tight row count across all batches.
+        num_experts: Number of batches E.
+        N, K:        Output / input feature dims.
+        dtype:       Activation dtype string ("float16" or "bfloat16").
+        sm_count:    Number of CTAs to launch (one per SM, persistent grid).
+        block_k:     K-tile size; required to be a divisor of K (K-aligned path).
+    """
+    accum_dtype = "float"
+    log2_up = max(1, math.ceil(math.log2(num_experts + 1)))
+
+    if K % block_k != 0:
+        raise ValueError(
+            f"GroupedGemmPersistent3WGKernel requires K-alignment "
+            f"(K={K} must be divisible by block_k={block_k}). "
+            f"Use GroupedGemmPersistentKernel for K-unaligned shapes."
+        )
+
+    @tilelang.jit(
+        out_idx=[],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16", "-include", _ANCHOR_HELPER_PATH],
+    )
+    def _func(block_m, block_n, block_k, num_stages, threads, group_size_m):
+        # 3-WG layout: 1 producer + 2 consumers, each WG = 128 threads.
+        assert threads == 384, (
+            f"3-WG persistent grouped GEMM requires threads=384 "
+            f"(1 producer + 2 consumer WGs); got threads={threads}"
+        )
+        _num_pid_n = math.ceil(N / block_n)
+        _max_tiles = numel // block_m + num_experts
+        _total_ctas_ub = _max_tiles * _num_pid_n
+        # Each iteration claims 2 tiles per CTA (atomic_add(+2)); slack of 2
+        # absorbs the case where total_ctas_ub is not a multiple of 2*sm_count.
+        _max_iters = (_total_ctas_ub + 2 * sm_count - 1) // (2 * sm_count) + 2
+        _k_iters = K // block_k
+        A_shape = (numel + block_m, K)
+
+        @T.prim_func
+        def _gemm_main(
+            A: T.Tensor(A_shape, dtype),                        # type: ignore  # noqa: F821
+            B: T.Tensor((num_experts, N, K), dtype),            # type: ignore  # noqa: F821
+            true_sizes: T.Tensor((num_experts,), "int32"),      # noqa: F821
+            true_offsets: T.Tensor((num_experts,), "int32"),    # noqa: F821
+            C: T.Tensor((numel, N), dtype),                     # type: ignore  # noqa: F821
+            tile_counter: T.Tensor((1,), "int32"),              # noqa: F821
+        ):
+            with T.Kernel(sm_count, threads=threads) as (pid,):
+                # ── Per-WG double-buffered SMEM (independent tiles) ──
+                A_smem_wg0_0 = T.alloc_shared((block_m, block_k), dtype)
+                A_smem_wg0_1 = T.alloc_shared((block_m, block_k), dtype)
+                B_smem_wg0_0 = T.alloc_shared((block_n, block_k), dtype)
+                B_smem_wg0_1 = T.alloc_shared((block_n, block_k), dtype)
+                A_smem_wg1_0 = T.alloc_shared((block_m, block_k), dtype)
+                A_smem_wg1_1 = T.alloc_shared((block_m, block_k), dtype)
+                B_smem_wg1_0 = T.alloc_shared((block_n, block_k), dtype)
+                B_smem_wg1_1 = T.alloc_shared((block_n, block_k), dtype)
+                C_local_wg0 = T.alloc_fragment((block_m, block_n), accum_dtype)
+                C_local_wg1 = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                # ── Scheduler SMEM ──
+                s_cum = T.alloc_shared((num_experts + 1,), "int32")
+                s_total = T.alloc_shared((1,), "int32")
+                # Two consecutive tile IDs claimed per producer iteration.
+                s_tile_pair = T.alloc_shared((2,), "int32")
+                lo = T.alloc_local((1,), "int32")
+                hi = T.alloc_local((1,), "int32")
+                # Per-tile metadata hoisted to alloc_local so the interleaved
+                # K-loop body can read m_start/n_start/expert_id across
+                # IfFrame boundaries (TileLang ir_builder forbids cross-frame
+                # reads of immutable Vars; Buffer loads are exempt).
+                ms0 = T.alloc_local((1,), "int32")
+                ns0 = T.alloc_local((1,), "int32")
+                ex0 = T.alloc_local((1,), "int32")
+                v0 = T.alloc_local((1,), "int32")
+                ms1 = T.alloc_local((1,), "int32")
+                ns1 = T.alloc_local((1,), "int32")
+                ex1 = T.alloc_local((1,), "int32")
+                v1 = T.alloc_local((1,), "int32")
+
+                T.annotate_layout({
+                    A_smem_wg0_0: tilelang.layout.make_swizzled_layout(A_smem_wg0_0),
+                    A_smem_wg0_1: tilelang.layout.make_swizzled_layout(A_smem_wg0_1),
+                    B_smem_wg0_0: tilelang.layout.make_swizzled_layout(B_smem_wg0_0),
+                    B_smem_wg0_1: tilelang.layout.make_swizzled_layout(B_smem_wg0_1),
+                    A_smem_wg1_0: tilelang.layout.make_swizzled_layout(A_smem_wg1_0),
+                    A_smem_wg1_1: tilelang.layout.make_swizzled_layout(A_smem_wg1_1),
+                    B_smem_wg1_0: tilelang.layout.make_swizzled_layout(B_smem_wg1_0),
+                    B_smem_wg1_1: tilelang.layout.make_swizzled_layout(B_smem_wg1_1),
+                })
+
+                # ── Per-WG producer/consumer barriers (arrive_count=128) ──
+                ab_full_wg0_0 = T.alloc_barrier(arrive_count=128)
+                ab_full_wg0_1 = T.alloc_barrier(arrive_count=128)
+                ab_empty_wg0_0 = T.alloc_barrier(arrive_count=128)
+                ab_empty_wg0_1 = T.alloc_barrier(arrive_count=128)
+                ab_full_wg1_0 = T.alloc_barrier(arrive_count=128)
+                ab_full_wg1_1 = T.alloc_barrier(arrive_count=128)
+                ab_empty_wg1_0 = T.alloc_barrier(arrive_count=128)
+                ab_empty_wg1_1 = T.alloc_barrier(arrive_count=128)
+
+                # ── Phase counters: monotonic, never reset ──
+                gi_prod_0 = T.alloc_var("int32", init=0)
+                gi_prod_1 = T.alloc_var("int32", init=0)
+                gi_cons_0 = T.alloc_var("int32", init=0)
+                gi_cons_1 = T.alloc_var("int32", init=0)
+
+                tx = T.get_thread_binding()
+
+                # ════════════════════════════════════════════════════════
+                # Producer WG: tx < 128
+                # ════════════════════════════════════════════════════════
+                # CUTLASS pingpong producer pattern: a *single* K-loop body
+                # issues the WG0 TMA pair followed by the WG1 TMA pair at
+                # each k, so WG1's first stage is ready right after WG0's
+                # first stage — both consumers start in parallel.  The
+                # previous "feed WG0 K-loop fully, then WG1 K-loop fully"
+                # form forced WG1 to wait K_iters TMAs before its first
+                # WGMMA could dispatch, defeating pingpong.
+                if tx < 128:
+                    T.dec_max_nreg(24)
+
+                    if tx == 0:
+                        s_cum[0] = T.int32(0)
+                        for e in T.serial(num_experts):
+                            s_cum[e + 1] = s_cum[e] + (true_sizes[e] + (block_m - 1)) // block_m
+                        s_total[0] = s_cum[num_experts] * T.int32(_num_pid_n)
+                    T.sync_threads()
+
+                    for _iter in T.serial(_max_iters):
+                        if tx == 0:
+                            # atomic_add(+2) → atomic claim of both tiles in
+                            # one transaction.  Two separate +1 adds would
+                            # let outsider CTAs interleave and break tile-
+                            # pair adjacency (Known trap #4).
+                            s_tile_pair[0] = T.atomic_add(
+                                tile_counter[0], T.int32(2), return_prev=True
+                            )
+                            s_tile_pair[1] = s_tile_pair[0] + T.int32(1)
+                        T.sync_threads()
+
+                        total = s_total[0]
+
+                        # ── Resolve WG0 tile metadata into alloc_local ──
+                        flat_id_0 = s_tile_pair[0]
+                        if flat_id_0 < total:
+                            if group_size_m == 1:
+                                m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
+                                n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
+                            else:
+                                num_pid_in_group = group_size_m * _num_pid_n
+                                m_tiles_total = s_cum[num_experts]
+                                pig_0 = flat_id_0 % T.int32(num_pid_in_group)
+                                g_id_0 = flat_id_0 // T.int32(num_pid_in_group)
+                                fp_m_0 = g_id_0 * T.int32(group_size_m)
+                                agsm_0 = T.min(m_tiles_total - fp_m_0,
+                                               T.int32(group_size_m))
+                                m_tile_0 = fp_m_0 + pig_0 % agsm_0
+                                n_tile_0 = pig_0 // agsm_0
+
+                            lo[0] = T.int32(0)
+                            hi[0] = T.int32(num_experts - 1)
+                            for _bs in T.serial(log2_up):
+                                mid = (lo[0] + hi[0]) >> T.int32(1)
+                                if s_cum[mid + 1] <= m_tile_0:
+                                    lo[0] = mid + T.int32(1)
+                                else:
+                                    hi[0] = mid
+                            ex0[0] = lo[0]
+                            ms0[0] = (true_offsets[ex0[0]]
+                                      + (m_tile_0 - s_cum[ex0[0]]) * T.int32(block_m))
+                            ns0[0] = n_tile_0 * T.int32(block_n)
+                            v0[0] = T.int32(1)
+                        else:
+                            v0[0] = T.int32(0)
+
+                        # ── Resolve WG1 tile metadata into alloc_local ──
+                        flat_id_1 = s_tile_pair[1]
+                        if flat_id_1 < total:
+                            if group_size_m == 1:
+                                m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
+                                n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
+                            else:
+                                num_pid_in_group = group_size_m * _num_pid_n
+                                m_tiles_total = s_cum[num_experts]
+                                pig_1 = flat_id_1 % T.int32(num_pid_in_group)
+                                g_id_1 = flat_id_1 // T.int32(num_pid_in_group)
+                                fp_m_1 = g_id_1 * T.int32(group_size_m)
+                                agsm_1 = T.min(m_tiles_total - fp_m_1,
+                                               T.int32(group_size_m))
+                                m_tile_1 = fp_m_1 + pig_1 % agsm_1
+                                n_tile_1 = pig_1 // agsm_1
+
+                            lo[0] = T.int32(0)
+                            hi[0] = T.int32(num_experts - 1)
+                            for _bs in T.serial(log2_up):
+                                mid = (lo[0] + hi[0]) >> T.int32(1)
+                                if s_cum[mid + 1] <= m_tile_1:
+                                    lo[0] = mid + T.int32(1)
+                                else:
+                                    hi[0] = mid
+                            ex1[0] = lo[0]
+                            ms1[0] = (true_offsets[ex1[0]]
+                                      + (m_tile_1 - s_cum[ex1[0]]) * T.int32(block_m))
+                            ns1[0] = n_tile_1 * T.int32(block_n)
+                            v1[0] = T.int32(1)
+                        else:
+                            v1[0] = T.int32(0)
+
+                        # ── Interleaved K-loop: WG0 then WG1 each k ──
+                        for k in T.Pipelined(_k_iters, num_stages=0):
+                            k_start = k * block_k
+
+                            # WG0 stream
+                            if v0[0] != 0:
+                                if gi_prod_0 % 2 == 0:
+                                    T.barrier_wait(ab_empty_wg0_0,
+                                                   (gi_prod_0 // 2 + 1) % 2)
+                                    T.tma_copy(
+                                        A[ms0[0]:ms0[0] + block_m,
+                                          k_start:k_start + block_k],
+                                        A_smem_wg0_0, barrier=ab_full_wg0_0,
+                                    )
+                                    T.tma_copy(
+                                        B[ex0[0],
+                                          ns0[0]:ns0[0] + block_n,
+                                          k_start:k_start + block_k],
+                                        B_smem_wg0_0, barrier=ab_full_wg0_0,
+                                    )
+                                    T.barrier_arrive(ab_full_wg0_0)
+                                else:
+                                    T.barrier_wait(ab_empty_wg0_1,
+                                                   (gi_prod_0 // 2 + 1) % 2)
+                                    T.tma_copy(
+                                        A[ms0[0]:ms0[0] + block_m,
+                                          k_start:k_start + block_k],
+                                        A_smem_wg0_1, barrier=ab_full_wg0_1,
+                                    )
+                                    T.tma_copy(
+                                        B[ex0[0],
+                                          ns0[0]:ns0[0] + block_n,
+                                          k_start:k_start + block_k],
+                                        B_smem_wg0_1, barrier=ab_full_wg0_1,
+                                    )
+                                    T.barrier_arrive(ab_full_wg0_1)
+                                gi_prod_0 = gi_prod_0 + 1
+
+                            # WG1 stream
+                            if v1[0] != 0:
+                                if gi_prod_1 % 2 == 0:
+                                    T.barrier_wait(ab_empty_wg1_0,
+                                                   (gi_prod_1 // 2 + 1) % 2)
+                                    T.tma_copy(
+                                        A[ms1[0]:ms1[0] + block_m,
+                                          k_start:k_start + block_k],
+                                        A_smem_wg1_0, barrier=ab_full_wg1_0,
+                                    )
+                                    T.tma_copy(
+                                        B[ex1[0],
+                                          ns1[0]:ns1[0] + block_n,
+                                          k_start:k_start + block_k],
+                                        B_smem_wg1_0, barrier=ab_full_wg1_0,
+                                    )
+                                    T.barrier_arrive(ab_full_wg1_0)
+                                else:
+                                    T.barrier_wait(ab_empty_wg1_1,
+                                                   (gi_prod_1 // 2 + 1) % 2)
+                                    T.tma_copy(
+                                        A[ms1[0]:ms1[0] + block_m,
+                                          k_start:k_start + block_k],
+                                        A_smem_wg1_1, barrier=ab_full_wg1_1,
+                                    )
+                                    T.tma_copy(
+                                        B[ex1[0],
+                                          ns1[0]:ns1[0] + block_n,
+                                          k_start:k_start + block_k],
+                                        B_smem_wg1_1, barrier=ab_full_wg1_1,
+                                    )
+                                    T.barrier_arrive(ab_full_wg1_1)
+                                gi_prod_1 = gi_prod_1 + 1
+
+                # ════════════════════════════════════════════════════════
+                # Consumer WG0: 128 ≤ tx < 256 — processes s_tile_pair[0]
+                # ════════════════════════════════════════════════════════
+                # Since cons0 and cons1 own *independent* SMEM buffers and
+                # *independent* ab_full/ab_empty barrier pairs, the two math
+                # WGs never collide on shared resources and no math-WG
+                # ordering protocol is needed.  An earlier version added a
+                # `math_wg_order_{0,1}` mbarrier pair (CUTLASS-style) but it
+                # introduced a phase-tracking race: a single-bit mbarrier
+                # parity cannot tolerate `arrive` running ahead of `wait` by
+                # more than one iteration, which happens whenever the two
+                # WGs' mainloop+epilogue durations diverge (e.g. one WG
+                # claims an invalid tile and skips its mainloop).
+                elif tx < 256:
+                    T.inc_max_nreg(240)
+                    T.sync_threads()
+
+                    for _iter in T.serial(_max_iters):
+                        T.sync_threads()
+
+                        flat_id_0 = s_tile_pair[0]
+                        total = s_total[0]
+                        valid_0 = flat_id_0 < total
+
+                        if valid_0:
+                            if group_size_m == 1:
+                                m_tile_0 = flat_id_0 // T.int32(_num_pid_n)
+                                n_tile_0 = flat_id_0 % T.int32(_num_pid_n)
+                            else:
+                                num_pid_in_group = group_size_m * _num_pid_n
+                                m_tiles_total = s_cum[num_experts]
+                                pig_0 = flat_id_0 % T.int32(num_pid_in_group)
+                                g_id_0 = flat_id_0 // T.int32(num_pid_in_group)
+                                fp_m_0 = g_id_0 * T.int32(group_size_m)
+                                agsm_0 = T.min(m_tiles_total - fp_m_0,
+                                               T.int32(group_size_m))
+                                m_tile_0 = fp_m_0 + pig_0 % agsm_0
+                                n_tile_0 = pig_0 // agsm_0
+
+                            lo[0] = T.int32(0)
+                            hi[0] = T.int32(num_experts - 1)
+                            for _bs in T.serial(log2_up):
+                                mid = (lo[0] + hi[0]) >> T.int32(1)
+                                if s_cum[mid + 1] <= m_tile_0:
+                                    lo[0] = mid + T.int32(1)
+                                else:
+                                    hi[0] = mid
+                            expert_id_0 = lo[0]
+                            row_0 = (m_tile_0 - s_cum[expert_id_0]) * T.int32(block_m)
+                            m_start_0 = true_offsets[expert_id_0] + row_0
+                            n_start_0 = n_tile_0 * T.int32(block_n)
+                            arows_0 = T.min(T.int32(block_m),
+                                            true_sizes[expert_id_0] - row_0)
+                            acols_0 = T.min(T.int32(block_n),
+                                            T.int32(N) - n_start_0)
+
+                            T.clear(C_local_wg0)
+
+                            for k in T.Pipelined(_k_iters, num_stages=0):
+                                if gi_cons_0 % 2 == 0:
+                                    T.barrier_wait(ab_full_wg0_0, gi_cons_0 // 2 % 2)
+                                    T.wgmma_gemm(
+                                        A_smem_wg0_0, B_smem_wg0_0, C_local_wg0,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(k == 0),
+                                    )
+                                    T.wait_wgmma(0)
+                                    T.warpgroup_fence_operand(C_local_wg0, num_regs=64)
+                                    T.barrier_arrive(ab_empty_wg0_0)
+                                else:
+                                    T.barrier_wait(ab_full_wg0_1, gi_cons_0 // 2 % 2)
+                                    T.wgmma_gemm(
+                                        A_smem_wg0_1, B_smem_wg0_1, C_local_wg0,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(k == 0),
+                                    )
+                                    T.wait_wgmma(0)
+                                    T.warpgroup_fence_operand(C_local_wg0, num_regs=64)
+                                    T.barrier_arrive(ab_empty_wg0_1)
+                                gi_cons_0 = gi_cons_0 + 1
+
+                            for i, j in T.Parallel(block_m, block_n):
+                                if i < arows_0 and j < acols_0:
+                                    C[m_start_0 + i, n_start_0 + j] = C_local_wg0[i, j]
+
+                # ════════════════════════════════════════════════════════
+                # Consumer WG1: tx ≥ 256 — processes s_tile_pair[1]
+                # ════════════════════════════════════════════════════════
+                else:
+                    T.inc_max_nreg(240)
+                    T.sync_threads()
+
+                    for _iter in T.serial(_max_iters):
+                        T.sync_threads()
+
+                        flat_id_1 = s_tile_pair[1]
+                        total = s_total[0]
+                        valid_1 = flat_id_1 < total
+
+                        if valid_1:
+                            if group_size_m == 1:
+                                m_tile_1 = flat_id_1 // T.int32(_num_pid_n)
+                                n_tile_1 = flat_id_1 % T.int32(_num_pid_n)
+                            else:
+                                num_pid_in_group = group_size_m * _num_pid_n
+                                m_tiles_total = s_cum[num_experts]
+                                pig_1 = flat_id_1 % T.int32(num_pid_in_group)
+                                g_id_1 = flat_id_1 // T.int32(num_pid_in_group)
+                                fp_m_1 = g_id_1 * T.int32(group_size_m)
+                                agsm_1 = T.min(m_tiles_total - fp_m_1,
+                                               T.int32(group_size_m))
+                                m_tile_1 = fp_m_1 + pig_1 % agsm_1
+                                n_tile_1 = pig_1 // agsm_1
+
+                            lo[0] = T.int32(0)
+                            hi[0] = T.int32(num_experts - 1)
+                            for _bs in T.serial(log2_up):
+                                mid = (lo[0] + hi[0]) >> T.int32(1)
+                                if s_cum[mid + 1] <= m_tile_1:
+                                    lo[0] = mid + T.int32(1)
+                                else:
+                                    hi[0] = mid
+                            expert_id_1 = lo[0]
+                            row_1 = (m_tile_1 - s_cum[expert_id_1]) * T.int32(block_m)
+                            m_start_1 = true_offsets[expert_id_1] + row_1
+                            n_start_1 = n_tile_1 * T.int32(block_n)
+                            arows_1 = T.min(T.int32(block_m),
+                                            true_sizes[expert_id_1] - row_1)
+                            acols_1 = T.min(T.int32(block_n),
+                                            T.int32(N) - n_start_1)
+
+                            T.clear(C_local_wg1)
+
+                            for k in T.Pipelined(_k_iters, num_stages=0):
+                                if gi_cons_1 % 2 == 0:
+                                    T.barrier_wait(ab_full_wg1_0, gi_cons_1 // 2 % 2)
+                                    T.wgmma_gemm(
+                                        A_smem_wg1_0, B_smem_wg1_0, C_local_wg1,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(k == 0),
+                                    )
+                                    T.wait_wgmma(0)
+                                    T.warpgroup_fence_operand(C_local_wg1, num_regs=64)
+                                    T.barrier_arrive(ab_empty_wg1_0)
+                                else:
+                                    T.barrier_wait(ab_full_wg1_1, gi_cons_1 // 2 % 2)
+                                    T.wgmma_gemm(
+                                        A_smem_wg1_1, B_smem_wg1_1, C_local_wg1,
+                                        transpose_B=True,
+                                        policy=T.GemmWarpPolicy.FullRow,
+                                        clear_accum=(k == 0),
+                                    )
+                                    T.wait_wgmma(0)
+                                    T.warpgroup_fence_operand(C_local_wg1, num_regs=64)
+                                    T.barrier_arrive(ab_empty_wg1_1)
+                                gi_cons_1 = gi_cons_1 + 1
+
+                            for i, j in T.Parallel(block_m, block_n):
+                                if i < arows_1 and j < acols_1:
+                                    C[m_start_1 + i, n_start_1 + j] = C_local_wg1[i, j]
+
+        return _gemm_main
+
+    return _func
+
+
+class GroupedGemmPersistent3WGKernel(Kernel):
+    """3-warpgroup persistent grouped GEMM (K-aligned only).
+
+    Extends the 2-WG GroupedGemmPersistentKernel design with a second
+    consumer warpgroup.  The two consumers process *independent* tiles
+    in parallel, each with its own double-buffered SMEM and barrier pair,
+    so epilogues naturally overlap with mainloops without any explicit
+    math-WG ordering.
+
+    Args:
+        numel:       Total tight row count across all batches.
+        num_experts: Number of batches E.
+        N:           Output feature dimension.
+        K:           Input feature dimension (must satisfy K % block_k == 0).
+        dtype:       Activation / weight dtype.
+        sm_count:    Number of CTAs (default = device SM count).
+        config:      Optional config dict; falls back to default_config.
+        tune:        If True, run autotune over autotune_configs.
+
+    Example:
+        >>> sm = torch.cuda.get_device_properties(0).multi_processor_count
+        >>> kernel = GroupedGemmPersistent3WGKernel(
+        ...     numel=16384, num_experts=128, N=4096, K=2048,
+        ...     dtype=torch.bfloat16, sm_count=sm)
+        >>> C = kernel(A, B, true_sizes, true_offsets)  # [numel, N]
+    """
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        numel: int,
+        num_experts: int,
+        N: int,
+        K: int,
+        dtype: torch.dtype = torch.bfloat16,
+        sm_count: int | None = None,
+        config=None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        self.numel = numel
+        self.num_experts = num_experts
+        self.N = N
+        self.K = K
+        self.dtype = dtype
+        if sm_count is None:
+            sm_count = torch.cuda.get_device_properties(
+                torch.cuda.current_device()
+            ).multi_processor_count
+        self.sm_count = sm_count
+        self.kernel = lambda: _persistent_grouped_gemm_3wg_kernel(
+            self.numel, self.num_experts, self.N, self.K,
+            self.dtype_str, self.sm_count, self.config["block_k"],
+        )
+        self.init_config(config, tune)
+        self._tile_counter: torch.Tensor | None = None
+
+    @property
+    def default_config(self) -> dict:
+        return dict(_DEFAULT_CONFIG)
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        # block_k=128 combinations are excluded: the 3-WG kernel uses 8
+        # independent SMEM double-buffers (4 per consumer × 2 stages), so
+        # block_k=128 doubles the SMEM per buffer beyond H100's 228 KB
+        # limit and the kernel fails to compile.
+        configs = []
+        for block_m in (64, 128):
+            for block_n in (128, 256):
+                for num_stages in (2, 3):
+                    configs.append({
+                        "block_m": block_m,
+                        "block_n": block_n,
+                        "block_k": 64,
+                        "num_stages": num_stages,
+                        "threads": 384,
+                        "group_size_m": 1,
+                    })
+        return configs
+
+    def forward(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        true_sizes: torch.Tensor,
+        true_offsets: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the 3-WG persistent grouped GEMM.
+
+        Args:
+            A: [numel, K] tight permuted hidden states.
+            B: [num_experts, N, K] per-batch weight matrix (NT: B^T applied).
+            true_sizes: [E] int32 true token count per batch.
+            true_offsets: [E] int32 tight start offset per batch in A.
+
+        Returns:
+            C: [numel, N] GEMM output.
+        """
+        if self._tile_counter is None or self._tile_counter.device != A.device:
+            self._tile_counter = torch.zeros(1, dtype=torch.int32, device=A.device)
+        else:
+            self._tile_counter.zero_()
+        C = torch.zeros(self.numel, self.N, dtype=self.dtype, device=A.device)
+        block_m = self.config["block_m"]
+        block_k = self.config["block_k"]
+        block_n = self.config["block_n"]
+        if self.K % block_k != 0:
+            raise ValueError(
+                f"GroupedGemmPersistent3WGKernel is K-aligned only "
+                f"(K={self.K} must be divisible by block_k={block_k})"
+            )
+        if self.N % block_n != 0:
+            raise ValueError(
+                f"GroupedGemmPersistent3WGKernel requires N to be a multiple "
+                f"of block_n={block_n}. Got N={self.N}."
+            )
+        # F.pad block_m zero rows so OOB TMA reads of the last M-tile land in
+        # valid memory (mirrors the 2-WG kernel; epilogue guard prevents the
+        # zeros from being written back to C).
+        A = F.pad(A, (0, 0, 0, block_m))
+        gemm_fn = _persistent_grouped_gemm_3wg_kernel(
+            self.numel, self.num_experts, self.N, self.K,
+            self.dtype_str, self.sm_count, block_k,
+        )(
+            block_m,
+            self.config["block_n"],
+            block_k,
+            self.config["num_stages"],
+            self.config["threads"],
+            self.config.get("group_size_m", 1),
+        )
+        gemm_fn(A, B, true_sizes, true_offsets, C, self._tile_counter)
+        return C


### PR DESCRIPTION
## Summary

Add `GroupedGemmPersistent3WGKernel`: a 3-warpgroup (1 producer + 2 consumer) persistent grouped GEMM kernel for K-aligned shapes on Hopper (SM90).

The two consumer WGs process independent tiles with their own double-buffered SMEM and barrier pairs, achieving natural epilogue/mainloop overlap without any explicit math-WG ordering protocol.

## Benchmark (H200, bf16, N=4096, K=7168)

Baseline: `torch._grouped_mm` (PyTorch 2.10+, CUTLASS-backed)

| Case | M_total | Groups | M_per_group | torch._grouped_mm | 3-WG | vs torch |
|------|---------|--------|-------------|-------------------|------|:--------:|
| decode E=128 uniform | 4096 | 128 | 32 | 2.36ms / 102TF | 1.95ms / 124TF | **1.21×** |
| decode E=128 skewed | 4096 | 128 | 1~849 | 2.82ms / 85TF | 2.22ms / 108TF | **1.27×** |
| prefill E=128 uniform | 32768 | 128 | 256 | 3.03ms / 636TF | 5.10ms / 377TF | 0.59× |
| prefill E=128 skewed | 32768 | 128 | 1~7513 | 5.37ms / 358TF | 6.24ms / 308TF | 0.86× |
| decode E=256 uniform | 4096 | 256 | 16 | 4.58ms / 53TF | 3.76ms / 64TF | **1.22×** |
| decode E=256 skewed | 4096 | 256 | 1~691 | 4.67ms / 52TF | 3.78ms / 64TF | **1.23×** |
| prefill E=256 uniform | 32768 | 256 | 128 | 4.71ms / 409TF | 5.93ms / 324TF | 0.79× |
| prefill E=256 skewed | 32768 | 256 | 1~6863 | 8.42ms / 228TF | 8.05ms / 239TF | **1.05×** |

**Decode (MoE inference primary workload): 21-27% faster than CUTLASS.**
Prefill uniform (large M per expert): CUTLASS is faster — its tile scheduling is optimized for large uniform GEMMs.

## Key Design Decisions

- **No math-WG ordering protocol**: independent SMEM/barriers per consumer make it unnecessary. An earlier mbarrier-based ordering caused hangs due to single-bit phase race conditions when one WG's mainloop duration diverged from the other's.
- **Default config**: `bm=64, bn=256, bk=64, stages=3` (selected via 128-job autotune sweep across 8 cases × 16 configs)
- **autotune_configs** excludes `bk=128` (SMEM exceeds H100/H200 228KB limit with 8 double-buffered tiles)
- **K-aligned only**: callers needing K-unaligned shapes use the existing 2-WG kernel

## Files Changed

- `tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py` — new 3-WG kernel
- `tileops/kernels/grouped_gemm/__init__.py` — re-export
- `benchmarks/ops/bench_grouped_gemm_3wg_vs_2wg.py` — benchmark vs torch._grouped_mm
- `scripts/cluster_multicast_poc.py` — TileLang 0.1.9 cluster multicast investigation (deferred)

## Testing

- 8/8 benchmark cases: `max_diff = 0.00e+00` vs torch._grouped_mm
- Correctness verified against 2-WG kernel (also `max_diff = 0`)
- ruff lint: all checks passed