### PR TITLE
[Chore][MANIFEST] enumerate source.test/source.bench in status-flip carve-out

### DIFF
--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -9,8 +9,9 @@ An implementation PR may edit the aligned op's manifest entry only at:
 
 - `status` (any direction).
 - `source.kernel_map` entries.
+- `source.test` and `source.bench` path values. Why: these are discoverability pointers (the validator only requires their presence and AST-checks the bench file for `load_workloads` / `eval_roofline`; it does not enforce path canonicality), so realigning them onto the per-op test/bench file an implementation PR has just authored does not weaken any trust-bearing field.
 - `workloads` — **only** when the same PR flips `status: spec-only → implemented` on that op (promotion forces non-empty workloads to satisfy `test_every_op_has_at_least_two_workloads`).
 
-Every other field — `signature`, `roofline.*`, `params`, output-dtype, shape rules, and any other `workloads` edit — needs a separate manifest-only PR with human review.
+Every other field — `signature`, `roofline.*`, `params`, output-dtype, shape rules, `source.kernel`, `source.op`, `source.bench_manifest_driven`, and any other `workloads` edit — needs a separate manifest-only PR with human review.
 
 The carve-out narrows the prohibition; it does not relax the trust boundary.

--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -12,6 +12,6 @@ An implementation PR may edit the aligned op's manifest entry only at:
 - `source.test` and `source.bench` path values. Why: these are discoverability pointers (the validator only requires their presence and AST-checks the bench file for `load_workloads` / `eval_roofline`; it does not enforce path canonicality), so realigning them onto the per-op test/bench file an implementation PR has just authored does not weaken any trust-bearing field.
 - `workloads` — **only** when the same PR flips `status: spec-only → implemented` on that op (promotion forces non-empty workloads to satisfy `test_every_op_has_at_least_two_workloads`).
 
-Every other field — `signature`, `roofline.*`, `params`, output-dtype, shape rules, `source.kernel`, `source.op`, `source.bench_manifest_driven`, and any other `workloads` edit — needs a separate manifest-only PR with human review.
+Every other field — `family`, `ref_api`, `signature`, `roofline.*`, `params`, `output-dtype`, `shape_rules`, `source.kernel`, `source.op`, `source.bench_manifest_driven`, and any other `workloads` edit — needs a separate manifest-only PR with human review.
 
 The carve-out narrows the prohibition; it does not relax the trust boundary.

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -25,7 +25,7 @@ Source of truth for op interfaces. Human-reviewed, separate PR.
 
 ### Status flip carve-out
 
-An implementation PR may edit only `status`, `source.kernel_map`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
+An implementation PR may edit only `status`, `source.kernel_map`, `source.test`, `source.bench`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
 
 Full enumeration: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
 

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -344,8 +344,8 @@ MoeGroupedGemmNopadFwdOp:
   source:
     kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
     op: tileops/ops/moe/moe_grouped_gemm_nopad.py
-    test: tests/ops/test_moe_fused_moe.py
-    bench: benchmarks/ops/bench_moe_fused_moe.py
+    test: tests/ops/test_moe_grouped_gemm_nopad.py
+    bench: benchmarks/ops/bench_moe_grouped_gemm_nopad.py
     kernel_map:
       moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
 


### PR DESCRIPTION
Closes #1492

## Summary

- Enumerate `source.test` and `source.bench` explicitly in the manifest carve-out (`.claude/rules/manifest-trust-model.md`) as **in-scope** for status-flip PRs, with a `Why:` line citing validator behavior (presence-only + AST check, no path canonicality).
- Re-align `MoeGroupedGemmNopadFwdOp` in `tileops/manifest/moe.yaml`:
  - `source.test`: `tests/ops/test_moe_fused_moe.py` → `tests/ops/test_moe_grouped_gemm_nopad.py`
  - `source.bench`: `benchmarks/ops/bench_moe_fused_moe.py` → `benchmarks/ops/bench_moe_grouped_gemm_nopad.py`
- Audit of all 132 ops: 0 missing files, 1 actionable umbrella mismatch (the one fixed here), 115 umbrella-by-design (per-family shared harness), 16 fully aligned.

## Decision rationale (Option A)

`source.test` / `source.bench` are **discoverability pointers**, not trust-bearing fields:

- `docs/design/trust-model.md` §Manifest §OWNS lists signatures, dtypes, workload shapes, roofline formulas, status, and `kernel_map`. `source.test` / `source.bench` are not OWNS items.
- `scripts/validate_manifest.py` only requires their **presence** (`_REQUIRED_SOURCE`); `check_l4_benchmark` opens the bench file to AST-check for `load_workloads` + `eval_roofline`, but does not enforce path canonicality.

Therefore: realigning these pointers onto the per-op test/bench file that an implementation PR has just authored does not weaken any trust-bearing field, and belongs in the carve-out alongside `status` and `source.kernel_map`. Every other `source.*` key (`source.kernel`, `source.op`, `source.bench_manifest_driven`) remains out of scope and continues to require a separate manifest-only PR.

## Audit (132 ops scanned)

| Category | Count |
| --- | --- |
| `test` or `bench` file missing | 0 |
| Actionable umbrella mismatch | 1 (`MoeGroupedGemmNopadFwdOp`, fixed in this PR) |
| Umbrella by design (per-family shared harness) | 115 |
| Fully aligned | 16 |

Umbrella-by-design breakdown: attention 7, convolution 2, elementwise 71, moe 6, normalization 8, reduction 19, scan 2. These reflect deliberate per-family harness choices (e.g. `test_unary_math.py` covers 17 unary math ops); splitting them is per-family design work, out of scope here.

Full audit artifact: `.foundry/runs/issue-1492/pipeline/audit-source-paths.md` (run-local, not shipped).

## Test plan

- [x] **AC-1**: `.claude/rules/manifest-trust-model.md` carve-out explicitly names `source.test` and `source.bench` with no ambiguity (line 12 lists them in-scope with `Why:` rationale; line 15 enumerates excluded `source.*` keys).
- [x] **AC-2**: Audit enumerates every manifest entry whose `source.test` / `source.bench` is stale or umbrella (132 ops scanned; classified as missing / actionable-umbrella / umbrella-by-design with explicit per-op canonical-path derivation rule).
- [x] **AC-3**: `MoeGroupedGemmNopadFwdOp.source.test = tests/ops/test_moe_grouped_gemm_nopad.py` and `source.bench = benchmarks/ops/bench_moe_grouped_gemm_nopad.py` (verified via `ruamel.yaml` parse of `tileops/manifest/moe.yaml`).
- [x] **AC-4**: `python scripts/validate_manifest.py --strict` exits 0.