### PR TITLE
[Maintain][Norm] flip RMSNormFwdOp to implemented

### DIFF
--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -7,8 +7,7 @@
 RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
-  # spec-only: shape_rules reference runtime-bound normalized_shape param without manifest default
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:


### PR DESCRIPTION
Closes #1482

## Summary

- Flip `RMSNormFwdOp` from `status: spec-only` to `status: implemented` in `tileops/manifest/normalization.yaml`.
- Remove the stale `# spec-only until ...` inline comment alongside the flip.
- No other manifest field is touched (no `signature`, `roofline`, `params`, `shape_rules`, or `workloads` edits) — within the trust-model status-flip carve-out.

## Test plan

- [x] Modified files pass unit tests — `pytest tests/ops/test_rms_norm.py` → 16 passed
- [x] `RMSNormFwdOp` carries `status: implemented` after the PR — verified via `yaml.safe_load` on `tileops/manifest/normalization.yaml`
- [x] `python scripts/validate_manifest.py --strict --check-op RMSNormFwdOp` exits 0 — single residual family-wide `_infer_output_shapes` codegen-pending warning; all manifest checks pass
- [x] Full `python scripts/validate_manifest.py --strict` exits 0
- [x] `pytest tests/test_validate_manifest.py` → 221/221 pass
- [x] pre-commit passed
