### PR TITLE
[Chore][Release] merge testbed into main: MOE + Elementwise + Norm flips

### DIFF
--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -9,7 +9,7 @@ An implementation PR may edit the aligned op's manifest entry only at:
 
 - `status` (any direction).
 - `source.kernel_map` entries.
-- `source.test` and `source.bench` path values. Why: these are discoverability pointers (the validator only requires their presence and AST-checks the bench file for `load_workloads` / `eval_roofline`; it does not enforce path canonicality), so realigning them onto the per-op test/bench file an implementation PR has just authored does not weaken any trust-bearing field.
+- `source.test` and `source.bench` path values. Discoverability pointers, not contractual fields — may be retargeted at the per-op test/bench file authored by the same PR.
 - `workloads` — **only** when the same PR flips `status: spec-only → implemented` on that op (promotion forces non-empty workloads to satisfy `test_every_op_has_at_least_two_workloads`).
 
 Every other field — `family`, `ref_api`, `signature`, `roofline.*`, `params`, `output-dtype`, `shape_rules`, `source.kernel`, `source.op`, `source.bench_manifest_driven`, and any other `workloads` edit — needs a separate manifest-only PR with human review.

--- a/.claude/rules/manifest-trust-model.md
+++ b/.claude/rules/manifest-trust-model.md
@@ -9,8 +9,9 @@ An implementation PR may edit the aligned op's manifest entry only at:
 
 - `status` (any direction).
 - `source.kernel_map` entries.
+- `source.test` and `source.bench` path values. Why: these are discoverability pointers (the validator only requires their presence and AST-checks the bench file for `load_workloads` / `eval_roofline`; it does not enforce path canonicality), so realigning them onto the per-op test/bench file an implementation PR has just authored does not weaken any trust-bearing field.
 - `workloads` — **only** when the same PR flips `status: spec-only → implemented` on that op (promotion forces non-empty workloads to satisfy `test_every_op_has_at_least_two_workloads`).
 
-Every other field — `signature`, `roofline.*`, `params`, output-dtype, shape rules, and any other `workloads` edit — needs a separate manifest-only PR with human review.
+Every other field — `family`, `ref_api`, `signature`, `roofline.*`, `params`, `output-dtype`, `shape_rules`, `source.kernel`, `source.op`, `source.bench_manifest_driven`, and any other `workloads` edit — needs a separate manifest-only PR with human review.
 
 The carve-out narrows the prohibition; it does not relax the trust boundary.

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -1,9 +1,6 @@
 """Benchmark for BatchNormFwdOp and BatchNormBwdOp.
 
 Compares TileOPs vs PyTorch cuDNN batch norm on common ResNet-style shapes.
-
-Run:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_batch_norm.py -vvs
 """
 
 import math

--- a/benchmarks/ops/bench_grouped_gemm_3wg_vs_cutlass.py
+++ b/benchmarks/ops/bench_grouped_gemm_3wg_vs_cutlass.py
@@ -7,11 +7,6 @@ internally, making it the strongest available baseline for Hopper grouped GEMM.C
   DeepSeek-V3-decode  E=256 T=512
   DeepSeek-V3-prefill E=256 T=4096
 × {uniform, skewed} distribution = 8 cases.
-
-Usage:
-    TILELANG_CLEANUP_TEMP_FILES=1 TMPDIR=/tmp/jieneng_tvm_tmp \\
-    conda run -n tileops-tl9 --no-capture-output \\
-    python benchmarks/ops/bench_grouped_gemm_3wg_vs_cutlass.py
 """
 from __future__ import annotations
 

--- a/benchmarks/ops/bench_grouped_gemm_block_m.py
+++ b/benchmarks/ops/bench_grouped_gemm_block_m.py
@@ -6,10 +6,6 @@ Qwen3-MoE with E=256.
 
 FLOPs and memory are computed from the TRUE (unpadded) batch_sum so that
 efficiency reflects useful work only; padding overhead shows up as lower TFLOPS.
-
-Usage:
-    conda run -n tileops python -m pytest \
-        benchmarks/ops/bench_grouped_gemm_block_m.py -vvs
 """
 
 import math

--- a/benchmarks/ops/bench_grouped_gemm_persistent_vs_nopad.py
+++ b/benchmarks/ops/bench_grouped_gemm_persistent_vs_nopad.py
@@ -5,9 +5,6 @@ Tests the three implementations across:
   - Skewed distribution (80% tokens to top-20% experts)
   - Both decode (T=512) and prefill (T=4096) shapes
   - Qwen3-235B (E=128) and DeepSeek-V3 (E=256)
-
-Usage:
-    conda run -n tileops python benchmarks/ops/bench_moe_persistent_vs_nopad.py
 """
 import math
 

--- a/benchmarks/ops/bench_masked_fill.py
+++ b/benchmarks/ops/bench_masked_fill.py
@@ -1,0 +1,147 @@
+"""Benchmark for MaskedFillFwdOp (Tensor-value masked_fill).
+
+Baseline:
+  - PyTorch reference: ``input.masked_fill(mask, value)`` with ``value`` a
+    0-dim Tensor on the same device.
+
+Workload shapes come from the manifest entry's ``workloads`` (via
+``load_workloads``); the benchmark reports TileOPs latency alongside the
+manifest-derived roofline (``op.eval_roofline()``).
+
+Usage:
+    conda run -n tileops python -m pytest benchmarks/ops/bench_masked_fill.py -vvs
+    conda run -n tileops python benchmarks/ops/bench_masked_fill.py
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tileops.manifest import load_manifest, load_workloads
+from tileops.ops.elementwise import MaskedFillFwdOp
+from workloads.workload_base import WorkloadBase
+
+_OP_NAME = "MaskedFillFwdOp"
+
+# Skip the whole module while the manifest entry is still spec-only:
+# the L4 `eval_roofline()` body is codegen-installed only on `implemented`
+# ops, so `op.eval_roofline()` would hit the L1 base stub.
+_OP_STATUS = load_manifest().get(_OP_NAME, {}).get("status", "spec-only")
+pytestmark = pytest.mark.skipif(
+    _OP_STATUS != "implemented",
+    reason=f"{_OP_NAME} manifest status is {_OP_STATUS!r}; "
+    f"eval_roofline body not installed until status flips to 'implemented'",
+)
+
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+
+
+class MaskedFillTest(WorkloadBase):
+    """Manifest-shaped inputs for the Tensor-value masked_fill kernel.
+
+    ``input`` and ``mask`` are sized per the manifest workload; ``value``
+    is a 0-dim Tensor as required by ``MaskedFillFwdOp``.
+    """
+
+    def __init__(
+        self,
+        input_shape: tuple[int, ...],
+        mask_shape: tuple[int, ...],
+        dtype: torch.dtype,
+    ):
+        self.input_shape = tuple(input_shape)
+        self.mask_shape = tuple(mask_shape)
+        self.dtype = dtype
+
+    def gen_inputs(self):
+        torch.manual_seed(42)
+        dev = "cuda"
+        x = torch.randn(self.input_shape, dtype=self.dtype, device=dev)
+        # Roughly half-true mask exercises both branches of the predicated select.
+        mask = torch.randint(0, 2, self.mask_shape, device=dev).bool()
+        value = torch.zeros((), dtype=self.dtype, device=dev)
+        return x, mask, value
+
+    def ref_program(self, *args):
+        return None
+
+
+class MaskedFillBenchmark(BenchmarkBase[MaskedFillTest]):
+
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: MaskedFillTest, op: MaskedFillFwdOp):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+def _manifest_params():
+    """Convert manifest workloads to pytest params."""
+    params = []
+    for w in load_workloads(_OP_NAME):
+        label = w.get("label", "unlabeled")
+        input_shape = tuple(w["input_shape"])
+        mask_shape = tuple(w["mask_shape"])
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                input_shape, mask_shape, dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize(
+    "input_shape, mask_shape, dtype_str",
+    _manifest_params(),
+)
+def test_masked_fill_bench(
+    input_shape: tuple[int, ...],
+    mask_shape: tuple[int, ...],
+    dtype_str: str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    test = MaskedFillTest(input_shape, mask_shape, dtype)
+    x, mask, value = test.gen_inputs()
+
+    op = MaskedFillFwdOp(
+        input=input_shape, mask=mask_shape, value=(),
+        dtype=dtype,
+    )
+    bm = MaskedFillBenchmark(test, op)
+
+    # Warmup: trigger JIT compilation before timed profiling.
+    op(x, mask, value)
+    torch.cuda.synchronize()
+
+    result = bm.profile(op, x, mask, value)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    def _torch_fn(x, mask, value):
+        return x.masked_fill(mask, value)
+
+    _torch_fn(x, mask, value)  # warmup
+    torch.cuda.synchronize()
+
+    result_torch = bm.profile(_torch_fn, x, mask, value)
+    BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/benchmarks/ops/bench_masked_fill.py
+++ b/benchmarks/ops/bench_masked_fill.py
@@ -7,10 +7,6 @@ Baseline:
 Workload shapes come from the manifest entry's ``workloads`` (via
 ``load_workloads``); the benchmark reports TileOPs latency alongside the
 manifest-derived roofline (``op.eval_roofline()``).
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_masked_fill.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_masked_fill.py
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_experts_nopad.py
+++ b/benchmarks/ops/bench_moe_experts_nopad.py
@@ -16,9 +16,6 @@ MoEExpertsPaddedFwdOp (shared workload set):
 Baselines:
   - vllm:      vLLM fused_experts (expert GEMM only, no routing)
   - torch-ref: per-expert GEMM loop with index_add_ (fallback when vLLM absent)
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_experts_nopad.py -vvs
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -1,22 +1,15 @@
-"""Benchmark for FusedMoe -- unified routed MoE FFN operator.
+"""Benchmark for FusedMoeFwdOp / FusedMoeFwdCbFwdOp (routed MoE FFN).
 
-Covers real model configurations in both decode (T small) and prefill (T large) regimes:
+Workload shapes come from each op's manifest ``workloads`` (via
+``load_workloads``); the benchmark reports TileOPs latency (nopad + padded
+layouts) alongside the manifest-derived roofline (``op.eval_roofline()``)
+and a vLLM / torch-ref baseline.
 
-  Model              H     F     E    K  scoring   renorm  bias   scale
-  Kimi K2          7168  2048  384   8  sigmoid   True    True   2.827
-  DeepSeek-V3      7168  2048  256   8  sigmoid   True    False  1.0
-  Qwen3-235B-A22B  7168  2048  128   8  softmax   False   False  1.0
-  Qwen3-30B-A3B    3072  1536  128   8  softmax   False   False  1.0
+Coverage:
 
-Baselines:
-  - tileops-padded: FusedMoe(layout="padded")
-  - vllm:           vLLM fused_topk + fused_experts (complete flow)
-  - torch-ref:      per-expert GEMM loop (fallback when vLLM is absent)
-
-FLOPs (same formula for both model families):
-  Gate+up: T*K * 2*F*H * 2  FLOPs
-  Down:    T*K *   H*F * 2  FLOPs
-  Total =  T*K * 6*F*H
+  Op                       Models (manifest workloads)
+  FusedMoeFwdOp            Qwen3-235B-A22B (softmax), DeepSeek-V3 (sigmoid)
+  FusedMoeFwdCbFwdOp       Kimi K2 (sigmoid + correction_bias)
 
 Usage:
     conda run -n tileops python -m pytest benchmarks/ops/bench_moe_fused_moe.py -vvs
@@ -40,27 +33,34 @@ except ImportError:
     _VLLM_AVAILABLE = False
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops.moe import FusedMoe, FusedTopKOp
-from workloads.workload_base import FixtureBase, WorkloadBase
+from tileops.manifest import load_workloads
+from tileops.ops.moe import FusedMoeFwdCbFwdOp, FusedMoeFwdOp, FusedTopKOp
+from workloads.workload_base import WorkloadBase
 
-# ---------------------------------------------------------------------------
-# Test / fixture types
-# ---------------------------------------------------------------------------
+_OP_NAME = "FusedMoeFwdOp"
+_OP_NAME_CB = "FusedMoeFwdCbFwdOp"
+
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
 
 
 class FusedMoeBenchTest(WorkloadBase):
