### PR TITLE
[Bench][Elementwise] preserve scalar clamp benchmark shape

### DIFF
--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -97,7 +97,7 @@ def test_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dtype)
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)
@@ -582,7 +582,7 @@ def test_fp8_unary_independent_bench(
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=(n_total,), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -97,7 +97,7 @@ def test_unary_independent_bench(op_name: str, shape: tuple, dtype: torch.dtype)
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=shape, dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)
@@ -582,7 +582,7 @@ def test_fp8_unary_independent_bench(
     inputs = test.gen_inputs()
 
     if op_cls.__name__ == "ClampScalarFwdOp":
-        op = op_cls(input=tuple(shape), dtype=dtype, **extra_kwargs)
+        op = op_cls(input=shape, dtype=dtype, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, dtype=dtype, **extra_kwargs)
     result = bm.profile(op, *inputs)


### PR DESCRIPTION
Closes #1545

## Summary

- Preserve the original workload tensor shape when constructing `ClampScalarFwdOp` in independent elementwise benchmarks.
- Keep benchmark FLOP and memory accounting based on `n_total`; only the op shape contract now matches generated inputs.
- Apply the same shape-preserving construction in the fp8 unary benchmark path, while fp8 clamp dtype support remains a separate existing limitation.

## Test plan

- [x] `env TILELANG_CLEANUP_TEMP_FILES=1 TMPDIR=/home/lyc/Project/TileOPs/.tmp python -m pytest "benchmarks/ops/bench_independent_elementwise.py::test_unary_independent_bench[clamp-shape36-dtype36]" -q` -> `1 passed`
- [x] `env TILELANG_CLEANUP_TEMP_FILES=1 TMPDIR=/home/lyc/Project/TileOPs/.tmp python -m pytest benchmarks/ops/bench_independent_elementwise.py -k "test_unary_independent_bench and clamp" -q` -> `9 passed, 138 deselected`
- [x] `env TILELANG_CLEANUP_TEMP_FILES=1 TMPDIR=/home/lyc/Project/TileOPs/.tmp python -m pytest tests/ops/test_special_elementwise_conformance.py -k "clamp_scalar_rejects_same_numel_wrong_shape or clamp_scalar_param_names or clamp_scalar_both_none_rejected" -q` -> `5 passed, 76 deselected`
- [x] `pre-commit run --all-files` -> passed

## Benchmark

- The scalar clamp benchmark failure from #1545 is fixed locally: all 9 regular `test_unary_independent_bench` clamp dtype/shape cases pass.
- No benchmark accounting changes were made; `UnaryBenchmark.calculate_flops()` and `calculate_memory()` still use `workload.n_total`.

## Regression

- Verified `ClampScalarFwdOp` still rejects same-numel wrong-shape inputs via the existing conformance test.
- Verified the fp8 clamp benchmark now reaches the existing dtype support limitation instead of the shape mismatch: `ClampFwdKernel only supports dtypes [torch.float16, torch.bfloat16, torch.float32], got torch.float8_e4m3fn`.