### PR TITLE
[Bench][Attention] Migrate benchmarks to manifest workloads

### DIFF
--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -1,11 +1,13 @@
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import dsa_decode_args, manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import DeepSeekSparseAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_dsa_decode import DsaDecodeTest
+
+_OP_NAME = "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp"
 
 
 class _DsaDecodeTestBaseline(DsaDecodeTest):
@@ -57,37 +59,11 @@ class _DsaDecodeTestBaseline(DsaDecodeTest):
         return o.to(torch.float16)
 
 
-class DsaDecodeBenchmark(BenchmarkBase[DsaDecodeTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        return t.batch * t.seq_len * (2 * t.dim + t.dim_tail) * t.topk * 2 * t.heads
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        # q: batch, seq_len, heads, dim + dim_tail
-        # kv: batch, seq_len_kv, heads_kv, dim + dim_tail
-        # indices: batch, seq_len, heads_kv, topk
-        # Output: batch, seq_len, heads, dim
-        q_memory = (
-            t.batch * t.seq_len * t.heads * (t.dim + t.dim_tail) * t.dtype.itemsize)
-        kv_memory = t.batch * t.seq_len_kv * t.heads_kv * (
-            t.dim + t.dim_tail) * t.dtype.itemsize
-        indices_memory = t.batch * t.seq_len * t.heads_kv * t.topk * 4  # int32
-        output_memory = t.batch * t.seq_len * t.heads * t.dim * t.dtype.itemsize
-        return q_memory + kv_memory + indices_memory + output_memory
-
-
-_DSA_DECODE_BENCH_PARAMS = [
-    pytest.param(
-        1, 128, 1024, 2048, 512, 64, 2048, 1, 1, 1024, None, torch.float16, False,
-        id="single-batch-mainstream",
-    ),
-    pytest.param(
-        1, 128, 512, 4096, 512, 64, 1024, 1, 1, 512, None, torch.float16, False,
-        id="longer-kv-lower-topk",
-    ),
-]
+_DSA_DECODE_BENCH_PARAMS = manifest_params(
+    load_workloads(_OP_NAME),
+    dsa_decode_args,
+    tune=False,
+)
 
 
 @pytest.mark.parametrize(
@@ -101,12 +77,12 @@ def test_dsa_decode_bench(batch: int, heads: int, seq_len_q: int, seq_len_kv: in
     test = _DsaDecodeTestBaseline(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype)
-    bm = DsaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
     op = DeepSeekSparseAttentionDecodeWithKVCacheFwdOp(
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, dtype=dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -1,13 +1,15 @@
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
 from einops import einsum, rearrange
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params, mla_decode_args
+from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadLatentAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.deepseek_mla_decode import MlaDecodeTest
+
+_OP_NAME = "MultiHeadLatentAttentionDecodeWithKVCacheFwdOp"
 
 
 class _MlaDecodeTestBaseline(MlaDecodeTest):
@@ -57,31 +59,7 @@ class _MlaDecodeTestBaseline(MlaDecodeTest):
         return out
 
 
-class MlaDecodeBenchmark(BenchmarkBase[MlaDecodeTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        # qk_flops = 2 * batch * heads * seq_len_kv * (dim + dim_pe)
-        # pv_flops = 2 * batch * heads * seq_len_kv * dim
-        qk_flops = 2 * t.batch * t.heads * t.seq_len_kv * (t.dim + t.dim_pe)
-        pv_flops = 2 * t.batch * t.heads * t.seq_len_kv * t.dim
-        return qk_flops + pv_flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        # Q: batch * heads * dim
-        # Q_pe: batch * heads * dim_pe
-        # K: batch * seq_len_kv * heads_kv * dim
-        # K_pe: batch * seq_len_kv * heads_kv * dim_pe
-        # Output: batch * heads * dim
-        return t.batch * (t.heads + t.seq_len_kv * t.heads_kv) * (
-            t.dim + t.dim_pe) * t.dtype.itemsize
-
-
-_MLA_DECODE_BENCH_PARAMS = [
-    pytest.param(32, 128, 1, 8192, 512, 64, torch.float16, True, id="mainstream-fp16"),
-    pytest.param(16, 128, 1, 4096, 512, 64, torch.float16, True, id="mid-cache-fp16"),
-]
+_MLA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mla_decode_args)
 
 
 @pytest.mark.parametrize(
@@ -91,11 +69,11 @@ _MLA_DECODE_BENCH_PARAMS = [
 def test_mla_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                           dim_pe: int, dtype: torch.dtype, tune: bool) -> None:
     test = _MlaDecodeTestBaseline(batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype)
-    bm = MlaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
     op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -4,17 +4,26 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import (
+    gqa_prefill_args,
+    gqa_prefill_paged_args,
+    gqa_prefill_with_kv_cache_args,
+    gqa_qkv_args,
+    manifest_params,
+)
 from tileops.kernels.attention import (
     GQAFwdKernel,
     GQAFwdWgmmaPipelinedKernel,
     GQAFwdWsPersistentCausalKernel,
     GQAFwdWsPersistentKernel,
 )
+from tileops.manifest import load_workloads
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
     GroupedQueryAttentionFwdOp,
     GroupedQueryAttentionPrefillFwdOp,
+    GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp,
     GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp,
     GroupedQueryAttentionPrefillVarlenFwdOp,
     GroupedQueryAttentionPrefillWithKVCacheFwdOp,
@@ -30,62 +39,20 @@ from workloads.attention.gqa_prefill import (
     GQAPrefillWithKVCacheFwdTest,
 )
 
-
-class GroupedQueryAttentionFwdBenchmark(BenchmarkBase[GroupedQueryAttentionFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len * t.seq_len * t.dim
-        flops = flops_per_matmul * 2
-        return flops / 2 if t.is_causal else flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        query_size = t.batch * t.seq_len * t.heads * t.dim
-        kv_size = t.batch * t.seq_len * t.heads_kv * t.dim
-        return 2 * (query_size + kv_size) * t.dtype.itemsize
-
-
-class GroupedQueryAttentionBwdBenchmark(BenchmarkBase[GroupedQueryAttentionBwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len * t.seq_len * t.dim
-        flops = flops_per_matmul * 5
-        return flops / 2 if t.is_causal else flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        total_heads = (3 * t.heads + 4 * t.heads_kv)
-        return t.batch * total_heads * t.seq_len * t.dim * t.dtype.itemsize
-
-
-class GQAPrefillFwdBenchmark(BenchmarkBase[GQAPrefillFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        visible = (
-            t.seq_len_q * t.seq_len_kv - t.seq_len_q * (t.seq_len_q - 1) / 2
-            if t.is_causal else t.seq_len_q * t.seq_len_kv)
-        return 4.0 * t.batch * t.heads * visible * t.dim
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        query_size = t.batch * t.seq_len_q * t.heads * t.dim
-        kv_size = t.batch * t.seq_len_kv * t.heads_kv * t.dim
-        output_size = query_size
-        return (query_size + 2 * kv_size + output_size) * t.dtype.itemsize
+_GQA_FWD_OP = "GroupedQueryAttentionFwdOp"
+_GQA_BWD_OP = "GroupedQueryAttentionBwdOp"
+_GQA_PREFILL_FWD_OP = "GroupedQueryAttentionPrefillFwdOp"
+_GQA_PREFILL_WITH_KV_CACHE_FWD_OP = "GroupedQueryAttentionPrefillWithKVCacheFwdOp"
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP = "GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp"
+_GQA_PREFILL_PAGED_WITH_FP8_KV_CACHE_FWD_OP = "GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp"
 
 
 class GQAPrefillVarlenFwdBenchmark(BenchmarkBase[GQAPrefillVarlenFwdTest]):
-
     def calculate_flops(self) -> Optional[float]:
         t = self.workload
         visible = 0
         for q_len, kv_len in zip(t.q_lens, t.kv_lens, strict=True):
-            visible += (
-                q_len * kv_len - q_len * (q_len - 1) / 2
-                if t.is_causal else q_len * kv_len)
+            visible += q_len * kv_len - q_len * (q_len - 1) / 2 if t.is_causal else q_len * kv_len
         return 4.0 * t.heads * visible * t.dim
 
     def calculate_memory(self) -> Optional[float]:
@@ -95,63 +62,8 @@ class GQAPrefillVarlenFwdBenchmark(BenchmarkBase[GQAPrefillVarlenFwdTest]):
         output_size = query_size
         cu_seqlens_size = 2 * (t.batch + 1)
         return (
-            (query_size + 2 * kv_size + output_size) * t.dtype.itemsize
-            + cu_seqlens_size * torch.int32.itemsize
-        )
-
-
-class GQAPrefillWithKVCacheFwdBenchmark(BenchmarkBase[GQAPrefillWithKVCacheFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        old_len = t.seq_len_cap - t.seq_len_new
-        visible = (
-            t.seq_len_new * old_len + t.seq_len_new * (t.seq_len_new + 1) / 2
-            if t.is_causal else t.seq_len_new * t.seq_len_cap)
-        return 4.0 * t.batch * t.heads * visible * t.dim
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        query_size = t.batch * t.seq_len_new * t.heads * t.dim
-        old_len = t.seq_len_cap - t.seq_len_new
-        old_kv_size = 2 * t.batch * old_len * t.heads_kv * t.dim
-        new_kv_size = 2 * t.batch * t.seq_len_new * t.heads_kv * t.dim
-        append_kv_size = new_kv_size
-        output_size = query_size
-        cache_seqlens_size = t.batch
-        return (
-            (query_size + old_kv_size + new_kv_size + append_kv_size + output_size)
-            * t.dtype.itemsize
-            + cache_seqlens_size * torch.int32.itemsize
-        )
-
-
-class GQAPrefillPagedWithKVCacheFwdBenchmark(
-        BenchmarkBase[GQAPrefillPagedWithKVCacheFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        visible = 0
-        for q_len, old_len in zip(t.q_lens, t.cache_lens, strict=True):
-            visible += (
-                q_len * old_len + q_len * (q_len + 1) / 2
-                if t.is_causal else q_len * (old_len + q_len))
-        return 4.0 * t.heads * visible * t.dim
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        query_size = t.total_q * t.heads * t.dim
-        old_kv_size = 2 * sum(t.cache_lens) * t.heads_kv * t.dim
-        new_kv_size = 2 * t.total_q * t.heads_kv * t.dim
-        append_kv_size = new_kv_size
-        output_size = query_size
-        metadata_size = (
-            (t.batch + 1 + t.batch + t.batch * t.max_pages_per_req) * torch.int32.itemsize)
-        return (
-            (query_size + old_kv_size + new_kv_size + append_kv_size + output_size)
-            * t.dtype.itemsize
-            + metadata_size
-        )
+            query_size + 2 * kv_size + output_size
+        ) * t.dtype.itemsize + cu_seqlens_size * torch.int32.itemsize
 
 
 def _fa3_gqa_fwd(test: GroupedQueryAttentionFwdTest):
@@ -202,15 +114,20 @@ def _flashinfer_gqa_fwd(test: GroupedQueryAttentionFwdTest, q, k, v):
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=q.device)
     wrapper = BatchPrefillWithRaggedKVCacheWrapper(workspace, kv_layout="NHD")
     wrapper.plan(
-        qo_indptr=cu_seqlens, kv_indptr=cu_seqlens,
-        num_qo_heads=H, num_kv_heads=Hkv, head_dim_qk=D,
+        qo_indptr=cu_seqlens,
+        kv_indptr=cu_seqlens,
+        num_qo_heads=H,
+        num_kv_heads=Hkv,
+        head_dim_qk=D,
         causal=test.is_causal,
         q_data_type=q.dtype,
     )
 
     def run_fn(q, k, v):
         return wrapper.run(
-            q.reshape(-1, H, D), k.reshape(-1, Hkv, D), v.reshape(-1, Hkv, D),
+            q.reshape(-1, H, D),
+            k.reshape(-1, Hkv, D),
+            v.reshape(-1, Hkv, D),
         ).reshape(B, S, H, D)
 
     return run_fn
@@ -218,31 +135,44 @@ def _flashinfer_gqa_fwd(test: GroupedQueryAttentionFwdTest, q, k, v):
 
 def _torch_gqa_fwd(test):
     """Torch SDPA forward baseline."""
+
     def fn(q, k, v):
         out = F.scaled_dot_product_attention(
-            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
-            is_causal=test.is_causal, enable_gqa=True)
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            is_causal=test.is_causal,
+            enable_gqa=True,
+        )
         return out.transpose(1, 2)
+
     return fn
 
 
 def _torch_gqa_bwd(test):
     """Torch SDPA backward baseline (includes forward recompute)."""
+
     @torch.enable_grad()
     def fn(q, k, v, o, grad_output, lse):
         q = q.detach().requires_grad_(True)
         k = k.detach().requires_grad_(True)
         v = v.detach().requires_grad_(True)
         out = F.scaled_dot_product_attention(
-            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
-            is_causal=test.is_causal, enable_gqa=True)
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            is_causal=test.is_causal,
+            enable_gqa=True,
+        )
         out.transpose(1, 2).contiguous().backward(grad_output)
         return q.grad, k.grad, v.grad
+
     return fn
 
 
 def _torch_gqa_prefill_ref(test: GQAPrefillFwdTest):
     """Materialized torch reference for dense prefill with bottom-right causal mask."""
+
     def fn(q, k, v):
         groups = test.heads // test.heads_kv
         q_bhsd = q.transpose(1, 2).float()
@@ -255,14 +185,17 @@ def _torch_gqa_prefill_ref(test: GQAPrefillFwdTest):
             k_pos = torch.arange(test.seq_len_kv, device=q.device)[None, :]
             mask = k_pos <= q_pos
             scores = scores.masked_fill(
-                ~mask.view(1, 1, test.seq_len_q, test.seq_len_kv), float("-inf"))
+                ~mask.view(1, 1, test.seq_len_q, test.seq_len_kv), float("-inf")
+            )
         probs = torch.softmax(scores, dim=-1)
         return torch.matmul(probs, v_bhsd).transpose(1, 2).to(q.dtype).contiguous()
+
     return fn
 
 
 def _torch_gqa_prefill_varlen_ref(test: GQAPrefillVarlenFwdTest):
     """Materialized torch reference for packed-varlen prefill."""
+
     def fn(q, k, v, cu_seqlens_q, cu_seqlens_kv):
         groups = test.heads // test.heads_kv
         outputs = []
@@ -286,11 +219,13 @@ def _torch_gqa_prefill_varlen_ref(test: GQAPrefillVarlenFwdTest):
             probs = torch.softmax(scores, dim=-1)
             outputs.append(torch.matmul(probs, v_i).transpose(0, 1).to(q.dtype).contiguous())
         return torch.cat(outputs, dim=0)
+
     return fn
 
 
 def _torch_gqa_prefill_with_kv_cache_ref(test: GQAPrefillWithKVCacheFwdTest):
     """Materialized torch reference for contiguous-cache prefill."""
+
     def fn(q, k_new, v_new, k_cache, v_cache, cache_seqlens):
         groups = test.heads // test.heads_kv
         outputs = []
@@ -307,12 +242,13 @@ def _torch_gqa_prefill_with_kv_cache_ref(test: GQAPrefillWithKVCacheFwdTest):
                 q_pos = torch.arange(test.seq_len_new, device=q.device)[:, None] + old_len
                 k_pos = torch.arange(total_len, device=q.device)[None, :]
                 mask = k_pos <= q_pos
-                scores = scores.masked_fill(~mask.view(1, test.seq_len_new, total_len),
-                                            float("-inf"))
+                scores = scores.masked_fill(
+                    ~mask.view(1, test.seq_len_new, total_len), float("-inf")
+                )
             probs = torch.softmax(scores, dim=-1)
-            outputs.append(
-                torch.matmul(probs, v_bhsd).transpose(0, 1).to(q.dtype).contiguous())
+            outputs.append(torch.matmul(probs, v_bhsd).transpose(0, 1).to(q.dtype).contiguous())
         return torch.stack(outputs, dim=0)
+
     return fn
 
 
@@ -343,50 +279,28 @@ def _tileops_gqa_variant(op: GroupedQueryAttentionFwdOp) -> str:
 # Training (bf16): seq_len 2K-8K covers SFT (2K) and pretraining (4K-8K).
 # B=1-2 reflects typical micro-batch sizes.  No long-context training configs
 # since >90% of pretraining compute is at 4K-8K.
-_GQA_FWD_BENCH_PARAMS = [
-    # ── WS/anchor validation cases on H200 ──
-    pytest.param(4, 512, 64, 4, 128, False, torch.float16, True, id="ws-noncausal-4x512"),
-    pytest.param(4, 512, 64, 4, 128, True, torch.float16, True, id="ws-causal-4x512"),
-    # ── Inference prefill: B=1, causal, fp16 ──
-    # Short chat prompt
-    pytest.param(1, 1024, 32, 8, 128, True, torch.float16, True, id="llama8b-1k"),
-    # Document QA / code completion
-    pytest.param(1, 4096, 32, 8, 128, True, torch.float16, True, id="llama8b-4k"),
-    # RAG context / Llama-4 chunk_size
-    pytest.param(1, 8192, 32, 8, 128, True, torch.float16, True, id="llama8b-8k"),
-    # Long-document summarization
-    pytest.param(1, 32768, 32, 8, 128, True, torch.float16, True, id="llama8b-32k"),
-    # Full-context (Llama-3.1 max)
-    pytest.param(1, 131072, 32, 8, 128, True, torch.float16, True, id="llama8b-128k"),
-    # 70B-class single-request prefill
-    pytest.param(1, 4096, 64, 8, 128, True, torch.float16, True, id="llama70b-4k"),
-    # 405B-class single-request prefill
-    pytest.param(1, 4096, 128, 8, 128, True, torch.float16, True, id="llama405b-4k"),
-    # ── Training: bf16, fwd benchmarked here, bwd below ──
-    # Pretraining main phase (8B-class, micro-batch=2)
-    pytest.param(2, 4096, 32, 8, 128, True, torch.bfloat16, True, id="train-8b-4k"),
-    # Pretraining longer sequences (8B-class)
-    pytest.param(1, 8192, 32, 8, 128, True, torch.bfloat16, True, id="train-8b-8k"),
-    # Pretraining 70B-class
-    pytest.param(1, 4096, 64, 8, 128, True, torch.bfloat16, True, id="train-70b-4k"),
-    # Pretraining 405B-class
-    pytest.param(1, 4096, 128, 8, 128, True, torch.bfloat16, True, id="train-405b-4k"),
-    # SFT / LoRA fine-tuning (shorter sequences, micro-batch=2)
-    pytest.param(2, 2048, 32, 8, 128, True, torch.bfloat16, True, id="sft-8b"),
-]
+_GQA_FWD_BENCH_PARAMS = manifest_params(load_workloads(_GQA_FWD_OP), gqa_qkv_args)
 
 
 @pytest.mark.parametrize(
     "batch, seq_len, heads, heads_kv, dim, causal, dtype, tune",
     _GQA_FWD_BENCH_PARAMS,
 )
-def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int,
-                       causal: bool, dtype: torch.dtype, tune: bool) -> None:
+def test_gqa_fwd_bench(
+    batch: int,
+    seq_len: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    causal: bool,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
     test = GroupedQueryAttentionFwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
-    bm = GroupedQueryAttentionFwdBenchmark(test)
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    bm = ManifestBenchmark(_GQA_FWD_OP, op, test)
     tileops_variant = _tileops_gqa_variant(op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag=f"tileops_{tileops_variant}")
@@ -409,23 +323,28 @@ def test_gqa_fwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
 # GQA backward benchmark parameters (training only).
 # Backward is only used during training — extract the training subset from
 # _GQA_FWD_BENCH_PARAMS by ID prefix to avoid manual duplication.
-_GQA_BWD_BENCH_PARAMS = [
-    p for p in _GQA_FWD_BENCH_PARAMS
-    if p.id.startswith(("train", "sft"))
-]
+_GQA_BWD_BENCH_PARAMS = manifest_params(load_workloads(_GQA_BWD_OP), gqa_qkv_args)
 
 
 @pytest.mark.parametrize(
     "batch, seq_len, heads, heads_kv, dim, causal, dtype, tune",
     _GQA_BWD_BENCH_PARAMS,
 )
-def test_gqa_bwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int,
-                       causal: bool, dtype: torch.dtype, tune: bool) -> None:
+def test_gqa_bwd_bench(
+    batch: int,
+    seq_len: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    causal: bool,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
     test = GroupedQueryAttentionBwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
-    bm = GroupedQueryAttentionBwdBenchmark(test)
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    bm = ManifestBenchmark(_GQA_BWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -439,29 +358,35 @@ def test_gqa_bwd_bench(batch: int, seq_len: int, heads: int, heads_kv: int, dim:
     # No FlashInfer baseline for bwd (FlashInfer has no backward API)
 
 
-_GQA_PREFILL_FWD_BENCH_PARAMS = [
-    pytest.param(1, 128, 128, 8, 2, 64, True, torch.float16, False,
-                 id="prefill-dense-q-eq-kv-fp16"),
-    pytest.param(1, 128, 256, 8, 2, 64, True, torch.float16, False,
-                 id="prefill-dense-q-lt-kv-fp16"),
-    pytest.param(1, 128, 256, 8, 2, 64, True, torch.bfloat16, False,
-                 id="prefill-dense-q-lt-kv-bf16"),
-]
+_GQA_PREFILL_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_GQA_PREFILL_FWD_OP),
+    gqa_prefill_args,
+    tune=False,
+)
 
 
 @pytest.mark.parametrize(
     "batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, dtype, tune",
     _GQA_PREFILL_FWD_BENCH_PARAMS,
 )
-def test_gqa_prefill_fwd_bench(batch: int, seq_len_q: int, seq_len_kv: int, heads: int,
-                               heads_kv: int, dim: int, causal: bool, dtype: torch.dtype,
-                               tune: bool) -> None:
+def test_gqa_prefill_fwd_bench(
+    batch: int,
+    seq_len_q: int,
+    seq_len_kv: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    causal: bool,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
     test = GQAPrefillFwdTest(batch, heads, heads_kv, seq_len_q, seq_len_kv, dim, causal, dtype)
-    bm = GQAPrefillFwdBenchmark(test)
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionPrefillFwdOp(
-        batch, heads, heads_kv, seq_len_q, seq_len_kv, dim, causal, dtype, tune=tune)
+        batch, heads, heads_kv, seq_len_q, seq_len_kv, dim, causal, dtype, tune=tune
+    )
+    bm = ManifestBenchmark(_GQA_PREFILL_FWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -470,12 +395,42 @@ def test_gqa_prefill_fwd_bench(batch: int, seq_len_q: int, seq_len_kv: int, head
 
 
 _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
-    pytest.param(4, [512, 512, 512, 512], [1024, 1024, 1024, 1024], 32, 8, 128, True,
-                 torch.float16, False, id="llama-3.1-8b-prefill-varlen-uniform-fp16"),
-    pytest.param(4, [128, 256, 640, 512], [512, 768, 1280, 1024], 32, 8, 128, True,
-                 torch.float16, False, id="llama-3.1-8b-prefill-varlen-mixed-fp16"),
-    pytest.param(2, [512, 512], [1024, 2048], 64, 8, 128, True, torch.bfloat16, False,
-                 id="llama-3.1-70b-prefill-varlen-q-lt-kv-bf16"),
+    pytest.param(
+        4,
+        [512, 512, 512, 512],
+        [1024, 1024, 1024, 1024],
+        32,
+        8,
+        128,
+        True,
+        torch.float16,
+        False,
+        id="llama-3.1-8b-prefill-varlen-uniform-fp16",
+    ),
+    pytest.param(
+        4,
+        [128, 256, 640, 512],
+        [512, 768, 1280, 1024],
+        32,
+        8,
+        128,
+        True,
+        torch.float16,
+        False,
+        id="llama-3.1-8b-prefill-varlen-mixed-fp16",
+    ),
+    pytest.param(
+        2,
+        [512, 512],
+        [1024, 2048],
+        64,
+        8,
+        128,
+        True,
+        torch.bfloat16,
+        False,
+        id="llama-3.1-70b-prefill-varlen-q-lt-kv-bf16",
+    ),
 ]
 
 
@@ -483,15 +438,23 @@ _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [
     "batch, q_lens, kv_lens, heads, heads_kv, dim, causal, dtype, tune",
     _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS,
 )
-def test_gqa_prefill_varlen_fwd_bench(batch: int, q_lens: list[int], kv_lens: list[int],
-                                      heads: int, heads_kv: int, dim: int, causal: bool,
-                                      dtype: torch.dtype, tune: bool) -> None:
+def test_gqa_prefill_varlen_fwd_bench(
+    batch: int,
+    q_lens: list[int],
+    kv_lens: list[int],
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    causal: bool,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
     test = GQAPrefillVarlenFwdTest(batch, heads, heads_kv, q_lens, kv_lens, dim, causal, dtype)
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionPrefillVarlenFwdOp(
-        batch, heads, heads_kv, dim, test.max_seqlen_q, test.max_seqlen_kv, causal, dtype,
-        tune=tune)
+        batch, heads, heads_kv, dim, test.max_seqlen_q, test.max_seqlen_kv, causal, dtype, tune=tune
+    )
     bm = GQAPrefillVarlenFwdBenchmark(test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -500,39 +463,63 @@ def test_gqa_prefill_varlen_fwd_bench(batch: int, q_lens: list[int], kv_lens: li
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-_GQA_PREFILL_WITH_KV_CACHE_FWD_BENCH_PARAMS = [
-    pytest.param(1, 64, 256, 8, 2, 64, True, torch.float16, False, False, None, None,
-                 id="prefill-contig-cache-fp16"),
-    pytest.param(2, 64, 320, 16, 4, 128, True, torch.float16, False, False, None, None,
-                 id="prefill-contig-cache-batch2-fp16"),
-    pytest.param(1, 64, 256, 8, 2, 64, True, torch.bfloat16, False, False, None, None,
-                 id="prefill-contig-cache-bf16"),
-    pytest.param(1, 1024, 33792, 32, 8, 256, True, torch.float16, False, True, 64, None,
-                 id="qwen35-9b-prefill-contig-fullattn-prefix32k-chunk1k-partial-rope64-fp16"),
-]
+_GQA_PREFILL_WITH_KV_CACHE_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_GQA_PREFILL_WITH_KV_CACHE_FWD_OP),
+    gqa_prefill_with_kv_cache_args,
+    tune=False,
+)
 
 
 @pytest.mark.parametrize(
-    "batch, seq_len_new, seq_len_cap, heads, heads_kv, dim, causal, dtype, tune, fuse_rope, "
-    "rotary_dim, softcap",
+    "batch, seq_len_new, seq_len_cap, heads, heads_kv, dim, causal, fuse_rope, rotary_dim, "
+    "softcap, dtype, tune",
     _GQA_PREFILL_WITH_KV_CACHE_FWD_BENCH_PARAMS,
 )
-def test_gqa_prefill_with_kv_cache_fwd_bench(batch: int, seq_len_new: int,
-                                             seq_len_cap: int, heads: int, heads_kv: int,
-                                             dim: int, causal: bool, dtype: torch.dtype,
-                                             tune: bool, fuse_rope: bool,
-                                             rotary_dim: Optional[int],
-                                             softcap: Optional[float]) -> None:
+def test_gqa_prefill_with_kv_cache_fwd_bench(
+    batch: int,
+    seq_len_new: int,
+    seq_len_cap: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    causal: bool,
+    fuse_rope: bool,
+    rotary_dim: Optional[int],
+    softcap: Optional[float],
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
     test = GQAPrefillWithKVCacheFwdTest(
-        batch, heads, heads_kv, seq_len_new, seq_len_cap, dim, causal, dtype,
-        fuse_rope=fuse_rope, rotary_dim=rotary_dim, softcap=softcap)
-    bm = GQAPrefillWithKVCacheFwdBenchmark(test)
+        batch,
+        heads,
+        heads_kv,
+        seq_len_new,
+        seq_len_cap,
+        dim,
+        causal,
+        dtype,
+        fuse_rope=fuse_rope,
+        rotary_dim=rotary_dim,
+        softcap=softcap,
+    )
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionPrefillWithKVCacheFwdOp(
-        batch, heads, heads_kv, seq_len_new, seq_len_cap, dim, causal, dtype,
-        softcap=softcap, tune=tune, fuse_rope=fuse_rope,
-        max_position=seq_len_cap if fuse_rope else None, rotary_dim=rotary_dim)
+        batch,
+        heads,
+        heads_kv,
+        seq_len_new,
+        seq_len_cap,
+        dim,
+        causal,
+        dtype,
+        softcap=softcap,
+        tune=tune,
+        fuse_rope=fuse_rope,
+        max_position=seq_len_cap if fuse_rope else None,
+        rotary_dim=rotary_dim,
+    )
+    bm = ManifestBenchmark(_GQA_PREFILL_WITH_KV_CACHE_FWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -541,28 +528,16 @@ def test_gqa_prefill_with_kv_cache_fwd_bench(batch: int, seq_len_new: int,
         BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_BENCH_PARAMS = [
-    pytest.param(
-        8, [1024] * 8, [32768] * 8, 32, 8, 64, 256, True, torch.float16, False, True, 64, None,
-        id="qwen35-9b-prefill-paged-fullattn-b8-prefix32k-chunk1k-p64-partial-rope64-fp16"),
-    pytest.param(
-        8,
-        [256, 512, 768, 1024, 384, 640, 896, 128],
-        [4096, 8192, 16384, 32768, 12288, 24576, 30720, 2048],
-        32, 8, 64, 256, True, torch.float16, False, True, 64, None,
-        id="qwen35-9b-prefill-paged-fullattn-mixed-b8-p64-partial-rope64-fp16"),
-    pytest.param(
-        8, [512] * 8, [4096] * 8, 32, 8, 64, 128, True, torch.float16, False, True, None, None,
-        id="llama31-8b-prefill-paged-b8-prefix4k-chunk512-p64-full-rope-fp16"),
-    pytest.param(
-        4, [512] * 4, [4096] * 4, 8, 2, 64, 64, True, torch.float16, False, False, None, 50.0,
-        id="gqa-prefill-paged-softcap50-b4-prefix4k-chunk512-p64-fp16"),
-]
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP),
+    gqa_prefill_paged_args,
+    tune=False,
+)
 
 
 @pytest.mark.parametrize(
-    "batch, q_lens, cache_lens, heads, heads_kv, page_size, dim, causal, dtype, tune, "
-    "fuse_rope, rotary_dim, softcap",
+    "batch, q_lens, cache_lens, heads, heads_kv, page_size, dim, causal, fuse_rope, "
+    "rotary_dim, softcap, dtype, tune",
     _GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_BENCH_PARAMS,
 )
 def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
@@ -574,16 +549,26 @@ def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
     page_size: int,
     dim: int,
     causal: bool,
-    dtype: torch.dtype,
-    tune: bool,
     fuse_rope: bool,
     rotary_dim: Optional[int],
     softcap: Optional[float],
+    dtype: torch.dtype,
+    tune: bool,
 ) -> None:
     test = GQAPrefillPagedWithKVCacheFwdTest(
-        batch, heads, heads_kv, q_lens, cache_lens, page_size, dim, causal, dtype,
-        fuse_rope=fuse_rope, rotary_dim=rotary_dim, softcap=softcap)
-    bm = GQAPrefillPagedWithKVCacheFwdBenchmark(test)
+        batch,
+        heads,
+        heads_kv,
+        q_lens,
+        cache_lens,
+        page_size,
+        dim,
+        causal,
+        dtype,
+        fuse_rope=fuse_rope,
+        rotary_dim=rotary_dim,
+        softcap=softcap,
+    )
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(
@@ -601,6 +586,105 @@ def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
         max_position=test.max_total_len if fuse_rope else None,
         rotary_dim=rotary_dim,
     )
+    op.total_q = test.total_q
+    op.q_lens = q_lens
+    op.cache_lens = cache_lens
+    op.max_seqlen_q = test.max_seqlen_q
+    bm = ManifestBenchmark(_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_OP, op, test)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+
+_GQA_PREFILL_PAGED_WITH_FP8_KV_CACHE_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_GQA_PREFILL_PAGED_WITH_FP8_KV_CACHE_FWD_OP),
+    gqa_prefill_paged_args,
+    tune=False,
+)
+
+
+def _fp8_paged_cache_inputs(
+    test: GQAPrefillPagedWithKVCacheFwdTest,
+) -> tuple[torch.Tensor, ...]:
+    q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens, block_table, max_seqlen_q = (
+        test.gen_inputs()
+    )
+    k_scale = torch.full((1,), 0.01, dtype=torch.float32, device=q.device)
+    v_scale = torch.full((1,), 0.01, dtype=torch.float32, device=q.device)
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    k_pages = (k_pages / k_scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn).contiguous()
+    v_pages = (v_pages / v_scale).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn).contiguous()
+    return (
+        q,
+        k_new,
+        v_new,
+        k_pages,
+        v_pages,
+        k_scale,
+        v_scale,
+        cu_seqlens_q,
+        cache_seqlens,
+        block_table,
+        max_seqlen_q,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch, q_lens, cache_lens, heads, heads_kv, page_size, dim, causal, fuse_rope, "
+    "rotary_dim, softcap, dtype, tune",
+    _GQA_PREFILL_PAGED_WITH_FP8_KV_CACHE_FWD_BENCH_PARAMS,
+)
+def test_gqa_prefill_paged_with_fp8_kv_cache_fwd_bench(
+    batch: int,
+    q_lens: list[int],
+    cache_lens: list[int],
+    heads: int,
+    heads_kv: int,
+    page_size: int,
+    dim: int,
+    causal: bool,
+    fuse_rope: bool,
+    rotary_dim: Optional[int],
+    softcap: Optional[float],
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    if fuse_rope or rotary_dim is not None:
+        pytest.skip("FP8 paged KV cache benchmark does not support fused RoPE")
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch fp8 is unavailable")
+
+    test = GQAPrefillPagedWithKVCacheFwdTest(
+        batch,
+        heads,
+        heads_kv,
+        q_lens,
+        cache_lens,
+        page_size,
+        dim,
+        causal,
+        dtype,
+        softcap=softcap,
+    )
+    inputs = _fp8_paged_cache_inputs(test)
+
+    op = GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        max_pages_per_req=test.max_pages_per_req,
+        page_size=page_size,
+        dim=dim,
+        is_causal=causal,
+        dtype=dtype,
+        cache_dtype=torch.float8_e4m3fn,
+        softcap=softcap,
+        tune=tune,
+    )
+    op.total_q = test.total_q
+    op.q_lens = q_lens
+    op.cache_lens = cache_lens
+    op.max_seqlen_q = test.max_seqlen_q
+    bm = ManifestBenchmark(_GQA_PREFILL_PAGED_WITH_FP8_KV_CACHE_FWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -1,13 +1,15 @@
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import gqa_decode_args, manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa_decode import GroupedQueryAttentionDecodeTest
+
+_OP_NAME = "GroupedQueryAttentionDecodeWithKVCacheFwdOp"
 
 
 class _GroupedQueryAttentionDecodeTestBaseline(GroupedQueryAttentionDecodeTest):
@@ -21,23 +23,6 @@ class _GroupedQueryAttentionDecodeTestBaseline(GroupedQueryAttentionDecodeTest):
             output_bhsd = F.scaled_dot_product_attention(q_bhsd, k_bhsd, v_bhsd, enable_gqa=True)
         output = output_bhsd.transpose(1, 2).squeeze(1).contiguous()
         return output
-
-
-class GroupedQueryAttentionDecodeBenchmark(BenchmarkBase[GroupedQueryAttentionDecodeTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len_kv * t.dim
-        flops = flops_per_matmul * 2
-        return flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        # Q: batch * 1 * heads * dim
-        # K, V: batch * seq_len_kv * heads_kv * dim
-        # Output: batch * 1 * heads * dim
-        return 2 * t.batch * t.dim * t.dtype.itemsize * (
-            t.heads + t.heads_kv * t.seq_len_kv)
 
 
 def _fa3_gqa_decode_fwd(test):
@@ -109,32 +94,17 @@ def _flashinfer_gqa_decode_fwd(test, q, k, v):
     return run_fn
 
 
-# GQA decode (non-paged) benchmark parameters.
-#
-# Non-paged KV cache is used for single-request inference (no serving framework).
-# B=1 exclusively — multi-request scenarios use paged KV cache instead.
-# Configs target the three standard head profiles (see bench_gqa.py) with
-# KV cache lengths representing typical chat (4K) and long-context (32K) use.
-_GQA_DECODE_BENCH_PARAMS = [
-    # Single-user chat (8B-class, 4K context)
-    pytest.param(1, 32, 8, 4096, 128, torch.float16, True, id="llama8b-4k"),
-    # Long-context generation (8B-class, 32K context)
-    pytest.param(1, 32, 8, 32768, 128, torch.float16, True, id="llama8b-32k"),
-    # 70B-class single-request decode
-    pytest.param(1, 64, 8, 4096, 128, torch.float16, True, id="llama70b-4k"),
-    # 405B-class single-request decode
-    pytest.param(1, 128, 8, 8192, 128, torch.float16, True, id="llama405b-8k"),
-]
+_GQA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), gqa_decode_args)
 
 
 @pytest.mark.parametrize("batch, heads, heads_kv, seq_len_kv, dim, dtype, tune", _GQA_DECODE_BENCH_PARAMS)
 def test_gqa_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim: int,
                           dtype: torch.dtype, tune: bool) -> None:
     test = _GroupedQueryAttentionDecodeTestBaseline(batch, heads, heads_kv, seq_len_kv, dim, dtype)
-    bm = GroupedQueryAttentionDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -1,14 +1,17 @@
 import math
-from typing import Optional
 
 import pytest
 import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import gqa_decode_paged_args, manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.gqa_decode_paged import GroupedQueryAttentionDecodePagedTest
+
+_OP_NAME = "GroupedQueryAttentionDecodePagedWithKVCacheFwdOp"
 
 
 class _GroupedQueryAttentionDecodePagedTestBaseline(GroupedQueryAttentionDecodePagedTest):
@@ -45,23 +48,6 @@ class _GroupedQueryAttentionDecodePagedTestBaseline(GroupedQueryAttentionDecodeP
             out_b = out_b.squeeze(2)
             out_list.append(out_b)
         return torch.cat(out_list, dim=0)
-
-
-class GroupedQueryAttentionDecodePagedBenchmark(BenchmarkBase[GroupedQueryAttentionDecodePagedTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seqlen_kv * t.dim
-        flops = flops_per_matmul * 2
-        return flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        num_pages = t.seqlen_kv // t.page_size
-        # Q, output: batch * heads * dim; K,V: seqlen_kv * heads_kv * dim; block_table, real_seqlen_kv: int32
-        return (t.batch * t.heads * t.dim * 2 +
-                2 * t.seqlen_kv * t.heads_kv * t.dim) * t.dtype.itemsize + \
-            t.batch * num_pages * 4 + t.batch * 4
 
 
 def _fa3_gqa_decode_paged(test, k, v):
@@ -143,42 +129,10 @@ def _flashinfer_gqa_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
     return run_fn
 
 
-# GQA paged decode benchmark parameters.
-#
-# Paged KV cache is the standard in production serving (vLLM, SGLang).
-# Batch sizes reflect real multi-request serving: B=4-64.
-#
-# Three page_size tiers:
-#   64  — TileOPs current minimum supported page_size (block_N constraint)
-#   256 — FlashInfer's optimized page_size, also FA3-compatible (multiple of 256)
-#   16  — vLLM/SGLang default; skip-marked until kernel supports page_size<64
-#
-# Head profiles and KV cache lengths match non-paged decode configs.
-_GQA_DECODE_PAGED_BENCH_PARAMS = [
-    # ── page_size=64 (TileOPs minimum) ──
-    # 8B-class online serving (B=32, 4K context)
-    pytest.param(32, 32, 8, 4096, 128, 64, torch.float16, True, id="serving-8b-p64"),
-    # 8B-class long-context serving (B=8, 32K context)
-    pytest.param(8, 32, 8, 32768, 128, 64, torch.float16, True, id="serving-8b-long-p64"),
-    # 8B-class high-throughput batch (B=64, short output)
-    pytest.param(64, 32, 8, 2048, 128, 64, torch.float16, True, id="throughput-8b-p64"),
-    # 70B-class online serving
-    pytest.param(8, 64, 8, 4096, 128, 64, torch.float16, True, id="serving-70b-p64"),
-    # ── page_size=256 (FlashInfer optimized, FA3 compatible) ──
-    # 8B-class online serving
-    pytest.param(32, 32, 8, 4096, 128, 256, torch.float16, True, id="serving-8b-p256"),
-    # 70B-class online serving
-    pytest.param(8, 64, 8, 4096, 128, 256, torch.float16, True, id="serving-70b-p256"),
-    # 405B-class online serving (B=4, limited by model size)
-    pytest.param(4, 128, 8, 4096, 128, 256, torch.float16, True, id="serving-405b-p256"),
-    # ── page_size=16 (vLLM/SGLang default) — skip until kernel support ──
-    pytest.param(32, 32, 8, 4096, 128, 16, torch.float16, True, id="serving-8b-p16",
-                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
-    pytest.param(64, 32, 8, 2048, 128, 16, torch.float16, True, id="throughput-8b-p16",
-                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
-    pytest.param(8, 64, 8, 4096, 128, 16, torch.float16, True, id="serving-70b-p16",
-                 marks=pytest.mark.skip(reason="page_size=16 not yet supported by kernel")),
-]
+_GQA_DECODE_PAGED_BENCH_PARAMS = manifest_params(
+    load_workloads(_OP_NAME),
+    gqa_decode_paged_args,
+)
 
 
 @pytest.mark.parametrize(
@@ -188,12 +142,12 @@ _GQA_DECODE_PAGED_BENCH_PARAMS = [
 def test_gqa_decode_paged_bench(batch: int, heads: int, heads_kv: int, seqlen_kv: int, dim: int,
                                 page_size: int, dtype: torch.dtype, tune: bool) -> None:
     test = _GroupedQueryAttentionDecodePagedTestBaseline(batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype)
-    bm = GroupedQueryAttentionDecodePagedBenchmark(test)
     inputs = test.gen_inputs()
     q, k, v, real_seqlen_kv, block_table = inputs
 
     op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -1,55 +1,46 @@
 """Benchmark for GroupedQueryAttentionSlidingWindowFwdOp vs FA3 baseline."""
-from typing import Optional
 
 import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import (
+    gqa_sliding_window_args,
+    manifest_params,
+)
+from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionSlidingWindowFwdOp
 from workloads.attention.gqa_sliding_window import GroupedQueryAttentionSlidingWindowFwdTest
 
-
-class GroupedQueryAttentionSlidingWindowFwdBenchmark(BenchmarkBase[GroupedQueryAttentionSlidingWindowFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        """Approximate FLOPs for QK^T and PV GEMMs."""
-        t = self.workload
-        S = t.seq
-        wl, wr = t.wl, t.wr
-        total_attended = 0
-        for q in range(S):
-            hi = q if t.is_causal else (min(S - 1, q + wr) if wr >= 0 else S - 1)
-            lo = max(0, q - wl) if wl >= 0 else 0
-            total_attended += hi - lo + 1
-        return 4 * t.batch * t.heads * total_attended * t.dim
-
-    def calculate_memory(self) -> Optional[float]:
-        """Approximate bytes accessed: read Q/K/V, write O."""
-        t = self.workload
-        elem = torch.tensor([], dtype=t.dtype).element_size()
-        return 2 * t.batch * t.seq * (t.heads + t.heads_kv) * t.dim * elem
+_OP_NAME = "GroupedQueryAttentionSlidingWindowFwdOp"
 
 
 def _torch_sliding_window_fwd(test):
     """Torch SDPA forward baseline with explicit sliding window mask."""
+
     def fn(q, k, v):
         S = test.seq
         q_idx = torch.arange(S, device=q.device).unsqueeze(1)
         k_idx = torch.arange(S, device=q.device).unsqueeze(0)
         mask = torch.zeros(S, S, dtype=torch.bool, device=q.device)
         if test.is_causal:
-            mask |= (k_idx > q_idx)
+            mask |= k_idx > q_idx
         if test.wl >= 0:
-            mask |= (k_idx < q_idx - test.wl)
+            mask |= k_idx < q_idx - test.wl
         if test.wr >= 0:
-            mask |= (k_idx > q_idx + test.wr)
+            mask |= k_idx > q_idx + test.wr
         attn_mask = torch.zeros(S, S, dtype=q.dtype, device=q.device)
-        attn_mask.masked_fill_(mask, float('-inf'))
+        attn_mask.masked_fill_(mask, float("-inf"))
         out = F.scaled_dot_product_attention(
-            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
-            attn_mask=attn_mask, enable_gqa=True)
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            attn_mask=attn_mask,
+            enable_gqa=True,
+        )
         return out.transpose(1, 2)
+
     return fn
 
 
@@ -86,8 +77,11 @@ def _flashinfer_sliding_window_fwd(test, q, k, v):
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=q.device)
     wrapper = BatchPrefillWithRaggedKVCacheWrapper(workspace, kv_layout="NHD")
     wrapper.plan(
-        qo_indptr=cu_seqlens, kv_indptr=cu_seqlens,
-        num_qo_heads=H, num_kv_heads=Hkv, head_dim_qk=D,
+        qo_indptr=cu_seqlens,
+        kv_indptr=cu_seqlens,
+        num_qo_heads=H,
+        num_kv_heads=Hkv,
+        head_dim_qk=D,
         causal=test.is_causal,
         window_left=test.wl,
         q_data_type=q.dtype,
@@ -95,19 +89,18 @@ def _flashinfer_sliding_window_fwd(test, q, k, v):
 
     def run_fn(q, k, v):
         return wrapper.run(
-            q.reshape(-1, H, D), k.reshape(-1, Hkv, D), v.reshape(-1, Hkv, D),
+            q.reshape(-1, H, D),
+            k.reshape(-1, Hkv, D),
+            v.reshape(-1, Hkv, D),
         ).reshape(B, S, H, D)
 
     return run_fn
 
 
-_GQA_SLIDING_WINDOW_FWD_BENCH_PARAMS = [
-    pytest.param(2, 512, 8, 2, 64, True, -1, -1, torch.float16, True, id="causal-mainstream"),
-    pytest.param(2, 512, 8, 2, 64, True, 128, -1, torch.float16, True, id="causal-left-window"),
-    pytest.param(2, 768, 8, 2, 64, False, 256, -1, torch.float16, True, id="bidirectional-long"),
-    pytest.param(2, 512, 8, 2, 64, False, 64, 64, torch.bfloat16, True, id="window-bf16"),
-    pytest.param(1, 2048, 8, 2, 64, True, 512, -1, torch.float16, True, id="long-sequence"),
-]
+_GQA_SLIDING_WINDOW_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_OP_NAME),
+    gqa_sliding_window_args,
+)
 
 
 @pytest.mark.parametrize(
@@ -126,14 +119,24 @@ def test_gqa_sliding_window_fwd_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = GroupedQueryAttentionSlidingWindowFwdTest(batch, seq, heads, heads_kv, dim, is_causal, wl, wr, dtype)
-    bm = GroupedQueryAttentionSlidingWindowFwdBenchmark(test)
+    test = GroupedQueryAttentionSlidingWindowFwdTest(
+        batch, seq, heads, heads_kv, dim, is_causal, wl, wr, dtype
+    )
     inputs = test.gen_inputs()
 
     op = GroupedQueryAttentionSlidingWindowFwdOp(
-        batch=batch, heads=heads, heads_kv=heads_kv, seq_len=seq, dim=dim,
-        is_causal=is_causal, window_size_left=wl, window_size_right=wr,
-        dtype=dtype, tune=tune)
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        seq_len=seq,
+        dim=dim,
+        is_causal=is_causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        dtype=dtype,
+        tune=tune,
+    )
+    bm = ManifestBenchmark(_OP_NAME, op, test)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -1,55 +1,32 @@
 """Benchmark for GroupedQueryAttentionSlidingWindowVarlenFwdOp vs FA3 baseline."""
-from typing import Optional
 
 import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import (
+    gqa_sliding_window_varlen_args,
+    manifest_params,
+)
+from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionSlidingWindowVarlenFwdOp
 from workloads.attention.gqa_sliding_window_varlen import (
     GroupedQueryAttentionSlidingWindowVarlenFwdTest,
 )
 
-_GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = [
-    pytest.param(1, [3000], [3000], 32, 8, 128, True, -1, -1, torch.float16, False, id="single-seq-causal"),
-    pytest.param(2, [1537, 3073], [1537, 3073], 32, 8, 128, True, 2000, -1, torch.float16, False, id="mixed-length-left-window"),
-    pytest.param(4, [1500, 2000, 3000, 3500], [1500, 2000, 3000, 3500], 32, 8, 128, False, 1500, 1500, torch.float16, False, id="moderate-batch-window"),
-    pytest.param(2, [512, 1024], [4096, 8192], 32, 8, 128, True, -1, -1, torch.float16, False, id="prefill-cache"),
-    pytest.param(2, [5001, 8193], [5001, 8193], 32, 8, 128, True, -1, -1, torch.float16, False, id="long-sequence-stress"),
-]
+_OP_NAME = "GroupedQueryAttentionSlidingWindowVarlenFwdOp"
 
-
-class GroupedQueryAttentionSlidingWindowVarlenFwdBenchmark(BenchmarkBase[GroupedQueryAttentionSlidingWindowVarlenFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        """Approximate FLOPs for QK^T and PV GEMMs, summed over all samples."""
-        t = self.workload
-        total = 0.0
-        for sq, sk in zip(t.seqlens_q, t.seqlens_k, strict=True):
-            offset = sk - sq
-            seq_attended = 0
-            for q_pos in range(sq):
-                hi = min(q_pos + offset, sk - 1) if t.is_causal else (
-                    min(q_pos + offset + t.wr, sk - 1) if t.wr >= 0 else sk - 1)
-                lo = max(0, q_pos + offset - t.wl) if t.wl >= 0 else 0
-                seq_attended += max(0, hi - lo + 1)
-            total += 4 * t.heads * seq_attended * t.dim
-        return total
-
-    def calculate_memory(self) -> Optional[float]:
-        """Approximate bytes accessed: read Q/K/V, write O."""
-        t = self.workload
-        elem = torch.tensor([], dtype=t.dtype).element_size()
-        total_q = sum(t.seqlens_q)
-        total_k = sum(t.seqlens_k)
-        return (total_q * t.heads * t.dim +
-                total_k * t.heads_kv * t.dim * 2 +
-                total_q * t.heads * t.dim) * elem
+_GQA_SLIDING_WINDOW_VARLEN_FWD_BENCH_PARAMS = manifest_params(
+    load_workloads(_OP_NAME),
+    gqa_sliding_window_varlen_args,
+    tune=False,
+)
 
 
 def _torch_sliding_window_varlen_fwd(test):
     """Torch SDPA forward baseline: unpack varlen to padded batch, single SDPA call."""
+
     def fn(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q):
         B = test.batch
         seqlens_q = test.seqlens_q
@@ -65,9 +42,9 @@ def _torch_sliding_window_varlen_fwd(test):
         for i in range(B):
             qs, qe = cu_seqlens_q[i].item(), cu_seqlens_q[i + 1].item()
             ks, ke = cu_seqlens_k[i].item(), cu_seqlens_k[i + 1].item()
-            q_pad[i, :qe - qs] = q[qs:qe]
-            k_pad[i, :ke - ks] = k[ks:ke]
-            v_pad[i, :ke - ks] = v[ks:ke]
+            q_pad[i, : qe - qs] = q[qs:qe]
+            k_pad[i, : ke - ks] = k[ks:ke]
+            v_pad[i, : ke - ks] = v[ks:ke]
 
         # Build combined mask [B, max_sq, max_sk]
         q_idx = torch.arange(max_sq, device=q.device).view(1, -1, 1)
@@ -87,17 +64,22 @@ def _torch_sliding_window_varlen_fwd(test):
             mask = mask | (k_idx > q_idx + offsets + test.wr)
 
         attn_mask = torch.zeros(B, max_sq, max_sk, dtype=q.dtype, device=q.device)
-        attn_mask.masked_fill_(mask, float('-inf'))
+        attn_mask.masked_fill_(mask, float("-inf"))
 
         # SDPA call: transpose to [B, H, S, D], mask broadcasts as [B, 1, max_sq, max_sk]
         out = F.scaled_dot_product_attention(
-            q_pad.transpose(1, 2), k_pad.transpose(1, 2), v_pad.transpose(1, 2),
-            attn_mask=attn_mask.unsqueeze(1), enable_gqa=True)
+            q_pad.transpose(1, 2),
+            k_pad.transpose(1, 2),
+            v_pad.transpose(1, 2),
+            attn_mask=attn_mask.unsqueeze(1),
+            enable_gqa=True,
+        )
         out = out.transpose(1, 2)  # [B, max_sq, H, D]
 
         # Repack valid positions to [total_q, H, D]
-        parts = [out[i, :seqlens_q[i]] for i in range(B)]
+        parts = [out[i, : seqlens_q[i]] for i in range(B)]
         return torch.cat(parts, dim=0)
+
     return fn
 
 
@@ -110,7 +92,9 @@ def _fa3_varlen_baseline(max_seqlen_k, is_causal, wl, wr):
 
     def baseline_fn(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q):
         out = flash_attn_varlen_func(
-            q, k, v,
+            q,
+            k,
+            v,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
@@ -172,15 +156,29 @@ def test_gqa_sliding_window_varlen_fwd_bench(
     tune: bool,
 ) -> None:
     test = GroupedQueryAttentionSlidingWindowVarlenFwdTest(
-        batch, seqlens_q, seqlens_k, heads, heads_kv, dim, is_causal, wl, wr, dtype)
-    bm = GroupedQueryAttentionSlidingWindowVarlenFwdBenchmark(test)
+        batch, seqlens_q, seqlens_k, heads, heads_kv, dim, is_causal, wl, wr, dtype
+    )
     inputs = test.gen_inputs()
     q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q = inputs
 
     op = GroupedQueryAttentionSlidingWindowVarlenFwdOp(
-        batch=batch, heads=heads, heads_kv=heads_kv, dim=dim,
-        is_causal=is_causal, window_size_left=wl, window_size_right=wr,
-        dtype=dtype, tune=tune)
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        is_causal=is_causal,
+        window_size_left=wl,
+        window_size_right=wr,
+        dtype=dtype,
+        tune=tune,
+    )
+    op.total_q = sum(seqlens_q)
+    op.total_k = sum(seqlens_k)
+    op.q_lens = seqlens_q
+    op.k_lens = seqlens_k
+    op.max_seqlen_q = max(seqlens_q)
+    op.max_seqlen_k = max(seqlens_k)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -1,41 +1,18 @@
-from typing import Optional
-
 import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params, mha_qkv_args
+from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import (
     MhaBwdTest,
     MhaFwdTest,
 )
 
-
-class MhaFwdBenchmark(BenchmarkBase[MhaFwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len * t.seq_len * t.dim
-        flops = flops_per_matmul * 2
-        return flops / 2 if t.is_causal else flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        return 4 * t.batch * t.heads * t.seq_len * t.dim * t.dtype.itemsize
-
-
-class MhaBwdBenchmark(BenchmarkBase[MhaBwdTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len * t.seq_len * t.dim
-        flops = flops_per_matmul * 5
-        return flops / 2 if t.is_causal else flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        return 7 * t.batch * t.heads * t.seq_len * t.dim * t.dtype.itemsize
+_MHA_FWD_OP = "MultiHeadAttentionFwdOp"
+_MHA_BWD_OP = "MultiHeadAttentionBwdOp"
 
 
 def _fa3_mha_fwd(test: MhaFwdTest):
@@ -124,21 +101,17 @@ def _torch_mha_bwd(test):
     return fn
 
 
-_MHA_FWD_BENCH_PARAMS = [
-    pytest.param(1, 1024, 8, 64, False, torch.float16, True, id="prefill-fp16"),
-    pytest.param(16, 2048, 16, 128, False, torch.float16, True, id="throughput-fp16"),
-    pytest.param(4, 4096, 16, 128, False, torch.bfloat16, True, id="long-seq-bf16"),
-]
+_MHA_FWD_BENCH_PARAMS = manifest_params(load_workloads(_MHA_FWD_OP), mha_qkv_args)
 
 
 @pytest.mark.parametrize("batch, seq_len, heads, dim, causal, dtype, tune", _MHA_FWD_BENCH_PARAMS)
 def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: bool,
                        dtype: torch.dtype, tune: bool) -> None:
     test = MhaFwdTest(batch, heads, seq_len, dim, causal, dtype)
-    bm = MhaFwdBenchmark(test)
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    bm = ManifestBenchmark(_MHA_FWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -157,17 +130,17 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
         BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
 
 
-_MHA_BWD_BENCH_PARAMS = _MHA_FWD_BENCH_PARAMS
+_MHA_BWD_BENCH_PARAMS = manifest_params(load_workloads(_MHA_BWD_OP), mha_qkv_args)
 
 
 @pytest.mark.parametrize("batch, seq_len, heads, dim, causal, dtype, tune", _MHA_BWD_BENCH_PARAMS)
 def test_mha_bwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: bool,
                        dtype: torch.dtype, tune: bool) -> None:
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
-    bm = MhaBwdBenchmark(test)
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    bm = ManifestBenchmark(_MHA_BWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -1,13 +1,15 @@
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params, mha_decode_args
+from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.mha_decode import MhaDecodeTest
+
+_OP_NAME = "MultiHeadAttentionDecodeWithKVCacheFwdOp"
 
 
 class _MhaDecodeTestBaseline(MhaDecodeTest):
@@ -21,23 +23,6 @@ class _MhaDecodeTestBaseline(MhaDecodeTest):
             output_bhsd = F.scaled_dot_product_attention(q_bhsd, k_bhsd, v_bhsd)
         output = output_bhsd.transpose(1, 2).contiguous()
         return output
-
-
-class MhaDecodeBenchmark(BenchmarkBase[MhaDecodeTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seq_len_q * t.seq_len_kv * t.dim
-        flops = flops_per_matmul * 2
-        return flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        # Q: batch * seq_len_q * heads * dim
-        # K, V: batch * seq_len_kv * heads * dim
-        # Output: batch * seq_len_q * heads * dim
-        return (t.batch * t.heads * (2 * t.seq_len_q + 2 * t.seq_len_kv) * t.dim *
-                t.dtype.itemsize)
 
 
 def _fa3_mha_decode_fwd(test):
@@ -82,21 +67,17 @@ def _flashinfer_mha_decode_fwd(test, q, k, v):
     return run_fn
 
 
-_MHA_DECODE_BENCH_PARAMS = [
-    pytest.param(1, 32, 128, 8192, 128, torch.float16, True, id="fp16-long-cache"),
-    pytest.param(1, 32, 128, 8192, 128, torch.bfloat16, True, id="bf16-long-cache"),
-    pytest.param(1, 32, 128, 5, 128, torch.float16, True, id="short-kv-tail"),
-]
+_MHA_DECODE_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mha_decode_args)
 
 
 @pytest.mark.parametrize("b, h, s_q, s_kv, d, dtype, tune", _MHA_DECODE_BENCH_PARAMS)
 def test_mha_decode_bench(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: torch.dtype,
                           tune: bool) -> None:
     test = _MhaDecodeTestBaseline(b, h, s_q, s_kv, d, dtype)
-    bm = MhaDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -1,13 +1,16 @@
 import math
-from typing import Optional
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params, mha_decode_paged_args
+from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionDecodePagedWithKVCacheFwdOp
 from workloads.attention.mha_decode_paged import MhaDecodePagedTest
+
+_OP_NAME = "MultiHeadAttentionDecodePagedWithKVCacheFwdOp"
 
 
 class _MhaDecodePagedTestBaseline(MhaDecodePagedTest):
@@ -43,23 +46,6 @@ class _MhaDecodePagedTestBaseline(MhaDecodePagedTest):
             out_b = out_b.transpose(1, 2).contiguous()
             out_list.append(out_b)
         return torch.cat(out_list, dim=0)
-
-
-class MhaDecodePagedBenchmark(BenchmarkBase[MhaDecodePagedTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        flops_per_matmul = 2.0 * t.batch * t.heads * t.seqlen_q * t.seqlen_kv * t.dim
-        flops = flops_per_matmul * 2
-        return flops
-
-    def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        num_pages = t.seqlen_kv // t.page_size
-        # Q, output: batch * seqlen_q * heads * dim; K,V: seqlen_kv * heads * dim; block_table, real_seqlen_kv: int32
-        return (t.batch * t.seqlen_q * t.heads * t.dim * 2 +
-                2 * t.seqlen_kv * t.heads * t.dim) * t.dtype.itemsize + \
-            t.batch * num_pages * 4 + t.batch * 4
 
 
 def _fa3_mha_decode_paged(test, k, v):
@@ -132,12 +118,7 @@ def _flashinfer_mha_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
     return run_fn
 
 
-_MHA_DECODE_PAGED_BENCH_PARAMS = [
-    pytest.param(1, 16, 1, 512, 128, 128, False, torch.float16, True, id="single-token-page128"),
-    pytest.param(2, 8, 1, 1024, 64, 256, False, torch.float16, True, id="batch2-page256"),
-    pytest.param(1, 8, 1, 1024, 64, 256, False, torch.float16, True, id="longer-cache"),
-    pytest.param(1, 8, 1, 512, 64, 256, False, torch.float16, True, id="shorter-cache"),
-]
+_MHA_DECODE_PAGED_BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), mha_decode_paged_args)
 
 
 @pytest.mark.parametrize(
@@ -148,12 +129,12 @@ def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv
                                 page_size: int, is_causal: bool, dtype: torch.dtype,
                                 tune: bool) -> None:
     test = _MhaDecodePagedTestBaseline(batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype)
-    bm = MhaDecodePagedBenchmark(test)
     inputs = test.gen_inputs()
     q, k, v, real_seqlen_kv, block_table = inputs
 
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/attention/manifest_params.py
+++ b/benchmarks/ops/attention/manifest_params.py
@@ -1,0 +1,205 @@
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import pytest
+import torch
+
+
+def torch_dtype(dtype_name: str) -> torch.dtype:
+    return getattr(torch, dtype_name)
+
+
+def manifest_params(
+    workloads: Iterable[dict[str, Any]],
+    build_args: Callable[[dict[str, Any]], tuple[Any, ...]],
+    *,
+    tune: bool = True,
+) -> list:
+    params = []
+    for workload in workloads:
+        label = workload.get("label", "manifest")
+        marks = ()
+        if reason := workload.get("bench_skip_reason"):
+            marks = (pytest.mark.skip(reason=reason),)
+        for dtype_name in workload["dtypes"]:
+            dtype = torch_dtype(dtype_name)
+            params.append(
+                pytest.param(
+                    *build_args(workload),
+                    dtype,
+                    tune,
+                    id=f"{label}-{dtype_name}",
+                    marks=marks,
+                )
+            )
+    return params
+
+
+def mha_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, bool]:
+    batch, seq_len, heads, dim = workload["q_shape"]
+    return batch, seq_len, heads, dim, workload.get("is_causal", True)
+
+
+def gqa_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, bool]:
+    batch, seq_len, heads, dim = workload["q_shape"]
+    _, kv_seq_len, heads_kv, _ = workload["kv_shape"]
+    if seq_len != kv_seq_len:
+        raise ValueError("gqa_qkv_args requires q_shape and kv_shape to share seq_len")
+    return batch, seq_len, heads, heads_kv, dim, workload.get("is_causal", True)
+
+
+def gqa_prefill_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int, bool]:
+    batch, seq_len_q, heads, dim = workload["q_shape"]
+    _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
+    return batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, workload.get("is_causal", True)
+
+
+def gqa_prefill_with_kv_cache_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, int, bool, bool, int | None, float | None]:
+    batch, seq_len_new, heads, dim = workload["q_shape"]
+    _, seq_len_cap, heads_kv, _ = workload["k_cache_shape"]
+    return (
+        batch,
+        seq_len_new,
+        seq_len_cap,
+        heads,
+        heads_kv,
+        dim,
+        workload.get("is_causal", True),
+        workload.get("fuse_rope", False),
+        workload.get("rotary_dim"),
+        workload.get("softcap"),
+    )
+
+
+def gqa_prefill_paged_args(
+    workload: dict[str, Any],
+) -> tuple[
+    int,
+    list[int],
+    list[int],
+    int,
+    int,
+    int,
+    int,
+    bool,
+    bool,
+    int | None,
+    float | None,
+]:
+    batch = workload["batch"]
+    q_lens = list(workload.get("q_lens") or [workload["total_q"] // batch] * batch)
+    cache_lens = list(
+        workload.get("cache_lens")
+        or [(workload["physical_tokens"] // batch) - (workload["total_q"] // batch)] * batch
+    )
+    return (
+        batch,
+        q_lens,
+        cache_lens,
+        workload["heads"],
+        workload["heads_kv"],
+        workload["page_size"],
+        workload["dim"],
+        workload.get("is_causal", True),
+        workload.get("fuse_rope", False),
+        workload.get("rotary_dim"),
+        workload.get("softcap"),
+    )
+
+
+def mha_decode_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int]:
+    batch, seq_len_q, heads, dim = workload["q_shape"]
+    _, seq_len_kv, _, _ = workload["kv_shape"]
+    return batch, heads, seq_len_q, seq_len_kv, dim
+
+
+def mha_decode_paged_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int, bool]:
+    batch, seq_len_q, heads, dim = workload["q_shape"]
+    seq_len_kv, _, _ = workload["kv_shape"]
+    return (
+        batch,
+        heads,
+        seq_len_q,
+        seq_len_kv,
+        dim,
+        workload["page_size"],
+        workload.get("is_causal", False),
+    )
+
+
+def gqa_decode_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int]:
+    batch, heads, dim = workload["q_shape"]
+    _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
+    return batch, heads, heads_kv, seq_len_kv, dim
+
+
+def gqa_decode_paged_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int]:
+    batch, heads, dim = workload["q_shape"]
+    seq_len_kv, heads_kv, _ = workload["kv_shape"]
+    return batch, heads, heads_kv, seq_len_kv, dim, workload["page_size"]
+
+
+def gqa_sliding_window_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, bool, int, int]:
+    batch, seq_len, heads, dim = workload["q_shape"]
+    _, _, heads_kv, _ = workload["kv_shape"]
+    return (
+        batch,
+        seq_len,
+        heads,
+        heads_kv,
+        dim,
+        workload.get("is_causal", True),
+        workload.get("window_size_left", -1),
+        workload.get("window_size_right", -1),
+    )
+
+
+def gqa_sliding_window_varlen_args(
+    workload: dict[str, Any],
+) -> tuple[int, list[int], list[int], int, int, int, bool, int, int]:
+    batch = workload["batch"]
+    q_lens = list(workload.get("q_lens") or [workload["total_q"] // batch] * batch)
+    k_lens = list(workload.get("k_lens") or [workload["total_k"] // batch] * batch)
+    return (
+        batch,
+        q_lens,
+        k_lens,
+        workload["heads"],
+        workload["heads_kv"],
+        workload["dim"],
+        workload.get("is_causal", True),
+        workload.get("window_size_left", -1),
+        workload.get("window_size_right", -1),
+    )
+
+
+def mla_decode_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int]:
+    batch, heads, dim = workload["q_shape"]
+    _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
+    return batch, heads, heads_kv, seq_len_kv, dim, workload["pe_dim"]
+
+
+def dsa_decode_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, int, int, int, int, int, float | None]:
+    batch, seq_len_q, heads, q_dim = workload["q_shape"]
+    _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
+    dim_tail = workload["dim_tail"]
+    dim = q_dim - dim_tail
+    return (
+        batch,
+        heads,
+        seq_len_q,
+        seq_len_kv,
+        dim,
+        dim_tail,
+        workload["topk"],
+        workload["stride_kv"],
+        heads_kv,
+        workload["q_start_index_s"],
+        workload.get("sm_scale"),
+    )

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -34,13 +34,16 @@ from pathlib import Path
 
 import yaml
 
-from tileops.manifest.shape_rules import (
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tileops.manifest.shape_rules import (  # noqa: E402
     dim_range_validity,
     dim_uniqueness,
     reduced_axes,
 )
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_DIR = REPO_ROOT / "tileops" / "manifest"
 
 # Valid torch dtype base names (without same_as references)

--- a/tests/perf/test_gqa_prefill_paged_roofline.py
+++ b/tests/perf/test_gqa_prefill_paged_roofline.py
@@ -29,7 +29,7 @@ def test_gqa_prefill_paged_mixed_manifest_matches_benchmark_lengths() -> None:
 def test_gqa_prefill_paged_roofline_accepts_mixed_manifest_workload() -> None:
     workload = _workload_by_label(_MIXED_QWEN_LABEL)
 
-    roofline = gqa_prefill_paged_with_kv_cache_fwd_roofline(**workload)
+    flops, nbytes = gqa_prefill_paged_with_kv_cache_fwd_roofline(**workload)
 
-    assert roofline["flops"] > 0
-    assert roofline["bytes"] > 0
+    assert flops > 0
+    assert nbytes > 0

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -42,6 +42,7 @@ MultiHeadAttentionFwdOp:
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
     bench: benchmarks/ops/attention/bench_mha.py
+    bench_manifest_driven: true
 
 MultiHeadAttentionBwdOp:
   ref_api: "torch.nn.functional.scaled_dot_product_attention"
@@ -93,6 +94,7 @@ MultiHeadAttentionBwdOp:
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
     bench: benchmarks/ops/attention/bench_mha.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionFwdOp:
   ref_api: "torch.nn.functional.scaled_dot_product_attention"
@@ -133,6 +135,7 @@ GroupedQueryAttentionFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionPrefillFwdOp:
   ref_api: "none"
@@ -175,6 +178,7 @@ GroupedQueryAttentionPrefillFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionPrefillFP8TensorCoreFwdOp:
   ref_api: "flash_attn_interface.flash_attn_func"
@@ -285,6 +289,7 @@ GroupedQueryAttentionPrefillWithKVCacheFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp:
   ref_api: "none"
@@ -350,6 +355,7 @@ GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_prefill_paged.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp:
   ref_api: "none"
@@ -407,7 +413,7 @@ GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp:
   roofline:
     # Approximate: reuses the non-FP8 paged prefill estimate and does not model
     # online old-cache dequantization cost separately.
-    func: "tileops.perf.formulas.gqa_prefill_with_kv_cache_fwd_roofline"
+    func: "tileops.perf.formulas.gqa_prefill_paged_with_kv_cache_fwd_roofline"
 
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
@@ -416,6 +422,7 @@ GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_prefill_paged.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionBwdOp:
   ref_api: "torch.nn.functional.scaled_dot_product_attention"
@@ -468,6 +475,7 @@ GroupedQueryAttentionBwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py
+    bench_manifest_driven: true
 
 # ---------------------------------------------------------------------------
 # attention — decode (single-query against KV cache)
@@ -512,6 +520,7 @@ MultiHeadAttentionDecodeWithKVCacheFwdOp:
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha_decode.py
     bench: benchmarks/ops/attention/bench_mha_decode.py
+    bench_manifest_driven: true
 
 MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
   ref_api: "none"
@@ -539,22 +548,10 @@ MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
       - "o.shape == (B, S_q, H, D)"
 
   workloads:
-    # Llama-3.1-8B (H=32, D=128), short KV, page_size=1
-    - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
-    # Llama-3.1-8B, short KV, page_size=64
-    - {q_shape: [32, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
-    # Llama-3.1-8B, long KV, page_size=1
-    - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
-    # Llama-3.1-8B, long KV, page_size=64
-    - {q_shape: [8, 1, 32, 128], kv_shape: [131072, 32, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
-    # Llama-3.1-70B (H=64, D=128), short KV, page_size=1
-    - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
-    # Llama-3.1-70B, short KV, page_size=64
-    - {q_shape: [16, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
-    # Llama-3.1-70B, long KV, page_size=1
-    - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
-    # Llama-3.1-70B, long KV, page_size=64
-    - {q_shape: [4, 1, 64, 128], kv_shape: [131072, 64, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
+    - {q_shape: [1, 1, 16, 128], kv_shape: [512, 16, 128], page_size: 128, dtypes: [float16], label: "single-token-page128"}
+    - {q_shape: [2, 1, 8, 64], kv_shape: [1024, 8, 64], page_size: 256, dtypes: [float16], label: "batch2-page256"}
+    - {q_shape: [1, 1, 8, 64], kv_shape: [1024, 8, 64], page_size: 256, dtypes: [float16], label: "longer-cache"}
+    - {q_shape: [1, 1, 8, 64], kv_shape: [512, 8, 64], page_size: 256, dtypes: [float16], label: "shorter-cache"}
 
   roofline:
     func: "tileops.perf.formulas.mha_decode_paged_roofline"
@@ -566,6 +563,7 @@ MultiHeadAttentionDecodePagedWithKVCacheFwdOp:
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha_decode_paged.py
     bench: benchmarks/ops/attention/bench_mha_decode_paged.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionDecodeWithKVCacheFwdOp:
   ref_api: "none"
@@ -607,6 +605,7 @@ GroupedQueryAttentionDecodeWithKVCacheFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_decode.py
     bench: benchmarks/ops/attention/bench_gqa_decode.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
   ref_api: "none"
@@ -634,22 +633,16 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
       - "H % H_kv == 0"
 
   workloads:
-    # Llama-3.1-8B (H=32, H_kv=8, D=128), short KV, page_size=1
-    - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg1"}
-    # Llama-3.1-8B, short KV, page_size=64
-    - {q_shape: [32, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-4k-pg64"}
-    # Llama-3.1-8B, long KV, page_size=1
-    - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg1"}
-    # Llama-3.1-8B, long KV, page_size=64
-    - {q_shape: [8, 32, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-8b-32k-pg64"}
-    # Llama-3.1-70B (H=64, H_kv=8, D=128), short KV, page_size=1
-    - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg1"}
-    # Llama-3.1-70B, short KV, page_size=64
-    - {q_shape: [16, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-4k-pg64"}
-    # Llama-3.1-70B, long KV, page_size=1
-    - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 1, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg1"}
-    # Llama-3.1-70B, long KV, page_size=64
-    - {q_shape: [4, 64, 128], kv_shape: [131072, 8, 128], page_size: 64, dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k-pg64"}
+    - {q_shape: [32, 32, 128], kv_shape: [4096, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-p64"}
+    - {q_shape: [8, 32, 128], kv_shape: [32768, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-long-p64"}
+    - {q_shape: [64, 32, 128], kv_shape: [2048, 8, 128], page_size: 64, dtypes: [float16], label: "throughput-8b-p64"}
+    - {q_shape: [8, 64, 128], kv_shape: [4096, 8, 128], page_size: 64, dtypes: [float16], label: "serving-70b-p64"}
+    - {q_shape: [32, 32, 128], kv_shape: [4096, 8, 128], page_size: 256, dtypes: [float16], label: "serving-8b-p256"}
+    - {q_shape: [8, 64, 128], kv_shape: [4096, 8, 128], page_size: 256, dtypes: [float16], label: "serving-70b-p256"}
+    - {q_shape: [4, 128, 128], kv_shape: [4096, 8, 128], page_size: 256, dtypes: [float16], label: "serving-405b-p256"}
+    - {q_shape: [32, 32, 128], kv_shape: [4096, 8, 128], page_size: 16, dtypes: [float16], bench_skip_reason: "page_size=16 not yet supported by kernel", label: "serving-8b-p16"}
+    - {q_shape: [64, 32, 128], kv_shape: [2048, 8, 128], page_size: 16, dtypes: [float16], bench_skip_reason: "page_size=16 not yet supported by kernel", label: "throughput-8b-p16"}
+    - {q_shape: [8, 64, 128], kv_shape: [4096, 8, 128], page_size: 16, dtypes: [float16], bench_skip_reason: "page_size=16 not yet supported by kernel", label: "serving-70b-p16"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_decode_paged_roofline"
@@ -661,6 +654,7 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_decode_paged.py
     bench: benchmarks/ops/attention/bench_gqa_decode_paged.py
+    bench_manifest_driven: true
 
 # ---------------------------------------------------------------------------
 # attention — sliding window
@@ -707,6 +701,7 @@ GroupedQueryAttentionSlidingWindowFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_sliding_window.py
     bench: benchmarks/ops/attention/bench_gqa_sliding_window.py
+    bench_manifest_driven: true
 
 GroupedQueryAttentionSlidingWindowVarlenFwdOp:
   ref_api: "none"
@@ -754,6 +749,7 @@ GroupedQueryAttentionSlidingWindowVarlenFwdOp:
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_sliding_window_varlen.py
     bench: benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+    bench_manifest_driven: true
 
 # ---------------------------------------------------------------------------
 # attention — Multi-Head Latent Attention / DeepSeek Sparse Attention decode
@@ -801,6 +797,7 @@ MultiHeadLatentAttentionDecodeWithKVCacheFwdOp:
     op: tileops/ops/attention/deepseek_mla.py
     test: tests/ops/attention/test_deepseek_mla_decode.py
     bench: benchmarks/ops/attention/bench_deepseek_mla_decode.py
+    bench_manifest_driven: true
 
 DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
   ref_api: "none"
@@ -828,12 +825,8 @@ DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
       - "o.shape == (B, S, H, D)"
 
   workloads:
-    # DeepSeek-V2 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
-    - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-4k"}
-    - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [float16, bfloat16], label: "deepseek-v2-32k"}
-    # DeepSeek-V3 (H=128, H_kv=1, D=128, dim_tail=64, topk=8, stride_kv=64)
-    - {q_shape: [4, 1, 128, 192], kv_shape: [4, 4096, 1, 192], indices_shape: [4, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-4k"}
-    - {q_shape: [2, 1, 128, 192], kv_shape: [2, 32768, 1, 192], indices_shape: [2, 1, 1, 8], topk: 8, stride_kv: 64, dim_tail: 64, q_start_index_s: 0, dtypes: [bfloat16], label: "deepseek-v3-32k"}
+    - {q_shape: [1, 1024, 128, 576], kv_shape: [1, 2048, 1, 576], indices_shape: [1, 1024, 1, 2048], topk: 2048, stride_kv: 1, dim_tail: 64, q_start_index_s: 1024, dtypes: [float16], label: "single-batch-mainstream"}
+    - {q_shape: [1, 512, 128, 576], kv_shape: [1, 4096, 1, 576], indices_shape: [1, 512, 1, 1024], topk: 1024, stride_kv: 1, dim_tail: 64, q_start_index_s: 512, dtypes: [float16], label: "longer-kv-lower-topk"}
 
   roofline:
     func: "tileops.perf.formulas.deepseek_dsa_decode_roofline"
@@ -845,3 +838,4 @@ DeepSeekSparseAttentionDecodeWithKVCacheFwdOp:
     op: tileops/ops/attention/deepseek_dsa.py
     test: tests/ops/attention/test_deepseek_dsa_decode.py
     bench: benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+    bench_manifest_driven: true

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -623,8 +623,7 @@ class GroupedQueryAttentionPrefillVarlenFwdOp(Op):
         kwargs = dict(self._roofline_kwargs)
         kwargs["q_lens"] = self._lengths_from_cu_seqlens(kwargs.pop("cu_seqlens_q"))
         kwargs["kv_lens"] = self._lengths_from_cu_seqlens(kwargs.pop("cu_seqlens_kv"))
-        result = gqa_prefill_varlen_fwd_roofline(**kwargs)
-        return result["flops"], result["bytes"]
+        return gqa_prefill_varlen_fwd_roofline(**kwargs)
 
 
 class GroupedQueryAttentionPrefillWithKVCacheFwdOp(Op):

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -72,20 +72,57 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-def mha_fwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for multi-head attention forward (prefill).
+def _shape_or_attrs(op: Any | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+    if op is not None and not isinstance(op, dict):
+        return vars(op)
+    if isinstance(op, dict):
+        return op
+    return kwargs
 
-    TODO: implement full formula based on B, S, H, D, is_causal.
-    """
-    raise NotImplementedError
+
+def mha_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for multi-head attention forward (prefill)."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, dim = data["q_shape"]
+    else:
+        batch, seq_len, heads, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 4 * batch * heads * seq_len * seq_len * dim
+    if is_causal:
+        flops //= 2
+    q_elems = batch * seq_len * heads * dim
+    kv_elems = q_elems
+    return int(flops), int(2 * (q_elems + kv_elems) * elem_bytes)
 
 
-def mha_bwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for multi-head attention backward.
+def mha_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for multi-head attention backward."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, dim = data["q_shape"]
+    else:
+        batch, seq_len, heads, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    TODO: implement full formula based on B, S, H, D, is_causal.
-    """
-    raise NotImplementedError
+    flops = 10 * batch * heads * seq_len * seq_len * dim
+    if is_causal:
+        flops //= 2
+    nbytes = batch * 7 * heads * seq_len * dim * elem_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------
@@ -93,12 +130,29 @@ def mha_bwd_roofline(**kwargs: Any) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def gqa_fwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for grouped-query attention forward (prefill).
+def gqa_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for grouped-query attention forward (prefill)."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, dim = data["q_shape"]
+        _, _, heads_kv, _ = data["kv_shape"]
+    else:
+        batch, seq_len, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    TODO: implement full formula based on B, S, H, H_kv, D, is_causal.
-    """
-    raise NotImplementedError
+    flops = 4 * batch * heads * seq_len * seq_len * dim
+    if is_causal:
+        flops //= 2
+    q_elems = batch * seq_len * heads * dim
+    kv_elems = batch * seq_len * heads_kv * dim
+    return int(flops), int(2 * (q_elems + kv_elems) * elem_bytes)
 
 
 def _dtype_itemsize(dtype: Any) -> int:
@@ -120,38 +174,64 @@ def _causal_prefill_visible_scores(seq_len_q: int, seq_len_kv: int) -> int:
     return seq_len_q * seq_len_kv - seq_len_q * (seq_len_q - 1) // 2
 
 
-def gqa_prefill_fwd_roofline(**kwargs: Any) -> dict[str, int]:
+def gqa_prefill_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
     """Conservative roofline for dense GQA prefill.
 
     Workloads bind ``q_shape`` and ``kv_shape``. Causal mode uses bottom-right
     alignment with ``S_q <= S_kv``.
     """
-    q_shape = kwargs["q_shape"]
-    kv_shape = kwargs.get("kv_shape", kwargs.get("k_shape"))
-    batch, seq_len_q, heads, dim = q_shape
-    _, seq_len_kv, heads_kv, _ = kv_shape
-    is_causal = bool(kwargs.get("is_causal", True))
-    elem_bytes = _dtype_itemsize(kwargs.get("dtype", kwargs.get("dtypes", "float16")))
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        q_shape = data["q_shape"]
+        kv_shape = data.get("kv_shape", data.get("k_shape"))
+        batch, seq_len_q, heads, dim = q_shape
+        _, seq_len_kv, heads_kv, _ = kv_shape
+    else:
+        batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len_q"],
+            data["seq_len_kv"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
     visible = (
         _causal_prefill_visible_scores(seq_len_q, seq_len_kv)
-        if is_causal else seq_len_q * seq_len_kv)
+        if is_causal
+        else seq_len_q * seq_len_kv
+    )
     flops = 4 * batch * heads * visible * dim
 
     q_elems = batch * seq_len_q * heads * dim
     kv_elems = batch * seq_len_kv * heads_kv * dim
     o_elems = q_elems
     nbytes = (q_elems + 2 * kv_elems + o_elems) * elem_bytes
-    return {"flops": int(flops), "bytes": int(nbytes)}
+    return int(flops), int(nbytes)
 
 
-def gqa_prefill_fp8_tensor_core_roofline(**kwargs: Any) -> dict[str, int]:
+def gqa_prefill_fp8_tensor_core_roofline(
+    op: Any | None = None,
+    **kwargs: Any,
+) -> tuple[int, int]:
     """Roofline for dense no-cache FP8 Tensor Core GQA prefill."""
-    q_shape = kwargs["q_shape"]
-    kv_shape = kwargs.get("kv_shape", kwargs.get("k_shape"))
-    batch, seq_len, heads, dim = q_shape
-    _, _, heads_kv, _ = kv_shape
-    out_bytes = _dtype_itemsize(kwargs.get("dtype", kwargs.get("dtypes", "float16")))
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        q_shape = data["q_shape"]
+        kv_shape = data.get("kv_shape", data.get("k_shape"))
+        batch, seq_len, heads, dim = q_shape
+        _, _, heads_kv, _ = kv_shape
+    else:
+        batch, seq_len, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
+    out_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
     flops = 4 * batch * heads * seq_len * seq_len * dim
     q_elems = batch * seq_len * heads * dim
@@ -159,7 +239,7 @@ def gqa_prefill_fp8_tensor_core_roofline(**kwargs: Any) -> dict[str, int]:
     # Public FP8 descales follow the FA3-compatible [batch, heads_kv] contract.
     descale_bytes = 3 * batch * heads_kv * 4
     nbytes = q_elems + 2 * kv_elems + q_elems * out_bytes + descale_bytes
-    return {"flops": int(flops), "bytes": int(nbytes)}
+    return int(flops), int(nbytes)
 
 
 def _distribute_total(total: int, batch: int, max_len: int) -> list[int]:
@@ -202,7 +282,9 @@ def gqa_prefill_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
     for q_len, kv_len in zip(q_lens, kv_lens, strict=True):
         visible += (
             _causal_prefill_visible_scores(int(q_len), int(kv_len))
-            if is_causal else int(q_len) * int(kv_len))
+            if is_causal
+            else int(q_len) * int(kv_len)
+        )
     flops = 4 * heads * visible * dim
 
     q_elems = total_q * heads * dim
@@ -213,25 +295,41 @@ def gqa_prefill_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
     return {"flops": int(flops), "bytes": int(nbytes)}
 
 
-def gqa_prefill_with_kv_cache_fwd_roofline(**kwargs: Any) -> dict[str, int]:
+def gqa_prefill_with_kv_cache_fwd_roofline(
+    op: Any | None = None,
+    **kwargs: Any,
+) -> tuple[int, int]:
     """Conservative roofline for contiguous-cache GQA prefill.
 
     The benchmark workload convention uses
     ``old_len = S_kv_cap - S_new`` for every batch item.
     """
-    q_shape = kwargs["q_shape"]
-    k_new_shape = kwargs["k_new_shape"]
-    k_cache_shape = kwargs["k_cache_shape"]
-    batch, seq_len_new, heads, dim = q_shape
-    _, _, heads_kv, _ = k_new_shape
-    _, seq_len_cap, _, _ = k_cache_shape
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        q_shape = data["q_shape"]
+        k_new_shape = data["k_new_shape"]
+        k_cache_shape = data["k_cache_shape"]
+        batch, seq_len_new, heads, dim = q_shape
+        _, _, heads_kv, _ = k_new_shape
+        _, seq_len_cap, _, _ = k_cache_shape
+    else:
+        seq_len_cap = data["seq_len_cap"] if "seq_len_cap" in data else data["seqlen_kv"]
+        batch, seq_len_new, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len_new"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
     old_len = seq_len_cap - seq_len_new
-    is_causal = bool(kwargs.get("is_causal", True))
-    elem_bytes = _dtype_itemsize(kwargs.get("dtype", kwargs.get("dtypes", "float16")))
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
     visible = (
         seq_len_new * old_len + seq_len_new * (seq_len_new + 1) // 2
-        if is_causal else seq_len_new * (old_len + seq_len_new))
+        if is_causal
+        else seq_len_new * (old_len + seq_len_new)
+    )
     flops = 4 * batch * heads * visible * dim
 
     q_elems = batch * seq_len_new * heads * dim
@@ -241,38 +339,44 @@ def gqa_prefill_with_kv_cache_fwd_roofline(**kwargs: Any) -> dict[str, int]:
     o_elems = q_elems
     cache_seqlens_bytes = batch * 4
     nbytes = (
-        (q_elems + old_kv_elems + new_kv_elems + append_kv_elems + o_elems) * elem_bytes
-        + cache_seqlens_bytes)
-    return {"flops": int(flops), "bytes": int(nbytes)}
+        q_elems + old_kv_elems + new_kv_elems + append_kv_elems + o_elems
+    ) * elem_bytes + cache_seqlens_bytes
+    return int(flops), int(nbytes)
 
 
-def gqa_prefill_paged_with_kv_cache_fwd_roofline(**kwargs: Any) -> dict[str, int]:
+def gqa_prefill_paged_with_kv_cache_fwd_roofline(
+    op: Any | None = None,
+    **kwargs: Any,
+) -> tuple[int, int]:
     """Conservative roofline for paged-cache GQA prefill.
 
     Paged workloads should bind explicit per-request ``q_lens`` and
     ``cache_lens``. If they are absent, fall back to a deterministic fill from
     aggregate metadata so older workload entries remain evaluable.
     """
-    total_q = int(kwargs["total_q"])
-    batch = int(kwargs["batch"])
-    heads = int(kwargs["heads"])
-    heads_kv = int(kwargs["heads_kv"])
-    dim = int(kwargs["dim"])
-    max_pages_per_req = int(kwargs["max_pages_per_req"])
-    page_size = int(kwargs["page_size"])
-    max_seqlen_q = int(kwargs["max_seqlen_q"])
-    is_causal = bool(kwargs.get("is_causal", True))
-    elem_bytes = _dtype_itemsize(kwargs.get("dtype", kwargs.get("dtypes", "float16")))
+    data = _shape_or_attrs(op, kwargs)
+    total_q = int(data["total_q"]) if "total_q" in data else None
+    batch = int(data["batch"])
+    heads = int(data["heads"])
+    heads_kv = int(data["heads_kv"])
+    dim = int(data["dim"])
+    max_pages_per_req = int(data["max_pages_per_req"])
+    page_size = int(data["page_size"])
+    max_seqlen_q = int(data.get("max_seqlen_q", max_pages_per_req * page_size))
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    q_lens = kwargs.get("q_lens")
+    q_lens = data.get("q_lens")
+    if total_q is None and q_lens is not None:
+        total_q = int(sum(q_lens))
+    if total_q is None:
+        total_q = batch * max_seqlen_q
     if q_lens is None:
         q_lens = _distribute_total(total_q, batch, max_seqlen_q)
-    cache_lens = kwargs.get("cache_lens")
+    cache_lens = data.get("cache_lens")
     if cache_lens is None:
-        max_position = kwargs.get("max_position")
-        max_total_len = (
-            max_pages_per_req * page_size if max_position is None else int(max_position)
-        )
+        max_position = data.get("max_position")
+        max_total_len = max_pages_per_req * page_size if max_position is None else int(max_position)
         cache_lens = [max(max_total_len - int(q_len), 0) for q_len in q_lens]
 
     visible = 0
@@ -282,8 +386,7 @@ def gqa_prefill_paged_with_kv_cache_fwd_roofline(**kwargs: Any) -> dict[str, int
         old_len = int(old_len)
         old_kv_tokens += old_len
         visible += (
-            q_len * old_len + q_len * (q_len + 1) // 2
-            if is_causal else q_len * (old_len + q_len)
+            q_len * old_len + q_len * (q_len + 1) // 2 if is_causal else q_len * (old_len + q_len)
         )
     flops = 4 * heads * visible * dim
 
@@ -292,25 +395,35 @@ def gqa_prefill_paged_with_kv_cache_fwd_roofline(**kwargs: Any) -> dict[str, int
     new_kv_elems = 2 * total_q * heads_kv * dim
     append_kv_elems = new_kv_elems
     o_elems = q_elems
-    metadata_bytes = (
-        (batch + 1) * 4
-        + batch * 4
-        + batch * max_pages_per_req * 4
-    )
+    metadata_bytes = (batch + 1) * 4 + batch * 4 + batch * max_pages_per_req * 4
     nbytes = (
-        (q_elems + old_kv_elems + new_kv_elems + append_kv_elems + o_elems)
-        * elem_bytes
-        + metadata_bytes
-    )
-    return {"flops": int(flops), "bytes": int(nbytes)}
+        q_elems + old_kv_elems + new_kv_elems + append_kv_elems + o_elems
+    ) * elem_bytes + metadata_bytes
+    return int(flops), int(nbytes)
 
 
-def gqa_bwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for grouped-query attention backward.
+def gqa_bwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for grouped-query attention backward."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, dim = data["q_shape"]
+        _, _, heads_kv, _ = data["kv_shape"]
+    else:
+        batch, seq_len, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    TODO: implement full formula based on B, S, H, H_kv, D, is_causal.
-    """
-    raise NotImplementedError
+    flops = 10 * batch * heads * seq_len * seq_len * dim
+    if is_causal:
+        flops //= 2
+    nbytes = batch * (3 * heads + 4 * heads_kv) * seq_len * dim * elem_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------
@@ -318,20 +431,52 @@ def gqa_bwd_roofline(**kwargs: Any) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def mha_decode_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for MHA decode with KV cache.
+def mha_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for MHA decode with KV cache."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seqlen_q, heads, dim = data["q_shape"]
+        _, seqlen_kv, _, _ = data["kv_shape"]
+    else:
+        batch, seqlen_q, heads, seqlen_kv, dim = (
+            data["batch"],
+            data["seqlen_q"],
+            data["heads"],
+            data["seqlen_kv"],
+            data["dim"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 4 * batch * heads * seqlen_q * seqlen_kv * dim
+    q_elems = batch * seqlen_q * heads * dim
+    kv_elems = batch * seqlen_kv * heads * dim
+    nbytes = (q_elems + 2 * kv_elems + q_elems) * elem_bytes
+    return int(flops), int(nbytes)
 
-    TODO: implement full formula based on B, H, N_kv, D.
-    """
-    raise NotImplementedError
 
-
-def mha_decode_paged_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for paged MHA decode with KV cache.
-
-    TODO: implement full formula based on B, H, N_kv, D, page_size.
-    """
-    raise NotImplementedError
+def mha_decode_paged_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for paged MHA decode with KV cache."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seqlen_q, heads, dim = data["q_shape"]
+        seqlen_kv, _, _ = data["kv_shape"]
+    else:
+        batch, seqlen_q, heads, seqlen_kv, dim = (
+            data["batch"],
+            data["seqlen_q"],
+            data["heads"],
+            data["seqlen_kv"],
+            data["dim"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 4 * batch * heads * seqlen_q * seqlen_kv * dim
+    q_elems = batch * seqlen_q * heads * dim
+    kv_elems = seqlen_kv * heads * dim
+    metadata_bytes = (
+        batch * 4
+        + batch * max(1, (seqlen_kv + int(data["page_size"]) - 1) // int(data["page_size"])) * 4
+    )
+    nbytes = (q_elems + 2 * kv_elems + q_elems) * elem_bytes + metadata_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------
@@ -339,20 +484,50 @@ def mha_decode_paged_roofline(**kwargs: Any) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def gqa_decode_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for GQA decode with KV cache.
+def gqa_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for GQA decode with KV cache."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, heads, dim = data["q_shape"]
+        _, seqlen_kv, heads_kv, _ = data["kv_shape"]
+    else:
+        batch, heads, heads_kv, seqlen_kv, dim = (
+            data["batch"],
+            data["heads"],
+            data["heads_kv"],
+            data["seqlen_kv"],
+            data["dim"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 4 * batch * heads * seqlen_kv * dim
+    q_elems = batch * heads * dim
+    kv_elems = batch * seqlen_kv * heads_kv * dim
+    nbytes = (q_elems + 2 * kv_elems + q_elems) * elem_bytes
+    return int(flops), int(nbytes)
 
-    TODO: implement full formula based on B, H, H_kv, N_kv, D.
-    """
-    raise NotImplementedError
 
-
-def gqa_decode_paged_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for paged GQA decode with KV cache.
-
-    TODO: implement full formula based on B, H, H_kv, N_kv, D, page_size.
-    """
-    raise NotImplementedError
+def gqa_decode_paged_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for paged GQA decode with KV cache."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, heads, dim = data["q_shape"]
+        seqlen_kv, heads_kv, _ = data["kv_shape"]
+    else:
+        batch, heads, heads_kv, seqlen_kv, dim = (
+            data["batch"],
+            data["heads"],
+            data["heads_kv"],
+            data["seqlen_kv"],
+            data["dim"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 4 * batch * heads * seqlen_kv * dim
+    q_elems = batch * heads * dim
+    kv_elems = seqlen_kv * heads_kv * dim
+    page_size = int(data["page_size"])
+    metadata_bytes = batch * 4 + batch * max(1, (seqlen_kv + page_size - 1) // page_size) * 4
+    nbytes = (q_elems + 2 * kv_elems + q_elems) * elem_bytes + metadata_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------
@@ -360,20 +535,78 @@ def gqa_decode_paged_roofline(**kwargs: Any) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def gqa_sliding_window_fwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for GQA sliding window forward.
+def gqa_sliding_window_fwd_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for GQA sliding window forward."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, dim = data["q_shape"]
+        _, _, heads_kv, _ = data["kv_shape"]
+    else:
+        batch, seq_len, heads, heads_kv, dim = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["heads_kv"],
+            data["dim"],
+        )
+    is_causal = bool(data.get("is_causal", True))
+    wl = int(data.get("window_size_left", -1))
+    wr = int(data.get("window_size_right", -1))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    TODO: implement full formula based on B, S, H, H_kv, D, window_size.
-    """
-    raise NotImplementedError
+    total_attended = 0
+    for q_idx in range(seq_len):
+        hi = q_idx if is_causal else (min(seq_len - 1, q_idx + wr) if wr >= 0 else seq_len - 1)
+        lo = max(0, q_idx - wl) if wl >= 0 else 0
+        total_attended += hi - lo + 1
+    flops = 4 * batch * heads * total_attended * dim
+    nbytes = 2 * batch * seq_len * (heads + heads_kv) * dim * elem_bytes
+    return int(flops), int(nbytes)
 
 
-def gqa_sliding_window_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for variable-length GQA sliding window forward.
+def gqa_sliding_window_varlen_fwd_roofline(
+    op: Any | None = None,
+    **kwargs: Any,
+) -> tuple[int, int]:
+    """Roofline for variable-length GQA sliding window forward."""
+    data = _shape_or_attrs(op, kwargs)
+    batch = int(data["batch"])
+    heads = int(data["heads"])
+    heads_kv = int(data["heads_kv"])
+    dim = int(data["dim"])
+    total_q = int(data.get("total_q", 0))
+    total_k = int(data.get("total_k", 0))
+    max_seqlen_q = int(data.get("max_seqlen_q", total_q // batch if batch else total_q))
+    q_lens = data.get("q_lens")
+    k_lens = data.get("k_lens")
+    if q_lens is None:
+        q_lens = _distribute_total(total_q, batch, max_seqlen_q)
+    if k_lens is None:
+        max_seqlen_k = int(data.get("max_seqlen_k", total_k // batch if batch else total_k))
+        k_lens = _distribute_total(total_k, batch, max_seqlen_k)
+    total_q = sum(q_lens)
+    total_k = sum(k_lens)
+    is_causal = bool(data.get("is_causal", True))
+    wl = int(data.get("window_size_left", -1))
+    wr = int(data.get("window_size_right", -1))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    TODO: implement full formula based on B, H, H_kv, D, window_size.
-    """
-    raise NotImplementedError
+    total_attended = 0
+    for sq, sk in zip(q_lens, k_lens, strict=True):
+        offset = int(sk) - int(sq)
+        for q_pos in range(int(sq)):
+            hi = (
+                min(q_pos + offset, int(sk) - 1)
+                if is_causal
+                else (min(q_pos + offset + wr, int(sk) - 1) if wr >= 0 else int(sk) - 1)
+            )
+            lo = max(0, q_pos + offset - wl) if wl >= 0 else 0
+            total_attended += max(0, hi - lo + 1)
+    flops = 4 * heads * total_attended * dim
+    nbytes = (
+        total_q * heads * dim + 2 * total_k * heads_kv * dim + total_q * heads * dim
+    ) * elem_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------
@@ -381,20 +614,60 @@ def gqa_sliding_window_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def deepseek_mla_decode_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for DeepSeek MLA decode with KV cache.
+def deepseek_mla_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for DeepSeek MLA decode with KV cache."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, heads, dim = data["q_shape"]
+        _, seqlen_kv, heads_kv, _ = data["kv_shape"]
+        pe_dim = data["pe_dim"]
+    else:
+        batch, heads, heads_kv, seqlen_kv, dim, pe_dim = (
+            data["batch"],
+            data["heads"],
+            data["heads_kv"],
+            data["seqlen_kv"],
+            data["dim"],
+            data["pe_dim"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 2 * batch * heads * seqlen_kv * (2 * dim + pe_dim)
+    nbytes = (
+        batch * heads * (dim + pe_dim)
+        + batch * seqlen_kv * heads_kv * (dim + pe_dim)
+        + batch * heads * dim
+    ) * elem_bytes
+    return int(flops), int(nbytes)
 
-    TODO: implement full formula based on B, H, H_kv, N_kv, D, pe_dim.
-    """
-    raise NotImplementedError
 
-
-def deepseek_dsa_decode_roofline(**kwargs: Any) -> dict[str, int]:
-    """Roofline for DeepSeek sparse attention decode.
-
-    TODO: implement full formula based on B, H, S, S_kv, D, D_tail, topk.
-    """
-    raise NotImplementedError
+def deepseek_dsa_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for DeepSeek sparse attention decode."""
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" in data:
+        batch, seq_len, heads, q_dim = data["q_shape"]
+        _, seq_len_kv, heads_kv, _ = data["kv_shape"]
+        dim_tail = data["dim_tail"]
+        dim = q_dim - dim_tail
+        topk = data["topk"]
+    else:
+        batch, seq_len, heads, seq_len_kv, dim, dim_tail, topk, heads_kv = (
+            data["batch"],
+            data["seq_len"],
+            data["heads"],
+            data["seq_len_kv"],
+            data["dim"],
+            data["dim_tail"],
+            data["topk"],
+            data["heads_kv"],
+        )
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+    flops = 2 * batch * seq_len * heads * topk * (2 * dim + dim_tail)
+    q_elems = batch * seq_len * heads * (dim + dim_tail)
+    kv_elems = batch * seq_len_kv * heads_kv * (dim + dim_tail)
+    o_elems = batch * seq_len * heads * dim
+    index_bytes = batch * seq_len * heads_kv * topk * 4
+    nbytes = (q_elems + kv_elems + o_elems) * elem_bytes + index_bytes
+    return int(flops), int(nbytes)
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -253,7 +253,10 @@ def _distribute_total(total: int, batch: int, max_len: int) -> list[int]:
     return lengths
 
 
-def gqa_prefill_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
+def gqa_prefill_varlen_fwd_roofline(
+    op: Any | None = None,
+    **kwargs: Any,
+) -> tuple[int, int]:
     """Conservative roofline for packed-varlen GQA prefill.
 
     Preferred workload binding supplies explicit ``q_lens`` and ``kv_lens``.
@@ -261,18 +264,27 @@ def gqa_prefill_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
     totals and ``max_seqlen_*`` so benchmark metadata remains reproducible.
     Causal mode uses bottom-right alignment independently per request.
     """
-    q_shape = kwargs["q_shape"]
-    k_shape = kwargs["k_shape"]
+    data = _shape_or_attrs(op, kwargs)
+    if "q_shape" not in data and data.get("_roofline_kwargs") is not None:
+        data = dict(data["_roofline_kwargs"])
+    q_shape = data["q_shape"]
+    k_shape = data["k_shape"]
     total_q, heads, dim = q_shape
     total_kv, heads_kv, _ = k_shape
-    batch = int(kwargs["batch"])
-    max_seqlen_q = int(kwargs["max_seqlen_q"])
-    max_seqlen_kv = int(kwargs["max_seqlen_kv"])
-    is_causal = bool(kwargs.get("is_causal", True))
-    elem_bytes = _dtype_itemsize(kwargs.get("dtype", kwargs.get("dtypes", "float16")))
+    batch = int(data["batch"])
+    max_seqlen_q = int(data["max_seqlen_q"])
+    max_seqlen_kv = int(data["max_seqlen_kv"])
+    is_causal = bool(data.get("is_causal", True))
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
 
-    q_lens = kwargs.get("q_lens")
-    kv_lens = kwargs.get("kv_lens")
+    q_lens = data.get("q_lens")
+    kv_lens = data.get("kv_lens")
+    if q_lens is None and (cu_seqlens_q := data.get("cu_seqlens_q")) is not None:
+        values = [int(x) for x in cu_seqlens_q.detach().cpu().tolist()]
+        q_lens = [values[idx + 1] - values[idx] for idx in range(len(values) - 1)]
+    if kv_lens is None and (cu_seqlens_kv := data.get("cu_seqlens_kv")) is not None:
+        values = [int(x) for x in cu_seqlens_kv.detach().cpu().tolist()]
+        kv_lens = [values[idx + 1] - values[idx] for idx in range(len(values) - 1)]
     if q_lens is None:
         q_lens = _distribute_total(total_q, batch, max_seqlen_q)
     if kv_lens is None:
@@ -292,7 +304,7 @@ def gqa_prefill_varlen_fwd_roofline(**kwargs: Any) -> dict[str, int]:
     o_elems = q_elems
     cu_bytes = 2 * (batch + 1) * 4
     nbytes = (q_elems + 2 * kv_elems + o_elems) * elem_bytes + cu_bytes
-    return {"flops": int(flops), "bytes": int(nbytes)}
+    return int(flops), int(nbytes)
 
 
 def gqa_prefill_with_kv_cache_fwd_roofline(


### PR DESCRIPTION
## Summary

- migrate attention benchmark params to manifest workloads and shared manifest param helpers
- enable `source.bench_manifest_driven: true` for validated attention benchmarks
- add attention roofline formulas needed by `ManifestBenchmark` / `op.eval_roofline()`
- keep unsupported GQA paged decode `page_size=16` cases explicit with skip reasons

Closes #1560.

## Validation

- `ruff check scripts/validate_manifest.py benchmarks/ops/attention tileops/perf/formulas.py`
- `git diff --check`
- `python -m pytest --collect-only -q ...attention benchmark files...` -> 117 collected
- `python scripts/validate_manifest.py --levels schema,shape,dtype,bench` -> passed

## Nightly Benchmarking

Ran with `tileops-runner:nightly-tl019-fullstack-no-tileops-ldfix` on host GPU1. Container-visible GPU UUID matched host GPU1:

`GPU-bea8d0b6-e3c4-082c-e524-50f7791c9a1e`.

Results:

- affected attention run: 109 collected, 59 passed, 50 skipped, 0 failures
- FP8 tensor-core GQA benchmark: 8 passed, 0 failures
- targeted recheck: 14 passed, 0 failures

No clear regression attributable to this change. The suspicious GQA varlen slowdown was reproduced on a clean base worktree at the original commit, so it appears to be environmental/runtime variance rather than this migration.