### PR TITLE
[Feat][Elementwise] cover full dtype union for MaskedFillTensorValueFwdKernel; flip MaskedFillFwdOp to implemented

### DIFF
--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -350,25 +350,61 @@ def test_clamp_max_nan_propagation(dtype):
 # ---------------------------------------------------------------------------
 
 
+_MASKED_FILL_TENSOR_VALUE_FLOAT_DTYPES = [
+    torch.float16, torch.bfloat16, torch.float32,
+]
+_MASKED_FILL_TENSOR_VALUE_INT_DTYPES = [
+    torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
+]
+
+
+def _masked_fill_tensor_value_inputs(input_shape, mask_shape, dtype):
+    if dtype == torch.bool:
+        inp = torch.randint(0, 2, input_shape, device="cuda").bool()
+        value = torch.tensor(True, device="cuda", dtype=torch.bool)
+    elif dtype in _MASKED_FILL_TENSOR_VALUE_INT_DTYPES:
+        iinfo = torch.iinfo(dtype)
+        lo = max(iinfo.min, -1000)
+        hi = min(iinfo.max, 1000) + 1
+        inp = torch.randint(lo, hi, input_shape, device="cuda", dtype=dtype)
+        value = torch.tensor(7, device="cuda", dtype=dtype)
+    else:
+        inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+        value = torch.tensor(-1.5, device="cuda", dtype=dtype)
+    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
+    return inp, mask, value
+
+
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "input_shape, mask_shape",
     [((4, 8), (4, 8)), ((1, 8), (4, 8)), ((4, 8), (1, 8)), ((2, 1), (2, 3))],
 )
-def test_masked_fill_tensor_value(input_shape, mask_shape):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bool, *_MASKED_FILL_TENSOR_VALUE_INT_DTYPES,
+     *_MASKED_FILL_TENSOR_VALUE_FLOAT_DTYPES],
+)
+def test_masked_fill_tensor_value(input_shape, mask_shape, dtype):
     from tileops.ops.elementwise import MaskedFillFwdOp
 
-    inp = torch.randn(input_shape, device="cuda", dtype=torch.float32)
-    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
-    value = torch.tensor(-1.5, device="cuda", dtype=torch.float32)
+    inp, mask, value = _masked_fill_tensor_value_inputs(input_shape, mask_shape, dtype)
 
     out_shape = torch.broadcast_shapes(input_shape, mask_shape)
     ref = inp.expand(out_shape).clone().masked_fill(mask.expand(out_shape), value.item())
 
     op = MaskedFillFwdOp(input=tuple(inp.shape), mask=tuple(mask.shape),
-                        value=tuple(value.shape), dtype=torch.float32)
+                        value=tuple(value.shape), dtype=dtype)
     out = op(inp, mask, value)
-    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+    if dtype == torch.float16:
+        tol = {"atol": 1e-3, "rtol": 1e-3}
+    elif dtype == torch.bfloat16:
+        tol = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    elif dtype == torch.float32:
+        tol = {"atol": 1e-5, "rtol": 1e-5}
+    else:
+        tol = {"atol": 0, "rtol": 0}
+    torch.testing.assert_close(out, ref, **tol)
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -3264,9 +3264,16 @@ class MaskedFillTensorValueFwdKernel(ParametricUnaryKernel):
     ``N_total``. The Op layer broadcasts ``input`` and ``mask`` to the
     output shape, flattens them, packs the mask as uint8, and reshapes
     the 0-dim ``value`` to a length-1 tensor before dispatch.
