### PR TITLE
[Fix][MoE] Order C_shared write before TMA read in 3WG grouped-GEMM epilogue

### DIFF
--- a/tests/ops/test_moe_fused_moe.py
+++ b/tests/ops/test_moe_fused_moe.py
@@ -172,6 +172,69 @@ def test_fused_moe_qwen3(
     )
 
 
+# Cases for the FusedMoe non-determinism regression. The cooperative 3WG
+# grouped-GEMM TMA-store epilogue race is intermittent (~3% of calls at the
+# qwen3-medium scale) and only manifests inside the full FusedMoe pipeline
+# (adjacent activation/permute kernels keep the timing window open) — an
+# isolated grouped-GEMM loop never trips it, so this must run the op. The
+# nightly case repeats many times: at 3% per call, 200 repeats give >99%
+# detection. The smoke case is a fast path-coverage check.
+_DET_CASES = [
+    pytest.param(
+        dict(num_tokens=32, num_experts=8, top_k=2, hidden_size=64,
+             ffn_size=32, reps=3),
+        marks=pytest.mark.smoke, id="smoke",
+    ),
+    pytest.param(
+        dict(num_tokens=2048, num_experts=128, top_k=8, hidden_size=2048,
+             ffn_size=1024, reps=200),
+        marks=pytest.mark.nightly, id="qwen3-medium",
+    ),
+]
+
+
+@pytest.mark.parametrize("case", _DET_CASES)
+def test_fused_moe_deterministic(case):
+    """Regression for the cooperative 3WG grouped-GEMM TMA-store epilogue race.
+
+    The fast-path epilogue staged each full tile through a per-WG ``C_shared``
+    SMEM buffer without ordering the register→SMEM write before the async TMA
+    read, so the store could read a half-written ``C_shared`` on a small
+    fraction of calls, corrupting a sub-tile of the output non-deterministically.
+    The race only manifests inside the full FusedMoe pipeline; qwen3-medium
+    (E=128, ~128 rows/expert) drives the cooperative full-tile fast path heavily.
+    Run the op many times on fixed seed-42 inputs and assert every call matches
+    the PyTorch reference and is bitwise-identical to the first. Pre-fix the
+    qwen3-medium case trips within ~100 repeats; post-fix it is deterministic.
+    """
+    torch.manual_seed(42)
+    dev = "cuda"
+    dtype = torch.bfloat16
+    nt, ne, tk = case["num_tokens"], case["num_experts"], case["top_k"]
+    hs, ff, reps = case["hidden_size"], case["ffn_size"], case["reps"]
+    hidden = torch.randn(nt, hs, dtype=dtype, device=dev)
+    gating = torch.randn(nt, ne, dtype=dtype, device=dev)
+    w_gate_up = torch.randn(ne, ff * 2, hs, dtype=dtype, device=dev) * 0.02
+    w_down = torch.randn(ne, hs, ff, dtype=dtype, device=dev) * 0.02
+
+    op = FusedMoe(
+        num_tokens=nt, num_experts=ne, top_k=tk, hidden_size=hs,
+        ffn_size=ff, scoring_func="softmax", renormalize=False, dtype=dtype,
+    )
+    fk = FusedTopKOp(nt, ne, tk, "softmax", False)
+    topk_weights, topk_ids = fk(gating)
+    ref = _ref_moe_ffn(hidden, w_gate_up, w_down, topk_weights, topk_ids.long())
+
+    first = op(hidden, gating, w_gate_up, w_down)
+    torch.testing.assert_close(first.float(), ref.float(), rtol=1e-2, atol=1e-2)
+    for i in range(reps):
+        out = op(hidden, gating, w_gate_up, w_down)
+        assert torch.equal(out, first), (
+            f"non-deterministic FusedMoe output on call {i + 1}/{reps}: "
+            "3WG grouped-GEMM TMA-store epilogue write→read race regressed"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Test fixture — Kimi K2 config
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
+++ b/tileops/kernels/grouped_gemm/grouped_gemm_persistent_3wg.py
@@ -472,6 +472,12 @@ def _make_pingpong_kernel(numel, num_experts, N, K, dtype, sm_count,
                             # only WGs with a full tile reach the barrier.
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
+                            # Order the generic-proxy SMEM writes above before
+                            # the async-proxy TMA read below, and align all 128
+                            # WG0 threads so the TMA store never reads a
+                            # half-written C_shared (intra-wave write→read race).
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_shared_wg0,
                                    C[m_start_0, n_start_0])
                         else:
@@ -542,6 +548,10 @@ def _make_pingpong_kernel(numel, num_experts, N, K, dtype, sm_count,
                             # WG1's own named barrier (id=5) guards C_shared reuse.
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
+                            # See the WG0 epilogue: fence + WG barrier order the
+                            # SMEM writes before the async TMA read.
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_shared_wg1,
                                    C[m_start_1, n_start_1])
                         else:
@@ -787,6 +797,12 @@ def _make_cooperative_kernel(numel, num_experts, N, K, dtype, sm_count,
                             # rationale (and why a CTA-wide sync would deadlock).
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_local_cast_wg0, C_shared_wg0)
+                            # Order the generic-proxy SMEM writes above before
+                            # the async-proxy TMA read below, and align all 128
+                            # WG0 threads so the TMA store never reads a
+                            # half-written C_shared (intra-wave write→read race).
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(C_shared_wg0,
                                    C[m_start, n_start])
                         else:
@@ -854,6 +870,10 @@ def _make_cooperative_kernel(numel, num_experts, N, K, dtype, sm_count,
                             # own named barrier (id=5).
                             T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_local_cast_wg1, C_shared_wg1)
+                            # See the top-half epilogue: fence + WG barrier order
+                            # the SMEM writes before the async TMA read.
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=5, arrive_count=128)
                             T.copy(C_shared_wg1,
                                    C[m_start + half_m, n_start])
                         elif arows1 > T.int32(0):


