### PR TITLE
[Test][MOE] add MoeGroupedGemmNopadFwdOp test and bench and flip to implemented

### DIFF
--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -1,0 +1,136 @@
+"""Benchmark for MoeGroupedGemmNopadFwdOp (tight, no-pad grouped GEMM).
+
+Baseline:
+  - PyTorch reference: per-expert NT matmul loop (`a_e @ b[e].T`).
+
+Workload shapes come from the manifest entry's `workloads` (via
+`load_workloads`); the benchmark reports TileOPs latency alongside the
+manifest-derived roofline (`op.eval_roofline()`).
+
+Usage:
+    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_grouped_gemm_nopad.py -vvs
+    conda run -n tileops python benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tileops.manifest import load_workloads
+from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
+from workloads.workload_base import WorkloadBase
+
+_OP_NAME = "MoeGroupedGemmNopadFwdOp"
+
+
+class MoeGroupedGemmNopadTest(WorkloadBase):
+    """Manifest-shaped inputs: tight A, expert weights B, uniform per-expert sizes."""
+
+    def __init__(self, numel: int, num_experts: int, n: int, k: int, dtype: torch.dtype):
+        self.numel = numel
+        self.num_experts = num_experts
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+
+    def gen_inputs(self):
+        torch.manual_seed(42)
+        dev = "cuda"
+        base = max(1, self.numel // self.num_experts)
+        sizes = torch.full((self.num_experts,), base, dtype=torch.int32, device=dev)
+        sizes[-1] = self.numel - base * (self.num_experts - 1)
+        offsets = torch.zeros(self.num_experts, dtype=torch.int32, device=dev)
+        offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+        a = torch.randn(self.numel, self.k, dtype=self.dtype, device=dev) * 0.02
+        b = torch.randn(self.num_experts, self.n, self.k, dtype=self.dtype, device=dev) * 0.02
+        return a, b, sizes, offsets
+
+    def ref_program(self, *args):
+        return None
+
+
+class MoeGroupedGemmNopadBenchmark(BenchmarkBase[MoeGroupedGemmNopadTest]):
+
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test, op):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+def _manifest_params():
+    """Convert manifest workloads to pytest params (numel, E, N, K, dtype)."""
+    params = []
+    for w in load_workloads(_OP_NAME):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["numel"], w["num_experts"], w["n"], w["k"], dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize(
+    "numel, num_experts, n, k, dtype_str",
+    _manifest_params(),
+)
+def test_moe_grouped_gemm_nopad_bench(
+    numel: int, num_experts: int, n: int, k: int, dtype_str: str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    test = MoeGroupedGemmNopadTest(numel, num_experts, n, k, dtype)
+    a, b, true_sizes, true_offsets = test.gen_inputs()
+
+    op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k, dtype=dtype)
+    bm = MoeGroupedGemmNopadBenchmark(test, op)
+
+    # Warmup: trigger JIT compilation before timed profiling.
+    op(a, b, true_sizes, true_offsets)
+    torch.cuda.synchronize()
+
+    result = bm.profile(op, a, b, true_sizes, true_offsets)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    # PyTorch baseline: per-expert NT matmul.
+    sizes_l = true_sizes.tolist()
+    offsets_l = true_offsets.tolist()
+
+    def _torch_fn(a, b, true_sizes, true_offsets):
+        out = torch.empty(numel, n, dtype=dtype, device=a.device)
+        for e in range(num_experts):
+            size_e = sizes_l[e]
+            if size_e == 0:
+                continue
+            off_e = offsets_l[e]
+            out[off_e:off_e + size_e] = a[off_e:off_e + size_e] @ b[e].T
+        return out
+
+    _torch_fn(a, b, true_sizes, true_offsets)  # warmup
+    torch.cuda.synchronize()
+
+    result_torch = bm.profile(_torch_fn, a, b, true_sizes, true_offsets)
+    BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_grouped_gemm_nopad.py
+++ b/tests/ops/test_moe_grouped_gemm_nopad.py
@@ -1,0 +1,150 @@
+"""Op-level tests for MoeGroupedGemmNopadFwdOp (tight, no-pad grouped GEMM).
+
+Verifies that the tile-scheduled grouped GEMM produces the same per-expert
+NT matmul as a pure-PyTorch reference, across:
+  - uniform and skewed token-to-expert distributions
+  - bf16 and fp16 activations
+  - K block-aligned (TMA fast path) and K non-aligned (predicated path)
+"""
+
+import pytest
+import torch
+
+from tests.test_base import FixtureBase
+from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
+from workloads.workload_base import WorkloadBase
+
+
+def _make_sizes_offsets(numel: int, num_experts: int, distribution: str, device: str):
+    """Build (true_sizes, true_offsets) for a fixed token-to-expert distribution.
+
+    Args:
+        numel: Total token-expert pairs (T * top_k).
+        num_experts: Number of experts E.
+        distribution: "uniform" — evenly split; "skewed" — most tokens on first
+            20% of experts (one-token floor for the rest).
+        device: CUDA device string.
+
+    Returns:
+        true_sizes [E] int32, true_offsets [E] int32.
+    """
+    if distribution == "uniform":
+        base = max(1, numel // num_experts)
+        sizes = torch.full((num_experts,), base, dtype=torch.int32, device=device)
+        sizes[-1] = numel - base * (num_experts - 1)
+    elif distribution == "skewed":
+        sizes = torch.ones(num_experts, dtype=torch.int32, device=device)
+        extra = numel - num_experts
+        top_experts = max(1, num_experts // 5)
+        per_top = extra // top_experts
+        sizes[:top_experts] += per_top
+        sizes[0] += extra - per_top * top_experts
+    else:
+        raise ValueError(f"unknown distribution: {distribution}")
+
+    offsets = torch.zeros(num_experts, dtype=torch.int32, device=device)
+    offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+    assert int(sizes.sum().item()) == numel
+    return sizes, offsets
+
+
+def _ref_grouped_gemm_nopad(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Pure-PyTorch reference: per-expert NT matmul over the tight permute layout.
+
+    Args:
+        a: [numel, K] tight permuted activations.
+        b: [num_experts, N, K] expert weights (NT: B^T applied).
+        true_sizes: [E] int32 token count per expert.
+        true_offsets: [E] int32 start offset per expert into a.
+
+    Returns:
+        c: [numel, N] reference output. Rows belonging to expert e are
+            `a[off:off+size] @ b[e].T`; rows outside any expert range (none
+            for valid inputs) are left zero.
+    """
+    numel, _ = a.shape
+    num_experts, N, _ = b.shape
+    c = torch.zeros(numel, N, dtype=a.dtype, device=a.device)
+    sizes_l = true_sizes.tolist()
+    offsets_l = true_offsets.tolist()
+    for e in range(num_experts):
+        size_e = sizes_l[e]
+        if size_e == 0:
+            continue
+        off_e = offsets_l[e]
+        a_e = a[off_e:off_e + size_e].to(torch.float32)
+        b_e = b[e].to(torch.float32)
+        c[off_e:off_e + size_e] = (a_e @ b_e.T).to(a.dtype)
+    return c
+
+
+class MoeGroupedGemmNopadTest(WorkloadBase):
+    """Generates inputs for the tight grouped-GEMM op."""
+
+    def __init__(self, numel, num_experts, n, k, distribution, dtype):
+        self.numel = numel
+        self.num_experts = num_experts
+        self.n = n
+        self.k = k
+        self.distribution = distribution
+        self.dtype = dtype
+
+    def gen_inputs(self):
+        torch.manual_seed(42)
+        dev = "cuda"
+        true_sizes, true_offsets = _make_sizes_offsets(
+            self.numel, self.num_experts, self.distribution, dev
+        )
+        # Small scale keeps fp16 accumulation well within the parity tolerance.
+        a = torch.randn(self.numel, self.k, dtype=self.dtype, device=dev) * 0.02
+        b = torch.randn(self.num_experts, self.n, self.k, dtype=self.dtype, device=dev) * 0.02
+        return a, b, true_sizes, true_offsets
+
+
+class MoeGroupedGemmNopadFixture(FixtureBase):
+    PARAMS = [
+        ("numel, num_experts, n, k, distribution, dtype", [
+            # K block_k-aligned (TMA fast path), uniform distribution, bf16.
+            pytest.param(
+                64, 4, 128, 64, "uniform", torch.bfloat16,
+                marks=pytest.mark.smoke, id="aligned-uniform-bf16",
+            ),
+            # K block_k-aligned, skewed distribution, fp16 — covers dtype branch.
+            pytest.param(
+                64, 4, 128, 64, "skewed", torch.float16,
+                marks=pytest.mark.smoke, id="aligned-skewed-fp16",
+            ),
+            # K NOT block_k-aligned (default block_k=64 → K=96 falls in predicated path).
+            pytest.param(
+                128, 8, 256, 96, "uniform", torch.bfloat16,
+                marks=pytest.mark.full, id="unaligned-uniform-bf16",
+            ),
+        ]),
+    ]
+
+
+@MoeGroupedGemmNopadFixture
+def test_moe_grouped_gemm_nopad_op(numel, num_experts, n, k, distribution, dtype):
+    test = MoeGroupedGemmNopadTest(numel, num_experts, n, k, distribution, dtype)
+    a, b, true_sizes, true_offsets = test.gen_inputs()
+
+    op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k, dtype=dtype)
+    c = op(a, b, true_sizes, true_offsets)
+    c_ref = _ref_grouped_gemm_nopad(a, b, true_sizes, true_offsets)
+
+    assert c.shape == (numel, n), f"expected ({numel}, {n}), got {tuple(c.shape)}"
+    assert c.dtype == dtype
+
+    # bf16/fp16 accumulation in fp32 — match kernel's accum_dtype.
+    torch.testing.assert_close(
+        c.float(), c_ref.float(), atol=1e-2, rtol=1e-2,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -344,8 +344,8 @@ MoeGroupedGemmNopadFwdOp:
   source:
     kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
     op: tileops/ops/moe/moe_grouped_gemm_nopad.py
-    test: tests/ops/test_moe_grouped_gemm_nopad.py
-    bench: benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+    test: tests/ops/test_moe_fused_moe.py
+    bench: benchmarks/ops/bench_moe_fused_moe.py
     kernel_map:
       moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
 

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -311,7 +311,7 @@ FusedMoeExpertsPaddedFwdOp:
 MoeGroupedGemmNopadFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -330,7 +330,12 @@ MoeGroupedGemmNopadFwdOp:
       - "c.shape == (numel, n)"
 
   workloads:
-    - {numel: 4096, num_experts: 256, n: 4096, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-gate-up"}
+    # Tight grouped-GEMM shapes representative of DeepSeek-V3 MoE
+    # (E=256, K=8, H=7168, F=2048; numel = num_tokens * top_k).
+    - {numel: 4096, num_experts: 256, n: 4096, k: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode-gate-up"}
+    - {numel: 32768, num_experts: 256, n: 4096, k: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill-gate-up"}
+    - {numel: 4096, num_experts: 256, n: 7168, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode-down"}
+    - {numel: 32768, num_experts: 256, n: 7168, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill-down"}
 
   roofline:
     flops: "2 * numel * n * k"
@@ -339,8 +344,10 @@ MoeGroupedGemmNopadFwdOp:
   source:
     kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
     op: tileops/ops/moe/moe_grouped_gemm_nopad.py
-    test: tests/ops/test_moe_fused_moe.py
-    bench: benchmarks/ops/bench_moe_fused_moe.py
+    test: tests/ops/test_moe_grouped_gemm_nopad.py
+    bench: benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+    kernel_map:
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
 
 MoEExpertsNopadFwdOp:
   ref_api: "none"

--- a/tileops/ops/moe/moe_grouped_gemm_nopad.py
+++ b/tileops/ops/moe/moe_grouped_gemm_nopad.py
@@ -48,8 +48,8 @@ class MoeGroupedGemmNopadFwdOp(Op):
     ) -> None:
         self.numel = numel
         self.num_experts = num_experts
-        self.N = n
-        self.K = k
+        self.n = n
+        self.k = k
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)


### PR DESCRIPTION
Closes #1475

## Summary

- Add `tests/ops/test_moe_grouped_gemm_nopad.py` — 3 curated parity cases covering bf16/fp16, uniform + skewed expert distribution, and K-aligned + K-unaligned (TMA fast path + predicated path).
- Add `benchmarks/ops/bench_moe_grouped_gemm_nopad.py` — manifest-driven (`load_workloads`), runs the 4 DeepSeek-V3 workloads (gate-up / down × decode / prefill) and reports latency alongside `op.eval_roofline()`.
- Flip `MoeGroupedGemmNopadFwdOp` manifest entry to `status: implemented`, add `source.kernel_map`, and declare 4 representative workloads (per status-flip carve-out in `.claude/rules/manifest-trust-model.md`).
- Rename `self.N` / `self.K` → `self.n` / `self.k` in `MoeGroupedGemmNopadFwdOp` so the codegen-emitted `eval_roofline` body (per `docs/design/roofline.md` §4.4) can read the params by manifest name; no external code referenced the uppercase attributes.



## Test plan

- [x] AC1 — `tests/ops/test_moe_grouped_gemm_nopad.py`: 3 passed
- [x] AC2 — ≥2 conformance cases, each covering a manifest workload branch (gate-up + down GEMM + K-alignment); curated shapes per `.claude/domain-rules/testing-budget.md` (manifest workloads are consumed by the bench, not the test). Same precedent as #1487 (closes #1474).
- [x] AC3 — Manifest entry has 4 `workloads`, `source.kernel_map: MoeGroupedGemmNopadKernel`, and `status: implemented`.
- [x] AC4 — `python scripts/validate_manifest.py --strict --check-op MoeGroupedGemmNopadFwdOp` exits 0 (1 warning: shape-inference codegen pending for ops without `shape` on inputs; fires for 14+ other implemented ops, not a regression).
- [x] AC5 — `benchmarks/ops/bench_moe_grouped_gemm_nopad.py` runs end-to-end on the 4 manifest workloads.
- [x] Downstream smoke: `tests/ops/test_moe_experts_nopad.py -m smoke` — 15 passed (`FusedMoeExperts` + `MoEExpertsNopad` call this op).

## Benchmark

**Workloads** (manifest-driven, DeepSeek-V3 MoE shapes, E=256):

| Label                            | numel | n    | k    | dtype    |
| -------------------------------- | ----- | ---- | ---- | -------- |
| deepseek-v3-decode-gate-up       | 4096  | 4096 | 7168 | bfloat16 |
| deepseek-v3-prefill-gate-up      | 32768 | 4096 | 7168 | bfloat16 |
| deepseek-v3-decode-down          | 4096  | 7168 | 2048 | bfloat16 |
| deepseek-v3-prefill-down         | 32768 | 7168 | 2048 | bfloat16 |

End-to-end pass: 4/4. Detailed latency / roofline numbers will be exercised by the H100/H200 CI bench job.

**Command:** `PYTHONPATH="$PWD" python -m pytest benchmarks/ops/bench_moe_grouped_gemm_nopad.py -v`