### PR TITLE
[Feat][Convolution] Add native groups support and string padding coverage for conv1d

### DIFF
--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -60,24 +60,24 @@ class Conv1dFixture(FixtureBase):
                 id="full-dilation-k3-d2-fp16",
             ),
             pytest.param(
+                1, 32, 128, 64, 3, 1, "valid", 1, 1, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-padding-valid-fp16",
+            ),
+            pytest.param(
+                1, 32, 128, 64, 3, 1, "same", 1, 1, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-padding-same-fp16",
+            ),
+            pytest.param(
                 1, 32, 128, 64, 3, 1, 1, 1, 2, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-groups2-k3-fp16",
             ),
             pytest.param(
-                1, 32, 128, 64, 1, 1, 0, 1, 2, torch.float16, False,
-                marks=pytest.mark.full,
-                id="full-groups2-pointwise-k1-fp16",
-            ),
-            pytest.param(
                 1, 48, 128, 72, 3, 1, 1, 1, 3, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-groups3-coutg24-fp16",
-            ),
-            pytest.param(
-                1, 30, 128, 48, 3, 1, 1, 1, 3, torch.float16, False,
-                marks=pytest.mark.full,
-                id="full-groups3-cing10-fp16",
             ),
             pytest.param(
                 1, 64, 128, 64, 31, 1, 15, 1, 64, torch.float16, False,
@@ -98,7 +98,7 @@ class Conv1dTest(TestBase):
         c_out: int,
         kernel_size: int,
         stride: int,
-        padding: int,
+        padding: int | str,
         dilation: int,
         groups: int,
         dtype: torch.dtype,
@@ -149,7 +149,7 @@ def test_conv1d(
     c_out: int,
     kernel_size: int,
     stride: int,
-    padding: int,
+    padding: int | str,
     dilation: int,
     groups: int,
     dtype: torch.dtype,
@@ -172,7 +172,7 @@ def test_conv1d(
     if groups > 1:
         assert isinstance(op.kernel, GroupConv1dKernel)
         assert op.kernel.use_direct is (c_in // groups == 1 and c_out // groups == 1)
-    atol, rtol = ((5e-3, 5e-3) if groups > 1 else (1e-3, 1e-3))
+    atol, rtol = (1e-3, 1e-3)
     if dtype == torch.bfloat16:
         atol, rtol = (1.6e-2, 1.6e-2)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
@@ -282,32 +282,6 @@ def test_conv1d_dispatches_kernel(
         dilation=dilation,
     )
     assert isinstance(op.kernel, expected_kernel)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    "padding, kernel_size, stride",
-    [
-        pytest.param("valid", 3, 1, id="valid"),
-        pytest.param("same", 3, 1, id="same"),
-    ],
-)
-def test_conv1d_string_padding_matches_torch(padding: str, kernel_size: int, stride: int) -> None:
-    n, c_in, l_in, c_out = 1, 32, 128, 64
-    op = Conv1dFwdOp(
-        n=n,
-        c_in=c_in,
-        l_in=l_in,
-        c_out=c_out,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-    )
-    x = torch.randn(n, c_in, l_in, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(c_out, c_in, kernel_size, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight)
-    ref = F.conv1d(x, weight, bias=None, stride=stride, padding=padding).contiguous()
-    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 class Conv2dFixture(FixtureBase):

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -249,6 +249,92 @@ def test_conv1d_dispatches_kernel(
     assert isinstance(op.kernel, expected_kernel)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "padding, kernel_size, stride",
+    [
+        pytest.param("valid", 3, 1, id="valid"),
+        pytest.param("same", 3, 1, id="same"),
+    ],
+)
+def test_conv1d_string_padding_matches_torch(padding: str, kernel_size: int, stride: int) -> None:
+    n, c_in, l_in, c_out = 1, 32, 128, 64
+    op = Conv1dFwdOp(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
+        c_out=c_out,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+    )
+    x = torch.randn(n, c_in, l_in, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(c_out, c_in, kernel_size, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    ref = F.conv1d(x, weight, bias=None, stride=stride, padding=padding).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "op_cls, groups, c_in, c_out, use_bias",
+    [
+        pytest.param(Conv1dFwdOp, 2, 32, 64, False, marks=pytest.mark.smoke, id="groups2-no-bias"),
+        pytest.param(Conv1dBiasFwdOp, 2, 32, 64, True, marks=pytest.mark.full, id="groups2-bias"),
+        pytest.param(Conv1dFwdOp, 4, 64, 64, False, marks=pytest.mark.full, id="groups4-no-bias"),
+        pytest.param(Conv1dBiasFwdOp, 4, 64, 64, True, marks=pytest.mark.full, id="groups4-bias"),
+    ],
+)
+def test_conv1d_groups_matches_torch(op_cls, groups: int, c_in: int, c_out: int, use_bias: bool) -> None:
+    n, l_in, kernel_size = 1, 128, 3
+    stride, padding = 1, 1
+    op_kwargs = {"bias": use_bias} if op_cls is Conv1dBiasFwdOp else {}
+    op = op_cls(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
+        c_out=c_out,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        groups=groups,
+        **op_kwargs,
+    )
+    x = torch.randn(n, c_in, l_in, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(c_out, c_in // groups, kernel_size, device="cuda", dtype=torch.float16).contiguous()
+    bias = (
+        torch.randn(c_out, device="cuda", dtype=torch.float16).contiguous()
+        if use_bias else None
+    )
+    out = op(x, weight, bias) if use_bias else op(x, weight)
+    ref = F.conv1d(
+        x,
+        weight,
+        bias=bias,
+        stride=stride,
+        padding=padding,
+        groups=groups,
+    )
+    ref = ref.contiguous()
+    torch.testing.assert_close(out, ref, atol=2e-3, rtol=3e-3)
+
+
+@pytest.mark.smoke
+def test_conv1d_groups_forces_generic_kernel() -> None:
+    """When groups>1, pointwise conditions must not dispatch to Conv1dPointwiseKernel."""
+    op = Conv1dFwdOp(
+        n=1,
+        c_in=32,
+        l_in=256,
+        c_out=64,
+        kernel_size=1,
+        stride=1,
+        padding=0,
+        groups=2,
+    )
+    assert isinstance(op.kernel, Conv1dKernel)
+    assert not isinstance(op.kernel, Conv1dPointwiseKernel)
+
+
 class Conv2dFixture(FixtureBase):
     PARAMS = [
         ("n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune", [

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -11,7 +11,6 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
-    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
@@ -19,46 +18,71 @@ from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
 
 class Conv1dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype, tune", [
+        ("n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype, tune", [
             pytest.param(
-                2, 64, 512, 128, 3, 1, 1, 1, torch.float16, False,
+                2, 64, 512, 128, 3, 1, 1, 1, 1, torch.float16, False,
                 marks=[pytest.mark.smoke, pytest.mark.packaging],
                 id="smoke-tcn-k3-s1-fp16",
             ),
             pytest.param(
-                2, 64, 512, 128, 3, 1, 1, 1, torch.bfloat16, False,
+                2, 64, 512, 128, 3, 1, 1, 1, 1, torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-tcn-k3-s1-bf16",
             ),
             pytest.param(
-                4, 256, 32000, 512, 1, 1, 0, 1, torch.float16, False,
+                4, 256, 32000, 512, 1, 1, 0, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-convtasnet-pointwise-k1-s1-fp16",
             ),
             pytest.param(
-                4, 128, 4096, 256, 3, 1, 1, 1, torch.float16, False,
+                4, 128, 4096, 256, 3, 1, 1, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-seanet-residual-k3-s1-fp16",
             ),
             pytest.param(
-                4, 64, 16000, 128, 5, 2, 2, 1, torch.float16, False,
+                4, 64, 16000, 128, 5, 2, 2, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-audio-downsample-k5-s2-fp16",
             ),
             pytest.param(
-                1, 32, 256, 64, 7, 1, 3, 1, torch.float16, False,
+                1, 32, 256, 64, 7, 1, 3, 1, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-small-seanet-stem-k7-s1-fp16",
             ),
             pytest.param(
-                2, 128, 4096, 256, 3, 2, 1, 1, torch.bfloat16, False,
+                2, 128, 4096, 256, 3, 2, 1, 1, 1, torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-sequence-downsample-k3-s2-bf16",
             ),
             pytest.param(
-                1, 32, 512, 64, 3, 1, 2, 2, torch.float16, False,
+                1, 32, 512, 64, 3, 1, 2, 2, 1, torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-dilation-k3-d2-fp16",
+            ),
+            pytest.param(
+                1, 32, 128, 64, 3, 1, 1, 1, 2, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-groups2-k3-fp16",
+            ),
+            pytest.param(
+                1, 32, 128, 64, 1, 1, 0, 1, 2, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-groups2-pointwise-k1-fp16",
+            ),
+            pytest.param(
+                1, 48, 128, 72, 3, 1, 1, 1, 3, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-groups3-coutg24-fp16",
+            ),
+            pytest.param(
+                1, 30, 128, 48, 3, 1, 1, 1, 3, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-groups3-cing10-fp16",
+            ),
+            pytest.param(
+                1, 64, 128, 64, 31, 1, 15, 1, 64, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-conformer-depthwise-k31-fp16",
             ),
         ]),
     ]
@@ -76,6 +100,7 @@ class Conv1dTest(TestBase):
         stride: int,
         padding: int,
         dilation: int,
+        groups: int,
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -86,12 +111,13 @@ class Conv1dTest(TestBase):
         self.stride = stride
         self.padding = padding
         self.dilation = dilation
+        self.groups = groups
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         x = torch.randn(self.n, self.c_in, self.l_in, device="cuda", dtype=self.dtype).contiguous()
         weight = torch.randn(
-            self.c_out, self.c_in, self.kernel_size,
+            self.c_out, self.c_in // self.groups, self.kernel_size,
             device="cuda", dtype=self.dtype,
         ).contiguous()
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
@@ -110,7 +136,7 @@ class Conv1dTest(TestBase):
             stride=self.stride,
             padding=self.padding,
             dilation=self.dilation,
-            groups=1,
+            groups=self.groups,
         )
         return out.contiguous()
 
@@ -125,10 +151,11 @@ def test_conv1d(
     stride: int,
     padding: int,
     dilation: int,
+    groups: int,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, dtype)
+    test = Conv1dTest(n, c_in, l_in, c_out, kernel_size, stride, padding, dilation, groups, dtype)
     op = Conv1dBiasFwdOp(
         n=n,
         c_in=c_in,
@@ -138,10 +165,16 @@ def test_conv1d(
         stride=stride,
         padding=padding,
         dilation=dilation,
+        groups=groups,
         dtype=dtype,
         tune=tune,
     )
-    atol, rtol = ((1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2))
+    if groups > 1:
+        assert isinstance(op.kernel, GroupConv1dKernel)
+        assert op.kernel.use_direct is (c_in // groups == 1 and c_out // groups == 1)
+    atol, rtol = ((5e-3, 5e-3) if groups > 1 else (1e-3, 1e-3))
+    if dtype == torch.bfloat16:
+        atol, rtol = (1.6e-2, 1.6e-2)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
@@ -275,134 +308,6 @@ def test_conv1d_string_padding_matches_torch(padding: str, kernel_size: int, str
     out = op(x, weight)
     ref = F.conv1d(x, weight, bias=None, stride=stride, padding=padding).contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.parametrize(
-    "op_cls, groups, c_in, c_out, use_bias",
-    [
-        pytest.param(Conv1dFwdOp, 2, 32, 64, False, marks=pytest.mark.smoke, id="groups2-no-bias"),
-        pytest.param(Conv1dBiasFwdOp, 2, 32, 64, True, marks=pytest.mark.full, id="groups2-bias"),
-        pytest.param(Conv1dFwdOp, 4, 64, 64, False, marks=pytest.mark.full, id="groups4-no-bias"),
-        pytest.param(Conv1dBiasFwdOp, 4, 64, 64, True, marks=pytest.mark.full, id="groups4-bias"),
-    ],
-)
-def test_conv1d_groups_matches_torch(op_cls, groups: int, c_in: int, c_out: int, use_bias: bool) -> None:
-    n, l_in, kernel_size = 1, 128, 3
-    stride, padding = 1, 1
-    op_kwargs = {"bias": use_bias} if op_cls is Conv1dBiasFwdOp else {}
-    op = op_cls(
-        n=n,
-        c_in=c_in,
-        l_in=l_in,
-        c_out=c_out,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        groups=groups,
-        **op_kwargs,
-    )
-    x = torch.randn(n, c_in, l_in, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(c_out, c_in // groups, kernel_size, device="cuda", dtype=torch.float16).contiguous()
-    bias = (
-        torch.randn(c_out, device="cuda", dtype=torch.float16).contiguous()
-        if use_bias else None
-    )
-    out = op(x, weight, bias) if use_bias else op(x, weight)
-    ref = F.conv1d(
-        x,
-        weight,
-        bias=bias,
-        stride=stride,
-        padding=padding,
-        groups=groups,
-    )
-    ref = ref.contiguous()
-    torch.testing.assert_close(out, ref, atol=2e-3, rtol=3e-3)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    "groups, c_in, c_out",
-    [
-        pytest.param(3, 48, 72, id="coutg24"),
-    ],
-)
-def test_conv1d_groups_rejects_unimplemented_shapes(groups: int, c_in: int, c_out: int) -> None:
-    with pytest.raises(NotImplementedError):
-        Conv1dFwdOp(
-            n=1,
-            c_in=c_in,
-            l_in=128,
-            c_out=c_out,
-            kernel_size=3,
-            padding=1,
-            groups=groups,
-        )
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize("use_bias", [False, True], ids=["no-bias", "bias"])
-def test_conv1d_depthwise_conformer_matches_torch(use_bias: bool) -> None:
-    """Conformer convolution modules use depthwise Conv1d with groups=channels."""
-    n, channels, l_in = 1, 64, 128
-    kernel_size = 31
-    padding = kernel_size // 2
-    op_cls = Conv1dBiasFwdOp if use_bias else Conv1dFwdOp
-    op_kwargs = {"bias": True} if use_bias else {}
-    op = op_cls(
-        n=n,
-        c_in=channels,
-        l_in=l_in,
-        c_out=channels,
-        kernel_size=kernel_size,
-        stride=1,
-        padding=padding,
-        groups=channels,
-        **op_kwargs,
-    )
-    assert isinstance(op.kernel, DirectConv1dKernel)
-    x = torch.randn(n, channels, l_in, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(channels, 1, kernel_size, device="cuda", dtype=torch.float16).contiguous()
-    bias = (
-        torch.randn(channels, device="cuda", dtype=torch.float16).contiguous()
-        if use_bias else None
-    )
-    out = op(x, weight, bias) if use_bias else op(x, weight)
-    ref = F.conv1d(x, weight, bias=bias, stride=1, padding=padding, groups=channels).contiguous()
-    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
-
-
-@pytest.mark.smoke
-def test_conv1d_grouped_kernel_locks_block_m_to_channels_per_group() -> None:
-    op = Conv1dFwdOp(
-        n=1,
-        c_in=32,
-        l_in=128,
-        c_out=64,
-        kernel_size=3,
-        padding=1,
-        groups=2,
-    )
-    assert isinstance(op.kernel, GroupConv1dKernel)
-    assert op.kernel.config["block_m"] == 32
-    assert {config["block_m"] for config in op.kernel.autotune_configs} == {16, 32}
-
-
-@pytest.mark.smoke
-def test_conv1d_groups_forces_generic_kernel() -> None:
-    """When groups>1, pointwise conditions must not dispatch to Conv1dPointwiseKernel."""
-    op = Conv1dFwdOp(
-        n=1,
-        c_in=32,
-        l_in=256,
-        c_out=64,
-        kernel_size=1,
-        stride=1,
-        padding=0,
-        groups=2,
-    )
-    assert isinstance(op.kernel, GroupConv1dKernel)
-    assert not isinstance(op.kernel, Conv1dPointwiseKernel)
 
 
 class Conv2dFixture(FixtureBase):

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -11,6 +11,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
@@ -323,7 +324,6 @@ def test_conv1d_groups_matches_torch(op_cls, groups: int, c_in: int, c_out: int,
 @pytest.mark.parametrize(
     "groups, c_in, c_out",
     [
-        pytest.param(64, 64, 64, id="depthwise-cing1-coutg1"),
         pytest.param(3, 48, 72, id="coutg24"),
     ],
 )
@@ -338,6 +338,38 @@ def test_conv1d_groups_rejects_unimplemented_shapes(groups: int, c_in: int, c_ou
             padding=1,
             groups=groups,
         )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no-bias", "bias"])
+def test_conv1d_depthwise_conformer_matches_torch(use_bias: bool) -> None:
+    """Conformer convolution modules use depthwise Conv1d with groups=channels."""
+    n, channels, l_in = 1, 64, 128
+    kernel_size = 31
+    padding = kernel_size // 2
+    op_cls = Conv1dBiasFwdOp if use_bias else Conv1dFwdOp
+    op_kwargs = {"bias": True} if use_bias else {}
+    op = op_cls(
+        n=n,
+        c_in=channels,
+        l_in=l_in,
+        c_out=channels,
+        kernel_size=kernel_size,
+        stride=1,
+        padding=padding,
+        groups=channels,
+        **op_kwargs,
+    )
+    assert isinstance(op.kernel, DirectConv1dKernel)
+    x = torch.randn(n, channels, l_in, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(channels, 1, kernel_size, device="cuda", dtype=torch.float16).contiguous()
+    bias = (
+        torch.randn(channels, device="cuda", dtype=torch.float16).contiguous()
+        if use_bias else None
+    )
+    out = op(x, weight, bias) if use_bias else op(x, weight)
+    ref = F.conv1d(x, weight, bias=bias, stride=1, padding=padding, groups=channels).contiguous()
+    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -11,6 +11,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    GroupConv1dKernel,
 )
 from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
 
@@ -319,6 +320,43 @@ def test_conv1d_groups_matches_torch(op_cls, groups: int, c_in: int, c_out: int,
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize(
+    "groups, c_in, c_out",
+    [
+        pytest.param(64, 64, 64, id="depthwise-cing1-coutg1"),
+        pytest.param(3, 48, 72, id="coutg24"),
+    ],
+)
+def test_conv1d_groups_rejects_unimplemented_shapes(groups: int, c_in: int, c_out: int) -> None:
+    with pytest.raises(NotImplementedError):
+        Conv1dFwdOp(
+            n=1,
+            c_in=c_in,
+            l_in=128,
+            c_out=c_out,
+            kernel_size=3,
+            padding=1,
+            groups=groups,
+        )
+
+
+@pytest.mark.smoke
+def test_conv1d_grouped_kernel_locks_block_m_to_channels_per_group() -> None:
+    op = Conv1dFwdOp(
+        n=1,
+        c_in=32,
+        l_in=128,
+        c_out=64,
+        kernel_size=3,
+        padding=1,
+        groups=2,
+    )
+    assert isinstance(op.kernel, GroupConv1dKernel)
+    assert op.kernel.config["block_m"] == 32
+    assert {config["block_m"] for config in op.kernel.autotune_configs} == {16, 32}
+
+
+@pytest.mark.smoke
 def test_conv1d_groups_forces_generic_kernel() -> None:
     """When groups>1, pointwise conditions must not dispatch to Conv1dPointwiseKernel."""
     op = Conv1dFwdOp(
@@ -331,7 +369,7 @@ def test_conv1d_groups_forces_generic_kernel() -> None:
         padding=0,
         groups=2,
     )
-    assert isinstance(op.kernel, Conv1dKernel)
+    assert isinstance(op.kernel, GroupConv1dKernel)
     assert not isinstance(op.kernel, Conv1dPointwiseKernel)
 
 

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -38,7 +38,6 @@ from .convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
-    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from .deltanet import DeltaNetBwdKernel, DeltaNetFwdKernel
@@ -94,7 +93,6 @@ __all__ = [
     "DeltaNetDecodeFP32Kernel",
     "DeltaNetDecodeKernel",
     "DeltaNetFwdKernel",
-    "DirectConv1dKernel",
     "DropoutKernel",
     "EngramDecodeKernel",
     "EngramGateConvBwdKernel",

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -38,6 +38,7 @@ from .convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    GroupConv1dKernel,
 )
 from .deltanet import DeltaNetBwdKernel, DeltaNetFwdKernel
 from .deltanet_recurrence import DeltaNetDecodeFP32Kernel, DeltaNetDecodeKernel
@@ -129,6 +130,7 @@ __all__ = [
     "GatedDeltaNetFwdKernel",
     "GemmKernel",
     "GemvKernel",
+    "GroupConv1dKernel",
     "GroupNormKernel",
     "GroupedGemmKernel",
     "Kernel",

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -38,6 +38,7 @@ from .convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from .deltanet import DeltaNetBwdKernel, DeltaNetFwdKernel
@@ -93,6 +94,7 @@ __all__ = [
     "DeltaNetDecodeFP32Kernel",
     "DeltaNetDecodeKernel",
     "DeltaNetFwdKernel",
+    "DirectConv1dKernel",
     "DropoutKernel",
     "EngramDecodeKernel",
     "EngramGateConvBwdKernel",

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -57,10 +57,15 @@ def _conv1d_kernel(
     dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
+    groups: int = 1,
+    c_in_g: int = 0,
+    c_out_g: int = 0,
 ):
     accum_dtype = "float"
     out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-    k_total = c_in * kernel_l
+    c_in_g = c_in_g if c_in_g > 0 else c_in // groups
+    c_out_g = c_out_g if c_out_g > 0 else c_out // groups
+    k_total = c_in_g * kernel_l
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _conv1d_func(
@@ -109,11 +114,12 @@ def _conv1d_kernel(
                     for i, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + i
                         ol = bx * block_n + j
-                        kw = k_idx // c_in
-                        ci = k_idx % c_in
+                        kw = k_idx // c_in_g
+                        ci = k_idx % c_in_g
+                        group_id = (by * block_m) // c_out_g
                         il = ol * stride_l + kw * dilation_l - pad_l
                         if tile_full:
-                            data_shared[i, j] = x[bz, ci, il]
+                            data_shared[i, j] = x[bz, group_id * c_in_g + ci, il]
                         else:
                             in_bound = (
                                 (k_idx < k_total)
@@ -123,7 +129,7 @@ def _conv1d_kernel(
                             )
                             data_shared[i, j] = T.if_then_else(
                                 in_bound,
-                                x[bz, ci, il],
+                                x[bz, group_id * c_in_g + ci, il],
                                 T.cast(0.0, dtype),
                             )
 
@@ -252,6 +258,9 @@ def _conv1d_wrapped_kernel(
     dilation_l: int,
     has_bias: bool,
     dtype: str,
+    groups: int,
+    c_in_g: int,
+    c_out_g: int,
     block_m: int,
     block_n: int,
     block_k: int,
@@ -263,7 +272,7 @@ def _conv1d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -457,6 +466,9 @@ class Conv1dKernel(Kernel):
         dtype: torch.dtype,
         dilation_l: int = 1,
         has_bias: bool = False,
+        groups: int = 1,
+        c_in_g: Optional[int] = None,
+        c_out_g: Optional[int] = None,
         config: Optional[dict] = None,
         tune: bool = False,
     ) -> None:
@@ -469,11 +481,14 @@ class Conv1dKernel(Kernel):
         self.stride_l = stride_l
         self.pad_l = pad_l
         self.dilation_l = dilation_l
+        self.groups = groups
+        self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
+        self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
         self.dtype = dtype
         self.has_bias = has_bias
         self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
-        self.k_total = c_in * kernel_l
+        self.k_total = self.c_in_g * kernel_l
         self._weight_flat_cache_source: Optional[torch.Tensor] = None
         self._weight_flat_cache_version: Optional[int] = None
         self._weight_flat_cache: Optional[torch.Tensor] = None
@@ -488,8 +503,21 @@ class Conv1dKernel(Kernel):
             dilation_l,
             has_bias,
             self.dtype_str,
+            groups,
+            self.c_in_g,
+            self.c_out_g,
         )
         self.init_config(config, tune)
+        # For grouped conv, ensure block_m does not exceed c_out_g so that all
+        # output channels in a tile belong to the same group.
+        if self.groups > 1 and self.c_out_g < self.config["block_m"]:
+            if self.c_out_g < 16:
+                raise NotImplementedError(
+                    f"Conv1dKernel grouped conv requires c_out_g >= 16 due to "
+                    f"TensorCore warp constraints, but got c_out_g={self.c_out_g}. "
+                    f"Consider using a larger group size or ops-layer decomposition."
+                )
+            self.config["block_m"] = self.c_out_g
 
     @property
     def default_config(self) -> dict:
@@ -574,6 +602,9 @@ class Conv1dKernel(Kernel):
             self.dilation_l,
             self.has_bias,
             self.dtype_str,
+            self.groups,
+            self.c_in_g,
+            self.c_out_g,
             self.config["block_m"],
             self.config["block_n"],
             self.config["block_k"],

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -15,6 +15,7 @@ __all__ = [
     "Conv2d1x1Kernel",
     "Conv2dKernel",
     "Conv3dKernel",
+    "DirectConv1dKernel",
     "GroupConv1dKernel",
 ]
 
@@ -166,6 +167,78 @@ def _conv1d_kernel(
 
     return _conv1d_func
 
+
+@functools.lru_cache(maxsize=32)
+def _conv1d_direct_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+
+    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _conv1d_direct_func(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_stages: int,
+        threads: int,
+        enable_rasterization: bool,
+    ):
+        @T.prim_func
+        def _conv1d_direct_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, 1, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+            bias: T.Tensor((c_out,), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_l, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
+                threads=threads,
+            ) as (bx, by, bz):
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                for kw in T.serial(kernel_l):
+                    for i, j in T.Parallel(block_m, block_n):
+                        oc = by * block_m + i
+                        ol = bx * block_n + j
+                        il = ol * stride_l + kw * dilation_l - pad_l
+                        valid = (oc < c_out) & (ol < out_l) & (il >= 0) & (il < l_in)
+                        out_local[i, j] += T.if_then_else(
+                            valid,
+                            T.cast(x[bz, oc, il] * weight[oc, 0, kw], accum_dtype),
+                            T.cast(0.0, accum_dtype),
+                        )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc = by * block_m + i
+                    ol = bx * block_n + j
+                    if oc < c_out and ol < out_l:
+                        if has_bias:
+                            out[bz, oc, ol] = T.cast(
+                                out_local[i, j] + T.cast(bias[oc], accum_dtype),
+                                dtype,
+                            )
+                        else:
+                            out[bz, oc, ol] = T.cast(out_local[i, j], dtype)
+
+        return _conv1d_direct_main
+
+    return _conv1d_direct_func
+
+
 @functools.lru_cache(maxsize=32)
 def _conv1d_pointwise_kernel(
     n: int,
@@ -279,6 +352,34 @@ def _conv1d_wrapped_kernel(
         n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
+
+@torch.library.custom_op("top::conv1d_direct_wrapped_kernel", mutates_args=())
+def _conv1d_direct_wrapped_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    return _conv1d_direct_kernel(
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+
+
 @torch.library.custom_op("top::conv1d_pointwise_wrapped_kernel", mutates_args=())
 def _conv1d_pointwise_wrapped_kernel(
     n: int,
@@ -327,6 +428,31 @@ def _(
 ) -> torch.Tensor:
     out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+@_conv1d_direct_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    *inputs: tuple[torch.Tensor, ...],
+) -> torch.Tensor:
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
+
 
 @_conv1d_pointwise_wrapped_kernel.register_fake
 def _(
@@ -599,6 +725,107 @@ class Conv1dKernel(Kernel):
             self.config["enable_rasterization"],
             x,
             weight_flat,
+            bias,
+        )
+
+
+class DirectConv1dKernel(Kernel):
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        l_in: int,
+        c_out: int,
+        kernel_l: int,
+        stride_l: int,
+        pad_l: int,
+        dtype: torch.dtype,
+        dilation_l: int = 1,
+        has_bias: bool = False,
+        groups: int = 1,
+        c_in_g: Optional[int] = None,
+        c_out_g: Optional[int] = None,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.l_in = l_in
+        self.c_out = c_out
+        self.kernel_l = kernel_l
+        self.stride_l = stride_l
+        self.pad_l = pad_l
+        self.dilation_l = dilation_l
+        self.groups = groups
+        self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
+        self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
+        self.dtype = dtype
+        self.has_bias = has_bias
+        self._validate_direct_shape()
+        self.kernel = _conv1d_direct_kernel(
+            n,
+            c_in,
+            l_in,
+            c_out,
+            kernel_l,
+            stride_l,
+            pad_l,
+            dilation_l,
+            has_bias,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    def _validate_direct_shape(self) -> None:
+        if self.groups <= 1:
+            raise ValueError("DirectConv1dKernel requires groups > 1")
+        if self.c_in_g != 1 or self.c_out_g != 1:
+            raise NotImplementedError(
+                f"DirectConv1dKernel currently requires c_in_g == c_out_g == 1, "
+                f"but got c_in_g={self.c_in_g}, c_out_g={self.c_out_g}"
+            )
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 1,
+            "block_n": 128,
+            "block_k": 1,
+            "num_stages": 1,
+            "threads": 128,
+            "enable_rasterization": True,
+        }
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if bias is None:
+            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
+        return _conv1d_direct_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.l_in,
+            self.c_out,
+            self.kernel_l,
+            self.stride_l,
+            self.pad_l,
+            self.dilation_l,
+            self.has_bias,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["block_n"],
+            self.config["block_k"],
+            self.config["num_stages"],
+            self.config["threads"],
+            self.config["enable_rasterization"],
+            x,
+            weight,
             bias,
         )
 

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -63,15 +63,10 @@ def _conv1d_kernel(
     dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
-    groups: int = 1,
-    c_in_g: int = 0,
-    c_out_g: int = 0,
 ):
     accum_dtype = "float"
     out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-    c_in_g = c_in_g if c_in_g > 0 else c_in // groups
-    c_out_g = c_out_g if c_out_g > 0 else c_out // groups
-    k_total = c_in_g * kernel_l
+    k_total = c_in * kernel_l
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _conv1d_func(
@@ -120,12 +115,11 @@ def _conv1d_kernel(
                     for i, j in T.Parallel(block_k, block_n):
                         k_idx = k_iter * block_k + i
                         ol = bx * block_n + j
-                        kw = k_idx // c_in_g
-                        ci = k_idx % c_in_g
-                        group_id = (by * block_m) // c_out_g
+                        kw = k_idx // c_in
+                        ci = k_idx % c_in
                         il = ol * stride_l + kw * dilation_l - pad_l
                         if tile_full:
-                            data_shared[i, j] = x[bz, group_id * c_in_g + ci, il]
+                            data_shared[i, j] = x[bz, ci, il]
                         else:
                             in_bound = (
                                 (k_idx < k_total)
@@ -135,7 +129,7 @@ def _conv1d_kernel(
                             )
                             data_shared[i, j] = T.if_then_else(
                                 in_bound,
-                                x[bz, group_id * c_in_g + ci, il],
+                                x[bz, ci, il],
                                 T.cast(0.0, dtype),
                             )
 
@@ -218,7 +212,8 @@ def _conv1d_direct_kernel(
                         valid = (oc < c_out) & (ol < out_l) & (il >= 0) & (il < l_in)
                         out_local[i, j] += T.if_then_else(
                             valid,
-                            T.cast(x[bz, oc, il] * weight[oc, 0, kw], accum_dtype),
+                            T.cast(x[bz, oc, il], accum_dtype)
+                            * T.cast(weight[oc, 0, kw], accum_dtype),
                             T.cast(0.0, accum_dtype),
                         )
 
@@ -449,9 +444,6 @@ def _conv1d_wrapped_kernel(
     dilation_l: int,
     has_bias: bool,
     dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
     block_m: int,
     block_n: int,
     block_k: int,
@@ -463,7 +455,7 @@ def _conv1d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -559,9 +551,6 @@ def _(
     dilation_l: int,
     has_bias: bool,
     dtype: str,
-    groups: int,
-    c_in_g: int,
-    c_out_g: int,
     block_m: int,
     block_n: int,
     block_k: int,
@@ -885,9 +874,6 @@ class Conv1dKernel(Kernel):
             self.dilation_l,
             self.has_bias,
             self.dtype_str,
-            1,
-            self.c_in,
-            self.c_out,
             self.config["block_m"],
             self.config["block_n"],
             self.config["block_k"],

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -15,6 +15,7 @@ __all__ = [
     "Conv2d1x1Kernel",
     "Conv2dKernel",
     "Conv3dKernel",
+    "GroupConv1dKernel",
 ]
 
 
@@ -39,6 +40,10 @@ def conv_shared_memory_bytes(
     per_stage_bytes = (block_m * block_k + block_k * block_n) * dtype_bytes
     out_shared_bytes = block_m * block_n * dtype_bytes
     return per_stage_bytes * max(1, num_stages) + out_shared_bytes
+
+
+def _group_conv1d_block_m_choices(c_out_g: int) -> list[int]:
+    return [block_m for block_m in [16, 32, 64, 128] if c_out_g % block_m == 0]
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +166,6 @@ def _conv1d_kernel(
 
     return _conv1d_func
 
-
 @functools.lru_cache(maxsize=32)
 def _conv1d_pointwise_kernel(
     n: int,
@@ -275,7 +279,6 @@ def _conv1d_wrapped_kernel(
         n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
-
 @torch.library.custom_op("top::conv1d_pointwise_wrapped_kernel", mutates_args=())
 def _conv1d_pointwise_wrapped_kernel(
     n: int,
@@ -311,6 +314,9 @@ def _(
     dilation_l: int,
     has_bias: bool,
     dtype: str,
+    groups: int,
+    c_in_g: int,
+    c_out_g: int,
     block_m: int,
     block_n: int,
     block_k: int,
@@ -321,7 +327,6 @@ def _(
 ) -> torch.Tensor:
     out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
-
 
 @_conv1d_pointwise_wrapped_kernel.register_fake
 def _(
@@ -466,9 +471,6 @@ class Conv1dKernel(Kernel):
         dtype: torch.dtype,
         dilation_l: int = 1,
         has_bias: bool = False,
-        groups: int = 1,
-        c_in_g: Optional[int] = None,
-        c_out_g: Optional[int] = None,
         config: Optional[dict] = None,
         tune: bool = False,
     ) -> None:
@@ -481,14 +483,11 @@ class Conv1dKernel(Kernel):
         self.stride_l = stride_l
         self.pad_l = pad_l
         self.dilation_l = dilation_l
-        self.groups = groups
-        self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
-        self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
         self.dtype = dtype
         self.has_bias = has_bias
         self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
-        self.k_total = self.c_in_g * kernel_l
+        self.k_total = c_in * kernel_l
         self._weight_flat_cache_source: Optional[torch.Tensor] = None
         self._weight_flat_cache_version: Optional[int] = None
         self._weight_flat_cache: Optional[torch.Tensor] = None
@@ -503,21 +502,8 @@ class Conv1dKernel(Kernel):
             dilation_l,
             has_bias,
             self.dtype_str,
-            groups,
-            self.c_in_g,
-            self.c_out_g,
         )
         self.init_config(config, tune)
-        # For grouped conv, ensure block_m does not exceed c_out_g so that all
-        # output channels in a tile belong to the same group.
-        if self.groups > 1 and self.c_out_g < self.config["block_m"]:
-            if self.c_out_g < 16:
-                raise NotImplementedError(
-                    f"Conv1dKernel grouped conv requires c_out_g >= 16 due to "
-                    f"TensorCore warp constraints, but got c_out_g={self.c_out_g}. "
-                    f"Consider using a larger group size or ops-layer decomposition."
-                )
-            self.config["block_m"] = self.c_out_g
 
     @property
     def default_config(self) -> dict:
@@ -545,6 +531,191 @@ class Conv1dKernel(Kernel):
         shared_memory_limit_bytes = get_shared_memory_limit_bytes()
         configs = itertools.product(
             [32, 64, 128],
+            [64, 128, 256],
+            [32, 64, 128],
+            [2, 3],
+            [128, 256],
+            [True],
+        )
+        valid_configs = []
+        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
+            shared_memory_bytes = conv_shared_memory_bytes(
+                block_m, block_n, block_k, num_stages, self.dtype)
+            if shared_memory_bytes > shared_memory_limit_bytes:
+                continue
+            valid_configs.append({
+                "block_m": block_m,
+                "block_n": block_n,
+                "block_k": block_k,
+                "num_stages": num_stages,
+                "threads": threads,
+                "enable_rasterization": enable_rasterization,
+            })
+        return valid_configs
+
+    def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
+        weight_version = weight._version
+        if (
+            self._weight_flat_cache_source is weight
+            and self._weight_flat_cache_version == weight_version
+            and self._weight_flat_cache is not None
+        ):
+            return self._weight_flat_cache
+
+        weight_flat = weight.permute(0, 2, 1).contiguous().view(self.c_out, self.k_total)
+        self._weight_flat_cache_source = weight
+        self._weight_flat_cache_version = weight_version
+        self._weight_flat_cache = weight_flat
+        return weight_flat
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if bias is None:
+            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
+        weight_flat = self._get_weight_flat(weight)
+        return _conv1d_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.l_in,
+            self.c_out,
+            self.kernel_l,
+            self.stride_l,
+            self.pad_l,
+            self.dilation_l,
+            self.has_bias,
+            self.dtype_str,
+            1,
+            self.c_in,
+            self.c_out,
+            self.config["block_m"],
+            self.config["block_n"],
+            self.config["block_k"],
+            self.config["num_stages"],
+            self.config["threads"],
+            self.config["enable_rasterization"],
+            x,
+            weight_flat,
+            bias,
+        )
+
+
+class GroupConv1dKernel(Kernel):
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        l_in: int,
+        c_out: int,
+        kernel_l: int,
+        stride_l: int,
+        pad_l: int,
+        dtype: torch.dtype,
+        dilation_l: int = 1,
+        has_bias: bool = False,
+        groups: int = 1,
+        c_in_g: Optional[int] = None,
+        c_out_g: Optional[int] = None,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.l_in = l_in
+        self.c_out = c_out
+        self.kernel_l = kernel_l
+        self.stride_l = stride_l
+        self.pad_l = pad_l
+        self.dilation_l = dilation_l
+        self.groups = groups
+        self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
+        self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
+        self.dtype = dtype
+        self.has_bias = has_bias
+        self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+        self.m = n * self.out_l
+        self.k_total = self.c_in_g * kernel_l
+        self._validate_group_shape()
+        self._weight_flat_cache_source: Optional[torch.Tensor] = None
+        self._weight_flat_cache_version: Optional[int] = None
+        self._weight_flat_cache: Optional[torch.Tensor] = None
+        self.kernel = _conv1d_kernel(
+            n,
+            c_in,
+            l_in,
+            c_out,
+            kernel_l,
+            stride_l,
+            pad_l,
+            dilation_l,
+            has_bias,
+            self.dtype_str,
+            groups,
+            self.c_in_g,
+            self.c_out_g,
+        )
+        self.init_config(config, tune)
+        if self.config["block_m"] not in self._block_m_choices:
+            raise ValueError(
+                f"GroupConv1dKernel requires block_m to divide c_out_g and be a multiple "
+                f"of 16; got block_m={self.config['block_m']}, c_out_g={self.c_out_g}"
+            )
+
+    def _validate_group_shape(self) -> None:
+        if self.groups <= 1:
+            raise ValueError("GroupConv1dKernel requires groups > 1")
+        if self.c_out_g < 16 or self.c_out_g % 16 != 0:
+            raise NotImplementedError(
+                f"GroupConv1dKernel currently requires c_out_g >= 16 and divisible by 16, "
+                f"but got c_out_g={self.c_out_g}"
+            )
+        if self.c_in_g < 16 or self.c_in_g % 16 != 0:
+            raise NotImplementedError(
+                f"GroupConv1dKernel currently requires c_in_g >= 16 and divisible by 16, "
+                f"but got c_in_g={self.c_in_g}"
+            )
+        if not self._block_m_choices:
+            raise NotImplementedError(
+                f"GroupConv1dKernel found no supported block_m for c_out_g={self.c_out_g}"
+            )
+
+    @property
+    def _block_m_choices(self) -> list[int]:
+        return _group_conv1d_block_m_choices(self.c_out_g)
+
+    @property
+    def default_config(self) -> dict:
+        block_m = 64 if 64 in self._block_m_choices else max(self._block_m_choices)
+        sm_version = get_sm_version()
+        if sm_version in {90}:
+            return {
+                "block_m": block_m,
+                "block_n": 128,
+                "block_k": 128,
+                "num_stages": 3,
+                "threads": 128,
+                "enable_rasterization": True,
+            }
+        return {
+            "block_m": block_m,
+            "block_n": 128,
+            "block_k": 128,
+            "num_stages": 2,
+            "threads": 128,
+            "enable_rasterization": True,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
+        configs = itertools.product(
+            self._block_m_choices,
             [64, 128, 256],
             [32, 64, 128],
             [2, 3],

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -15,7 +15,6 @@ __all__ = [
     "Conv2d1x1Kernel",
     "Conv2dKernel",
     "Conv3dKernel",
-    "DirectConv1dKernel",
     "GroupConv1dKernel",
 ]
 
@@ -44,7 +43,8 @@ def conv_shared_memory_bytes(
 
 
 def _group_conv1d_block_m_choices(c_out_g: int) -> list[int]:
-    return [block_m for block_m in [16, 32, 64, 128] if c_out_g % block_m == 0]
+    del c_out_g
+    return [16, 32, 64, 128]
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +239,120 @@ def _conv1d_direct_kernel(
     return _conv1d_direct_func
 
 
+@functools.lru_cache(maxsize=64)
+def _conv1d_group_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str = "float16",
+    groups: int = 1,
+    c_in_g: int = 0,
+    c_out_g: int = 0,
+):
+    accum_dtype = "float"
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    c_in_g = c_in_g if c_in_g > 0 else c_in // groups
+    c_out_g = c_out_g if c_out_g > 0 else c_out // groups
+    k_total = c_in_g * kernel_l
+
+    @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _conv1d_group_func(
+        block_m: int,
+        block_n: int,
+        block_k: int,
+        num_stages: int,
+        threads: int,
+        enable_rasterization: bool,
+    ):
+        @T.prim_func
+        def _conv1d_group_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in_g, kernel_l), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_l), dtype),  # type: ignore
+            bias: T.Tensor((c_out,), dtype),  # type: ignore
+        ):
+            with T.Kernel(
+                T.ceildiv(out_l, block_n),
+                T.ceildiv(c_out_g, block_m),
+                n * groups,
+                threads=threads,
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
+                out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                out_shared = T.alloc_shared((block_m, block_n), dtype)
+
+                T.use_swizzle(10, enable=enable_rasterization)
+                T.clear(out_local)
+
+                batch_id = bz // groups
+                group_id = bz % groups
+
+                for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
+                    for i, k in T.Parallel(block_m, block_k):
+                        oc_g = by * block_m + i
+                        oc = group_id * c_out_g + oc_g
+                        k_idx = k_iter * block_k + k
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
+                        weight_shared[i, k] = T.if_then_else(
+                            (oc_g < c_out_g) & (k_idx < k_total),
+                            weight[oc, ci_g, kw],
+                            T.cast(0.0, dtype),
+                        )
+
+                    for k, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + k
+                        ol = bx * block_n + j
+                        kw = k_idx // c_in_g
+                        ci_g = k_idx % c_in_g
+                        il = ol * stride_l + kw * dilation_l - pad_l
+                        data_shared[k, j] = T.if_then_else(
+                            (k_idx < k_total)
+                            & (ol < out_l)
+                            & (il >= 0)
+                            & (il < l_in),
+                            x[batch_id, group_id * c_in_g + ci_g, il],
+                            T.cast(0.0, dtype),
+                        )
+
+                    T.gemm(weight_shared, data_shared, out_local)
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    ol = bx * block_n + j
+                    if has_bias:
+                        out_shared[i, j] = T.if_then_else(
+                            (oc_g < c_out_g) & (ol < out_l),
+                            T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
+                            T.cast(0.0, dtype),
+                        )
+                    else:
+                        out_shared[i, j] = T.if_then_else(
+                            (oc_g < c_out_g) & (ol < out_l),
+                            T.cast(out_local[i, j], dtype),
+                            T.cast(0.0, dtype),
+                        )
+
+                for i, j in T.Parallel(block_m, block_n):
+                    oc_g = by * block_m + i
+                    oc = group_id * c_out_g + oc_g
+                    ol = bx * block_n + j
+                    if oc_g < c_out_g and ol < out_l:
+                        out[batch_id, oc, ol] = out_shared[i, j]
+
+        return _conv1d_group_main
+
+    return _conv1d_group_func
+
+
 @functools.lru_cache(maxsize=32)
 def _conv1d_pointwise_kernel(
     n: int,
@@ -380,6 +494,36 @@ def _conv1d_direct_wrapped_kernel(
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
+@torch.library.custom_op("top::conv1d_group_wrapped_kernel", mutates_args=())
+def _conv1d_group_wrapped_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    groups: int,
+    c_in_g: int,
+    c_out_g: int,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    return _conv1d_group_kernel(
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
+    )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
+
+
 @torch.library.custom_op("top::conv1d_pointwise_wrapped_kernel", mutates_args=())
 def _conv1d_pointwise_wrapped_kernel(
     n: int,
@@ -442,6 +586,33 @@ def _(
     dilation_l: int,
     has_bias: bool,
     dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    enable_rasterization: bool,
+    *inputs: tuple[torch.Tensor, ...],
+) -> torch.Tensor:
+    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+@_conv1d_group_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    l_in: int,
+    c_out: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dilation_l: int,
+    has_bias: bool,
+    dtype: str,
+    groups: int,
+    c_in_g: int,
+    c_out_g: int,
     block_m: int,
     block_n: int,
     block_k: int,
@@ -729,107 +900,6 @@ class Conv1dKernel(Kernel):
         )
 
 
-class DirectConv1dKernel(Kernel):
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        l_in: int,
-        c_out: int,
-        kernel_l: int,
-        stride_l: int,
-        pad_l: int,
-        dtype: torch.dtype,
-        dilation_l: int = 1,
-        has_bias: bool = False,
-        groups: int = 1,
-        c_in_g: Optional[int] = None,
-        c_out_g: Optional[int] = None,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        self.n = n
-        self.c_in = c_in
-        self.l_in = l_in
-        self.c_out = c_out
-        self.kernel_l = kernel_l
-        self.stride_l = stride_l
-        self.pad_l = pad_l
-        self.dilation_l = dilation_l
-        self.groups = groups
-        self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
-        self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
-        self.dtype = dtype
-        self.has_bias = has_bias
-        self._validate_direct_shape()
-        self.kernel = _conv1d_direct_kernel(
-            n,
-            c_in,
-            l_in,
-            c_out,
-            kernel_l,
-            stride_l,
-            pad_l,
-            dilation_l,
-            has_bias,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
-
-    def _validate_direct_shape(self) -> None:
-        if self.groups <= 1:
-            raise ValueError("DirectConv1dKernel requires groups > 1")
-        if self.c_in_g != 1 or self.c_out_g != 1:
-            raise NotImplementedError(
-                f"DirectConv1dKernel currently requires c_in_g == c_out_g == 1, "
-                f"but got c_in_g={self.c_in_g}, c_out_g={self.c_out_g}"
-            )
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 1,
-            "block_n": 128,
-            "block_k": 1,
-            "num_stages": 1,
-            "threads": 128,
-            "enable_rasterization": True,
-        }
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        bias: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        if bias is None:
-            bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        return _conv1d_direct_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.c_out,
-            self.kernel_l,
-            self.stride_l,
-            self.pad_l,
-            self.dilation_l,
-            self.has_bias,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["block_k"],
-            self.config["num_stages"],
-            self.config["threads"],
-            self.config["enable_rasterization"],
-            x,
-            weight,
-            bias,
-        )
-
-
 class GroupConv1dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
 
@@ -865,60 +935,81 @@ class GroupConv1dKernel(Kernel):
         self.c_out_g = c_out_g if c_out_g is not None else c_out // groups
         self.dtype = dtype
         self.has_bias = has_bias
-        self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
-        self.m = n * self.out_l
-        self.k_total = self.c_in_g * kernel_l
+        self.use_direct = self.c_in_g == 1 and self.c_out_g == 1
         self._validate_group_shape()
-        self._weight_flat_cache_source: Optional[torch.Tensor] = None
-        self._weight_flat_cache_version: Optional[int] = None
-        self._weight_flat_cache: Optional[torch.Tensor] = None
-        self.kernel = _conv1d_kernel(
-            n,
-            c_in,
-            l_in,
-            c_out,
-            kernel_l,
-            stride_l,
-            pad_l,
-            dilation_l,
-            has_bias,
-            self.dtype_str,
-            groups,
-            self.c_in_g,
-            self.c_out_g,
-        )
+        if self.use_direct:
+            self.kernel = _conv1d_direct_kernel(
+                n,
+                c_in,
+                l_in,
+                c_out,
+                kernel_l,
+                stride_l,
+                pad_l,
+                dilation_l,
+                has_bias,
+                self.dtype_str,
+            )
+        else:
+            self.kernel = _conv1d_group_kernel(
+                n,
+                c_in,
+                l_in,
+                c_out,
+                kernel_l,
+                stride_l,
+                pad_l,
+                dilation_l,
+                has_bias,
+                self.dtype_str,
+                groups,
+                self.c_in_g,
+                self.c_out_g,
+            )
         self.init_config(config, tune)
-        if self.config["block_m"] not in self._block_m_choices:
+        if not self.use_direct and self.config["block_m"] % 16 != 0:
             raise ValueError(
-                f"GroupConv1dKernel requires block_m to divide c_out_g and be a multiple "
-                f"of 16; got block_m={self.config['block_m']}, c_out_g={self.c_out_g}"
+                f"GroupConv1dKernel requires block_m to be a multiple of 16; "
+                f"got block_m={self.config['block_m']}"
+            )
+        if not self.use_direct and self.config["block_k"] % 16 != 0:
+            raise ValueError(
+                f"GroupConv1dKernel requires block_k to be a multiple of 16; "
+                f"got block_k={self.config['block_k']}"
             )
 
     def _validate_group_shape(self) -> None:
         if self.groups <= 1:
             raise ValueError("GroupConv1dKernel requires groups > 1")
-        if self.c_out_g < 16 or self.c_out_g % 16 != 0:
-            raise NotImplementedError(
-                f"GroupConv1dKernel currently requires c_out_g >= 16 and divisible by 16, "
-                f"but got c_out_g={self.c_out_g}"
-            )
-        if self.c_in_g < 16 or self.c_in_g % 16 != 0:
-            raise NotImplementedError(
-                f"GroupConv1dKernel currently requires c_in_g >= 16 and divisible by 16, "
-                f"but got c_in_g={self.c_in_g}"
-            )
-        if not self._block_m_choices:
-            raise NotImplementedError(
-                f"GroupConv1dKernel found no supported block_m for c_out_g={self.c_out_g}"
+        if self.use_direct:
+            return
+        if self.c_in % self.groups != 0 or self.c_out % self.groups != 0:
+            raise ValueError(
+                f"GroupConv1dKernel requires c_in and c_out divisible by groups; "
+                f"got c_in={self.c_in}, c_out={self.c_out}, groups={self.groups}"
             )
 
     @property
     def _block_m_choices(self) -> list[int]:
+        if self.use_direct:
+            return [1]
         return _group_conv1d_block_m_choices(self.c_out_g)
 
     @property
     def default_config(self) -> dict:
-        block_m = 64 if 64 in self._block_m_choices else max(self._block_m_choices)
+        if self.use_direct:
+            return {
+                "block_m": 1,
+                "block_n": 128,
+                "block_k": 1,
+                "num_stages": 1,
+                "threads": 128,
+                "enable_rasterization": True,
+            }
+        block_m = next(
+            (choice for choice in self._block_m_choices if choice >= self.c_out_g),
+            max(self._block_m_choices),
+        )
         sm_version = get_sm_version()
         if sm_version in {90}:
             return {
@@ -940,6 +1031,8 @@ class GroupConv1dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
+        if self.use_direct:
+            return [self.default_config]
         shared_memory_limit_bytes = get_shared_memory_limit_bytes()
         configs = itertools.product(
             self._block_m_choices,
@@ -965,21 +1058,6 @@ class GroupConv1dKernel(Kernel):
             })
         return valid_configs
 
-    def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
-        weight_version = weight._version
-        if (
-            self._weight_flat_cache_source is weight
-            and self._weight_flat_cache_version == weight_version
-            and self._weight_flat_cache is not None
-        ):
-            return self._weight_flat_cache
-
-        weight_flat = weight.permute(0, 2, 1).contiguous().view(self.c_out, self.k_total)
-        self._weight_flat_cache_source = weight
-        self._weight_flat_cache_version = weight_version
-        self._weight_flat_cache = weight_flat
-        return weight_flat
-
     def forward(
         self,
         x: torch.Tensor,
@@ -988,8 +1066,29 @@ class GroupConv1dKernel(Kernel):
     ) -> torch.Tensor:
         if bias is None:
             bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        weight_flat = self._get_weight_flat(weight)
-        return _conv1d_wrapped_kernel(
+        if self.use_direct:
+            return _conv1d_direct_wrapped_kernel(
+                self.n,
+                self.c_in,
+                self.l_in,
+                self.c_out,
+                self.kernel_l,
+                self.stride_l,
+                self.pad_l,
+                self.dilation_l,
+                self.has_bias,
+                self.dtype_str,
+                self.config["block_m"],
+                self.config["block_n"],
+                self.config["block_k"],
+                self.config["num_stages"],
+                self.config["threads"],
+                self.config["enable_rasterization"],
+                x,
+                weight,
+                bias,
+            )
+        return _conv1d_group_wrapped_kernel(
             self.n,
             self.c_in,
             self.l_in,
@@ -1010,7 +1109,7 @@ class GroupConv1dKernel(Kernel):
             self.config["threads"],
             self.config["enable_rasterization"],
             x,
-            weight_flat,
+            weight,
             bias,
         )
 

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -8,7 +8,7 @@ Conv1dFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias=None)
   family: convolution
-  status: spec-only  # TODO: pointwise kernel still groups=1 only; promote after full validation
+  status: spec-only  # TODO: impl lacks dilation, groups, string padding
 
   signature:
     inputs:
@@ -72,7 +72,7 @@ Conv1dBiasFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: pointwise kernel still groups=1 only; promote after full validation
+  status: spec-only  # TODO: impl lacks dilation, groups, string padding
   variant_of: Conv1dFwdOp
 
   signature:

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -8,7 +8,7 @@ Conv1dFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias=None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups, string padding
+  status: spec-only  # TODO: pointwise kernel still groups=1 only; promote after full validation
 
   signature:
     inputs:
@@ -71,7 +71,7 @@ Conv1dBiasFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups, string padding
+  status: spec-only  # TODO: pointwise kernel still groups=1 only; promote after full validation
   variant_of: Conv1dFwdOp
 
   signature:

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -62,6 +62,7 @@ Conv1dFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
+      group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py
     bench: benchmarks/ops/bench_convolution.py
@@ -114,6 +115,7 @@ Conv1dBiasFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
+      group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py
     bench: benchmarks/ops/bench_convolution.py

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -62,7 +62,6 @@ Conv1dFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
-      direct_conv1d_kernel: DirectConv1dKernel
       group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py
@@ -116,7 +115,6 @@ Conv1dBiasFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
-      direct_conv1d_kernel: DirectConv1dKernel
       group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -62,6 +62,7 @@ Conv1dFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
+      direct_conv1d_kernel: DirectConv1dKernel
       group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py
@@ -115,6 +116,7 @@ Conv1dBiasFwdOp:
     kernel_map:
       conv1d_pointwise_kernel: Conv1dPointwiseKernel
       conv1d_kernel: Conv1dKernel
+      direct_conv1d_kernel: DirectConv1dKernel
       group_conv1d_kernel: GroupConv1dKernel
     op: tileops/ops/convolution.py
     test: tests/ops/test_convolution.py

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -164,12 +164,13 @@ class Conv1dFwdOp(Op):
         _validate_positive_int("l_in", l_in, "Conv1d")
         _validate_positive_int("c_out", c_out, "Conv1d")
         _validate_conv_groups("Conv1d", c_in, c_out, groups)
-        if groups != 1:
-            raise NotImplementedError("Conv1d currently supports groups=1 only")
         self.n = n
         self.c_in = c_in
         self.l_in = l_in
         self.c_out = c_out
+        self.groups = groups
+        self.c_in_g = c_in // groups
+        self.c_out_g = c_out // groups
         kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
         stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
         dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
@@ -188,7 +189,6 @@ class Conv1dFwdOp(Op):
         self.stride = stride_tuple[0]
         self.padding = padding_tuple[0]
         self.dilation = dilation_tuple[0]
-        self.groups = groups
         self.has_bias = _has_bias
         self.dtype = dtype
 
@@ -203,7 +203,8 @@ class Conv1dFwdOp(Op):
             tune=tune,
         )
         if (
-            self.kernel_size == 1
+            self.groups == 1
+            and self.kernel_size == 1
             and self.stride == 1
             and self.padding == 0
             and self.dilation == 1
@@ -217,6 +218,9 @@ class Conv1dFwdOp(Op):
                 stride_l=self.stride,
                 pad_l=self.padding,
                 dilation_l=self.dilation,
+                groups=self.groups,
+                c_in_g=self.c_in_g,
+                c_out_g=self.c_out_g,
             )
         else:
             raise NotImplementedError(
@@ -240,7 +244,7 @@ class Conv1dFwdOp(Op):
             "Conv1d",
             "weight",
             weight,
-            (self.c_out, self.c_in, self.kernel_size),
+            (self.c_out, self.c_in // self.groups, self.kernel_size),
         )
         return self.kernel(input, weight, None)
 
@@ -300,7 +304,7 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
             "Conv1d",
             "weight",
             weight,
-            (self.c_out, self.c_in, self.kernel_size),
+            (self.c_out, self.c_in // self.groups, self.kernel_size),
         )
         _validate_tensor_shape("Conv1d", "bias", bias, (self.c_out,))
         return self.kernel(input, weight, bias)

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -8,6 +8,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from tileops.kernels.kernel_base import Kernel
@@ -212,6 +213,22 @@ class Conv1dFwdOp(Op):
             and "conv1d_pointwise_kernel" in self.kernel_map
         ):
             self.kernel = self.kernel_map["conv1d_pointwise_kernel"](**kernel_kwargs)
+        elif (
+            self.groups > 1
+            and self.c_in_g == 1
+            and self.c_out_g == 1
+            and "direct_conv1d_kernel" in self.kernel_map
+        ):
+            self.kernel = self.kernel_map["direct_conv1d_kernel"](
+                **kernel_kwargs,
+                kernel_l=self.kernel_size,
+                stride_l=self.stride,
+                pad_l=self.padding,
+                dilation_l=self.dilation,
+                groups=self.groups,
+                c_in_g=self.c_in_g,
+                c_out_g=self.c_out_g,
+            )
         elif self.groups > 1 and "group_conv1d_kernel" in self.kernel_map:
             self.kernel = self.kernel_map["group_conv1d_kernel"](
                 **kernel_kwargs,
@@ -242,6 +259,7 @@ class Conv1dFwdOp(Op):
         return {
             "conv1d_pointwise_kernel": Conv1dPointwiseKernel,
             "conv1d_kernel": Conv1dKernel,
+            "direct_conv1d_kernel": DirectConv1dKernel,
             "group_conv1d_kernel": GroupConv1dKernel,
         }
 

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -8,6 +8,7 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
+    GroupConv1dKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 
@@ -211,8 +212,8 @@ class Conv1dFwdOp(Op):
             and "conv1d_pointwise_kernel" in self.kernel_map
         ):
             self.kernel = self.kernel_map["conv1d_pointwise_kernel"](**kernel_kwargs)
-        elif "conv1d_kernel" in self.kernel_map:
-            self.kernel = self.kernel_map["conv1d_kernel"](
+        elif self.groups > 1 and "group_conv1d_kernel" in self.kernel_map:
+            self.kernel = self.kernel_map["group_conv1d_kernel"](
                 **kernel_kwargs,
                 kernel_l=self.kernel_size,
                 stride_l=self.stride,
@@ -222,9 +223,18 @@ class Conv1dFwdOp(Op):
                 c_in_g=self.c_in_g,
                 c_out_g=self.c_out_g,
             )
+        elif self.groups == 1 and "conv1d_kernel" in self.kernel_map:
+            self.kernel = self.kernel_map["conv1d_kernel"](
+                **kernel_kwargs,
+                kernel_l=self.kernel_size,
+                stride_l=self.stride,
+                pad_l=self.padding,
+                dilation_l=self.dilation,
+            )
         else:
             raise NotImplementedError(
-                "Conv1dFwdOp requires 'conv1d_pointwise_kernel' or 'conv1d_kernel' in kernel_map"
+                "Conv1dFwdOp requires 'conv1d_pointwise_kernel', 'conv1d_kernel', "
+                "or 'group_conv1d_kernel' in kernel_map"
             )
 
     @property
@@ -232,6 +242,7 @@ class Conv1dFwdOp(Op):
         return {
             "conv1d_pointwise_kernel": Conv1dPointwiseKernel,
             "conv1d_kernel": Conv1dKernel,
+            "group_conv1d_kernel": GroupConv1dKernel,
         }
 
     def forward(

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -8,7 +8,6 @@ from tileops.kernels.convolution import (
     Conv2d1x1Kernel,
     Conv2dKernel,
     Conv3dKernel,
-    DirectConv1dKernel,
     GroupConv1dKernel,
 )
 from tileops.kernels.kernel_base import Kernel
@@ -213,22 +212,6 @@ class Conv1dFwdOp(Op):
             and "conv1d_pointwise_kernel" in self.kernel_map
         ):
             self.kernel = self.kernel_map["conv1d_pointwise_kernel"](**kernel_kwargs)
-        elif (
-            self.groups > 1
-            and self.c_in_g == 1
-            and self.c_out_g == 1
-            and "direct_conv1d_kernel" in self.kernel_map
-        ):
-            self.kernel = self.kernel_map["direct_conv1d_kernel"](
-                **kernel_kwargs,
-                kernel_l=self.kernel_size,
-                stride_l=self.stride,
-                pad_l=self.padding,
-                dilation_l=self.dilation,
-                groups=self.groups,
-                c_in_g=self.c_in_g,
-                c_out_g=self.c_out_g,
-            )
         elif self.groups > 1 and "group_conv1d_kernel" in self.kernel_map:
             self.kernel = self.kernel_map["group_conv1d_kernel"](
                 **kernel_kwargs,
@@ -259,7 +242,6 @@ class Conv1dFwdOp(Op):
         return {
             "conv1d_pointwise_kernel": Conv1dPointwiseKernel,
             "conv1d_kernel": Conv1dKernel,
-            "direct_conv1d_kernel": DirectConv1dKernel,
             "group_conv1d_kernel": GroupConv1dKernel,
         }
 


### PR DESCRIPTION
## Summary
Closes #1515.

Adds native `groups` support for `Conv1dFwdOp` / `Conv1dBiasFwdOp` with a dedicated `GroupConv1dKernel` path:

- Adds `_conv1d_group_kernel`, which treats `groups` as an explicit grid dimension so output-channel tiles stay within one group.
- Keeps `_conv1d_kernel` and `_conv1d_pointwise_kernel` as `groups=1` paths only.
- Uses the grouped kernel for `groups > 1`, including pointwise-shaped grouped convs.
- Keeps a low-level `_conv1d_direct_kernel` fast path for depthwise cases where `c_in_g == 1 && c_out_g == 1`; no public direct kernel class is exposed.
- Supports non-16-multiple `c_out_g` by masking within the grouped kernel while keeping TensorCore block choices 16-aligned.

## Test plan
- Extended `Conv1dFixture` so the main `test_conv1d` covers:
  - normal `groups=1` conv1d
  - string padding: `padding='valid'` and `padding='same'`
  - grouped conv: `groups=2`
  - non-16 output channels per group: `groups=3, c_out_g=24`
  - Conformer-style depthwise conv: `groups=channels, kernel_size=31`
- Tightened fp16 conv1d comparison tolerance to `1e-3 / 1e-3`; bf16 keeps the existing tolerance.
- Verified locally:
  - `python -m ruff check tests/ops/test_convolution.py tileops/kernels/convolution.py tileops/ops/convolution.py tileops/kernels/__init__.py`
  - `TMPDIR=/home/lyc/Project/TileOps-workspace2/.tmp python -m pytest tests/ops/test_convolution.py -q`
  - `python scripts/validate_manifest.py --check-op Conv1dFwdOp`
  - `git diff --check HEAD`

## Regression
- No public API changes for `groups=1` users.
- `groups=1` dispatch remains on the existing generic or pointwise conv1d kernels.
- `Conv1dPointwiseKernel` remains `groups=1` only; grouped pointwise-shaped cases dispatch to `GroupConv1dKernel`.
- Dilation behavior is unchanged.

## Additional context
- Earlier grouped indexing could allow a tile to cross group boundaries unless `c_out_g` aligned with `block_m`. The new grouped kernel avoids this by launching tiles within each group instead of deriving `group_id` from a global output-channel tile.
- The grouped kernel masks partial `block_m` and `block_k` tiles, so legal grouped shapes are covered for correctness even when per-group channels are not multiples of 16.
- The depthwise direct kernel casts operands to the accumulator dtype before multiplication to keep fp16 numerical differences within the standard conv1d tolerance.
