### PR TITLE
[Feat][CODEGEN] generate _validate_dtypes bodies from manifest dtype_combos

### DIFF
--- a/tests/test_dtype_codegen.py
+++ b/tests/test_dtype_codegen.py
@@ -233,7 +233,9 @@ class TestSynthesizeDtypeCombos:
                weight=torch.empty(0, dtype=torch.float16),
                bias=torch.empty(0, dtype=torch.bfloat16))
 
-    def test_rejects_same_as_token_inside_combo_row(self):
+    def test_same_as_token_inside_combo_row_resolved(self):
+        """``same_as(ref)`` inside a combo row resolves to the sibling's
+        concrete dtype before tuple comparison (validator R4/R6)."""
         sig = {
             "inputs": {
                 "x": {"dtype": "float16 | bfloat16"},
@@ -241,10 +243,49 @@ class TestSynthesizeDtypeCombos:
             },
             "dtype_combos": [
                 {"x": "float16", "weight": "same_as(x)"},
+                {"x": "bfloat16", "weight": "same_as(x)"},
             ],
         }
-        with pytest.raises(ValueError, match="same_as"):
-            synthesize_validate_dtypes("BadOp", sig)
+        fn = synthesize_validate_dtypes("SameAsComboOp", sig)
+        m = self._mock()
+        fn(m,
+           x=torch.empty(0, dtype=torch.float16),
+           weight=torch.empty(0, dtype=torch.float16))
+        fn(m,
+           x=torch.empty(0, dtype=torch.bfloat16),
+           weight=torch.empty(0, dtype=torch.bfloat16))
+        # Mismatched pair is rejected because the resolved combo is
+        # (float16, float16) or (bfloat16, bfloat16), not the mix.
+        with pytest.raises(ValueError, match="dtype_combos"):
+            fn(m,
+               x=torch.empty(0, dtype=torch.float16),
+               weight=torch.empty(0, dtype=torch.bfloat16))
+
+    def test_rejects_same_as_cycle_in_combo_row(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "y": {"dtype": "float16 | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "same_as(y)", "y": "same_as(x)"},
+            ],
+        }
+        with pytest.raises(ValueError, match="cycle"):
+            synthesize_validate_dtypes("CycleOp", sig)
+
+    def test_rejects_same_as_dangling_sibling_in_combo_row(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "same_as(missing)"},
+            ],
+        }
+        with pytest.raises(ValueError, match="not present in the same"):
+            synthesize_validate_dtypes("DanglingOp", sig)
 
     def test_rejects_unknown_input_in_combo_row(self):
         sig = {

--- a/tests/test_dtype_codegen.py
+++ b/tests/test_dtype_codegen.py
@@ -133,6 +133,132 @@ class TestSynthesizeSignature:
         assert params == ["self", "q", "k"]
 
 
+class TestSynthesizeDtypeCombos:
+    """When ``dtype_combos`` is present, it is the exhaustive list of
+    accepted cross-tensor dtype rows (manifest.md R6)."""
+
+    def _mock(self):
+        class Mock:
+            pass
+
+        return Mock()
+
+    def test_listed_combo_accepted(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | float8_e4m3fn | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "float16"},
+                {"x": "float16", "weight": "float8_e4m3fn"},
+                {"x": "bfloat16", "weight": "bfloat16"},
+            ],
+        }
+        fn = synthesize_validate_dtypes("MixedGemmOp", sig)
+        m = self._mock()
+        fn(m,
+           x=torch.empty(0, dtype=torch.float16),
+           weight=torch.empty(0, dtype=torch.float16))
+        fn(m,
+           x=torch.empty(0, dtype=torch.float16),
+           weight=torch.empty(0, dtype=torch.float8_e4m3fn))
+        fn(m,
+           x=torch.empty(0, dtype=torch.bfloat16),
+           weight=torch.empty(0, dtype=torch.bfloat16))
+
+    def test_unlisted_cross_combo_rejected(self):
+        """A row that passes per-input unions but is not in
+        ``dtype_combos`` must still be rejected."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | float8_e4m3fn | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "float16"},
+                {"x": "bfloat16", "weight": "bfloat16"},
+            ],
+        }
+        fn = synthesize_validate_dtypes("MixedGemmOp", sig)
+        m = self._mock()
+        # Each input dtype is in its declared union, but the (x, weight)
+        # pair is not in the combo list.
+        with pytest.raises(ValueError, match="dtype_combos"):
+            fn(m,
+               x=torch.empty(0, dtype=torch.bfloat16),
+               weight=torch.empty(0, dtype=torch.float16))
+
+    def test_out_of_union_still_rejected_before_combo_check(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "float16"},
+            ],
+        }
+        fn = synthesize_validate_dtypes("MixedGemmOp", sig)
+        m = self._mock()
+        with pytest.raises(ValueError):
+            fn(m,
+               x=torch.empty(0, dtype=torch.float32),
+               weight=torch.empty(0, dtype=torch.float16))
+
+    def test_combo_ignores_same_as_axis(self):
+        """``same_as`` inputs do not contribute a combo axis; they are
+        still validated by the per-input pass."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | float8_e4m3fn"},
+                "bias": {"dtype": "same_as(x)"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "float16"},
+                {"x": "float16", "weight": "float8_e4m3fn"},
+            ],
+        }
+        fn = synthesize_validate_dtypes("MixedGemmBiasOp", sig)
+        m = self._mock()
+        fn(m,
+           x=torch.empty(0, dtype=torch.float16),
+           weight=torch.empty(0, dtype=torch.float8_e4m3fn),
+           bias=torch.empty(0, dtype=torch.float16))
+        # same_as(x) violated
+        with pytest.raises(ValueError):
+            fn(m,
+               x=torch.empty(0, dtype=torch.float16),
+               weight=torch.empty(0, dtype=torch.float16),
+               bias=torch.empty(0, dtype=torch.bfloat16))
+
+    def test_rejects_same_as_token_inside_combo_row(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "same_as(x)"},
+            ],
+        }
+        with pytest.raises(ValueError, match="same_as"):
+            synthesize_validate_dtypes("BadOp", sig)
+
+    def test_rejects_unknown_input_in_combo_row(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "missing": "float16"},
+            ],
+        }
+        with pytest.raises(ValueError, match="unknown input"):
+            synthesize_validate_dtypes("BadOp", sig)
+
+
 class TestAutoInstallHook:
     def test_subclass_with_manifest_status_implemented_gets_validator(self):
         sig = {"inputs": {"x": {"dtype": "float16"}}}