+
+    Supports the PyTorch ``Tensor.masked_fill(mask, value: Tensor)``
+    dtype union of integer and floating-point input dtypes. The bool
+    dtype path is handled at the Op layer by viewing input and value as
+    uint8, so the kernel itself only sees integer and floating-point
+    storage dtypes.
     """
 
     _DEFAULT_THREADS = 512
+    SUPPORTED_DTYPES = _BITWISE_DTYPES[1:] + _FLOAT_DTYPES  # uint8/intN + fp16/bf16/fp32
 
     @staticmethod
     def _builder_fn():

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -61,7 +61,7 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/ops/elementwise/masked_fill.py
+++ b/tileops/ops/elementwise/masked_fill.py
@@ -51,6 +51,21 @@ class MaskedFillFwdOp(Op):
             raise ValueError(
                 f"MaskedFillFwdOp requires a 0-dim value Tensor; got shape {tuple(value)}"
             )
+        # The kernel handles ints and fp16/bf16/fp32 directly. The bool
+        # dtype is supported here at the Op layer via uint8 storage view,
+        # since TileLang's bool tensor codegen is not vectorized; the
+        # user-facing contract still exposes ``torch.bool``.
+        kernel_supported = MaskedFillTensorValueFwdKernel.SUPPORTED_DTYPES
+        if (
+            dtype != torch.bool
+            and kernel_supported is not None
+            and dtype not in kernel_supported
+        ):
+            names = ", ".join(str(dt) for dt in (torch.bool, *kernel_supported))
+            raise ValueError(
+                f"{self._op_name} does not support dtype {dtype}. "
+                f"Supported: [{names}]"
+            )
         self.input_shape = tuple(input)
         self.mask_shape = tuple(mask)
         self.value_shape = tuple(value)
@@ -58,7 +73,10 @@ class MaskedFillFwdOp(Op):
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["masked_fill_tensor_value"](self.N_total, dtype)
+        # Bool input path: the kernel runs in uint8 storage.
+        self._bool_storage = dtype == torch.bool
+        kernel_dtype = torch.uint8 if self._bool_storage else dtype
+        self.kernel = self.kernel_map["masked_fill_tensor_value"](self.N_total, kernel_dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -79,10 +97,16 @@ class MaskedFillFwdOp(Op):
         # the 0-dim value to (1,), and dispatch the TileLang kernel.
         out_shape = self.out_shape if self.out_shape else (1,)
         x_flat = self._expand_flat(input, out_shape)
+        if self._bool_storage:
+            x_flat = x_flat.view(torch.uint8)
         mask_b = mask if mask.dtype == torch.bool else mask.bool()
         mask_flat = self._expand_flat(mask_b, out_shape).view(torch.uint8)
         value_1d = value.contiguous().view(1)
+        if self._bool_storage:
+            value_1d = value_1d.view(torch.uint8)
         result = self.kernel(x_flat, mask_flat, value_1d)
+        if self._bool_storage:
+            result = result.view(torch.bool)
         return result.view(self.out_shape if self.out_shape else ())
 
     def forward(


### PR DESCRIPTION
Closes #1498

## Summary

- Extend `MaskedFillTensorValueFwdKernel.SUPPORTED_DTYPES` to the full manifest signature union — `float16 | bfloat16 | float32 | bool | uint8 | int8 | int16 | int32 | int64`.
- Route `bool` through `uint8` storage at the Op layer, mirroring `MaskedFillScalarFwdOp`.
- Flip `MaskedFillFwdOp.status: spec-only -> implemented` in `tileops/manifest/elementwise_binary.yaml` (status-only edit; carve-out compliant).
- Expand `tests/ops/test_special_elementwise_conformance.py::test_masked_fill_tensor_value` parametrization to all 9 manifest dtypes × 4 shapes.

## Test plan

- [x] `pytest tests/ops/test_special_elementwise.py tests/ops/test_special_elementwise_conformance.py -k masked_fill` — 67 passed
- [x] `pytest tests/ops/test_special_elementwise_conformance.py::test_masked_fill_tensor_value` — 36 passed (9 dtypes × 4 shapes)
- [x] `python scripts/validate_manifest.py --strict --check-op MaskedFillFwdOp` — `All manifest checks passed`
- [x] `python scripts/validate_manifest.py --strict` — `All manifest checks passed`
- [x] `pytest benchmarks/ops/bench_masked_fill.py -v` — 5 params pass

## Test node delta

```
File                                                 Base    HEAD    Delta
--------------------------------------------------------------------------
tests/ops/test_special_elementwise_conformance.py      49      81      +32
--------------------------------------------------------------------------
TOTAL                                                  49      81      +32
```

Parametrization expanded to cover the full 9-dtype manifest signature × 4 shape variants on `test_masked_fill_tensor_value`, matching the dtype union the kernel now constructs for.