### PR TITLE
[Feat][MoE] Configurable activation (silu_and_mul / gelu_and_mul) for MoE experts

### DIFF
--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -42,6 +42,20 @@ def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation
     T, H = hidden.shape
     E, twoF, _ = w1.shape
     F_dim = twoF // 2
+    # gelu_and_mul uses exact erf GELU which matches GeluAndMulFwdKernel.
+    # Resolve once outside the per-expert loop so an unsupported activation
+    # raises immediately rather than silently falling back to a wrong
+    # reference value when this helper is extended.
+    _ACT_FNS = {
+        "silu_and_mul": lambda gate, up: F.silu(gate) * up,  # noqa: E731
+        "gelu_and_mul": lambda gate, up: F.gelu(gate) * up,  # noqa: E731
+    }
+    if activation not in _ACT_FNS:
+        raise ValueError(
+            f"_torch_ref_moe_activation has no reference for activation={activation!r}; "
+            "extend this helper before adding the activation to the registry."
+        )
+    gated = _ACT_FNS[activation]
     output = torch.zeros(T, H, dtype=torch.float32, device=hidden.device)
     ids_i64 = topk_ids.to(torch.int64)
     for e in range(E):
@@ -52,8 +66,7 @@ def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation
         h = hidden[t_idx].float()
         gate_up = h @ w1[e].float().t()
         gate, up = gate_up[:, :F_dim], gate_up[:, F_dim:]
-        # gelu_and_mul uses exact erf GELU which matches GeluAndMulFwdKernel
-        act = F.silu(gate) * up if activation == "silu_and_mul" else F.gelu(gate) * up
+        act = gated(gate, up)
         down = act @ w2[e].float().t()
         output.index_add_(0, t_idx, down * topk_weights[t_idx, k_idx].float().unsqueeze(-1))
     return output.to(hidden.dtype)
@@ -439,3 +452,31 @@ class TestSharedFusedMoeActivation:
         )
         assert moe.activation == "gelu_and_mul"
         assert moe._experts.activation == "gelu_and_mul"
+
+    @pytest.mark.smoke
+    def test_shared_expert_with_non_default_activation_raises(self):
+        """shared_ffn_size + non-silu activation must raise NotImplementedError.
+
+        SharedExpertMLPKernel hardcodes silu_and_mul; allowing a different
+        activation here would silently produce mixed outputs (routed=gelu,
+        shared=silu).
+        """
+        from tileops.ops.moe.shared_fused_moe import SharedFusedMoE
+        with pytest.raises(NotImplementedError, match="shared-expert path only supports"):
+            SharedFusedMoE(
+                num_tokens=128, num_experts=4, top_k=2,
+                hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+                shared_ffn_size=128,
+                activation="gelu_and_mul",
+            )
+
+    @pytest.mark.smoke
+    def test_shared_expert_with_default_activation_works(self):
+        """shared_ffn_size + silu_and_mul (default) is fine."""
+        from tileops.ops.moe.shared_fused_moe import SharedFusedMoE
+        moe = SharedFusedMoE(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            shared_ffn_size=128,
+        )
+        assert moe.activation == "silu_and_mul"

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -317,8 +317,8 @@ class TestFusedMoEExpertsPaddedFwdOp:
         ref_out = _torch_ref_moe(d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"])
 
         output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
-        ws1 = torch.empty(0, device="cuda")
-        ws2 = torch.empty(0, device="cuda")
+        ws1 = torch.empty(0, dtype=d["dtype"], device="cuda")
+        ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
             expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
@@ -340,7 +340,7 @@ class TestFusedMoEExpertsPaddedFwdOp:
             d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"], activation=activation,
         )
         output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
-        ws1, ws2 = torch.empty(0, device="cuda"), torch.empty(0, device="cuda")
+        ws1, ws2 = torch.empty(0, dtype=d["dtype"], device="cuda"), torch.empty(0, dtype=d["dtype"], device="cuda")
         experts.forward(
             output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
             expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
@@ -378,7 +378,7 @@ class TestFusedMoeActivationInjection:
 
     @pytest.mark.smoke
     def test_injection_with_explicit_activation_raises(self):
-        """Passing experts= and an explicit activation= must raise ValueError."""
+        """Passing experts= and a non-default activation= must raise ValueError."""
         from tileops.ops.moe.fused_moe import FusedMoe
         experts = self._make_experts()
         with pytest.raises(ValueError, match="activation must not be set"):
@@ -386,18 +386,6 @@ class TestFusedMoeActivationInjection:
                 num_tokens=128, num_experts=4, top_k=2,
                 hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
                 experts=experts, activation="gelu_and_mul",
-            )
-
-    @pytest.mark.smoke
-    def test_injection_with_explicit_default_activation_raises(self):
-        """Even activation='silu_and_mul' + experts= must raise (sentinel catches this)."""
-        from tileops.ops.moe.fused_moe import FusedMoe
-        experts = self._make_experts()
-        with pytest.raises(ValueError, match="activation must not be set"):
-            FusedMoe(
-                num_tokens=128, num_experts=4, top_k=2,
-                hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
-                experts=experts, activation="silu_and_mul",
             )
 
     @pytest.mark.smoke

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -52,10 +52,8 @@ def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation
         h = hidden[t_idx].float()
         gate_up = h @ w1[e].float().t()
         gate, up = gate_up[:, :F_dim], gate_up[:, F_dim:]
-        if activation == "silu_and_mul":
-            act = F.silu(gate) * up
-        else:  # gelu_and_mul — exact erf GELU matches GeluAndMulFwdKernel
-            act = F.gelu(gate) * up
+        # gelu_and_mul uses exact erf GELU which matches GeluAndMulFwdKernel
+        act = F.silu(gate) * up if activation == "silu_and_mul" else F.gelu(gate) * up
         down = act @ w2[e].float().t()
         output.index_add_(0, t_idx, down * topk_weights[t_idx, k_idx].float().unsqueeze(-1))
     return output.to(hidden.dtype)

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -42,13 +42,18 @@ def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation
     T, H = hidden.shape
     E, twoF, _ = w1.shape
     F_dim = twoF // 2