--- a/tests/test_dtype_codegen.py
+++ b/tests/test_dtype_codegen.py
@@ -299,6 +299,73 @@ class TestSynthesizeDtypeCombos:
         with pytest.raises(ValueError, match="unknown input"):
             synthesize_validate_dtypes("BadOp", sig)
 
+    def test_rejects_incomplete_combo_row_axes(self):
+        """Rows that omit a declared combo axis must fail synthesis
+        rather than silently produce an unreachable combo key padded
+        with ``None``."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "w": {"dtype": "float16 | bfloat16"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "w": "float16"},
+                {"x": "bfloat16"},
+            ],
+        }
+        with pytest.raises(
+            ValueError, match="must enumerate the same input axes"
+        ):
+            synthesize_validate_dtypes("IncompleteRowOp", sig)
+
+    def test_rejects_extra_combo_row_axes(self):
+        """Rows with axes not present in row 0 are also rejected."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16"},
+                "w": {"dtype": "float16"},
+            },
+            "dtype_combos": [
+                {"x": "float16"},
+                {"x": "float16", "w": "float16"},
+            ],
+        }
+        with pytest.raises(
+            ValueError, match="must enumerate the same input axes"
+        ):
+            synthesize_validate_dtypes("ExtraAxisOp", sig)
+
+
+class TestSameAsRefValidation:
+    def test_rejects_same_as_unknown_input_at_synthesis(self):
+        """A ``same_as(ref)`` token inside an input dtype expression
+        must name a sibling input declared in ``signature.inputs``;
+        otherwise synthesis fails up front instead of waiting for a
+        runtime fallback path to surface the typo."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | same_as(missing)"},
+            },
+        }
+        with pytest.raises(
+            ValueError,
+            match=r"same_as\(missing\).*not declared in signature.inputs",
+        ):
+            synthesize_validate_dtypes("BadRefOp", sig)
+
+    def test_rejects_same_as_unknown_input_pure_ref(self):
+        """Same check fires when ``same_as`` is the sole token."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16"},
+                "y": {"dtype": "same_as(typo)"},
+            },
+        }
+        with pytest.raises(
+            ValueError, match="not declared in signature.inputs"
+        ):
+            synthesize_validate_dtypes("BadRefOp2", sig)
+
 
 class TestAutoInstallHook:
     def test_subclass_with_manifest_status_implemented_gets_validator(self):

--- a/tests/test_dtype_codegen.py
+++ b/tests/test_dtype_codegen.py
@@ -1,0 +1,172 @@
+"""Tests for manifest-driven ``_validate_dtypes`` codegen.
+
+Covers ``tileops.ops._dtype_codegen.synthesize_validate_dtypes`` and the
+``Op.__init_subclass__`` auto-installation hook in ``tileops.ops.op_base``.
+"""
+
+import pytest
+import torch
+
+from tileops.ops._dtype_codegen import synthesize_validate_dtypes
+from tileops.ops.op_base import Op
+
+pytestmark = pytest.mark.smoke
+
+
+def _make_op(name, sig, *, status="implemented", extra_attrs=None):
+    """Build a concrete Op subclass with a manifest signature attached."""
+    attrs = {
+        "default_kernel_map": property(lambda self: {}),
+        "forward": lambda self, *a, **kw: None,
+        "__manifest_signature__": sig,
+        "__manifest_status__": status,
+    }
+    if extra_attrs:
+        attrs.update(extra_attrs)
+    return type(name, (Op,), attrs)
+
+
+class TestSynthesizeSimpleUnion:
+    def test_accepts_listed_dtypes(self):
+        sig = {"inputs": {"x": {"dtype": "float16 | bfloat16"}}}
+        fn = synthesize_validate_dtypes("FooOp", sig)
+
+        class Mock:
+            pass
+
+        m = Mock()
+        m.dtype = torch.float16
+        fn(m, x=torch.empty(0, dtype=torch.float16))
+        fn(m, x=torch.empty(0, dtype=torch.bfloat16))
+
+    def test_rejects_out_of_union(self):
+        sig = {"inputs": {"x": {"dtype": "float16 | bfloat16"}}}
+        fn = synthesize_validate_dtypes("FooOp", sig)
+
+        class Mock:
+            pass
+
+        m = Mock()
+        m.dtype = torch.float16
+        with pytest.raises(ValueError):
+            fn(m, x=torch.empty(0, dtype=torch.float32))
+
+
+class TestSynthesizeSameAs:
+    def test_same_as_matching_pair_accepted(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "y": {"dtype": "same_as(x)"},
+            }
+        }
+        fn = synthesize_validate_dtypes("FooOp", sig)
+
+        class Mock:
+            pass
+
+        m = Mock()
+        m.dtype = torch.float16
+        fn(m, x=torch.empty(0, dtype=torch.float16),
+              y=torch.empty(0, dtype=torch.float16))
+
+    def test_same_as_mismatching_pair_rejected(self):
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "y": {"dtype": "same_as(x)"},
+            }
+        }
+        fn = synthesize_validate_dtypes("FooOp", sig)
+
+        class Mock:
+            pass
+
+        m = Mock()
+        m.dtype = torch.float16
+        with pytest.raises(ValueError):
+            fn(m, x=torch.empty(0, dtype=torch.float16),
+                  y=torch.empty(0, dtype=torch.bfloat16))
+
+
+class TestSynthesizeBoolDtype:
+    def test_bool_input_only_accepts_bool(self):
+        sig = {
+            "inputs": {
+                "cond": {"dtype": "bool"},
+                "x": {"dtype": "float16 | bfloat16 | float32"},
+                "y": {"dtype": "same_as(x)"},
+            }
+        }
+        fn = synthesize_validate_dtypes("WhereLikeOp", sig)
+
+        class Mock:
+            pass
+
+        m = Mock()
+        m.dtype = torch.float16
+        fn(m,
+           cond=torch.empty(0, dtype=torch.bool),
+           x=torch.empty(0, dtype=torch.float16),
+           y=torch.empty(0, dtype=torch.float16))
+        with pytest.raises(ValueError):
+            fn(m,
+               cond=torch.empty(0, dtype=torch.float16),
+               x=torch.empty(0, dtype=torch.float16),
+               y=torch.empty(0, dtype=torch.float16))
+
+
+class TestSynthesizeSignature:
+    def test_keyword_arg_names_match_manifest(self):
+        """The synthesized function must accept inputs as keyword arguments
+        (validator probes via kwargs)."""
+        import inspect
+        sig = {
+            "inputs": {
+                "q": {"dtype": "float16 | bfloat16"},
+                "k": {"dtype": "same_as(q)"},
+            }
+        }
+        fn = synthesize_validate_dtypes("MhaOp", sig)
+        params = list(inspect.signature(fn).parameters.keys())
+        # Self plus q, k
+        assert params == ["self", "q", "k"]
+
+
+class TestAutoInstallHook:
+    def test_subclass_with_manifest_status_implemented_gets_validator(self):
+        sig = {"inputs": {"x": {"dtype": "float16"}}}
+        Cls = _make_op("AutoInstalledOp", sig, status="implemented")
+        # The synthesized method must live in cls.__dict__, not be the base stub
+        assert "_validate_dtypes" in Cls.__dict__
+        assert Cls._validate_dtypes is not Op._validate_dtypes
+
+    def test_subclass_spec_only_does_not_install(self):
+        sig = {"inputs": {"x": {"dtype": "float16"}}}
+        Cls = _make_op("SpecOnlyOp", sig, status="spec-only")
+        assert "_validate_dtypes" not in Cls.__dict__
+        assert Cls._validate_dtypes is Op._validate_dtypes
+
+    def test_subclass_explicit_override_not_clobbered(self):
+        sig = {"inputs": {"x": {"dtype": "float16"}}}
+
+        def manual_validator(self, x):
+            raise RuntimeError("manual")
+
+        Cls = _make_op(
+            "ManualOp", sig, status="implemented",
+            extra_attrs={"_validate_dtypes": manual_validator},
+        )
+        assert Cls._validate_dtypes is manual_validator
+
+    def test_subclass_without_manifest_metadata_leaves_stub(self):
+        # No __manifest_signature__: hook can't synthesize; stub remains.
+        class NoMetaOp(Op):
+            @property
+            def default_kernel_map(self):
+                return {}
+
+            def forward(self, *a, **kw):
+                return None
+
+        assert NoMetaOp._validate_dtypes is Op._validate_dtypes

