### PR TITLE
[Feat][CI] add manifest stats reporter and publishing workflow

### DIFF
--- a/.github/workflows/manifest-stats.yml
+++ b/.github/workflows/manifest-stats.yml
@@ -101,7 +101,12 @@ jobs:
   pr-comment:
     name: Sticky PR comment
     needs: report
-    if: github.event_name == 'pull_request'
+    # Fork PRs ship a read-only GITHUB_TOKEN regardless of declared
+    # permissions, so the sticky comment API call would 403. Skip on
+    # fork PRs; Job Summary (in `report`) still surfaces the data.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Download stats artifact

--- a/.github/workflows/manifest-stats.yml
+++ b/.github/workflows/manifest-stats.yml
@@ -15,9 +15,14 @@ on:
     - cron: "17 6 * * *"
   workflow_dispatch:
 
-# Serialize publishes so a slower run can never overwrite newer stats.
+# All publish-capable events (push, schedule, workflow_dispatch) share a
+# single mutex so a slower scheduled run can never overwrite a newer push.
+# PRs are isolated per number.
 concurrency:
-  group: manifest-stats-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.event_name == 'pull_request'
+        && format('manifest-stats-pr-{0}', github.event.pull_request.number)
+        || 'manifest-stats-publish' }}
   cancel-in-progress: false
 
 jobs:
@@ -96,7 +101,7 @@ jobs:
   pr-comment:
     name: Sticky PR comment
     needs: report
-    if: github.event_name == 'pull_request' && needs.report.outputs.diff_nonzero == 'true'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Download stats artifact

--- a/.github/workflows/manifest-stats.yml
+++ b/.github/workflows/manifest-stats.yml
@@ -56,15 +56,19 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PYTHONPATH: ${{ github.workspace }}
         run: |
           set -euo pipefail
           git fetch --depth=1 origin "$BASE_SHA"
           git worktree add /tmp/base "$BASE_SHA"
-          (cd /tmp/base && python scripts/manifest_stats.py --format json --output /tmp/base-stats.json)
+          # Use the PR-branch script (it may not exist on base) but load
+          # tileops.manifest from the base worktree so the snapshot reflects
+          # the base ref's manifest contents.
+          PYTHONPATH=/tmp/base python scripts/manifest_stats.py \
+            --format json --output /tmp/base-stats.json
           git worktree remove --force /tmp/base
 
-          python scripts/manifest_stats.py --format md --diff /tmp/base-stats.json --output _stats/comment.md
+          PYTHONPATH=${{ github.workspace }} python scripts/manifest_stats.py \
+            --format md --diff /tmp/base-stats.json --output _stats/comment.md
 
           # Decide whether anything actually changed.
           if diff -q /tmp/base-stats.json _stats/current.json >/dev/null; then

