### PR TITLE
[Maintain][Benchmark] Skip unsupported fp8 elementwise benchmarks

### DIFF
--- a/benchmarks/ops/bench_elementwise_fp8.py
+++ b/benchmarks/ops/bench_elementwise_fp8.py
@@ -1,8 +1,8 @@
-"""Benchmarks for fp8 elementwise ops (e4m3fn, e5m2).
+"""Skipped benchmarks for unsupported fp8 elementwise ops (e4m3fn, e5m2).
 
-Profiles TileOPs fp8 kernels vs PyTorch fp16-compute-then-cast baselines
-for unary (relu, exp), binary (add), and fused gated (silu_and_mul) ops
-across three shapes and both fp8 dtypes.
+Keeps unsupported fp8 benchmark cases visible without turning the nightly
+benchmark suite red. Current elementwise dtype contracts reject these fp8
+inputs; remove the skip marks when the corresponding ops add fp8 support.
 """
 
 from math import prod
@@ -17,9 +17,9 @@ from tileops.ops.elementwise import AddFwdOp, ExpFwdOp, ReluFwdOp, SiluAndMulFwd
 from workloads.workload_base import FixtureBase
 
 # Shapes modeled on real LLM workloads: (batch, seq_len, hidden_dim).
-# Small:  (1, 2048, 4096) — single-batch inference, LLaMA-7B hidden.
-# Medium: (8, 2048, 4096) — multi-batch inference.
-# Large:  (4, 4096, 8192) — training, LLaMA-70B hidden.
+# Small:  (1, 2048, 4096) - single-batch inference, LLaMA-7B hidden.
+# Medium: (8, 2048, 4096) - multi-batch inference.
+# Large:  (4, 4096, 8192) - training, LLaMA-70B hidden.
 # A non-pow2 hidden (LLaMA-7B intermediate=11008) is added in the
 # unary/binary sweep to exercise tail handling.
 _SHAPES = (
@@ -29,6 +29,12 @@ _SHAPES = (
     (1, 2048, 11008),
 )
 _FP8_DTYPES = [torch.float8_e4m3fn, torch.float8_e5m2]
+_UNSUPPORTED_FP8_SKIP = pytest.mark.skip(
+    reason=(
+        "TileOPs elementwise ops currently reject fp8 dtypes; "
+        "benchmark is kept as an explicit unsupported case"
+    )
+)
 
 
 def _shape_id(shape: tuple[int, ...]) -> str:
@@ -121,6 +127,7 @@ for _op_name, _op_cls, _bl_fn in [
         for _dt in _FP8_DTYPES:
             _unary_params.append(pytest.param(
                 _op_name, _shape, _dt, _op_cls, _bl_fn,
+                marks=_UNSUPPORTED_FP8_SKIP,
                 id=f"{_op_name}-{_shape_id(_shape)}-{_dt}",
             ))
 
@@ -161,6 +168,7 @@ for _shape in _SHAPES:
     for _dt in _FP8_DTYPES:
         _binary_params.append(pytest.param(
             "add_fp8", _shape, _dt,
+            marks=_UNSUPPORTED_FP8_SKIP,
             id=f"add_fp8-{_shape_id(_shape)}-{_dt}",
         ))
 
@@ -208,6 +216,7 @@ for _shape in _GATED_SHAPES:
     for _dt in _FP8_DTYPES:
         _gated_params.append(pytest.param(
             "silu_and_mul_fp8", _shape, _dt,
+            marks=_UNSUPPORTED_FP8_SKIP,
             id=f"silu_and_mul_fp8-{_shape_id(_shape)}-{_dt}",
         ))
 

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -1,7 +1,7 @@
 """Benchmarks for 11 independent elementwise ops.
 
 Profiles TileOPs vs PyTorch baselines using DNN-realistic 2-D shapes
-(tokens × hidden_dim) across all supported dtypes.
+(tokens x hidden_dim) across all supported dtypes.
 """
 
 from math import prod
@@ -524,6 +524,12 @@ def test_generative_bench(op_name: str, seq_len: int, dim: int, dtype: torch.dty
 # ---------------------------------------------------------------------------
 
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+_UNSUPPORTED_FP8_SKIP = pytest.mark.skip(
+    reason=(
+        "TileOPs elementwise ops currently reject fp8 dtypes; "
+        "benchmark is kept as an explicit unsupported case"
+    )
+)
 
 
 class Fp8UnaryBenchCase:
@@ -563,7 +569,12 @@ def _fp8_unary_params():
                     if (shape == _UNARY_SHAPES[0] and dtype == torch.float8_e4m3fn)
                     else pytest.mark.full
                 )
-                params.append(pytest.param(op_name, shape, dtype, marks=mark))
+                params.append(
+                    pytest.param(
+                        op_name, shape, dtype,
+                        marks=[mark, _UNSUPPORTED_FP8_SKIP],
+                    )
+                )
     return params
 
 
@@ -597,7 +608,7 @@ def test_fp8_unary_independent_bench(
 
 
 # ---------------------------------------------------------------------------
-# fp8 where / masked_fill (selection ops — pass fp8 through directly)
+# fp8 where / masked_fill (selection ops - pass fp8 through directly)
 # ---------------------------------------------------------------------------
 
 
@@ -660,7 +671,10 @@ def _fp8_selection_params():
                     if (shape == _UNARY_SHAPES[0] and dtype == torch.float8_e4m3fn)
                     else pytest.mark.full
                 )
-                params.append(pytest.param(op_name, shape, dtype, marks=mark))
+                marks = [mark]
+                if op_name == "masked_fill":
+                    marks.append(_UNSUPPORTED_FP8_SKIP)
+                params.append(pytest.param(op_name, shape, dtype, marks=marks))
     return params
 
 


### PR DESCRIPTION
Fixes #1542.

## Summary

This PR marks FP8 benchmark cases for currently unsupported elementwise ops as explicit skips, instead of letting nightly benchmark fail during op/kernel dtype validation.

Current elementwise dtype contracts reject FP8 for these TileOPs benchmark cases:

- `relu`
- `exp`
- `add`
- `silu_and_mul`
- `leaky_relu`
- `elu`
- `clamp`
- `masked_fill`

The skip keeps these unsupported FP8 cases visible in pytest collection while preventing nightly from treating expected dtype rejection as benchmark failure.

`where_fp8` is unchanged because it already records only the `torch.where` baseline and does not instantiate `WhereFwdOp` with FP8.

## Validation

```bash
python -m ruff check \
  benchmarks/ops/bench_elementwise_fp8.py \
  benchmarks/ops/bench_independent_elementwise.py
```

Result:

```text
All checks passed!
```

```bash
python -m pytest -q \
  benchmarks/ops/bench_elementwise_fp8.py \
  benchmarks/ops/bench_independent_elementwise.py::test_fp8_unary_independent_bench \
  benchmarks/ops/bench_independent_elementwise.py::test_fp8_selection_bench \
  -k 'not where' -rs
```

Result:

```text
54 skipped, 6 deselected
```

## Notes

The code intentionally does not weaken dtype validation. These benchmark cases can be unskipped when the corresponding TileOPs ops add FP8 support.