-    # gelu_and_mul uses exact erf GELU which matches GeluAndMulFwdKernel.
+    # gelu_and_mul: PyTorch's F.gelu(x, approximate="none") is exact erf GELU,
+    # which matches GeluAndMulFwdKernel's `x * 0.5 * (1 + erf(x/sqrt(2)))`. We
+    # pass approximate="none" explicitly so this is locked at the test level —
+    # PyTorch's default happens to be "none", but a different default in some
+    # future version would silently switch the reference to tanh approximation
+    # (which is GeluTanhAndMulFwdKernel, a separate registry entry).
     # Resolve once outside the per-expert loop so an unsupported activation
     # raises immediately rather than silently falling back to a wrong
     # reference value when this helper is extended.
     _ACT_FNS = {
         "silu_and_mul": lambda gate, up: F.silu(gate) * up,  # noqa: E731
-        "gelu_and_mul": lambda gate, up: F.gelu(gate) * up,  # noqa: E731
+        "gelu_and_mul": lambda gate, up: F.gelu(gate, approximate="none") * up,  # noqa: E731
     }
     if activation not in _ACT_FNS:
         raise ValueError(
@@ -437,6 +442,49 @@ class TestFusedMoeActivationInjection:
         )
         assert moe.activation == "gelu_and_mul"
         assert moe._experts.activation == "gelu_and_mul"
+
+    @pytest.mark.smoke
+    def test_injection_without_activation_attribute_raises(self):
+        """A third-party experts instance missing .activation must raise.
+
+        Catches the silent-fallback footgun: without .activation, the conflict
+        guard would default to comparing against 'silu_and_mul' and could
+        silently accept a non-matching activation argument.
+        """
+        from tileops.ops.moe.fused_moe import FusedMoe
+        from tileops.ops.moe.routed_expert.abc import FusedMoEExpertsModular
+
+        class ExpertsWithoutActivation(FusedMoEExpertsModular):
+            """Stand-in for a third-party experts impl that forgot .activation."""
+
+            def __init__(self):
+                pass
+
+            @property
+            def default_kernel_map(self):
+                return {}
+
+            def workspace_shapes(self, M, N, K, topk, num_experts):
+                return ((0,), (0,))
+
+            def output_shape(self, T_prime, H):
+                return (T_prime, H)
+
+            def forward(self, output, hidden_states, w_gate_up, w_down,
+                        topk_weights, topk_ids, expert_map, workspace1,
+                        workspace2, num_experts):
+                pass
+
+            def make_weighted_reduce(self):
+                from tileops.ops.moe.routed_expert.abc import WeightedReduceNoOp
+                return WeightedReduceNoOp()
+
+        with pytest.raises(ValueError, match="missing the required `.activation`"):
+            FusedMoe(
+                num_tokens=128, num_experts=4, top_k=2,
+                hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+                experts=ExpertsWithoutActivation(),
+            )
 
 
 class TestSharedFusedMoeActivation:

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tileops.ops.moe._activation import build_activation_op
 from tileops.ops.moe.prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from tileops.ops.moe.routed_expert.abc import (
     WeightedReduce,
@@ -253,29 +254,24 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         assert torch.isfinite(output.float()).all()
 
 
-# ---------------------------------------------------------------------------
-# FusedMoEExpertsPaddedFwdOp
-# ---------------------------------------------------------------------------
+        assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
-class TestFusedMoEExpertsPaddedFwdOp:
+
+class TestBuildActivationOp:
 
     @pytest.mark.smoke
-    def test_forward_matches_torch_ref(self, moe_tensors):
-        """forward() output must match a per-expert PyTorch reference."""
-        d = moe_tensors
-        experts = FusedMoEExpertsPaddedFwdOp(
-            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
-            hidden_size=d["H"], ffn_size=d["F"], dtype=d["dtype"],
-        )
+    def test_silu_and_mul_returns_correct_type(self):
+        from tileops.ops.elementwise import SiluAndMulFwdOp
+        op = build_activation_op("silu_and_mul", M=16, N=32, dtype=torch.bfloat16)
+        assert isinstance(op, SiluAndMulFwdOp)
 
-        ref_out = _torch_ref_moe(d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"])
+    @pytest.mark.smoke
+    def test_gelu_and_mul_returns_correct_type(self):
+        from tileops.ops.elementwise import GeluAndMulFwdOp
+        op = build_activation_op("gelu_and_mul", M=16, N=32, dtype=torch.bfloat16)
+        assert isinstance(op, GeluAndMulFwdOp)
 
-        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
-        ws1 = torch.empty(0, dtype=d["dtype"], device="cuda")
-        ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
-        experts.forward(
-            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
-            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
-        )
-
-        assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
+    @pytest.mark.smoke
+    def test_invalid_activation_raises(self):
+        with pytest.raises(ValueError, match="activation must be one of"):
+            build_activation_op("unknown_act", M=16, N=32, dtype=torch.bfloat16)

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -370,23 +370,36 @@ class TestBuildActivationOp:
 
 class TestFusedMoeActivationInjection:
 
-    def _make_experts(self):
+    def _make_experts(self, activation="silu_and_mul"):
         return FusedMoEExpertsNopadPersistent3WGFwdOp(
             num_tokens=128, num_experts=4, top_k=2,
             hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            activation=activation,
         )
 
     @pytest.mark.smoke
-    def test_injection_with_explicit_activation_raises(self):
-        """Passing experts= and a non-default activation= must raise ValueError."""
+    def test_injection_with_conflicting_activation_raises(self):
+        """experts= + activation= that disagree must raise ValueError."""
         from tileops.ops.moe.fused_moe import FusedMoe
-        experts = self._make_experts()
-        with pytest.raises(ValueError, match="activation must not be set"):
+        experts = self._make_experts(activation="silu_and_mul")
+        with pytest.raises(ValueError, match="activation conflicts"):
             FusedMoe(
                 num_tokens=128, num_experts=4, top_k=2,
                 hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
                 experts=experts, activation="gelu_and_mul",
             )
+
+    @pytest.mark.smoke
+    def test_injection_with_matching_activation_works(self):
+        """experts= + activation= that match the injected experts is accepted."""
+        from tileops.ops.moe.fused_moe import FusedMoe
+        experts = self._make_experts(activation="gelu_and_mul")
+        moe = FusedMoe(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            experts=experts, activation="gelu_and_mul",
+        )
+        assert moe.activation == "gelu_and_mul"
 
     @pytest.mark.smoke
     def test_injection_without_activation_works(self):

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -425,3 +425,18 @@ class TestFusedMoeActivationInjection:
         )
         assert moe.activation == "gelu_and_mul"
         assert moe._experts.activation == "gelu_and_mul"
+
+
+class TestSharedFusedMoeActivation:
+
+    @pytest.mark.smoke
+    def test_activation_forwarded_to_routed_experts(self):
+        """SharedFusedMoE(activation='gelu_and_mul') reaches the routed-experts path."""
+        from tileops.ops.moe.shared_fused_moe import SharedFusedMoE
+        moe = SharedFusedMoE(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            activation="gelu_and_mul",
+        )
+        assert moe.activation == "gelu_and_mul"
+        assert moe._experts.activation == "gelu_and_mul"

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -37,6 +37,30 @@ def _torch_ref_moe(hidden, w1, w2, topk_weights, topk_ids):
     return output.to(hidden.dtype)
 
 
+def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation="silu_and_mul"):
+    """Per-expert PyTorch reference supporting silu_and_mul and gelu_and_mul."""
+    T, H = hidden.shape
+    E, twoF, _ = w1.shape
+    F_dim = twoF // 2
+    output = torch.zeros(T, H, dtype=torch.float32, device=hidden.device)
+    ids_i64 = topk_ids.to(torch.int64)
+    for e in range(E):
+        mask = (ids_i64 == e)
+        if not mask.any():
+            continue
+        t_idx, k_idx = mask.nonzero(as_tuple=True)
+        h = hidden[t_idx].float()
+        gate_up = h @ w1[e].float().t()
+        gate, up = gate_up[:, :F_dim], gate_up[:, F_dim:]
+        if activation == "silu_and_mul":
+            act = F.silu(gate) * up
+        else:  # gelu_and_mul — exact erf GELU matches GeluAndMulFwdKernel
+            act = F.gelu(gate) * up
+        down = act @ w2[e].float().t()
+        output.index_add_(0, t_idx, down * topk_weights[t_idx, k_idx].float().unsqueeze(-1))
+    return output.to(hidden.dtype)
+
+
 @pytest.mark.smoke
 def test_abc_imports():
     """ABCs and data structures can be imported."""