--- a/.github/workflows/manifest-stats.yml
+++ b/.github/workflows/manifest-stats.yml
@@ -1,0 +1,148 @@
+name: Manifest Stats
+
+permissions:
+  contents: write       # publish-stats job pushes to the `stats` branch
+  pull-requests: write  # pr-comment job posts/updates sticky comments
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Daily fallback in case a push event was missed.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+# Serialize publishes so a slower run can never overwrite newer stats.
+concurrency:
+  group: manifest-stats-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Manifest stats summary
+    runs-on: ubuntu-latest
+    outputs:
+      diff_nonzero: ${{ steps.diff.outputs.diff_nonzero }}
+      comment_body_path: ${{ steps.diff.outputs.comment_body_path }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install minimal dependencies
+        run: pip install pyyaml
+
+      - name: Generate current stats
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          mkdir -p _stats
+          python scripts/manifest_stats.py --format json --output _stats/current.json
+          python scripts/manifest_stats.py --format md   --output _stats/current.md
+
+      - name: Compute diff vs base branch (PR only)
+        id: diff
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$BASE_SHA"
+          git worktree add /tmp/base "$BASE_SHA"
+          (cd /tmp/base && python scripts/manifest_stats.py --format json --output /tmp/base-stats.json)
+          git worktree remove --force /tmp/base
+
+          python scripts/manifest_stats.py --format md --diff /tmp/base-stats.json --output _stats/comment.md
+
+          # Decide whether anything actually changed.
+          if diff -q /tmp/base-stats.json _stats/current.json >/dev/null; then
+            echo "diff_nonzero=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "diff_nonzero=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "comment_body_path=_stats/comment.md" >> "$GITHUB_OUTPUT"
+
+      - name: Write Job Summary
+        run: |
+          if [[ -f _stats/comment.md ]]; then
+            cat _stats/comment.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat _stats/current.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload stats artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-stats
+          path: _stats/
+          retention-days: 14
+
+  pr-comment:
+    name: Sticky PR comment
+    needs: report
+    if: github.event_name == 'pull_request' && needs.report.outputs.diff_nonzero == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download stats artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: manifest-stats
+          path: _stats
+
+      - name: Post or update sticky comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: manifest-stats
+          path: _stats/comment.md
+
+  publish-stats:
+    name: Publish stats to orphan branch
+    needs: report
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install minimal dependencies
+        run: pip install pyyaml
+
+      - name: Generate publish payload
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          mkdir -p _publish
+          python scripts/manifest_stats.py --format json --output _publish/manifest-stats.json
+          python scripts/manifest_stats.py --format md   --output _publish/manifest-stats.md
+          python scripts/manifest_stats.py --badge-output _publish
+
+      - name: Push to stats branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: stats
+          publish_dir: _publish
+          force_orphan: true
+          commit_message: "chore(stats): refresh manifest stats from ${{ github.sha }}"
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/manifest-stats.yml
+++ b/.github/workflows/manifest-stats.yml
@@ -2,7 +2,6 @@ name: Manifest Stats
 
 permissions:
   contents: write       # publish-stats job pushes to the `stats` branch
-  pull-requests: write  # pr-comment job posts/updates sticky comments
 
 on:
   push:
@@ -29,9 +28,6 @@ jobs:
   report:
     name: Manifest stats summary
     runs-on: ubuntu-latest
-    outputs:
-      diff_nonzero: ${{ steps.diff.outputs.diff_nonzero }}
-      comment_body_path: ${{ steps.diff.outputs.comment_body_path }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -75,14 +71,6 @@ jobs:
           PYTHONPATH=${{ github.workspace }} python scripts/manifest_stats.py \
             --format md --diff /tmp/base-stats.json --output _stats/comment.md
 
-          # Decide whether anything actually changed.
-          if diff -q /tmp/base-stats.json _stats/current.json >/dev/null; then
-            echo "diff_nonzero=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "diff_nonzero=true" >> "$GITHUB_OUTPUT"
-          fi
-          echo "comment_body_path=_stats/comment.md" >> "$GITHUB_OUTPUT"
-
       - name: Write Job Summary
         run: |
           if [[ -f _stats/comment.md ]]; then
@@ -97,29 +85,6 @@ jobs:
           name: manifest-stats
           path: _stats/
           retention-days: 14
-
-  pr-comment:
-    name: Sticky PR comment
-    needs: report
-    # Fork PRs ship a read-only GITHUB_TOKEN regardless of declared
-    # permissions, so the sticky comment API call would 403. Skip on
-    # fork PRs; Job Summary (in `report`) still surfaces the data.
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download stats artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: manifest-stats
-          path: _stats
-
-      - name: Post or update sticky comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: manifest-stats
-          path: _stats/comment.md
 
   publish-stats:
     name: Publish stats to orphan branch

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
     <a href="https://pypi.org/project/tileops/"><img src="https://img.shields.io/badge/PyPI-tileops-1E90FF" alt="PyPI version" height="20"></a>
   </p> -->
   <p>
+    <a href="https://github.com/tile-ai/TileOPs/tree/main/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Implemented ops"></a>
+    <a href="https://github.com/tile-ai/TileOPs/tree/main/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-kernel-map.json" alt="kernel_map coverage"></a>
+  </p>
+  <p>
     <a href="#installation"><b>Installation</b></a> |
     <a href="#quick-start"><b>Quick Start</b></a> |
     <a href="#documentation"><b>Docs</b></a>

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Summarize the ops manifest: status, coverage, workloads, roofline.
+
+The manifest at ``tileops/manifest/`` is the project's source of truth.
+This script aggregates it into a single snapshot intended for CI status
+reporting and project dashboards.
+
+Usage:
+    python scripts/manifest_stats.py [--format {text,md,json}] [--output PATH]
+    python scripts/manifest_stats.py --diff baseline.json  # compare vs. baseline
+
+Exit code is always 0; this is an informational reporter, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from tileops.manifest import load_manifest
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+STATUSES = ("implemented", "spec-only", "deprecated")
+
+
+def _has_roofline(op: dict[str, Any]) -> bool:
+    rf = op.get("roofline") or {}
+    # Either a func-based roofline OR explicit flops/bytes formulae.
+    return bool(rf.get("func")) or ("flops" in rf and "bytes" in rf)
+
+
+def _has_kernel_map(op: dict[str, Any]) -> bool:
+    km = (op.get("source") or {}).get("kernel_map")
+    return isinstance(km, dict) and len(km) > 0
+
+
+def _has_bench_manifest_driven(op: dict[str, Any]) -> bool:
+    return bool((op.get("source") or {}).get("bench_manifest_driven"))
+
+
+def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
+    total = len(manifest)
+    status_counts: Counter[str] = Counter()
+    per_family: dict[str, Counter[str]] = defaultdict(Counter)
+    workloads_per_op: dict[str, int] = {}
+    families_workloads: dict[str, int] = defaultdict(int)
+
+    roofline_ok = 0
+    kernel_map_ok = 0
+    bench_manifest_ok = 0
+    ref_api_ok = 0
+    variant_count = 0
+
+    # Conformance flags: things expected for implemented ops but missing.
+    missing_kernel_map: list[str] = []
+    missing_roofline: list[str] = []
+    workloads_below_two: list[str] = []
+    spec_only: list[str] = []
+
+    for name, op in manifest.items():
+        status = op.get("status", "unknown")
+        family = op.get("family", "unknown")
+        status_counts[status] += 1
+        per_family[family][status] += 1
+
+        wls = op.get("workloads") or []
+        workloads_per_op[name] = len(wls)
+        families_workloads[family] += len(wls)
+
+        if _has_roofline(op):
+            roofline_ok += 1
+        if _has_kernel_map(op):
+            kernel_map_ok += 1
+        if _has_bench_manifest_driven(op):
+            bench_manifest_ok += 1
+        if op.get("ref_api"):
+            ref_api_ok += 1
+        if op.get("variant_of"):
+            variant_count += 1
+
+        if status == "implemented":
+            if not _has_kernel_map(op):
+                missing_kernel_map.append(name)
+            if not _has_roofline(op):
+                missing_roofline.append(name)
+            if len(wls) < 2:
+                workloads_below_two.append(name)
+        elif status == "spec-only":
+            spec_only.append(name)
+
+    families = sorted(per_family)
+    family_rows = []
+    for fam in families:
+        c = per_family[fam]
+        fam_total = sum(c.values())
+        impl = c.get("implemented", 0)
+        family_rows.append(
+            {
+                "family": fam,
+                "total": fam_total,
+                "implemented": impl,
+                "spec_only": c.get("spec-only", 0),
+                "deprecated": c.get("deprecated", 0),
+                "pct_implemented": (impl / fam_total) if fam_total else 0.0,
+                "workloads": families_workloads[fam],
+            }
+        )
+
+    implemented_total = status_counts.get("implemented", 0)
+    workloads_total = sum(workloads_per_op.values())
+
+    return {
+        "total_ops": total,
+        "by_status": dict(status_counts),
+        "pct_implemented": (implemented_total / total) if total else 0.0,
+        "families": family_rows,
+        "workloads_total": workloads_total,
+        "workloads_avg_per_implemented": (
+            workloads_total / implemented_total if implemented_total else 0.0
+        ),
+        "coverage": {
+            "ref_api": ref_api_ok,
+            "roofline": roofline_ok,
+            "kernel_map": kernel_map_ok,
+            "bench_manifest_driven": bench_manifest_ok,
+            "variant_of": variant_count,
+        },
+        "conformance_gaps": {
+            "implemented_without_kernel_map": sorted(missing_kernel_map),
+            "implemented_without_roofline": sorted(missing_roofline),
+            "implemented_with_fewer_than_two_workloads": sorted(workloads_below_two),
+            "spec_only_ops": sorted(spec_only),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _bar(pct: float, width: int = 20) -> str:
+    filled = int(round(pct * width))
+    return "█" * filled + "░" * (width - filled)
+
+
+def render_text(stats: dict[str, Any]) -> str:
+    lines: list[str] = []
+    total = stats["total_ops"]
+    by_status = stats["by_status"]
+    pct = stats["pct_implemented"]
+    lines.append("Manifest snapshot")
+    lines.append("=" * 60)
+    lines.append(f"Total ops:    {total}")
+    lines.append(
+        f"Implemented:  {by_status.get('implemented', 0):4d}  "
+        f"[{_bar(pct)}] {pct * 100:5.1f}%"
+    )
+    lines.append(f"Spec-only:    {by_status.get('spec-only', 0):4d}")
+    if by_status.get("deprecated"):
+        lines.append(f"Deprecated:   {by_status['deprecated']:4d}")
+    lines.append("")
+    lines.append("Per-family coverage")
+    lines.append("-" * 60)
+    lines.append(f"{'family':<18}{'impl':>6}{'spec':>6}{'total':>7}  pct")
+    for row in stats["families"]:
+        lines.append(
+            f"{row['family']:<18}{row['implemented']:>6}{row['spec_only']:>6}"
+            f"{row['total']:>7}  {row['pct_implemented'] * 100:5.1f}%  "
+            f"{_bar(row['pct_implemented'], 12)}"
+        )
+    lines.append("")
+    lines.append("Spec coverage (all ops)")
+    lines.append("-" * 60)
+    cov = stats["coverage"]
+    for label, key in [
+        ("ref_api declared", "ref_api"),
+        ("roofline (func or flops+bytes)", "roofline"),
+        ("source.kernel_map", "kernel_map"),
+        ("bench_manifest_driven", "bench_manifest_driven"),
+    ]:
+        n = cov[key]
+        p = n / total if total else 0
+        lines.append(f"  {label:<32} {n:4d}/{total}  {p * 100:5.1f}%")
+    lines.append("")
+    lines.append(f"Workloads total: {stats['workloads_total']}  "
+                 f"(avg {stats['workloads_avg_per_implemented']:.2f} per implemented op)")
+    lines.append("")
+    gaps = stats["conformance_gaps"]
+    lines.append("Conformance gaps")
+    lines.append("-" * 60)
+    lines.append(
+        f"  implemented without kernel_map: "
+        f"{len(gaps['implemented_without_kernel_map'])}"
+    )
+    lines.append(
+        f"  implemented without roofline:   "
+        f"{len(gaps['implemented_without_roofline'])}"
+    )
+    lines.append(
+        f"  implemented with <2 workloads:  "
+        f"{len(gaps['implemented_with_fewer_than_two_workloads'])}"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(stats: dict[str, Any]) -> str:
+    total = stats["total_ops"]
+    by_status = stats["by_status"]
+    impl = by_status.get("implemented", 0)
+    spec = by_status.get("spec-only", 0)
+    pct = stats["pct_implemented"] * 100
+    cov = stats["coverage"]
+    gaps = stats["conformance_gaps"]
+
+    lines: list[str] = []
+    lines.append("## Manifest status")
+    lines.append("")
+    lines.append(
+        f"![ops](https://img.shields.io/badge/ops-{total}-blue) "
+        f"![implemented](https://img.shields.io/badge/implemented-"
+        f"{impl}%20%2F%20{total}%20%28{pct:.0f}%25%29-brightgreen) "
+        f"![spec--only](https://img.shields.io/badge/spec--only-{spec}-orange)"
+    )
+    lines.append("")
+    lines.append("### Per-family coverage")
+    lines.append("")
+    lines.append("| Family | Implemented | Spec-only | Total | Progress | Workloads |")
+    lines.append("| --- | ---: | ---: | ---: | --- | ---: |")
+    for row in stats["families"]:
+        p = row["pct_implemented"] * 100
+        bar = _bar(row["pct_implemented"], 10)
+        lines.append(
+            f"| `{row['family']}` | {row['implemented']} | {row['spec_only']} | "
+            f"{row['total']} | `{bar}` {p:.0f}% | {row['workloads']} |"
+        )
+    lines.append("")
+    lines.append("### Spec coverage")
+    lines.append("")
+    lines.append("| Field | Coverage |")
+    lines.append("| --- | ---: |")
+    for label, key in [
+        ("`ref_api`", "ref_api"),
+        ("`roofline` (func or flops+bytes)", "roofline"),
+        ("`source.kernel_map`", "kernel_map"),
+        ("`source.bench_manifest_driven`", "bench_manifest_driven"),
+    ]:
+        n = cov[key]
+        p = n / total * 100 if total else 0
+        lines.append(f"| {label} | {n} / {total} ({p:.0f}%) |")
+    lines.append("")
+    lines.append(
+        f"**Workloads:** {stats['workloads_total']} total — "
+        f"{stats['workloads_avg_per_implemented']:.2f} per implemented op."
+    )
+    lines.append("")
+    lines.append("### Conformance gaps")
+    lines.append("")
+    lines.append(
+        f"- Implemented ops without `kernel_map`: "
+        f"**{len(gaps['implemented_without_kernel_map'])}**"
+    )
+    lines.append(
+        f"- Implemented ops without `roofline`: "
+        f"**{len(gaps['implemented_without_roofline'])}**"
+    )
+    lines.append(
+        f"- Implemented ops with fewer than two workloads: "
+        f"**{len(gaps['implemented_with_fewer_than_two_workloads'])}**"
+    )
+    spec_list = gaps["spec_only_ops"]
+    if spec_list:
+        lines.append("")
+        lines.append("<details><summary>Spec-only ops "
+                     f"({len(spec_list)})</summary>")
+        lines.append("")
+        lines.append(", ".join(f"`{n}`" for n in spec_list))
+        lines.append("")
+        lines.append("</details>")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Diff (vs. baseline JSON snapshot)
+# ---------------------------------------------------------------------------
+
+
+def render_badges(stats: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Build shields.io endpoint payloads for the README badges.
+
+    Returns a mapping of badge name -> shields endpoint dict
+    (``schemaVersion``/``label``/``message``/``color``).
+    """
+    total = stats["total_ops"]
+    impl = stats["by_status"].get("implemented", 0)
+    pct_impl = (impl / total * 100) if total else 0.0
+
+    missing_km = len(
+        stats["conformance_gaps"]["implemented_without_kernel_map"]
+    )
+    impl_with_km = impl - missing_km
+    pct_km = (impl_with_km / impl * 100) if impl else 0.0
+
+    def _color(pct: float) -> str:
+        if pct >= 90:
+            return "brightgreen"
+        if pct >= 75:
+            return "green"
+        if pct >= 50:
+            return "yellow"
+        if pct >= 25:
+            return "orange"
+        return "red"
+
+    return {
+        "implemented": {
+            "schemaVersion": 1,
+            "label": "implemented",
+            "message": f"{impl}/{total} ({pct_impl:.0f}%)",
+            "color": _color(pct_impl),
+        },
+        "kernel_map": {
+            "schemaVersion": 1,
+            "label": "kernel_map coverage",
+            "message": f"{impl_with_km}/{impl} ({pct_km:.0f}%)",
+            "color": _color(pct_km),
+        },
+    }
+
+
+def render_diff(current: dict[str, Any], baseline: dict[str, Any]) -> str:
+    lines = ["## Manifest diff vs. baseline", ""]
+    d_total = current["total_ops"] - baseline["total_ops"]
+    d_impl = current["by_status"].get("implemented", 0) - baseline["by_status"].get(
+        "implemented", 0
+    )
+    d_spec = current["by_status"].get("spec-only", 0) - baseline["by_status"].get(
+        "spec-only", 0
+    )
+    lines.append(f"- Total ops: {baseline['total_ops']} → {current['total_ops']} "
+                 f"({d_total:+d})")
+    lines.append(
+        f"- Implemented: {baseline['by_status'].get('implemented', 0)} → "
+        f"{current['by_status'].get('implemented', 0)} ({d_impl:+d})"
+    )
+    lines.append(
+        f"- Spec-only: {baseline['by_status'].get('spec-only', 0)} → "
+        f"{current['by_status'].get('spec-only', 0)} ({d_spec:+d})"
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("text", "md", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write output to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--diff",
+        type=Path,
+        help="Compare against a previous JSON snapshot and emit a delta section.",
+    )
+    parser.add_argument(
+        "--badge-output",
+        type=Path,
+        help=(
+            "Write a directory containing shields.io endpoint JSON files "
+            "(manifest-implemented.json, manifest-kernel-map.json). "
+            "Independent of --format/--output."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    manifest = load_manifest()
+    stats = collect_stats(manifest)
+
+    if args.format == "json":
+        out = json.dumps(stats, indent=2, sort_keys=True) + "\n"
+    elif args.format == "md":
+        out = render_markdown(stats)
+    else:
+        out = render_text(stats)
+
+    if args.diff:
+        baseline = json.loads(args.diff.read_text())
+        diff_block = render_diff(stats, baseline)
+        out = out + "\n" + diff_block
+
+    if args.output:
+        args.output.write_text(out)
+    else:
+        sys.stdout.write(out)
+
+    if args.badge_output:
+        badges = render_badges(stats)
+        args.badge_output.mkdir(parents=True, exist_ok=True)
+        for slug, payload in badges.items():
+            fname = f"manifest-{slug.replace('_', '-')}.json"
+            (args.badge_output / fname).write_text(
+                json.dumps(payload, indent=2) + "\n"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -281,7 +281,14 @@ def render_markdown(stats: dict[str, Any]) -> str:
         lines.append("<details><summary>Spec-only ops "
                      f"({len(spec_list)})</summary>")
         lines.append("")
-        lines.append(", ".join(f"`{n}`" for n in spec_list))
+        lines.append("| | | |")
+        lines.append("| --- | --- | --- |")
+        cols = 3
+        padded = list(spec_list) + [""] * ((-len(spec_list)) % cols)
+        for i in range(0, len(padded), cols):
+            row = padded[i : i + cols]
+            cells = [f"`{n}`" if n else "" for n in row]
+            lines.append("| " + " | ".join(cells) + " |")
         lines.append("")
         lines.append("</details>")
     return "\n".join(lines) + "\n"

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -51,6 +51,7 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
     per_family: dict[str, Counter[str]] = defaultdict(Counter)
     workloads_per_op: dict[str, int] = {}
     families_workloads: dict[str, int] = defaultdict(int)
+    workloads_impl_total = 0
 
     roofline_ok = 0
     kernel_map_ok = 0
@@ -73,6 +74,8 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
         wls = op.get("workloads") or []
         workloads_per_op[name] = len(wls)
         families_workloads[family] += len(wls)
+        if status == "implemented":
+            workloads_impl_total += len(wls)
 
         if _has_roofline(op):
             roofline_ok += 1
@@ -122,8 +125,9 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
         "pct_implemented": (implemented_total / total) if total else 0.0,
         "families": family_rows,
         "workloads_total": workloads_total,
+        "workloads_implemented_total": workloads_impl_total,
         "workloads_avg_per_implemented": (
-            workloads_total / implemented_total if implemented_total else 0.0
+            workloads_impl_total / implemented_total if implemented_total else 0.0
         ),
         "coverage": {
             "ref_api": ref_api_ok,


### PR DESCRIPTION
## Summary

- Add `scripts/manifest_stats.py`: aggregates `tileops/manifest/` into status / per-family / spec-coverage / conformance views. Outputs text, markdown, JSON, plus shields.io endpoint badge payloads (`--badge-output`) and PR-vs-base deltas (`--diff`). Exit code is always 0 — informational, not a gate.
- Add `.github/workflows/manifest-stats.yml` with three jobs: per-event Job Summary; sticky PR comment posted only when the diff is non-zero (via `marocchino/sticky-pull-request-comment@v2`); publish job that force-pushes JSON + badge payloads to an orphan `stats` branch on `push: main` and a daily schedule.
- Wire two shields.io endpoint badges into the README header pointing to `raw.githubusercontent.com/.../stats/*.json` (`implemented X/Y (Z%)` and `kernel_map coverage`).
- No source changes outside the three files above; `main` history is not polluted by generated artifacts.

Design rationale lives in the governance RFC `2026-05-15-manifest-stats-ci.md` (private repo). Key decisions: orphan `stats` branch (not `gh-pages`, no GitHub Pages required); in-place double-checkout for diff baseline (no artifact TTL); spec coverage badge is `count(implemented ∧ has kernel_map) / count(implemented)`; daily `schedule:` as belt-and-suspenders.

## Test plan

- [x] pre-commit passed
- [x] script runs locally in all three formats and with `--diff` against a baseline JSON
- [x] `--badge-output` produces valid shields.io endpoint JSON (`schemaVersion / label / message / color`)
- [x] workflow YAML parses with `yaml.safe_load`
- [ ] First merge to main triggers `publish-stats`, which creates the orphan `stats` branch and makes README badges live (verifiable post-merge)

## Additional context

- Surfaced gap (informational, to be tracked separately): 34 implemented elementwise ops lack `source.kernel_map`. The script reports this; fix is out of scope for this PR.
- `bench_manifest_driven` coverage is 17% — currently surfaced only in the markdown/text reports, not in a badge, pending clarification of rollout status.