### PR DESCRIPTION
## Summary

Fixes #1570 — the intermittent nightly failure of `tests/ops/test_moe_fused_moe.py::test_fused_moe_qwen3[qwen3-medium]`.

**Root cause.** The cooperative/pingpong 3WG grouped-GEMM TMA-store fast-path epilogue stages each full tile through a per-WG `C_shared` SMEM buffer: all 128 WG threads write it (generic proxy), then a TMA store reads it (async proxy) into global memory. There was **no synchronization between the write and the read**, so the TMA store could read a half-written `C_shared` on a small fraction of launches, corrupting a sub-tile of the output non-deterministically (~3% of FusedMoe calls). qwen3-medium has balanced expert sizes (E=128, ~128 rows/expert), so it drives the full-tile fast path heavily and exposes the hazard; kimi's many zero-experts mostly hit the STG slow path and hid it.

This is **distinct from the earlier cross-wave `C_shared` reuse race** — the pre-write barrier guards reuse across waves but never covered the intra-wave write→read hazard.

**Fix.** Insert `T.fence_proxy_async()` + a WG-scoped named barrier between the register→SMEM write and the SMEM→global TMA read at all four epilogue sites (cooperative + pingpong, WG0/WG1), matching the canonical pattern in `gqa_fwd_ws.py`. The pre-write cross-wave barrier is unchanged.

## Verification

- **Reproduced** locally on H200 (env tilelang 0.1.9): 3/100 FusedMoe calls corrupted, signature matching the nightly report (localized sub-tile, maxabs ~0.1).
- **Bisection**: forcing the epilogue to STG-only (bypassing the C_shared TMA store) is 300/300 bitwise-deterministic → isolates the race to this epilogue.
- **Fixed**: 300/300 bitwise-deterministic; full MoE + 3WG kernel sweep **43 passed**.
- **Regression test** (`tests/ops/test_moe_fused_moe.py::test_fused_moe_deterministic`, smoke + nightly): **fails on the unfixed kernel** (trips within ~10 of 200 repeats) and **passes on the fixed kernel**. The race only manifests inside the full FusedMoe pipeline, so the test runs the op rather than the bare kernel.
- **Latency**: grouped-GEMM A/B is **~+0.3%** (epilogue sync is off the K-loop critical path) — negligible.

## Acceptance criteria

- [x] Modified files pass unit tests
- [x] `test_fused_moe_qwen3[qwen3-medium]` passes repeatedly
- [x] Root cause documented with the failing component boundary identified
- [x] No tolerance change — the race is fixed at the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)