### PR TITLE
[Refactor][CI] retarget README badges to spec / bench coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
     <a href="https://pypi.org/project/tileops/"><img src="https://img.shields.io/badge/PyPI-tileops-1E90FF" alt="PyPI version" height="20"></a>
   </p> -->
   <p>
-    <a href="https://github.com/tile-ai/TileOPs/tree/main/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Implemented ops"></a>
-    <a href="https://github.com/tile-ai/TileOPs/tree/main/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-kernel-map.json" alt="kernel_map coverage"></a>
+    <a href="https://github.com/tile-ai/TileOPs/tree/main/tileops/manifest"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-implemented.json" alt="Spec coverage"></a>
+    <a href="https://github.com/tile-ai/TileOPs/tree/main/benchmarks"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftile-ai%2FTileOPs%2Fstats%2Fmanifest-benchmark.json" alt="Bench coverage"></a>
   </p>
   <p>
     <a href="#installation"><b>Installation</b></a> |

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -213,6 +213,10 @@ def render_text(stats: dict[str, Any]) -> str:
         f"{len(gaps['implemented_without_roofline'])}"
     )
     lines.append(
+        f"  implemented without bench:      "
+        f"{len(gaps['implemented_without_bench_manifest_driven'])}"
+    )
+    lines.append(
         f"  implemented with <2 workloads:  "
         f"{len(gaps['implemented_with_fewer_than_two_workloads'])}"
     )
@@ -278,6 +282,10 @@ def render_markdown(stats: dict[str, Any]) -> str:
     lines.append(
         f"- Implemented ops without `roofline`: "
         f"**{len(gaps['implemented_without_roofline'])}**"
+    )
+    lines.append(
+        f"- Implemented ops without `source.bench_manifest_driven`: "
+        f"**{len(gaps['implemented_without_bench_manifest_driven'])}**"
     )
     lines.append(
         f"- Implemented ops with fewer than two workloads: "

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -62,6 +62,7 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
     # Conformance flags: things expected for implemented ops but missing.
     missing_kernel_map: list[str] = []
     missing_roofline: list[str] = []
+    missing_bench: list[str] = []
     workloads_below_two: list[str] = []
     spec_only: list[str] = []
 
@@ -93,6 +94,8 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
                 missing_kernel_map.append(name)
             if not _has_roofline(op):
                 missing_roofline.append(name)
+            if not _has_bench_manifest_driven(op):
+                missing_bench.append(name)
             if len(wls) < 2:
                 workloads_below_two.append(name)
         elif status == "spec-only":
@@ -139,6 +142,7 @@ def collect_stats(manifest: dict[str, dict]) -> dict[str, Any]:
         "conformance_gaps": {
             "implemented_without_kernel_map": sorted(missing_kernel_map),
             "implemented_without_roofline": sorted(missing_roofline),
+            "implemented_without_bench_manifest_driven": sorted(missing_bench),
             "implemented_with_fewer_than_two_workloads": sorted(workloads_below_two),
             "spec_only_ops": sorted(spec_only),
         },
@@ -313,11 +317,11 @@ def render_badges(stats: dict[str, Any]) -> dict[str, dict[str, Any]]:
     impl = stats["by_status"].get("implemented", 0)
     pct_impl = (impl / total * 100) if total else 0.0
 
-    missing_km = len(
-        stats["conformance_gaps"]["implemented_without_kernel_map"]
+    missing_bench = len(
+        stats["conformance_gaps"]["implemented_without_bench_manifest_driven"]
     )
-    impl_with_km = impl - missing_km
-    pct_km = (impl_with_km / impl * 100) if impl else 0.0
+    impl_benched = impl - missing_bench
+    pct_bench = (impl_benched / impl * 100) if impl else 0.0
 
     def _color(pct: float) -> str:
         if pct >= 90:
@@ -337,11 +341,11 @@ def render_badges(stats: dict[str, Any]) -> dict[str, dict[str, Any]]:
             "message": f"{impl}/{total} ({pct_impl:.0f}%)",
             "color": _color(pct_impl),
         },
-        "kernel_map": {
+        "benchmark": {
             "schemaVersion": 1,
-            "label": "kernel_map coverage",
-            "message": f"{impl_with_km}/{impl} ({pct_km:.0f}%)",
-            "color": _color(pct_km),
+            "label": "bench coverage",
+            "message": f"{impl_benched}/{impl} ({pct_bench:.0f}%)",
+            "color": _color(pct_bench),
         },
     }
 

--- a/scripts/manifest_stats.py
+++ b/scripts/manifest_stats.py
@@ -333,7 +333,7 @@ def render_badges(stats: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {
         "implemented": {
             "schemaVersion": 1,
-            "label": "implemented",
+            "label": "spec coverage",
             "message": f"{impl}/{total} ({pct_impl:.0f}%)",
             "color": _color(pct_impl),
         },


### PR DESCRIPTION
## Summary

- Badge 1: relabel `implemented` → `spec coverage` (same metric, 108/132).
- Badge 2: swap from internal `kernel_map coverage` to `bench coverage` = `implemented ∧ source.bench_manifest_driven` (17/108, 16%). Badges advertise external commitments; `kernel_map` is a schema-internal field.
- Surface the new bench gap in `--format text` / `--format md` and in the JSON's `conformance_gaps`.
- README badge URL updated to `manifest-benchmark.json`. After merge, `push: main` regenerates the `stats` orphan branch and drops the old `manifest-kernel-map.json`.

Design rationale: `TileOpsGov/rfcs/2026-05-15-manifest-stats-ci.md` §6.2.

## Test plan

- [x] pre-commit passed
- [x] `--format text` / `--format md` / `--badge-output` all show the new bench gap
- [ ] Post-merge: `push: main` regenerates stats branch; README badges live within ~2 min