### PR TITLE
[Perf][Attention] Tune GQA decode split policy for high-ratio single requests

### DIFF
--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -26,15 +26,18 @@ class _GroupedQueryAttentionDecodeTestBaseline(GroupedQueryAttentionDecodeTest):
 
 
 def _fa3_gqa_decode_fwd(test):
-    """Return FA3 forward baseline callable, or None if not installed."""
+    """Return FA3 KV-cache decode baseline callable, or None if not installed."""
     try:
-        from flash_attn_interface import flash_attn_func  # noqa: PLC0415
+        from flash_attn_interface import flash_attn_with_kvcache  # noqa: PLC0415
     except ImportError:
         return None
 
+    cache_seqlens = torch.full(
+        (test.batch,), test.seq_len_kv, dtype=torch.int32, device="cuda")
+
     def baseline_fn(q, k, v):
-        # Q is (B, H, D) — add seq dim for flash_attn
-        out = flash_attn_func(q.unsqueeze(1), k, v)
+        # Q is (B, H, D); FA3 KV-cache decode expects (B, S_q, H, D).
+        out = flash_attn_with_kvcache(q.unsqueeze(1), k, v, cache_seqlens=cache_seqlens)
         out = out[0] if isinstance(out, tuple) else out
         return out.squeeze(1)
 

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -28,6 +28,7 @@ class GroupedQueryAttentionDecodeFixture(FixtureBase):
         ("batch, heads, heads_kv, seq_len_kv, dim, dtype, tune", [
             pytest.param(1, 32, 8, 8192, 128, torch.float16, False, marks=pytest.mark.smoke),
             pytest.param(1, 32, 8, 8192, 128, torch.bfloat16, False, marks=pytest.mark.smoke),
+            pytest.param(1, 16, 2, 8192, 128, torch.float16, False, marks=pytest.mark.smoke),
             pytest.param(8, 64, 16, 8192, 128, torch.float16, False, marks=pytest.mark.full),
         ]),
     ]
@@ -67,9 +68,21 @@ def test_gqa_decode_split_policy_filters_short_kv_autotune_configs() -> None:
 
 
 @pytest.mark.smoke
-def test_gqa_decode_rejects_invalid_kv_heads() -> None:
+def test_gqa_decode_rejects_non_positive_groups() -> None:
     with pytest.raises(ValueError, match="groups must be positive"):
         GQADecodeKernel(1, 16, 0, 8192, 128, dtype="float16")
