### PR TITLE
[Bench][Reduction] Handle large argreduce skips

### DIFF
--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -18,6 +18,20 @@ _ARGMAX_OP = "ArgmaxFwdOp"
 _ARGMIN_OP = "ArgminFwdOp"
 
 
+def _is_unsupported_large_argreduce_error(exc: Exception) -> bool:
+    """Return True for known staged-rollout large-N argreduce failures."""
+    msg = str(exc)
+    return (
+        "scalable vector" in msg
+        or "No configurations to tune" in msg
+        or (
+            "A single row requires" in msg
+            and "shared memory" in msg
+            and "exceeds" in msg
+        )
+    )
+
+
 # ===================================================================
 # Argmax benchmarks
 # ===================================================================
@@ -33,13 +47,13 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
     # Broken invariant: benchmark must execute all manifest workload shapes
-    # Why: kernel crashes on N>=102400 ("Can't fetch the lanes of a scalable vector")
-    # Cleanup: remove try/skip once ArgreduceKernel handles arbitrary N
+    # Why: the current single-tile shared-memory kernel cannot fit lm-head
+    #      N=102400 rows (204800 bytes per fp16/bf16 row exceeds 49152 bytes).
+    # Cleanup: remove try/skip once ArgreduceKernel has a tiled-N path.
     try:
         result = bm.profile(op, *inputs)
     except Exception as exc:
-        msg = str(exc)
-        if "scalable vector" in msg or "No configurations to tune" in msg:
+        if _is_unsupported_large_argreduce_error(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -68,13 +82,13 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
     # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
     #
     # Broken invariant: benchmark must execute all manifest workload shapes
-    # Why: kernel crashes on N>=102400 ("Can't fetch the lanes of a scalable vector")
-    # Cleanup: remove try/skip once ArgreduceKernel handles arbitrary N
+    # Why: the current single-tile shared-memory kernel cannot fit lm-head
+    #      N=102400 rows (204800 bytes per fp16/bf16 row exceeds 49152 bytes).
+    # Cleanup: remove try/skip once ArgreduceKernel has a tiled-N path.
     try:
         result = bm.profile(op, *inputs)
     except Exception as exc:
-        msg = str(exc)
-        if "scalable vector" in msg or "No configurations to tune" in msg:
+        if _is_unsupported_large_argreduce_error(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
     BenchmarkReport.record(op, locals(), result, tag="tileops")


### PR DESCRIPTION
Closes #1543

## Summary

- Add a shared benchmark helper for known staged-rollout argreduce large-N failures.
- Treat shared-memory budget errors as explicit skips for lm-head argmax/argmin workloads.
- Update benchmark comments to document the single-tile shared-memory limitation and tiled-N cleanup path.

## Test plan

- [x] `python -m py_compile benchmarks/ops/bench_argreduce.py`
- [x] `python -m pytest benchmarks/ops/bench_argreduce.py -vvs -k lm-head`

## Regression

- Full `python -m pytest benchmarks/ops/bench_argreduce.py -vvs` was attempted locally. The lm-head cases skipped as expected, but hidden-state cases were blocked by local `/tmp/tvm-debug-mode-tempdirs` permissions owned by another user.