### PR TITLE
[Maintain][Convolution] Promote conv1d ops to implemented

### DIFF
--- a/tests/ops/test_convolution.py
+++ b/tests/ops/test_convolution.py
@@ -265,6 +265,37 @@ def test_conv1d_dilation_matches_torch(op_cls, dilation, use_bias: bool) -> None
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
+    "op_cls, use_bias",
+    [
+        pytest.param(Conv1dFwdOp, False, id="no-bias"),
+        pytest.param(Conv1dBiasFwdOp, True, id="bias"),
+    ],
+)
+def test_conv1d_same_padding_even_kernel_matches_torch(op_cls, use_bias: bool) -> None:
+    n, c_in, l_in, c_out, kernel_size = 1, 16, 129, 32, 2
+    op_kwargs = {"bias": use_bias} if op_cls is Conv1dBiasFwdOp else {}
+    op = op_cls(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
+        c_out=c_out,
+        kernel_size=kernel_size,
+        padding="same",
+        **op_kwargs,
+    )
+    x = torch.randn(n, c_in, l_in, device="cuda", dtype=torch.float16).contiguous()
+    weight = torch.randn(c_out, c_in, kernel_size, device="cuda", dtype=torch.float16).contiguous()
+    bias = (
+        torch.randn(c_out, device="cuda", dtype=torch.float16).contiguous()
+        if use_bias else None
+    )
+    out = op(x, weight, bias) if use_bias else op(x, weight)
+    ref = F.conv1d(x, weight, bias=bias, padding="same").contiguous()
+    torch.testing.assert_close(out, ref, atol=2e-3, rtol=3e-3)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
     "kernel_size, stride, padding, dilation, expected_kernel",
     [
         pytest.param(3, 1, 1, 1, Conv1dKernel, id="generic"),

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional
+from typing import Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -59,13 +59,14 @@ def _conv1d_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     k_total = c_in * kernel_l
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
@@ -100,8 +101,8 @@ def _conv1d_kernel(
 
                 tile_ol_start = bx * block_n
                 tile_ol_end = tile_ol_start + block_n - 1
-                tile_input_start = tile_ol_start * stride_l - pad_l
-                tile_input_end = tile_ol_end * stride_l + (kernel_l - 1) * dilation_l - pad_l
+                tile_input_start = tile_ol_start * stride_l - pad_left
+                tile_input_end = tile_ol_end * stride_l + (kernel_l - 1) * dilation_l - pad_left
                 tile_spatial_full = (
                     (tile_ol_end < out_l)
                     & (tile_input_start >= 0)
@@ -117,7 +118,7 @@ def _conv1d_kernel(
                         ol = bx * block_n + j
                         kw = k_idx // c_in
                         ci = k_idx % c_in
-                        il = ol * stride_l + kw * dilation_l - pad_l
+                        il = ol * stride_l + kw * dilation_l - pad_left
                         if tile_full:
                             data_shared[i, j] = x[bz, ci, il]
                         else:
@@ -170,13 +171,14 @@ def _conv1d_direct_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
 ):
     accum_dtype = "float"
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
 
     @tilelang.jit(out_idx=[2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _conv1d_direct_func(
@@ -208,7 +210,7 @@ def _conv1d_direct_kernel(
                     for i, j in T.Parallel(block_m, block_n):
                         oc = by * block_m + i
                         ol = bx * block_n + j
-                        il = ol * stride_l + kw * dilation_l - pad_l
+                        il = ol * stride_l + kw * dilation_l - pad_left
                         valid = (oc < c_out) & (ol < out_l) & (il >= 0) & (il < l_in)
                         out_local[i, j] += T.if_then_else(
                             valid,
@@ -242,7 +244,8 @@ def _conv1d_group_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str = "float16",
@@ -251,7 +254,7 @@ def _conv1d_group_kernel(
     c_out_g: int = 0,
 ):
     accum_dtype = "float"
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     c_in_g = c_in_g if c_in_g > 0 else c_in // groups
     c_out_g = c_out_g if c_out_g > 0 else c_out // groups
     k_total = c_in_g * kernel_l
@@ -307,7 +310,7 @@ def _conv1d_group_kernel(
                         ol = bx * block_n + j
                         kw = k_idx // c_in_g
                         ci_g = k_idx % c_in_g
-                        il = ol * stride_l + kw * dilation_l - pad_l
+                        il = ol * stride_l + kw * dilation_l - pad_left
                         data_shared[k, j] = T.if_then_else(
                             (k_idx < k_total)
                             & (ol < out_l)
@@ -440,7 +443,8 @@ def _conv1d_wrapped_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -455,7 +459,7 @@ def _conv1d_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -467,7 +471,8 @@ def _conv1d_direct_wrapped_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -482,7 +487,7 @@ def _conv1d_direct_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_direct_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -494,7 +499,8 @@ def _conv1d_group_wrapped_kernel(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -512,7 +518,7 @@ def _conv1d_group_wrapped_kernel(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     return _conv1d_group_kernel(
-        n, c_in, l_in, c_out, kernel_l, stride_l, pad_l, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
+        n, c_in, l_in, c_out, kernel_l, stride_l, pad_left, pad_right, dilation_l, has_bias, dtype, groups, c_in_g, c_out_g
     )(block_m, block_n, block_k, num_stages, threads, enable_rasterization)(x, weight, bias)
 
 
@@ -547,7 +553,8 @@ def _(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -559,7 +566,7 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
@@ -571,7 +578,8 @@ def _(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -583,7 +591,7 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
@@ -595,7 +603,8 @@ def _(
     c_out: int,
     kernel_l: int,
     stride_l: int,
-    pad_l: int,
+    pad_left: int,
+    pad_right: int,
     dilation_l: int,
     has_bias: bool,
     dtype: str,
@@ -610,7 +619,7 @@ def _(
     enable_rasterization: bool,
     *inputs: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
-    out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+    out_l = (l_in + pad_left + pad_right - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
     return torch.empty((n, c_out, out_l), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
@@ -753,7 +762,7 @@ class Conv1dKernel(Kernel):
         c_out: int,
         kernel_l: int,
         stride_l: int,
-        pad_l: int,
+        pad_l: Tuple[int, int],
         dtype: torch.dtype,
         dilation_l: int = 1,
         has_bias: bool = False,
@@ -768,10 +777,11 @@ class Conv1dKernel(Kernel):
         self.kernel_l = kernel_l
         self.stride_l = stride_l
         self.pad_l = pad_l
+        self.pad_left, self.pad_right = pad_l
         self.dilation_l = dilation_l
         self.dtype = dtype
         self.has_bias = has_bias
-        self.out_l = (l_in + 2 * pad_l - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
+        self.out_l = (l_in + sum(pad_l) - dilation_l * (kernel_l - 1) - 1) // stride_l + 1
         self.m = n * self.out_l
         self.k_total = c_in * kernel_l
         self._weight_flat_cache_source: Optional[torch.Tensor] = None
@@ -784,7 +794,8 @@ class Conv1dKernel(Kernel):
             c_out,
             kernel_l,
             stride_l,
-            pad_l,
+            self.pad_left,
+            self.pad_right,
             dilation_l,
             has_bias,
             self.dtype_str,
@@ -870,7 +881,8 @@ class Conv1dKernel(Kernel):
             self.c_out,
             self.kernel_l,
             self.stride_l,
-            self.pad_l,
+            self.pad_left,
+            self.pad_right,
             self.dilation_l,
             self.has_bias,
             self.dtype_str,
@@ -897,7 +909,7 @@ class GroupConv1dKernel(Kernel):
         c_out: int,
         kernel_l: int,
         stride_l: int,
-        pad_l: int,
+        pad_l: Tuple[int, int],
         dtype: torch.dtype,
         dilation_l: int = 1,
         has_bias: bool = False,
@@ -915,6 +927,7 @@ class GroupConv1dKernel(Kernel):
         self.kernel_l = kernel_l
         self.stride_l = stride_l
         self.pad_l = pad_l
+        self.pad_left, self.pad_right = pad_l
         self.dilation_l = dilation_l
         self.groups = groups
         self.c_in_g = c_in_g if c_in_g is not None else c_in // groups
@@ -931,7 +944,8 @@ class GroupConv1dKernel(Kernel):
                 c_out,
                 kernel_l,
                 stride_l,
-                pad_l,
+                self.pad_left,
+                self.pad_right,
                 dilation_l,
                 has_bias,
                 self.dtype_str,
@@ -944,7 +958,8 @@ class GroupConv1dKernel(Kernel):
                 c_out,
                 kernel_l,
                 stride_l,
-                pad_l,
+                self.pad_left,
+                self.pad_right,
                 dilation_l,
                 has_bias,
                 self.dtype_str,
@@ -1060,7 +1075,8 @@ class GroupConv1dKernel(Kernel):
                 self.c_out,
                 self.kernel_l,
                 self.stride_l,
-                self.pad_l,
+                self.pad_left,
+                self.pad_right,
                 self.dilation_l,
                 self.has_bias,
                 self.dtype_str,
@@ -1081,7 +1097,8 @@ class GroupConv1dKernel(Kernel):
             self.c_out,
             self.kernel_l,
             self.stride_l,
-            self.pad_l,
+            self.pad_left,
+            self.pad_right,
             self.dilation_l,
             self.has_bias,
             self.dtype_str,

--- a/tileops/manifest/convolution.yaml
+++ b/tileops/manifest/convolution.yaml
@@ -8,7 +8,7 @@ Conv1dFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias=None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups, string padding
+  status: implemented
 
   signature:
     inputs:
@@ -72,7 +72,7 @@ Conv1dBiasFwdOp:
   ref_api: "torch.nn.functional.conv1d"
   # Equivalent to torch.nn.functional.conv1d (bias≠None)
   family: convolution
-  status: spec-only  # TODO: impl lacks dilation, groups, string padding
+  status: implemented
   variant_of: Conv1dFwdOp
 
   signature:

--- a/tileops/ops/convolution.py
+++ b/tileops/ops/convolution.py
@@ -96,7 +96,7 @@ def _validate_conv_params(
     input_size: Tuple[int, ...],
     kernel_size: Tuple[int, ...],
     stride: Tuple[int, ...],
-    padding: Tuple[int, ...],
+    padding: Tuple[int | Tuple[int, int], ...],
     dilation: Optional[Tuple[int, ...]] = None,
 ) -> None:
     ndim = len(input_size)
@@ -116,11 +116,18 @@ def _validate_conv_params(
         ("input_size", input_size),
         ("kernel_size", kernel_size),
         ("stride", stride),
-        ("padding", padding),
         ("dilation", dilation),
     ):
         if not all(isinstance(v, int) and not isinstance(v, bool) for v in values):
             raise TypeError(f"{op_name} {name} must contain only ints")
+    for pad in padding:
+        if isinstance(pad, tuple):
+            if len(pad) != 2:
+                raise ValueError(f"{op_name} asymmetric padding entries must have length 2")
+            if not all(isinstance(v, int) and not isinstance(v, bool) for v in pad):
+                raise TypeError(f"{op_name} padding must contain only ints")
+        elif not isinstance(pad, int) or isinstance(pad, bool):
+            raise TypeError(f"{op_name} padding must contain only ints or int pairs")
 
     if any(v <= 0 for v in input_size):
         raise ValueError(f"{op_name} input spatial dimensions must be greater than zero")
@@ -128,13 +135,18 @@ def _validate_conv_params(
         raise ValueError(f"{op_name} kernel_size must be greater than zero")
     if any(v <= 0 for v in stride):
         raise ValueError(f"{op_name} stride must be greater than zero")
-    if any(v < 0 for v in padding):
+    if any(any(axis_pad < 0 for axis_pad in pad) if isinstance(pad, tuple) else pad < 0 for pad in padding):
         raise ValueError(f"{op_name} padding must be non-negative")
     if any(v <= 0 for v in dilation):
         raise ValueError(f"{op_name} dilation must be greater than zero")
 
     output_size = tuple(
-        (input_dim + 2 * pad - dilation_dim * (kernel_dim - 1) - 1) // stride_dim + 1
+        (
+            input_dim
+            + (sum(pad) if isinstance(pad, tuple) else 2 * pad)
+            - dilation_dim * (kernel_dim - 1)
+            - 1
+        ) // stride_dim + 1
         for input_dim, kernel_dim, stride_dim, pad, dilation_dim in zip(
             input_size, kernel_size, stride, padding, dilation, strict=True
         )
@@ -147,6 +159,51 @@ def _validate_tensor_shape(op_name: str, name: str, tensor: torch.Tensor, expect
     actual_shape = tuple(tensor.shape)
     if actual_shape != expected_shape:
         raise ValueError(f"{op_name} expects {name} shape {expected_shape}, but got {actual_shape}")
+
+
+def _conv1d_padding_pair_and_l_out(
+    l_in: int,
+    kernel_size: int,
+    stride: int | Tuple[int],
+    padding: int | Tuple[int] | str,
+    dilation: int | Tuple[int],
+) -> tuple[int, int, int]:
+    kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
+    stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
+    dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
+    if padding == "same":
+        if stride_tuple[0] != 1:
+            raise ValueError("Conv1d padding='same' requires stride == 1")
+        total_pad = dilation_tuple[0] * (kernel_size_tuple[0] - 1)
+        pad_left = total_pad // 2
+        return pad_left, total_pad - pad_left, l_in
+    padding_tuple = _conv_padding_to_tuple(
+        padding, stride_tuple, kernel_size_tuple, "Conv1d", dilation_tuple
+    )
+    l_out = (
+        l_in
+        + 2 * padding_tuple[0]
+        - dilation_tuple[0] * (kernel_size_tuple[0] - 1)
+        - 1
+    ) // stride_tuple[0] + 1
+    return padding_tuple[0], padding_tuple[0], l_out
+
+
+def _conv1d_l_out(
+    l_in: int,
+    kernel_size: int,
+    stride: int | Tuple[int],
+    padding: int | Tuple[int] | str,
+    dilation: int | Tuple[int],
+) -> int:
+    _, _, l_out = _conv1d_padding_pair_and_l_out(
+        l_in,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+    )
+    return l_out
 
 
 class Conv1dFwdOp(Op):
@@ -182,21 +239,29 @@ class Conv1dFwdOp(Op):
         kernel_size_tuple = _conv_tuple(kernel_size, 1, "kernel_size", "Conv1d")
         stride_tuple = _conv_tuple(stride, 1, "stride", "Conv1d")
         dilation_tuple = _conv_tuple(dilation, 1, "dilation", "Conv1d")
-        padding_tuple = _conv_padding_to_tuple(
-            padding, stride_tuple, kernel_size_tuple, "Conv1d", dilation_tuple
+        pad_left, pad_right, out_l = _conv1d_padding_pair_and_l_out(
+            l_in,
+            kernel_size_tuple[0],
+            stride_tuple,
+            padding,
+            dilation_tuple,
         )
         _validate_conv_params(
             op_name="Conv1d",
             input_size=(l_in,),
             kernel_size=kernel_size_tuple,
             stride=stride_tuple,
-            padding=padding_tuple,
+            padding=((pad_left, pad_right),),
             dilation=dilation_tuple,
         )
         self.kernel_size = kernel_size_tuple[0]
         self.stride = stride_tuple[0]
-        self.padding = padding_tuple[0]
+        self.padding = pad_left
+        self.padding_right = pad_right
+        self.padding_pair = (pad_left, pad_right)
+        self._padding_arg = padding
         self.dilation = dilation_tuple[0]
+        self.out_l = out_l
         self.has_bias = _has_bias
         self.dtype = dtype
 
@@ -224,7 +289,7 @@ class Conv1dFwdOp(Op):
                 **kernel_kwargs,
                 kernel_l=self.kernel_size,
                 stride_l=self.stride,
-                pad_l=self.padding,
+                pad_l=self.padding_pair,
                 dilation_l=self.dilation,
                 groups=self.groups,
                 c_in_g=self.c_in_g,
@@ -235,7 +300,7 @@ class Conv1dFwdOp(Op):
                 **kernel_kwargs,
                 kernel_l=self.kernel_size,
                 stride_l=self.stride,
-                pad_l=self.padding,
+                pad_l=self.padding_pair,
                 dilation_l=self.dilation,
             )
         else:
@@ -257,6 +322,7 @@ class Conv1dFwdOp(Op):
         input: torch.Tensor,
         weight: torch.Tensor,
     ) -> torch.Tensor:
+        self._validate_dtypes(input, weight)
         _validate_tensor_shape("Conv1d", "input", input, (self.n, self.c_in, self.l_in))
         _validate_tensor_shape(
             "Conv1d",
@@ -265,6 +331,47 @@ class Conv1dFwdOp(Op):
             (self.c_out, self.c_in // self.groups, self.kernel_size),
         )
         return self.kernel(input, weight, None)
+
+    def _infer_output_shapes(
+        self,
+        input_shape: tuple[int, int, int],
+        weight_shape: tuple[int, int, int],
+    ) -> Dict[str, tuple[int, int, int]]:
+        n, _, l_in = input_shape
+        c_out, _, kernel_size = weight_shape
+        l_out = _conv1d_l_out(
+            l_in,
+            kernel_size,
+            self.stride,
+            getattr(self, "_padding_arg", self.padding),
+            self.dilation,
+        )
+        return {"output": (n, c_out, l_out)}
+
+    def _validate_dtypes(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+    ) -> None:
+        if input.dtype not in {torch.float16, torch.bfloat16}:
+            raise ValueError(f"input.dtype must be float16 or bfloat16, got {input.dtype}")
+        if weight.dtype != input.dtype:
+            raise ValueError(
+                f"weight.dtype must match input.dtype {input.dtype}, got {weight.dtype}"
+            )
+        if self.dtype is not None and input.dtype != self.dtype:
+            raise ValueError(f"input.dtype must match op dtype {self.dtype}, got {input.dtype}")
+
+    def eval_roofline(self) -> tuple[int, int]:
+        l_out = self.out_l
+        flops = 2 * self.n * self.c_out * l_out * self.c_in_g * self.kernel_size
+        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
+        bytes_ = (
+            self.n * self.c_in * self.l_in
+            + self.c_out * self.c_in_g * self.kernel_size
+            + self.n * self.c_out * l_out
+        ) * elem_bytes
+        return int(flops), int(bytes_)
 
 
 class Conv1dBiasFwdOp(Conv1dFwdOp):
@@ -317,6 +424,7 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
         weight: torch.Tensor,
         bias: torch.Tensor,
     ) -> torch.Tensor:
+        self._validate_dtypes(input, weight, bias)
         _validate_tensor_shape("Conv1d", "input", input, (self.n, self.c_in, self.l_in))
         _validate_tensor_shape(
             "Conv1d",
@@ -326,6 +434,42 @@ class Conv1dBiasFwdOp(Conv1dFwdOp):
         )
         _validate_tensor_shape("Conv1d", "bias", bias, (self.c_out,))
         return self.kernel(input, weight, bias)
+
+    def _infer_output_shapes(
+        self,
+        input_shape: tuple[int, int, int],
+        weight_shape: tuple[int, int, int],
+        bias_shape: tuple[int],
+    ) -> Dict[str, tuple[int, int, int]]:
+        del bias_shape
+        return super()._infer_output_shapes(input_shape, weight_shape)
+
+    def _validate_dtypes(
+        self,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> None:
+        super()._validate_dtypes(input, weight)
+        if bias.dtype != input.dtype:
+            raise ValueError(
+                f"bias.dtype must match input.dtype {input.dtype}, got {bias.dtype}"
+            )
+
+    def eval_roofline(self) -> tuple[int, int]:
+        l_out = self.out_l
+        flops = (
+            2 * self.n * self.c_out * l_out * self.c_in_g * self.kernel_size
+            + self.n * self.c_out * l_out
+        )
+        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
+        bytes_ = (
+            self.n * self.c_in * self.l_in
+            + self.c_out * self.c_in_g * self.kernel_size
+            + self.c_out
+            + self.n * self.c_out * l_out
+        ) * elem_bytes
+        return int(flops), int(bytes_)
 
 
 def _pair(value: int | Tuple[int, int]) -> Tuple[int, int]:


### PR DESCRIPTION
Closes #1555

## Summary

- Add Conv1d output-shape inference, dtype validation, and roofline methods for no-bias and bias variants.
- Validate Conv1d dtypes in `forward()` before dispatching kernels.
- Promote `Conv1dFwdOp` and `Conv1dBiasFwdOp` manifest entries from `spec-only` to `implemented`.

## Test plan

- [x] `python scripts/validate_manifest.py --strict --check-op Conv1dFwdOp`
- [x] `python scripts/validate_manifest.py --strict --check-op Conv1dBiasFwdOp`
- [x] `PYTHONPATH="$PWD" python -m pytest -q tests/ops/test_convolution.py -k "conv1d"`
- [x] `python scripts/validate_manifest.py --strict`
- [x] `PYTHONPATH="$PWD" python -m pytest -q tests/ops/test_convolution.py`
- [x] `git diff --check`
- [x] `python -m compileall -q tileops/ops/convolution.py`
- [x] Commit/push hooks passed

## Regression

- Conv1d targeted tests: `19 passed, 24 deselected`
- Full convolution test file: `43 passed`
- Manifest strict validation passes for both Conv1d entries; remaining Conv1d L4 benchmark manifest-driven messages are advisory because `source.bench_manifest_driven` remains false.

## Additional context

- `scripts/validate.sh` is not present in this checkout, so the PR lifecycle pre/post gates from the skill could not be run directly. The repo-available manifest, pytest, diff, compile, and hook checks above were used instead.