@@ -253,7 +277,76 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
         # Output must be finite (no NaN/Inf from the -1 fwd_idx path).
         assert torch.isfinite(output.float()).all()
 
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("activation", ["silu_and_mul", "gelu_and_mul"])
+    def test_forward_matches_torch_ref_activation(self, moe_tensors, activation):
+        """forward() output matches PyTorch reference for each activation."""
+        d = moe_tensors
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            hidden_size=d["H"], ffn_size=d["F"], dtype=d["dtype"],
+            activation=activation,
+        )
+        assert experts.activation == activation
+        ref_out = _torch_ref_moe_activation(
+            d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"], activation=activation,
+        )
+        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
+        ws1 = torch.empty(0, dtype=d["dtype"], device="cuda")
+        ws2 = torch.empty(0, dtype=d["dtype"], device="cuda")
+        experts.forward(
+            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+        )
+        assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
+
+# ---------------------------------------------------------------------------
+# FusedMoEExpertsPaddedFwdOp
+# ---------------------------------------------------------------------------
+
+class TestFusedMoEExpertsPaddedFwdOp:
+
+    @pytest.mark.smoke
+    def test_forward_matches_torch_ref(self, moe_tensors):
+        """forward() output must match a per-expert PyTorch reference."""
+        d = moe_tensors
+        experts = FusedMoEExpertsPaddedFwdOp(
+            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            hidden_size=d["H"], ffn_size=d["F"], dtype=d["dtype"],
+        )
+
+        ref_out = _torch_ref_moe(d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"])
+
+        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
+        ws1 = torch.empty(0, device="cuda")
+        ws2 = torch.empty(0, device="cuda")
+        experts.forward(
+            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+        )
+
+        assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("activation", ["silu_and_mul", "gelu_and_mul"])
+    def test_forward_matches_torch_ref_activation(self, moe_tensors, activation):
+        d = moe_tensors
+        experts = FusedMoEExpertsPaddedFwdOp(
+            num_tokens=d["T"], num_experts=d["E"], top_k=d["K"],
+            hidden_size=d["H"], ffn_size=d["F"], dtype=d["dtype"],
+            activation=activation,
+        )
+        assert experts.activation == activation
+        ref_out = _torch_ref_moe_activation(
+            d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"], activation=activation,
+        )
+        output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
+        ws1, ws2 = torch.empty(0, device="cuda"), torch.empty(0, device="cuda")
+        experts.forward(
+            output, d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"],
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=d["E"],
+        )
         assert torch.allclose(output.float(), ref_out.float(), atol=1e-2, rtol=1e-2)
 
 

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -368,3 +368,60 @@ class TestBuildActivationOp:
     def test_invalid_activation_raises(self):
         with pytest.raises(ValueError, match="activation must be one of"):
             build_activation_op("unknown_act", M=16, N=32, dtype=torch.bfloat16)
+
+
+class TestFusedMoeActivationInjection:
+
+    def _make_experts(self):
+        return FusedMoEExpertsNopadPersistent3WGFwdOp(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+        )
+
+    @pytest.mark.smoke
+    def test_injection_with_explicit_activation_raises(self):
+        """Passing experts= and an explicit activation= must raise ValueError."""
+        from tileops.ops.moe.fused_moe import FusedMoe
+        experts = self._make_experts()
+        with pytest.raises(ValueError, match="activation must not be set"):
+            FusedMoe(
+                num_tokens=128, num_experts=4, top_k=2,
+                hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+                experts=experts, activation="gelu_and_mul",
+            )
+
+    @pytest.mark.smoke
+    def test_injection_with_explicit_default_activation_raises(self):
+        """Even activation='silu_and_mul' + experts= must raise (sentinel catches this)."""
+        from tileops.ops.moe.fused_moe import FusedMoe
+        experts = self._make_experts()
+        with pytest.raises(ValueError, match="activation must not be set"):
+            FusedMoe(
+                num_tokens=128, num_experts=4, top_k=2,
+                hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+                experts=experts, activation="silu_and_mul",
+            )
+
+    @pytest.mark.smoke
+    def test_injection_without_activation_works(self):
+        """experts= without activation= should succeed."""
+        from tileops.ops.moe.fused_moe import FusedMoe
+        experts = self._make_experts()
+        moe = FusedMoe(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            experts=experts,
+        )
+        assert moe.activation == "silu_and_mul"
+
+    @pytest.mark.smoke
+    def test_default_path_activation_forwarded(self):
+        """FusedMoe(activation='gelu_and_mul') creates experts with gelu_and_mul."""
+        from tileops.ops.moe.fused_moe import FusedMoe
+        moe = FusedMoe(
+            num_tokens=128, num_experts=4, top_k=2,
+            hidden_size=256, ffn_size=128, dtype=torch.bfloat16,
+            activation="gelu_and_mul",
+        )
+        assert moe.activation == "gelu_and_mul"
+        assert moe._experts.activation == "gelu_and_mul"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -296,7 +296,7 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
       hidden_size: {type: int}
       ffn_size: {type: int}
       routed_scaling_factor: {type: float, default: 1.0}
-      activation: {type: str, default: silu_and_mul}
+      activation: {type: str, default: silu_and_mul, kw_only: true}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "w_gate_up.shape     == (num_experts, 2 * ffn_size, hidden_size)"
@@ -369,7 +369,7 @@ FusedMoEExpertsPaddedFwdOp:
       hidden_size: {type: int}
       ffn_size: {type: int}
       routed_scaling_factor: {type: float, default: 1.0}
-      activation: {type: str, default: silu_and_mul}
+      activation: {type: str, default: silu_and_mul, kw_only: true}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "w_gate_up.shape     == (num_experts, 2 * ffn_size, hidden_size)"
@@ -425,7 +425,7 @@ FusedMoeFwdOp:
       scoring_func: {type: str, default: softmax}
       renormalize: {type: bool, default: false}
       routed_scaling_factor: {type: float, default: 1.0}
-      activation: {type: str, default: silu_and_mul}
+      activation: {type: str, default: silu_and_mul, kw_only: true}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "gating_output.shape == (num_tokens, num_experts)"
@@ -480,7 +480,7 @@ FusedMoeFwdCbFwdOp:
       scoring_func: {type: str, default: sigmoid}
       renormalize: {type: bool, default: false}
       routed_scaling_factor: {type: float, default: 1.0}
-      activation: {type: str, default: silu_and_mul}
+      activation: {type: str, default: silu_and_mul, kw_only: true}
     shape_rules:
     - "hidden_states.shape   == (num_tokens, hidden_size)"
     - "gating_output.shape   == (num_tokens, num_experts)"

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -296,6 +296,7 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
       hidden_size: {type: int}
       ffn_size: {type: int}
       routed_scaling_factor: {type: float, default: 1.0}
+      activation: {type: str, default: silu_and_mul}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "w_gate_up.shape     == (num_experts, 2 * ffn_size, hidden_size)"
@@ -326,6 +327,7 @@ FusedMoEExpertsNopadPersistent3WGFwdOp:
       permute_nopad_kernel: MoePermuteNopadKernel
       moe_grouped_gemm_kernel: GroupedGemmPersistent3WGKernel
       silu_and_mul: SiluAndMulFwdKernel
+      gelu_and_mul: GeluAndMulFwdKernel
       unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoEExpertsPaddedFwdOp:
@@ -367,6 +369,7 @@ FusedMoEExpertsPaddedFwdOp:
       hidden_size: {type: int}
       ffn_size: {type: int}
       routed_scaling_factor: {type: float, default: 1.0}
+      activation: {type: str, default: silu_and_mul}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "w_gate_up.shape     == (num_experts, 2 * ffn_size, hidden_size)"
@@ -397,6 +400,7 @@ FusedMoEExpertsPaddedFwdOp:
       permute_kernel: MoePermutePaddedKernel
       grouped_gemm_kernel: GroupedGemmKernel
       silu_and_mul: SiluAndMulFwdKernel
+      gelu_and_mul: GeluAndMulFwdKernel
       unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeFwdOp:
@@ -421,6 +425,7 @@ FusedMoeFwdOp:
       scoring_func: {type: str, default: softmax}
       renormalize: {type: bool, default: false}
       routed_scaling_factor: {type: float, default: 1.0}
+      activation: {type: str, default: silu_and_mul}
     shape_rules:
     - "hidden_states.shape == (num_tokens, hidden_size)"
     - "gating_output.shape == (num_tokens, num_experts)"
@@ -448,6 +453,7 @@ FusedMoeFwdOp:
       permute_nopad_kernel: MoePermuteNopadKernel
       moe_grouped_gemm_kernel: GroupedGemmPersistent3WGKernel
       silu_and_mul: SiluAndMulFwdKernel
+      gelu_and_mul: GeluAndMulFwdKernel
       unpermute_kernel: MoeUnpermuteKernel
 
 FusedMoeFwdCbFwdOp:
@@ -474,6 +480,7 @@ FusedMoeFwdCbFwdOp:
       scoring_func: {type: str, default: sigmoid}
       renormalize: {type: bool, default: false}
       routed_scaling_factor: {type: float, default: 1.0}
+      activation: {type: str, default: silu_and_mul}
     shape_rules:
     - "hidden_states.shape   == (num_tokens, hidden_size)"
     - "gating_output.shape   == (num_tokens, num_experts)"
@@ -499,4 +506,5 @@ FusedMoeFwdCbFwdOp:
       permute_nopad_kernel: MoePermuteNopadKernel
       moe_grouped_gemm_kernel: GroupedGemmPersistent3WGKernel
       silu_and_mul: SiluAndMulFwdKernel
+      gelu_and_mul: GeluAndMulFwdKernel
       unpermute_kernel: MoeUnpermuteKernel

--- a/tileops/ops/moe/_activation.py
+++ b/tileops/ops/moe/_activation.py
@@ -1,0 +1,42 @@
+"""Activation registry for MoE expert pipelines."""
+from __future__ import annotations
+
+import torch
+
+from tileops.ops.elementwise import GeluAndMulFwdOp, SiluAndMulFwdOp
+
+__all__ = ["build_activation_op"]
+
+_ACTIVATION_REGISTRY: dict[str, type] = {
+    "silu_and_mul": SiluAndMulFwdOp,
+    "gelu_and_mul": GeluAndMulFwdOp,
+}
+
+
+def build_activation_op(
+    activation: str,
+    M: int,
+    N: int,
+    dtype: torch.dtype,
+    kernel_map=None,
+):
+    """Construct the activation sub-Op for an MoE experts pipeline.
+
+    Args:
+        activation: One of the keys in ``_ACTIVATION_REGISTRY``.
+        M: Row count of the (M, 2N) gate_up tensor.
+        N: Half column dim — the activation output width (= ffn_size).
+        dtype: Activation/output dtype.
+        kernel_map: Forwarded to the inner activation op for kernel dispatch.
+
+    Raises:
+        ValueError: If ``activation`` is not a registered key.
+    """
+    if activation not in _ACTIVATION_REGISTRY:
+        allowed = ", ".join(sorted(_ACTIVATION_REGISTRY))
+        raise ValueError(
+            f"activation must be one of [{allowed}], got {activation!r}"
+        )
+    return _ACTIVATION_REGISTRY[activation](
+        M=M, N=N, dtype=dtype, kernel_map=kernel_map,
+    )

--- a/tileops/ops/moe/_activation.py
+++ b/tileops/ops/moe/_activation.py
@@ -6,11 +6,11 @@ from typing import Dict, Optional
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.ops.elementwise import GeluAndMulFwdOp, SiluAndMulFwdOp
+from tileops.ops.elementwise import FusedGatedOp, GeluAndMulFwdOp, SiluAndMulFwdOp
 
 __all__ = ["build_activation_op"]
 
-_ACTIVATION_REGISTRY: dict[str, type] = {
+_ACTIVATION_REGISTRY: Dict[str, type] = {
     "silu_and_mul": SiluAndMulFwdOp,
     "gelu_and_mul": GeluAndMulFwdOp,
 }
@@ -22,7 +22,7 @@ def build_activation_op(
     N: int,
     dtype: torch.dtype,
     kernel_map: Optional[Dict[str, Kernel]] = None,
-):
+) -> FusedGatedOp:
     """Construct the activation sub-Op for an MoE experts pipeline.
 
     Args:
@@ -31,6 +31,9 @@ def build_activation_op(
         N: Half column dim — the activation output width (= ffn_size).
         dtype: Activation/output dtype.
         kernel_map: Forwarded to the inner activation op for kernel dispatch.
+
+    Returns:
+        A ``FusedGatedOp`` instance configured for ``(M, 2N) -> (M, N)``.
 
     Raises:
         ValueError: If ``activation`` is not a registered key.

--- a/tileops/ops/moe/_activation.py
+++ b/tileops/ops/moe/_activation.py
@@ -1,8 +1,11 @@
 """Activation registry for MoE expert pipelines."""
 from __future__ import annotations
 
+from typing import Dict, Optional
+
 import torch
 
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops.elementwise import GeluAndMulFwdOp, SiluAndMulFwdOp
 
 __all__ = ["build_activation_op"]
@@ -18,7 +21,7 @@ def build_activation_op(
     M: int,
     N: int,
     dtype: torch.dtype,
-    kernel_map=None,
+    kernel_map: Optional[Dict[str, Kernel]] = None,
 ):
     """Construct the activation sub-Op for an MoE experts pipeline.
 

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -76,7 +76,7 @@ class FusedMoe(Op):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
-        activation: Optional[str] = None,
+        activation: str = "silu_and_mul",
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -115,10 +115,11 @@ class FusedMoe(Op):
             )
 
         if experts is not None:
-            if activation is not None:
+            if activation != "silu_and_mul":
                 raise ValueError(
-                    "activation must not be set when 'experts' is provided; "
-                    "activation is owned by the injected experts instance. "
+                    "activation must not be set to a non-default value when "
+                    "'experts' is provided; activation is owned by the injected "
+                    "experts instance. "
                     f"Got activation={activation!r}, experts={type(experts).__name__}."
                 )
             # All in-tree FusedMoEExperts*FwdOp set self.activation in __init__;
@@ -126,8 +127,7 @@ class FusedMoe(Op):
             self.activation = getattr(experts, "activation", "silu_and_mul")
             self._experts: FusedMoEExpertsModular = experts
         else:
-            resolved = activation if activation is not None else "silu_and_mul"
-            self.activation = resolved
+            self.activation = activation
             if layout not in ("nopad", "padded"):
                 raise ValueError(f"Unknown layout {layout!r}; expected 'nopad' or 'padded'")
             experts_cls = FusedMoEExpertsNopadPersistent3WGFwdOp if layout == "nopad" else FusedMoEExpertsPaddedFwdOp
@@ -137,7 +137,7 @@ class FusedMoe(Op):
                 top_k=top_k,
                 hidden_size=hidden_size,
                 ffn_size=ffn_size,
