### PR TITLE
[BugFix][NORM] align InstanceNormFwdOp._validate_dtypes with manifest

### DIFF
--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -182,6 +182,23 @@ def test_instance_norm_forward_required_signature() -> None:
 
 
 @pytest.mark.smoke
+def test_instance_norm_validate_dtypes_matches_manifest_inputs() -> None:
+    """``_validate_dtypes`` accepts kwargs matching manifest ``signature.inputs``.
+
+    Regression guard for a signature drift where the hand-written override
+    accepted only ``x`` while the manifest declared ``x``, ``weight`` and
+    ``bias``. The manifest-validator dtype-parity check binds by kwargs and
+    requires the impl to honor the manifest order.
+    """
+    sig = inspect.signature(InstanceNormFwdOp._validate_dtypes)
+    params = [p for p in sig.parameters if p != "self"]
+    assert set(params) == {"x", "weight", "bias"}, (
+        f"_validate_dtypes params {params} must equal manifest inputs "
+        "{'x', 'weight', 'bias'}"
+    )
+
+
+@pytest.mark.smoke
 def test_instance_norm_rejects_device_mismatch() -> None:
     """Forward must raise ValueError when input device differs from kernel device.
 

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -192,9 +192,9 @@ def test_instance_norm_validate_dtypes_matches_manifest_inputs() -> None:
     """
     sig = inspect.signature(InstanceNormFwdOp._validate_dtypes)
     params = [p for p in sig.parameters if p != "self"]
-    assert set(params) == {"x", "weight", "bias"}, (
-        f"_validate_dtypes params {params} must equal manifest inputs "
-        "{'x', 'weight', 'bias'}"
+    assert params == ["x", "weight", "bias"], (
+        f"_validate_dtypes params {params} must match manifest inputs "
+        "['x', 'weight', 'bias'] in order"
     )
 
 

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -200,10 +200,6 @@ class InstanceNormFwdOp(Op):
             raise ValueError(
                 f"Expected weight on {x.device}, got {weight.device}"
             )
-        if weight.dtype != self.dtype:
-            raise ValueError(
-                f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
-            )
         if weight.ndim != 1 or weight.shape[0] != self.C:
             raise ValueError(
                 f"Expected weight shape ({self.C},), got {weight.shape}"
@@ -213,10 +209,6 @@ class InstanceNormFwdOp(Op):
         if bias.device != x.device:
             raise ValueError(
                 f"Expected bias on {x.device}, got {bias.device}"
-            )
-        if bias.dtype != self.dtype:
-            raise ValueError(
-                f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
             )
         if bias.ndim != 1 or bias.shape[0] != self.C:
             raise ValueError(

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -149,34 +149,6 @@ class InstanceNormFwdOp(Op):
             (2 * self.N * self.C * self.spatial_size + 2 * self.C) * elem_bytes,
         )
 
-    def _validate_dtypes(self, x: torch.Tensor) -> None:
-        """Validate ``x.dtype`` and ``self.dtype`` against the manifest dtype union.
-
-        Manifest declares ``x.dtype`` as ``float32 | float16 | bfloat16``
-        and the configured op dtype must be drawn from the same union and
-        match the input.
-
-        Args:
-            x: Input tensor.
-
-        Raises:
-            ValueError: If ``self.dtype`` or ``x.dtype`` is outside the
-                supported union, or ``x.dtype`` does not match ``self.dtype``.
-        """
-        allowed = (torch.float32, torch.float16, torch.bfloat16)
-        if self.dtype not in allowed:
-            raise ValueError(
-                f"self.dtype must be one of {allowed}, got {self.dtype}"
-            )
-        if x.dtype not in allowed:
-            raise ValueError(
-                f"x.dtype must be one of {allowed}, got {x.dtype}"
-            )
-        if x.dtype != self.dtype:
-            raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
-            )
-
     def forward(
         self,
         x: torch.Tensor,
@@ -199,7 +171,17 @@ class InstanceNormFwdOp(Op):
             ValueError: If any tensor is not on CUDA, dtypes mismatch, or
                 shapes are incompatible with the configured dimensions.
         """
-        self._validate_dtypes(x)
+        if not isinstance(weight, torch.Tensor):
+            raise ValueError(
+                "weight is required; use InstanceNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        if not isinstance(bias, torch.Tensor):
+            raise ValueError(
+                "bias is required; use InstanceNormFwdOpNoAffine for the "
+                "affine-free path"
+            )
+        self._validate_dtypes(x, weight, bias)
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.device != self._kernel_device:
@@ -211,16 +193,6 @@ class InstanceNormFwdOp(Op):
         if tuple(x.shape) != self._expected_shape:
             raise ValueError(
                 f"Expected x shape {self._expected_shape}, got {tuple(x.shape)}"
-            )
-        if not isinstance(weight, torch.Tensor):
-            raise ValueError(
-                "weight is required; use InstanceNormFwdOpNoAffine for the "
-                "affine-free path"
-            )
-        if not isinstance(bias, torch.Tensor):
-            raise ValueError(
-                "bias is required; use InstanceNormFwdOpNoAffine for the "
-                "affine-free path"
             )
         if not weight.is_cuda:
             raise ValueError("weight must be a CUDA tensor")


### PR DESCRIPTION
Closes #1460

## Summary

- Drop the hand-written `InstanceNormFwdOp._validate_dtypes`; the base-class hook installed by `__init_subclass__` now generates the validator from the manifest `signature.inputs` (`x`, `weight`, `bias`), so the override is no longer needed.
- Re-order `InstanceNormFwdOp.forward` to call `_validate_dtypes(x, weight, bias)` after the isinstance checks for `weight` / `bias`, and remove the duplicate `weight.dtype` / `bias.dtype` assertions that the codegen-generated validator already covers.
- Add `tests/ops/test_instance_norm.py::test_instance_norm_validate_dtypes_matches_manifest_inputs` as a regression guard: it pins the validator's accepted-kwarg order to the manifest input list, so future signature drift fails fast.

## Test plan

- [x] Modified files pass unit tests — `python -m pytest -q tests/test_dtype_codegen.py tests/ops/test_instance_norm.py` → 61 passed
- [x] AC-1: `python scripts/validate_manifest.py --strict --check-op InstanceNormFwdOp` → All manifest checks passed (0 errors mentioning `InstanceNormFwdOp`)
- [x] AC-2: Linked from meta #1372 as a prerequisite (recorded in the issue body's strict-parity gate chain)

## Test node delta

```
File                               Base    HEAD    Delta
--------------------------------------------------------
tests/ops/test_instance_norm.py      37      38       +1
--------------------------------------------------------
TOTAL                                37      38       +1

Growth: +2.7%
```

**Justification:** The new node is a single regression test that pins `InstanceNormFwdOp._validate_dtypes`'s accepted kwargs to the manifest `signature.inputs` order; it is the smallest unit that catches future signature drift between the manifest and the op.
