### PR TITLE
[Test][ATTENTION] extend is_causal-default smoke to GQA prefill ops

### DIFF
--- a/tests/ops/attention/test_is_causal_defaults.py
+++ b/tests/ops/attention/test_is_causal_defaults.py
@@ -8,6 +8,10 @@ import pytest
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
     GroupedQueryAttentionFwdOp,
+    GroupedQueryAttentionPrefillFwdOp,
+    GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp,
+    GroupedQueryAttentionPrefillVarlenFwdOp,
+    GroupedQueryAttentionPrefillWithKVCacheFwdOp,
     GroupedQueryAttentionSlidingWindowFwdOp,
     GroupedQueryAttentionSlidingWindowVarlenFwdOp,
     MultiHeadAttentionBwdOp,
@@ -24,6 +28,13 @@ from tileops.ops import (
         pytest.param(GroupedQueryAttentionBwdOp, marks=pytest.mark.smoke),
         pytest.param(GroupedQueryAttentionSlidingWindowFwdOp, marks=pytest.mark.smoke),
         pytest.param(GroupedQueryAttentionSlidingWindowVarlenFwdOp, marks=pytest.mark.smoke),
+        pytest.param(GroupedQueryAttentionPrefillFwdOp, marks=pytest.mark.smoke),
+        pytest.param(GroupedQueryAttentionPrefillVarlenFwdOp, marks=pytest.mark.smoke),
+        pytest.param(GroupedQueryAttentionPrefillWithKVCacheFwdOp, marks=pytest.mark.smoke),
+        pytest.param(
+            GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp,
+            marks=pytest.mark.smoke,
+        ),
     ],
 )
 def test_is_causal_default_true_on_init(op_cls):


### PR DESCRIPTION
Closes #1463

## Summary

- Extend `tests/ops/attention/test_is_causal_defaults.py` parametrize block to cover the four GQA prefill ops (`GroupedQueryAttentionPrefillFwdOp`, `GroupedQueryAttentionPrefillVarlenFwdOp`, `GroupedQueryAttentionPrefillWithKVCacheFwdOp`, `GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp`).
- All 10 ops whose manifest declares `is_causal: true` as a default are now locked under the C3 ctor-defaults invariant.
- Test-only change; no source file under `tileops/ops/attention/` is modified.

## Test plan

- [x] AC-1: parametrize block has 10 entries (existing 6 + 4 GQA prefill).
- [x] AC-2: `pytest tests/ops/attention/test_is_causal_defaults.py -q` → 10 passed, 2 warnings in 4.41s.
- [x] AC-3: `git diff --name-only upstream/testbed...HEAD` lists only `tests/ops/attention/test_is_causal_defaults.py`.

## Test node delta

```
File                                              Base    HEAD    Delta
-----------------------------------------------------------------------
tests/ops/attention/test_is_causal_defaults.py       6      10       +4
-----------------------------------------------------------------------
TOTAL                                                6      10       +4

Growth: +66.7%
```

**Justification:** The 4 new parametrize entries correspond 1:1 with the 4 GQA prefill ops added to the C3 invariant scope; growth is locked to the manifest's `is_causal: true` default set, not unbounded.
