### PR TITLE
[Feat][CONVOLUTION] Add conv2d conv3d manifest entries

### DIFF
--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -116,3 +116,211 @@ Conv1dBiasFwdOp:
     test: tests/ops/test_convolution.py
     bench: benchmarks/ops/bench_convolution.py
     bench_manifest_driven: false
+
+Conv2dFwdOp:
+  ref_api: "torch.nn.functional.conv2d"
+  # Equivalent to torch.nn.functional.conv2d (bias=None)
+  family: convolution
+  status: spec-only  # TODO: align op/kernel classes in #1507
+
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, H, W]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kH, kW]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, out_H, out_W]"}
+    params:
+      kernel_size: {type: "int | tuple[int, int]"}
+      stride: {type: "int | tuple[int, int]", default: 1}
+      padding: {type: "int | tuple[int, int] | str", default: 0}
+    shape_rules:
+      - "_s_h == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_w == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "_p_h != 'same' or _s_h == 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+
+  workloads:
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kernel_size: [5, 5], stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+
+  roofline:
+    flops: "2 * N * C_out * out_H * out_W * C_in * kH * kW"
+    bytes: "(N * C_in * H * W + C_out * C_in * kH * kW + N * C_out * out_H * out_W) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv2d_kernel: Conv2dKernel
+      conv2d_1x1_kernel: Conv2d1x1Kernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false
+
+Conv2dBiasFwdOp:
+  ref_api: "torch.nn.functional.conv2d"
+  # Equivalent to torch.nn.functional.conv2d (bias≠None)
+  family: convolution
+  status: spec-only  # TODO: align op/kernel classes in #1507
+  variant_of: Conv2dFwdOp
+
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, H, W]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kH, kW]"}
+      bias: {dtype: "same_as(input)", shape: "[C_out]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, out_H, out_W]"}
+    params:
+      kernel_size: {type: "int | tuple[int, int]"}
+      stride: {type: "int | tuple[int, int]", default: 1}
+      padding: {type: "int | tuple[int, int] | str", default: 0}
+    shape_rules:
+      - "_s_h == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_w == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "_p_h != 'same' or _s_h == 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+
+  workloads:
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kernel_size: [5, 5], stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+
+  roofline:
+    # bias adds one addition per output element
+    flops: "2 * N * C_out * out_H * out_W * C_in * kH * kW + N * C_out * out_H * out_W"
+    bytes: "(N * C_in * H * W + C_out * C_in * kH * kW + C_out + N * C_out * out_H * out_W) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv2d_kernel: Conv2dKernel
+      conv2d_1x1_kernel: Conv2d1x1Kernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false
+
+Conv3dFwdOp:
+  ref_api: "torch.nn.functional.conv3d"
+  # Equivalent to torch.nn.functional.conv3d (bias=None)
+  family: convolution
+  status: spec-only  # TODO: align op/kernel classes in #1507
+
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, D, H, W]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kD, kH, kW]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, out_D, out_H, out_W]"}
+    params:
+      kernel_size: {type: "int | tuple[int, int, int]"}
+      stride: {type: "int | tuple[int, int, int]", default: 1}
+      padding: {type: "int | tuple[int, int, int] | str", default: 0}
+    shape_rules:
+      - "_s_d == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_h == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_w == (stride[2] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p_d == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_h == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_w == (padding[2] if isinstance(padding, (tuple, list)) else padding)"
+      - "not isinstance(_p_d, str) or _p_d in ('valid', 'same')"
+      - "_p_d != 'same' or _s_d == 1"
+      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - kD) // _s_d + 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+
+  workloads:
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kernel_size: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
+
+  roofline:
+    flops: "2 * N * C_out * out_D * out_H * out_W * C_in * kD * kH * kW"
+    bytes: "(N * C_in * D * H * W + C_out * C_in * kD * kH * kW + N * C_out * out_D * out_H * out_W) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv3d_kernel: Conv3dKernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false
+
+Conv3dBiasFwdOp:
+  ref_api: "torch.nn.functional.conv3d"
+  # Equivalent to torch.nn.functional.conv3d (bias≠None)
+  family: convolution
+  status: spec-only  # TODO: align op/kernel classes in #1507
+  variant_of: Conv3dFwdOp
+
+  signature:
+    inputs:
+      input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, D, H, W]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kD, kH, kW]"}
+      bias: {dtype: "same_as(input)", shape: "[C_out]"}
+    outputs:
+      output: {dtype: "same_as(input)", shape: "[N, C_out, out_D, out_H, out_W]"}
+    params:
+      kernel_size: {type: "int | tuple[int, int, int]"}
+      stride: {type: "int | tuple[int, int, int]", default: 1}
+      padding: {type: "int | tuple[int, int, int] | str", default: 0}
+    shape_rules:
+      - "_s_d == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_h == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
+      - "_s_w == (stride[2] if isinstance(stride, (tuple, list)) else stride)"
+      - "_p_d == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_h == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "_p_w == (padding[2] if isinstance(padding, (tuple, list)) else padding)"
+      - "not isinstance(_p_d, str) or _p_d in ('valid', 'same')"
+      - "_p_d != 'same' or _s_d == 1"
+      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - kD) // _s_d + 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+
+  workloads:
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kernel_size: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
+
+  roofline:
+    # bias adds one addition per output element
+    flops: "2 * N * C_out * out_D * out_H * out_W * C_in * kD * kH * kW + N * C_out * out_D * out_H * out_W"
+    bytes: "(N * C_in * D * H * W + C_out * C_in * kD * kH * kW + C_out + N * C_out * out_D * out_H * out_W) * elem_bytes"
+
+  source:
+    kernel: tileops/kernels/convolution.py
+    kernel_map:
+      conv3d_kernel: Conv3dKernel
+    op: tileops/ops/convolution.py
+    test: tests/ops/test_convolution.py
+    bench: benchmarks/ops/bench_convolution.py
+    bench_manifest_driven: false

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -121,19 +121,23 @@ Conv2dFwdOp:
   ref_api: "torch.nn.functional.conv2d"
   # Equivalent to torch.nn.functional.conv2d (bias=None)
   family: convolution