--- a/tests/test_dtype_codegen.py
+++ b/tests/test_dtype_codegen.py
@@ -206,9 +206,11 @@ class TestSynthesizeDtypeCombos:
                x=torch.empty(0, dtype=torch.float32),
                weight=torch.empty(0, dtype=torch.float16))
 
-    def test_combo_ignores_same_as_axis(self):
-        """``same_as`` inputs do not contribute a combo axis; they are
-        still validated by the per-input pass."""
+    def test_combo_row_must_enumerate_same_as_bound_inputs(self):
+        """Combo rows must enumerate every declared input, including
+        ``same_as``-bound tensors (manifest validator R6 combo-row
+        completeness, scripts/validate_manifest.py). A row that omits a
+        declared input is a synthesis-time error."""
         sig = {
             "inputs": {
                 "x": {"dtype": "float16 | bfloat16"},
@@ -218,6 +220,28 @@ class TestSynthesizeDtypeCombos:
             "dtype_combos": [
                 {"x": "float16", "weight": "float16"},
                 {"x": "float16", "weight": "float8_e4m3fn"},
+            ],
+        }
+        with pytest.raises(
+            ValueError, match="must enumerate every declared input",
+        ):
+            synthesize_validate_dtypes("MixedGemmBiasOp", sig)
+
+    def test_combo_full_row_with_same_as_bound_resolved(self):
+        """When every row enumerates every input (including same_as-bound
+        tensors), the observed tuple compares fully-resolved concrete
+        dtypes — matching validator R6 semantics."""
+        sig = {
+            "inputs": {
+                "x": {"dtype": "float16 | bfloat16"},
+                "weight": {"dtype": "float16 | float8_e4m3fn"},
+                "bias": {"dtype": "same_as(x)"},
+            },
+            "dtype_combos": [
+                {"x": "float16", "weight": "float16",
+                 "bias": "same_as(x)"},
+                {"x": "float16", "weight": "float8_e4m3fn",
+                 "bias": "same_as(x)"},
             ],
         }
         fn = synthesize_validate_dtypes("MixedGemmBiasOp", sig)
@@ -314,7 +338,7 @@ class TestSynthesizeDtypeCombos:
             ],
         }
         with pytest.raises(
-            ValueError, match="must enumerate the same input axes"
+            ValueError, match="must enumerate every declared input"
         ):
             synthesize_validate_dtypes("IncompleteRowOp", sig)
 
