### PR TITLE
[CI] flip manifest validator to strict-parity blocking mode

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -250,7 +250,7 @@ jobs:
         run: pip install -e .
 
       - name: Validate ops manifest
-        run: python scripts/validate_manifest.py --levels schema,shape,dtype,bench --strict
+        run: python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict
 
   actionlint:
     needs: [validate-pr-title, ci-gate]

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -250,7 +250,7 @@ jobs:
         run: pip install -e .
 
       - name: Validate ops manifest
-        run: python scripts/validate_manifest.py --levels schema,shape,dtype,bench
+        run: python scripts/validate_manifest.py --levels schema,shape,dtype,bench --strict
 
   actionlint:
     needs: [validate-pr-title, ci-gate]


### PR DESCRIPTION
## Summary

One-line CI change that flips `scripts/validate_manifest.py` from advisory to strict-parity blocking, and adds the `signature` level so C3 / C4 / C5 actually run (they're gated on `"signature" in levels` at `scripts/validate_manifest.py:3674`). Closes the two META issues that have been tracking this rollout:

- Closes #1291 (META: enforce strict CI parity for `status: implemented` ops)
- Closes #1372 (META: clear strict-parity error backlog and flip CI to blocking)

## Context

All five 2026-05-15 prerequisite issues are now closed:

| Bucket | Issue | Resolved by |
|---|---|---|
| C3 `kw_only` (58 errors / 34 ops) | #1456 | #1483 |
| C3 `is_causal` defaults (6 errors / 6 ops) | #1457 | #1461 |
| C6 `_validate_dtypes` stubs (105 errors) | #1458 | #1466 |
| C7 `eval_roofline` stubs (41 errors) | #1459 | #1471 |
| C2 `InstanceNormFwdOp` dtype signature (1 error) | #1460 | #1472 |

After those landed, `python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict` on `main` exits 0 (verified locally).

## Test plan

- [ ] `preflight` job passes on this PR (proves the strict gate exits 0 on current main + this trivial diff)
- [ ] After merge, open a sanity PR with a deliberate strict-parity violation and confirm CI blocks it