### PR TITLE
[Feat][convolution] Align conv fwd op entrypoints

### DIFF
--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -281,9 +281,9 @@ class Conv3dBenchCase:
         self,
         n: int,
         c_in: int,
-        d_in: int,
-        h_in: int,
-        w_in: int,
+        d: int,
+        h: int,
+        w: int,
         c_out: int,
         kernel_size: tuple[int, int, int],
         stride: tuple[int, int, int],
@@ -292,9 +292,9 @@ class Conv3dBenchCase:
     ) -> None:
         self.n = n
         self.c_in = c_in
-        self.d_in = d_in
-        self.h_in = h_in
-        self.w_in = w_in
+        self.d = d
+        self.h = h
+        self.w = w
         self.c_out = c_out
         self.kernel_size = kernel_size
         self.stride = stride
@@ -303,7 +303,7 @@ class Conv3dBenchCase:
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         x = torch.randn(
-            self.n, self.d_in, self.h_in, self.w_in, self.c_in,
+            self.n, self.d, self.h, self.w, self.c_in,
             device="cuda", dtype=self.dtype,
         ).contiguous()
         weight = torch.randn(
@@ -350,18 +350,18 @@ class Conv3dBenchmark(BenchmarkBase[Conv3dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
-        out_d = (t.d_in + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_h = (t.h_in + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
-        out_w = (t.w_in + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
+        out_d = (t.d + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
+        out_h = (t.h + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
+        out_w = (t.w + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
         return 2.0 * t.n * t.c_out * out_d * out_h * out_w * t.c_in * t.kernel_size[0] * t.kernel_size[1] * t.kernel_size[2]
 
     def calculate_memory(self) -> Optional[float]:
         t = self.workload
-        out_d = (t.d_in + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_h = (t.h_in + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
-        out_w = (t.w_in + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
+        out_d = (t.d + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
+        out_h = (t.h + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
+        out_w = (t.w + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
         bytes_ = (
-            t.n * t.c_in * t.d_in * t.h_in * t.w_in
+            t.n * t.c_in * t.d * t.h * t.w
             + t.c_out * t.c_in * t.kernel_size[0] * t.kernel_size[1] * t.kernel_size[2]
             + t.n * t.c_out * out_d * out_h * out_w
         ) * t.dtype.itemsize
@@ -376,15 +376,15 @@ _CONV3D_BENCH_PARAMS = [
 
 
 @pytest.mark.parametrize(
-    "n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune",
+    "n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype, tune",
     _CONV3D_BENCH_PARAMS,
 )
 def test_conv3d_bench(
     n: int,
     c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
+    d: int,
+    h: int,
+    w: int,
     c_out: int,
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int],
@@ -392,7 +392,7 @@ def test_conv3d_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv3dBenchCase(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
+    test = Conv3dBenchCase(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype)
     bm = Conv3dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
@@ -400,9 +400,9 @@ def test_conv3d_bench(
     op = Conv3dBiasFwdOp(
         n=n,
         c_in=c_in,
-        d_in=d_in,
-        h_in=h_in,
-        w_in=w_in,
+        d=d,
+        h=h,
+        w=w,
         c_out=c_out,
         kernel_size=kernel_size,
         stride=stride,

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops import Conv1dBiasFwdOp, Conv2dOp, Conv3dOp
+from tileops.ops import Conv1dBiasFwdOp, Conv2dBiasFwdOp, Conv3dBiasFwdOp
 
 
 class Conv1dBenchCase:
@@ -249,10 +249,8 @@ def test_conv2d_bench(
     bm = Conv2dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
-    x_nchw = x.permute(0, 3, 1, 2).contiguous()
-    x_nhwc = x_nchw.contiguous(memory_format=torch.channels_last)
 
-    op = Conv2dOp(
+    op = Conv2dBiasFwdOp(
         n=n,
         c_in=c_in,
         h=h,
@@ -261,12 +259,14 @@ def test_conv2d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("conv2d", locals(), result, tag="tileops")
+
+    x_nchw = x.permute(0, 3, 1, 2).contiguous()
+    x_nhwc = x_nchw.contiguous(memory_format=torch.channels_last)
 
     result_bl = bm.profile(test.ref_program_nchw, x_nchw, weight, bias)
     BenchmarkReport.record("conv2d", locals(), result_bl, tag="torch-nchw")
@@ -313,7 +313,23 @@ class Conv3dBenchCase:
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
         return x, weight, bias
 
-    def ref_program(
+    def ref_program_ncdhw(
+        self,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        return F.conv3d(
+            x,
+            weight,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=1,
+            groups=1,
+        )
+
+    def ref_program_ndhwc(
         self,
         x: torch.Tensor,
         weight: torch.Tensor,
@@ -380,10 +396,8 @@ def test_conv3d_bench(
     bm = Conv3dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
-    x_ncdhw = x.permute(0, 4, 1, 2, 3).contiguous()
-    x_ndhwc = x_ncdhw.contiguous(memory_format=torch.channels_last_3d)
 
-    op = Conv3dOp(
+    op = Conv3dBiasFwdOp(
         n=n,
         c_in=c_in,
         d_in=d_in,
@@ -393,15 +407,17 @@ def test_conv3d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("conv3d", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x_ncdhw, weight, bias)
+    x_ncdhw = x.permute(0, 4, 1, 2, 3).contiguous()
+    x_ndhwc = x_ncdhw.contiguous(memory_format=torch.channels_last_3d)
+
+    result_bl = bm.profile(test.ref_program_ncdhw, x_ncdhw, weight, bias)
     BenchmarkReport.record("conv3d", locals(), result_bl, tag="torch-ncdhw")
 
-    result_bl = bm.profile(test.ref_program, x_ndhwc, weight, bias)
+    result_bl = bm.profile(test.ref_program_ndhwc, x_ndhwc, weight, bias)
     BenchmarkReport.record("conv3d", locals(), result_bl, tag="torch-ndhwc")

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -534,7 +534,7 @@ def test_conv2d_dispatches_5x5_kernel() -> None:
 
 class Conv3dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype, tune", [
+        ("n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype, tune", [
             pytest.param(
                 1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False,
                 marks=pytest.mark.smoke,
@@ -570,9 +570,9 @@ class Conv3dTest(TestBase):
         self,
         n: int,
         c_in: int,
-        d_in: int,
-        h_in: int,
-        w_in: int,
+        d: int,
+        h: int,
+        w: int,
         c_out: int,
         kernel_size: tuple[int, int, int],
         stride: tuple[int, int, int],
@@ -581,9 +581,9 @@ class Conv3dTest(TestBase):
     ) -> None:
         self.n = n
         self.c_in = c_in
-        self.d_in = d_in
-        self.h_in = h_in
-        self.w_in = w_in
+        self.d = d
+        self.h = h
+        self.w = w
         self.c_out = c_out
         self.kernel_size = kernel_size
         self.stride = stride
@@ -592,7 +592,7 @@ class Conv3dTest(TestBase):
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         x = torch.randn(
-            self.n, self.d_in, self.h_in, self.w_in, self.c_in,
+            self.n, self.d, self.h, self.w, self.c_in,
             device="cuda", dtype=self.dtype,
         ).contiguous()
         weight = torch.randn(
@@ -624,9 +624,9 @@ class Conv3dTest(TestBase):
 def test_conv3d(
     n: int,
     c_in: int,
-    d_in: int,
-    h_in: int,
-    w_in: int,
+    d: int,
+    h: int,
+    w: int,
     c_out: int,
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int],
@@ -634,13 +634,13 @@ def test_conv3d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv3dTest(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
+    test = Conv3dTest(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype)
     op = Conv3dBiasFwdOp(
         n=n,
         c_in=c_in,
-        d_in=d_in,
-        h_in=h_in,
-        w_in=w_in,
+        d=d,
+        h=h,
+        w=w,
         c_out=c_out,
         kernel_size=kernel_size,
         stride=stride,
@@ -657,9 +657,9 @@ def test_conv3d_no_bias_matches_torch() -> None:
     op = Conv3dFwdOp(
         n=1,
         c_in=8,
-        d_in=4,
-        h_in=16,
-        w_in=16,
+        d=4,
+        h=16,
+        w=16,
         c_out=16,
         kernel_size=3,
         stride=2,
@@ -684,9 +684,9 @@ def test_conv3d_bias_requires_bias_tensor() -> None:
     op = Conv3dBiasFwdOp(
         n=1,
         c_in=8,
-        d_in=4,
-        h_in=16,
-        w_in=16,
+        d=4,
+        h=16,
+        w=16,
         c_out=16,
         kernel_size=3,
         stride=2,
@@ -712,9 +712,9 @@ def test_conv3d_accepts_zero_bias() -> None:
     op = Conv3dBiasFwdOp(
         n=1,
         c_in=8,
-        d_in=8,
-        h_in=16,
-        w_in=16,
+        d=8,
+        h=16,
+        w=16,
         c_out=16,
         kernel_size=3,
         stride=2,
@@ -740,9 +740,9 @@ def test_conv3d_dispatches_kernel() -> None:
     op = Conv3dFwdOp(
         n=1,
         c_in=8,
-        d_in=8,
-        h_in=16,
-        w_in=16,
+        d=8,
+        h=16,
+        w=16,
         c_out=16,
         kernel_size=3,
         stride=1,

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -12,7 +12,14 @@ from tileops.kernels.convolution import (
     Conv2dKernel,
     Conv3dKernel,
 )
-from tileops.ops import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
+from tileops.ops import (
+    Conv1dBiasFwdOp,
+    Conv1dFwdOp,
+    Conv2dBiasFwdOp,
+    Conv2dFwdOp,
+    Conv3dBiasFwdOp,
+    Conv3dFwdOp,
+)
 
 
 class Conv1dFixture(FixtureBase):
@@ -376,7 +383,7 @@ def test_conv2d(
     tune: bool,
 ) -> None:
     test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
-    op = Conv2dOp(
+    op = Conv2dBiasFwdOp(
         n=n,
         c_in=c_in,
         h=h,
@@ -385,7 +392,6 @@ def test_conv2d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )
@@ -394,8 +400,61 @@ def test_conv2d(
 
 
 @pytest.mark.smoke
+def test_conv2d_no_bias_matches_torch() -> None:
+    op = Conv2dFwdOp(
+        n=1,
+        c_in=32,
+        h=16,
+        w=16,
+        c_out=64,
+        kernel_size=5,
+        stride=2,
+        padding=2,
+    )
+    x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    ref = F.conv2d(
+        x.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias=None,
+        stride=2,
+        padding=2,
+    )
+    ref = ref.permute(0, 2, 3, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv2d_bias_requires_bias_tensor() -> None:
+    op = Conv2dBiasFwdOp(
+        n=1,
+        c_in=32,
+        h=16,
+        w=16,
+        c_out=64,
+        kernel_size=5,
+        stride=2,
+        padding=2,
+    )
+    x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
+    bias = torch.zeros(64, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight, bias)
+    ref = F.conv2d(
+        x.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias=bias,
+        stride=2,
+        padding=2,
+    )
+    ref = ref.permute(0, 2, 3, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
 def test_conv2d_accepts_zero_bias() -> None:
-    op = Conv2dOp(
+    op = Conv2dBiasFwdOp(
         n=1,
         c_in=32,
         h=16,
@@ -403,34 +462,37 @@ def test_conv2d_accepts_zero_bias() -> None:
         c_out=32,
         kernel_size=3,
         padding=1,
-        bias=True,
     )
     x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(32, 32, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     bias = torch.zeros(32, device="cuda", dtype=torch.float16).contiguous()
     out = op(x, weight, bias)
-    ref = F.conv2d(x.permute(0, 3, 1, 2).contiguous(), weight, bias=bias, padding=1)
+    ref = F.conv2d(
+        x.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias=bias,
+        padding=1,
+    )
     ref = ref.permute(0, 2, 3, 1).contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
 def test_conv2d_dispatches_1x1_kernel() -> None:
-    op = Conv2dOp(
+    op = Conv2dFwdOp(
         n=1,
         c_in=32,
         h=16,
         w=16,
         c_out=64,
         kernel_size=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv2d1x1Kernel)
 
 
 @pytest.mark.smoke
 def test_conv2d_does_not_dispatch_1x1_kernel_with_padding() -> None:
-    op = Conv2dOp(
+    op = Conv2dFwdOp(
         n=1,
         c_in=32,
         h=16,
@@ -438,14 +500,13 @@ def test_conv2d_does_not_dispatch_1x1_kernel_with_padding() -> None:
         c_out=64,
         kernel_size=1,
         padding=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv2dKernel)
 
 
 @pytest.mark.smoke
 def test_conv2d_dispatches_3x3_kernel() -> None:
-    op = Conv2dOp(
+    op = Conv2dFwdOp(
         n=1,
         c_in=32,
         h=16,
@@ -453,14 +514,13 @@ def test_conv2d_dispatches_3x3_kernel() -> None:
         c_out=64,
         kernel_size=3,
         padding=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv2dKernel)
 
 
 @pytest.mark.smoke
 def test_conv2d_dispatches_5x5_kernel() -> None:
-    op = Conv2dOp(
+    op = Conv2dFwdOp(
         n=1,
         c_in=32,
         h=16,
@@ -468,7 +528,6 @@ def test_conv2d_dispatches_5x5_kernel() -> None:
         c_out=64,
         kernel_size=5,
         padding=2,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv2dKernel)
 
@@ -576,7 +635,7 @@ def test_conv3d(
     tune: bool,
 ) -> None:
     test = Conv3dTest(n, c_in, d_in, h_in, w_in, c_out, kernel_size, stride, padding, dtype)
-    op = Conv3dOp(
+    op = Conv3dBiasFwdOp(
         n=n,
         c_in=c_in,
         d_in=d_in,
@@ -586,7 +645,6 @@ def test_conv3d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
-        bias=True,
         dtype=dtype,
         tune=tune,
     )
@@ -595,8 +653,63 @@ def test_conv3d(
 
 
 @pytest.mark.smoke
+def test_conv3d_no_bias_matches_torch() -> None:
+    op = Conv3dFwdOp(
+        n=1,
+        c_in=8,
+        d_in=4,
+        h_in=16,
+        w_in=16,
+        c_out=16,
+        kernel_size=3,
+        stride=2,
+        padding=1,
+    )
+    x = torch.randn(1, 4, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight)
+    ref = F.conv3d(
+        x.permute(0, 4, 1, 2, 3).contiguous(),
+        weight,
+        bias=None,
+        stride=2,
+        padding=1,
+    )
+    ref = ref.permute(0, 2, 3, 4, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+def test_conv3d_bias_requires_bias_tensor() -> None:
+    op = Conv3dBiasFwdOp(
+        n=1,
+        c_in=8,
+        d_in=4,
+        h_in=16,
+        w_in=16,
+        c_out=16,
+        kernel_size=3,
+        stride=2,
+        padding=1,
+    )
+    x = torch.randn(1, 4, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
+    bias = torch.zeros(16, device="cuda", dtype=torch.float16).contiguous()
+    out = op(x, weight, bias)
+    ref = F.conv3d(
+        x.permute(0, 4, 1, 2, 3).contiguous(),
+        weight,
+        bias=bias,
+        stride=2,
+        padding=1,
+    )
+    ref = ref.permute(0, 2, 3, 4, 1).contiguous()
+    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
 def test_conv3d_accepts_zero_bias() -> None:
-    op = Conv3dOp(
+    op = Conv3dBiasFwdOp(
         n=1,
         c_in=8,
         d_in=8,
@@ -606,7 +719,6 @@ def test_conv3d_accepts_zero_bias() -> None:
         kernel_size=3,
         stride=2,
         padding=1,
-        bias=True,
     )
     x = torch.randn(1, 8, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
@@ -625,7 +737,7 @@ def test_conv3d_accepts_zero_bias() -> None:
 
 @pytest.mark.smoke
 def test_conv3d_dispatches_kernel() -> None:
-    op = Conv3dOp(
+    op = Conv3dFwdOp(
         n=1,
         c_in=8,
         d_in=8,
@@ -635,7 +747,6 @@ def test_conv3d_dispatches_kernel() -> None:
         kernel_size=3,
         stride=1,
         padding=1,
-        bias=True,
     )
     assert isinstance(op.kernel, Conv3dKernel)
 

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -20,7 +20,14 @@ from .attention import (
     NSAFwdVarlenOp,
     NSATopkVarlenOp,
 )
-from .convolution import Conv1dBiasFwdOp, Conv1dFwdOp, Conv2dOp, Conv3dOp
+from .convolution import (
+    Conv1dBiasFwdOp,
+    Conv1dFwdOp,
+    Conv2dBiasFwdOp,
+    Conv2dFwdOp,
+    Conv3dBiasFwdOp,
+    Conv3dFwdOp,
+)
 from .da_cumsum import DaCumsumFwdOp
 from .deltanet import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
 from .deltanet_recurrence import DeltaNetDecodeOp
@@ -107,8 +114,10 @@ __all__ = [
     "BatchNormFwdOp",
     "Conv1dBiasFwdOp",
     "Conv1dFwdOp",
-    "Conv2dOp",
-    "Conv3dOp",
+    "Conv2dBiasFwdOp",
+    "Conv2dFwdOp",
+    "Conv3dBiasFwdOp",
+    "Conv3dFwdOp",
     "DaCumsumFwdOp",
     "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp",
     "DropoutOp",

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -13,7 +13,14 @@ from tileops.kernels.kernel_base import Kernel
 
 from .op_base import Op
 
-__all__ = ["Conv1dBiasFwdOp", "Conv1dFwdOp", "Conv2dOp", "Conv3dOp"]
+__all__ = [
+    "Conv1dBiasFwdOp",
+    "Conv1dFwdOp",
+    "Conv2dBiasFwdOp",
+    "Conv2dFwdOp",
+    "Conv3dBiasFwdOp",
+    "Conv3dFwdOp",
+]
 
 
 def _conv_tuple(
@@ -310,7 +317,7 @@ def _pair(value: int | Tuple[int, int]) -> Tuple[int, int]:
     return _conv_tuple(value, 2, "value", "Conv2d")  # type: ignore[return-value]
 
 
-class Conv2dOp(Op):
+class Conv2dFwdOp(Op):
 
     def __init__(
         self,
@@ -322,16 +329,21 @@ class Conv2dOp(Op):
         kernel_size: int | Tuple[int, int],
         stride: int | Tuple[int, int] = 1,
         padding: int | Tuple[int, int] | str = 0,
-        bias: bool = False,
+        dilation: int | Tuple[int, int] = 1,
+        groups: int = 1,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        _has_bias: bool = False,
     ) -> None:
         _validate_positive_int("n", n, "Conv2d")
         _validate_positive_int("c_in", c_in, "Conv2d")
         _validate_positive_int("h", h, "Conv2d")
         _validate_positive_int("w", w, "Conv2d")
         _validate_positive_int("c_out", c_out, "Conv2d")
+        _validate_conv_groups("Conv2d", c_in, c_out, groups)
+        if groups != 1:
+            raise NotImplementedError("Conv2d currently supports groups=1 only")
         self.n = n
         self.c_in = c_in
         self.h = h
@@ -339,15 +351,23 @@ class Conv2dOp(Op):
         self.c_out = c_out
         self.kernel_size = _pair(kernel_size)
         self.stride = _pair(stride)
-        self.padding = _conv_padding_to_tuple(padding, self.stride, self.kernel_size, "Conv2d")
+        dilation_tuple = _conv_tuple(dilation, 2, "dilation", "Conv2d")
+        self.padding = _conv_padding_to_tuple(
+            padding, self.stride, self.kernel_size, "Conv2d", dilation_tuple
+        )
         _validate_conv_params(
             op_name="Conv2d",
             input_size=(h, w),
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
+            dilation=dilation_tuple,
         )
-        self.has_bias = bias
+        if dilation_tuple != (1, 1):
+            raise NotImplementedError("Conv2d currently supports dilation=1 only")
+        self.dilation = dilation_tuple
+        self.groups = groups
+        self.has_bias = _has_bias
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
@@ -362,13 +382,14 @@ class Conv2dOp(Op):
             pad_h=self.padding[0],
             pad_w=self.padding[1],
             dtype=dtype,
-            has_bias=bias,
+            has_bias=_has_bias,
             tune=tune,
         )
         if (
             self.kernel_size == (1, 1)
             and self.stride == (1, 1)
             and self.padding == (0, 0)
+            and self.dilation == (1, 1)
             and "conv2d_1x1_kernel" in self.kernel_map
         ):
             self.kernel = self.kernel_map["conv2d_1x1_kernel"](**kernel_kwargs)
@@ -380,7 +401,7 @@ class Conv2dOp(Op):
             )
         else:
             raise NotImplementedError(
-                "Conv2dOp requires 'conv2d_1x1_kernel' or 'conv2d_kernel' in kernel_map"
+                "Conv2dFwdOp requires 'conv2d_1x1_kernel' or 'conv2d_kernel' in kernel_map"
             )
 
     @property
@@ -392,27 +413,87 @@ class Conv2dOp(Op):
 
     def forward(
         self,
-        x: torch.Tensor,
+        input: torch.Tensor,
         weight: torch.Tensor,
-        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        _validate_tensor_shape("Conv2d", "x", x, (self.n, self.h, self.w, self.c_in))
+        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.h, self.w, self.c_in))
         _validate_tensor_shape(
             "Conv2d",
             "weight",
             weight,
             (self.c_out, self.c_in, self.kernel_size[0], self.kernel_size[1]),
         )
-        if bias is not None:
-            _validate_tensor_shape("Conv2d", "bias", bias, (self.c_out,))
-        return self.kernel(x, weight, bias)
+        return self.kernel(input, weight, None)
+
+
+class Conv2dBiasFwdOp(Conv2dFwdOp):
+    """Conv2d forward with bias=True default.
+
+    Identical to :class:`Conv2dFwdOp` but defaults ``bias=True`` so the
+    manifest key ``Conv2dBiasFwdOp`` resolves to a distinct class name.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h: int,
+        w: int,
+        c_out: int,
+        kernel_size: int | Tuple[int, int],
+        stride: int | Tuple[int, int] = 1,
+        padding: int | Tuple[int, int] | str = 0,
+        dilation: int | Tuple[int, int] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        dtype: torch.dtype = torch.float16,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        if not bias:
+            raise ValueError(
+                "Conv2dBiasFwdOp requires bias=True. "
+                "Use Conv2dFwdOp for the no-bias variant."
+            )
+        super().__init__(
+            n=n,
+            c_in=c_in,
+            h=h,
+            w=w,
+            c_out=c_out,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            dtype=dtype,
+            kernel_map=kernel_map,
+            tune=tune,
+            _has_bias=True,
+        )
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.h, self.w, self.c_in))
+        _validate_tensor_shape(
+            "Conv2d",
+            "weight",
+            weight,
+            (self.c_out, self.c_in, self.kernel_size[0], self.kernel_size[1]),
+        )
+        _validate_tensor_shape("Conv2d", "bias", bias, (self.c_out,))
+        return self.kernel(input, weight, bias)
 
 
 def _triple(value: int | Tuple[int, int, int]) -> Tuple[int, int, int]:
     return _conv_tuple(value, 3, "value", "Conv3d")  # type: ignore[return-value]
 
 
-class Conv3dOp(Op):
+class Conv3dFwdOp(Op):
 
     def __init__(
         self,
@@ -425,10 +506,12 @@ class Conv3dOp(Op):
         kernel_size: int | Tuple[int, int, int],
         stride: int | Tuple[int, int, int] = 1,
         padding: int | Tuple[int, int, int] | str = 0,
-        bias: bool = False,
+        dilation: int | Tuple[int, int, int] = 1,
+        groups: int = 1,
         dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        _has_bias: bool = False,
     ) -> None:
         _validate_positive_int("n", n, "Conv3d")
         _validate_positive_int("c_in", c_in, "Conv3d")
@@ -436,6 +519,9 @@ class Conv3dOp(Op):
         _validate_positive_int("h_in", h_in, "Conv3d")
         _validate_positive_int("w_in", w_in, "Conv3d")
         _validate_positive_int("c_out", c_out, "Conv3d")
+        _validate_conv_groups("Conv3d", c_in, c_out, groups)
+        if groups != 1:
+            raise NotImplementedError("Conv3d currently supports groups=1 only")
         self.n = n
         self.c_in = c_in
         self.d_in = d_in
@@ -444,20 +530,28 @@ class Conv3dOp(Op):
         self.c_out = c_out
         self.kernel_size = _triple(kernel_size)
         self.stride = _triple(stride)
-        self.padding = _conv_padding_to_tuple(padding, self.stride, self.kernel_size, "Conv3d")
+        dilation_tuple = _conv_tuple(dilation, 3, "dilation", "Conv3d")
+        self.padding = _conv_padding_to_tuple(
+            padding, self.stride, self.kernel_size, "Conv3d", dilation_tuple
+        )
         _validate_conv_params(
             op_name="Conv3d",
             input_size=(d_in, h_in, w_in),
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
+            dilation=dilation_tuple,
         )
-        self.has_bias = bias
+        if dilation_tuple != (1, 1, 1):
+            raise NotImplementedError("Conv3d currently supports dilation=1 only")
+        self.dilation = dilation_tuple
+        self.groups = groups
+        self.has_bias = _has_bias
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
         if "conv3d_kernel" not in self.kernel_map:
-            raise NotImplementedError("Conv3dOp requires 'conv3d_kernel' in kernel_map")
+            raise NotImplementedError("Conv3dFwdOp requires 'conv3d_kernel' in kernel_map")
         self.kernel = self.kernel_map["conv3d_kernel"](
             n=n,
             c_in=c_in,
@@ -475,7 +569,7 @@ class Conv3dOp(Op):
             pad_h=self.padding[1],
             pad_w=self.padding[2],
             dtype=dtype,
-            has_bias=bias,
+            has_bias=_has_bias,
             tune=tune,
         )
 
@@ -485,14 +579,13 @@ class Conv3dOp(Op):
 
     def forward(
         self,
-        x: torch.Tensor,
+        input: torch.Tensor,
         weight: torch.Tensor,
-        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         _validate_tensor_shape(
             "Conv3d",
-            "x",
-            x,
+            "input",
+            input,
             (self.n, self.d_in, self.h_in, self.w_in, self.c_in),
         )
         _validate_tensor_shape(
@@ -507,6 +600,80 @@ class Conv3dOp(Op):
                 self.kernel_size[2],
             ),
         )
-        if bias is not None:
-            _validate_tensor_shape("Conv3d", "bias", bias, (self.c_out,))
-        return self.kernel(x, weight, bias)
+        return self.kernel(input, weight, None)
+
+
+class Conv3dBiasFwdOp(Conv3dFwdOp):
+    """Conv3d forward with bias=True default.
+
+    Identical to :class:`Conv3dFwdOp` but defaults ``bias=True`` so the
+    manifest key ``Conv3dBiasFwdOp`` resolves to a distinct class name.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        d_in: int,
+        h_in: int,
+        w_in: int,
+        c_out: int,
+        kernel_size: int | Tuple[int, int, int],
+        stride: int | Tuple[int, int, int] = 1,
+        padding: int | Tuple[int, int, int] | str = 0,
+        dilation: int | Tuple[int, int, int] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        dtype: torch.dtype = torch.float16,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        if not bias:
+            raise ValueError(
+                "Conv3dBiasFwdOp requires bias=True. "
+                "Use Conv3dFwdOp for the no-bias variant."
+            )
+        super().__init__(
+            n=n,
+            c_in=c_in,
+            d_in=d_in,
+            h_in=h_in,
+            w_in=w_in,
+            c_out=c_out,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=groups,
+            dtype=dtype,
+            kernel_map=kernel_map,
+            tune=tune,
+            _has_bias=True,
+        )
+
+    def forward(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        _validate_tensor_shape(
+            "Conv3d",
+            "input",
+            input,
+            (self.n, self.d_in, self.h_in, self.w_in, self.c_in),
+        )
+        _validate_tensor_shape(
+            "Conv3d",
+            "weight",
+            weight,
+            (
+                self.c_out,
+                self.c_in,
+                self.kernel_size[0],
+                self.kernel_size[1],
+                self.kernel_size[2],
+            ),
+        )
+        _validate_tensor_shape("Conv3d", "bias", bias, (self.c_out,))
+        return self.kernel(input, weight, bias)

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -499,9 +499,9 @@ class Conv3dFwdOp(Op):
         self,
         n: int,
         c_in: int,
-        d_in: int,
-        h_in: int,
-        w_in: int,
+        d: int,
+        h: int,
+        w: int,
         c_out: int,
         kernel_size: int | Tuple[int, int, int],
         stride: int | Tuple[int, int, int] = 1,
@@ -515,18 +515,18 @@ class Conv3dFwdOp(Op):
     ) -> None:
         _validate_positive_int("n", n, "Conv3d")
         _validate_positive_int("c_in", c_in, "Conv3d")
-        _validate_positive_int("d_in", d_in, "Conv3d")
-        _validate_positive_int("h_in", h_in, "Conv3d")
-        _validate_positive_int("w_in", w_in, "Conv3d")
+        _validate_positive_int("d", d, "Conv3d")
+        _validate_positive_int("h", h, "Conv3d")
+        _validate_positive_int("w", w, "Conv3d")
         _validate_positive_int("c_out", c_out, "Conv3d")
         _validate_conv_groups("Conv3d", c_in, c_out, groups)
         if groups != 1:
             raise NotImplementedError("Conv3d currently supports groups=1 only")
         self.n = n
         self.c_in = c_in
-        self.d_in = d_in
-        self.h_in = h_in
-        self.w_in = w_in
+        self.d = d
+        self.h = h
+        self.w = w
         self.c_out = c_out
         self.kernel_size = _triple(kernel_size)
         self.stride = _triple(stride)
@@ -536,7 +536,7 @@ class Conv3dFwdOp(Op):
         )
         _validate_conv_params(
             op_name="Conv3d",
-            input_size=(d_in, h_in, w_in),
+            input_size=(d, h, w),
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
@@ -555,9 +555,9 @@ class Conv3dFwdOp(Op):
         self.kernel = self.kernel_map["conv3d_kernel"](
             n=n,
             c_in=c_in,
-            d_in=d_in,
-            h_in=h_in,
-            w_in=w_in,
+            d_in=d,
+            h_in=h,
+            w_in=w,
             c_out=c_out,
             kernel_d=self.kernel_size[0],
             kernel_h=self.kernel_size[1],
@@ -586,7 +586,7 @@ class Conv3dFwdOp(Op):
             "Conv3d",
             "input",
             input,
-            (self.n, self.d_in, self.h_in, self.w_in, self.c_in),
+            (self.n, self.d, self.h, self.w, self.c_in),
         )
         _validate_tensor_shape(
             "Conv3d",
@@ -614,9 +614,9 @@ class Conv3dBiasFwdOp(Conv3dFwdOp):
         self,
         n: int,
         c_in: int,
-        d_in: int,
-        h_in: int,
-        w_in: int,
+        d: int,
+        h: int,
+        w: int,
         c_out: int,
         kernel_size: int | Tuple[int, int, int],
         stride: int | Tuple[int, int, int] = 1,
@@ -636,9 +636,9 @@ class Conv3dBiasFwdOp(Conv3dFwdOp):
         super().__init__(
             n=n,
             c_in=c_in,
-            d_in=d_in,
-            h_in=h_in,
-            w_in=w_in,
+            d=d,
+            h=h,
+            w=w,
             c_out=c_out,
             kernel_size=kernel_size,
             stride=stride,
@@ -661,7 +661,7 @@ class Conv3dBiasFwdOp(Conv3dFwdOp):
             "Conv3d",
             "input",
             input,
-            (self.n, self.d_in, self.h_in, self.w_in, self.c_in),
+            (self.n, self.d, self.h, self.w, self.c_in),
         )
         _validate_tensor_shape(
             "Conv3d",


### PR DESCRIPTION
Closes #1507

## Summary

- Adds manifest-aligned Conv2d/Conv3d forward op classes and bias variants.
- Removes legacy Conv2dOp/Conv3dOp public exports and updates tests/benchmarks to use the new classes.
- Keeps dilation, groups, and layout follow-ups out of this pass; tracked separately in #1519, #1520, and #1521.
- Tracks current benchmark follow-ups separately in #1522 and #1523.

## Test plan

- [x] pre-commit passed
- [x] python -c "from tileops.ops import Conv2dFwdOp, Conv2dBiasFwdOp, Conv3dFwdOp, Conv3dBiasFwdOp; print('imports ok')"
- [x] python scripts/validate_manifest.py
- [x] python -m pytest tests/ops/test_convolution.py --collect-only -q
- [x] python -m pytest tests/ops/test_convolution.py -vvs (41 passed)

## Additional context

- scripts/validate.sh is not present in this checkout, so the skill-specific pre/post validation command could not be run.
- python -m pytest benchmarks/ops/bench_convolution.py -vvs does not pass yet: Conv1d seanet-k3-s1-d2-fp16 fails autotuning, and Conv2d/Conv3d benchmark cases are skipped. These are tracked in #1522 and #1523.
- Current string padding support was checked for Conv2d/Conv3d with padding="valid" and padding="same"; both construct successfully for representative supported shapes.