@@ -331,7 +355,7 @@ class TestSynthesizeDtypeCombos:
             ],
         }
         with pytest.raises(
-            ValueError, match="must enumerate the same input axes"
+            ValueError, match="must enumerate every declared input"
         ):
             synthesize_validate_dtypes("ExtraAxisOp", sig)
 

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -220,137 +220,92 @@ def synthesize_validate_dtypes(
     combos = _parse_dtype_combos(
         op_name, sig.get("dtype_combos"), input_names,
     )
-    # When dtype_combos is present, freeze each row to a hashable key
-    # over the combo-axis inputs. ``same_as`` inputs do not contribute
-    # an axis (R6); they are still validated by the per-input loop.
+    # When dtype_combos is present, every row enumerates every declared
+    # input (manifest validator R6, scripts/validate_manifest.py R6
+    # combo-row completeness check). The observed combo key is built
+    # over the full input_names tuple, with same_as-bound inputs included
+    # at their resolved concrete dtype.
     combo_keys: set[tuple] | None = None
-    combo_axis_names: list[str] | None = None
     if combos is not None:
-        # Every row must enumerate the same axis set so each combo key is
-        # built from a consistent tuple — never padded with ``None`` for a
-        # missing axis. A row that omits a declared axis is a manifest bug
-        # and must fail synthesis, not produce an unreachable combo key.
-        first_axes = list(combos[0].keys())
-        first_axes_set = set(first_axes)
-        for idx, row in enumerate(combos[1:], start=1):
-            row_axes = set(row.keys())
-            if row_axes != first_axes_set:
-                missing = first_axes_set - row_axes
-                extra = row_axes - first_axes_set
+        input_names_set = set(input_names)
+        for idx, row in enumerate(combos):
+            row_keys = set(row.keys())
+            if row_keys != input_names_set:
+                missing = input_names_set - row_keys
+                extra = row_keys - input_names_set
                 detail_parts: list[str] = []
                 if missing:
-                    detail_parts.append(
-                        f"missing {sorted(missing)!r}"
-                    )
+                    detail_parts.append(f"missing {sorted(missing)!r}")
                 if extra:
                     detail_parts.append(f"extra {sorted(extra)!r}")
                 detail = "; ".join(detail_parts)
                 raise ValueError(
                     f"{op_name}: signature.dtype_combos[{idx}] keys "
-                    f"{sorted(row_axes)!r} differ from row 0 keys "
-                    f"{sorted(first_axes_set)!r} ({detail}); every row "
-                    f"must enumerate the same input axes"
+                    f"{sorted(row_keys)!r} do not cover every declared "
+                    f"signature.inputs name {sorted(input_names_set)!r} "
+                    f"({detail}); every combo row must enumerate every "
+                    f"declared input"
                 )
-        combo_axis_names = first_axes
         combo_keys = {
-            tuple(row[n] for n in combo_axis_names) for row in combos
+            tuple(row[n] for n in input_names) for row in combos
         }
 
-    def _validate_dtypes(self, **kwargs: torch.Tensor) -> None:  # noqa: D401
-        # Callers always reach this function through ``_rebuild_with_named_kwargs``,
-        # which binds every declared input via ``inspect.Signature.bind``
-        # and raises ``TypeError`` for missing arguments before forwarding.
-        # A manual presence check here would be unreachable.
-        for name in input_names:
-            concrete, refs, dtype_str = per_input[name]
-            t = kwargs[name]
-            actual = t.dtype
-            if actual in concrete:
-                continue
-            # Resolve ``same_as`` refs against the actual tensors passed.
-            matched_ref = False
-            for ref in refs:
-                ref_tensor = kwargs.get(ref)
-                if ref_tensor is None:
-                    raise ValueError(
-                        f"{op_name}: input {name!r} declares "
-                        f"same_as({ref}) but {ref!r} was not supplied"
-                    )
-                if actual == ref_tensor.dtype:
-                    matched_ref = True
-                    break
-            if matched_ref:
-                continue
-            raise ValueError(
-                f"{op_name}: input {name!r} has dtype {actual}, "
-                f"expected {dtype_str!r}"
-            )
-        # dtype_combos, when present, is exhaustive: only the listed
-        # cross-tensor combinations are valid.
-        if combo_keys is not None and combo_axis_names is not None:
-            observed = tuple(
-                kwargs[n].dtype for n in combo_axis_names
-            )
-            if observed not in combo_keys:
-                pairs = ", ".join(
-                    f"{n}={d}"
-                    for n, d in zip(
-                        combo_axis_names, observed, strict=True,
-                    )
-                )
-                raise ValueError(
-                    f"{op_name}: dtype combination ({pairs}) is not "
-                    f"listed in signature.dtype_combos"
-                )
-
+    # Generate the validator with explicit named parameters via ``exec``
+    # so its native ``inspect.signature`` reports the manifest inputs and
+    # no per-call ``inspect.Signature.bind`` is paid on the hot path.
+    # ``_validate_dtypes`` is invoked on every ``forward()``; using a
+    # ``**kwargs`` body with a wrapper that calls ``Signature.bind`` per
+    # call adds measurable overhead.
+    closure: dict[str, Any] = {
+        "per_input": per_input,
+        "input_names": input_names,
+        "combo_keys": combo_keys,
+        "ValueError": ValueError,
+        "op_name": op_name,
+    }
+    params_src = ", ".join(input_names)
+    src_lines = [
+        f"def _validate_dtypes(self, {params_src}):",
+        f'    """Synthesized from manifest signature for {op_name}."""',
+        "    _locals = locals()",
+        "    for _name in input_names:",
+        "        _concrete, _refs, _dtype_str = per_input[_name]",
+        "        _actual = _locals[_name].dtype",
+        "        if _actual in _concrete:",
+        "            continue",
+        "        _matched = False",
+        "        for _ref in _refs:",
+        "            _ref_tensor = _locals.get(_ref)",
+        "            if _ref_tensor is None:",
+        "                raise ValueError(",
+        "                    f\"{op_name}: input {_name!r} declares \"",
+        "                    f\"same_as({_ref}) but {_ref!r} was not supplied\"",
+        "                )",
+        "            if _actual == _ref_tensor.dtype:",
+        "                _matched = True",
+        "                break",
+        "        if _matched:",
+        "            continue",
+        "        raise ValueError(",
+        "            f\"{op_name}: input {_name!r} has dtype {_actual}, \"",
+        "            f\"expected {_dtype_str!r}\"",
+        "        )",
+        "    if combo_keys is not None:",
+        "        _observed = tuple(_locals[_n].dtype for _n in input_names)",
+        "        if _observed not in combo_keys:",
+        "            _pairs = \", \".join(",
+        "                f\"{_n}={_d}\" for _n, _d in zip(input_names, _observed)",
+        "            )",
+        "            raise ValueError(",
+        "                f\"{op_name}: dtype combination ({_pairs}) is not \"",
+        "                f\"listed in signature.dtype_combos\"",
+        "            )",
+    ]
+    exec("\n".join(src_lines), closure)
+    _validate_dtypes = closure["_validate_dtypes"]
     _validate_dtypes.__name__ = "_validate_dtypes"
     _validate_dtypes.__qualname__ = f"{op_name}._validate_dtypes"
-    _validate_dtypes.__doc__ = (
-        f"Synthesized from manifest signature for {op_name}."
-    )
-    # Rebuild the function so its inspect.signature reflects the
-    # manifest's named inputs as keyword-only parameters. The manifest
-    # validator probes via kwargs only.
-    _validate_dtypes = _rebuild_with_named_kwargs(
-        _validate_dtypes, input_names,
-    )
     return _validate_dtypes
-
-
-def _rebuild_with_named_kwargs(
-    fn: Callable[..., None], input_names: list[str],
-) -> Callable[..., None]:
-    """Wrap *fn* so its ``inspect.signature`` exposes ``input_names`` as
-    keyword-or-positional parameters.
-
-    The original implementation accepts ``**kwargs`` for simplicity; the
-    validator binds via ``inspect.signature(...).bind(self, **tensors)``,
-    which already succeeds with a ``**kwargs`` body. Exposing the named
-    parameters also lets callers introspect the manifest contract.
-    """
-    import inspect
-
-    params = [
-        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
-    ]
-    for n in input_names:
-        params.append(
-            inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        )
-    new_sig = inspect.Signature(parameters=params, return_annotation=None)
-
-    def wrapper(self, *args, **kwargs):  # noqa: ANN001, ANN002
-        bound = new_sig.bind(self, *args, **kwargs)
-        bound.apply_defaults()
-        call_kwargs = {n: bound.arguments[n] for n in input_names}
-        return fn(self, **call_kwargs)
-
-    wrapper.__name__ = fn.__name__
-    wrapper.__qualname__ = fn.__qualname__
-    wrapper.__doc__ = fn.__doc__
-    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
-    wrapper.__wrapped__ = fn  # type: ignore[attr-defined]
-    return wrapper
 
 
 def _lookup_manifest_entry(op_name: str) -> dict[str, Any] | None:

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -72,16 +72,20 @@ def _parse_dtype_combos(
 ) -> list[dict[str, torch.dtype]] | None:
     """Validate and normalize ``signature.dtype_combos`` rows.
 
-    Each row is a mapping ``{input_name: dtype_token}`` listing the
-    concrete dtype for combo-axis inputs. Rows MUST NOT reference inputs
-    declared via ``same_as(ref)`` (per manifest R6: such inputs do not
-    contribute an independent axis to the combo space).
+    Each row is a mapping ``{input_name: dtype_token}`` where each value
+    is either a concrete torch dtype token (``"float16"``) or a
+    ``same_as(ref)`` expression naming another input in the same row.
+    ``same_as`` tokens are resolved against their sibling within the row
+    before tuple comparison (manifest.md R4/R6; see
+    ``scripts/validate_manifest.py``'s ``check_l3_dtype_combos_data``).
 
     Returns:
         A list of normalized rows, or ``None`` when *combos* is absent.
 
     Raises:
-        ValueError: when an entry is malformed or names an unknown input.
+        ValueError: when an entry is malformed, names an unknown input,
+            or contains a ``same_as`` reference that cannot be resolved
+            within the row (dangling sibling, cycle, or union expression).
     """
     if combos is None:
         return None
@@ -97,7 +101,8 @@ def _parse_dtype_combos(
                 f"{op_name}: signature.dtype_combos[{idx}] must be a "
                 f"non-empty mapping"
             )
-        norm: dict[str, torch.dtype] = {}
+        # First pass: type-check entries and capture raw tokens.
+        raw: dict[str, str] = {}
         for name, tok in row.items():
             if name not in input_names:
                 raise ValueError(
@@ -109,18 +114,49 @@ def _parse_dtype_combos(
                     f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
                     f"must be a string dtype token"
                 )
-            if _SAME_AS_RE.match(tok.strip()):
+            tok_stripped = tok.strip()
+            if "|" in tok_stripped:
                 raise ValueError(
                     f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
-                    f"may not use same_as(...); list concrete dtypes only"
+                    f"= {tok!r} — combo values must be a single concrete "
+                    f"dtype, not a union"
                 )
-            dt = getattr(torch, tok.strip(), None)
-            if not isinstance(dt, torch.dtype):
-                raise ValueError(
-                    f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
-                    f"unknown dtype token {tok!r}"
-                )
-            norm[name] = dt
+            raw[name] = tok_stripped
+        # Second pass: resolve same_as references to siblings in the row.
+        norm: dict[str, torch.dtype] = {}
+        # Iterative resolution: a same_as may chain through several
+        # siblings before reaching a concrete dtype. Bail on cycles.
+        for name in raw:
+            seen: list[str] = []
+            cur = name
+            while True:
+                if cur in seen:
+                    chain = " -> ".join(seen + [cur])
+                    raise ValueError(
+                        f"{op_name}: signature.dtype_combos[{idx}] has "
+                        f"a same_as cycle ({chain})"
+                    )
+                seen.append(cur)
+                tok = raw[cur]
+                m = _SAME_AS_RE.match(tok)
+                if not m:
+                    dt = getattr(torch, tok, None)
+                    if not isinstance(dt, torch.dtype):
+                        raise ValueError(
+                            f"{op_name}: signature.dtype_combos[{idx}]"
+                            f"[{cur!r}] unknown dtype token {tok!r}"
+                        )
+                    norm[name] = dt
+                    break
+                ref = m.group(1)
+                if ref not in raw:
+                    raise ValueError(
+                        f"{op_name}: signature.dtype_combos[{idx}]"
+                        f"[{cur!r}] = {tok!r} references sibling "
+                        f"{ref!r} which is not present in the same "
+                        f"combo row"
+                    )
+                cur = ref
         normalized.append(norm)
     return normalized
 

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -206,6 +206,17 @@ def synthesize_validate_dtypes(
         per_input[name] = (concrete, refs, dtype_str)
 
     input_names = list(inputs.keys())
+    # Validate every same_as(ref) names a sibling in the same signature.
+    # Doing this at synthesis time turns typos into class-construction
+    # errors instead of deferring them to a runtime fallback path.
+    for name, (_concrete, refs, _dtype_str) in per_input.items():
+        for ref in refs:
+            if ref not in input_names:
+                raise ValueError(
+                    f"{op_name}: signature.inputs[{name!r}].dtype "
+                    f"references same_as({ref}) but {ref!r} is not "
+                    f"declared in signature.inputs"
+                )
     combos = _parse_dtype_combos(
         op_name, sig.get("dtype_combos"), input_names,
     )
@@ -215,25 +226,41 @@ def synthesize_validate_dtypes(
     combo_keys: set[tuple] | None = None
     combo_axis_names: list[str] | None = None
     if combos is not None:
-        # Combo axes are the union of names that appear in any row.
-        seen: list[str] = []
-        for row in combos:
-            for n in row:
-                if n not in seen:
-                    seen.append(n)
-        combo_axis_names = seen
+        # Every row must enumerate the same axis set so each combo key is
+        # built from a consistent tuple — never padded with ``None`` for a
+        # missing axis. A row that omits a declared axis is a manifest bug
+        # and must fail synthesis, not produce an unreachable combo key.
+        first_axes = list(combos[0].keys())
+        first_axes_set = set(first_axes)
+        for idx, row in enumerate(combos[1:], start=1):
+            row_axes = set(row.keys())
+            if row_axes != first_axes_set:
+                missing = first_axes_set - row_axes
+                extra = row_axes - first_axes_set
+                detail_parts: list[str] = []
+                if missing:
+                    detail_parts.append(
+                        f"missing {sorted(missing)!r}"
+                    )
+                if extra:
+                    detail_parts.append(f"extra {sorted(extra)!r}")
+                detail = "; ".join(detail_parts)
+                raise ValueError(
+                    f"{op_name}: signature.dtype_combos[{idx}] keys "
+                    f"{sorted(row_axes)!r} differ from row 0 keys "
+                    f"{sorted(first_axes_set)!r} ({detail}); every row "
+                    f"must enumerate the same input axes"
+                )
+        combo_axis_names = first_axes
         combo_keys = {
-            tuple(row.get(n) for n in combo_axis_names) for row in combos
+            tuple(row[n] for n in combo_axis_names) for row in combos
         }
 
     def _validate_dtypes(self, **kwargs: torch.Tensor) -> None:  # noqa: D401
-        # Verify all manifest-declared inputs are present.
-        for name in input_names:
-            if name not in kwargs:
-                raise TypeError(
-                    f"{op_name}._validate_dtypes() missing required "
-                    f"keyword argument {name!r}"
-                )
+        # Callers always reach this function through ``_rebuild_with_named_kwargs``,
+        # which binds every declared input via ``inspect.Signature.bind``
+        # and raises ``TypeError`` for missing arguments before forwarding.
+        # A manual presence check here would be unreachable.
         for name in input_names:
             concrete, refs, dtype_str = per_input[name]
             t = kwargs[name]

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -1,0 +1,256 @@
+"""Synthesize ``_validate_dtypes`` bodies from manifest signatures.
+
+The L1 ``Op`` base declares ``_validate_dtypes`` as a staged-rollout stub
+that raises ``NotImplementedError``. Per ``docs/design/ops-design.md``
+§Step 5, every concrete op with ``status: implemented`` must override
+the stub with a body derived from its manifest ``signature.inputs``
+dtype unions and ``same_as`` references.
+
+This module provides a single codegen entry point — ``synthesize_validate_dtypes``
+— that emits an equivalent function from the manifest signature, and an
+``Op.__init_subclass__`` hook (installed in ``tileops.ops.op_base``) that
+auto-applies the generated method to subclasses that do not supply their
+own override.
+
+Manifest constructs handled:
+
+- Plain dtype tokens (``"float16"``).
+- Pipe-separated unions (``"float16 | bfloat16 | float32"``).
+- ``same_as(ref)`` — the input's dtype must equal ``ref``'s dtype.
+- ``same_as`` inside a union (e.g. ``"float32 | same_as(input)"``) — accept
+  the listed concrete tokens or the ref's dtype.
+
+The synthesized function raises ``ValueError`` on any deviation. Its
+keyword-argument names mirror ``signature.inputs`` so the manifest
+validator's parity probes (which bind via ``inspect.signature``) work
+unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+import torch
+
+_SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
+
+
+def _parse_tokens(dtype_str: str) -> list[str]:
+    """Split a dtype expression into ``|``-separated tokens."""
+    return [t.strip() for t in dtype_str.split("|") if t.strip()]
+
+
+def _classify_tokens(
+    tokens: list[str],
+) -> tuple[list[torch.dtype], list[str]]:
+    """Partition tokens into concrete torch dtypes and ``same_as`` refs.
+
+    Returns:
+        (concrete_dtypes, same_as_refs)
+    """
+    concrete: list[torch.dtype] = []
+    refs: list[str] = []
+    for tok in tokens:
+        m = _SAME_AS_RE.match(tok)
+        if m:
+            refs.append(m.group(1))
+            continue
+        dt = getattr(torch, tok, None)
+        if not isinstance(dt, torch.dtype):
+            raise ValueError(
+                f"unknown dtype token {tok!r} in manifest signature"
+            )
+        concrete.append(dt)
+    return concrete, refs
+
+
+def synthesize_validate_dtypes(
+    op_name: str, sig: dict[str, Any],
+) -> Callable[..., None]:
+    """Build a ``_validate_dtypes`` function from a manifest signature.
+
+    Args:
+        op_name: Manifest op name; used in error messages.
+        sig: The ``signature`` block from the manifest entry. Must contain
+            an ``inputs`` mapping; each entry's ``dtype`` is the union
+            expression to enforce.
+
+    Returns:
+        A function with signature ``(self, **inputs) -> None`` that
+        raises ``ValueError`` when any input's dtype lies outside the
+        declared union (or, for ``same_as(ref)``, differs from the
+        referenced input's dtype).
+    """
+    inputs = sig.get("inputs") or {}
+    if not isinstance(inputs, dict) or not inputs:
+        raise ValueError(
+            f"{op_name}: signature.inputs is missing or empty; cannot "
+            f"synthesize _validate_dtypes"
+        )
+
+    # Pre-parse every input's dtype expression so the generated body
+    # does minimal work on the hot path.
+    per_input: dict[str, tuple[list[torch.dtype], list[str], str]] = {}
+    for name, attrs in inputs.items():
+        if not isinstance(attrs, dict):
+            raise ValueError(
+                f"{op_name}: signature.inputs[{name!r}] must be a mapping"
+            )
+        dtype_str = attrs.get("dtype", "")
+        tokens = _parse_tokens(dtype_str)
+        if not tokens:
+            raise ValueError(
+                f"{op_name}: signature.inputs[{name!r}].dtype is empty"
+            )
+        concrete, refs = _classify_tokens(tokens)
+        per_input[name] = (concrete, refs, dtype_str)
+
+    input_names = list(inputs.keys())
+
+    def _validate_dtypes(self, **kwargs: torch.Tensor) -> None:  # noqa: D401
+        # Verify all manifest-declared inputs are present.
+        for name in input_names:
+            if name not in kwargs:
+                raise TypeError(
+                    f"{op_name}._validate_dtypes() missing required "
+                    f"keyword argument {name!r}"
+                )
+        for name in input_names:
+            concrete, refs, dtype_str = per_input[name]
+            t = kwargs[name]
+            actual = t.dtype
+            if actual in concrete:
+                continue
+            # Resolve ``same_as`` refs against the actual tensors passed.
+            matched_ref = False
+            for ref in refs:
+                ref_tensor = kwargs.get(ref)
+                if ref_tensor is None:
+                    raise ValueError(
+                        f"{op_name}: input {name!r} declares "
+                        f"same_as({ref}) but {ref!r} was not supplied"
+                    )
+                if actual == ref_tensor.dtype:
+                    matched_ref = True
+                    break
+            if matched_ref:
+                continue
+            raise ValueError(
+                f"{op_name}: input {name!r} has dtype {actual}, "
+                f"expected {dtype_str!r}"
+            )
+
+    _validate_dtypes.__name__ = "_validate_dtypes"
+    _validate_dtypes.__qualname__ = f"{op_name}._validate_dtypes"
+    _validate_dtypes.__doc__ = (
+        f"Synthesized from manifest signature for {op_name}."
+    )
+    # Rebuild the function so its inspect.signature reflects the
+    # manifest's named inputs as keyword-only parameters. The manifest
+    # validator probes via kwargs only.
+    _validate_dtypes = _rebuild_with_named_kwargs(
+        _validate_dtypes, input_names,
+    )
+    return _validate_dtypes
+
+
+def _rebuild_with_named_kwargs(
+    fn: Callable[..., None], input_names: list[str],
+) -> Callable[..., None]:
+    """Wrap *fn* so its ``inspect.signature`` exposes ``input_names`` as
+    keyword-or-positional parameters.
+
+    The original implementation accepts ``**kwargs`` for simplicity; the
+    validator binds via ``inspect.signature(...).bind(self, **tensors)``,
+    which already succeeds with a ``**kwargs`` body. Exposing the named
+    parameters also lets callers introspect the manifest contract.
+    """
+    import inspect
+
+    params = [
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+    for n in input_names:
+        params.append(
+            inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        )
+    new_sig = inspect.Signature(parameters=params, return_annotation=None)
+
+    def wrapper(self, *args, **kwargs):  # noqa: ANN001, ANN002
+        bound = new_sig.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        call_kwargs = {n: bound.arguments[n] for n in input_names}
+        return fn(self, **call_kwargs)
+
+    wrapper.__name__ = fn.__name__
+    wrapper.__qualname__ = fn.__qualname__
+    wrapper.__doc__ = fn.__doc__
+    wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
+    wrapper.__wrapped__ = fn  # type: ignore[attr-defined]
+    return wrapper
+
+
+def _lookup_manifest_entry(op_name: str) -> dict[str, Any] | None:
+    """Return the manifest entry for *op_name* or None if absent.
+
+    Lazy-imports the manifest loader to avoid pulling YAML I/O in the
+    ``Op`` base import path when no subclass has been declared yet.
+    Failures (missing key, load errors) downgrade to ``None`` so an
+    incomplete manifest never blocks op-class construction.
+    """
+    try:
+        from tileops.manifest import load_manifest
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        ops = load_manifest()
+    except Exception:  # noqa: BLE001
+        return None
+    entry = ops.get(op_name)
+    if not isinstance(entry, dict):
+        return None
+    return entry
+
+
+def maybe_install_validator(cls: type) -> None:
+    """Install a synthesized ``_validate_dtypes`` on *cls* when warranted.
+
+    Resolution order for the manifest source:
+
+    1. Class-attached ``__manifest_signature__`` + ``__manifest_status__``
+       (used by unit tests and by callers that want to bypass the YAML
+       loader).
+    2. Manifest entry whose key matches ``cls.__name__``.
+
+    Conditions for installation:
+
+    - Resolved status is ``"implemented"`` (spec-only entries
+      intentionally leave the L1 stub in place).
+    - The class did not already define ``_validate_dtypes`` in its own
+      ``__dict__`` (manual overrides are honored verbatim).
+    - The manifest signature has a non-empty ``inputs`` mapping the
+      codegen recognizes.
+    """
+    if "_validate_dtypes" in cls.__dict__:
+        return
+
+    sig = getattr(cls, "__manifest_signature__", None)
+    status = getattr(cls, "__manifest_status__", None)
+    if sig is None or status is None:
+        entry = _lookup_manifest_entry(cls.__name__)
+        if entry is None:
+            return
+        sig = entry.get("signature")
+        status = entry.get("status")
+    if status != "implemented":
+        return
+    if not isinstance(sig, dict):
+        return
+    try:
+        fn = synthesize_validate_dtypes(cls.__name__, sig)
+    except ValueError:
+        # Manifest signature too irregular to synthesize from; leave the
+        # base stub in place rather than mask the gap.
+        return
+    cls._validate_dtypes = fn  # type: ignore[assignment]

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -65,6 +65,66 @@ def _classify_tokens(
     return concrete, refs
 
 
+def _parse_dtype_combos(
+    op_name: str,
+    combos: Any,
+    input_names: list[str],
+) -> list[dict[str, torch.dtype]] | None:
+    """Validate and normalize ``signature.dtype_combos`` rows.
+
+    Each row is a mapping ``{input_name: dtype_token}`` listing the
+    concrete dtype for combo-axis inputs. Rows MUST NOT reference inputs
+    declared via ``same_as(ref)`` (per manifest R6: such inputs do not
+    contribute an independent axis to the combo space).
+
+    Returns:
+        A list of normalized rows, or ``None`` when *combos* is absent.
+
+    Raises:
+        ValueError: when an entry is malformed or names an unknown input.
+    """
+    if combos is None:
+        return None
+    if not isinstance(combos, list) or not combos:
+        raise ValueError(
+            f"{op_name}: signature.dtype_combos must be a non-empty list "
+            f"when present"
+        )
+    normalized: list[dict[str, torch.dtype]] = []
+    for idx, row in enumerate(combos):
+        if not isinstance(row, dict) or not row:
+            raise ValueError(
+                f"{op_name}: signature.dtype_combos[{idx}] must be a "
+                f"non-empty mapping"
+            )
+        norm: dict[str, torch.dtype] = {}
+        for name, tok in row.items():
+            if name not in input_names:
+                raise ValueError(
+                    f"{op_name}: signature.dtype_combos[{idx}] references "
+                    f"unknown input {name!r}"
+                )
+            if not isinstance(tok, str):
+                raise ValueError(
+                    f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
+                    f"must be a string dtype token"
+                )
+            if _SAME_AS_RE.match(tok.strip()):
+                raise ValueError(
+                    f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
+                    f"may not use same_as(...); list concrete dtypes only"
+                )
+            dt = getattr(torch, tok.strip(), None)
+            if not isinstance(dt, torch.dtype):
+                raise ValueError(
+                    f"{op_name}: signature.dtype_combos[{idx}][{name!r}] "
+                    f"unknown dtype token {tok!r}"
+                )
+            norm[name] = dt
+        normalized.append(norm)
+    return normalized
+
+
 def synthesize_validate_dtypes(
     op_name: str, sig: dict[str, Any],
 ) -> Callable[..., None]:
@@ -74,13 +134,16 @@ def synthesize_validate_dtypes(
         op_name: Manifest op name; used in error messages.
         sig: The ``signature`` block from the manifest entry. Must contain
             an ``inputs`` mapping; each entry's ``dtype`` is the union
-            expression to enforce.
+            expression to enforce. May also contain ``dtype_combos`` —
+            when present, it is the exhaustive list of accepted
+            cross-tensor dtype rows (per ``docs/design/manifest.md`` R6).
 
     Returns:
         A function with signature ``(self, **inputs) -> None`` that
         raises ``ValueError`` when any input's dtype lies outside the
-        declared union (or, for ``same_as(ref)``, differs from the
-        referenced input's dtype).
+        declared union, when a ``same_as(ref)`` constraint is violated,
+        or when ``dtype_combos`` is present and the observed combo row
+        is not listed.
     """
     inputs = sig.get("inputs") or {}
     if not isinstance(inputs, dict) or not inputs:
@@ -107,6 +170,25 @@ def synthesize_validate_dtypes(
         per_input[name] = (concrete, refs, dtype_str)
 
     input_names = list(inputs.keys())
+    combos = _parse_dtype_combos(
+        op_name, sig.get("dtype_combos"), input_names,
+    )
+    # When dtype_combos is present, freeze each row to a hashable key
+    # over the combo-axis inputs. ``same_as`` inputs do not contribute
+    # an axis (R6); they are still validated by the per-input loop.
+    combo_keys: set[tuple] | None = None
+    combo_axis_names: list[str] | None = None
+    if combos is not None:
+        # Combo axes are the union of names that appear in any row.
+        seen: list[str] = []
+        for row in combos:
+            for n in row:
+                if n not in seen:
+                    seen.append(n)
+        combo_axis_names = seen
+        combo_keys = {
+            tuple(row.get(n) for n in combo_axis_names) for row in combos
+        }
 
     def _validate_dtypes(self, **kwargs: torch.Tensor) -> None:  # noqa: D401
         # Verify all manifest-declared inputs are present.
@@ -140,6 +222,23 @@ def synthesize_validate_dtypes(
                 f"{op_name}: input {name!r} has dtype {actual}, "
                 f"expected {dtype_str!r}"
             )
+        # dtype_combos, when present, is exhaustive: only the listed
+        # cross-tensor combinations are valid.
+        if combo_keys is not None and combo_axis_names is not None:
+            observed = tuple(
+                kwargs[n].dtype for n in combo_axis_names
+            )
+            if observed not in combo_keys:
+                pairs = ", ".join(
+                    f"{n}={d}"
+                    for n, d in zip(
+                        combo_axis_names, observed, strict=True,
+                    )
+                )
+                raise ValueError(
+                    f"{op_name}: dtype combination ({pairs}) is not "
+                    f"listed in signature.dtype_combos"
+                )
 
     _validate_dtypes.__name__ = "_validate_dtypes"
     _validate_dtypes.__qualname__ = f"{op_name}._validate_dtypes"

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -52,6 +52,18 @@ class Op(ABC):
     # manifest `static_dims`. Default empty = no committed axes.
     _static_axes: frozenset[tuple[int, int]] = frozenset()
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Auto-install a manifest-derived ``_validate_dtypes`` on subclasses.
+
+        Lazy-imports the codegen module to avoid a circular import at
+        ``Op`` definition time. The hook is a no-op when the subclass
+        does not advertise manifest metadata, defines its own
+        ``_validate_dtypes``, or is marked ``status: spec-only``.
+        """
+        super().__init_subclass__(**kwargs)
+        from tileops.ops._dtype_codegen import maybe_install_validator
+        maybe_install_validator(cls)
+
     @property
     @abstractmethod
     def default_kernel_map(self) -> dict[str, Kernel]:


### PR DESCRIPTION
Closes #1458

## Summary

- Add `tileops/ops/_dtype_codegen.py`: generator that synthesizes `_validate_dtypes` bodies from manifest `signature.dtype_combos`.
- Wire the generator into `Op.__init_subclass__` so every op class transparently inherits a manifest-driven dtype validator; manual overrides win.
- Resolve `same_as(ref)` references inside dtype-combo rows so cross-tensor dtype constraints lower correctly.
- Eliminates the C6 base-stub class of `_validate_dtypes` errors; replaces hand-written overrides with codegen.

## Test plan

- [x] pre-commit run --all-files
- [x] pytest tests/test_dtype_codegen.py tests/ops/attention/test_is_causal_defaults.py → 33 passed
- [x] pytest tests/test_validate_manifest.py → 221 passed
- [x] pytest tests/ops/test_elementwise_fp8.py → 15 passed
- [x] python scripts/validate_manifest.py --strict → 0 C6 "_validate_dtypes is the Op base stub" errors
- [x] Direct probe: MultiHeadAttentionFwdOp._validate_dtypes rejects an out-of-spec dtype combination

## Test node delta

```
File                                              Base    HEAD    Delta
-----------------------------------------------------------------------
tests/ops/attention/test_is_causal_defaults.py     new      10    (new)
tests/test_dtype_codegen.py                        new      23    (new)
-----------------------------------------------------------------------
TOTAL                                                0      33      +33

All 33 nodes are from new files.
```

**Justification:** New codegen feature requires dedicated unit tests covering the synthesizer (`test_dtype_codegen.py`: dtype_combos parsing, same_as resolution, row-completeness enforcement, synthesis-time validation) and the GQA prefill smoke extension for is_causal defaults (`test_is_causal_defaults.py`: 4 added parametrize cases). All 33 nodes are net-new tests for code added in this PR.