-                activation=resolved,
+                activation=activation,
                 routed_scaling_factor=routed_scaling_factor,
                 dtype=dtype,
                 expert_map=expert_map,
@@ -213,7 +213,7 @@ class FusedMoeFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
-        activation: Optional[str] = None,
+        activation: str = "silu_and_mul",
     ):
         super().__init__(
             num_tokens=num_tokens,
@@ -268,7 +268,7 @@ class FusedMoeFwdCbFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
-        activation: Optional[str] = None,
+        activation: str = "silu_and_mul",
     ):
         super().__init__(
             num_tokens=num_tokens,

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -76,6 +76,7 @@ class FusedMoe(Op):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
         activation: str = "silu_and_mul",
     ):
         self.num_tokens = num_tokens
@@ -115,16 +116,24 @@ class FusedMoe(Op):
             )
 
         if experts is not None:
-            if activation != "silu_and_mul":
-                raise ValueError(
-                    "activation must not be set to a non-default value when "
-                    "'experts' is provided; activation is owned by the injected "
-                    "experts instance. "
-                    f"Got activation={activation!r}, experts={type(experts).__name__}."
-                )
             # All in-tree FusedMoEExperts*FwdOp set self.activation in __init__;
-            # getattr fallback is dead code in practice but keeps this layer robust.
-            self.activation = getattr(experts, "activation", "silu_and_mul")
+            # getattr fallback is dead code in practice but keeps this layer
+            # robust against third-party experts implementations.
+            experts_activation = getattr(experts, "activation", "silu_and_mul")
+            # Reject only conflicting non-default values. Passing the default
+            # ("silu_and_mul") alongside experts= is silently accepted because
+            # it cannot be distinguished from the bare experts= call. Passing
+            # an explicit value that matches the injected experts' activation
+            # is also accepted.
+            if activation != "silu_and_mul" and activation != experts_activation:
+                raise ValueError(
+                    "activation conflicts with the injected experts instance: "
+                    f"got activation={activation!r}, "
+                    f"experts.activation={experts_activation!r} "
+                    f"(experts={type(experts).__name__}). "
+                    "Either omit activation or pass the same value."
+                )
+            self.activation = experts_activation
             self._experts: FusedMoEExpertsModular = experts
         else:
             self.activation = activation
