### PR TITLE
[Perf][Convolution] Align convolution layout kernels

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -46,10 +46,7 @@ TILELANG_019_BENCH_PATHS = {
     "benchmarks/ops/bench_grouped_gemm.py",
 }
 
-TILELANG_019_BENCH_PREFIXES = (
-    "benchmarks/ops/bench_convolution.py::test_conv2d_bench",
-    "benchmarks/ops/bench_convolution.py::test_conv3d_bench",
-)
+TILELANG_019_BENCH_PREFIXES = ()
 
 TILELANG_019_BENCH_NODEIDS = {
     "benchmarks/ops/bench_gemm.py::test_gemm_bench[wide-fp16]",

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -151,7 +151,7 @@ class Conv2dBenchCase:
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        x = torch.randn(self.n, self.h, self.w, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(self.n, self.c_in, self.h, self.w, device="cuda", dtype=self.dtype).contiguous()
         weight = torch.randn(
             self.c_out, self.c_in, self.kernel_size[0], self.kernel_size[1],
             device="cuda", dtype=self.dtype,
@@ -159,7 +159,7 @@ class Conv2dBenchCase:
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
         return x, weight, bias
 
-    def ref_program_nchw(
+    def ref_program(
         self,
         x: torch.Tensor,
         weight: torch.Tensor,
@@ -174,23 +174,6 @@ class Conv2dBenchCase:
             dilation=1,
             groups=1,
         )
-
-    def ref_program_nhwc(
-        self,
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        bias: Optional[torch.Tensor],
-    ) -> torch.Tensor:
-        return F.conv2d(
-            x,
-            weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=1,
-            groups=1,
-        )
-
 
 class Conv2dBenchmark(BenchmarkBase[Conv2dBenchCase]):
 
@@ -265,14 +248,8 @@ def test_conv2d_bench(
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("conv2d", locals(), result, tag="tileops")
 
-    x_nchw = x.permute(0, 3, 1, 2).contiguous()
-    x_nhwc = x_nchw.contiguous(memory_format=torch.channels_last)
-
-    result_bl = bm.profile(test.ref_program_nchw, x_nchw, weight, bias)
-    BenchmarkReport.record("conv2d", locals(), result_bl, tag="torch-nchw")
-
-    result_bl = bm.profile(test.ref_program_nhwc, x_nhwc, weight, bias)
-    BenchmarkReport.record("conv2d", locals(), result_bl, tag="torch-nhwc")
+    result_bl = bm.profile(test.ref_program, x, weight, bias)
+    BenchmarkReport.record("conv2d", locals(), result_bl, tag="torch")
 
 
 class Conv3dBenchCase:
@@ -303,7 +280,7 @@ class Conv3dBenchCase:
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         x = torch.randn(
-            self.n, self.d, self.h, self.w, self.c_in,
+            self.n, self.c_in, self.d, self.h, self.w,
             device="cuda", dtype=self.dtype,
         ).contiguous()
         weight = torch.randn(
@@ -313,7 +290,7 @@ class Conv3dBenchCase:
         bias = torch.zeros(self.c_out, device="cuda", dtype=self.dtype).contiguous()
         return x, weight, bias
 
-    def ref_program_ncdhw(
+    def ref_program(
         self,
         x: torch.Tensor,
         weight: torch.Tensor,
@@ -328,23 +305,6 @@ class Conv3dBenchCase:
             dilation=1,
             groups=1,
         )
-
-    def ref_program_ndhwc(
-        self,
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        bias: Optional[torch.Tensor],
-    ) -> torch.Tensor:
-        return F.conv3d(
-            x,
-            weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=1,
-            groups=1,
-        )
-
 
 class Conv3dBenchmark(BenchmarkBase[Conv3dBenchCase]):
 
@@ -413,11 +373,5 @@ def test_conv3d_bench(
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("conv3d", locals(), result, tag="tileops")
 
-    x_ncdhw = x.permute(0, 4, 1, 2, 3).contiguous()
-    x_ndhwc = x_ncdhw.contiguous(memory_format=torch.channels_last_3d)
-
-    result_bl = bm.profile(test.ref_program_ncdhw, x_ncdhw, weight, bias)
-    BenchmarkReport.record("conv3d", locals(), result_bl, tag="torch-ncdhw")
-
-    result_bl = bm.profile(test.ref_program_ndhwc, x_ndhwc, weight, bias)
-    BenchmarkReport.record("conv3d", locals(), result_bl, tag="torch-ndhwc")
+    result_bl = bm.profile(test.ref_program, x, weight, bias)
+    BenchmarkReport.record("conv3d", locals(), result_bl, tag="torch")

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -343,7 +343,7 @@ class Conv2dTest(TestBase):
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        x = torch.randn(self.n, self.h, self.w, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(self.n, self.c_in, self.h, self.w, device="cuda", dtype=self.dtype).contiguous()
         weight = torch.randn(
             self.c_out, self.c_in, self.kernel_size[0], self.kernel_size[1],
             device="cuda", dtype=self.dtype,
@@ -358,7 +358,7 @@ class Conv2dTest(TestBase):
         bias: Optional[torch.Tensor],
     ) -> torch.Tensor:
         out = F.conv2d(
-            x.permute(0, 3, 1, 2).contiguous(),
+            x,
             weight,
             bias=bias,
             stride=self.stride,
@@ -366,7 +366,7 @@ class Conv2dTest(TestBase):
             dilation=1,
             groups=1,
         )
-        return out.permute(0, 2, 3, 1).contiguous()
+        return out.contiguous()
 
 
 @Conv2dFixture
@@ -411,69 +411,17 @@ def test_conv2d_no_bias_matches_torch() -> None:
         stride=2,
         padding=2,
     )
-    x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
+    x = torch.randn(1, 32, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
     out = op(x, weight)
     ref = F.conv2d(
-        x.permute(0, 3, 1, 2).contiguous(),
+        x,
         weight,
         bias=None,
         stride=2,
         padding=2,
     )
-    ref = ref.permute(0, 2, 3, 1).contiguous()
-    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv2d_bias_requires_bias_tensor() -> None:
-    op = Conv2dBiasFwdOp(
-        n=1,
-        c_in=32,
-        h=16,
-        w=16,
-        c_out=64,
-        kernel_size=5,
-        stride=2,
-        padding=2,
-    )
-    x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
-    bias = torch.zeros(64, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight, bias)
-    ref = F.conv2d(
-        x.permute(0, 3, 1, 2).contiguous(),
-        weight,
-        bias=bias,
-        stride=2,
-        padding=2,
-    )
-    ref = ref.permute(0, 2, 3, 1).contiguous()
-    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv2d_accepts_zero_bias() -> None:
-    op = Conv2dBiasFwdOp(
-        n=1,
-        c_in=32,
-        h=16,
-        w=16,
-        c_out=32,
-        kernel_size=3,
-        padding=1,
-    )
-    x = torch.randn(1, 16, 16, 32, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(32, 32, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    bias = torch.zeros(32, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight, bias)
-    ref = F.conv2d(
-        x.permute(0, 3, 1, 2).contiguous(),
-        weight,
-        bias=bias,
-        padding=1,
-    )
-    ref = ref.permute(0, 2, 3, 1).contiguous()
+    ref = ref.contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
@@ -592,7 +540,7 @@ class Conv3dTest(TestBase):
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         x = torch.randn(
-            self.n, self.d, self.h, self.w, self.c_in,
+            self.n, self.c_in, self.d, self.h, self.w,
             device="cuda", dtype=self.dtype,
         ).contiguous()
         weight = torch.randn(
@@ -609,7 +557,7 @@ class Conv3dTest(TestBase):
         bias: Optional[torch.Tensor],
     ) -> torch.Tensor:
         out = F.conv3d(
-            x.permute(0, 4, 1, 2, 3).contiguous(),
+            x,
             weight,
             bias=bias,
             stride=self.stride,
@@ -617,7 +565,7 @@ class Conv3dTest(TestBase):
             dilation=1,
             groups=1,
         )
-        return out.permute(0, 2, 3, 4, 1).contiguous()
+        return out.contiguous()
 
 
 @Conv3dFixture
@@ -665,45 +613,17 @@ def test_conv3d_no_bias_matches_torch() -> None:
         stride=2,
         padding=1,
     )
-    x = torch.randn(1, 4, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
+    x = torch.randn(1, 8, 4, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     out = op(x, weight)
     ref = F.conv3d(
-        x.permute(0, 4, 1, 2, 3).contiguous(),
+        x,
         weight,
         bias=None,
         stride=2,
         padding=1,
     )
-    ref = ref.permute(0, 2, 3, 4, 1).contiguous()
-    torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
-
-
-@pytest.mark.smoke
-def test_conv3d_bias_requires_bias_tensor() -> None:
-    op = Conv3dBiasFwdOp(
-        n=1,
-        c_in=8,
-        d=4,
-        h=16,
-        w=16,
-        c_out=16,
-        kernel_size=3,
-        stride=2,
-        padding=1,
-    )
-    x = torch.randn(1, 4, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
-    weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
-    bias = torch.zeros(16, device="cuda", dtype=torch.float16).contiguous()
-    out = op(x, weight, bias)
-    ref = F.conv3d(
-        x.permute(0, 4, 1, 2, 3).contiguous(),
-        weight,
-        bias=bias,
-        stride=2,
-        padding=1,
-    )
-    ref = ref.permute(0, 2, 3, 4, 1).contiguous()
+    ref = ref.contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
@@ -720,18 +640,18 @@ def test_conv3d_accepts_zero_bias() -> None:
         stride=2,
         padding=1,
     )
-    x = torch.randn(1, 8, 16, 16, 8, device="cuda", dtype=torch.float16).contiguous()
+    x = torch.randn(1, 8, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     bias = torch.zeros(16, device="cuda", dtype=torch.float16).contiguous()
     out = op(x, weight, bias)
     ref = F.conv3d(
-        x.permute(0, 4, 1, 2, 3).contiguous(),
+        x,
         weight,
         bias=bias,
         stride=2,
         padding=1,
     )
-    ref = ref.permute(0, 2, 3, 4, 1).contiguous()
+    ref = ref.contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -620,21 +620,21 @@ def _conv2d_1x1_kernel(
     ):
         @T.prim_func
         def _conv2d_1x1_main(
-            x: T.Tensor((n, h, w, c_in), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
             weight: T.Tensor((c_out, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, h, w, c_out), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, h, w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
-            x_flat = T.Tensor((n, hw, c_in), dtype, x.data)
-            out_flat = T.Tensor((n, hw, c_out), dtype, out.data)
+            x_flat = T.Tensor((n, c_in, hw), dtype, x.data)
+            out_flat = T.Tensor((n, c_out, hw), dtype, out.data)
             with T.Kernel(
-                T.ceildiv(c_out, block_n),
-                T.ceildiv(hw, block_m),
+                T.ceildiv(hw, block_n),
+                T.ceildiv(c_out, block_m),
                 n,
                 threads=threads,
             ) as (bx, by, bz):
-                data_shared = T.alloc_shared((block_m, block_k), dtype)
-                weight_shared = T.alloc_shared((block_n, block_k), dtype)
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
 
@@ -642,22 +642,22 @@ def _conv2d_1x1_kernel(
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(c_in, block_k), num_stages=num_stages):
-                    T.copy(x_flat[bz, by * block_m, k_iter * block_k], data_shared)
-                    T.copy(weight[bx * block_n, k_iter * block_k], weight_shared)
-                    T.gemm(data_shared, weight_shared, out_local, transpose_B=True)
+                    T.copy(weight[by * block_m, k_iter * block_k], weight_shared)
+                    T.copy(x_flat[bz, k_iter * block_k, bx * block_n], data_shared)
+                    T.gemm(weight_shared, data_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):
-                    m_idx = by * block_m + i
-                    oc = bx * block_n + j
+                    oc = by * block_m + i
+                    hw_idx = bx * block_n + j
                     if has_bias:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < hw) & (oc < c_out),
+                            (oc < c_out) & (hw_idx < hw),
                             T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
                             T.cast(0.0, dtype),
                         )
                     else:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < hw) & (oc < c_out),
+                            (oc < c_out) & (hw_idx < hw),
                             T.cast(out_local[i, j], dtype),
                             T.cast(0.0, dtype),
                         )
@@ -707,92 +707,76 @@ def _conv2d_kernel(
     ):
         @T.prim_func
         def _conv2d_main(
-            x: T.Tensor((n, h, w, c_in), dtype),  # type: ignore
-            weight: T.Tensor((kernel_h, kernel_w, c_in, c_out), dtype),  # type: ignore
-            out: T.Tensor((n, out_h, out_w, c_out), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, h, w), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_h, out_w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
-            use_hopper_im2col = (
-                get_sm_version() == 90
-                and stride_h == stride_w
-                and pad_h == pad_w
-                and kernel_h == kernel_w
-                and c_in % block_k == 0
-            )
+            out_hw = out_h * out_w
             with T.Kernel(
-                T.ceildiv(c_out, block_n),
-                T.ceildiv(n * out_h * out_w, block_m),
+                T.ceildiv(out_hw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
                 threads=threads,
-            ) as (bx, by):
-                data_shared = T.alloc_shared((block_m, block_k), dtype)
-                weight_shared = T.alloc_shared((block_k, block_n), dtype)
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                weight_flat = T.Tensor((k_total, c_out), dtype, weight.data)
-                out_flat = T.Tensor((n * out_h * out_w, c_out), dtype, out.data)
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_hw), dtype, out.data)
 
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    if use_hopper_im2col:
-                        T.c2d_im2col(x, data_shared, by, k_iter, kernel_h, stride_h, 1, pad_h)
-                    else:
-                        for i, j in T.Parallel(block_m, block_k):
-                            m_idx = by * block_m + i
-                            k_idx = k_iter * block_k + j
-                            kh = k_idx // (kernel_w * c_in)
-                            kw = (k_idx // c_in) % kernel_w
-                            ci = k_idx % c_in
-                            out_idx = m_idx % (out_h * out_w)
-                            batch = m_idx // (out_h * out_w)
-                            oh = out_idx // out_w
-                            ow = out_idx % out_w
-                            ih = oh * stride_h + kh - pad_h
-                            iw = ow * stride_w + kw - pad_w
-                            in_bound = (
-                                (m_idx < n * out_h * out_w)
-                                & (k_idx < k_total)
-                                & (ih >= 0)
-                                & (iw >= 0)
-                                & (ih < h)
-                                & (iw < w)
-                            )
-                            data_shared[i, j] = T.if_then_else(
-                                in_bound,
-                                x[batch, ih, iw, ci],
-                                T.cast(0.0, dtype),
-                            )
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        spatial_idx = bx * block_n + j
+                        ci = k_idx // (kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_h * kernel_w)
+                        kh = kernel_idx // kernel_w
+                        kw = kernel_idx % kernel_w
+                        oh = spatial_idx // out_w
+                        ow = spatial_idx % out_w
+                        ih = oh * stride_h + kh - pad_h
+                        iw = ow * stride_w + kw - pad_w
+                        in_bound = (
+                            (spatial_idx < out_hw)
+                            & (k_idx < k_total)
+                            & (ih >= 0)
+                            & (iw >= 0)
+                            & (ih < h)
+                            & (iw < w)
+                        )
+                        data_shared[i, j] = T.if_then_else(
+                            in_bound,
+                            x[bz, ci, ih, iw],
+                            T.cast(0.0, dtype),
+                        )
 
-                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
+                    T.copy(weight_flat[by * block_m, k_iter * block_k], weight_shared)
 
-                    T.gemm(data_shared, weight_shared, out_local)
+                    T.gemm(weight_shared, data_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):
-                    m_idx = by * block_m + i
-                    oc = bx * block_n + j
+                    oc = by * block_m + i
+                    spatial_idx = bx * block_n + j
                     if has_bias:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < n * out_h * out_w) & (oc < c_out),
+                            (oc < c_out) & (spatial_idx < out_hw),
                             T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
                             T.cast(0.0, dtype),
                         )
                     else:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < n * out_h * out_w) & (oc < c_out),
+                            (oc < c_out) & (spatial_idx < out_hw),
                             T.cast(out_local[i, j], dtype),
                             T.cast(0.0, dtype),
                         )
 
-                if use_hopper_im2col:
-                    T.copy(out_shared, out_flat[by * block_m, bx * block_n])
-                else:
-                    for i, j in T.Parallel(block_m, block_n):
-                        m_idx = by * block_m + i
-                        oc = bx * block_n + j
-                        if m_idx < n * out_h * out_w and oc < c_out:
-                            out_flat[m_idx, oc] = out_shared[i, j]
+                T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
         return _conv2d_main
 
@@ -840,7 +824,7 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    return torch.empty((n, h, w, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
+    return torch.empty((n, c_out, h, w), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
 @torch.library.custom_op("top::conv2d_wrapped_kernel", mutates_args=())
@@ -898,7 +882,7 @@ def _(
 ) -> torch.Tensor:
     out_h = (h + 2 * pad_h - kernel_h) // stride_h + 1
     out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
-    return torch.empty((n, out_h, out_w, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
+    return torch.empty((n, c_out, out_h, out_w), dtype=inputs[0].dtype, device=inputs[0].device)
 
 class Conv2dKernel(Kernel):
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -1022,8 +1006,6 @@ class Conv2dKernel(Kernel):
     ) -> torch.Tensor:
         if bias is None:
             bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        # OIHW -> HWIO to match the kernel layout expected by the implicit GEMM path.
-        weight_hwcf = weight.permute(2, 3, 1, 0).contiguous()
         return _conv2d_wrapped_kernel(
             self.n,
             self.c_in,
@@ -1045,7 +1027,7 @@ class Conv2dKernel(Kernel):
             self.config["threads"],
             self.config["enable_rasterization"],
             x,
-            weight_hwcf,
+            weight,
             bias,
         )
 
@@ -1231,45 +1213,46 @@ def _conv3d_kernel(
     ):
         @T.prim_func
         def _conv3d_main(
-            x: T.Tensor((n, d_in, h_in, w_in, c_in), dtype),  # type: ignore
-            weight: T.Tensor((kernel_d, kernel_h, kernel_w, c_in, c_out), dtype),  # type: ignore
-            out: T.Tensor((n, out_d, out_h, out_w, c_out), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            weight: T.Tensor((c_out, c_in, kernel_d, kernel_h, kernel_w), dtype),  # type: ignore
+            out: T.Tensor((n, c_out, out_d, out_h, out_w), dtype),  # type: ignore
             bias: T.Tensor((c_out,), dtype),  # type: ignore
         ):
+            out_dhw = out_d * out_h * out_w
             with T.Kernel(
-                T.ceildiv(c_out, block_n),
-                T.ceildiv(n * out_d * out_h * out_w, block_m),
+                T.ceildiv(out_dhw, block_n),
+                T.ceildiv(c_out, block_m),
+                n,
                 threads=threads,
-            ) as (bx, by):
-                data_shared = T.alloc_shared((block_m, block_k), dtype)
-                weight_shared = T.alloc_shared((block_k, block_n), dtype)
+            ) as (bx, by, bz):
+                weight_shared = T.alloc_shared((block_m, block_k), dtype)
+                data_shared = T.alloc_shared((block_k, block_n), dtype)
                 out_local = T.alloc_fragment((block_m, block_n), accum_dtype)
                 out_shared = T.alloc_shared((block_m, block_n), dtype)
 
-                weight_flat = T.Tensor((k_total, c_out), dtype, weight.data)
-                out_flat = T.Tensor((n * out_d * out_h * out_w, c_out), dtype, out.data)
+                weight_flat = T.Tensor((c_out, k_total), dtype, weight.data)
+                out_flat = T.Tensor((n, c_out, out_dhw), dtype, out.data)
 
                 T.use_swizzle(10, enable=enable_rasterization)
                 T.clear(out_local)
 
                 for k_iter in T.Pipelined(T.ceildiv(k_total, block_k), num_stages=num_stages):
-                    for i, j in T.Parallel(block_m, block_k):
-                        m_idx = by * block_m + i
-                        k_idx = k_iter * block_k + j
-                        kd = k_idx // (kernel_h * kernel_w * c_in)
-                        kh = (k_idx // (kernel_w * c_in)) % kernel_h
-                        kw = (k_idx // c_in) % kernel_w
-                        ci = k_idx % c_in
-                        out_idx = m_idx % (out_d * out_h * out_w)
-                        batch = m_idx // (out_d * out_h * out_w)
-                        od = out_idx // (out_h * out_w)
-                        oh = (out_idx // out_w) % out_h
-                        ow = out_idx % out_w
+                    for i, j in T.Parallel(block_k, block_n):
+                        k_idx = k_iter * block_k + i
+                        spatial_idx = bx * block_n + j
+                        ci = k_idx // (kernel_d * kernel_h * kernel_w)
+                        kernel_idx = k_idx % (kernel_d * kernel_h * kernel_w)
+                        kd = kernel_idx // (kernel_h * kernel_w)
+                        kh = (kernel_idx // kernel_w) % kernel_h
+                        kw = kernel_idx % kernel_w
+                        od = spatial_idx // (out_h * out_w)
+                        oh = (spatial_idx // out_w) % out_h
+                        ow = spatial_idx % out_w
                         id_ = od * stride_d + kd - pad_d
                         ih = oh * stride_h + kh - pad_h
                         iw = ow * stride_w + kw - pad_w
                         in_bound = (
-                            (m_idx < n * out_d * out_h * out_w)
+                            (spatial_idx < out_dhw)
                             & (k_idx < k_total)
                             & (id_ >= 0)
                             & (ih >= 0)
@@ -1280,34 +1263,30 @@ def _conv3d_kernel(
                         )
                         data_shared[i, j] = T.if_then_else(
                             in_bound,
-                            x[batch, id_, ih, iw, ci],
+                            x[bz, ci, id_, ih, iw],
                             T.cast(0.0, dtype),
                         )
 
-                    T.copy(weight_flat[k_iter * block_k, bx * block_n], weight_shared)
-                    T.gemm(data_shared, weight_shared, out_local)
+                    T.copy(weight_flat[by * block_m, k_iter * block_k], weight_shared)
+                    T.gemm(weight_shared, data_shared, out_local)
 
                 for i, j in T.Parallel(block_m, block_n):
-                    m_idx = by * block_m + i
-                    oc = bx * block_n + j
+                    oc = by * block_m + i
+                    spatial_idx = bx * block_n + j
                     if has_bias:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < n * out_d * out_h * out_w) & (oc < c_out),
+                            (oc < c_out) & (spatial_idx < out_dhw),
                             T.cast(out_local[i, j] + T.cast(bias[oc], accum_dtype), dtype),
                             T.cast(0.0, dtype),
                         )
                     else:
                         out_shared[i, j] = T.if_then_else(
-                            (m_idx < n * out_d * out_h * out_w) & (oc < c_out),
+                            (oc < c_out) & (spatial_idx < out_dhw),
                             T.cast(out_local[i, j], dtype),
                             T.cast(0.0, dtype),
                         )
 
-                for i, j in T.Parallel(block_m, block_n):
-                    m_idx = by * block_m + i
-                    oc = bx * block_n + j
-                    if m_idx < n * out_d * out_h * out_w and oc < c_out:
-                        out_flat[m_idx, oc] = out_shared[i, j]
+                T.copy(out_shared, out_flat[bz, by * block_m, bx * block_n])
 
         return _conv3d_main
 
@@ -1394,7 +1373,11 @@ def _(
     out_d = (d_in + 2 * pad_d - kernel_d) // stride_d + 1
     out_h = (h_in + 2 * pad_h - kernel_h) // stride_h + 1
     out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
-    return torch.empty((n, out_d, out_h, out_w, c_out), dtype=inputs[0].dtype, device=inputs[0].device)
+    return torch.empty(
+        (n, c_out, out_d, out_h, out_w),
+        dtype=inputs[0].dtype,
+        device=inputs[0].device,
+    )
 
 
 class Conv3dKernel(Kernel):
@@ -1523,8 +1506,6 @@ class Conv3dKernel(Kernel):
     ) -> torch.Tensor:
         if bias is None:
             bias = torch.zeros(self.c_out, device=x.device, dtype=x.dtype)
-        # OIDHW -> DHWIO so the kernel can flatten weights into [K_total, C_out].
-        weight_kdhwio = weight.permute(2, 3, 4, 1, 0).contiguous()
         return _conv3d_wrapped_kernel(
             self.n,
             self.c_in,
@@ -1550,6 +1531,6 @@ class Conv3dKernel(Kernel):
             self.config["threads"],
             self.config["enable_rasterization"],
             x,
-            weight_kdhwio,
+            weight,
             bias,
         )

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -416,7 +416,7 @@ class Conv2dFwdOp(Op):
         input: torch.Tensor,
         weight: torch.Tensor,
     ) -> torch.Tensor:
-        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.h, self.w, self.c_in))
+        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.c_in, self.h, self.w))
         _validate_tensor_shape(
             "Conv2d",
             "weight",
@@ -478,7 +478,7 @@ class Conv2dBiasFwdOp(Conv2dFwdOp):
         weight: torch.Tensor,
         bias: torch.Tensor,
     ) -> torch.Tensor:
-        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.h, self.w, self.c_in))
+        _validate_tensor_shape("Conv2d", "input", input, (self.n, self.c_in, self.h, self.w))
         _validate_tensor_shape(
             "Conv2d",
             "weight",
@@ -586,7 +586,7 @@ class Conv3dFwdOp(Op):
             "Conv3d",
             "input",
             input,
-            (self.n, self.d, self.h, self.w, self.c_in),
+            (self.n, self.c_in, self.d, self.h, self.w),
         )
         _validate_tensor_shape(
             "Conv3d",
@@ -661,7 +661,7 @@ class Conv3dBiasFwdOp(Conv3dFwdOp):
             "Conv3d",
             "input",
             input,
-            (self.n, self.d, self.h, self.w, self.c_in),
+            (self.n, self.c_in, self.d, self.h, self.w),
         )
         _validate_tensor_shape(
             "Conv3d",


### PR DESCRIPTION
Close #1516 
## Summary

- Move Conv2d and Conv3d layout handling into TileLang kernels so benchmark execution no longer depends on the skipped external layout path.
- Align Conv2d pointwise with the Conv1d pointwise data/weight ordering pattern.
- Re-enable Conv2d/Conv3d benchmark cases under TileLang 0.1.9 by clearing the convolution-specific skip prefixes.

## Test plan

- `TMPDIR=/home/lyc/tvm_tmp conda run --no-capture-output -n tileops-dev python -m pytest benchmarks/ops/bench_convolution.py -vvs --tb=short`
  - Current branch: `22 passed in 643.83s`
  - main comparison worktree: `22 passed in 317.00s`

## Benchmark

Compared current branch `e04aeb1` plus benchmark enable commit against main `63f3022` on NVIDIA H200, Driver 575.57.08, Torch 2.9.0+cu128, CUDA 12.8. Benchmarks used the default benchmark parameters; no tune-disabling override was passed, so cases without special handling ran with `tune=True`.

Summary by TileOps latency, where speed ratio is `main_latency / current_latency`:

| Op | Cases | Avg speed ratio | Faster | Similar | Slower | Notes |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Conv1d | 6 | 1.01x | 0 | 6 | 0 | Essentially unchanged. |
| Conv2d | 13 | 0.71x | 1 | 3 | 9 | Layout-integrated kernels regress most non-1x1 large-spatial and 5x5 cases; one small stem case improves. |
| Conv3d | 3 | 0.89x | 1 | 0 | 2 | Stem case improves, but larger bf16 case regresses significantly. |

Notable Conv2d changes:

| Case | main ms | current ms | ratio | change |
| --- | ---: | ---: | ---: | ---: |
| N=1, Cin=3, HxW=112x112, Cout=64, K=3x3, S=2, fp16 | 0.0067 | 0.0035 | 1.91x | -47.8% latency |
| N=1, Cin=256, HxW=112x112, Cout=512, K=3x3, S=1, fp16 | 0.0686 | 0.4381 | 0.16x | +538.6% latency |
| N=1, Cin=128, HxW=56x56, Cout=256, K=5x5, S=2, fp16 | 0.0221 | 0.0882 | 0.25x | +299.1% latency |
| N=2, Cin=64, HxW=56x56, Cout=256, K=1x1, fp16 | 0.0041 | 0.0043 | 0.95x | +4.9% latency |
| N=1, Cin=512, HxW=7x7, Cout=2048, K=1x1, fp16 | 0.0050 | 0.0108 | 0.46x | +116.0% latency |

Notable Conv3d changes:

| Case | main ms | current ms | ratio | change |
| --- | ---: | ---: | ---: | ---: |
| N=1, Cin=3, DxHxW=16x112x112, Cout=64, K=3x3x3, fp16 | 0.0445 | 0.0253 | 1.76x | -43.1% latency |
| N=1, Cin=64, DxHxW=8x56x56, Cout=128, K=3x3x3, S=2, fp16 | 0.0248 | 0.0333 | 0.74x | +34.3% latency |
| N=1, Cin=32, DxHxW=32x64x64, Cout=64, K=3x3x3, bf16 | 0.0845 | 0.4726 | 0.18x | +459.3% latency |

Full local report: `output_mid/conv_benchmark_full_tune_20260528/report.md`.