### PR TITLE
[Fix][Convolution] Add dilation support

### DIFF
--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -138,6 +138,7 @@ class Conv2dBenchCase:
         kernel_size: tuple[int, int],
         stride: tuple[int, int],
         padding: tuple[int, int],
+        dilation: tuple[int, int],
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -148,6 +149,7 @@ class Conv2dBenchCase:
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -171,7 +173,7 @@ class Conv2dBenchCase:
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
 
@@ -179,14 +181,14 @@ class Conv2dBenchmark(BenchmarkBase[Conv2dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
-        out_h = (t.h + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_w = (t.w + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
+        out_h = (t.h + 2 * t.padding[0] - t.dilation[0] * (t.kernel_size[0] - 1) - 1) // t.stride[0] + 1
+        out_w = (t.w + 2 * t.padding[1] - t.dilation[1] * (t.kernel_size[1] - 1) - 1) // t.stride[1] + 1
         return 2.0 * t.n * t.c_out * out_h * out_w * t.c_in * t.kernel_size[0] * t.kernel_size[1]
 
     def calculate_memory(self) -> Optional[float]:
         t = self.workload
-        out_h = (t.h + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_w = (t.w + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
+        out_h = (t.h + 2 * t.padding[0] - t.dilation[0] * (t.kernel_size[0] - 1) - 1) // t.stride[0] + 1
+        out_w = (t.w + 2 * t.padding[1] - t.dilation[1] * (t.kernel_size[1] - 1) - 1) // t.stride[1] + 1
         bytes_ = (
             t.n * t.c_in * t.h * t.w
             + t.c_out * t.c_in * t.kernel_size[0] * t.kernel_size[1]
@@ -196,24 +198,26 @@ class Conv2dBenchmark(BenchmarkBase[Conv2dBenchCase]):
 
 
 _CONV2D_BENCH_PARAMS = [
-    pytest.param(2, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), torch.float16, True, id="resnet-3x3-fp16"),
-    pytest.param(1, 3, 112, 112, 64, (3, 3), (2, 2), (1, 1), torch.float16, True, id="stem-3x3-s2-fp16"),
-    pytest.param(1, 128, 56, 56, 256, (3, 3), (2, 2), (1, 1), torch.float16, True, id="stage-transition-3x3-s2-fp16"),
-    pytest.param(1, 256, 112, 112, 512, (3, 3), (1, 1), (1, 1), torch.float16, True, id="highres-3x3-s1-fp16"),
-    pytest.param(1, 64, 56, 56, 128, (5, 5), (1, 1), (2, 2), torch.float16, True, id="midres-5x5-s1-fp16"),
-    pytest.param(1, 128, 56, 56, 256, (5, 5), (2, 2), (2, 2), torch.float16, True, id="stage-transition-5x5-s2-fp16"),
-    pytest.param(1, 128, 28, 28, 128, (3, 3), (2, 2), (1, 1), torch.bfloat16, True, id="stride2-bf16"),
-    pytest.param(2, 64, 56, 56, 256, (1, 1), (1, 1), (0, 0), torch.float16, True, id="resnet-1x1-fp16"),
-    pytest.param(2, 128, 28, 28, 512, (1, 1), (1, 1), (0, 0), torch.float16, True, id="bottleneck-expand-1x1-fp16"),
-    pytest.param(2, 512, 28, 28, 128, (1, 1), (1, 1), (0, 0), torch.float16, True, id="bottleneck-reduce-1x1-fp16"),
-    pytest.param(1, 256, 14, 14, 1024, (1, 1), (1, 1), (0, 0), torch.float16, True, id="late-stage-1x1-fp16"),
-    pytest.param(1, 512, 7, 7, 2048, (1, 1), (1, 1), (0, 0), torch.float16, True, id="classifier-1x1-fp16"),
-    pytest.param(2, 64, 56, 56, 256, (1, 1), (1, 1), (0, 0), torch.bfloat16, True, id="resnet-1x1-bf16"),
+    pytest.param(2, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), (1, 1), torch.float16, True, id="resnet-3x3-fp16"),
+    pytest.param(1, 3, 112, 112, 64, (3, 3), (2, 2), (1, 1), (1, 1), torch.float16, True, id="stem-3x3-s2-fp16"),
+    pytest.param(1, 128, 56, 56, 256, (3, 3), (2, 2), (1, 1), (1, 1), torch.float16, True, id="stage-transition-3x3-s2-fp16"),
+    pytest.param(1, 256, 112, 112, 512, (3, 3), (1, 1), (1, 1), (1, 1), torch.float16, True, id="highres-3x3-s1-fp16"),
+    pytest.param(1, 64, 56, 56, 128, (5, 5), (1, 1), (2, 2), (1, 1), torch.float16, True, id="midres-5x5-s1-fp16"),
+    pytest.param(1, 128, 56, 56, 256, (5, 5), (2, 2), (2, 2), (1, 1), torch.float16, True, id="stage-transition-5x5-s2-fp16"),
+    pytest.param(1, 128, 28, 28, 128, (3, 3), (2, 2), (1, 1), (1, 1), torch.bfloat16, True, id="stride2-bf16"),
+    pytest.param(2, 64, 56, 56, 256, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True, id="resnet-1x1-fp16"),
+    pytest.param(2, 128, 28, 28, 512, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True, id="bottleneck-expand-1x1-fp16"),
+    pytest.param(2, 512, 28, 28, 128, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True, id="bottleneck-reduce-1x1-fp16"),
+    pytest.param(1, 256, 14, 14, 1024, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True, id="late-stage-1x1-fp16"),
+    pytest.param(1, 512, 7, 7, 2048, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True, id="classifier-1x1-fp16"),
+    pytest.param(2, 64, 56, 56, 256, (1, 1), (1, 1), (0, 0), (1, 1), torch.bfloat16, True, id="resnet-1x1-bf16"),
+    # DeepLabV3/DeepLabV3+ ASPP branch: 3x3 atrous conv on stride-16 encoder features.
+    pytest.param(1, 2048, 32, 32, 256, (3, 3), (1, 1), (12, 12), (12, 12), torch.float16, True, id="deeplabv3-aspp-3x3-rate12-fp16"),
 ]
 
 
 @pytest.mark.parametrize(
-    "n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune",
+    "n, c_in, h, w, c_out, kernel_size, stride, padding, dilation, dtype, tune",
     _CONV2D_BENCH_PARAMS,
 )
 def test_conv2d_bench(
@@ -225,10 +229,11 @@ def test_conv2d_bench(
     kernel_size: tuple[int, int],
     stride: tuple[int, int],
     padding: tuple[int, int],
+    dilation: tuple[int, int],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv2dBenchCase(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
+    test = Conv2dBenchCase(n, c_in, h, w, c_out, kernel_size, stride, padding, dilation, dtype)
     bm = Conv2dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
@@ -242,6 +247,7 @@ def test_conv2d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         dtype=dtype,
         tune=tune,
     )
@@ -265,6 +271,7 @@ class Conv3dBenchCase:
         kernel_size: tuple[int, int, int],
         stride: tuple[int, int, int],
         padding: tuple[int, int, int],
+        dilation: tuple[int, int, int],
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -276,6 +283,7 @@ class Conv3dBenchCase:
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -302,7 +310,7 @@ class Conv3dBenchCase:
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
 
@@ -310,16 +318,16 @@ class Conv3dBenchmark(BenchmarkBase[Conv3dBenchCase]):
 
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
-        out_d = (t.d + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_h = (t.h + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
-        out_w = (t.w + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
+        out_d = (t.d + 2 * t.padding[0] - t.dilation[0] * (t.kernel_size[0] - 1) - 1) // t.stride[0] + 1
+        out_h = (t.h + 2 * t.padding[1] - t.dilation[1] * (t.kernel_size[1] - 1) - 1) // t.stride[1] + 1
+        out_w = (t.w + 2 * t.padding[2] - t.dilation[2] * (t.kernel_size[2] - 1) - 1) // t.stride[2] + 1
         return 2.0 * t.n * t.c_out * out_d * out_h * out_w * t.c_in * t.kernel_size[0] * t.kernel_size[1] * t.kernel_size[2]
 
     def calculate_memory(self) -> Optional[float]:
         t = self.workload
-        out_d = (t.d + 2 * t.padding[0] - t.kernel_size[0]) // t.stride[0] + 1
-        out_h = (t.h + 2 * t.padding[1] - t.kernel_size[1]) // t.stride[1] + 1
-        out_w = (t.w + 2 * t.padding[2] - t.kernel_size[2]) // t.stride[2] + 1
+        out_d = (t.d + 2 * t.padding[0] - t.dilation[0] * (t.kernel_size[0] - 1) - 1) // t.stride[0] + 1
+        out_h = (t.h + 2 * t.padding[1] - t.dilation[1] * (t.kernel_size[1] - 1) - 1) // t.stride[1] + 1
+        out_w = (t.w + 2 * t.padding[2] - t.dilation[2] * (t.kernel_size[2] - 1) - 1) // t.stride[2] + 1
         bytes_ = (
             t.n * t.c_in * t.d * t.h * t.w
             + t.c_out * t.c_in * t.kernel_size[0] * t.kernel_size[1] * t.kernel_size[2]
@@ -329,14 +337,16 @@ class Conv3dBenchmark(BenchmarkBase[Conv3dBenchCase]):
 
 
 _CONV3D_BENCH_PARAMS = [
-    pytest.param(1, 3, 16, 112, 112, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, True, id="r3d-stem-k3-s1-fp16"),
-    pytest.param(1, 64, 8, 56, 56, 128, (3, 3, 3), (2, 2, 2), (1, 1, 1), torch.float16, True, id="video-stage-downsample-k3-s2-fp16"),
-    pytest.param(1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, True, id="unet-encoder-k3-s1-bf16"),
+    pytest.param(1, 3, 16, 112, 112, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.float16, True, id="r3d-stem-k3-s1-fp16"),
+    pytest.param(1, 64, 8, 56, 56, 128, (3, 3, 3), (2, 2, 2), (1, 1, 1), (1, 1, 1), torch.float16, True, id="video-stage-downsample-k3-s2-fp16"),
+    pytest.param(1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.bfloat16, True, id="unet-encoder-k3-s1-bf16"),
+    # 3D U-Net + 3D ASPP medical segmentation branch: 3x3x3 atrous conv on low-resolution volume features.
+    pytest.param(1, 256, 8, 16, 16, 256, (3, 3, 3), (1, 1, 1), (6, 6, 6), (6, 6, 6), torch.float16, True, id="3d-unet-aspp-3x3x3-rate6-fp16"),
 ]
 
 
 @pytest.mark.parametrize(
-    "n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype, tune",
+    "n, c_in, d, h, w, c_out, kernel_size, stride, padding, dilation, dtype, tune",
     _CONV3D_BENCH_PARAMS,
 )
 def test_conv3d_bench(
@@ -349,10 +359,11 @@ def test_conv3d_bench(
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int],
     padding: tuple[int, int, int],
+    dilation: tuple[int, int, int],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv3dBenchCase(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype)
+    test = Conv3dBenchCase(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dilation, dtype)
     bm = Conv3dBenchmark(test)
     inputs = test.gen_inputs()
     x, weight, bias = inputs
@@ -367,6 +378,7 @@ def test_conv3d_bench(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         dtype=dtype,
         tune=tune,
     )

--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -293,61 +293,66 @@ def test_conv1d_dispatches_kernel(
 
 class Conv2dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, h, w, c_out, kernel_size, stride, padding, dtype, tune", [
+        ("n, c_in, h, w, c_out, kernel_size, stride, padding, dilation, dtype, tune", [
             pytest.param(
-                2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.float16, False,
+                2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), (1, 1), torch.float16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-fp16-3x3",
             ),
             pytest.param(
-                2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), torch.bfloat16, False,
+                2, 32, 32, 32, 64, (3, 3), (1, 1), (1, 1), (1, 1), torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-bf16-3x3",
             ),
             pytest.param(
-                1, 3, 112, 112, 64, (3, 3), (2, 2), (1, 1), torch.float16, False,
+                1, 3, 112, 112, 64, (3, 3), (2, 2), (1, 1), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-stem-3x3-s2-fp16",
             ),
             pytest.param(
-                1, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), torch.float16, False,
+                1, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-resblock-3x3-s1-fp16",
             ),
             pytest.param(
-                1, 128, 56, 56, 256, (3, 3), (2, 2), (1, 1), torch.float16, False,
+                1, 128, 56, 56, 256, (3, 3), (2, 2), (1, 1), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-stage-transition-3x3-s2-fp16",
             ),
             pytest.param(
-                1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), torch.float16, False,
+                1, 32, 28, 28, 64, (5, 5), (1, 1), (2, 2), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-small-5x5-s1-fp16",
             ),
             pytest.param(
-                1, 64, 28, 28, 128, (5, 5), (2, 2), (2, 2), torch.float16, False,
+                1, 64, 28, 28, 128, (5, 5), (2, 2), (2, 2), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-small-5x5-s2-fp16",
             ),
             pytest.param(
-                2, 32, 32, 32, 64, (1, 1), (1, 1), (0, 0), torch.float16, True,
+                2, 32, 32, 32, 64, (1, 1), (1, 1), (0, 0), (1, 1), torch.float16, True,
                 marks=pytest.mark.full,
                 id="full-fp16-1x1-tuned",
             ),
             pytest.param(
-                1, 64, 28, 28, 128, (3, 3), (2, 2), (1, 1), torch.float16, False,
+                1, 64, 28, 28, 128, (3, 3), (2, 2), (1, 1), (1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-fp16-stride2",
             ),
             pytest.param(
-                1, 64, 56, 56, 128, (3, 3), (2, 2), (1, 1), torch.bfloat16, False,
+                1, 64, 56, 56, 128, (3, 3), (2, 2), (1, 1), (1, 1), torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-bf16-3x3-s2",
             ),
             pytest.param(
-                1, 64, 28, 28, 64, (1, 1), (1, 1), (0, 0), torch.bfloat16, False,
+                1, 64, 28, 28, 64, (1, 1), (1, 1), (0, 0), (1, 1), torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-bf16-1x1",
+            ),
+            pytest.param(
+                1, 64, 32, 32, 128, (3, 3), (1, 1), (2, 2), (2, 2), torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-deeplab-aspp-3x3-d2-fp16",
             ),
         ]),
     ]
@@ -365,6 +370,7 @@ class Conv2dTest(TestBase):
         kernel_size: tuple[int, int],
         stride: tuple[int, int],
         padding: tuple[int, int],
+        dilation: tuple[int, int],
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -375,6 +381,7 @@ class Conv2dTest(TestBase):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -398,7 +405,7 @@ class Conv2dTest(TestBase):
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
         return out.contiguous()
@@ -414,10 +421,11 @@ def test_conv2d(
     kernel_size: tuple[int, int],
     stride: tuple[int, int],
     padding: tuple[int, int],
+    dilation: tuple[int, int],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dtype)
+    test = Conv2dTest(n, c_in, h, w, c_out, kernel_size, stride, padding, dilation, dtype)
     op = Conv2dBiasFwdOp(
         n=n,
         c_in=c_in,
@@ -427,6 +435,7 @@ def test_conv2d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         dtype=dtype,
         tune=tune,
     )
@@ -444,7 +453,8 @@ def test_conv2d_no_bias_matches_torch() -> None:
         c_out=64,
         kernel_size=5,
         stride=2,
-        padding=2,
+        padding=4,
+        dilation=2,
     )
     x = torch.randn(1, 32, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(64, 32, 5, 5, device="cuda", dtype=torch.float16).contiguous()
@@ -454,7 +464,8 @@ def test_conv2d_no_bias_matches_torch() -> None:
         weight,
         bias=None,
         stride=2,
-        padding=2,
+        padding=4,
+        dilation=2,
     )
     ref = ref.contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
@@ -517,31 +528,36 @@ def test_conv2d_dispatches_5x5_kernel() -> None:
 
 class Conv3dFixture(FixtureBase):
     PARAMS = [
-        ("n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype, tune", [
+        ("n, c_in, d, h, w, c_out, kernel_size, stride, padding, dilation, dtype, tune", [
             pytest.param(
-                1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False,
+                1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.float16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-3d-unet-k3-s1-fp16",
             ),
             pytest.param(
-                1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False,
+                1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-3d-unet-k3-s1-bf16",
             ),
             pytest.param(
-                1, 3, 16, 112, 112, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.float16, False,
+                1, 3, 16, 112, 112, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-r3d-stem-k3-s1-fp16",
             ),
             pytest.param(
-                1, 64, 8, 56, 56, 128, (3, 3, 3), (2, 2, 2), (1, 1, 1), torch.float16, False,
+                1, 64, 8, 56, 56, 128, (3, 3, 3), (2, 2, 2), (1, 1, 1), (1, 1, 1), torch.float16, False,
                 marks=pytest.mark.full,
                 id="full-video-stage-downsample-k3-s2-fp16",
             ),
             pytest.param(
-                1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), torch.bfloat16, False,
+                1, 32, 32, 64, 64, 64, (3, 3, 3), (1, 1, 1), (1, 1, 1), (1, 1, 1), torch.bfloat16, False,
                 marks=pytest.mark.full,
                 id="full-unet-encoder-k3-s1-bf16",
+            ),
+            pytest.param(
+                1, 16, 8, 32, 32, 32, (3, 3, 3), (1, 1, 1), (2, 2, 2), (2, 2, 2), torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-3d-aspp-3x3x3-d2-fp16",
             ),
         ]),
     ]
@@ -560,6 +576,7 @@ class Conv3dTest(TestBase):
         kernel_size: tuple[int, int, int],
         stride: tuple[int, int, int],
         padding: tuple[int, int, int],
+        dilation: tuple[int, int, int],
         dtype: torch.dtype,
     ) -> None:
         self.n = n
@@ -571,6 +588,7 @@ class Conv3dTest(TestBase):
         self.kernel_size = kernel_size
         self.stride = stride
         self.padding = padding
+        self.dilation = dilation
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
@@ -597,7 +615,7 @@ class Conv3dTest(TestBase):
             bias=bias,
             stride=self.stride,
             padding=self.padding,
-            dilation=1,
+            dilation=self.dilation,
             groups=1,
         )
         return out.contiguous()
@@ -614,10 +632,11 @@ def test_conv3d(
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int],
     padding: tuple[int, int, int],
+    dilation: tuple[int, int, int],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = Conv3dTest(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dtype)
+    test = Conv3dTest(n, c_in, d, h, w, c_out, kernel_size, stride, padding, dilation, dtype)
     op = Conv3dBiasFwdOp(
         n=n,
         c_in=c_in,
@@ -628,6 +647,7 @@ def test_conv3d(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
+        dilation=dilation,
         dtype=dtype,
         tune=tune,
     )
@@ -640,15 +660,16 @@ def test_conv3d_no_bias_matches_torch() -> None:
     op = Conv3dFwdOp(
         n=1,
         c_in=8,
-        d=4,
+        d=8,
         h=16,
         w=16,
         c_out=16,
         kernel_size=3,
         stride=2,
-        padding=1,
+        padding=2,
+        dilation=2,
     )
-    x = torch.randn(1, 8, 4, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    x = torch.randn(1, 8, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     weight = torch.randn(16, 8, 3, 3, 3, device="cuda", dtype=torch.float16).contiguous()
     out = op(x, weight)
     ref = F.conv3d(
@@ -656,7 +677,8 @@ def test_conv3d_no_bias_matches_torch() -> None:
         weight,
         bias=None,
         stride=2,
-        padding=1,
+        padding=2,
+        dilation=2,
     )
     ref = ref.contiguous()
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -1196,12 +1196,14 @@ def _conv2d_kernel(
     stride_w: int,
     pad_h: int,
     pad_w: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_h = (h + 2 * pad_h - kernel_h) // stride_h + 1
-    out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
+    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     k_total = kernel_h * kernel_w * c_in
 
     # Re-enable automatic async copy once TileLang lowers scalar cp.async
@@ -1254,8 +1256,8 @@ def _conv2d_kernel(
                         kw = kernel_idx % kernel_w
                         oh = spatial_idx // out_w
                         ow = spatial_idx % out_w
-                        ih = oh * stride_h + kh - pad_h
-                        iw = ow * stride_w + kw - pad_w
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
                         in_bound = (
                             (spatial_idx < out_hw)
                             & (k_idx < k_total)
@@ -1354,6 +1356,8 @@ def _conv2d_wrapped_kernel(
     stride_w: int,
     pad_h: int,
     pad_w: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -1367,7 +1371,7 @@ def _conv2d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv2d_kernel(
-        n, c_in, h, w, c_out, kernel_h, kernel_w, stride_h, stride_w, pad_h, pad_w, has_bias, dtype
+        n, c_in, h, w, c_out, kernel_h, kernel_w, stride_h, stride_w, pad_h, pad_w, dilation_h, dilation_w, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -1384,6 +1388,8 @@ def _(
     stride_w: int,
     pad_h: int,
     pad_w: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -1394,8 +1400,8 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_h = (h + 2 * pad_h - kernel_h) // stride_h + 1
-    out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
+    out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     return torch.empty((n, c_out, out_h, out_w), dtype=inputs[0].dtype, device=inputs[0].device)
 
 class Conv2dKernel(Kernel):
@@ -1414,6 +1420,8 @@ class Conv2dKernel(Kernel):
         stride_w: int,
         pad_h: int,
         pad_w: int,
+        dilation_h: int,
+        dilation_w: int,
         dtype: torch.dtype,
         has_bias: bool = False,
         config: Optional[dict] = None,
@@ -1431,10 +1439,12 @@ class Conv2dKernel(Kernel):
         self.stride_w = stride_w
         self.pad_h = pad_h
         self.pad_w = pad_w
+        self.dilation_h = dilation_h
+        self.dilation_w = dilation_w
         self.dtype = dtype
         self.has_bias = has_bias
-        self.out_h = (h + 2 * pad_h - kernel_h) // stride_h + 1
-        self.out_w = (w + 2 * pad_w - kernel_w) // stride_w + 1
+        self.out_h = (h + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+        self.out_w = (w + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
         self.m = n * self.out_h * self.out_w
         self.k_total = c_in * kernel_h * kernel_w
 
@@ -1450,6 +1460,8 @@ class Conv2dKernel(Kernel):
             stride_w,
             pad_h,
             pad_w,
+            dilation_h,
+            dilation_w,
             has_bias,
             self.dtype_str,
         )
@@ -1532,6 +1544,8 @@ class Conv2dKernel(Kernel):
             self.stride_w,
             self.pad_h,
             self.pad_w,
+            self.dilation_h,
+            self.dilation_w,
             self.has_bias,
             self.dtype_str,
             self.config["block_m"],
@@ -1701,13 +1715,16 @@ def _conv3d_kernel(
     pad_d: int,
     pad_h: int,
     pad_w: int,
+    dilation_d: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_d = (d_in + 2 * pad_d - kernel_d) // stride_d + 1
-    out_h = (h_in + 2 * pad_h - kernel_h) // stride_h + 1
-    out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
+    out_d = (d_in + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
+    out_h = (h_in + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     k_total = kernel_d * kernel_h * kernel_w * c_in
 
     # Re-enable automatic async copy once TileLang lowers scalar cp.async
@@ -1762,9 +1779,9 @@ def _conv3d_kernel(
                         od = spatial_idx // (out_h * out_w)
                         oh = (spatial_idx // out_w) % out_h
                         ow = spatial_idx % out_w
-                        id_ = od * stride_d + kd - pad_d
-                        ih = oh * stride_h + kh - pad_h
-                        iw = ow * stride_w + kw - pad_w
+                        id_ = od * stride_d + kd * dilation_d - pad_d
+                        ih = oh * stride_h + kh * dilation_h - pad_h
+                        iw = ow * stride_w + kw * dilation_w - pad_w
                         in_bound = (
                             (spatial_idx < out_dhw)
                             & (k_idx < k_total)
@@ -1824,6 +1841,9 @@ def _conv3d_wrapped_kernel(
     pad_d: int,
     pad_h: int,
     pad_w: int,
+    dilation_d: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -1852,6 +1872,9 @@ def _conv3d_wrapped_kernel(
         pad_d,
         pad_h,
         pad_w,
+        dilation_d,
+        dilation_h,
+        dilation_w,
         has_bias,
         dtype,
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
@@ -1874,6 +1897,9 @@ def _(
     pad_d: int,
     pad_h: int,
     pad_w: int,
+    dilation_d: int,
+    dilation_h: int,
+    dilation_w: int,
     has_bias: bool,
     dtype: str,
     block_m: int,
@@ -1884,9 +1910,9 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_d = (d_in + 2 * pad_d - kernel_d) // stride_d + 1
-    out_h = (h_in + 2 * pad_h - kernel_h) // stride_h + 1
-    out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
+    out_d = (d_in + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
+    out_h = (h_in + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+    out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
     return torch.empty(
         (n, c_out, out_d, out_h, out_w),
         dtype=inputs[0].dtype,
@@ -1914,6 +1940,9 @@ class Conv3dKernel(Kernel):
         pad_d: int,
         pad_h: int,
         pad_w: int,
+        dilation_d: int,
+        dilation_h: int,
+        dilation_w: int,
         dtype: torch.dtype,
         has_bias: bool = False,
         config: Optional[dict] = None,
@@ -1935,11 +1964,14 @@ class Conv3dKernel(Kernel):
         self.pad_d = pad_d
         self.pad_h = pad_h
         self.pad_w = pad_w
+        self.dilation_d = dilation_d
+        self.dilation_h = dilation_h
+        self.dilation_w = dilation_w
         self.dtype = dtype
         self.has_bias = has_bias
-        self.out_d = (d_in + 2 * pad_d - kernel_d) // stride_d + 1
-        self.out_h = (h_in + 2 * pad_h - kernel_h) // stride_h + 1
-        self.out_w = (w_in + 2 * pad_w - kernel_w) // stride_w + 1
+        self.out_d = (d_in + 2 * pad_d - dilation_d * (kernel_d - 1) - 1) // stride_d + 1
+        self.out_h = (h_in + 2 * pad_h - dilation_h * (kernel_h - 1) - 1) // stride_h + 1
+        self.out_w = (w_in + 2 * pad_w - dilation_w * (kernel_w - 1) - 1) // stride_w + 1
         self.m = n * self.out_d * self.out_h * self.out_w
         self.k_total = c_in * kernel_d * kernel_h * kernel_w
 
@@ -1959,6 +1991,9 @@ class Conv3dKernel(Kernel):
             pad_d,
             pad_h,
             pad_w,
+            dilation_d,
+            dilation_h,
+            dilation_w,
             has_bias,
             self.dtype_str,
         )
@@ -2036,6 +2071,9 @@ class Conv3dKernel(Kernel):
             self.pad_d,
             self.pad_h,
             self.pad_w,
+            self.dilation_d,
+            self.dilation_h,
+            self.dilation_w,
             self.has_bias,
             self.dtype_str,
             self.config["block_m"],

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -125,7 +125,7 @@ Conv2dFwdOp:
   ref_api: "torch.nn.functional.conv2d"
   # Equivalent to torch.nn.functional.conv2d (bias=None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups
+  status: spec-only  # TODO: impl lacks groups
 
   signature:
     inputs:
@@ -136,7 +136,7 @@ Conv2dFwdOp:
     params:
       stride: {type: "int | tuple[int, int]", default: 1}
       padding: {type: "int | tuple[int, int] | str", default: 0}
-      dilation: {type: "int | tuple[int, int]", default: 1}  # TODO: not supported by kernel
+      dilation: {type: "int | tuple[int, int]", default: 1}
       groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
       - "C_in % groups == 0"
@@ -188,7 +188,7 @@ Conv2dBiasFwdOp:
   ref_api: "torch.nn.functional.conv2d"
   # Equivalent to torch.nn.functional.conv2d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups
+  status: spec-only  # TODO: impl lacks groups
   variant_of: Conv2dFwdOp
 
   signature:
@@ -201,7 +201,7 @@ Conv2dBiasFwdOp:
     params:
       stride: {type: "int | tuple[int, int]", default: 1}
       padding: {type: "int | tuple[int, int] | str", default: 0}
-      dilation: {type: "int | tuple[int, int]", default: 1}  # TODO: not supported by kernel
+      dilation: {type: "int | tuple[int, int]", default: 1}
       groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
       - "C_in % groups == 0"
@@ -254,7 +254,7 @@ Conv3dFwdOp:
   ref_api: "torch.nn.functional.conv3d"
   # Equivalent to torch.nn.functional.conv3d (bias=None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups
+  status: spec-only  # TODO: impl lacks groups
 
   signature:
     inputs:
@@ -265,7 +265,7 @@ Conv3dFwdOp:
     params:
       stride: {type: "int | tuple[int, int, int]", default: 1}
       padding: {type: "int | tuple[int, int, int] | str", default: 0}
-      dilation: {type: "int | tuple[int, int, int]", default: 1}  # TODO: not supported by kernel
+      dilation: {type: "int | tuple[int, int, int]", default: 1}
       groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
       - "C_in % groups == 0"
@@ -312,7 +312,7 @@ Conv3dBiasFwdOp:
   ref_api: "torch.nn.functional.conv3d"
   # Equivalent to torch.nn.functional.conv3d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups
+  status: spec-only  # TODO: impl lacks groups
   variant_of: Conv3dFwdOp
 
   signature:
@@ -325,7 +325,7 @@ Conv3dBiasFwdOp:
     params:
       stride: {type: "int | tuple[int, int, int]", default: 1}
       padding: {type: "int | tuple[int, int, int] | str", default: 0}
-      dilation: {type: "int | tuple[int, int, int]", default: 1}  # TODO: not supported by kernel
+      dilation: {type: "int | tuple[int, int, int]", default: 1}
       groups: {type: int, default: 1}  # TODO: not supported by kernel
     shape_rules:
       - "C_in % groups == 0"

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -378,8 +378,6 @@ class Conv2dFwdOp(Op):
             padding=self.padding,
             dilation=dilation_tuple,
         )
-        if dilation_tuple != (1, 1):
-            raise NotImplementedError("Conv2d currently supports dilation=1 only")
         self.dilation = dilation_tuple
         self.groups = groups
         self.has_bias = _has_bias
@@ -413,6 +411,8 @@ class Conv2dFwdOp(Op):
                 **kernel_kwargs,
                 kernel_h=self.kernel_size[0],
                 kernel_w=self.kernel_size[1],
+                dilation_h=self.dilation[0],
+                dilation_w=self.dilation[1],
             )
         else:
             raise NotImplementedError(
@@ -557,8 +557,6 @@ class Conv3dFwdOp(Op):
             padding=self.padding,
             dilation=dilation_tuple,
         )
-        if dilation_tuple != (1, 1, 1):
-            raise NotImplementedError("Conv3d currently supports dilation=1 only")
         self.dilation = dilation_tuple
         self.groups = groups
         self.has_bias = _has_bias
@@ -583,6 +581,9 @@ class Conv3dFwdOp(Op):
             pad_d=self.padding[0],
             pad_h=self.padding[1],
             pad_w=self.padding[2],
+            dilation_d=self.dilation[0],
+            dilation_h=self.dilation[1],
+            dilation_w=self.dilation[2],
             dtype=dtype,
             has_bias=_has_bias,
             tune=tune,


### PR DESCRIPTION
Closes #1519

## Summary

- Add dilation support to Conv2d/Conv2dBias and Conv3d/Conv3dBias kernel dispatch and indexing.
- Extend convolution tests with dilation cases in the existing Conv2dFixture and Conv3dFixture, without adding standalone dilation-only tests.
- Add model-derived dilation benchmark cases for DeepLabV3 ASPP Conv2d and 3D U-Net ASPP Conv3d.

## Test plan

- [x] `CUDA_VISIBLE_DEVICES=1 TMPDIR=/home/lyc/Project/TileOPs/.tmp/tvm python -m pytest tests/ops/test_convolution.py -q` (`45 passed in 8.75s`)
- [x] `CUDA_VISIBLE_DEVICES=1 TMPDIR=/home/lyc/Project/TileOPs/.tmp/tvm python -m pytest benchmarks/ops/bench_convolution.py -k "rate12 or rate6" -vvs` (`2 passed, 22 deselected in 8.05s`)
- [x] `python -m ruff check tests/ops/test_convolution.py benchmarks/ops/bench_convolution.py tileops/ops/convolution.py tileops/kernels/convolution.py`
- [x] `git diff --check -- tests/ops/test_convolution.py benchmarks/ops/bench_convolution.py tileops/ops/convolution.py tileops/kernels/convolution.py tileops/manifest/convolution.yaml`
- [x] `python scripts/validate_manifest.py --check-op Conv2dFwdOp` (passed with existing advisory warnings)
- [x] `python scripts/validate_manifest.py --check-op Conv3dFwdOp` (passed with existing advisory warnings)

## Benchmark

Run on GPU 1 with `CUDA_VISIBLE_DEVICES=1`; GPU reported by benchmark harness: NVIDIA H200. Ratio uses the repository benchmark convention: `torch_latency / tileops_latency`.

| Case | Source | TileOps latency | PyTorch baseline latency | Baseline / TileOps |
| --- | --- | ---: | ---: | ---: |
| `deeplabv3-aspp-3x3-rate12-fp16` | DeepLabV3/DeepLabV3+ ASPP 3x3 atrous conv on stride-16 encoder features | 0.2963 ms | 0.1273 ms | 0.43x |
| `3d-unet-aspp-3x3x3-rate6-fp16` | 3D U-Net + 3D ASPP medical segmentation branch | 0.0970 ms | 0.5258 ms | 5.42x |

## Regression

- Conv2d no-bias regression now covers `dilation=2` against `torch.nn.functional.conv2d`.
- Conv3d no-bias regression now covers `dilation=2` against `torch.nn.functional.conv3d`.