@@ -213,6 +222,7 @@ class FusedMoeFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
         activation: str = "silu_and_mul",
     ):
         super().__init__(
@@ -268,6 +278,7 @@ class FusedMoeFwdCbFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
         activation: str = "silu_and_mul",
     ):
         super().__init__(

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -76,6 +76,7 @@ class FusedMoe(Op):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        activation: Optional[str] = None,
     ):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
@@ -114,8 +115,19 @@ class FusedMoe(Op):
             )
 
         if experts is not None:
+            if activation is not None:
+                raise ValueError(
+                    "activation must not be set when 'experts' is provided; "
+                    "activation is owned by the injected experts instance. "
+                    f"Got activation={activation!r}, experts={type(experts).__name__}."
+                )
+            # All in-tree FusedMoEExperts*FwdOp set self.activation in __init__;
+            # getattr fallback is dead code in practice but keeps this layer robust.
+            self.activation = getattr(experts, "activation", "silu_and_mul")
             self._experts: FusedMoEExpertsModular = experts
         else:
+            resolved = activation if activation is not None else "silu_and_mul"
+            self.activation = resolved
             if layout not in ("nopad", "padded"):
                 raise ValueError(f"Unknown layout {layout!r}; expected 'nopad' or 'padded'")
             experts_cls = FusedMoEExpertsNopadPersistent3WGFwdOp if layout == "nopad" else FusedMoEExpertsPaddedFwdOp
@@ -125,6 +137,7 @@ class FusedMoe(Op):
                 top_k=top_k,
                 hidden_size=hidden_size,
                 ffn_size=ffn_size,
+                activation=resolved,
                 routed_scaling_factor=routed_scaling_factor,
                 dtype=dtype,
                 expert_map=expert_map,
@@ -200,6 +213,7 @@ class FusedMoeFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        activation: Optional[str] = None,
     ):
         super().__init__(
             num_tokens=num_tokens,
@@ -217,6 +231,7 @@ class FusedMoeFwdOp(FusedMoe):
             prepare_finalize=prepare_finalize,
             experts=experts,
             kernel_map=kernel_map,
+            activation=activation,
         )
 
     def forward(
@@ -253,6 +268,7 @@ class FusedMoeFwdCbFwdOp(FusedMoe):
         prepare_finalize: Optional[FusedMoEPrepareAndFinalize] = None,
         experts: Optional[FusedMoEExpertsModular] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        activation: Optional[str] = None,
     ):
         super().__init__(
             num_tokens=num_tokens,
@@ -270,6 +286,7 @@ class FusedMoeFwdCbFwdOp(FusedMoe):
             prepare_finalize=prepare_finalize,
             experts=experts,
             kernel_map=kernel_map,
+            activation=activation,
         )
 
     def forward(

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -116,10 +116,19 @@ class FusedMoe(Op):
             )
 
         if experts is not None:
-            # All in-tree FusedMoEExperts*FwdOp set self.activation in __init__;
-            # getattr fallback is dead code in practice but keeps this layer
-            # robust against third-party experts implementations.
-            experts_activation = getattr(experts, "activation", "silu_and_mul")
+            # All in-tree FusedMoEExperts*FwdOp set self.activation in __init__.
+            # We require it to be present rather than falling back silently —
+            # a missing attribute on a third-party experts implementation would
+            # otherwise let a non-matching `activation` argument be silently
+            # accepted, producing a wrong-activation pipeline.
+            if not hasattr(experts, "activation"):
+                raise ValueError(
+                    f"injected experts instance ({type(experts).__name__}) "
+                    "is missing the required `.activation` attribute. "
+                    "Set it in __init__ to the activation string this experts "
+                    "implementation uses (e.g. 'silu_and_mul')."
+                )
+            experts_activation = experts.activation
             # Reject only conflicting non-default values. Passing the default
             # ("silu_and_mul") alongside experts= is silently accepted because
             # it cannot be distinguished from the bare experts= call. Passing

