### PR TITLE
[Fix][Bench] Fix FA3 FP8 GQA benchmark interface

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -57,7 +57,7 @@ RUN pip install --no-cache-dir \
 RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation "flash-attn==2.8.3" \
     || echo "WARNING: flash-attn failed to install -- non-fatal"
 
-RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.7.2" \
+RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.8.3" \
     || echo "WARNING: flash-attn-interface (FA3) failed to install -- non-fatal"
 
 RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation \

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -84,9 +84,9 @@ def _fa3_gqa_fp8_fwd():
             k,
             v,
             causal=False,
-            descale_q=q_descale,
-            descale_k=k_descale,
-            descale_v=v_descale,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
         )
 
     return _run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
 ]
 bench = [
     "flash-attn==2.8.3",
-    "flash-attn-interface>=2.7.2",
+    "flash-attn-interface>=2.8.3",
     "flash-linear-attention==0.4.2",
     "flashinfer>=0.6.6",
     "vllm==0.18.0",


### PR DESCRIPTION
## Summary
- update the FP8 GQA FA3 baseline call to use the FA3 2.8.3 q_descale/k_descale/v_descale keywords
- require flash-attn-interface >= 2.8.3 in the bench extra and runner Dockerfile

Fixes #1541.

## Testing
- python -m py_compile benchmarks/ops/attention/bench_gqa_fp8.py
- rg -n "descale_q|descale_k|descale_v" benchmarks tests tileops pyproject.toml .github/runner/Dockerfile -g '!*.cu' -g '!*.ptx' (no matches)
- python -m pytest benchmarks/ops/attention/bench_gqa_fp8.py -q (fails locally because TileLang cannot create /tmp/tvm-debug-mode-tempdirs/*: Permission denied)