### PR TITLE
[Fix][MoE] Fix C_shared TMA-store epilogue race in 3WG persistent grouped GEMM

### DIFF
--- a/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -462,6 +462,15 @@ def _make_pingpong_kernel(numel, num_experts, N, K, dtype, sm_count,
                         T.copy(C_local_wg0, C_local_cast_wg0)
                         if arows_0 == T.int32(block_m):
                             # Fast path: full tile → SMEM staging → TMA store.
+                            # C_shared_wg0 is reused on every wave of this persistent
+                            # loop.  Before refilling it we must guarantee the
+                            # PREVIOUS wave's TMA store finished reading it; the
+                            # WG-scoped named barrier aligns all 128 WG0 threads after
+                            # the prior store (T.copy's store already drains via
+                            # tma_store_wait).  A CTA-wide T.sync_threads() would
+                            # deadlock here — this branch is warpgroup-divergent, so
+                            # only WGs with a full tile reach the barrier.
+                            T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
                             T.copy(C_shared_wg0,
                                    C[m_start_0, n_start_0])
@@ -530,6 +539,8 @@ def _make_pingpong_kernel(numel, num_experts, N, K, dtype, sm_count,
                         T.copy(C_local_wg1, C_local_cast_wg1)
                         if arows_1 == T.int32(block_m):
                             # Fast path: full tile → SMEM staging → TMA store.
+                            # WG1's own named barrier (id=5) guards C_shared reuse.
+                            T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
                             T.copy(C_shared_wg1,
                                    C[m_start_1, n_start_1])
@@ -771,6 +782,10 @@ def _make_cooperative_kernel(numel, num_experts, N, K, dtype, sm_count,
                         T.copy(C_local_wg0, C_local_cast_wg0)
                         if arows0 == T.int32(half_m):
                             # Fast path: full top-half tile via TMA store.
+                            # WG-scoped named barrier guards C_shared reuse across
+                            # waves; see the pingpong WG0 epilogue for the full
+                            # rationale (and why a CTA-wide sync would deadlock).
+                            T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
                             T.copy(C_shared_wg0,
                                    C[m_start, n_start])
@@ -835,6 +850,9 @@ def _make_cooperative_kernel(numel, num_experts, N, K, dtype, sm_count,
                         T.copy(C_local_wg1, C_local_cast_wg1)
                         if arows1 == T.int32(half_m):
                             # Fast path: full bottom-half tile via TMA store.
+                            # Same C_shared reuse ordering as the top half, on WG1's
+                            # own named barrier (id=5).
+                            T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
                             T.copy(C_shared_wg1,
                                    C[m_start + half_m, n_start])


### PR DESCRIPTION
Summary
Fixes a non-deterministic correctness race in the 3WG persistent grouped-GEMM kernel (grouped_gemm_persistent_3wg.py) that corrupted MoE outputs at scale.

The TMA-store epilogue stages each result tile through a per-warpgroup C_shared SMEM buffer (cast → C_shared → TMA store). C_shared is allocated once but reused on every wave of the persistent loop, and nothing ordered the next wave's refill against the previous wave's in-flight async TMA store. The next wave could overwrite C_shared before the prior store finished reading it, intermittently corrupting ~1 tile of output.

The race stayed latent under the kernel's own tests (E=8, few waves) but surfaces with many small / zero-size experts (E=384, sparse routing → many waves, tight epilogue reuse). Corrupted gate_up output then blows up through SiLU (exp) and the down GEMM into nan / garbage values.

Fix
Add a warpgroup-scoped named barrier before each C_shared refill, so all 128 WG threads pass the prior store (whose T.copy already drains via tma_store_wait) before any thread overwrites the buffer. Applied to all four epilogue sites — both pingpong and cooperative templates, WG0 uses barrier id=4, WG1 uses id=5.

A CTA-wide T.sync_threads() cannot be used here: the epilogue fast path is gated by a warpgroup-divergent condition (arows == block_m), so a block-wide barrier would deadlock when only some warpgroups enter. The named barrier (bar.sync id, 128) keeps the sync scoped to a single warpgroup.

Testing
Env: tileops-tl9.

The three previously-failing / scale-sensitive cases now pass (verified across repeated runs to confirm the intermittency is gone):

test_fused_moe_kimi[kimi-k2-small-bf16] — was ~8/10 intermittent → passes
test_fused_moe_kimi[kimi-k2-medium-bf16] — was 10/10 deterministic fail → passes
test_fused_moe_qwen3[qwen3-medium] — passes
Full suites green:

tests/kernels/test_grouped_gemm_persistent_3wg.py — 18 passed
tests/ops/test_moe_fused_moe.py — 23 passed
ruff check clean.

Closes #1544