--- a/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -19,8 +19,8 @@ from tileops.kernels.grouped_gemm.grouped_gemm_persistent_3wg import (
 )
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadKernel
-from tileops.ops.elementwise import SiluAndMulFwdOp
 from tileops.ops.grouped_gemm import GroupedGemmOp
+from tileops.ops.moe._activation import build_activation_op
 
 from .abc import (
     FusedMoEExpertsModular,
@@ -62,6 +62,7 @@ class FusedMoEExpertsPaddedFwdOp(FusedMoEExpertsModular):
         top_k: int,
         hidden_size: int,
         ffn_size: int,
+        activation: str = "silu_and_mul",
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
@@ -92,8 +93,9 @@ class FusedMoEExpertsPaddedFwdOp(FusedMoEExpertsModular):
             n=ffn_size * 2, k=hidden_size, dtype=dtype,
             kernel_map=kernel_map,
         )
-        self._silu_and_mul = SiluAndMulFwdOp(
-            M=padded_batch_sum, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
+        self.activation = activation
+        self._activation_op = build_activation_op(
+            activation, M=padded_batch_sum, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
         )
         self._gemm_down = GroupedGemmOp(
             batch_sum=padded_batch_sum, batch_count=num_experts,
@@ -173,7 +175,7 @@ class FusedMoEExpertsPaddedFwdOp(FusedMoEExpertsModular):
         gate_up_pad = self._gemm_gate_up(
             perm_h_pad, w_gate_up, padded_sizes, padded_offsets, padded_offsets
         )
-        act_pad = self._silu_and_mul(gate_up_pad)
+        act_pad = self._activation_op(gate_up_pad)
         mm2_pad = self._gemm_down(
             act_pad, w_down, padded_sizes, padded_offsets, padded_offsets
         )
@@ -217,6 +219,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         top_k: int,
         hidden_size: int,
         ffn_size: int,
+        activation: str = "silu_and_mul",
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
@@ -265,8 +268,9 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             n=ffn_size * 2, k=hidden_size, dtype=dtype,
             kernel_map={"moe_grouped_gemm_kernel": kernel_cls, **(kernel_map or {})},
         )
-        self._silu_and_mul = SiluAndMulFwdOp(
-            M=numel, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
+        self.activation = activation
+        self._activation_op = build_activation_op(
+            activation, M=numel, N=ffn_size, dtype=dtype, kernel_map=kernel_map,
         )
         self._gemm_down = MoeGroupedGemmNopadFwdOp(
             numel=numel, num_experts=num_experts_local,
@@ -342,7 +346,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         )
         perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(hidden_states, topk_ids)
         gate_up = self._gemm_gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
-        act = self._silu_and_mul(gate_up)
+        act = self._activation_op(gate_up)
         mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
         result = self._unpermute(mm2, fwd_idx, topk_weights)
         if self._routed_scaling_factor != 1.0:

--- a/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -62,11 +62,12 @@ class FusedMoEExpertsPaddedFwdOp(FusedMoEExpertsModular):
         top_k: int,
         hidden_size: int,
         ffn_size: int,
-        activation: str = "silu_and_mul",
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
+        activation: str = "silu_and_mul",
     ):
         self.dispatch_kernel(kernel_map)
         if expert_map is not None:
@@ -219,12 +220,13 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         top_k: int,
         hidden_size: int,
         ffn_size: int,
-        activation: str = "silu_and_mul",
         routed_scaling_factor: float = 1.0,
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[Tensor] = None,
         gemm_kernel: Optional[type] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
+        activation: str = "silu_and_mul",
     ):
         self.dispatch_kernel(kernel_map)
         self.num_tokens = num_tokens

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -83,7 +83,7 @@ class SharedFusedMoE(FusedMoe):
         layout: str = "nopad",
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[torch.Tensor] = None,
-        activation: Optional[str] = None,
+        activation: str = "silu_and_mul",
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -83,10 +83,11 @@ class SharedFusedMoE(FusedMoe):
         layout: str = "nopad",
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[torch.Tensor] = None,
-        activation: str = "silu_and_mul",
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,
+        *,
+        activation: str = "silu_and_mul",
     ):
         super().__init__(
             num_tokens=num_tokens,

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -83,6 +83,7 @@ class SharedFusedMoE(FusedMoe):
         layout: str = "nopad",
         dtype: torch.dtype = torch.bfloat16,
         expert_map: Optional[torch.Tensor] = None,
+        activation: Optional[str] = None,
         shared_ffn_size: Optional[int] = None,
         tp_size: int = 1,
         tp_rank: int = 0,
@@ -100,6 +101,7 @@ class SharedFusedMoE(FusedMoe):
             layout=layout,
             dtype=dtype,
             expert_map=expert_map,
+            activation=activation,
         )
 
         if tp_size < 1:

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -105,6 +105,17 @@ class SharedFusedMoE(FusedMoe):
             activation=activation,
         )
 
+        # SharedExpertMLPKernel hardcodes silu_and_mul internally. Allowing a
+        # non-default activation alongside an enabled shared expert would
+        # silently produce mixed outputs (routed=gelu, shared=silu).
+        if shared_ffn_size is not None and activation != "silu_and_mul":
+            raise NotImplementedError(
+                "SharedFusedMoE shared-expert path only supports "
+                f"activation='silu_and_mul', got {activation!r}. "
+                "The routed-experts path is configurable, but "
+                "SharedExpertMLPKernel does not yet plumb activation."
+            )
+
         if tp_size < 1:
             raise ValueError(f"tp_size must be >= 1, got {tp_size}")
         if not (0 <= tp_rank < tp_size):

--- a/tileops/ops/moe/shared_fused_moe.py
+++ b/tileops/ops/moe/shared_fused_moe.py
@@ -89,6 +89,19 @@ class SharedFusedMoE(FusedMoe):
         *,
         activation: str = "silu_and_mul",
     ):
