### PR TITLE
[BugFix][MOE] count topk_ids read in MoePermuteNopadFwdOp roofline.bytes

### DIFF
--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -165,7 +165,7 @@ MoePermuteNopadFwdOp:
     # Permute is memory-bound; flops = 0
     flops: "0"
     # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 2 * total_tokens * top_k * 4 + num_experts * 8"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -165,7 +165,7 @@ MoePermuteNopadFwdOp:
     # Permute is memory-bound; flops = 0
     flops: "0"
     # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 2 * total_tokens * top_k * 4 + num_experts * 8"
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 4 * total_tokens * top_k * 4 + num_experts * 8"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py

--- a/tileops/ops/moe/permute_nopad.py
+++ b/tileops/ops/moe/permute_nopad.py
@@ -60,18 +60,8 @@ class MoePermuteNopadFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"permute_nopad_kernel": MoePermuteNopadKernel}
 
-    def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
-        flops = 0
-        mem_bytes = (
-            (self.total_tokens * self.hidden_size
-             + self.total_tokens * self.top_k * self.hidden_size)
-            * elem_bytes
-            + (self.num_experts + 1) * 8
-            + self.total_tokens * self.top_k * 4
-            + self.num_experts * 8
-        )
-        return flops, mem_bytes
+    # eval_roofline is installed by tileops.ops._roofline_codegen from the
+    # manifest roofline.bytes / roofline.flops expressions; no manual override.
 
     def forward(
         self,


### PR DESCRIPTION
Closes #1488

## Summary

- `MoePermuteNopadFwdOp.roofline.bytes` now counts the **four** int32 transits over the `[total_tokens, top_k]` metadata: `topk_ids` read + `fwd_idx` write + `permuted_idx` write (Phase 1) + `permuted_idx` read (Phase 2). The `total_tokens * top_k * 4` term carries a `4` multiplier (`4 * total_tokens * top_k * 4`).
- Op-side stale override removed: `MoePermuteNopadFwdOp.eval_roofline` in `tileops/ops/moe/permute_nopad.py` was a literal copy of the pre-fix manifest expression. Deleted so `tileops.ops._roofline_codegen.maybe_install_eval_roofline` synthesizes the body from the corrected manifest `roofline.bytes`; benchmark bandwidth now uses the 4x-counted formula.

## Test plan

- [x] AC-1: `tileops/manifest/moe.yaml` `MoePermuteNopadFwdOp.roofline.bytes` contains `4 * total_tokens * top_k * 4` (topk_ids read + fwd_idx write + permuted_idx write + permuted_idx read).
- [x] AC-2: `python scripts/validate_manifest.py --check-op MoePermuteNopadFwdOp --strict` exits 0.
- [x] AC-3: PR diff is confined to `tileops/manifest/moe.yaml` and `tileops/ops/moe/permute_nopad.py` (the latter only deletes the stale override; no roofline logic authored on the Op side, so the trust-model status-flip carve-out is not bent).
- [x] AC-4: Op-side benchmark path now consumes the corrected manifest: `MoePermuteNopadFwdOp(...).eval_roofline()` returns `529012744` bytes on the kimi-k2-prefill workload (pre-fix `eval_roofline` returned `528619528`; delta matches the 3x increase in the metadata term).

## Regression

- Pre-fix `bytes` undercounted int32 metadata traffic: the original term counted only one int32 tensor, missing the `topk_ids` read, the `fwd_idx` write, and both transits of the intermediate `permuted_idx` buffer (written in Phase 1, read in Phase 2 — two separate kernels). The 4x multiplier restores full read+write traffic across all four int32 metadata transits.
- Op-side override deletion has no behavioural regression surface: the deleted method body was algebraically identical to the pre-fix manifest expression, and the codegen replacement is generated from the post-fix manifest expression. Manifest validator (`--strict`) is the regression gate and passes.