-  status: spec-only  # TODO: align op/kernel classes in #1507
+  status: spec-only  # TODO: impl lacks dilation, groups
 
   signature:
     inputs:
       input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, H, W]"}
-      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kH, kW]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kH, kW]"}
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C_out, out_H, out_W]"}
     params:
-      kernel_size: {type: "int | tuple[int, int]"}
       stride: {type: "int | tuple[int, int]", default: 1}
       padding: {type: "int | tuple[int, int] | str", default: 0}
+      dilation: {type: "int | tuple[int, int]", default: 1}  # TODO: not supported by kernel
+      groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
       - "_s_h == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
@@ -144,18 +148,19 @@ Conv2dFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
 
   workloads:
-    - {input_shape: [2, 64, 56, 56], C_out: 64, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
-    - {input_shape: [1, 3, 112, 112], C_out: 64, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
-    - {input_shape: [1, 256, 112, 112], C_out: 512, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
-    - {input_shape: [1, 64, 56, 56], C_out: 128, kernel_size: [5, 5], stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
-    - {input_shape: [1, 128, 28, 28], C_out: 128, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
-    - {input_shape: [2, 128, 28, 28], C_out: 512, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
-    - {input_shape: [2, 512, 28, 28], C_out: 128, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
-    - {input_shape: [1, 256, 14, 14], C_out: 1024, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
-    - {input_shape: [1, 512, 7, 7], C_out: 2048, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [bfloat16], label: "resnet-1x1-bf16"}
 
   roofline:
     flops: "2 * N * C_out * out_H * out_W * C_in * kH * kW"
@@ -175,21 +180,25 @@ Conv2dBiasFwdOp:
   ref_api: "torch.nn.functional.conv2d"
   # Equivalent to torch.nn.functional.conv2d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: align op/kernel classes in #1507
+  status: spec-only  # TODO: impl lacks dilation, groups
   variant_of: Conv2dFwdOp
 
   signature:
     inputs:
       input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, H, W]"}
-      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kH, kW]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kH, kW]"}
       bias: {dtype: "same_as(input)", shape: "[C_out]"}
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C_out, out_H, out_W]"}
     params:
-      kernel_size: {type: "int | tuple[int, int]"}
       stride: {type: "int | tuple[int, int]", default: 1}
       padding: {type: "int | tuple[int, int] | str", default: 0}
+      dilation: {type: "int | tuple[int, int]", default: 1}  # TODO: not supported by kernel
+      groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
       - "_s_h == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
@@ -200,18 +209,19 @@ Conv2dBiasFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
 
   workloads:
-    - {input_shape: [2, 64, 56, 56], C_out: 64, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
-    - {input_shape: [1, 3, 112, 112], C_out: 64, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
-    - {input_shape: [1, 256, 112, 112], C_out: 512, kernel_size: [3, 3], stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
-    - {input_shape: [1, 64, 56, 56], C_out: 128, kernel_size: [5, 5], stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
-    - {input_shape: [1, 128, 56, 56], C_out: 256, kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
-    - {input_shape: [1, 128, 28, 28], C_out: 128, kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
-    - {input_shape: [2, 64, 56, 56], C_out: 256, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
-    - {input_shape: [2, 128, 28, 28], C_out: 512, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
-    - {input_shape: [2, 512, 28, 28], C_out: 128, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
-    - {input_shape: [1, 256, 14, 14], C_out: 1024, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
-    - {input_shape: [1, 512, 7, 7], C_out: 2048, kernel_size: [1, 1], stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
+    - {input_shape: [1, 3, 112, 112], C_out: 64, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stem-3x3-s2-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "stage-transition-3x3-s2-fp16"}
+    - {input_shape: [1, 256, 112, 112], C_out: 512, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16], label: "highres-3x3-s1-fp16"}
+    - {input_shape: [1, 64, 56, 56], C_out: 128, kH: 5, kW: 5, stride: [1, 1], padding: [2, 2], dtypes: [float16], label: "midres-5x5-s1-fp16"}
+    - {input_shape: [1, 128, 56, 56], C_out: 256, kH: 5, kW: 5, stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "stage-transition-5x5-s2-fp16"}
+    - {input_shape: [1, 128, 28, 28], C_out: 128, kH: 3, kW: 3, stride: [2, 2], padding: [1, 1], dtypes: [bfloat16], label: "stride2-bf16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16, bfloat16], label: "resnet-1x1-fp16"}
+    - {input_shape: [2, 128, 28, 28], C_out: 512, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-expand-1x1-fp16"}
+    - {input_shape: [2, 512, 28, 28], C_out: 128, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "bottleneck-reduce-1x1-fp16"}
+    - {input_shape: [1, 256, 14, 14], C_out: 1024, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "late-stage-1x1-fp16"}
+    - {input_shape: [1, 512, 7, 7], C_out: 2048, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [float16], label: "classifier-1x1-fp16"}
+    - {input_shape: [2, 64, 56, 56], C_out: 256, kH: 1, kW: 1, stride: [1, 1], padding: [0, 0], dtypes: [bfloat16], label: "resnet-1x1-bf16"}
 
   roofline:
     # bias adds one addition per output element
@@ -232,19 +242,23 @@ Conv3dFwdOp:
   ref_api: "torch.nn.functional.conv3d"
   # Equivalent to torch.nn.functional.conv3d (bias=None)
   family: convolution
-  status: spec-only  # TODO: align op/kernel classes in #1507
+  status: spec-only  # TODO: impl lacks dilation, groups
 
   signature:
     inputs:
       input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, D, H, W]"}
-      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kD, kH, kW]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kD, kH, kW]"}
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C_out, out_D, out_H, out_W]"}
     params:
-      kernel_size: {type: "int | tuple[int, int, int]"}
       stride: {type: "int | tuple[int, int, int]", default: 1}
       padding: {type: "int | tuple[int, int, int] | str", default: 0}
+      dilation: {type: "int | tuple[int, int, int]", default: 1}  # TODO: not supported by kernel
+      groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
       - "_s_d == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_h == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_w == (stride[2] if isinstance(stride, (tuple, list)) else stride)"
@@ -258,9 +272,9 @@ Conv3dFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
 
   workloads:
-    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
-    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kernel_size: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
-    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
 
   roofline:
     flops: "2 * N * C_out * out_D * out_H * out_W * C_in * kD * kH * kW"
@@ -279,21 +293,25 @@ Conv3dBiasFwdOp:
   ref_api: "torch.nn.functional.conv3d"
   # Equivalent to torch.nn.functional.conv3d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: align op/kernel classes in #1507
+  status: spec-only  # TODO: impl lacks dilation, groups
   variant_of: Conv3dFwdOp
 
   signature:
     inputs:
       input: {dtype: "float32 | float16 | bfloat16", shape: "[N, C_in, D, H, W]"}
-      weight: {dtype: "same_as(input)", shape: "[C_out, C_in, kD, kH, kW]"}
+      weight: {dtype: "same_as(input)", shape: "[C_out, C_in_g, kD, kH, kW]"}
       bias: {dtype: "same_as(input)", shape: "[C_out]"}
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C_out, out_D, out_H, out_W]"}
     params:
-      kernel_size: {type: "int | tuple[int, int, int]"}
       stride: {type: "int | tuple[int, int, int]", default: 1}
       padding: {type: "int | tuple[int, int, int] | str", default: 0}
+      dilation: {type: "int | tuple[int, int, int]", default: 1}  # TODO: not supported by kernel
+      groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
+      - "C_in % groups == 0"
+      - "C_out % groups == 0"
+      - "C_in_g == C_in // groups"
       - "_s_d == (stride[0] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_h == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_s_w == (stride[2] if isinstance(stride, (tuple, list)) else stride)"
@@ -307,9 +325,9 @@ Conv3dBiasFwdOp:
       - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
 
   workloads:
-    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
-    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kernel_size: [3, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
-    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kernel_size: [3, 3, 3], stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
+    - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
+    - {input_shape: [1, 64, 8, 56, 56], C_out: 128, kD: 3, kH: 3, kW: 3, stride: [2, 2, 2], padding: [1, 1, 1], dtypes: [float16], label: "video-stage-downsample-k3-s2-fp16"}
+    - {input_shape: [1, 32, 32, 64, 64], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [bfloat16], label: "unet-encoder-k3-s1-bf16"}
 
   roofline:
     # bias adds one addition per output element

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -142,10 +142,14 @@ Conv2dFwdOp:
       - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_w == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d_h == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_w == (dilation[1] if isinstance(dilation, (tuple, list)) else dilation)"
       - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "not isinstance(_p_w, str) or _p_w in ('valid', 'same')"
       - "_p_h != 'same' or _s_h == 1"
-      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
-      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+      - "_p_w != 'same' or _s_w == 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - _d_h * (kH - 1) - 1) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
     - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
@@ -203,10 +207,14 @@ Conv2dBiasFwdOp:
       - "_s_w == (stride[1] if isinstance(stride, (tuple, list)) else stride)"
       - "_p_h == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_w == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d_h == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_w == (dilation[1] if isinstance(dilation, (tuple, list)) else dilation)"
       - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "not isinstance(_p_w, str) or _p_w in ('valid', 'same')"
       - "_p_h != 'same' or _s_h == 1"
-      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
-      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+      - "_p_w != 'same' or _s_w == 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - _d_h * (kH - 1) - 1) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
     - {input_shape: [2, 64, 56, 56], C_out: 64, kH: 3, kW: 3, stride: [1, 1], padding: [1, 1], dtypes: [float16, bfloat16], label: "resnet-3x3-fp16"}
@@ -265,11 +273,18 @@ Conv3dFwdOp:
       - "_p_d == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_h == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_w == (padding[2] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_h == (dilation[1] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_w == (dilation[2] if isinstance(dilation, (tuple, list)) else dilation)"
       - "not isinstance(_p_d, str) or _p_d in ('valid', 'same')"
+      - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "not isinstance(_p_w, str) or _p_w in ('valid', 'same')"
       - "_p_d != 'same' or _s_d == 1"
-      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - kD) // _s_d + 1"
-      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
-      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+      - "_p_h != 'same' or _s_h == 1"
+      - "_p_w != 'same' or _s_w == 1"
+      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - _d_d * (kD - 1) - 1) // _s_d + 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - _d_h * (kH - 1) - 1) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
     - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}
@@ -318,11 +333,18 @@ Conv3dBiasFwdOp:
       - "_p_d == (padding[0] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_h == (padding[1] if isinstance(padding, (tuple, list)) else padding)"
       - "_p_w == (padding[2] if isinstance(padding, (tuple, list)) else padding)"
+      - "_d_d == (dilation[0] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_h == (dilation[1] if isinstance(dilation, (tuple, list)) else dilation)"
+      - "_d_w == (dilation[2] if isinstance(dilation, (tuple, list)) else dilation)"
       - "not isinstance(_p_d, str) or _p_d in ('valid', 'same')"
+      - "not isinstance(_p_h, str) or _p_h in ('valid', 'same')"
+      - "not isinstance(_p_w, str) or _p_w in ('valid', 'same')"
       - "_p_d != 'same' or _s_d == 1"
-      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - kD) // _s_d + 1"
-      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - kH) // _s_h + 1"
-      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - kW) // _s_w + 1"
+      - "_p_h != 'same' or _s_h == 1"
+      - "_p_w != 'same' or _s_w == 1"
+      - "out_D == D if _p_d == 'same' else (D + 2 * (0 if _p_d == 'valid' else _p_d) - _d_d * (kD - 1) - 1) // _s_d + 1"
+      - "out_H == H if _p_h == 'same' else (H + 2 * (0 if _p_h == 'valid' else _p_h) - _d_h * (kH - 1) - 1) // _s_h + 1"
+      - "out_W == W if _p_w == 'same' else (W + 2 * (0 if _p_w == 'valid' else _p_w) - _d_w * (kW - 1) - 1) // _s_w + 1"
 
   workloads:
     - {input_shape: [1, 3, 16, 112, 112], C_out: 64, kD: 3, kH: 3, kW: 3, stride: [1, 1, 1], padding: [1, 1, 1], dtypes: [float16], label: "r3d-stem-k3-s1-fp16"}

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -373,6 +373,7 @@ class Conv2dOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        self._validate_dtypes(x, weight, bias)
         _validate_tensor_shape("Conv2d", "x", x, (self.n, self.h, self.w, self.c_in))
         _validate_tensor_shape(
             "Conv2d",
@@ -383,6 +384,67 @@ class Conv2dOp(Op):
         if bias is not None:
             _validate_tensor_shape("Conv2d", "bias", bias, (self.c_out,))
         return self.kernel(x, weight, bias)
+
+    def _infer_output_shapes(
+        self, x_shape: tuple, weight_shape: tuple, bias_shape: Optional[tuple] = None
+    ) -> Dict[str, tuple]:
+        """Infer output tensor shapes from input shapes."""
+        # Derive spatial dims and params from shapes when self is not
+        # initialized (validator mock path).  When self is initialized
+        # (normal forward path) the cached attributes take precedence.
+        n = getattr(self, "n", x_shape[0])
+        c_out = getattr(self, "c_out", weight_shape[0])
+        h = getattr(self, "h", x_shape[1])
+        w = getattr(self, "w", x_shape[2])
+        kernel_size = getattr(self, "kernel_size", (weight_shape[2], weight_shape[3]))
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size, kernel_size)
+        stride = getattr(self, "stride", (1, 1))
+        if isinstance(stride, int):
+            stride = (stride, stride)
+        padding = getattr(self, "padding", (0, 0))
+        if isinstance(padding, int):
+            padding = (padding, padding)
+        out_h = (h + 2 * padding[0] - kernel_size[0]) // stride[0] + 1
+        out_w = (w + 2 * padding[1] - kernel_size[1]) // stride[1] + 1
+        return {"output": (n, out_h, out_w, c_out)}
+
+    def _validate_dtypes(
+        self, x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> None:
+        """Validate dtypes of input tensors passed to forward."""
+        supported = {torch.float32, torch.float16, torch.bfloat16}
+        if x.dtype not in supported:
+            raise ValueError(f"x.dtype must be float32/float16/bfloat16, got {x.dtype}")
+        if weight.dtype != x.dtype:
+            raise ValueError(
+                f"weight.dtype must match x.dtype ({x.dtype}), got {weight.dtype}"
+            )
+        if bias is not None and bias.dtype != x.dtype:
+            raise ValueError(
+                f"bias.dtype must match x.dtype ({x.dtype}), got {bias.dtype}"
+            )
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return (flops, bytes) for this op instance."""
+        out_h = (self.h + 2 * self.padding[0] - self.kernel_size[0]) // self.stride[0] + 1
+        out_w = (self.w + 2 * self.padding[1] - self.kernel_size[1]) // self.stride[1] + 1
+        flops = (
+            2
+            * self.n
+            * self.c_out
+            * out_h
+            * out_w
+            * self.c_in
+            * self.kernel_size[0]
+            * self.kernel_size[1]
+        )
+        bytes_ = (
+            self.n * self.c_in * self.h * self.w
+            + self.c_out * self.c_in * self.kernel_size[0] * self.kernel_size[1]
+            + self.n * self.c_out * out_h * out_w
+        ) * self.dtype.itemsize
+        return flops, bytes_
 
 
 def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
@@ -466,6 +528,7 @@ class Conv3dOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        self._validate_dtypes(x, weight, bias)
         _validate_tensor_shape(
             "Conv3d",
             "x",
@@ -487,3 +550,71 @@ class Conv3dOp(Op):
         if bias is not None:
             _validate_tensor_shape("Conv3d", "bias", bias, (self.c_out,))
         return self.kernel(x, weight, bias)
+
+    def _infer_output_shapes(
+        self, x_shape: tuple, weight_shape: tuple, bias_shape: Optional[tuple] = None
+    ) -> Dict[str, tuple]:
+        """Infer output tensor shapes from input shapes."""
+        # Derive spatial dims and params from shapes when self is not
+        # initialized (validator mock path).  When self is initialized
+        # (normal forward path) the cached attributes take precedence.
+        n = getattr(self, "n", x_shape[0])
+        c_out = getattr(self, "c_out", weight_shape[0])
+        d_in = getattr(self, "d_in", x_shape[1])
+        h_in = getattr(self, "h_in", x_shape[2])
+        w_in = getattr(self, "w_in", x_shape[3])
+        kernel_size = getattr(
+            self, "kernel_size", (weight_shape[2], weight_shape[3], weight_shape[4])
+        )
+        if isinstance(kernel_size, int):
+            kernel_size = (kernel_size, kernel_size, kernel_size)
+        stride = getattr(self, "stride", (1, 1, 1))
+        if isinstance(stride, int):
+            stride = (stride, stride, stride)
+        padding = getattr(self, "padding", (0, 0, 0))
+        if isinstance(padding, int):
+            padding = (padding, padding, padding)
+        out_d = (d_in + 2 * padding[0] - kernel_size[0]) // stride[0] + 1
+        out_h = (h_in + 2 * padding[1] - kernel_size[1]) // stride[1] + 1
+        out_w = (w_in + 2 * padding[2] - kernel_size[2]) // stride[2] + 1
+        return {"output": (n, out_d, out_h, out_w, c_out)}
+
+    def _validate_dtypes(
+        self, x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> None:
+        """Validate dtypes of input tensors passed to forward."""
+        supported = {torch.float32, torch.float16, torch.bfloat16}
+        if x.dtype not in supported:
+            raise ValueError(f"x.dtype must be float32/float16/bfloat16, got {x.dtype}")
+        if weight.dtype != x.dtype:
+            raise ValueError(
+                f"weight.dtype must match x.dtype ({x.dtype}), got {weight.dtype}"
+            )
+        if bias is not None and bias.dtype != x.dtype:
+            raise ValueError(
+                f"bias.dtype must match x.dtype ({x.dtype}), got {bias.dtype}"
+            )
+
+    def eval_roofline(self) -> tuple[int, int]:
+        """Return (flops, bytes) for this op instance."""
+        out_d = (self.d_in + 2 * self.padding[0] - self.kernel_size[0]) // self.stride[0] + 1
+        out_h = (self.h_in + 2 * self.padding[1] - self.kernel_size[1]) // self.stride[1] + 1
+        out_w = (self.w_in + 2 * self.padding[2] - self.kernel_size[2]) // self.stride[2] + 1
+        flops = (
+            2
+            * self.n
+            * self.c_out
+            * out_d
+            * out_h
+            * out_w
+            * self.c_in
+            * self.kernel_size[0]
+            * self.kernel_size[1]
+            * self.kernel_size[2]
+        )
+        bytes_ = (
+            self.n * self.c_in * self.d_in * self.h_in * self.w_in
+            + self.c_out * self.c_in * self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2]
+            + self.n * self.c_out * out_d * out_h * out_w
+        ) * self.dtype.itemsize
+        return flops, bytes_

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -373,7 +373,6 @@ class Conv2dOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        self._validate_dtypes(x, weight, bias)
         _validate_tensor_shape("Conv2d", "x", x, (self.n, self.h, self.w, self.c_in))
         _validate_tensor_shape(
             "Conv2d",
@@ -384,67 +383,6 @@ class Conv2dOp(Op):
         if bias is not None:
             _validate_tensor_shape("Conv2d", "bias", bias, (self.c_out,))
         return self.kernel(x, weight, bias)
-
-    def _infer_output_shapes(
-        self, x_shape: tuple, weight_shape: tuple, bias_shape: Optional[tuple] = None
-    ) -> Dict[str, tuple]:
-        """Infer output tensor shapes from input shapes."""
-        # Derive spatial dims and params from shapes when self is not
-        # initialized (validator mock path).  When self is initialized
-        # (normal forward path) the cached attributes take precedence.
-        n = getattr(self, "n", x_shape[0])
-        c_out = getattr(self, "c_out", weight_shape[0])
-        h = getattr(self, "h", x_shape[1])
-        w = getattr(self, "w", x_shape[2])
-        kernel_size = getattr(self, "kernel_size", (weight_shape[2], weight_shape[3]))
-        if isinstance(kernel_size, int):
-            kernel_size = (kernel_size, kernel_size)
-        stride = getattr(self, "stride", (1, 1))
-        if isinstance(stride, int):
-            stride = (stride, stride)
-        padding = getattr(self, "padding", (0, 0))
-        if isinstance(padding, int):
-            padding = (padding, padding)
-        out_h = (h + 2 * padding[0] - kernel_size[0]) // stride[0] + 1
-        out_w = (w + 2 * padding[1] - kernel_size[1]) // stride[1] + 1
-        return {"output": (n, out_h, out_w, c_out)}
-
-    def _validate_dtypes(
-        self, x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
-    ) -> None:
-        """Validate dtypes of input tensors passed to forward."""
-        supported = {torch.float32, torch.float16, torch.bfloat16}
-        if x.dtype not in supported:
-            raise ValueError(f"x.dtype must be float32/float16/bfloat16, got {x.dtype}")
-        if weight.dtype != x.dtype:
-            raise ValueError(
-                f"weight.dtype must match x.dtype ({x.dtype}), got {weight.dtype}"
-            )
-        if bias is not None and bias.dtype != x.dtype:
-            raise ValueError(
-                f"bias.dtype must match x.dtype ({x.dtype}), got {bias.dtype}"
-            )
-
-    def eval_roofline(self) -> tuple[int, int]:
-        """Return (flops, bytes) for this op instance."""
-        out_h = (self.h + 2 * self.padding[0] - self.kernel_size[0]) // self.stride[0] + 1
-        out_w = (self.w + 2 * self.padding[1] - self.kernel_size[1]) // self.stride[1] + 1
-        flops = (
-            2
-            * self.n
-            * self.c_out
-            * out_h
-            * out_w
-            * self.c_in
-            * self.kernel_size[0]
-            * self.kernel_size[1]
-        )
-        bytes_ = (
-            self.n * self.c_in * self.h * self.w
-            + self.c_out * self.c_in * self.kernel_size[0] * self.kernel_size[1]
-            + self.n * self.c_out * out_h * out_w
-        ) * self.dtype.itemsize
-        return flops, bytes_
 
 
 def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
@@ -528,7 +466,6 @@ class Conv3dOp(Op):
         weight: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        self._validate_dtypes(x, weight, bias)
         _validate_tensor_shape(
             "Conv3d",
             "x",
@@ -550,71 +487,3 @@ class Conv3dOp(Op):
         if bias is not None:
             _validate_tensor_shape("Conv3d", "bias", bias, (self.c_out,))
         return self.kernel(x, weight, bias)
-
-    def _infer_output_shapes(
-        self, x_shape: tuple, weight_shape: tuple, bias_shape: Optional[tuple] = None
-    ) -> Dict[str, tuple]:
-        """Infer output tensor shapes from input shapes."""
-        # Derive spatial dims and params from shapes when self is not
-        # initialized (validator mock path).  When self is initialized
-        # (normal forward path) the cached attributes take precedence.
-        n = getattr(self, "n", x_shape[0])
-        c_out = getattr(self, "c_out", weight_shape[0])
-        d_in = getattr(self, "d_in", x_shape[1])
-        h_in = getattr(self, "h_in", x_shape[2])
-        w_in = getattr(self, "w_in", x_shape[3])
-        kernel_size = getattr(
-            self, "kernel_size", (weight_shape[2], weight_shape[3], weight_shape[4])
-        )
-        if isinstance(kernel_size, int):
-            kernel_size = (kernel_size, kernel_size, kernel_size)
-        stride = getattr(self, "stride", (1, 1, 1))
-        if isinstance(stride, int):
-            stride = (stride, stride, stride)
-        padding = getattr(self, "padding", (0, 0, 0))
-        if isinstance(padding, int):
-            padding = (padding, padding, padding)
-        out_d = (d_in + 2 * padding[0] - kernel_size[0]) // stride[0] + 1
-        out_h = (h_in + 2 * padding[1] - kernel_size[1]) // stride[1] + 1
-        out_w = (w_in + 2 * padding[2] - kernel_size[2]) // stride[2] + 1
-        return {"output": (n, out_d, out_h, out_w, c_out)}
-
-    def _validate_dtypes(
-        self, x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
-    ) -> None:
-        """Validate dtypes of input tensors passed to forward."""
-        supported = {torch.float32, torch.float16, torch.bfloat16}
-        if x.dtype not in supported:
-            raise ValueError(f"x.dtype must be float32/float16/bfloat16, got {x.dtype}")
-        if weight.dtype != x.dtype:
-            raise ValueError(
-                f"weight.dtype must match x.dtype ({x.dtype}), got {weight.dtype}"
-            )
-        if bias is not None and bias.dtype != x.dtype:
-            raise ValueError(
-                f"bias.dtype must match x.dtype ({x.dtype}), got {bias.dtype}"
-            )
-
-    def eval_roofline(self) -> tuple[int, int]:
-        """Return (flops, bytes) for this op instance."""
-        out_d = (self.d_in + 2 * self.padding[0] - self.kernel_size[0]) // self.stride[0] + 1
-        out_h = (self.h_in + 2 * self.padding[1] - self.kernel_size[1]) // self.stride[1] + 1
-        out_w = (self.w_in + 2 * self.padding[2] - self.kernel_size[2]) // self.stride[2] + 1
-        flops = (
-            2
-            * self.n
-            * self.c_out
-            * out_d
-            * out_h
-            * out_w
-            * self.c_in
-            * self.kernel_size[0]
-            * self.kernel_size[1]
-            * self.kernel_size[2]
-        )
-        bytes_ = (
-            self.n * self.c_in * self.d_in * self.h_in * self.w_in
-            + self.c_out * self.c_in * self.kernel_size[0] * self.kernel_size[1] * self.kernel_size[2]
-            + self.n * self.c_out * out_d * out_h * out_w
-        ) * self.dtype.itemsize
-        return flops, bytes_


### PR DESCRIPTION
## Summary

- Add spec-only manifest entries for `Conv2dFwdOp` and `Conv2dBiasFwdOp`
- Add spec-only manifest entries for `Conv3dFwdOp` and `Conv3dBiasFwdOp`
- Link the new entries to the follow-up operator/kernel alignment work in #1507

Closes #1505

## Test plan

- `python scripts/validate_manifest.py`
- pre-commit hooks on `tileops/manifest/convolution.yaml`

## Additional context

The new entries are intentionally marked `spec-only` because op/kernel class alignment is split into #1507. Targeted `--check-op` validation for these entries will become part of that follow-up implementation work.
