### PR TITLE
[Feat][Pool] align avg_pool1d with manifest

### DIFF
--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -6,7 +6,10 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.pool.common import pool_output_dim
+from tileops.manifest import load_workloads
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
+
+_AVG_POOL1D_OP_NAME = "AvgPool1dFwdOp"
 
 
 class AvgPool1dBenchCase:
@@ -68,16 +71,39 @@ class AvgPool1dBenchmark(BenchmarkBase[AvgPool1dBenchCase]):
         return self._get_roofline()[1]
 
 
-_AVG_POOL1D_BENCH_PARAMS = [
-    pytest.param(4, 128, 4096, 3, 2, 1, False, True, torch.float16, True, id="audio-downsample-fp16"),
-    pytest.param(2, 256, 32000, 5, 4, 2, False, True, torch.float16, True, id="long-temporal-fp16"),
-    pytest.param(2, 128, 2048, 4, 2, 1, True, False, torch.bfloat16, True, id="ceil-bf16"),
-]
+def _avg_pool1d_bench_params() -> list:
+    params = []
+    for workload in load_workloads(_AVG_POOL1D_OP_NAME):
+        n, c_in, l_in = workload["input_shape"]
+        kernel_size = workload["kernel_size"]
+        stride = workload.get("stride")
+        padding = workload.get("padding", 0)
+        ceil_mode = workload.get("ceil_mode", False)
+        count_include_pad = workload.get("count_include_pad", True)
+        label = workload.get("label", f"{n}x{c_in}x{l_in}")
+        for dtype_str in workload["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(
+                pytest.param(
+                    n,
+                    c_in,
+                    l_in,
+                    kernel_size,
+                    stride,
+                    padding,
+                    ceil_mode,
+                    count_include_pad,
+                    dtype,
+                    True,
+                    id=f"{label}-{dtype_str}",
+                )
+            )
+    return params
 
 
 @pytest.mark.parametrize(
     "n, c_in, l_in, kernel_size, stride, padding, ceil_mode, count_include_pad, dtype, tune",
-    _AVG_POOL1D_BENCH_PARAMS,
+    _avg_pool1d_bench_params(),
 )
 def test_avg_pool1d_bench(
     n: int,

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -89,11 +89,15 @@ def test_avg_pool1d_bench(
     inputs = test.gen_inputs()
 
     op = AvgPool1dFwdOp(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,
+        dtype=dtype,
         tune=tune,
     )
     result = bm.profile(op, *inputs)

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -50,15 +50,22 @@ class AvgPool1dBenchCase:
 
 class AvgPool1dBenchmark(BenchmarkBase[AvgPool1dBenchCase]):
 
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: AvgPool1dBenchCase, op: AvgPool1dFwdOp) -> None:
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        out_l = pool_output_dim(t.l_in, t.kernel_size, t.stride, t.padding, t.ceil_mode)
-        return t.n * t.c_in * out_l * t.kernel_size
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        out_l = pool_output_dim(t.l_in, t.kernel_size, t.stride, t.padding, t.ceil_mode)
-        return (t.n * t.c_in * t.l_in + t.n * t.c_in * out_l) * t.dtype.itemsize
+        return self._get_roofline()[1]
 
 
 _AVG_POOL1D_BENCH_PARAMS = [
@@ -85,7 +92,6 @@ def test_avg_pool1d_bench(
     tune: bool,
 ) -> None:
     test = AvgPool1dBenchCase(n, c_in, l_in, kernel_size, stride, padding, ceil_mode, count_include_pad, dtype)
-    bm = AvgPool1dBenchmark(test)
     inputs = test.gen_inputs()
 
     op = AvgPool1dFwdOp(
@@ -100,8 +106,8 @@ def test_avg_pool1d_bench(
         dtype=dtype,
         tune=tune,
     )
+    bm = AvgPool1dBenchmark(test, op)
     result = bm.profile(op, *inputs)
-    _ = op.eval_roofline()
     BenchmarkReport.record("avg_pool1d", locals(), result, tag="tileops")
 
     result_bl = bm.profile(test.ref_program, *inputs)

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.pool.common import pool_output_dim
-from tileops.ops import AvgPool1dOp, AvgPool2dOp, AvgPool3dOp
+from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
 
 
 class AvgPool1dBenchCase:
@@ -34,7 +34,7 @@ class AvgPool1dBenchCase:
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.n, self.l_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(self.n, self.c_in, self.l_in, device="cuda", dtype=self.dtype).contiguous()
         return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
@@ -87,25 +87,20 @@ def test_avg_pool1d_bench(
     test = AvgPool1dBenchCase(n, c_in, l_in, kernel_size, stride, padding, ceil_mode, count_include_pad, dtype)
     bm = AvgPool1dBenchmark(test)
     inputs = test.gen_inputs()
-    (x,) = inputs
-    x_ncl = x.permute(0, 2, 1).contiguous()
 
-    op = AvgPool1dOp(
-        n=n,
-        c_in=c_in,
-        l_in=l_in,
+    op = AvgPool1dFwdOp(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,
-        dtype=dtype,
         tune=tune,
     )
     result = bm.profile(op, *inputs)
+    _ = op.eval_roofline()
     BenchmarkReport.record("avg_pool1d", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x_ncl)
+    result_bl = bm.profile(test.ref_program, *inputs)
     BenchmarkReport.record("avg_pool1d", locals(), result_bl, tag="torch-ref")
 
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
-from tileops.ops import AvgPool1dOp, AvgPool2dOp, AvgPool3dOp
+from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
 
 
 class _DummyKernel(Kernel):
@@ -68,19 +68,18 @@ class AvgPool1dTest(TestBase):
         self.dtype = dtype
 
     def gen_inputs(self, n: int, c_in: int, l_in: int) -> tuple[torch.Tensor]:
-        x = torch.randn(n, l_in, c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(n, c_in, l_in, device="cuda", dtype=self.dtype).contiguous()
         return (x,)
 
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        out = F.avg_pool1d(
-            x.permute(0, 2, 1).contiguous(),
+    def ref_program(self, input: torch.Tensor) -> torch.Tensor:
+        return F.avg_pool1d(
+            input,
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
             ceil_mode=self.ceil_mode,
             count_include_pad=self.count_include_pad,
         )
-        return out.permute(0, 2, 1).contiguous()
 
 
 @AvgPool1dFixture
@@ -97,16 +96,12 @@ def test_avg_pool1d(
     tune: bool,
 ) -> None:
     test = AvgPool1dTest(kernel_size, stride, padding, ceil_mode, count_include_pad, dtype)
-    op = AvgPool1dOp(
-        n=n,
-        c_in=c_in,
-        l_in=l_in,
+    op = AvgPool1dFwdOp(
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,
-        dtype=dtype,
         tune=tune,
     )
     atol, rtol = ((1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2))
@@ -115,20 +110,23 @@ def test_avg_pool1d(
 
 @pytest.mark.smoke
 def test_avg_pool1d_dispatches_kernel() -> None:
-    op = AvgPool1dOp(n=1, c_in=32, l_in=128, kernel_size=3, stride=2, padding=1)
+    op = AvgPool1dFwdOp(kernel_size=3, stride=2, padding=1)
+    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16)
+    out = op(x)
     assert isinstance(op.kernel, AvgPool1dKernel)
+    assert out.shape == (1, 32, 64)
 
 
 @pytest.mark.smoke
 def test_avg_pool1d_rejects_wrong_tuple_arity() -> None:
     with pytest.raises(ValueError, match="kernel_size must be an int or a tuple of 1 ints"):
-        AvgPool1dOp(n=1, c_in=8, l_in=32, kernel_size=(3, 4))
+        AvgPool1dFwdOp(kernel_size=(3, 4))
 
 
 @pytest.mark.smoke
 def test_avg_pool1d_rejects_non_positive_stride() -> None:
     with pytest.raises(ValueError, match="stride must be greater than zero"):
-        AvgPool1dOp(n=1, c_in=8, l_in=32, kernel_size=3, stride=0)
+        AvgPool1dFwdOp(kernel_size=3, stride=0)
 
 
 @pytest.mark.smoke
@@ -141,32 +139,24 @@ def test_avg_pool1d_rejects_non_positive_stride() -> None:
     ],
 )
 def test_avg_pool1d_rejects_bool_pool_params(kwargs: dict[str, object], match: str) -> None:
-    base_kwargs = {
-        "n": 1,
-        "c_in": 8,
-        "l_in": 32,
-        "kernel_size": 3,
-    }
+    base_kwargs = {"kernel_size": 3}
     base_kwargs.update(kwargs)
     with pytest.raises(TypeError, match=match):
-        AvgPool1dOp(**base_kwargs)
+        AvgPool1dFwdOp(**base_kwargs)
 
 
 @pytest.mark.smoke
-def test_avg_pool1d_forward_warns_on_ambiguous_nlc_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_avg_pool1d_rejects_non_3d_input(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
-    op = AvgPool1dOp(
-        n=1,
-        c_in=8,
-        l_in=8,
-        kernel_size=2,
-        stride=2,
+    op = AvgPool1dFwdOp(
+        kernel_size=3,
+        stride=1,
+        padding=1,
         kernel_map={"avg_pool1d_kernel": _DummyKernel},
     )
-    x = torch.randn(1, 8, 8)
-    with pytest.warns(UserWarning, match="ambiguous NLC shape"):
-        out = op(x)
-    assert out is x
+    x = torch.randn(2, 8, 16, 4)
+    with pytest.raises(ValueError, match="expects input to be a 3D NCL tensor"):
+        op(x)
 
 
 class _DummyKernel(Kernel):

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
+from tileops.kernels.pool import AvgPool2dKernel, AvgPool3dKernel
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
 
 
@@ -97,11 +97,15 @@ def test_avg_pool1d(
 ) -> None:
     test = AvgPool1dTest(kernel_size, stride, padding, ceil_mode, count_include_pad, dtype)
     op = AvgPool1dFwdOp(
+        n=n,
+        c_in=c_in,
+        l_in=l_in,
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         ceil_mode=ceil_mode,
         count_include_pad=count_include_pad,
+        dtype=dtype,
         tune=tune,
     )
     atol, rtol = ((1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2))
@@ -109,24 +113,15 @@ def test_avg_pool1d(
 
 
 @pytest.mark.smoke
-def test_avg_pool1d_dispatches_kernel() -> None:
-    op = AvgPool1dFwdOp(kernel_size=3, stride=2, padding=1)
-    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16)
-    out = op(x)
-    assert isinstance(op.kernel, AvgPool1dKernel)
-    assert out.shape == (1, 32, 64)
-
-
-@pytest.mark.smoke
 def test_avg_pool1d_rejects_wrong_tuple_arity() -> None:
     with pytest.raises(ValueError, match="kernel_size must be an int or a tuple of 1 ints"):
-        AvgPool1dFwdOp(kernel_size=(3, 4))
+        AvgPool1dFwdOp(n=1, c_in=32, l_in=128, kernel_size=(3, 4))
 
 
 @pytest.mark.smoke
 def test_avg_pool1d_rejects_non_positive_stride() -> None:
     with pytest.raises(ValueError, match="stride must be greater than zero"):
-        AvgPool1dFwdOp(kernel_size=3, stride=0)
+        AvgPool1dFwdOp(n=1, c_in=32, l_in=128, kernel_size=3, stride=0)
 
 
 @pytest.mark.smoke
@@ -139,7 +134,7 @@ def test_avg_pool1d_rejects_non_positive_stride() -> None:
     ],
 )
 def test_avg_pool1d_rejects_bool_pool_params(kwargs: dict[str, object], match: str) -> None:
-    base_kwargs = {"kernel_size": 3}
+    base_kwargs = {"n": 1, "c_in": 32, "l_in": 128, "kernel_size": 3}
     base_kwargs.update(kwargs)
     with pytest.raises(TypeError, match=match):
         AvgPool1dFwdOp(**base_kwargs)
@@ -149,9 +144,13 @@ def test_avg_pool1d_rejects_bool_pool_params(kwargs: dict[str, object], match: s
 def test_avg_pool1d_rejects_non_3d_input(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
     op = AvgPool1dFwdOp(
+        n=2,
+        c_in=8,
+        l_in=16,
         kernel_size=3,
         stride=1,
         padding=1,
+        dtype=torch.float32,
         kernel_map={"avg_pool1d_kernel": _DummyKernel},
     )
     x = torch.randn(2, 8, 16, 4)

--- a/tileops/kernels/pool/avg_pool1d.py
+++ b/tileops/kernels/pool/avg_pool1d.py
@@ -31,16 +31,14 @@ def _avg_pool1d_kernel(
     def _avg_pool1d_func(block_m: int, block_c: int, threads: int):
         @T.prim_func
         def _avg_pool1d_main(
-            x: T.Tensor((n, l_in, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, out_l, c_in), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
         ):
             with T.Kernel(
                 T.ceildiv(c_in, block_c),
                 T.ceildiv(n * out_l, block_m),
                 threads=threads,
             ) as (bx, by):
-                out_flat = T.Tensor((n * out_l, c_in), dtype, out.data)
-
                 for i, j in T.Parallel(block_m, block_c):
                     m_idx = by * block_m + i
                     c_idx = bx * block_c + j
@@ -53,7 +51,7 @@ def _avg_pool1d_kernel(
                         for kw in T.serial(kernel_l):
                             il = ol * stride_l + kw - pad_l
                             if il >= 0 and il < l_in:
-                                sum_val += T.cast(x[batch, il, c_idx], accum_dtype)
+                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
 
                         window_start = ol * stride_l - pad_l
                         window_end = window_start + kernel_l
@@ -67,7 +65,7 @@ def _avg_pool1d_kernel(
                             T.if_then_else(count_include_pad, padded_count, valid_count),
                             1,
                         )
-                        out_flat[m_idx, c_idx] = T.cast(
+                        out[batch, c_idx, ol] = T.cast(
                             sum_val / T.cast(divisor, accum_dtype),
                             dtype,
                         )
@@ -124,7 +122,7 @@ def _(
 ) -> torch.Tensor:
     _ = (count_include_pad, dtype, block_m, block_c, threads)
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
-    return torch.empty((n, out_l, c_in), dtype=x.dtype, device=x.device)
+    return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
 
 
 class AvgPool1dKernel(Kernel):

--- a/tileops/kernels/pool/avg_pool1d.py
+++ b/tileops/kernels/pool/avg_pool1d.py
@@ -35,40 +35,59 @@ def _avg_pool1d_kernel(
             out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
         ):
             with T.Kernel(
+                T.ceildiv(out_l, block_m),
                 T.ceildiv(c_in, block_c),
-                T.ceildiv(n * out_l, block_m),
+                n,
                 threads=threads,
-            ) as (bx, by):
+            ) as (bx, by, bz):
+                T.use_swizzle(10)
+                tile_ol_start = bx * block_m
+                tile_ol_end = tile_ol_start + block_m - 1
+                tile_input_start = tile_ol_start * stride_l - pad_l
+                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
+                tile_spatial_full = (
+                    (tile_ol_end < out_l)
+                    & (tile_input_start >= 0)
+                    & (tile_input_end < l_in)
+                )
                 for i, j in T.Parallel(block_m, block_c):
-                    m_idx = by * block_m + i
-                    c_idx = bx * block_c + j
-                    if m_idx < n * out_l and c_idx < c_in:
-                        batch = m_idx // out_l
-                        ol = m_idx % out_l
+                    ol = bx * block_m + i
+                    c_idx = by * block_c + j
+                    batch = bz
+                    if ol < out_l and c_idx < c_in:
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
 
-                        for kw in T.serial(kernel_l):
-                            il = ol * stride_l + kw - pad_l
-                            if il >= 0 and il < l_in:
+                        if tile_spatial_full:
+                            for kw in T.serial(kernel_l):
+                                il = ol * stride_l + kw - pad_l
                                 sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
+                            out[batch, c_idx, ol] = T.cast(
+                                sum_val / T.cast(kernel_l, accum_dtype),
+                                dtype,
+                            )
+                        else:
+                            for kw in T.serial(kernel_l):
+                                il = ol * stride_l + kw - pad_l
+                                if il >= 0 and il < l_in:
+                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
 
-                        window_start = ol * stride_l - pad_l
-                        window_end = window_start + kernel_l
-                        valid_start = T.max(window_start, 0)
-                        valid_end = T.min(window_end, l_in)
-                        valid_count = T.max(valid_end - valid_start, 0)
-                        padded_start = T.max(window_start, -pad_l)
-                        padded_end = T.min(window_end, l_in + pad_l)
-                        padded_count = T.max(padded_end - padded_start, 0)
-                        divisor = T.max(
-                            T.if_then_else(count_include_pad, padded_count, valid_count),
-                            1,
-                        )
-                        out[batch, c_idx, ol] = T.cast(
-                            sum_val / T.cast(divisor, accum_dtype),
-                            dtype,
-                        )
+                            window_start = ol * stride_l - pad_l
+                            window_end = window_start + kernel_l
+                            valid_start = T.max(window_start, 0)
+                            valid_end = T.min(window_end, l_in)
+                            valid_count = T.max(valid_end - valid_start, 0)
+                            padded_start = T.max(window_start, -pad_l)
+                            padded_end = T.min(window_end, l_in + pad_l)
+                            padded_count = T.max(padded_end - padded_start, 0)
+                            divisor = T.max(
+                                T.if_then_else(count_include_pad, padded_count, valid_count),
+                                1,
+                            )
+                            out[batch, c_idx, ol] = T.cast(
+                                sum_val / T.cast(divisor, accum_dtype),
+                                dtype,
+                            )
 
         return _avg_pool1d_main
 

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -51,7 +51,7 @@ AvgPool1dFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 AvgPool2dFwdOp:
   ref_api: "torch.nn.functional.avg_pool2d"

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -7,7 +7,7 @@
 AvgPool1dFwdOp:
   ref_api: "torch.nn.functional.avg_pool1d"
   family: pool
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -64,7 +64,7 @@ from .norm import (
     RMSNormFwdOp,
 )
 from .op_base import Op
-from .pool import AvgPool1dOp, AvgPool2dOp, AvgPool3dOp
+from .pool import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
 
 # --- Reduction ops (uncomment as sub-category PRs land) ---
 from .reduction import (
@@ -108,7 +108,7 @@ from .topk_selector import TopkSelectorOp
 
 __all__ = [
     "BinaryOp",
-    "AvgPool1dOp",
+    "AvgPool1dFwdOp",
     "AvgPool2dOp",
     "AvgPool3dOp",
     "AdaLayerNormFwdOp",

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -16,19 +16,36 @@ from .op_base import Op
 __all__ = ["AvgPool1dFwdOp", "AvgPool2dOp", "AvgPool3dOp"]
 
 
+def _validate_positive_int(name: str, value: int, op_name: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{op_name} {name} must be an int")
+    if value <= 0:
+        raise ValueError(f"{op_name} {name} must be greater than zero")
+
+
 class AvgPool1dFwdOp(Op):
     """Average pooling over PyTorch-compatible NCL inputs."""
 
     def __init__(
         self,
+        n: int,
+        c_in: int,
+        l_in: int,
         kernel_size: int | tuple[int],
         stride: Optional[int | tuple[int]] = None,
         padding: int | tuple[int] = 0,
         ceil_mode: bool = False,
         count_include_pad: bool = True,
+        dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        _validate_positive_int("n", n, "AvgPool1dFwdOp")
+        _validate_positive_int("c_in", c_in, "AvgPool1dFwdOp")
+        _validate_positive_int("l_in", l_in, "AvgPool1dFwdOp")
+        self.n = n
+        self.c_in = c_in
+        self.l_in = l_in
         self.kernel_size = _normalize_pool_dims("kernel_size", kernel_size, 1)[0]
         self.stride = (
             (self.kernel_size,)
@@ -48,12 +65,26 @@ class AvgPool1dFwdOp(Op):
         self.dispatch_kernel(kernel_map)
         if "avg_pool1d_kernel" not in self.kernel_map:
             raise NotImplementedError("AvgPool1dFwdOp requires 'avg_pool1d_kernel' in kernel_map")
-        self._kernel_cache: Dict[tuple[int, int, int, torch.dtype], Kernel] = {}
-        self.n = 0
-        self.c_in = 0
-        self.l_in = 0
-        self.out_l = 0
-        self.dtype = None
+        self.out_l = pool_output_dim(
+            self.l_in,
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.ceil_mode,
+        )
+        self.dtype = dtype
+        self.kernel = self.kernel_map["avg_pool1d_kernel"](
+            n=n,
+            c_in=c_in,
+            l_in=l_in,
+            kernel_l=self.kernel_size,
+            stride_l=self.stride,
+            pad_l=self.padding,
+            ceil_mode=self.ceil_mode,
+            count_include_pad=self.count_include_pad,
+            dtype=dtype,
+            tune=tune,
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -78,24 +109,8 @@ class AvgPool1dFwdOp(Op):
                 "input.dtype must be float16, bfloat16, or float32, "
                 f"got {input.dtype}"
             )
-
-    def _get_kernel(self, input: torch.Tensor) -> Kernel:
-        n, c_in, l_in = input.shape
-        key = (n, c_in, l_in, input.dtype)
-        if key not in self._kernel_cache:
-            self._kernel_cache[key] = self.kernel_map["avg_pool1d_kernel"](
-                n=n,
-                c_in=c_in,
-                l_in=l_in,
-                kernel_l=self.kernel_size,
-                stride_l=self.stride,
-                pad_l=self.padding,
-                ceil_mode=self.ceil_mode,
-                count_include_pad=self.count_include_pad,
-                dtype=input.dtype,
-                tune=self.tune,
-            )
-        return self._kernel_cache[key]
+        if input.dtype != self.dtype:
+            raise ValueError(f"input.dtype must match op dtype {self.dtype}, got {input.dtype}")
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         self._validate_dtypes(input)
@@ -105,22 +120,16 @@ class AvgPool1dFwdOp(Op):
             raise ValueError("input must be a CUDA tensor")
 
         input = input.contiguous()
-        self.n, self.c_in, self.l_in = input.shape
-        self.dtype = input.dtype
-        self.out_l = pool_output_dim(
-            self.l_in,
-            self.kernel_size,
-            self.stride,
-            self.padding,
-            self.ceil_mode,
-        )
-        kernel = self._get_kernel(input)
-        self.kernel = kernel
-        return kernel(input)
+        expected_shape = (self.n, self.c_in, self.l_in)
+        actual_shape = tuple(input.shape)
+        if actual_shape != expected_shape:
+            raise ValueError(
+                f"AvgPool1dFwdOp expects input shape {expected_shape}, "
+                f"but got {actual_shape}"
+            )
+        return self.kernel(input)
 
     def eval_roofline(self) -> tuple[int, int]:
-        if self.dtype is None or self.n <= 0 or self.c_in <= 0 or self.l_in <= 0:
-            raise ValueError("eval_roofline requires a prior forward() call")
         elem_bytes = torch.empty((), dtype=self.dtype).element_size()
         flops = self.n * self.c_in * self.out_l * self.kernel_size
         bytes_ = (self.n * self.c_in * self.l_in + self.n * self.c_in * self.out_l) * elem_bytes

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -6,40 +6,29 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
 from tileops.kernels.pool.common import (
     _normalize_pool_dims,
+    pool_output_dim,
     validate_channels_last_input,
     validate_pool_params,
 )
 
 from .op_base import Op
 
-__all__ = ["AvgPool1dOp", "AvgPool2dOp", "AvgPool3dOp"]
+__all__ = ["AvgPool1dFwdOp", "AvgPool2dOp", "AvgPool3dOp"]
 
 
-class AvgPool1dOp(Op):
-    """Average pooling over channels-last `NLC` inputs.
-
-    This op intentionally uses the TileOPs channels-last contract rather than
-    PyTorch's default `NCL` layout. Ambiguous shapes where `NLC` and `NCL`
-    would look identical, such as `(N, 8, 8)`, are rejected eagerly.
-    """
+class AvgPool1dFwdOp(Op):
+    """Average pooling over PyTorch-compatible NCL inputs."""
 
     def __init__(
         self,
-        n: int,
-        c_in: int,
-        l_in: int,
         kernel_size: int | tuple[int],
         stride: Optional[int | tuple[int]] = None,
         padding: int | tuple[int] = 0,
         ceil_mode: bool = False,
         count_include_pad: bool = True,
-        dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.n = n
-        self.c_in = c_in
-        self.l_in = l_in
         self.kernel_size = _normalize_pool_dims("kernel_size", kernel_size, 1)[0]
         self.stride = (
             (self.kernel_size,)
@@ -49,43 +38,93 @@ class AvgPool1dOp(Op):
         self.padding = _normalize_pool_dims("padding", padding, 1)[0]
         self.ceil_mode = ceil_mode
         self.count_include_pad = count_include_pad
-        self.dtype = dtype
+        self.tune = tune
         validate_pool_params(
             ndim=1,
             kernel_size=(self.kernel_size,),
             stride=(self.stride,),
             padding=(self.padding,),
         )
-
         self.dispatch_kernel(kernel_map)
         if "avg_pool1d_kernel" not in self.kernel_map:
-            raise NotImplementedError("AvgPool1dOp requires 'avg_pool1d_kernel' in kernel_map")
-        self.kernel = self.kernel_map["avg_pool1d_kernel"](
-            n=n,
-            c_in=c_in,
-            l_in=l_in,
-            kernel_l=self.kernel_size,
-            stride_l=self.stride,
-            pad_l=self.padding,
-            ceil_mode=ceil_mode,
-            count_include_pad=count_include_pad,
-            dtype=dtype,
-            tune=tune,
-        )
+            raise NotImplementedError("AvgPool1dFwdOp requires 'avg_pool1d_kernel' in kernel_map")
+        self._kernel_cache: Dict[tuple[int, int, int, torch.dtype], Kernel] = {}
+        self.n = 0
+        self.c_in = 0
+        self.l_in = 0
+        self.out_l = 0
+        self.dtype = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"avg_pool1d_kernel": AvgPool1dKernel}
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        validate_channels_last_input(
-            op_name=type(self).__name__,
-            x_shape=tuple(x.shape),
-            expected_shape=(self.n, self.l_in, self.c_in),
-            layout="NLC",
-            ambiguous_layout_shape=(self.n, self.c_in, self.l_in),
+    def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:
+        if len(input_shape) != 3:
+            raise ValueError("AvgPool1dFwdOp expects input_shape to be 3D NCL")
+        n, c_in, l_in = input_shape
+        kernel_size = getattr(self, "kernel_size", None)
+        stride = getattr(self, "stride", None)
+        padding = getattr(self, "padding", None)
+        ceil_mode = getattr(self, "ceil_mode", False)
+        if kernel_size is None or stride is None or padding is None:
+            return {"output": (n, c_in, 0)}
+        out_l = pool_output_dim(l_in, kernel_size, stride, padding, ceil_mode)
+        return {"output": (n, c_in, out_l)}
+
+    def _validate_dtypes(self, input: torch.Tensor) -> None:
+        if input.dtype not in {torch.float16, torch.bfloat16, torch.float32}:
+            raise ValueError(
+                "input.dtype must be float16, bfloat16, or float32, "
+                f"got {input.dtype}"
+            )
+
+    def _get_kernel(self, input: torch.Tensor) -> Kernel:
+        n, c_in, l_in = input.shape
+        key = (n, c_in, l_in, input.dtype)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["avg_pool1d_kernel"](
+                n=n,
+                c_in=c_in,
+                l_in=l_in,
+                kernel_l=self.kernel_size,
+                stride_l=self.stride,
+                pad_l=self.padding,
+                ceil_mode=self.ceil_mode,
+                count_include_pad=self.count_include_pad,
+                dtype=input.dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self._validate_dtypes(input)
+        if input.ndim != 3:
+            raise ValueError("AvgPool1dFwdOp expects input to be a 3D NCL tensor")
+        if not input.is_cuda:
+            raise ValueError("input must be a CUDA tensor")
+
+        input = input.contiguous()
+        self.n, self.c_in, self.l_in = input.shape
+        self.dtype = input.dtype
+        self.out_l = pool_output_dim(
+            self.l_in,
+            self.kernel_size,
+            self.stride,
+            self.padding,
+            self.ceil_mode,
         )
-        return self.kernel(x)
+        kernel = self._get_kernel(input)
+        self.kernel = kernel
+        return kernel(input)
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.dtype is None or self.n <= 0 or self.c_in <= 0 or self.l_in <= 0:
+            raise ValueError("eval_roofline requires a prior forward() call")
+        elem_bytes = torch.empty((), dtype=self.dtype).element_size()
+        flops = self.n * self.c_in * self.out_l * self.kernel_size
+        bytes_ = (self.n * self.c_in * self.l_in + self.n * self.c_in * self.out_l) * elem_bytes
+        return flops, bytes_
 
 
 class AvgPool2dOp(Op):


### PR DESCRIPTION
## Summary
- Replace the legacy `AvgPool1dOp` public surface with manifest-aligned `AvgPool1dFwdOp`.
- Switch AvgPool1d implementation to native NCL layout across op, kernel, tests, and benchmark.
- Promote `AvgPool1dFwdOp` to `status: implemented` in `tileops/manifest/pool.yaml`.
- Build the AvgPool1d kernel in `AvgPool1dFwdOp.__init__`; `forward()` only validates inputs and invokes the existing kernel.
- Route benchmark roofline metrics through `AvgPool1dFwdOp.eval_roofline()`.
- Drive AvgPool1d benchmark cases from manifest workloads and set `source.bench_manifest_driven: true` for `AvgPool1dFwdOp`.

Closes #1569

## Test plan
- `python -m pytest tests/ops/test_pool.py -k avg_pool1d -v`：11 passed
- `python -m pytest benchmarks/ops/bench_pool.py -k avg_pool1d -v`：3 passed
- `python scripts/validate_manifest.py --check-op AvgPool1dFwdOp --strict`：passed with existing advisory shape-rule helper warnings for `_kW`, `_sW`, `_pW`

## Benchmark
Latest local H200 run after the kernel mapping optimization:

| case | tileops latency_ms | torch-ref latency_ms | gap |
| --- | ---: | ---: | ---: |
| audio-downsample-fp16 | 0.0319 | 0.0157 | 2.03x |
| long-temporal-fp16 | 0.2244 | 0.0826 | 2.72x |
| ceil-bf16 | 0.0124 | 0.0057 | 2.18x |

Compared with the pre-optimization report, the long-temporal tileops latency improved from `0.2565 ms` to `0.2244 ms` (~12.5% faster). The optimization stayed within `_avg_pool1d_kernel` and did not change the public kernel interface.

## Notes
- `scripts/validate.sh --pre/--post` is not present in this repository checkout, so targeted pytest, manifest validation, and commit/branch regex checks were used locally.
- Existing manifest shape-rule warnings are not changed in this PR follow-up; `pool.yaml` shape rules remain in their current helper-variable form.