### PR TITLE
[Bench][Mamba] Fix ssd_state_passing baseline dtype and autotune stability

### DIFF
--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -560,27 +560,34 @@ _SSD_STATE_PASSING_FWD_BENCH_PARAMS = [
     _SSD_STATE_PASSING_FWD_BENCH_PARAMS,
 )
 def test_ssd_state_passing_fwd_bench(
-    batch: int, num_chunks: int, n_heads: int, d_state: int, dtype: torch.dtype, tune: bool,
+    batch: int, num_chunks: int, n_heads: int, d_state: int,
+    dtype: torch.dtype, tune: bool,
 ) -> None:
     test = SSDStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
     bm = SSDStatePassingFwdBenchmark(test)
     inputs = test.gen_inputs()
+    states, dA_chunk_cumsum, initial_states = inputs
 
     op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     if _mamba_state_passing_fwd is not None:
-        states, dA_chunk_cumsum, initial_states = inputs
-
         def mamba_fwd():
-            # mamba_ssm _state_passing_fwd expects (b, h, c) for dA_chunk_cumsum,
-            # matching TileOPs layout — no permutation needed.
+            # mamba_ssm _state_passing_fwd: dA_chunk_cumsum layout (b, h, c) matches
+            # TileOPs — no permutation needed.  out_dtype=float32 matches TileOPs output
+            # dtype for an apples-to-apples comparison.
             return _mamba_state_passing_fwd(
                 states.contiguous(),
                 dA_chunk_cumsum.contiguous(),
                 initial_states=initial_states.contiguous(),
+                out_dtype=torch.float32,
             )
+
+        # Pre-warm: run once outside bm.profile so the Triton autotuner
+        # selects its best config before the CUPTI window opens.
+        mamba_fwd()
+        torch.cuda.synchronize()
 
         result_mamba = bm.profile(mamba_fwd)
         BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -74,7 +74,7 @@ class Kernel(ABC):
         """
         return None
 
-    def autotune(self, warmup: int = 10, rep: int = 10) -> None:
+    def autotune(self, warmup: int = 25, rep: int = 50) -> None:
         if self.autotune_configs is None:
             return  # kernel doesn't support autotuning
         if not hasattr(self, 'kernel') or self.kernel is None:


### PR DESCRIPTION
## Summary

Two fixes to make `test_ssd_state_passing_fwd_bench` produce stable, apples-to-apples numbers.

## Change 1 — `benchmarks/ops/bench_mamba.py`

### out_dtype=torch.float32 on Triton baseline

TileOPs always outputs `float32`. Without this fix, the Triton baseline defaults to `out_dtype=states.dtype` (fp16), writing half as many bytes. This makes TileOPs appear artificially fast on write-bandwidth-bound shapes.

### Triton autotuner pre-warm

`@triton.autotune` runs all 6 `BLOCK_SIZE` candidates on the first call. In a fresh nightly process, this fires inside `bench_kernel`'s first CUPTI active step, polluting the sum with 5 extra kernel launches. The result is inflated and non-reproducible.

**Nightly evidence:** N108 showed 10/20 Triton configs with anomalous values (e.g. 0.1878ms, 0.1985ms = 6 candidates × ~0.03ms each). N109 happened to have a warm cache and showed correct 0.013ms values for the same configs.

Fix: call `mamba_fwd(); torch.cuda.synchronize()` once before `bm.profile(mamba_fwd)`.

## Change 2 — `tileops/kernels/kernel_base.py`

### autotune warmup 10→25, rep 10→50

With `rep=10` the autotuner measured each candidate with 10 CUPTI samples. For 2–20µs kernels this produces ~50% measurement noise, making the winning config non-deterministic across runs.

**Nightly evidence:** longctx shapes in `SSDStatePassingFwdOp` flipped between configs across consecutive nightly runs, causing 3–10x latency swings (e.g. 0.2093ms vs 0.0753ms for `longctx-370m-32k`). With `rep=50` the same config is selected consistently.

This affects **all kernels using `tune=True`**, not just ssd_state_passing.

## Testing

- 20/20 `test_ssd_state_passing_fwd_bench` pass
- 5 consecutive runs: 20/20 stable within ±2% (verified on H200 at 1830 MHz)
- Nightly Triton baseline: 19/20 stable (1 remaining case is GPU clock noise at ~3µs floor)