+
+
+@pytest.mark.smoke
+def test_gqa_decode_rejects_non_divisible_heads() -> None:
+    with pytest.raises(ValueError, match="heads must be divisible by groups"):
+        GQADecodeKernel(1, 15, 2, 8192, 128, dtype="float16")
+
+
+@pytest.mark.smoke
+def test_gqa_decode_rejects_non_positive_seqlen_kv() -> None:
+    with pytest.raises(ValueError, match="seqlen_kv must be positive"):
+        GQADecodeKernel(1, 16, 2, 0, 128, dtype="float16")
 
 
 if __name__ == "__main__":

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.attention.gqa_decode import GQADecodeKernel
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
 from workloads.attention.gqa_decode import (
     GroupedQueryAttentionDecodeTest as _GroupedQueryAttentionDecodeTestWorkload,
@@ -38,6 +39,18 @@ def test_gqa_decode(batch: int, heads: int, heads_kv: int, seq_len_kv: int, dim:
     test = GroupedQueryAttentionDecodeTest(batch, heads, heads_kv, seq_len_kv, dim, dtype)
     op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(batch, heads, heads_kv, seq_len_kv, dim, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_gqa_decode_default_split_policy() -> None:
+    qwen_like = GQADecodeKernel(1, 16, 2, 8192, 128, dtype="float16")
+    assert qwen_like.config["num_split"] == 32
+
+    llama_like = GQADecodeKernel(1, 40, 8, 8192, 128, dtype="float16")
+    assert llama_like.config["num_split"] == 16
+
+    batched_qwen_like = GQADecodeKernel(8, 16, 2, 8192, 128, dtype="float16")
+    assert batched_qwen_like.config["num_split"] == 16
 
 
 if __name__ == "__main__":

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -46,11 +46,30 @@ def test_gqa_decode_default_split_policy() -> None:
     qwen_like = GQADecodeKernel(1, 16, 2, 8192, 128, dtype="float16")
     assert qwen_like.config["num_split"] == 32
 
+    short_qwen_like = GQADecodeKernel(1, 16, 2, 8, 128, dtype="float16")
+    assert short_qwen_like.config["num_split"] == 8
+
     llama_like = GQADecodeKernel(1, 40, 8, 8192, 128, dtype="float16")
     assert llama_like.config["num_split"] == 16
 
     batched_qwen_like = GQADecodeKernel(8, 16, 2, 8192, 128, dtype="float16")
     assert batched_qwen_like.config["num_split"] == 16
+
+
+@pytest.mark.smoke
+def test_gqa_decode_split_policy_filters_short_kv_autotune_configs() -> None:
+    kernel = GQADecodeKernel(1, 16, 2, 8, 128, dtype="float16")
+    assert {cfg["num_split"] for cfg in kernel.autotune_configs} == {2, 4, 8}
+
+    tiny_kernel = GQADecodeKernel(1, 16, 2, 1, 128, dtype="float16")
+    assert tiny_kernel.config["num_split"] == 1
+    assert {cfg["num_split"] for cfg in tiny_kernel.autotune_configs} == {1}
+
+
+@pytest.mark.smoke
+def test_gqa_decode_rejects_invalid_kv_heads() -> None:
+    with pytest.raises(ValueError, match="groups must be positive"):
+        GQADecodeKernel(1, 16, 0, 8192, 128, dtype="float16")
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/attention/gqa_decode.py
+++ b/tileops/kernels/attention/gqa_decode.py
@@ -373,13 +373,31 @@ class GQADecodeKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {"block_H": 64, "block_N": 128, "num_split": 16, "num_stages": 2, "threads": 128}
+        return {
+            "block_H": 64,
+            "block_N": 128,
+            "num_split": self._default_num_split(),
+            "num_stages": 2,
+            "threads": 128,
+        }
+
+    def _default_num_split(self) -> int:
+        """Choose a conservative default split policy for GQA decode.
+
+        Single-request, high-ratio GQA decode with very few KV heads benefits
+        from more split parallelism. Keep the existing split=16 default for
+        other shapes to avoid changing batched Llama-like workloads.
+        """
+        kv_group_num = self.heads // self.groups
+        if self.batch == 1 and self.dim == 128 and self.groups <= 2 and kv_group_num >= 8:
+            return 32
+        return 16
 
     @property
     def autotune_configs(self) -> list[dict]:
         block_N = [64, 128]
         block_H = [64]
-        num_split = [2, 4, 8]
+        num_split = [2, 4, 8, 16, 32]
         num_stages = [1, 2, 3]
         threads = [128]
         _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))

--- a/tileops/kernels/attention/gqa_decode.py
+++ b/tileops/kernels/attention/gqa_decode.py
@@ -331,6 +331,12 @@ class GQADecodeKernel(Kernel):
         self.seqlen_kv = seqlen_kv
         self.dim = dim
         self.dtype = dtype
+        if self.groups <= 0:
+            raise ValueError("groups must be positive")
+        if self.heads % self.groups != 0:
+            raise ValueError("heads must be divisible by groups")
+        if self.seqlen_kv <= 0:
+            raise ValueError("seqlen_kv must be positive")
 
         self.no_split_jit = _gqa_decode_no_split_kernel(
             self.batch, self.heads, self.groups, self.seqlen_kv, self.dim, self.dtype_str)
@@ -390,14 +396,16 @@ class GQADecodeKernel(Kernel):
         """
         kv_group_num = self.heads // self.groups
         if self.batch == 1 and self.dim == 128 and self.groups <= 2 and kv_group_num >= 8:
-            return 32
-        return 16
+            candidate = 32
+        else:
+            candidate = 16
+        return min(candidate, self.seqlen_kv)
 
     @property
     def autotune_configs(self) -> list[dict]:
         block_N = [64, 128]
         block_H = [64]
-        num_split = [2, 4, 8, 16, 32]
+        num_split = [ns for ns in [2, 4, 8, 16, 32] if ns <= self.seqlen_kv] or [1]
         num_stages = [1, 2, 3]
         threads = [128]
         _configs = list(itertools.product(block_N, block_H, num_split, num_stages, threads))


### PR DESCRIPTION
## Summary
- choose `num_split=32` by default for Qwen-like single-request GQA decode shapes (`B=1`, `D=128`, `H_kv<=2`, `H/H_kv>=8`)
- keep the existing `num_split=16` default for other shapes, including batched Llama-like workloads
- include `num_split=16` and `num_split=32` in the autotune search space
- add a smoke test for the default split policy
- switch the GQA decode FA3 benchmark baseline from `flash_attn_func` to the KV-cache decode API, `flash_attn_with_kvcache`

## Motivation
Internal microbenchmarks showed that the current fixed `num_split=16` default under-splits Qwen-like GQA decode. Moving these shapes to `split=32` improves latency versus the current default while preserving the upstream kernel body.

The FA3 comparison should use the decode-specific KV-cache API. The previous benchmark baseline used `flash_attn_func(q.unsqueeze(1), k, v)`, which is not the right infrastructure for decode comparisons and made long-context FA3 look artificially slow.

## Local Benchmark Notes
Measured on H200 at a locked 1500 MHz SM clock, fp16, `B=1, H=16, H_kv=2, D=128`.

Use the repository benchmark protocol (`bench_kernel`): CUPTI kernel-only timing, L2 flush between iterations, and cloned tensor inputs when feasible. This avoids the hot-cache artifact from repeatedly timing the same KV cache with CUDA events.

TileOps `split=32` versus FA3 `flash_attn_with_kvcache`:

```text
S=4K:    TileOps 0.010490 ms, FA3 0.021095 ms, FA3/TileOps 2.011x
S=16K:   TileOps 0.015743 ms, FA3 0.026555 ms, FA3/TileOps 1.687x
S=64K:   TileOps 0.035642 ms, FA3 0.041514 ms, FA3/TileOps 1.165x
S=128K:  TileOps 0.062437 ms, FA3 0.064863 ms, FA3/TileOps 1.039x
```

The Qwen-like `B=1, H=16, H_kv=2` shape only launches `B * (H / min(block_H, H / H_kv)) * num_split = 64` split CTAs with `split=32`, so it is still occupancy-limited on H200. The split policy improves TileOps defaults for this shape, but this PR intentionally does not change the kernel body.

## Validation
- `python -m ruff check benchmarks/ops/attention/bench_gqa_decode.py`
- `python -m pytest --collect-only -q benchmarks/ops/attention/bench_gqa_decode.py tests/ops/attention/test_gqa_decode.py`
- FA3 KV-cache baseline smoke in the TileOps docker runner environment
- local `bench_kernel` comparison for Qwen-like GQA decode shapes listed above