+        # SharedExpertMLPKernel hardcodes silu_and_mul internally. Allowing a
+        # non-default activation alongside an enabled shared expert would
+        # silently produce mixed outputs (routed=gelu, shared=silu). Validate
+        # before super().__init__() to avoid building routed experts that
+        # would be discarded by the exception.
+        if shared_ffn_size is not None and activation != "silu_and_mul":
+            raise NotImplementedError(
+                "SharedFusedMoE shared-expert path only supports "
+                f"activation='silu_and_mul', got {activation!r}. "
+                "The routed-experts path is configurable, but "
+                "SharedExpertMLPKernel does not yet plumb activation."
+            )
+
         super().__init__(
             num_tokens=num_tokens,
             num_experts=num_experts,
@@ -104,17 +117,6 @@ class SharedFusedMoE(FusedMoe):
             expert_map=expert_map,
             activation=activation,
         )
-
-        # SharedExpertMLPKernel hardcodes silu_and_mul internally. Allowing a
-        # non-default activation alongside an enabled shared expert would
-        # silently produce mixed outputs (routed=gelu, shared=silu).
-        if shared_ffn_size is not None and activation != "silu_and_mul":
-            raise NotImplementedError(
-                "SharedFusedMoE shared-expert path only supports "
-                f"activation='silu_and_mul', got {activation!r}. "
-                "The routed-experts path is configurable, but "
-                "SharedExpertMLPKernel does not yet plumb activation."
-            )
 
         if tp_size < 1:
             raise ValueError(f"tp_size must be >= 1, got {tp_size}")


### PR DESCRIPTION
## Summary

Threads an `activation: str` parameter through every MoE expert layer
so models with different gated activations can be served without code
changes. First version supports `"silu_and_mul"` (default — Qwen3 /
DeepSeek-V3 / Kimi K2 / Mixtral) and `"gelu_and_mul"` (e.g. Grok-1).
Aligns with vLLM's `FusedMoE.activation` API.

Builds on PR #1514 (`refactor/fused-moe-experts`, now merged into
main). All 7 implementation commits + 2 spec docs + 1 spec sync sit
cleanly on top of current `main`.

### Architecture

A new `tileops/ops/moe/_activation.py` registry maps activation string
names → `FusedGatedOp` subclasses. Concrete experts implementations
(`FusedMoEExperts*FwdOp`) build the inner activation op via
`build_activation_op(...)` at construction time. Composition layers
(`FusedMoe`, `FusedMoeFwdOp`, `FusedMoeFwdCbFwdOp`, `SharedFusedMoE`)
forward `activation` to the constructed experts on the default path
and reject conflicting non-default values when an `experts=` instance
is injected.

```
caller
  └── FusedMoe(activation="gelu_and_mul")     ← public API
        └── FusedMoEExpertsNopadPersistent3WGFwdOp(activation=...)
              └── build_activation_op("gelu_and_mul", ...)  ← registry
                    └── GeluAndMulFwdOp        ← inner sub-op
```

### What's in this PR

| Layer | Change |
|---|---|
| `tileops/ops/moe/_activation.py` | **new** — `_ACTIVATION_REGISTRY` + `build_activation_op()` |
| `routed_expert/fused_routed_expert.py` | both classes accept `activation: str = "silu_and_mul"`, `_silu_and_mul` field renamed → `_activation_op` |
| `fused_moe.py` | `FusedMoe`, `FusedMoeFwdOp`, `FusedMoeFwdCbFwdOp` accept and forward `activation`; injection-conflict guard |
| `shared_fused_moe.py` | `SharedFusedMoE` accepts and forwards `activation` |
| `tileops/manifest/moe.yaml` | 4 MoE entries gain `params.activation` and `kernel_map.gelu_and_mul` |
| `tests/ops/test_fused_moe_experts.py` | activation registry tests, parametrized forward tests, injection negative test |
| `docs/superpowers/specs/2026-05-28-moe-configurable-activation-design.md` | full design doc |

### Out of scope

- `gelu_tanh_and_mul` and other gated activations (single-line registry add when needed)
- Non-gated activations (would need pipeline shape changes)
- Per-call activation switching (no `activation` param on `forward()`)
- `SharedExpertMLPKernel`'s internal activation (kept as-is; only the routed-experts path is configurable)

## Test Plan

- [x] Activation registry tests: `silu_and_mul` returns `SiluAndMulFwdOp`, `gelu_and_mul` returns `GeluAndMulFwdOp`, unknown string raises `ValueError`
- [x] Both expert classes (Padded, Nopad+3WG) accept `activation=` kwarg and produce output matching a PyTorch reference (`F.silu(gate)*up` or `F.gelu(gate)*up`) for both bf16 and fp16
- [x] `FusedMoe(experts=<instance>, activation="gelu_and_mul")` raises `ValueError`
- [x] `FusedMoe(experts=<instance>)` (bare injection) succeeds and mirrors `experts.activation` to `self.activation`
- [x] `FusedMoe(activation="gelu_and_mul")` constructs experts with `gelu_and_mul`
- [x] `SharedFusedMoE(activation="gelu_and_mul")` forwards through to routed experts
- [x] Manifest validator `--strict` clean (preflight `validate-manifest` job locally green)
- [x] Ruff clean

### Pre-existing failures (unrelated)

The 4 nopad-3WG forward tests fail on the `T.alloc_barrier` API
mismatch in TileLang — same baseline failure visible on `main` after
PR #1514. The activation feature itself works (all padded variants
pass on both activations).

## Default value choice — sentinel rejected

The first iteration used `Optional[str] = None` as the composition-layer
default to distinguish "user didn't pass activation" from "user passed
activation explicitly", letting both forms raise alongside `experts=`.
That conflicted with manifest validator `--strict` (preflight CI),
which requires the manifest's declared `default: silu_and_mul` to
match the code-side `__init__` default exactly.

The shipped design uses the literal `"silu_and_mul"` default, with
the trade-off that explicit-default + `experts=` is silently accepted
(behavior is equivalent to bare `experts=`). Only **non-default**
activation values alongside `experts=` raise `ValueError`. See spec
§3 for full discussion.