+    """Inputs for a single FusedMoe benchmark configuration."""
+
     def __init__(
         self,
-        num_tokens,
-        num_experts,
-        top_k,
-        hidden_size,
-        ffn_size,
-        scoring_func,
-        renormalize,
-        with_correction_bias,
-        routed_scaling_factor,
-        dtype,
+        num_tokens: int,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        ffn_size: int,
+        scoring_func: str,
+        renormalize: bool,
+        with_correction_bias: bool,
+        routed_scaling_factor: float,
+        dtype: torch.dtype,
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -77,10 +77,10 @@ class FusedMoeBenchTest(WorkloadBase):
         torch.manual_seed(42)
         dev = "cuda"
         hidden = torch.randn(
-            self.num_tokens, self.hidden_size, dtype=self.dtype, device=dev
+            self.num_tokens, self.hidden_size, dtype=self.dtype, device=dev,
         )
         gating = torch.randn(
-            self.num_tokens, self.num_experts, dtype=self.dtype, device=dev
+            self.num_tokens, self.num_experts, dtype=torch.float32, device=dev,
         )
         correction_bias = (
             torch.randn(self.num_experts, dtype=torch.float32, device=dev) * 0.1
@@ -100,123 +100,117 @@ class FusedMoeBenchTest(WorkloadBase):
         return None
 
 
-# ---------------------------------------------------------------------------
-# Benchmark class
-# ---------------------------------------------------------------------------
-
-
 class FusedMoeBenchmark(BenchmarkBase[FusedMoeBenchTest]):
+    """Benchmark wrapper sourcing flops/bytes from the bound op's roofline."""
+
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test, op):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        cache = self._roofline_cache
+        if cache is None:
+            cache = self._op.eval_roofline()
+            self._roofline_cache = cache
+        return cache
 
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        return (
-            t.num_tokens * t.top_k
-            * (2 * t.ffn_size * t.hidden_size * 2
-               + t.hidden_size * t.ffn_size * 2)
-        )
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        elem = 2
-        w = (t.num_experts * 2 * t.ffn_size * t.hidden_size
-             + t.num_experts * t.hidden_size * t.ffn_size) * elem
-        a = t.num_tokens * t.hidden_size * elem * 2
-        return w + a
+        return self._get_roofline()[1]
 
 
-class FusedMoeBenchFixture(FixtureBase):
-    PARAMS = [
-        (
-            "num_tokens, num_experts, top_k, hidden_size, ffn_size,"
-            " scoring_func, renormalize, with_correction_bias,"
-            " routed_scaling_factor, dtype",
-            [
-                (1,    384, 8, 7168, 2048, "sigmoid", True, True, 2.827, torch.bfloat16),
-                (32,   384, 8, 7168, 2048, "sigmoid", True, True, 2.827, torch.bfloat16),
-                (512,  384, 8, 7168, 2048, "sigmoid", True, True, 2.827, torch.bfloat16),
-                (4096, 384, 8, 7168, 2048, "sigmoid", True, True, 2.827, torch.bfloat16),
-                (1,    256, 8, 7168, 2048, "sigmoid", True, False, 1.0, torch.bfloat16),
-                (32,   256, 8, 7168, 2048, "sigmoid", True, False, 1.0, torch.bfloat16),
-                (512,  256, 8, 7168, 2048, "sigmoid", True, False, 1.0, torch.bfloat16),
-                (4096, 256, 8, 7168, 2048, "sigmoid", True, False, 1.0, torch.bfloat16),
-                (1,    128, 8, 7168, 2048, "softmax", False, False, 1.0, torch.bfloat16),
-                (32,   128, 8, 7168, 2048, "softmax", False, False, 1.0, torch.bfloat16),
-                (512,  128, 8, 7168, 2048, "softmax", False, False, 1.0, torch.bfloat16),
-                (4096, 128, 8, 7168, 2048, "softmax", False, False, 1.0, torch.bfloat16),
-                (1,    128, 8, 3072, 1536, "softmax", False, False, 1.0, torch.bfloat16),
-                (32,   128, 8, 3072, 1536, "softmax", False, False, 1.0, torch.bfloat16),
-                (512,  128, 8, 3072, 1536, "softmax", False, False, 1.0, torch.bfloat16),
-                (4096, 128, 8, 3072, 1536, "softmax", False, False, 1.0, torch.bfloat16),
-            ],
-        )
-    ]
+def _routed_scaling_factor(w: dict) -> float:
+    return float(w.get("routed_scaling_factor", 1.0))
 
 
-# ---------------------------------------------------------------------------
-# Benchmark test
-# ---------------------------------------------------------------------------
+def _renormalize(w: dict) -> bool:
+    return bool(w.get("renormalize", False))
 
 
-@FusedMoeBenchFixture
-def test_fused_moe_bench(
-    num_tokens, num_experts, top_k, hidden_size, ffn_size,
-    scoring_func, renormalize, with_correction_bias,
-    routed_scaling_factor, dtype,
+def _to_params(workloads, *, with_correction_bias: bool):
+    """Convert a manifest entry's workloads to pytest params."""
+    params = []
+    for w in workloads:
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["num_tokens"], w["num_experts"], w["top_k"],
+                w["hidden_size"], w["ffn_size"],
+                w["scoring_func"], _renormalize(w),
+                with_correction_bias,
+                _routed_scaling_factor(w),
+                dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+_FWD_PARAMS = _to_params(load_workloads(_OP_NAME), with_correction_bias=False)
+_FWD_CB_PARAMS = _to_params(load_workloads(_OP_NAME_CB), with_correction_bias=True)
+
+
+def _run_bench(
+    op_cls,
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    hidden_size: int,
+    ffn_size: int,
+    scoring_func: str,
+    renormalize: bool,
+    with_correction_bias: bool,
+    routed_scaling_factor: float,
+    dtype: torch.dtype,
 ) -> None:
     test = FusedMoeBenchTest(
         num_tokens, num_experts, top_k, hidden_size, ffn_size,
         scoring_func, renormalize, with_correction_bias,
         routed_scaling_factor, dtype,
     )
-    bm = FusedMoeBenchmark(test)
     hidden, gating, correction_bias, w_gate_up, w_down = test.gen_inputs()
 
-    # -- TileOPs nopad -----------------------------------------------------
-    op = FusedMoe(
-        num_tokens=num_tokens,
-        num_experts=num_experts,
-        top_k=top_k,
-        hidden_size=hidden_size,
-        ffn_size=ffn_size,
-        scoring_func=scoring_func,
-        renormalize=renormalize,
-        with_correction_bias=with_correction_bias,
-        routed_scaling_factor=routed_scaling_factor,
-        layout="nopad",
-        dtype=dtype,
+    common_kwargs = dict(
+        num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
+        hidden_size=hidden_size, ffn_size=ffn_size,
+        scoring_func=scoring_func, renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor, dtype=dtype,
     )
-    op(hidden, gating, w_gate_up, w_down, correction_bias)  # warmup / JIT compile
+
+    if with_correction_bias:
+        forward_args_tileops = (hidden, gating, correction_bias, w_gate_up, w_down)
+    else:
+        forward_args_tileops = (hidden, gating, w_gate_up, w_down)
+
+    # -- TileOPs nopad -----------------------------------------------------
+    op = op_cls(layout="nopad", **common_kwargs)
+    bm = FusedMoeBenchmark(test, op)
+    op(*forward_args_tileops)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(op, hidden, gating, w_gate_up, w_down, correction_bias)
+    result = bm.profile(op, *forward_args_tileops)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # -- TileOPs padded ----------------------------------------------------
-    op_pad = FusedMoe(
-        num_tokens=num_tokens,
-        num_experts=num_experts,
-        top_k=top_k,
-        hidden_size=hidden_size,
-        ffn_size=ffn_size,
-        scoring_func=scoring_func,
-        renormalize=renormalize,
-        with_correction_bias=with_correction_bias,
-        routed_scaling_factor=routed_scaling_factor,
-        layout="padded",
-        dtype=dtype,
-    )
-    op_pad(hidden, gating, w_gate_up, w_down, correction_bias)
+    op_pad = op_cls(layout="padded", **common_kwargs)
+    op_pad(*forward_args_tileops)  # warmup
     torch.cuda.synchronize()
 
-    result_pad = bm.profile(op_pad, hidden, gating, w_gate_up, w_down, correction_bias)
+    result_pad = bm.profile(op_pad, *forward_args_tileops)
     BenchmarkReport.record(op_pad, locals(), result_pad, tag="tileops-padded")
 
-    # -- vLLM baseline (optional) ------------------------------------------
-    if _VLLM_AVAILABLE:
+    # -- Baseline ----------------------------------------------------------
+    # vLLM's ``fused_topk`` has no correction_bias parameter, so routing for
+    # FusedMoeFwdCbFwdOp would diverge from TileOPs. Fall back to torch-ref
+    # for correction-bias workloads; otherwise prefer vLLM when available.
+    use_vllm = _VLLM_AVAILABLE and not with_correction_bias
+    if use_vllm:
         gating_f32 = gating.float()
 
         def _vllm_fn(hidden, gating, correction_bias, w_gate_up, w_down):
-            # vLLM: routing + GEMM (complete flow like TileOPs)
             tw, tids, _ = _vllm_fused_topk(
                 hidden_states=hidden,
                 gating_output=gating_f32,
@@ -229,20 +223,24 @@ def test_fused_moe_bench(
                 out = out * routed_scaling_factor
             return out
 
-        _vllm_fn(hidden, gating, correction_bias, w_gate_up, w_down)  # warmup
+        _vllm_fn(hidden, gating, correction_bias, w_gate_up, w_down)
         torch.cuda.synchronize()
 
         result_vllm = bm.profile(
-            _vllm_fn, hidden, gating, correction_bias, w_gate_up, w_down
+            _vllm_fn, hidden, gating, correction_bias, w_gate_up, w_down,
         )
         BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
     else:
-        # torch-ref baseline: memory-efficient per-expert GEMM loop
-        fk = FusedTopKOp(num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
-                         scoring_func=scoring_func, renormalize=renormalize,
-                         with_correction_bias=with_correction_bias)
+        # torch-ref baseline: memory-efficient per-expert GEMM loop.
+        fk = FusedTopKOp(
+            num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
+            scoring_func=scoring_func, renormalize=renormalize,
+            with_correction_bias=with_correction_bias,
+        )
         topk_weights, topk_ids = fk(gating, correction_bias)
-        output_buf = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device=hidden.device)
+        output_buf = torch.zeros(
+            num_tokens, hidden_size, dtype=torch.float32, device=hidden.device,
+        )
         ids_i64 = topk_ids.to(torch.int64)
 
         def _ref_fn(hidden, gating, correction_bias, w_gate_up, w_down):
@@ -262,10 +260,54 @@ def test_fused_moe_bench(
                 output_buf.index_add_(0, t_idx, down * weights)
             return (output_buf * routed_scaling_factor).to(hidden.dtype)
 
-        _ref_fn(hidden, gating, correction_bias, w_gate_up, w_down)  # warmup
+        _ref_fn(hidden, gating, correction_bias, w_gate_up, w_down)
         torch.cuda.synchronize()
 
         result_ref = bm.profile(
-            _ref_fn, hidden, gating, correction_bias, w_gate_up, w_down
+            _ref_fn, hidden, gating, correction_bias, w_gate_up, w_down,
         )
         BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, top_k, hidden_size, ffn_size,"
+    " scoring_func, renormalize, with_correction_bias,"
+    " routed_scaling_factor, dtype_str",
+    _FWD_PARAMS,
+)
+def test_fused_moe_fwd_bench(
+    num_tokens, num_experts, top_k, hidden_size, ffn_size,
+    scoring_func, renormalize, with_correction_bias,
+    routed_scaling_factor, dtype_str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    _run_bench(
+        FusedMoeFwdOp,
+        num_tokens, num_experts, top_k, hidden_size, ffn_size,
+        scoring_func, renormalize, with_correction_bias,
+        routed_scaling_factor, dtype,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, top_k, hidden_size, ffn_size,"
+    " scoring_func, renormalize, with_correction_bias,"
+    " routed_scaling_factor, dtype_str",
+    _FWD_CB_PARAMS,
+)
+def test_fused_moe_fwd_cb_bench(
+    num_tokens, num_experts, top_k, hidden_size, ffn_size,
+    scoring_func, renormalize, with_correction_bias,
+    routed_scaling_factor, dtype_str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    _run_bench(
+        FusedMoeFwdCbFwdOp,
+        num_tokens, num_experts, top_k, hidden_size, ffn_size,
+        scoring_func, renormalize, with_correction_bias,
+        routed_scaling_factor, dtype,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -103,11 +103,10 @@ class FusedMoeBenchTest(WorkloadBase):
 class FusedMoeBenchmark(BenchmarkBase[FusedMoeBenchTest]):
     """Benchmark wrapper sourcing flops/bytes from the bound op's roofline."""
 
-    _roofline_cache: Optional[tuple[float, float]] = None
-
     def __init__(self, test, op):
         super().__init__(test)
         self._op = op
+        self._roofline_cache: Optional[tuple[float, float]] = None
 
     def _get_roofline(self) -> tuple[float, float]:
         cache = self._roofline_cache

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -10,9 +10,6 @@ Coverage:
   Op                       Models (manifest workloads)
   FusedMoeFwdOp            Qwen3-235B-A22B (softmax), DeepSeek-V3 (sigmoid)
   FusedMoeFwdCbFwdOp       Kimi K2 (sigmoid + correction_bias)
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_fused_moe.py -vvs
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -10,9 +10,6 @@ Real model configurations:
   DeepSeek-V3      256   8  sigmoid   True
   Qwen3-235B-A22B  128   8  softmax   False
   Qwen3-30B-A3B    128   8  softmax   False
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_fused_topk.py -vvs
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -1,0 +1,136 @@
+"""Benchmark for MoeGroupedGemmNopadFwdOp (tight, no-pad grouped GEMM).
+
+Baseline:
+  - PyTorch reference: per-expert NT matmul loop (`a_e @ b[e].T`).
+
+Workload shapes come from the manifest entry's `workloads` (via
+`load_workloads`); the benchmark reports TileOPs latency alongside the
+manifest-derived roofline (`op.eval_roofline()`).
+
+Usage:
+    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_grouped_gemm_nopad.py -vvs
+    conda run -n tileops python benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tileops.manifest import load_workloads
+from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
+from workloads.workload_base import WorkloadBase
+
+_OP_NAME = "MoeGroupedGemmNopadFwdOp"
+
+
+class MoeGroupedGemmNopadTest(WorkloadBase):
+    """Manifest-shaped inputs: tight A, expert weights B, uniform per-expert sizes."""
+
+    def __init__(self, numel: int, num_experts: int, n: int, k: int, dtype: torch.dtype):
+        self.numel = numel
+        self.num_experts = num_experts
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+
+    def gen_inputs(self):
+        torch.manual_seed(42)
+        dev = "cuda"
+        base = max(1, self.numel // self.num_experts)
+        sizes = torch.full((self.num_experts,), base, dtype=torch.int32, device=dev)
+        sizes[-1] = self.numel - base * (self.num_experts - 1)
+        offsets = torch.zeros(self.num_experts, dtype=torch.int32, device=dev)
+        offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+        a = torch.randn(self.numel, self.k, dtype=self.dtype, device=dev) * 0.02
+        b = torch.randn(self.num_experts, self.n, self.k, dtype=self.dtype, device=dev) * 0.02
+        return a, b, sizes, offsets
+
+    def ref_program(self, *args):
+        return None
+
+
+class MoeGroupedGemmNopadBenchmark(BenchmarkBase[MoeGroupedGemmNopadTest]):
+
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test, op):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+def _manifest_params():
+    """Convert manifest workloads to pytest params (numel, E, N, K, dtype)."""
+    params = []
+    for w in load_workloads(_OP_NAME):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["numel"], w["num_experts"], w["n"], w["k"], dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize(
+    "numel, num_experts, n, k, dtype_str",
+    _manifest_params(),
+)
+def test_moe_grouped_gemm_nopad_bench(
+    numel: int, num_experts: int, n: int, k: int, dtype_str: str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    test = MoeGroupedGemmNopadTest(numel, num_experts, n, k, dtype)
+    a, b, true_sizes, true_offsets = test.gen_inputs()
+
+    op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k, dtype=dtype)
+    bm = MoeGroupedGemmNopadBenchmark(test, op)
+
+    # Warmup: trigger JIT compilation before timed profiling.
+    op(a, b, true_sizes, true_offsets)
+    torch.cuda.synchronize()
+
+    result = bm.profile(op, a, b, true_sizes, true_offsets)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    # PyTorch baseline: per-expert NT matmul.
+    sizes_l = true_sizes.tolist()
+    offsets_l = true_offsets.tolist()
+
+    def _torch_fn(a, b, true_sizes, true_offsets):
+        out = torch.empty(numel, n, dtype=dtype, device=a.device)
+        for e in range(num_experts):
+            size_e = sizes_l[e]
+            if size_e == 0:
+                continue
+            off_e = offsets_l[e]
+            out[off_e:off_e + size_e] = a[off_e:off_e + size_e] @ b[e].T
+        return out
+
+    _torch_fn(a, b, true_sizes, true_offsets)  # warmup
+    torch.cuda.synchronize()
+
+    result_torch = bm.profile(_torch_fn, a, b, true_sizes, true_offsets)
+    BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -6,10 +6,6 @@ Baseline:
 Workload shapes come from the manifest entry's `workloads` (via
 `load_workloads`); the benchmark reports TileOPs latency alongside the
 manifest-derived roofline (`op.eval_roofline()`).
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_grouped_gemm_nopad.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_moe_grouped_gemm_nopad.py
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_kernel_breakdown.py
+++ b/benchmarks/ops/bench_moe_kernel_breakdown.py
@@ -7,9 +7,6 @@ Stages measured:
   padded : FusedTopK | Permute | GEMM_gate_up | SiluAndMul | GEMM_down | Unpermute
   nopad  : FusedTopK | Permute | Sched | GEMM_gate_up | SiluAndMul | Sched | GEMM_down | Unpermute
   vLLM   : torch.profiler top-CUDA-kernel breakdown
-
-Usage:
-    conda run -n tileops python benchmarks/ops/bench_moe_kernel_breakdown.py
 """
 
 import torch

--- a/benchmarks/ops/bench_moe_permute.py
+++ b/benchmarks/ops/bench_moe_permute.py
@@ -12,10 +12,6 @@ Real model configurations:
   DeepSeek-V3      7168  256   8
   Qwen3-235B-A22B  7168  128   8
   Qwen3-30B-A3B    3072  128   8
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_permute.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_moe_permute.py
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -5,10 +5,6 @@ Baselines:
       sglang/sgl-kernel/benchmark/bench_moe_align_block_size.py
   - sgl-kernel (optional): SGLang's production CUDA kernel; only runs when
       sgl_kernel is installed (`pip install sgl-kernel`).
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_permute_align.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_moe_permute_align.py
 """
 
 import math

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -200,7 +200,7 @@ def test_permute_align_bench(
     inputs = test.gen_inputs()
 
     # TileOPs
-    op = MoePermuteAlignFwdOp(numel, num_experts, block_size)
+    op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     bm = MoePermuteAlignBenchmark(test, op)
 
     # Warmup: trigger JIT compilation before timed profiling

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -10,10 +10,6 @@ Real model configurations:
   DeepSeek-V3      7168  256   8
   Qwen3-235B-A22B  7168  128   8
   Qwen3-30B-A3B    3072  128   8
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_permute_nopad.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_moe_permute_nopad.py
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -13,9 +13,6 @@ FLOPs:
   Routed:  T*K * 6*F*H   (gate+up + down)
   Shared:  T   * 6*Fs*H  (gate+up + down)
   Total  = T*K*6*F*H + T*6*Fs*H
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_shared_fused_moe.py -vvs
 """
 
 from typing import Optional

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -13,10 +13,6 @@ Real model configurations:
   DeepSeek-V3      7168   8
   Qwen3-235B-A22B  7168   8
   Qwen3-30B-A3B    3072   8
-
-Usage:
-    conda run -n tileops python -m pytest benchmarks/ops/bench_moe_unpermute.py -vvs
-    conda run -n tileops python benchmarks/ops/bench_moe_unpermute.py
 """
 
 from typing import Optional

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -25,7 +25,7 @@ Source of truth for op interfaces. Human-reviewed, separate PR.
 
 ### Status flip carve-out
 
-An implementation PR may edit only `status`, `source.kernel_map`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
+An implementation PR may edit only `status`, `source.kernel_map`, `source.test`, `source.bench`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
 
 Full enumeration: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
 

--- a/tests/ops/test_moe_fused_moe.py
+++ b/tests/ops/test_moe_fused_moe.py
@@ -14,7 +14,12 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase
-from tileops.ops.moe import FusedMoe, FusedTopKOp
+from tileops.ops.moe import (
+    FusedMoe,
+    FusedMoeFwdCbFwdOp,
+    FusedMoeFwdOp,
+    FusedTopKOp,
+)
 
 # ---------------------------------------------------------------------------
 # vLLM optional import
@@ -460,6 +465,78 @@ def test_fused_moe_vs_vllm(
 # ---------------------------------------------------------------------------
 # prepare_finalize / experts contract
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_fused_moe_fwd_op_identity() -> None:
+    """`FusedMoeFwdOp` (no correction bias) matches the FusedMoe core path.
+
+    Guards the manifest <-> class identity contract surfaced by
+    validate_manifest --check-op: both names must resolve to concrete Op
+    subclasses, each with the right `forward()` positional signature.
+    """
+    torch.manual_seed(42)
+    dev = "cuda"
+    T, E, K, H, F_ = 32, 8, 2, 64, 32
+    dtype = torch.bfloat16
+
+    hidden = torch.randn(T, H, dtype=dtype, device=dev)
+    gating = torch.randn(T, E, dtype=dtype, device=dev)
+    w_gate_up = torch.randn(E, F_ * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, F_, dtype=dtype, device=dev) * 0.02
+
+    op = FusedMoeFwdOp(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F_, dtype=dtype,
+    )
+    out = op(hidden, gating, w_gate_up, w_down)
+    assert out.shape == (T, H)
+    assert out.dtype == dtype
+
+    ref_op = FusedMoe(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F_, dtype=dtype,
+    )
+    ref = ref_op(hidden, gating, w_gate_up, w_down)
+    torch.testing.assert_close(out.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+    flops, nbytes = op.eval_roofline()
+    assert flops > 0 and nbytes > 0
+
+
+@pytest.mark.smoke
+def test_fused_moe_fwd_cb_op_identity() -> None:
+    """`FusedMoeFwdCbFwdOp` (with correction bias) end-to-end smoke."""
+    torch.manual_seed(7)
+    dev = "cuda"
+    T, E, K, H, F_ = 32, 8, 2, 64, 32
+    dtype = torch.bfloat16
+
+    hidden = torch.randn(T, H, dtype=dtype, device=dev)
+    gating = torch.randn(T, E, dtype=dtype, device=dev)
+    correction_bias = torch.randn(E, dtype=torch.float32, device=dev) * 0.1
+    w_gate_up = torch.randn(E, F_ * 2, H, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(E, H, F_, dtype=dtype, device=dev) * 0.02
+
+    op = FusedMoeFwdCbFwdOp(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F_, renormalize=True, dtype=dtype,
+    )
+    out = op(hidden, gating, correction_bias, w_gate_up, w_down)
+    assert out.shape == (T, H)
+    assert out.dtype == dtype
+
+    ref_op = FusedMoe(
+        num_tokens=T, num_experts=E, top_k=K,
+        hidden_size=H, ffn_size=F_,
+        scoring_func="sigmoid", renormalize=True, with_correction_bias=True,
+        dtype=dtype,
+    )
+    ref = ref_op(hidden, gating, w_gate_up, w_down, correction_bias)
+    torch.testing.assert_close(out.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+    flops, nbytes = op.eval_roofline()
+    assert flops > 0 and nbytes > 0
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_moe_fused_moe.py
+++ b/tests/ops/test_moe_fused_moe.py
@@ -469,12 +469,7 @@ def test_fused_moe_vs_vllm(
 
 @pytest.mark.smoke
 def test_fused_moe_fwd_op_identity() -> None:
-    """`FusedMoeFwdOp` (no correction bias) matches the FusedMoe core path.
-
-    Guards the manifest <-> class identity contract surfaced by
-    validate_manifest --check-op: both names must resolve to concrete Op
-    subclasses, each with the right `forward()` positional signature.
-    """
+    """`FusedMoeFwdOp` (no correction bias) matches the `FusedMoe` reference output."""
     torch.manual_seed(42)
     dev = "cuda"
     T, E, K, H, F_ = 32, 8, 2, 64, 32

--- a/tests/ops/test_moe_grouped_gemm_nopad.py
+++ b/tests/ops/test_moe_grouped_gemm_nopad.py
@@ -1,0 +1,150 @@
+"""Op-level tests for MoeGroupedGemmNopadFwdOp (tight, no-pad grouped GEMM).
+
+Verifies that the tile-scheduled grouped GEMM produces the same per-expert
+NT matmul as a pure-PyTorch reference, across:
+  - uniform and skewed token-to-expert distributions
+  - bf16 and fp16 activations
+  - K block-aligned (TMA fast path) and K non-aligned (predicated path)
+"""
+
+import pytest
+import torch
+
+from tests.test_base import FixtureBase
+from tileops.ops.moe import MoeGroupedGemmNopadFwdOp
+from workloads.workload_base import WorkloadBase
+
+
+def _make_sizes_offsets(numel: int, num_experts: int, distribution: str, device: str):
+    """Build (true_sizes, true_offsets) for a fixed token-to-expert distribution.
+
+    Args:
+        numel: Total token-expert pairs (T * top_k).
+        num_experts: Number of experts E.
+        distribution: "uniform" — evenly split; "skewed" — most tokens on first
+            20% of experts (one-token floor for the rest).
+        device: CUDA device string.
+
+    Returns:
+        true_sizes [E] int32, true_offsets [E] int32.
+    """
+    if distribution == "uniform":
+        base = max(1, numel // num_experts)
+        sizes = torch.full((num_experts,), base, dtype=torch.int32, device=device)
+        sizes[-1] = numel - base * (num_experts - 1)
+    elif distribution == "skewed":
+        sizes = torch.ones(num_experts, dtype=torch.int32, device=device)
+        extra = numel - num_experts
+        top_experts = max(1, num_experts // 5)
+        per_top = extra // top_experts
+        sizes[:top_experts] += per_top
+        sizes[0] += extra - per_top * top_experts
+    else:
+        raise ValueError(f"unknown distribution: {distribution}")
+
+    offsets = torch.zeros(num_experts, dtype=torch.int32, device=device)
+    offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+    assert int(sizes.sum().item()) == numel
+    return sizes, offsets
+
+
+def _ref_grouped_gemm_nopad(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    true_sizes: torch.Tensor,
+    true_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Pure-PyTorch reference: per-expert NT matmul over the tight permute layout.
+
+    Args:
+        a: [numel, K] tight permuted activations.
+        b: [num_experts, N, K] expert weights (NT: B^T applied).
+        true_sizes: [E] int32 token count per expert.
+        true_offsets: [E] int32 start offset per expert into a.
+
+    Returns:
+        c: [numel, N] reference output. Rows belonging to expert e are
+            `a[off:off+size] @ b[e].T`; rows outside any expert range (none
+            for valid inputs) are left zero.
+    """
+    numel, _ = a.shape
+    num_experts, N, _ = b.shape
+    c = torch.zeros(numel, N, dtype=a.dtype, device=a.device)
+    sizes_l = true_sizes.tolist()
+    offsets_l = true_offsets.tolist()
+    for e in range(num_experts):
+        size_e = sizes_l[e]
+        if size_e == 0:
+            continue
+        off_e = offsets_l[e]
+        a_e = a[off_e:off_e + size_e].to(torch.float32)
+        b_e = b[e].to(torch.float32)
+        c[off_e:off_e + size_e] = (a_e @ b_e.T).to(a.dtype)
+    return c
+
+
+class MoeGroupedGemmNopadTest(WorkloadBase):
+    """Generates inputs for the tight grouped-GEMM op."""
+
+    def __init__(self, numel, num_experts, n, k, distribution, dtype):
+        self.numel = numel
+        self.num_experts = num_experts
+        self.n = n
+        self.k = k
+        self.distribution = distribution
+        self.dtype = dtype
+
+    def gen_inputs(self):
+        torch.manual_seed(42)
+        dev = "cuda"
+        true_sizes, true_offsets = _make_sizes_offsets(
+            self.numel, self.num_experts, self.distribution, dev
+        )
+        # Small scale keeps fp16 accumulation well within the parity tolerance.
+        a = torch.randn(self.numel, self.k, dtype=self.dtype, device=dev) * 0.02
+        b = torch.randn(self.num_experts, self.n, self.k, dtype=self.dtype, device=dev) * 0.02
+        return a, b, true_sizes, true_offsets
+
+
+class MoeGroupedGemmNopadFixture(FixtureBase):
+    PARAMS = [
+        ("numel, num_experts, n, k, distribution, dtype", [
+            # K block_k-aligned (TMA fast path), uniform distribution, bf16.
+            pytest.param(
+                64, 4, 128, 64, "uniform", torch.bfloat16,
+                marks=pytest.mark.smoke, id="aligned-uniform-bf16",
+            ),
+            # K block_k-aligned, skewed distribution, fp16 — covers dtype branch.
+            pytest.param(
+                64, 4, 128, 64, "skewed", torch.float16,
+                marks=pytest.mark.smoke, id="aligned-skewed-fp16",
+            ),
+            # K NOT block_k-aligned (default block_k=64 → K=96 falls in predicated path).
+            pytest.param(
+                128, 8, 256, 96, "uniform", torch.bfloat16,
+                marks=pytest.mark.full, id="unaligned-uniform-bf16",
+            ),
+        ]),
+    ]
+
+
+@MoeGroupedGemmNopadFixture
+def test_moe_grouped_gemm_nopad_op(numel, num_experts, n, k, distribution, dtype):
+    test = MoeGroupedGemmNopadTest(numel, num_experts, n, k, distribution, dtype)
+    a, b, true_sizes, true_offsets = test.gen_inputs()
+
+    op = MoeGroupedGemmNopadFwdOp(numel, num_experts, n, k, dtype=dtype)
+    c = op(a, b, true_sizes, true_offsets)
+    c_ref = _ref_grouped_gemm_nopad(a, b, true_sizes, true_offsets)
+
+    assert c.shape == (numel, n), f"expected ({numel}, {n}), got {tuple(c.shape)}"
+    assert c.dtype == dtype
+
+    # bf16/fp16 accumulation in fp32 — match kernel's accum_dtype.
+    torch.testing.assert_close(
+        c.float(), c_ref.float(), atol=1e-2, rtol=1e-2,
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_moe_permute_align.py
+++ b/tests/ops/test_moe_permute_align.py
@@ -190,7 +190,7 @@ def test_permute_align_op(
 ) -> None:
     numel = total_tokens * top_k
     test = MoePermuteAlignTest(total_tokens, top_k, num_experts, block_size)
-    op = MoePermuteAlignFwdOp(numel, num_experts, block_size)
+    op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     inputs = test.gen_inputs()
 
     outputs = tuple(op(*inputs))
@@ -212,7 +212,7 @@ def test_permute_align_sentinel_padding() -> None:
     topk_ids = torch.randint(0, num_experts, (total_tokens, top_k),
                               dtype=torch.int32, device="cuda")
 
-    op = MoePermuteAlignFwdOp(numel, num_experts, block_size)
+    op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     sorted_ids, _, num_post_pad = op(topk_ids)
 
     n = num_post_pad.item()
@@ -229,7 +229,7 @@ def test_permute_align_expert_ids_range() -> None:
     topk_ids = torch.randint(0, num_experts, (total_tokens, top_k),
                               dtype=torch.int32, device="cuda")
 
-    op = MoePermuteAlignFwdOp(total_tokens * top_k, num_experts, block_size)
+    op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     _, expert_ids, num_post_pad = op(topk_ids)
 
     n = num_post_pad.item()
@@ -253,7 +253,7 @@ def test_permute_align_skewed_distribution() -> None:
     # All tokens go to expert 0
     topk_ids = torch.zeros((total_tokens, top_k), dtype=torch.int32, device="cuda")
 
-    op = MoePermuteAlignFwdOp(numel, num_experts, block_size)
+    op = MoePermuteAlignFwdOp(total_tokens, top_k, num_experts, block_size)
     outputs = tuple(op(topk_ids))
     outputs_ref = tuple(_ref_permute_align(topk_ids, block_size, num_experts))
 

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -1,0 +1,122 @@
+"""Op-level tests for MoePermuteNopadFwdOp (tight, non-padded permute).
+
+Verifies:
+  - perm_h: correct gather of hidden_states rows into tight expert layout
+  - true_offsets / true_sizes: tight per-expert start and count (int32)
+  - expert_first_token_offset: exclusive prefix-sum (int64)
+  - fwd_idx consistency: perm_h[fwd_idx[flat_idx]] == hidden_states[flat_idx // K]
+"""
+
+import pytest
+import torch
+
+from tests.test_base import FixtureBase, TestBase
+from tileops.ops.moe import MoePermuteNopadFwdOp
+from workloads.moe import MoePermuteTest as _MoePermuteTestWorkload
+
+
+def _ref_moe_permute_nopad(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch reference for moe_permute (tight, no padding)."""
+    T, H = hidden_states.shape
+    K = topk_ids.shape[1]
+    numel = T * K
+    flat_ids = topk_ids.flatten().cpu().tolist()
+    dev = hidden_states.device
+
+    counts = [0] * num_experts
+    for eid in flat_ids:
+        counts[eid] += 1
+
+    offsets = [0] * (num_experts + 1)
+    for e in range(num_experts):
+        offsets[e + 1] = offsets[e] + counts[e]
+
+    write_ptr = list(offsets[:-1])
+    slot_to_row = [0] * numel
+    fwd_idx_list = [0] * numel
+
+    for flat_idx, eid in enumerate(flat_ids):
+        slot = write_ptr[eid]
+        slot_to_row[slot] = flat_idx // K
+        fwd_idx_list[flat_idx] = slot
+        write_ptr[eid] += 1
+
+    perm_h = torch.empty(numel, H, dtype=hidden_states.dtype, device=dev)
+    for slot in range(numel):
+        perm_h[slot] = hidden_states[slot_to_row[slot]]
+
+    true_offsets_t = torch.tensor(offsets[:-1], dtype=torch.int32, device=dev)
+    true_sizes_t = torch.tensor(counts, dtype=torch.int32, device=dev)
+    expert_first_token_offset = torch.tensor(offsets, dtype=torch.int64, device=dev)
+    fwd_idx_t = torch.tensor(fwd_idx_list, dtype=torch.int32, device=dev)
+
+    return perm_h, true_offsets_t, true_sizes_t, expert_first_token_offset, fwd_idx_t
+
+
+class MoePermuteNopadTest(_MoePermuteTestWorkload, TestBase):
+    def ref_program(self, hidden_states, topk_ids):
+        return _ref_moe_permute_nopad(hidden_states, topk_ids, self.num_experts)
+
+
+def _compare(hidden_states, topk_ids, outputs, outputs_ref, num_experts):
+    perm_h, true_offsets, true_sizes, offsets, fwd_idx = outputs
+    _, ref_true_offsets, ref_true_sizes, ref_offsets, _ = outputs_ref
+
+    K = topk_ids.shape[1]
+    numel = topk_ids.numel()
+
+    # expert_first_token_offset (int64) must match exactly
+    assert torch.equal(offsets.cpu(), ref_offsets.cpu()), (
+        f"expert_first_token_offset mismatch:\n  got: {offsets.cpu()}\n  ref: {ref_offsets.cpu()}"
+    )
+
+    # true_offsets / true_sizes (int32) must match exactly
+    assert torch.equal(true_offsets.cpu(), ref_true_offsets.cpu()), (
+        f"true_offsets mismatch:\n  got: {true_offsets.cpu()}\n  ref: {ref_true_offsets.cpu()}"
+    )
+    assert torch.equal(true_sizes.cpu(), ref_true_sizes.cpu()), (
+        f"true_sizes mismatch:\n  got: {true_sizes.cpu()}\n  ref: {ref_true_sizes.cpu()}"
+    )
+
+    # Tight output: exactly numel rows, no padding gaps.
+    assert perm_h.shape[0] == numel, (
+        f"perm_h must have exactly {numel} rows (tight layout), got {perm_h.shape[0]}"
+    )
+
+    # Key consistency: perm_h[fwd_idx[flat_idx]] == hidden_states[flat_idx // K].
+    # This validates both perm_h layout and fwd_idx regardless of intra-expert ordering.
+    token_rows = torch.arange(numel, device=hidden_states.device) // K
+    gathered = perm_h[fwd_idx.long()]
+    assert torch.equal(gathered, hidden_states[token_rows]), (
+        "fwd_idx/perm_h mismatch: perm_h[fwd_idx] != hidden_states[flat_idx // K]"
+    )
+
+
+class MoePermuteNopadFixture(FixtureBase):
+    PARAMS = [
+        ("total_tokens, top_k, num_experts, hidden_size, dtype", [
+            pytest.param(4,  2, 4, 64,  torch.bfloat16, marks=pytest.mark.smoke, id="tiny-bf16"),
+            pytest.param(4,  2, 4, 64,  torch.float16,  marks=pytest.mark.smoke, id="tiny-fp16"),
+            pytest.param(16, 2, 8, 128, torch.bfloat16, marks=pytest.mark.full,  id="small"),
+        ]),
+    ]
+
+
+@MoePermuteNopadFixture
+def test_moe_permute_nopad_op(total_tokens, top_k, num_experts, hidden_size, dtype):
+    test = MoePermuteNopadTest(total_tokens, top_k, num_experts, hidden_size, dtype)
+    op = MoePermuteNopadFwdOp(total_tokens, top_k, num_experts, hidden_size, dtype)
+    hidden_states, topk_ids = test.gen_inputs()
+
+    outputs = op(hidden_states, topk_ids)
+    outputs_ref = test.ref_program(hidden_states, topk_ids)
+
+    _compare(hidden_states, topk_ids, outputs, outputs_ref, num_experts)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_special_elementwise_conformance.py
+++ b/tests/ops/test_special_elementwise_conformance.py
@@ -350,25 +350,61 @@ def test_clamp_max_nan_propagation(dtype):
 # ---------------------------------------------------------------------------
 
 
+_MASKED_FILL_TENSOR_VALUE_FLOAT_DTYPES = [
+    torch.float16, torch.bfloat16, torch.float32,
+]
+_MASKED_FILL_TENSOR_VALUE_INT_DTYPES = [
+    torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
+]
+
+
+def _masked_fill_tensor_value_inputs(input_shape, mask_shape, dtype):
+    if dtype == torch.bool:
+        inp = torch.randint(0, 2, input_shape, device="cuda").bool()
+        value = torch.tensor(True, device="cuda", dtype=torch.bool)
+    elif dtype in _MASKED_FILL_TENSOR_VALUE_INT_DTYPES:
+        iinfo = torch.iinfo(dtype)
+        lo = max(iinfo.min, -1000)
+        hi = min(iinfo.max, 1000) + 1
+        inp = torch.randint(lo, hi, input_shape, device="cuda", dtype=dtype)
+        value = torch.tensor(7, device="cuda", dtype=dtype)
+    else:
+        inp = torch.randn(input_shape, device="cuda", dtype=dtype)
+        value = torch.tensor(-1.5, device="cuda", dtype=dtype)
+    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
+    return inp, mask, value
+
+
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "input_shape, mask_shape",
     [((4, 8), (4, 8)), ((1, 8), (4, 8)), ((4, 8), (1, 8)), ((2, 1), (2, 3))],
 )
-def test_masked_fill_tensor_value(input_shape, mask_shape):
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bool, *_MASKED_FILL_TENSOR_VALUE_INT_DTYPES,
+     *_MASKED_FILL_TENSOR_VALUE_FLOAT_DTYPES],
+)
+def test_masked_fill_tensor_value(input_shape, mask_shape, dtype):
     from tileops.ops.elementwise import MaskedFillFwdOp
 
-    inp = torch.randn(input_shape, device="cuda", dtype=torch.float32)
-    mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
-    value = torch.tensor(-1.5, device="cuda", dtype=torch.float32)
+    inp, mask, value = _masked_fill_tensor_value_inputs(input_shape, mask_shape, dtype)
 
     out_shape = torch.broadcast_shapes(input_shape, mask_shape)
     ref = inp.expand(out_shape).clone().masked_fill(mask.expand(out_shape), value.item())
 
     op = MaskedFillFwdOp(input=tuple(inp.shape), mask=tuple(mask.shape),
-                        value=tuple(value.shape), dtype=torch.float32)
+                        value=tuple(value.shape), dtype=dtype)
     out = op(inp, mask, value)
-    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+    if dtype == torch.float16:
+        tol = {"atol": 1e-3, "rtol": 1e-3}
+    elif dtype == torch.bfloat16:
+        tol = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    elif dtype == torch.float32:
+        tol = {"atol": 1e-5, "rtol": 1e-5}
+    else:
+        tol = {"atol": 0, "rtol": 0}
+    torch.testing.assert_close(out, ref, **tol)
 
 
 @pytest.mark.smoke

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -126,11 +126,7 @@ class TestCacheKeyWarning:
 
 
 class TestCompositeKernelMapOverride:
-    """Composite ops (empty ``default_kernel_map``) must accept a non-empty
-    ``kernel_map`` override so they can forward per-sub-op slices into the
-    nested op constructors. The override is stored verbatim on ``self``;
-    sub-op ``_install_kernel_map`` calls handle their own arch-compat checks
-    when constructed."""
+    """Composite ops (empty ``default_kernel_map``) accept a non-empty override and store it verbatim."""
 
     def test_empty_default_with_empty_override_yields_empty_map(self):
         Cls = _make_op_subclass()
@@ -146,8 +142,6 @@ class TestCompositeKernelMapOverride:
         assert op.kernel_map == override
 
     def test_empty_default_override_is_copied_not_aliased(self):
-        """``self.kernel_map`` must be an independent dict so callers mutating
-        the original override do not corrupt installed state."""
         Cls = _make_op_subclass()
         op = Cls()
         override = {"permute_nopad_kernel": object()}

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -123,3 +123,34 @@ class TestCacheKeyWarning:
 
         user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
         assert len(user_warnings) == 2
+
+
+class TestCompositeKernelMapOverride:
+    """Composite ops (empty ``default_kernel_map``) must accept a non-empty
+    ``kernel_map`` override so they can forward per-sub-op slices into the
+    nested op constructors. The override is stored verbatim on ``self``;
+    sub-op ``_install_kernel_map`` calls handle their own arch-compat checks
+    when constructed."""
+
+    def test_empty_default_with_empty_override_yields_empty_map(self):
+        Cls = _make_op_subclass()
+        op = Cls()
+        op.dispatch_kernel(None)
+        assert op.kernel_map == {}
+
+    def test_empty_default_with_non_empty_override_stores_override(self):
+        Cls = _make_op_subclass()
+        op = Cls()
+        override = {"permute_nopad_kernel": object(), "unpermute_kernel": object()}
+        op.dispatch_kernel(override)
+        assert op.kernel_map == override
+
+    def test_empty_default_override_is_copied_not_aliased(self):
+        """``self.kernel_map`` must be an independent dict so callers mutating
+        the original override do not corrupt installed state."""
+        Cls = _make_op_subclass()
+        op = Cls()
+        override = {"permute_nopad_kernel": object()}
+        op.dispatch_kernel(override)
+        override["extra"] = object()
+        assert "extra" not in op.kernel_map

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -3264,9 +3264,16 @@ class MaskedFillTensorValueFwdKernel(ParametricUnaryKernel):
     ``N_total``. The Op layer broadcasts ``input`` and ``mask`` to the
     output shape, flattens them, packs the mask as uint8, and reshapes
     the 0-dim ``value`` to a length-1 tensor before dispatch.
+
+    Supports the PyTorch ``Tensor.masked_fill(mask, value: Tensor)``
+    dtype union of integer and floating-point input dtypes. The bool
+    dtype path is handled at the Op layer by viewing input and value as
+    uint8, so the kernel itself only sees integer and floating-point
+    storage dtypes.
     """
 
     _DEFAULT_THREADS = 512
+    SUPPORTED_DTYPES = _BITWISE_DTYPES[1:] + _FLOAT_DTYPES  # uint8/intN + fp16/bf16/fp32
 
     @staticmethod
     def _builder_fn():

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -3263,13 +3263,9 @@ class MaskedFillTensorValueFwdKernel(ParametricUnaryKernel):
     Computes ``out = mask ? value : x`` over flat tensors of length
     ``N_total``. The Op layer broadcasts ``input`` and ``mask`` to the
     output shape, flattens them, packs the mask as uint8, and reshapes
-    the 0-dim ``value`` to a length-1 tensor before dispatch.
-
-    Supports the PyTorch ``Tensor.masked_fill(mask, value: Tensor)``
-    dtype union of integer and floating-point input dtypes. The bool
-    dtype path is handled at the Op layer by viewing input and value as
-    uint8, so the kernel itself only sees integer and floating-point
-    storage dtypes.
+    the 0-dim ``value`` to a length-1 tensor before dispatch. The bool
+    input dtype is routed through uint8 at the Op layer, so this kernel
+    only sees integer and floating-point storage dtypes.
     """
 
     _DEFAULT_THREADS = 512

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -61,7 +61,6 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
-  # spec-only: kernel only supports float dtypes; manifest declares int/bool union
   status: spec-only
 
   signature:
@@ -89,8 +88,8 @@ MaskedFillFwdOp:
     kernel_map:
       masked_fill_tensor_value: MaskedFillTensorValueFwdKernel
     op: tileops/ops/elementwise/masked_fill.py
-    test: tests/ops/test_special_elementwise.py
-    bench: benchmarks/ops/bench_independent_elementwise.py
+    test: tests/ops/test_special_elementwise_conformance.py
+    bench: benchmarks/ops/bench_masked_fill.py
     bench_manifest_driven: false
 
 MaskedFillScalarFwdOp:

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -61,7 +61,7 @@ MaskedFillFwdOp:
   # value form lands as MaskedFillScalarFwdOp below per the
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -412,7 +412,7 @@ ClampFwdOp:
   # single-bound min-only form, and the single-bound max-only form each
   # land as their own variant_of entries below.
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -450,7 +450,7 @@ ClampScalarFwdOp:
   # with Number (or None) bounds. Per the "No Optional[Tensor]" manifest
   # rule, this is split from the Tensor-bound primary entry above.
   family: elementwise
-  status: spec-only
+  status: implemented
   variant_of: ClampFwdOp
 
   signature:
@@ -465,8 +465,8 @@ ClampScalarFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], min: -0.5, max: 0.5, dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], min: -0.5, max: 0.5, dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -491,7 +491,7 @@ ClampMinFwdOp:
   # Single-bound Tensor variant: torch.clamp_min(input, min: Tensor) —
   # equivalent to torch.clamp with only the lower bound provided.
   family: elementwise
-  status: spec-only
+  status: implemented
   variant_of: ClampFwdOp
 
   signature:
@@ -526,7 +526,7 @@ ClampMaxFwdOp:
   # Single-bound Tensor variant: torch.clamp_max(input, max: Tensor) —
   # equivalent to torch.clamp with only the upper bound provided.
   family: elementwise
-  status: spec-only
+  status: implemented
   variant_of: ClampFwdOp
 
   signature:

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -344,8 +344,8 @@ MoeGroupedGemmNopadFwdOp:
   source:
     kernel: tileops/kernels/moe/moe_grouped_gemm_nopad.py
     op: tileops/ops/moe/moe_grouped_gemm_nopad.py
-    test: tests/ops/test_moe_fused_moe.py
-    bench: benchmarks/ops/bench_moe_fused_moe.py
+    test: tests/ops/test_moe_grouped_gemm_nopad.py
+    bench: benchmarks/ops/bench_moe_grouped_gemm_nopad.py
     kernel_map:
       moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
 

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -7,7 +7,7 @@
 MoePermutePaddedFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -61,11 +61,13 @@ MoePermutePaddedFwdOp:
     test: tests/ops/test_moe_permute.py
     bench: benchmarks/ops/bench_moe_permute.py
     bench_manifest_driven: true
+    kernel_map:
+      permute_kernel: MoePermutePaddedKernel
 
 MoePermuteAlignFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -111,6 +113,8 @@ MoePermuteAlignFwdOp:
     test: tests/ops/test_moe_permute_align.py
     bench: benchmarks/ops/bench_moe_permute_align.py
     bench_manifest_driven: true
+    kernel_map:
+      permute_align_kernel: MoePermuteAlignKernel
 
 MoePermuteNopadFwdOp:
   ref_api: "none"
@@ -173,7 +177,7 @@ MoePermuteNopadFwdOp:
 MoeUnpermuteFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -213,11 +217,13 @@ MoeUnpermuteFwdOp:
     test: tests/ops/test_moe_unpermute.py
     bench: benchmarks/ops/bench_moe_unpermute.py
     bench_manifest_driven: true
+    kernel_map:
+      unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeExpertsFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -239,6 +245,7 @@ FusedMoeExpertsFwdOp:
       - "output.shape == hidden_states.shape"
 
   workloads:
+    - {num_tokens: 32, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode"}
     - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
 
   roofline:
@@ -250,11 +257,16 @@ FusedMoeExpertsFwdOp:
     op: tileops/ops/moe/fused_moe_experts.py
     test: tests/ops/test_moe_fused_moe.py
     bench: benchmarks/ops/bench_moe_fused_moe.py
+    kernel_map:
+      permute_nopad_kernel: MoePermuteNopadKernel
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeExpertsPaddedFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -276,6 +288,7 @@ FusedMoeExpertsPaddedFwdOp:
       - "output.shape == hidden_states.shape"
 
   workloads:
+    - {num_tokens: 32, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode"}
     - {num_tokens: 512, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
 
   roofline:
@@ -287,6 +300,11 @@ FusedMoeExpertsPaddedFwdOp:
     op: tileops/ops/moe/fused_moe_experts.py
     test: tests/ops/test_moe_fused_moe.py
     bench: benchmarks/ops/bench_moe_fused_moe.py
+    kernel_map:
+      permute_kernel: MoePermutePaddedKernel
+      grouped_gemm_kernel: GroupedGemmKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
 
 MoeGroupedGemmNopadFwdOp:
   ref_api: "none"
@@ -325,7 +343,7 @@ MoeGroupedGemmNopadFwdOp:
 MoEExpertsNopadFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -369,11 +387,16 @@ MoEExpertsNopadFwdOp:
     test: tests/ops/test_moe_experts_nopad.py
     bench: benchmarks/ops/bench_moe_experts_nopad.py
     bench_manifest_driven: false
+    kernel_map:
+      permute_nopad_kernel: MoePermuteNopadKernel
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
 
 MoEExpertsPaddedFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -417,6 +440,11 @@ MoEExpertsPaddedFwdOp:
     test: tests/ops/test_moe_experts_nopad.py
     bench: benchmarks/ops/bench_moe_experts_nopad.py
     bench_manifest_driven: false
+    kernel_map:
+      permute_kernel: MoePermutePaddedKernel
+      grouped_gemm_kernel: GroupedGemmKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeFwdOp:
   ref_api: "none"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -537,9 +537,9 @@ FusedMoeFwdCbFwdOp:
       - "output.shape          == (num_tokens, hidden_size)"
 
   workloads:
-    # Kimi K2: scoring_func=sigmoid, correction_bias
-    - {num_tokens: 512,  num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, scoring_func: sigmoid, renormalize: false, dtypes: [bfloat16], label: "kimi-k2-decode"}
-    - {num_tokens: 4096, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, scoring_func: sigmoid, renormalize: false, dtypes: [bfloat16], label: "kimi-k2-prefill"}
+    # Kimi K2: scoring_func=sigmoid, correction_bias, renormalize=True, routed_scaling_factor=2.827
+    - {num_tokens: 512,  num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, scoring_func: sigmoid, renormalize: true, routed_scaling_factor: 2.827, dtypes: [bfloat16], label: "kimi-k2-decode"}
+    - {num_tokens: 4096, num_experts: 256, top_k: 8, hidden_size: 7168, ffn_size: 2048, scoring_func: sigmoid, renormalize: true, routed_scaling_factor: 2.827, dtypes: [bfloat16], label: "kimi-k2-prefill"}
 
   roofline:
     func: "tileops.perf.formulas.fused_moe_fwd_bytes"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -165,7 +165,7 @@ MoePermuteNopadFwdOp:
     # Permute is memory-bound; flops = 0
     flops: "0"
     # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + total_tokens * top_k * 4 + num_experts * 8"
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 4 * total_tokens * top_k * 4 + num_experts * 8"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -311,7 +311,7 @@ FusedMoeExpertsPaddedFwdOp:
 MoeGroupedGemmNopadFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -330,7 +330,12 @@ MoeGroupedGemmNopadFwdOp:
       - "c.shape == (numel, n)"
 
   workloads:
-    - {numel: 4096, num_experts: 256, n: 4096, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-gate-up"}
+    # Tight grouped-GEMM shapes representative of DeepSeek-V3 MoE
+    # (E=256, K=8, H=7168, F=2048; numel = num_tokens * top_k).
+    - {numel: 4096, num_experts: 256, n: 4096, k: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode-gate-up"}
+    - {numel: 32768, num_experts: 256, n: 4096, k: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill-gate-up"}
+    - {numel: 4096, num_experts: 256, n: 7168, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-decode-down"}
+    - {numel: 32768, num_experts: 256, n: 7168, k: 2048, dtypes: [bfloat16], label: "deepseek-v3-prefill-down"}
 
   roofline:
     flops: "2 * numel * n * k"
@@ -341,6 +346,8 @@ MoeGroupedGemmNopadFwdOp:
     op: tileops/ops/moe/moe_grouped_gemm_nopad.py
     test: tests/ops/test_moe_fused_moe.py
     bench: benchmarks/ops/bench_moe_fused_moe.py
+    kernel_map:
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
 
 MoEExpertsNopadFwdOp:
   ref_api: "none"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -119,7 +119,7 @@ MoePermuteAlignFwdOp:
 MoePermuteNopadFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -170,9 +170,11 @@ MoePermuteNopadFwdOp:
   source:
     kernel: tileops/kernels/moe/permute_nopad.py
     op: tileops/ops/moe/permute_nopad.py
-    test: tests/ops/test_moe_permute.py
+    test: tests/ops/test_moe_permute_nopad.py
     bench: benchmarks/ops/bench_moe_permute_nopad.py
     bench_manifest_driven: true
+    kernel_map:
+      permute_nopad_kernel: MoePermuteNopadKernel
 
 MoeUnpermuteFwdOp:
   ref_api: "none"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -458,7 +458,7 @@ MoEExpertsPaddedFwdOp:
 FusedMoeFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -499,11 +499,17 @@ FusedMoeFwdOp:
     test: tests/ops/test_moe_fused_moe.py
     bench: benchmarks/ops/bench_moe_fused_moe.py
     bench_manifest_driven: true
+    kernel_map:
+      fused_topk_kernel: FusedTopKKernel
+      permute_nopad_kernel: MoePermuteNopadKernel
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeFwdCbFwdOp:
   ref_api: "none"
   family: moe
-  status: spec-only
+  status: implemented
   variant_of: FusedMoeFwdOp
 
   signature:
@@ -544,3 +550,9 @@ FusedMoeFwdCbFwdOp:
     test: tests/ops/test_moe_fused_moe.py
     bench: benchmarks/ops/bench_moe_fused_moe.py
     bench_manifest_driven: true
+    kernel_map:
+      fused_topk_kernel: FusedTopKKernel
+      permute_nopad_kernel: MoePermuteNopadKernel
+      moe_grouped_gemm_kernel: MoeGroupedGemmNopadKernel
+      silu_and_mul: SiluAndMulFwdKernel
+      unpermute_kernel: MoeUnpermuteKernel

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -165,7 +165,7 @@ MoePermuteNopadFwdOp:
     # Permute is memory-bound; flops = 0
     flops: "0"
     # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 4 * total_tokens * top_k * 4 + num_experts * 8"
+    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 2 * total_tokens * top_k * 4 + num_experts * 8"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -7,8 +7,7 @@
 RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
-  # spec-only: shape_rules reference runtime-bound normalized_shape param without manifest default
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/ops/elementwise/masked_fill.py
+++ b/tileops/ops/elementwise/masked_fill.py
@@ -51,6 +51,21 @@ class MaskedFillFwdOp(Op):
             raise ValueError(
                 f"MaskedFillFwdOp requires a 0-dim value Tensor; got shape {tuple(value)}"
             )
+        # The kernel handles ints and fp16/bf16/fp32 directly. The bool
+        # dtype is supported here at the Op layer via uint8 storage view,
+        # since TileLang's bool tensor codegen is not vectorized; the
+        # user-facing contract still exposes ``torch.bool``.
+        kernel_supported = MaskedFillTensorValueFwdKernel.SUPPORTED_DTYPES
+        if (
+            dtype != torch.bool
+            and kernel_supported is not None
+            and dtype not in kernel_supported
+        ):
+            names = ", ".join(str(dt) for dt in (torch.bool, *kernel_supported))
+            raise ValueError(
+                f"{self._op_name} does not support dtype {dtype}. "
+                f"Supported: [{names}]"
+            )
         self.input_shape = tuple(input)
         self.mask_shape = tuple(mask)
         self.value_shape = tuple(value)
@@ -58,7 +73,10 @@ class MaskedFillFwdOp(Op):
         self.out_shape = tuple(torch.broadcast_shapes(self.input_shape, self.mask_shape))
         self.N_total = prod(self.out_shape) if self.out_shape else 1
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["masked_fill_tensor_value"](self.N_total, dtype)
+        # Bool input path: the kernel runs in uint8 storage.
+        self._bool_storage = dtype == torch.bool
+        kernel_dtype = torch.uint8 if self._bool_storage else dtype
+        self.kernel = self.kernel_map["masked_fill_tensor_value"](self.N_total, kernel_dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
@@ -79,10 +97,16 @@ class MaskedFillFwdOp(Op):
         # the 0-dim value to (1,), and dispatch the TileLang kernel.
         out_shape = self.out_shape if self.out_shape else (1,)
         x_flat = self._expand_flat(input, out_shape)
+        if self._bool_storage:
+            x_flat = x_flat.view(torch.uint8)
         mask_b = mask if mask.dtype == torch.bool else mask.bool()
         mask_flat = self._expand_flat(mask_b, out_shape).view(torch.uint8)
         value_1d = value.contiguous().view(1)
+        if self._bool_storage:
+            value_1d = value_1d.view(torch.uint8)
         result = self.kernel(x_flat, mask_flat, value_1d)
+        if self._bool_storage:
+            result = result.view(torch.bool)
         return result.view(self.out_shape if self.out_shape else ())
 
     def forward(

--- a/tileops/ops/elementwise/masked_fill.py
+++ b/tileops/ops/elementwise/masked_fill.py
@@ -51,10 +51,8 @@ class MaskedFillFwdOp(Op):
             raise ValueError(
                 f"MaskedFillFwdOp requires a 0-dim value Tensor; got shape {tuple(value)}"
             )
-        # The kernel handles ints and fp16/bf16/fp32 directly. The bool
-        # dtype is supported here at the Op layer via uint8 storage view,
-        # since TileLang's bool tensor codegen is not vectorized; the
-        # user-facing contract still exposes ``torch.bool``.
+        # Bool routes through uint8 at the Op layer (TileLang bool codegen is unvectorized);
+        # all other dtypes go straight to the kernel.
         kernel_supported = MaskedFillTensorValueFwdKernel.SUPPORTED_DTYPES
         if (
             dtype != torch.bool
@@ -176,10 +174,8 @@ class MaskedFillScalarFwdOp(Op):
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
-        # The kernel handles ints and fp16/bf16/fp32 directly. The bool
-        # dtype is supported here at the Op layer via uint8 storage view,
-        # since TileLang's bool tensor codegen is not vectorized; the
-        # user-facing contract still exposes ``torch.bool``.
+        # Bool routes through uint8 at the Op layer (TileLang bool codegen is unvectorized);
+        # all other dtypes go straight to the kernel.
         kernel_supported = MaskedFillFwdKernel.SUPPORTED_DTYPES
         if (
             dtype != torch.bool

--- a/tileops/ops/moe/__init__.py
+++ b/tileops/ops/moe/__init__.py
@@ -10,7 +10,7 @@ from .abc import (
 )
 from .experts.nopad import MoEExpertsNopadFwdOp
 from .experts.padded import MoEExpertsPaddedFwdOp
-from .fused_moe import FusedMoe
+from .fused_moe import FusedMoe, FusedMoeFwdCbFwdOp, FusedMoeFwdOp
 from .fused_moe_experts import FusedMoeExpertsFwdOp, FusedMoeExpertsPaddedFwdOp
 from .fused_topk import FusedTopKOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
@@ -25,6 +25,8 @@ __all__ = [
     "FusedMoe",
     "FusedMoeExpertsFwdOp",
     "FusedMoeExpertsPaddedFwdOp",
+    "FusedMoeFwdCbFwdOp",
+    "FusedMoeFwdOp",
     "FusedTopKOp",
     "MoEExperts",
     "MoEExpertsModular",

--- a/tileops/ops/moe/experts/nopad.py
+++ b/tileops/ops/moe/experts/nopad.py
@@ -2,21 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from torch import Tensor
 
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops.elementwise import SiluAndMulFwdOp
 from tileops.ops.moe.abc import MoEExpertsModular, WeightedReduce, WeightedReduceNoOp
 from tileops.ops.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
 from tileops.ops.moe.permute_nopad import MoePermuteNopadFwdOp
 from tileops.ops.moe.unpermute import MoeUnpermuteFwdOp
+from tileops.ops.op_base import Op
 
 __all__ = ["MoEExpertsNopadFwdOp"]
 
 
-class MoEExpertsNopadFwdOp(MoEExpertsModular):
+class MoEExpertsNopadFwdOp(MoEExpertsModular, Op):
     """Expert GEMM using tight (T*K rows, no-pad) layout with GPU tile scheduler.
 
     Internal pipeline: MoePermuteNopadFwdOp → gate_up GEMM → SwiGLU →
@@ -36,7 +38,18 @@ class MoEExpertsNopadFwdOp(MoEExpertsModular):
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        self.num_tokens = num_tokens
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.ffn_size = ffn_size
+        self.dtype = dtype
+        self._expert_map = expert_map
+
+        self.dispatch_kernel(kernel_map)
+
         numel = num_tokens * top_k
         num_experts_local = (
             int((expert_map >= 0).sum().item()) if expert_map is not None else num_experts
@@ -45,21 +58,56 @@ class MoEExpertsNopadFwdOp(MoEExpertsModular):
         self._permute = MoePermuteNopadFwdOp(
             num_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
             hidden_size=hidden_size, dtype=dtype, expert_map=expert_map,
+            kernel_map=kernel_map,
         )
         self._gemm_gate_up = MoeGroupedGemmNopadFwdOp(
             numel=numel, num_experts=num_experts_local,
             n=ffn_size * 2, k=hidden_size, dtype=dtype,
+            kernel_map=kernel_map,
         )
-        self._silu_and_mul = SiluAndMulFwdOp(M=numel, N=ffn_size, dtype=dtype)
+        self._silu_and_mul = SiluAndMulFwdOp(
+            M=numel, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
+        )
         self._gemm_down = MoeGroupedGemmNopadFwdOp(
             numel=numel, num_experts=num_experts_local,
             n=hidden_size, k=ffn_size, dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._unpermute = MoeUnpermuteFwdOp(
-            num_tokens=num_tokens, top_k=top_k,
+            total_tokens=num_tokens, top_k=top_k,
             hidden_size=hidden_size, dtype=dtype, padded_batch_sum=numel,
+            kernel_map=kernel_map,
         )
         self._routed_scaling_factor = routed_scaling_factor
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {}
+
+    def forward(
+        self,
+        hidden_states: Tensor,   # [T, H]
+        w_gate_up: Tensor,       # [E, 2F, H]
+        w_down: Tensor,          # [E, H, F]
+        topk_weights: Tensor,    # [T, K] float32
+        topk_ids: Tensor,        # [T, K] int32
+    ) -> Tensor:                  # [T, H]
+        """Allocating wrapper around apply(): runs the expert pipeline and returns the output.
+
+        Mirrors FusedMoeExpertsFwdOp.forward() semantics so the manifest signature
+        (hidden_states, w_gate_up, w_down, topk_weights, topk_ids) -> output is
+        satisfied at the validator's Op-class resolution path.
+        """
+        perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(
+            hidden_states, topk_ids
+        )
+        gate_up = self._gemm_gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
+        act = self._silu_and_mul(gate_up)
+        mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
+        output = self._unpermute(mm2, fwd_idx, topk_weights)
+        if self._routed_scaling_factor != 1.0:
+            output.mul_(self._routed_scaling_factor)
+        return output
 
     def workspace_shapes(
         self, M: int, N: int, K: int, topk: int, num_experts: int,

--- a/tileops/ops/moe/experts/nopad.py
+++ b/tileops/ops/moe/experts/nopad.py
@@ -56,7 +56,7 @@ class MoEExpertsNopadFwdOp(MoEExpertsModular, Op):
         )
 
         self._permute = MoePermuteNopadFwdOp(
-            num_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
+            total_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
             hidden_size=hidden_size, dtype=dtype, expert_map=expert_map,
             kernel_map=kernel_map,
         )

--- a/tileops/ops/moe/experts/nopad.py
+++ b/tileops/ops/moe/experts/nopad.py
@@ -92,12 +92,7 @@ class MoEExpertsNopadFwdOp(MoEExpertsModular, Op):
         topk_weights: Tensor,    # [T, K] float32
         topk_ids: Tensor,        # [T, K] int32
     ) -> Tensor:                  # [T, H]
-        """Allocating wrapper around apply(): runs the expert pipeline and returns the output.
-
-        Mirrors FusedMoeExpertsFwdOp.forward() semantics so the manifest signature
-        (hidden_states, w_gate_up, w_down, topk_weights, topk_ids) -> output is
-        satisfied at the validator's Op-class resolution path.
-        """
+        """Allocating wrapper: run the expert pipeline and return the output tensor."""
         perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(
             hidden_states, topk_ids
         )

--- a/tileops/ops/moe/experts/padded.py
+++ b/tileops/ops/moe/experts/padded.py
@@ -2,24 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from torch import Tensor
 
 from tileops.kernels.grouped_gemm import _DEFAULT_CONFIGS as _GEMM_DEFAULT_CONFIGS
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops.elementwise import SiluAndMulFwdOp
 from tileops.ops.grouped_gemm import GroupedGemmOp
 from tileops.ops.moe.abc import MoEExpertsModular, WeightedReduce, WeightedReduceNoOp
 from tileops.ops.moe.permute_padded import MoePermutePaddedFwdOp
 from tileops.ops.moe.unpermute import MoeUnpermuteFwdOp
+from tileops.ops.op_base import Op
 
 __all__ = ["MoEExpertsPaddedFwdOp"]
 
 _BLOCK_M: int = _GEMM_DEFAULT_CONFIGS[(False, True)]["block_m"]
 
 
-class MoEExpertsPaddedFwdOp(MoEExpertsModular):
+class MoEExpertsPaddedFwdOp(MoEExpertsModular, Op):
     """Expert GEMM using block_m-aligned padded layout (reference baseline).
 
     Internal pipeline: MoePermutePaddedFwdOp → gate_up GEMM → SwiGLU →
@@ -38,7 +40,17 @@ class MoEExpertsPaddedFwdOp(MoEExpertsModular):
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        self.num_tokens = num_tokens
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.ffn_size = ffn_size
+        self.dtype = dtype
+
+        self.dispatch_kernel(kernel_map)
+
         if expert_map is not None:
             raise NotImplementedError(
                 "expert_map is not supported for padded layout. "
@@ -48,23 +60,61 @@ class MoEExpertsPaddedFwdOp(MoEExpertsModular):
         padded_batch_sum = numel + (num_experts * (_BLOCK_M - 1))
 
         self._permute = MoePermutePaddedFwdOp(
-            num_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
+            total_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
             hidden_size=hidden_size, dtype=dtype, block_m=_BLOCK_M,
+            kernel_map=kernel_map,
         )
         self._gemm_gate_up = GroupedGemmOp(
             batch_sum=padded_batch_sum, batch_count=num_experts,
             n=ffn_size * 2, k=hidden_size, dtype=dtype,
+            kernel_map=kernel_map,
         )
-        self._silu_and_mul = SiluAndMulFwdOp(M=padded_batch_sum, N=ffn_size, dtype=dtype)
+        self._silu_and_mul = SiluAndMulFwdOp(
+            M=padded_batch_sum, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
+        )
         self._gemm_down = GroupedGemmOp(
             batch_sum=padded_batch_sum, batch_count=num_experts,
             n=hidden_size, k=ffn_size, dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._unpermute = MoeUnpermuteFwdOp(
-            num_tokens=num_tokens, top_k=top_k,
+            total_tokens=num_tokens, top_k=top_k,
             hidden_size=hidden_size, dtype=dtype, padded_batch_sum=padded_batch_sum,
+            kernel_map=kernel_map,
         )
         self._routed_scaling_factor = routed_scaling_factor
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {}
+
+    def forward(
+        self,
+        hidden_states: Tensor,   # [T, H]
+        w_gate_up: Tensor,       # [E, 2F, H]
+        w_down: Tensor,          # [E, H, F]
+        topk_weights: Tensor,    # [T, K] float32
+        topk_ids: Tensor,        # [T, K] int32
+    ) -> Tensor:                  # [T, H]
+        """Allocating wrapper around apply(): runs the expert pipeline and returns the output.
+
+        Mirrors FusedMoeExpertsPaddedFwdOp.forward() semantics so the manifest
+        signature is satisfied at the validator's Op-class resolution path.
+        """
+        perm_h_pad, padded_offsets, padded_sizes, _, fwd_idx = self._permute(
+            hidden_states, topk_ids
+        )
+        gate_up_pad = self._gemm_gate_up(
+            perm_h_pad, w_gate_up, padded_sizes, padded_offsets, padded_offsets
+        )
+        act_pad = self._silu_and_mul(gate_up_pad)
+        mm2_pad = self._gemm_down(
+            act_pad, w_down, padded_sizes, padded_offsets, padded_offsets
+        )
+        output = self._unpermute(mm2_pad, fwd_idx, topk_weights)
+        if self._routed_scaling_factor != 1.0:
+            output.mul_(self._routed_scaling_factor)
+        return output
 
     def workspace_shapes(
         self, M: int, N: int, K: int, topk: int, num_experts: int,

--- a/tileops/ops/moe/experts/padded.py
+++ b/tileops/ops/moe/experts/padded.py
@@ -96,11 +96,7 @@ class MoEExpertsPaddedFwdOp(MoEExpertsModular, Op):
         topk_weights: Tensor,    # [T, K] float32
         topk_ids: Tensor,        # [T, K] int32
     ) -> Tensor:                  # [T, H]
-        """Allocating wrapper around apply(): runs the expert pipeline and returns the output.
-
-        Mirrors FusedMoeExpertsPaddedFwdOp.forward() semantics so the manifest
-        signature is satisfied at the validator's Op-class resolution path.
-        """
+        """Allocating wrapper: run the expert pipeline and return the output tensor."""
         perm_h_pad, padded_offsets, padded_sizes, _, fwd_idx = self._permute(
             hidden_states, topk_ids
         )

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -1,12 +1,16 @@
-"""Unified routed MoE FFN operator — FusedMoe.
+"""Routed Mixture-of-Experts (MoE) FFN operators.
 
-Combines FusedTopKOp (routing) and MoEExpertsModular (permute + GEMM + unpermute)
-with MoEPrepareAndFinalize (quantization + EP communication) via the ABC protocol.
+Two manifest identities share a single composite implementation:
 
-Backwards-compatible: existing callers pass num_tokens / num_experts / ... as before.
-When prepare_finalize / experts are None, defaults are created from the layout param.
+- ``FusedMoeFwdOp`` — routing + expert FFN without a routing correction bias
+  (Qwen3 / DeepSeek-V3 style).
+- ``FusedMoeFwdCbFwdOp`` — same flow but accepts a per-expert correction bias
+  applied during top-k selection (Kimi K2 style).
 
-Does NOT handle shared experts (handled by SharedFusedMoe).
+The shared core (`FusedMoe`) wires `FusedTopKOp` (routing),
+`MoEPrepareAndFinalize` (quantization / EP dispatch), and an
+`MoEExpertsModular` implementation (permute + GEMM + unpermute). Shared
+expert handling belongs to `SharedFusedMoE`.
 """
 
 from typing import Dict, Optional
@@ -22,32 +26,32 @@ from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPE
 
 from ..op_base import Op
 
-__all__ = ["FusedMoe"]
+__all__ = ["FusedMoe", "FusedMoeFwdCbFwdOp", "FusedMoeFwdOp"]
 
 
 class FusedMoe(Op):
-    """Unified routed MoE FFN Op (routing + GEMM), analogous to vLLM FusedMoE.
+    """Shared composite implementation for routed MoE FFN ops.
 
-    Does NOT process shared experts.  Shared expert handling belongs to the
-    upper layer (SharedFusedMoe / model-specific MoE).
+    Concrete manifest identities (`FusedMoeFwdOp`, `FusedMoeFwdCbFwdOp`)
+    subclass this to pin the correction-bias variant; both share the
+    routing-and-expert pipeline below.
 
     Args:
-        num_tokens: T — number of input tokens.
-        num_experts: E — total number of experts (global count).
-        top_k: K — experts selected per token.
-        hidden_size: H — model hidden dimension.
-        ffn_size: F — per-expert intermediate dimension.
+        num_tokens: T -- number of input tokens.
+        num_experts: E -- total number of experts (global count).
+        top_k: K -- experts selected per token.
+        hidden_size: H -- model hidden dimension.
+        ffn_size: F -- per-expert intermediate dimension.
         scoring_func: "softmax" (Qwen3) or "sigmoid" (Kimi K2 / DeepSeek-V3).
-        renormalize: Renormalize top-k weights to sum to 1. Default False.
-        with_correction_bias: Accept correction_bias in forward(). Default False.
+        renormalize: Renormalize top-k weights to sum to 1.
+        with_correction_bias: Accept `correction_bias` during routing.
         routed_scaling_factor: Multiplier on expert output (Kimi K2: 2.827).
-        layout: "nopad" (default) or "padded". Ignored when experts is provided.
+        layout: "nopad" (default) or "padded". Ignored when `experts` is provided.
         dtype: Activation and weight dtype.
-        expert_map: [E_global] int32 for EP local filtering. None = no EP.
+        expert_map: [E_global] int32 for Expert Parallel local filtering.
         prepare_finalize: Override the PrepareAndFinalize implementation.
-            Default: MoEPrepareAndFinalizeNoDPEP (no EP, no quantization).
         experts: Override the Experts implementation.
-            Default: MoEExpertsNopadFwdOp (layout="nopad") or MoEExpertsPaddedFwdOp.
+        kernel_map: Override the dispatched kernel map.
     """
 
     def __init__(
@@ -66,6 +70,7 @@ class FusedMoe(Op):
         expert_map: Optional[torch.Tensor] = None,
         prepare_finalize: Optional[MoEPrepareAndFinalize] = None,
         experts: Optional[MoEExpertsModular] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -80,6 +85,8 @@ class FusedMoe(Op):
         self.dtype = dtype
         self.expert_map = expert_map
 
+        self.dispatch_kernel(kernel_map)
+
         self._fused_topk = FusedTopKOp(
             num_tokens=num_tokens,
             num_experts=num_experts,
@@ -87,6 +94,7 @@ class FusedMoe(Op):
             scoring_func=scoring_func,
             renormalize=renormalize,
             with_correction_bias=with_correction_bias,
+            kernel_map=kernel_map,
         )
 
         self._prepare: MoEPrepareAndFinalize = (
@@ -115,6 +123,7 @@ class FusedMoe(Op):
                 routed_scaling_factor=routed_scaling_factor,
                 dtype=dtype,
                 expert_map=expert_map,
+                kernel_map=kernel_map,
             )
 
     @property
@@ -127,18 +136,15 @@ class FusedMoe(Op):
         gating_output: torch.Tensor,                    # [T, E]
         w_gate_up: torch.Tensor,                        # [E, 2*F, H]
         w_down: torch.Tensor,                           # [E, H, F]
-        correction_bias: Optional[torch.Tensor] = None, # [E] float32, or None
+        correction_bias: Optional[torch.Tensor] = None, # [E] float32
     ) -> torch.Tensor:                                  # [T, H]
-        # 1. Routing
         topk_weights, topk_ids = self._fused_topk(gating_output, correction_bias)
 
-        # 2. Prepare (quantization / EP dispatch)
         r = self._prepare.prepare(
             hidden_states, topk_weights, topk_ids,
             self.num_experts, expert_map=self.expert_map,
         )
 
-        # 3. Expert GEMM
         T_prime = r.hidden_q.shape[0]
         ws1_shape, ws2_shape = self._experts.workspace_shapes(
             T_prime, self.ffn_size, self.hidden_size,
@@ -157,10 +163,117 @@ class FusedMoe(Op):
             workspace1=ws1, workspace2=ws2,
         )
 
-        # 4. Finalize (weighted reduction / EP gather)
         self._prepare.finalize(
             output, expert_out,
             r.topk_weights, r.topk_ids,
             self._experts.make_weighted_reduce(),
         )
         return output
+
+
+class FusedMoeFwdOp(FusedMoe):
+    """Routed MoE FFN without a routing correction bias.
+
+    Covers Qwen3 (softmax) and DeepSeek-V3 (sigmoid) style configurations
+    where top-k is computed directly from the gating scores.
+    """
+
+    def __init__(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        ffn_size: int,
+        scoring_func: str = "softmax",
+        renormalize: bool = False,
+        routed_scaling_factor: float = 1.0,
+        layout: str = "nopad",
+        dtype: torch.dtype = torch.bfloat16,
+        expert_map: Optional[torch.Tensor] = None,
+        prepare_finalize: Optional[MoEPrepareAndFinalize] = None,
+        experts: Optional[MoEExpertsModular] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+    ):
+        super().__init__(
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            ffn_size=ffn_size,
+            scoring_func=scoring_func,
+            renormalize=renormalize,
+            with_correction_bias=False,
+            routed_scaling_factor=routed_scaling_factor,
+            layout=layout,
+            dtype=dtype,
+            expert_map=expert_map,
+            prepare_finalize=prepare_finalize,
+            experts=experts,
+            kernel_map=kernel_map,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        w_gate_up: torch.Tensor,
+        w_down: torch.Tensor,
+    ) -> torch.Tensor:
+        return super().forward(hidden_states, gating_output, w_gate_up, w_down, None)
+
+
+class FusedMoeFwdCbFwdOp(FusedMoe):
+    """Routed MoE FFN with a per-expert routing correction bias.
+
+    Covers Kimi K2 style configurations: top-k is selected from
+    ``sigmoid(score) + correction_bias`` while the final weights use the
+    original (unbiased) sigmoid scores, renormalized.
+    """
+
+    def __init__(
+        self,
+        num_tokens: int,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        ffn_size: int,
+        scoring_func: str = "sigmoid",
+        renormalize: bool = False,
+        routed_scaling_factor: float = 1.0,
+        layout: str = "nopad",
+        dtype: torch.dtype = torch.bfloat16,
+        expert_map: Optional[torch.Tensor] = None,
+        prepare_finalize: Optional[MoEPrepareAndFinalize] = None,
+        experts: Optional[MoEExpertsModular] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+    ):
+        super().__init__(
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            ffn_size=ffn_size,
+            scoring_func=scoring_func,
+            renormalize=renormalize,
+            with_correction_bias=True,
+            routed_scaling_factor=routed_scaling_factor,
+            layout=layout,
+            dtype=dtype,
+            expert_map=expert_map,
+            prepare_finalize=prepare_finalize,
+            experts=experts,
+            kernel_map=kernel_map,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        correction_bias: torch.Tensor,
+        w_gate_up: torch.Tensor,
+        w_down: torch.Tensor,
+    ) -> torch.Tensor:
+        return super().forward(
+            hidden_states, gating_output, w_gate_up, w_down, correction_bias,
+        )

--- a/tileops/ops/moe/fused_moe_experts.py
+++ b/tileops/ops/moe/fused_moe_experts.py
@@ -90,7 +90,7 @@ class FusedMoeExpertsFwdOp(Op):
         )
 
         self._permute = MoePermuteNopadFwdOp(
-            num_tokens=num_tokens,
+            total_tokens=num_tokens,
             top_k=top_k,
             num_experts=num_experts,
             hidden_size=hidden_size,

--- a/tileops/ops/moe/fused_moe_experts.py
+++ b/tileops/ops/moe/fused_moe_experts.py
@@ -72,6 +72,7 @@ class FusedMoeExpertsFwdOp(Op):
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[torch.Tensor] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -80,6 +81,8 @@ class FusedMoeExpertsFwdOp(Op):
         self.ffn_size = ffn_size
         self.routed_scaling_factor = routed_scaling_factor
         self.dtype = dtype
+
+        self.dispatch_kernel(kernel_map)
 
         numel = num_tokens * top_k
         num_experts_local = (
@@ -93,6 +96,7 @@ class FusedMoeExpertsFwdOp(Op):
             hidden_size=hidden_size,
             dtype=dtype,
             expert_map=expert_map,
+            kernel_map=kernel_map,
         )
         self._gemm_gate_up = MoeGroupedGemmNopadFwdOp(
             numel=numel,
@@ -100,11 +104,13 @@ class FusedMoeExpertsFwdOp(Op):
             n=ffn_size * 2,
             k=hidden_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._silu_and_mul = SiluAndMulFwdOp(
             M=numel,
             N=ffn_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._gemm_down = MoeGroupedGemmNopadFwdOp(
             numel=numel,
@@ -112,13 +118,15 @@ class FusedMoeExpertsFwdOp(Op):
             n=hidden_size,
             k=ffn_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._unpermute = MoeUnpermuteFwdOp(
-            num_tokens=num_tokens,
+            total_tokens=num_tokens,
             top_k=top_k,
             hidden_size=hidden_size,
             dtype=dtype,
             padded_batch_sum=numel,
+            kernel_map=kernel_map,
         )
 
     @property
@@ -188,6 +196,7 @@ class FusedMoeExpertsPaddedFwdOp(Op):
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[torch.Tensor] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -196,6 +205,9 @@ class FusedMoeExpertsPaddedFwdOp(Op):
         self.ffn_size = ffn_size
         self.routed_scaling_factor = routed_scaling_factor
         self.dtype = dtype
+
+        self.dispatch_kernel(kernel_map)
+
         if expert_map is not None:
             raise NotImplementedError(
                 "expert_map is not yet supported for the padded layout. "
@@ -206,12 +218,13 @@ class FusedMoeExpertsPaddedFwdOp(Op):
         _padded_batch_sum = numel + (num_experts * (_BLOCK_M - 1))
 
         self._permute = MoePermutePaddedFwdOp(
-            num_tokens=num_tokens,
+            total_tokens=num_tokens,
             top_k=top_k,
             num_experts=num_experts,
             hidden_size=hidden_size,
             dtype=dtype,
             block_m=_BLOCK_M,
+            kernel_map=kernel_map,
         )
         self._gemm_gate_up = GroupedGemmOp(
             batch_sum=_padded_batch_sum,
@@ -219,11 +232,13 @@ class FusedMoeExpertsPaddedFwdOp(Op):
             n=ffn_size * 2,
             k=hidden_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._silu_and_mul = SiluAndMulFwdOp(
             M=_padded_batch_sum,
             N=ffn_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._gemm_down = GroupedGemmOp(
             batch_sum=_padded_batch_sum,
@@ -231,13 +246,15 @@ class FusedMoeExpertsPaddedFwdOp(Op):
             n=hidden_size,
             k=ffn_size,
             dtype=dtype,
+            kernel_map=kernel_map,
         )
         self._unpermute = MoeUnpermuteFwdOp(
-            num_tokens=num_tokens,
+            total_tokens=num_tokens,
             top_k=top_k,
             hidden_size=hidden_size,
             dtype=dtype,
             padded_batch_sum=_padded_batch_sum,
+            kernel_map=kernel_map,
         )
 
     @property

--- a/tileops/ops/moe/moe_grouped_gemm_nopad.py
+++ b/tileops/ops/moe/moe_grouped_gemm_nopad.py
@@ -48,8 +48,8 @@ class MoeGroupedGemmNopadFwdOp(Op):
     ) -> None:
         self.numel = numel
         self.num_experts = num_experts
-        self.N = n
-        self.K = k
+        self.n = n
+        self.k = k
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)

--- a/tileops/ops/moe/permute_align.py
+++ b/tileops/ops/moe/permute_align.py
@@ -20,32 +20,36 @@ class MoePermuteAlignFwdOp(Op):
     padded token count.
 
     Args:
-        numel: Total (token, expert) assignments = total_tokens * top_k.
+        total_tokens: Number of input tokens T.
+        top_k: Number of experts selected per token K.
         num_experts: Number of experts.
-        block_size: GEMM tile size (M dimension).
+        block_size: GEMM tile size (M dimension); default 64.
         kernel_map: Optional kernel override dict.
         tune: Whether to autotune the kernel.
 
     Example:
-        >>> op = MoePermuteAlignFwdOp(numel=32, num_experts=8, block_size=16)
+        >>> op = MoePermuteAlignFwdOp(total_tokens=4, top_k=8, num_experts=8, block_size=16)
         >>> sorted_ids, expert_ids, num_post_pad = op(topk_ids)
     """
 
     def __init__(
         self,
-        numel: int,
+        total_tokens: int,
+        top_k: int,
         num_experts: int,
-        block_size: int,
+        block_size: int = 64,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.numel = numel
+        self.total_tokens = total_tokens
+        self.top_k = top_k
         self.num_experts = num_experts
         self.block_size = block_size
+        self.numel = total_tokens * top_k
 
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["permute_align_kernel"](
-            numel, num_experts, block_size
+            self.numel, num_experts, block_size
         )
 
     @property

--- a/tileops/ops/moe/permute_nopad.py
+++ b/tileops/ops/moe/permute_nopad.py
@@ -60,18 +60,8 @@ class MoePermuteNopadFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"permute_nopad_kernel": MoePermuteNopadKernel}
 
-    def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
-        flops = 0
-        mem_bytes = (
-            (self.total_tokens * self.hidden_size
-             + self.total_tokens * self.top_k * self.hidden_size)
-            * elem_bytes
-            + (self.num_experts + 1) * 8
-            + self.total_tokens * self.top_k * 4
-            + self.num_experts * 8
-        )
-        return flops, mem_bytes
+    # eval_roofline is installed by tileops.ops._roofline_codegen from the
+    # manifest roofline.bytes / roofline.flops expressions; no manual override.
 
     def forward(
         self,

--- a/tileops/ops/moe/permute_nopad.py
+++ b/tileops/ops/moe/permute_nopad.py
@@ -20,7 +20,7 @@ class MoePermuteNopadFwdOp(Op):
     the MoE pipeline.
 
     Args:
-        num_tokens: Number of input tokens T.
+        total_tokens: Number of input tokens T.
         top_k: Number of experts selected per token K.
         num_experts: Total number of experts E (global count).
         hidden_size: Hidden dimension H.
@@ -31,13 +31,13 @@ class MoePermuteNopadFwdOp(Op):
         kernel_map: Optional kernel override dict.
 
     Example:
-        >>> op = MoePermuteNopadFwdOp(num_tokens=4, top_k=2, num_experts=8, hidden_size=128)
+        >>> op = MoePermuteNopadFwdOp(total_tokens=4, top_k=2, num_experts=8, hidden_size=128)
         >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
     """
 
     def __init__(
         self,
-        num_tokens: int,
+        total_tokens: int,
         top_k: int,
         num_experts: int,
         hidden_size: int,
@@ -45,7 +45,7 @@ class MoePermuteNopadFwdOp(Op):
         expert_map: Optional[torch.Tensor] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
-        self.num_tokens = num_tokens
+        self.total_tokens = total_tokens
         self.top_k = top_k
         self.num_experts = num_experts
         self.hidden_size = hidden_size
@@ -53,7 +53,7 @@ class MoePermuteNopadFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["permute_nopad_kernel"](
-            num_tokens, top_k, num_experts, hidden_size, dtype, expert_map
+            total_tokens, top_k, num_experts, hidden_size, dtype, expert_map
         )
 
     @property
@@ -64,11 +64,11 @@ class MoePermuteNopadFwdOp(Op):
         elem_bytes = self.dtype.itemsize
         flops = 0
         mem_bytes = (
-            (self.num_tokens * self.hidden_size
-             + self.num_tokens * self.top_k * self.hidden_size)
+            (self.total_tokens * self.hidden_size
+             + self.total_tokens * self.top_k * self.hidden_size)
             * elem_bytes
             + (self.num_experts + 1) * 8
-            + self.num_tokens * self.top_k * 4
+            + self.total_tokens * self.top_k * 4
             + self.num_experts * 8
         )
         return flops, mem_bytes

--- a/tileops/ops/moe/permute_padded.py
+++ b/tileops/ops/moe/permute_padded.py
@@ -16,7 +16,7 @@ class MoePermutePaddedFwdOp(Op):
     """Route tokens to block_m-aligned padded expert layout for NT grouped-GEMM.
 
     Args:
-        num_tokens: Number of input tokens T.
+        total_tokens: Number of input tokens T.
         top_k: Number of experts selected per token K.
         num_experts: Total number of experts E.
         hidden_size: Hidden dimension H.
@@ -25,13 +25,13 @@ class MoePermutePaddedFwdOp(Op):
         kernel_map: Optional kernel override dict.
 
     Example:
-        >>> op = MoePermutePaddedFwdOp(num_tokens=4, top_k=2, num_experts=8, hidden_size=128)
+        >>> op = MoePermutePaddedFwdOp(total_tokens=4, top_k=2, num_experts=8, hidden_size=128)
         >>> perm_h_pad, p_offsets, p_sizes, offsets, fwd_idx = op(hidden_states, topk_ids)
     """
 
     def __init__(
         self,
-        num_tokens: int,
+        total_tokens: int,
         top_k: int,
         num_experts: int,
         hidden_size: int,
@@ -39,7 +39,7 @@ class MoePermutePaddedFwdOp(Op):
         block_m: int = 64,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
-        self.num_tokens = num_tokens
+        self.total_tokens = total_tokens
         self.top_k = top_k
         self.num_experts = num_experts
         self.hidden_size = hidden_size
@@ -48,7 +48,7 @@ class MoePermutePaddedFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["permute_kernel"](
-            num_tokens, top_k, num_experts, hidden_size, dtype, block_m
+            total_tokens, top_k, num_experts, hidden_size, dtype, block_m
         )
 
     @property
@@ -59,11 +59,11 @@ class MoePermutePaddedFwdOp(Op):
         elem_bytes = self.dtype.itemsize
         flops = 0
         mem_bytes = (
-            (self.num_tokens * self.hidden_size
-             + self.num_tokens * self.top_k * self.hidden_size)
+            (self.total_tokens * self.hidden_size
+             + self.total_tokens * self.top_k * self.hidden_size)
             * elem_bytes
             + (self.num_experts + 1) * 8
-            + self.num_tokens * self.top_k * 4
+            + self.total_tokens * self.top_k * 4
             + self.num_experts * 8
         )
         return flops, mem_bytes

--- a/tileops/ops/moe/unpermute.py
+++ b/tileops/ops/moe/unpermute.py
@@ -16,41 +16,41 @@ class MoeUnpermuteFwdOp(Op):
     """Scatter padded expert outputs back to original token order with weighted reduction.
 
     Args:
-        num_tokens: Number of input tokens T.
+        total_tokens: Number of input tokens T.
         top_k: Number of experts selected per token K.
         hidden_size: Hidden dimension H.
         dtype: Data type of mm2_pad and output (bf16 or fp16).
         padded_batch_sum: Size of the padded mm2_pad buffer (first dim of mm2_pad).
             Must be >= T*K. When used with MoePermuteOp, pass the padded_batch_sum
             value returned by the kernel (T*K + E*block_m upper bound).
-            Defaults to num_tokens * top_k for standalone testing only — do NOT
+            Defaults to total_tokens * top_k for standalone testing only — do NOT
             use the default when mm2_pad comes from MoePermuteOp, as the padded
             buffer will be larger and the kernel will index out of bounds.
         kernel_map: Optional kernel override dict.
 
     Example:
-        >>> op = MoeUnpermuteFwdOp(num_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
+        >>> op = MoeUnpermuteFwdOp(total_tokens=4, top_k=2, hidden_size=128, padded_batch_sum=512)
         >>> output = op(mm2_pad, fwd_idx, topk_weights)
     """
 
     def __init__(
         self,
-        num_tokens: int,
+        total_tokens: int,
         top_k: int,
         hidden_size: int,
         dtype: torch.dtype = torch.bfloat16,
         padded_batch_sum: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
-        self.num_tokens = num_tokens
+        self.total_tokens = total_tokens
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.dtype = dtype
-        self.padded_batch_sum = padded_batch_sum if padded_batch_sum is not None else num_tokens * top_k
+        self.padded_batch_sum = padded_batch_sum if padded_batch_sum is not None else total_tokens * top_k
 
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["unpermute_kernel"](
-            num_tokens, top_k, hidden_size, self.padded_batch_sum, dtype
+            total_tokens, top_k, hidden_size, self.padded_batch_sum, dtype
         )
 
     @property
@@ -59,13 +59,13 @@ class MoeUnpermuteFwdOp(Op):
 
     def eval_roofline(self) -> tuple[int, int]:
         elem_bytes = self.dtype.itemsize
-        flops = 2 * self.num_tokens * self.top_k * self.hidden_size
+        flops = 2 * self.total_tokens * self.top_k * self.hidden_size
         mem_bytes = (
-            (self.num_tokens * self.top_k * self.hidden_size
-             + self.num_tokens * self.hidden_size)
+            (self.total_tokens * self.top_k * self.hidden_size
+             + self.total_tokens * self.hidden_size)
             * elem_bytes
-            + self.num_tokens * self.top_k * 4
-            + self.num_tokens * self.top_k * 4
+            + self.total_tokens * self.top_k * 4
+            + self.total_tokens * self.top_k * 4
         )
         return flops, mem_bytes
 

--- a/tileops/ops/moe/unpermute.py
+++ b/tileops/ops/moe/unpermute.py
@@ -57,18 +57,6 @@ class MoeUnpermuteFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"unpermute_kernel": MoeUnpermuteKernel}
 
-    def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
-        flops = 2 * self.total_tokens * self.top_k * self.hidden_size
-        mem_bytes = (
-            (self.total_tokens * self.top_k * self.hidden_size
-             + self.total_tokens * self.hidden_size)
-            * elem_bytes
-            + self.total_tokens * self.top_k * 4
-            + self.total_tokens * self.top_k * 4
-        )
-        return flops, mem_bytes
-
     def forward(
         self,
         mm2_pad: torch.Tensor,

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -167,7 +167,13 @@ class Op(ABC):
         """
         default_map = self.default_kernel_map
         if default_map is None or len(default_map) == 0:
-            raise ValueError("default_kernel_map must be non-empty")
+            # Composite ops own no direct kernel — they orchestrate sub-ops
+            # whose own _install_kernel_map slices the override against
+            # their non-empty default_kernel_map (arch-compat is enforced
+            # there). The composite stores the override verbatim so its
+            # __init__ can forward it to each sub-op constructor.
+            self.kernel_map = dict(candidate_map) if candidate_map else {}
+            return
         resolved: dict[str, Kernel] = {}
         current_arch = get_sm_version()
         for name, default_kernel in default_map.items():

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -167,11 +167,7 @@ class Op(ABC):
         """
         default_map = self.default_kernel_map
         if default_map is None or len(default_map) == 0:
-            # Composite ops own no direct kernel — they orchestrate sub-ops
-            # whose own _install_kernel_map slices the override against
-            # their non-empty default_kernel_map (arch-compat is enforced
-            # there). The composite stores the override verbatim so its
-            # __init__ can forward it to each sub-op constructor.
+            # Composite op: store override verbatim; sub-ops enforce arch-compat themselves.
             self.kernel_map = dict(candidate_map) if candidate_map else {}
             return
         resolved: dict[str, Kernel] = {}

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -661,21 +661,34 @@ def bitwise_xor_fwd_roofline(op: "Op") -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 
 
-def fused_moe_fwd_bytes(**kwargs: Any) -> dict[str, int]:
+def fused_moe_fwd_bytes(op: "Op") -> tuple[int, int]:
     """Roofline for FusedMoeFwdOp / FusedMoeFwdCbFwdOp.
 
-    Mixed-dtype inputs: hidden_states (bf16/fp16) + gating_output (float32).
-    elem_bytes applies only to the bf16/fp16 tensors.
+    Func-mode is required because byte traffic mixes a float32 gating tensor
+    with hidden-states / weights in the configured ``op.dtype`` (and, for the
+    Cb variant, a float32 correction-bias broadcast over experts). Inline
+    mode binds a single ``elem_bytes`` and cannot express this.
+
+    Args:
+        op: A bound ``FusedMoeFwdOp`` or ``FusedMoeFwdCbFwdOp`` instance.
+
+    Returns:
+        ``(flops, bytes)`` as ints. FLOPs cover gate+up GEMM, SwiGLU, and
+        down GEMM (``T * K * 6 * F * H``). Bytes cover hidden states (in
+        and out), gating logits (float32), expert weights at ``op.dtype``,
+        and -- for the correction-bias variant -- the per-expert bias
+        (float32).
     """
-    num_tokens = kwargs["num_tokens"]
-    num_experts = kwargs["num_experts"]
-    top_k = kwargs["top_k"]
-    hidden_size = kwargs["hidden_size"]
-    ffn_size = kwargs["ffn_size"]
-    elem_bytes = kwargs.get("elem_bytes", 2)  # bf16 default
+    num_tokens = int(op.num_tokens)
+    num_experts = int(op.num_experts)
+    top_k = int(op.top_k)
+    hidden_size = int(op.hidden_size)
+    ffn_size = int(op.ffn_size)
+    elem_bytes = _dtype_itemsize(op.dtype)
 
     flops = num_tokens * top_k * 6 * ffn_size * hidden_size
     weight_bytes = num_experts * 3 * ffn_size * hidden_size * elem_bytes
     token_bytes = 2 * num_tokens * hidden_size * elem_bytes
-    gating_bytes = num_tokens * num_experts * 4  # float32
-    return {"flops": flops, "bytes": weight_bytes + token_bytes + gating_bytes}
+    gating_bytes = num_tokens * num_experts * 4  # float32 logits
+    bias_bytes = num_experts * 4 if getattr(op, "with_correction_bias", False) else 0
+    return flops, weight_bytes + token_bytes + gating_bytes + bias_bytes

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -664,20 +664,9 @@ def bitwise_xor_fwd_roofline(op: "Op") -> tuple[int, int]:
 def fused_moe_fwd_bytes(op: "Op") -> tuple[int, int]:
     """Roofline for FusedMoeFwdOp / FusedMoeFwdCbFwdOp.
 
-    Func-mode is required because byte traffic mixes a float32 gating tensor
-    with hidden-states / weights in the configured ``op.dtype`` (and, for the
-    Cb variant, a float32 correction-bias broadcast over experts). Inline
-    mode binds a single ``elem_bytes`` and cannot express this.
-
-    Args:
-        op: A bound ``FusedMoeFwdOp`` or ``FusedMoeFwdCbFwdOp`` instance.
-
-    Returns:
-        ``(flops, bytes)`` as ints. FLOPs cover gate+up GEMM, SwiGLU, and
-        down GEMM (``T * K * 6 * F * H``). Bytes cover hidden states (in
-        and out), gating logits (float32), expert weights at ``op.dtype``,
-        and -- for the correction-bias variant -- the per-expert bias
-        (float32).
+    Func-mode: byte traffic mixes float32 gating (and float32 correction bias
+    for the Cb variant) with hidden-states / weights at ``op.dtype``, so a
+    single ``elem_bytes`` cannot express the total.
     """
     num_tokens = int(op.num_tokens)
     num_experts = int(op.num_experts)


### PR DESCRIPTION
Promotes 10 nightshift-and-strict-parity PRs from `testbed` into `main`, with
four review-driven cleanup commits applied on the release branch.

## Summary

- **MOE**: declare `source.kernel_map` for 7 mechanical ops and flip to implemented (#1486); add `MoePermuteNopadFwdOp` test + flip (#1487); fix `topk_ids` read count in `roofline.bytes` (#1490); add `MoeGroupedGemmNopadFwdOp` test/bench + flip (#1491); split `FusedMoe` → `FusedMoeFwdOp` / `FusedMoeFwdCbFwdOp` (#1494).
- **Elementwise**: flip `Clamp` family to implemented (#1495); add manifest-driven bench for `MaskedFillFwdOp` + align `source.test` (#1497); cover full dtype union for `MaskedFillTensorValueFwdKernel` and flip `MaskedFillFwdOp` (#1499).
- **Norm**: flip `RMSNormFwdOp` to implemented after strict-parity rollout demotion (#1500).
- **Manifest carve-out**: enumerate `source.test` / `source.bench` in the status-flip allowlist (#1493).

## Test plan

- [x] All 10 component PRs passed pre-commit + pytest individually on testbed.
- [x] Full manifest validator (`python scripts/validate_manifest.py --strict`) exits 0 at testbed HEAD `66affa2`.
- [x] Pre-commit clean on every follow-up commit.
- [x] Targeted unit tests pass after each follow-up: `tests/test_op_base.py`, `tests/ops/test_special_elementwise_conformance.py`, `tests/ops/test_moe_unpermute.py`, `tests/ops/test_moe_permute_nopad.py`.