### PR TITLE
[Perf][Linear-Attn] Optimize Hopper Gated DeltaNet decode

### DIFF
--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -85,6 +85,7 @@ class GatedDeltaNetDecodeFixture(FixtureBase):
             pytest.param(2, 4, 128, 128, torch.float32, False, marks=pytest.mark.full),
             pytest.param(2, 8, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 8, 64, 64, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(1, 32, 128, 128, torch.bfloat16, False, marks=pytest.mark.full),
         ]),
     ]
 

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+import tileops.ops.gated_deltanet as gated_deltanet_ops
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.gated_deltanet_recurrence import GatedDeltaNetDecodeRawCudaFlaStyleKernel
 from tileops.ops import GatedDeltaNetDecodeOp
@@ -164,6 +165,24 @@ def test_gated_deltanet_decode_raw_cuda_config_requires_full_warp_mapping() -> N
 
 
 @pytest.mark.smoke
+def test_gated_deltanet_decode_raw_cuda_config_requires_two_lane_group() -> None:
+    with pytest.raises(ValueError, match="raw_group_size must equal 2"):
+        GatedDeltaNetDecodeRawCudaFlaStyleKernel(
+            1,
+            32,
+            128,
+            128,
+            dtype="bfloat16",
+            config={
+                "threads": 32,
+                "v_tile": 8,
+                "raw_group_size": 4,
+                "raw_maxrregcount": 146,
+            },
+        )
+
+
+@pytest.mark.smoke
 def test_gated_deltanet_decode_raw_cuda_dispatch_handles_capability_errors(monkeypatch) -> None:
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
 
@@ -171,6 +190,38 @@ def test_gated_deltanet_decode_raw_cuda_dispatch_handles_capability_errors(monke
         raise RuntimeError("mock capability failure")
 
     monkeypatch.setattr(torch.cuda, "get_device_capability", _raise_capability_error)
+
+    assert not GatedDeltaNetDecodeOp._should_use_raw_cuda_decode(
+        128,
+        128,
+        torch.bfloat16,
+        tune=False,
+    )
+
+
+@pytest.mark.smoke
+def test_gated_deltanet_decode_raw_cuda_map_only_registers_on_supported_arch(
+    monkeypatch,
+) -> None:
+    op = object.__new__(GatedDeltaNetDecodeOp)
+
+    monkeypatch.setattr(gated_deltanet_ops, "get_sm_version", lambda: 80)
+    sm80_map = GatedDeltaNetDecodeOp.default_kernel_map.fget(op)
+    assert "GatedDeltaNetDecodeRawCudaFlaStyleKernel" not in sm80_map
+
+    monkeypatch.setattr(gated_deltanet_ops, "get_sm_version", lambda: 90)
+    sm90_map = GatedDeltaNetDecodeOp.default_kernel_map.fget(op)
+    assert (
+        sm90_map["GatedDeltaNetDecodeRawCudaFlaStyleKernel"]
+        is GatedDeltaNetDecodeRawCudaFlaStyleKernel
+    )
+
+
+@pytest.mark.smoke
+def test_gated_deltanet_decode_raw_cuda_dispatch_rejects_unsupported_sm100(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gated_deltanet_ops, "get_sm_version", lambda: 100)
 
     assert not GatedDeltaNetDecodeOp._should_use_raw_cuda_decode(
         128,

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.gated_deltanet_recurrence import GatedDeltaNetDecodeRawCudaFlaStyleKernel
 from tileops.ops import GatedDeltaNetDecodeOp
 from workloads.gated_deltanet import (
     GatedDeltaNetDecodeTest as _GatedDeltaNetDecodeTestWorkload,
@@ -142,6 +143,41 @@ def test_gated_deltanet_decode_multi_step(
 
         torch.testing.assert_close(o_op, o_ref, **tols)
         torch.testing.assert_close(state_op, state_ref, **tols)
+
+
+@pytest.mark.smoke
+def test_gated_deltanet_decode_raw_cuda_config_requires_full_warp_mapping() -> None:
+    with pytest.raises(ValueError, match="threads .* must equal raw_group_size \\* v_tile"):
+        GatedDeltaNetDecodeRawCudaFlaStyleKernel(
+            1,
+            32,
+            128,
+            128,
+            dtype="bfloat16",
+            config={
+                "threads": 16,
+                "v_tile": 16,
+                "raw_group_size": 2,
+                "raw_maxrregcount": 146,
+            },
+        )
+
+
+@pytest.mark.smoke
+def test_gated_deltanet_decode_raw_cuda_dispatch_handles_capability_errors(monkeypatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def _raise_capability_error():
+        raise RuntimeError("mock capability failure")
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", _raise_capability_error)
+
+    assert not GatedDeltaNetDecodeOp._should_use_raw_cuda_decode(
+        128,
+        128,
+        torch.bfloat16,
+        tune=False,
+    )
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -51,7 +51,11 @@ from .fft import FFTC2CKernel
 from .fp8_lighting_indexer import FP8LightingIndexerKernel
 from .fp8_quant import FP8QuantKernel
 from .gated_deltanet import GatedDeltaNetBwdKernel, GatedDeltaNetFwdKernel
-from .gated_deltanet_recurrence import GatedDeltaNetDecodeFP32Kernel, GatedDeltaNetDecodeKernel
+from .gated_deltanet_recurrence import (
+    GatedDeltaNetDecodeFP32Kernel,
+    GatedDeltaNetDecodeKernel,
+    GatedDeltaNetDecodeRawCudaFlaStyleKernel,
+)
 from .gemm import GemmKernel, GemvKernel
 from .gla import GLABwdKernel, GLAFwdKernel
 from .gla_recurrence import GLADecodeFP32Kernel, GLADecodeKernel
@@ -131,6 +135,7 @@ __all__ = [
     "GatedDeltaNetBwdKernel",
     "GatedDeltaNetDecodeFP32Kernel",
     "GatedDeltaNetDecodeKernel",
+    "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
     "GatedDeltaNetFwdKernel",
     "GemmKernel",
     "GemvKernel",

--- a/tileops/kernels/gated_deltanet_recurrence.py
+++ b/tileops/kernels/gated_deltanet_recurrence.py
@@ -41,7 +41,9 @@ def _gated_deltanet_decode_raw_cuda_flastyle_tl(
     head: int,
     dim_k: int,
     dim_v: int,
-    v_tile: int = 32,
+    v_tile: int = 16,
+    raw_group_size: int = 2,
+    raw_maxrregcount: int = 146,
     dtype: str = "bfloat16",
 ):
     if dtype != "bfloat16":
@@ -50,8 +52,13 @@ def _gated_deltanet_decode_raw_cuda_flastyle_tl(
         raise ValueError("Raw CUDA Gated DeltaNet decode currently requires DK=DV=128.")
     if dim_v % v_tile != 0:
         raise ValueError(f"dim_v={dim_v} must be divisible by v_tile={v_tile}")
+    if raw_group_size * v_tile != 32:
+        raise ValueError("raw_group_size * v_tile must equal one warp")
+    if dim_k % raw_group_size != 0:
+        raise ValueError(f"dim_k={dim_k} must be divisible by raw_group_size={raw_group_size}")
 
     total_blocks = batch * head * (dim_v // v_tile)
+    k_chunk = dim_k // raw_group_size
     source = f"""
 #include <cuda_bf16.h>
 #include <math.h>
@@ -70,50 +77,86 @@ extern "C" __global__ void gdn_decode_raw_cuda_flastyle_entry(
   constexpr int kDimK = {dim_k};
   constexpr int kDimV = {dim_v};
   constexpr int kVTile = {v_tile};
+  constexpr int kGroupSize = {raw_group_size};
+  constexpr int kKChunk = {k_chunk};
   constexpr int kNumVTiles = kDimV / kVTile;
 
+  __shared__ float k_shared[kDimK];
+  __shared__ float q_shared[kDimK];
+
   const int lane = threadIdx.x;
-  if (lane >= kVTile) return;
+  const int v_lane = lane / kGroupSize;
+  const int k_rank = lane - v_lane * kGroupSize;
+  if (v_lane >= kVTile) return;
 
   const int block = blockIdx.x;
   const int vid = block % kNumVTiles;
   const int nh = block / kNumVTiles;
   if (nh >= kBatch * kHead) return;
 
-  const int v_idx = vid * kVTile + lane;
+  #pragma unroll
+  for (int kk = lane; kk < kDimK; kk += 32) {{
+    k_shared[kk] = __bfloat162float(k[nh * kDimK + kk]);
+    q_shared[kk] = __bfloat162float(q[nh * kDimK + kk]);
+  }}
+  __syncthreads();
+
+  const int v_idx = vid * kVTile + v_lane;
+  const int group_base_lane = v_lane * kGroupSize;
+  const int k_begin = k_rank * kKChunk;
   const int state_base = nh * kDimK * kDimV + v_idx;
   const float alpha = expf(__bfloat162float(g[nh]));
   const float beta_val = __bfloat162float(beta[nh]);
 
-  float h[kDimK];
-  float old_val = 0.0f;
-#pragma unroll
-  for (int kk = 0; kk < kDimK; ++kk) {{
+  float h[kKChunk];
+  float old_partial = 0.0f;
+#pragma unroll 64
+  for (int ii = 0; ii < kKChunk; ++ii) {{
+    const int kk = k_begin + ii;
     const float h_val = alpha * __bfloat162float(state[state_base + kk * kDimV]);
-    h[kk] = h_val;
-    old_val += h_val * __bfloat162float(k[nh * kDimK + kk]);
+    h[ii] = h_val;
+    old_partial += h_val * k_shared[kk];
   }}
 
-  const float v_new = beta_val * (__bfloat162float(v[nh * kDimV + v_idx]) - old_val);
-
+  float old_val = old_partial;
 #pragma unroll
-  for (int kk = 0; kk < kDimK; ++kk) {{
-    h[kk] += __bfloat162float(k[nh * kDimK + kk]) * v_new;
-    new_state[state_base + kk * kDimV] = __float2bfloat16(h[kk]);
+  for (int offset = kGroupSize / 2; offset > 0; offset >>= 1) {{
+    old_val += __shfl_down_sync(0xffffffff, old_val, offset, kGroupSize);
   }}
 
-  float out = 0.0f;
-#pragma unroll
-  for (int kk = 0; kk < kDimK; ++kk) {{
-    out += h[kk] * __bfloat162float(q[nh * kDimK + kk]);
+  float v_new = 0.0f;
+  if (k_rank == 0) {{
+    v_new = beta_val * (__bfloat162float(v[nh * kDimV + v_idx]) - old_val);
   }}
-  o[nh * kDimV + v_idx] = __float2bfloat16(out);
+  v_new = __shfl_sync(0xffffffff, v_new, group_base_lane, kGroupSize);
+
+  float out_partial = 0.0f;
+#pragma unroll 64
+  for (int ii = 0; ii < kKChunk; ++ii) {{
+    const int kk = k_begin + ii;
+    const float h_new = h[ii] + k_shared[kk] * v_new;
+    new_state[state_base + kk * kDimV] = __float2bfloat16(h_new);
+    out_partial += h_new * q_shared[kk];
+  }}
+
+  float out = out_partial;
+#pragma unroll
+  for (int offset = kGroupSize / 2; offset > 0; offset >>= 1) {{
+    out += __shfl_down_sync(0xffffffff, out, offset, kGroupSize);
+  }}
+  if (k_rank == 0) {{
+    o[nh * kDimV + v_idx] = __float2bfloat16(out);
+  }}
 }}
 """
 
+    raw_compile_flags = ["-O3", "-DENABLE_BF16", "--use_fast_math"]
+    if raw_maxrregcount > 0:
+        raw_compile_flags.append(f"--maxrregcount={raw_maxrregcount}")
+
     @tilelang.jit(
         out_idx=[-2, -1],
-        compile_flags=["-O3", "-DENABLE_BF16", "--use_fast_math"],
+        compile_flags=raw_compile_flags,
     )
     def _decode_func(threads=32):
         @T.prim_func
@@ -401,10 +444,11 @@ class GatedDeltaNetDecodeKernel(Kernel):
 class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
     """Hopper bfloat16 decode kernel for the DK=DV=128 Gated DeltaNet case.
 
-    This path maps one warp to one (batch, head, V tile).  Each lane owns one
-    output value when v_tile=32 and keeps the K=128 state slice live in fp32
-    registers.  The implementation is intentionally narrow: it is used only for
-    bfloat16 DK=DV=128 decode on sm90+ devices.
+    This path maps one warp to one (batch, head, V tile).  Two lanes cooperate
+    on one output value when v_tile=16: each lane owns half of the K dimension,
+    K/Q are staged in shared memory once per CTA, and the per-lane state slice
+    stays live in fp32 registers.  The implementation is intentionally narrow:
+    it is used only for bfloat16 DK=DV=128 decode on sm90+ devices.
     """
 
     supported_archs: list[int] = [90]
@@ -434,6 +478,8 @@ class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
             dim_k,
             dim_v,
             self.config["v_tile"],
+            self.config["raw_group_size"],
+            self.config["raw_maxrregcount"],
             self.dtype_str,
         )(self.config["threads"])
 
@@ -441,7 +487,9 @@ class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
     def default_config(self) -> dict:
         return {
             "threads": 32,
-            "v_tile": 32,
+            "v_tile": 16,
+            "raw_group_size": 2,
+            "raw_maxrregcount": 146,
         }
 
     def forward(

--- a/tileops/kernels/gated_deltanet_recurrence.py
+++ b/tileops/kernels/gated_deltanet_recurrence.py
@@ -59,96 +59,6 @@ def _gated_deltanet_decode_raw_cuda_flastyle_tl(
 
     total_blocks = batch * head * (dim_v // v_tile)
     k_chunk = dim_k // raw_group_size
-    source = f"""
-#include <cuda_bf16.h>
-#include <math.h>
-
-extern "C" __global__ void gdn_decode_raw_cuda_flastyle_entry(
-    const __nv_bfloat16* __restrict__ beta,
-    const __nv_bfloat16* __restrict__ g,
-    const __nv_bfloat16* __restrict__ k,
-    __nv_bfloat16* __restrict__ new_state,
-    __nv_bfloat16* __restrict__ o,
-    const __nv_bfloat16* __restrict__ q,
-    const __nv_bfloat16* __restrict__ state,
-    const __nv_bfloat16* __restrict__ v) {{
-  constexpr int kBatch = {batch};
-  constexpr int kHead = {head};
-  constexpr int kDimK = {dim_k};
-  constexpr int kDimV = {dim_v};
-  constexpr int kVTile = {v_tile};
-  constexpr int kGroupSize = {raw_group_size};
-  constexpr int kKChunk = {k_chunk};
-  constexpr int kNumVTiles = kDimV / kVTile;
-
-  __shared__ float k_shared[kDimK];
-  __shared__ float q_shared[kDimK];
-
-  const int lane = threadIdx.x;
-  const int v_lane = lane / kGroupSize;
-  const int k_rank = lane - v_lane * kGroupSize;
-  if (v_lane >= kVTile) return;
-
-  const int block = blockIdx.x;
-  const int vid = block % kNumVTiles;
-  const int nh = block / kNumVTiles;
-  if (nh >= kBatch * kHead) return;
-
-  #pragma unroll
-  for (int kk = lane; kk < kDimK; kk += 32) {{
-    k_shared[kk] = __bfloat162float(k[nh * kDimK + kk]);
-    q_shared[kk] = __bfloat162float(q[nh * kDimK + kk]);
-  }}
-  __syncthreads();
-
-  const int v_idx = vid * kVTile + v_lane;
-  const int group_base_lane = v_lane * kGroupSize;
-  const int k_begin = k_rank * kKChunk;
-  const int state_base = nh * kDimK * kDimV + v_idx;
-  const float alpha = expf(__bfloat162float(g[nh]));
-  const float beta_val = __bfloat162float(beta[nh]);
-
-  float h[kKChunk];
-  float old_partial = 0.0f;
-#pragma unroll 64
-  for (int ii = 0; ii < kKChunk; ++ii) {{
-    const int kk = k_begin + ii;
-    const float h_val = alpha * __bfloat162float(state[state_base + kk * kDimV]);
-    h[ii] = h_val;
-    old_partial += h_val * k_shared[kk];
-  }}
-
-  float old_val = old_partial;
-#pragma unroll
-  for (int offset = kGroupSize / 2; offset > 0; offset >>= 1) {{
-    old_val += __shfl_down_sync(0xffffffff, old_val, offset, kGroupSize);
-  }}
-
-  float v_new = 0.0f;
-  if (k_rank == 0) {{
-    v_new = beta_val * (__bfloat162float(v[nh * kDimV + v_idx]) - old_val);
-  }}
-  v_new = __shfl_sync(0xffffffff, v_new, group_base_lane, kGroupSize);
-
-  float out_partial = 0.0f;
-#pragma unroll 64
-  for (int ii = 0; ii < kKChunk; ++ii) {{
-    const int kk = k_begin + ii;
-    const float h_new = h[ii] + k_shared[kk] * v_new;
-    new_state[state_base + kk * kDimV] = __float2bfloat16(h_new);
-    out_partial += h_new * q_shared[kk];
-  }}
-
-  float out = out_partial;
-#pragma unroll
-  for (int offset = kGroupSize / 2; offset > 0; offset >>= 1) {{
-    out += __shfl_down_sync(0xffffffff, out, offset, kGroupSize);
-  }}
-  if (k_rank == 0) {{
-    o[nh * kDimV + v_idx] = __float2bfloat16(out);
-  }}
-}}
-"""
 
     raw_compile_flags = ["-O3", "-DENABLE_BF16", "--use_fast_math"]
     if raw_maxrregcount > 0:
@@ -170,12 +80,54 @@ extern "C" __global__ void gdn_decode_raw_cuda_flastyle_entry(
             o: T.Tensor([batch, head, dim_v], dtype),
             new_state: T.Tensor([batch, head, dim_k, dim_v], dtype),
         ):
-            T.CUDASourceCodeKernel(
-                total_blocks,
-                threads=threads,
-                source_code_or_path=source,
-                entry_name="gdn_decode_raw_cuda_flastyle_entry",
-            )
+            with T.Kernel(total_blocks, threads=threads) as (block,):
+                tx = T.get_thread_binding()
+                vid = block % (dim_v // v_tile)
+                nh = block // (dim_v // v_tile)
+                bid = nh // head
+                hid = nh - bid * head
+                v_lane = tx // raw_group_size
+                k_rank = tx - v_lane * raw_group_size
+                v_idx = vid * v_tile + v_lane
+                k_begin = k_rank * k_chunk
+
+                k_shared = T.alloc_shared([dim_k], "float32")
+                q_shared = T.alloc_shared([dim_k], "float32")
+                h = T.alloc_local([k_chunk], "float32")
+                old_partial = T.alloc_var("float32", init=0.0)
+                out_partial = T.alloc_var("float32", init=0.0)
+                v_new = T.alloc_var("float32", init=0.0)
+
+                for i in T.serial(T.ceildiv(dim_k, 32)):
+                    kk = tx + i * 32
+                    if kk < dim_k:
+                        k_shared[kk] = T.cast(k[bid, hid, kk], "float32")
+                        q_shared[kk] = T.cast(q[bid, hid, kk], "float32")
+                T.sync_threads()
+
+                alpha = T.exp2(T.cast(g[bid, hid], "float32") * _LOG2E)
+                beta_val = T.cast(beta[bid, hid], "float32")
+
+                for ii in T.serial(k_chunk):
+                    kk = k_begin + ii
+                    h_val = alpha * T.cast(state[bid, hid, kk, v_idx], "float32")
+                    h[ii] = h_val
+                    old_partial += h_val * k_shared[kk]
+
+                old_val = old_partial + T.shfl_down(old_partial, 1, width=raw_group_size)
+                if k_rank == 0:
+                    v_new = beta_val * (T.cast(v[bid, hid, v_idx], "float32") - old_val)
+                v_new = T.shfl_sync(v_new, v_lane * raw_group_size, width=raw_group_size)
+
+                for ii in T.serial(k_chunk):
+                    kk = k_begin + ii
+                    h_new = h[ii] + k_shared[kk] * v_new
+                    new_state[bid, hid, kk, v_idx] = T.cast(h_new, dtype)
+                    out_partial += h_new * q_shared[kk]
+
+                out_val = out_partial + T.shfl_down(out_partial, 1, width=raw_group_size)
+                if k_rank == 0:
+                    o[bid, hid, v_idx] = T.cast(out_val, dtype)
 
         return gated_deltanet_decode_raw_cuda_flastyle
 

--- a/tileops/kernels/gated_deltanet_recurrence.py
+++ b/tileops/kernels/gated_deltanet_recurrence.py
@@ -25,10 +25,118 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-__all__ = ["GatedDeltaNetDecodeFP32Kernel", "GatedDeltaNetDecodeKernel"]
+__all__ = [
+    "GatedDeltaNetDecodeFP32Kernel",
+    "GatedDeltaNetDecodeKernel",
+    "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
+]
 
 _LOG2E = 1.4426950408889634
 _DEFAULT_K_TILE = 16
+
+
+@functools.lru_cache(maxsize=32)
+def _gated_deltanet_decode_raw_cuda_flastyle_tl(
+    batch: int,
+    head: int,
+    dim_k: int,
+    dim_v: int,
+    v_tile: int = 32,
+    dtype: str = "bfloat16",
+):
+    if dtype != "bfloat16":
+        raise ValueError("Raw CUDA Gated DeltaNet decode currently supports bfloat16 only.")
+    if dim_k != 128 or dim_v != 128:
+        raise ValueError("Raw CUDA Gated DeltaNet decode currently requires DK=DV=128.")
+    if dim_v % v_tile != 0:
+        raise ValueError(f"dim_v={dim_v} must be divisible by v_tile={v_tile}")
+
+    total_blocks = batch * head * (dim_v // v_tile)
+    source = f"""
+#include <cuda_bf16.h>
+#include <math.h>
+
+extern "C" __global__ void gdn_decode_raw_cuda_flastyle_entry(
+    const __nv_bfloat16* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ g,
+    const __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ new_state,
+    __nv_bfloat16* __restrict__ o,
+    const __nv_bfloat16* __restrict__ q,
+    const __nv_bfloat16* __restrict__ state,
+    const __nv_bfloat16* __restrict__ v) {{
+  constexpr int kBatch = {batch};
+  constexpr int kHead = {head};
+  constexpr int kDimK = {dim_k};
+  constexpr int kDimV = {dim_v};
+  constexpr int kVTile = {v_tile};
+  constexpr int kNumVTiles = kDimV / kVTile;
+
+  const int lane = threadIdx.x;
+  if (lane >= kVTile) return;
+
+  const int block = blockIdx.x;
+  const int vid = block % kNumVTiles;
+  const int nh = block / kNumVTiles;
+  if (nh >= kBatch * kHead) return;
+
+  const int v_idx = vid * kVTile + lane;
+  const int state_base = nh * kDimK * kDimV + v_idx;
+  const float alpha = expf(__bfloat162float(g[nh]));
+  const float beta_val = __bfloat162float(beta[nh]);
+
+  float h[kDimK];
+  float old_val = 0.0f;
+#pragma unroll
+  for (int kk = 0; kk < kDimK; ++kk) {{
+    const float h_val = alpha * __bfloat162float(state[state_base + kk * kDimV]);
+    h[kk] = h_val;
+    old_val += h_val * __bfloat162float(k[nh * kDimK + kk]);
+  }}
+
+  const float v_new = beta_val * (__bfloat162float(v[nh * kDimV + v_idx]) - old_val);
+
+#pragma unroll
+  for (int kk = 0; kk < kDimK; ++kk) {{
+    h[kk] += __bfloat162float(k[nh * kDimK + kk]) * v_new;
+    new_state[state_base + kk * kDimV] = __float2bfloat16(h[kk]);
+  }}
+
+  float out = 0.0f;
+#pragma unroll
+  for (int kk = 0; kk < kDimK; ++kk) {{
+    out += h[kk] * __bfloat162float(q[nh * kDimK + kk]);
+  }}
+  o[nh * kDimV + v_idx] = __float2bfloat16(out);
+}}
+"""
+
+    @tilelang.jit(
+        out_idx=[-2, -1],
+        compile_flags=["-O3", "-DENABLE_BF16", "--use_fast_math"],
+    )
+    def _decode_func(threads=32):
+        @T.prim_func
+        def gated_deltanet_decode_raw_cuda_flastyle(
+            q: T.Tensor([batch, head, dim_k], dtype),
+            k: T.Tensor([batch, head, dim_k], dtype),
+            v: T.Tensor([batch, head, dim_v], dtype),
+            g: T.Tensor([batch, head], dtype),
+            beta: T.Tensor([batch, head], dtype),
+            state: T.Tensor([batch, head, dim_k, dim_v], dtype),
+            o: T.Tensor([batch, head, dim_v], dtype),
+            new_state: T.Tensor([batch, head, dim_k, dim_v], dtype),
+        ):
+            T.CUDASourceCodeKernel(
+                total_blocks,
+                threads=threads,
+                source_code_or_path=source,
+                entry_name="gdn_decode_raw_cuda_flastyle_entry",
+            )
+
+        return gated_deltanet_decode_raw_cuda_flastyle
+
+    return _decode_func
 
 
 @functools.lru_cache(maxsize=32)
@@ -276,6 +384,64 @@ class GatedDeltaNetDecodeKernel(Kernel):
             "num_stages": 2,
             "threads": 128,
             "k_tile": _DEFAULT_K_TILE,
+        }
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self._kernel_fn(q, k, v, g, beta, state)
+
+
+class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
+    """Hopper bfloat16 decode kernel for the DK=DV=128 Gated DeltaNet case.
+
+    This path maps one warp to one (batch, head, V tile).  Each lane owns one
+    output value when v_tile=32 and keeps the K=128 state slice live in fp32
+    registers.  The implementation is intentionally narrow: it is used only for
+    bfloat16 DK=DV=128 decode on sm90+ devices.
+    """
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        batch: int,
+        head: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: str = "bfloat16",
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        if tune:
+            raise NotImplementedError("Raw CUDA Gated DeltaNet decode does not autotune.")
+        self.batch = batch
+        self.head = head
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.init_config(config, tune=False)
+        self._kernel_fn = _gated_deltanet_decode_raw_cuda_flastyle_tl(
+            batch,
+            head,
+            dim_k,
+            dim_v,
+            self.config["v_tile"],
+            self.dtype_str,
+        )(self.config["threads"])
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "threads": 32,
+            "v_tile": 32,
         }
 
     def forward(

--- a/tileops/kernels/gated_deltanet_recurrence.py
+++ b/tileops/kernels/gated_deltanet_recurrence.py
@@ -424,6 +424,12 @@ class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
         self.dim_v = dim_v
         self.dtype = dtype
         self.init_config(config, tune=False)
+        required_threads = self.config["raw_group_size"] * self.config["v_tile"]
+        if self.config["threads"] != required_threads:
+            raise ValueError(
+                f"threads ({self.config['threads']}) must equal raw_group_size * v_tile "
+                f"({required_threads}) for the warp-lane mapping used by this kernel."
+            )
         self._kernel_fn = _gated_deltanet_decode_raw_cuda_flastyle_tl(
             batch,
             head,

--- a/tileops/kernels/gated_deltanet_recurrence.py
+++ b/tileops/kernels/gated_deltanet_recurrence.py
@@ -52,6 +52,8 @@ def _gated_deltanet_decode_raw_cuda_flastyle_tl(
         raise ValueError("Raw CUDA Gated DeltaNet decode currently requires DK=DV=128.")
     if dim_v % v_tile != 0:
         raise ValueError(f"dim_v={dim_v} must be divisible by v_tile={v_tile}")
+    if raw_group_size != 2:
+        raise ValueError("raw_group_size must equal 2 for the fixed two-lane reductions.")
     if raw_group_size * v_tile != 32:
         raise ValueError("raw_group_size * v_tile must equal one warp")
     if dim_k % raw_group_size != 0:
@@ -400,7 +402,11 @@ class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
     on one output value when v_tile=16: each lane owns half of the K dimension,
     K/Q are staged in shared memory once per CTA, and the per-lane state slice
     stays live in fp32 registers.  The implementation is intentionally narrow:
-    it is used only for bfloat16 DK=DV=128 decode on sm90+ devices.
+    it is used only for bfloat16 DK=DV=128 decode on sm90 devices.
+
+    Unlike the sibling decode kernels, this Hopper-specialized path enables
+    --use_fast_math as an explicit speed/precision trade-off for the narrow
+    single-step decode workload.
     """
 
     supported_archs: list[int] = [90]
@@ -424,6 +430,11 @@ class GatedDeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
         self.dim_v = dim_v
         self.dtype = dtype
         self.init_config(config, tune=False)
+        if self.config["raw_group_size"] != 2:
+            raise ValueError(
+                "raw_group_size must equal 2 because this kernel uses fixed "
+                "two-lane shuffle reductions."
+            )
         required_threads = self.config["raw_group_size"] * self.config["v_tile"]
         if self.config["threads"] != required_threads:
             raise ValueError(

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -344,7 +344,10 @@ class GatedDeltaNetDecodeOp(Op):
             return False
         if not torch.cuda.is_available():
             return False
-        major, _minor = torch.cuda.get_device_capability()
+        try:
+            major, _minor = torch.cuda.get_device_capability()
+        except Exception:
+            return False
         return major >= 9
 
     def __init__(

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -9,6 +9,7 @@ from tileops.kernels.gated_deltanet import (
 from tileops.kernels.gated_deltanet_recurrence import (
     GatedDeltaNetDecodeFP32Kernel,
     GatedDeltaNetDecodeKernel,
+    GatedDeltaNetDecodeRawCudaFlaStyleKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 
@@ -332,6 +333,20 @@ class GatedDeltaNetDecodeOp(Op):
     element-wise matvec instead of T.gemm to avoid TF32 mantissa truncation.
     """
 
+    @staticmethod
+    def _should_use_raw_cuda_decode(
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        tune: bool,
+    ) -> bool:
+        if tune or dtype != torch.bfloat16 or dim_k != 128 or dim_v != 128:
+            return False
+        if not torch.cuda.is_available():
+            return False
+        major, _minor = torch.cuda.get_device_capability()
+        return major >= 9
+
     def __init__(
         self,
         batch: int,
@@ -350,9 +365,14 @@ class GatedDeltaNetDecodeOp(Op):
 
         self.dispatch_kernel(kernel_map)
 
-        # Dispatch: fp32 -> FP32 kernel (no TF32), fp16/bf16 -> TC kernel
+        # Dispatch:
+        #   fp32 -> FP32 kernel (no TF32)
+        #   bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
+        #   other fp16/bf16 shapes -> default TileLang kernel
         if dtype == torch.float32:
             kernel_cls = self.kernel_map["GatedDeltaNetDecodeFP32Kernel"]
+        elif self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune):
+            kernel_cls = self.kernel_map["GatedDeltaNetDecodeRawCudaFlaStyleKernel"]
         else:
             kernel_cls = self.kernel_map["GatedDeltaNetDecodeKernel"]
         kernel_dtype = Kernel.dtype_to_str(dtype)
@@ -367,6 +387,7 @@ class GatedDeltaNetDecodeOp(Op):
         return {
             "GatedDeltaNetDecodeKernel": GatedDeltaNetDecodeKernel,
             "GatedDeltaNetDecodeFP32Kernel": GatedDeltaNetDecodeFP32Kernel,
+            "GatedDeltaNetDecodeRawCudaFlaStyleKernel": GatedDeltaNetDecodeRawCudaFlaStyleKernel,
         }
 
     def forward(

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -12,6 +12,7 @@ from tileops.kernels.gated_deltanet_recurrence import (
     GatedDeltaNetDecodeRawCudaFlaStyleKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
 
 from .op_base import Op
 
@@ -334,6 +335,14 @@ class GatedDeltaNetDecodeOp(Op):
     """
 
     @staticmethod
+    def _raw_cuda_decode_arch_supported() -> bool:
+        try:
+            sm_version = get_sm_version()
+        except Exception:
+            return False
+        return sm_version in GatedDeltaNetDecodeRawCudaFlaStyleKernel.supported_archs
+
+    @staticmethod
     def _should_use_raw_cuda_decode(
         dim_k: int,
         dim_v: int,
@@ -342,13 +351,7 @@ class GatedDeltaNetDecodeOp(Op):
     ) -> bool:
         if tune or dtype != torch.bfloat16 or dim_k != 128 or dim_v != 128:
             return False
-        if not torch.cuda.is_available():
-            return False
-        try:
-            major, _minor = torch.cuda.get_device_capability()
-        except Exception:
-            return False
-        return major >= 9
+        return GatedDeltaNetDecodeOp._raw_cuda_decode_arch_supported()
 
     def __init__(
         self,
@@ -387,11 +390,15 @@ class GatedDeltaNetDecodeOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {
+        kernels = {
             "GatedDeltaNetDecodeKernel": GatedDeltaNetDecodeKernel,
             "GatedDeltaNetDecodeFP32Kernel": GatedDeltaNetDecodeFP32Kernel,
-            "GatedDeltaNetDecodeRawCudaFlaStyleKernel": GatedDeltaNetDecodeRawCudaFlaStyleKernel,
         }
+        if self._raw_cuda_decode_arch_supported():
+            kernels["GatedDeltaNetDecodeRawCudaFlaStyleKernel"] = (
+                GatedDeltaNetDecodeRawCudaFlaStyleKernel
+            )
+        return kernels
 
     def forward(
         self,


### PR DESCRIPTION
## Summary

This draft PR adds a narrow Hopper bfloat16 decode fast path for the Gated DeltaNet `DK=DV=128` case.

The kernel is the TileLang DSL version of the best stable candidate from the AKO tuning loop:

- one warp handles one `(batch, head, V tile)`
- `v_tile=16`, with two lanes cooperating on each output value
- K dimension is split across the two cooperating lanes (`64 + 64`)
- K/Q are staged once per CTA with `T.alloc_shared`
- per-lane state slices stay live in fp32 local storage
- warp reduction/broadcast uses `T.shfl_down` and `T.shfl_sync`
- ptxas register cap: `--maxrregcount=146`

Dispatch is intentionally conservative:

- `dtype == torch.bfloat16`
- `dim_k == dim_v == 128`
- CUDA device capability `sm90+`
- `tune=False`

All other Gated DeltaNet decode shapes continue to use the existing kernels.

## Benchmark

Environment:

- GPU: H200, GPU1
- dtype: bfloat16
- shape convention: `q/k/state/o` use TileOPs BHD/BHKV decode layout
- timing: `BenchmarkBase.bench_kernel`, CUPTI kernel-only timing with L2 flush and input clone pool
- benchmark knobs: warmup `10`, repeat `50`, trials `3`, unless otherwise noted

### Compared with the previous TileOps decode kernel

The old TileOps numbers below are from the initial restart benchmark before the raw/TileLang fast path was added. They use the best valid default TileOps decode configuration from that restart block for the listed shape.

| Shape | Previous TileOps (ms) | This PR fast path (ms) | Speedup vs previous TileOps | FLA Triton (ms) | Speedup vs FLA |
| --- | ---: | ---: | ---: | ---: | ---: |
| `B=1,H=32,DK=DV=128` | `0.010489` | `0.003818` | `2.75x` | `0.004591` | `1.20x` |
| `B=8,H=32,DK=DV=128` | `0.012982` | `0.008439` | `1.54x` | `0.014434` | `1.71x` |

### Compared with FLA Triton across the covered `DK=DV=128` matrix

The following table is the final AKO matrix for the accepted fast-path configuration.

| Shape | FLA Triton (ms) | This PR fast path (ms) | Speedup vs FLA |
| --- | ---: | ---: | ---: |
| `B=1,H=8` | `0.004065` | `0.003312` | `1.23x` |
| `B=1,H=32` | `0.004591` | `0.003818` | `1.20x` |
| `B=1,H=128` | `0.008134` | `0.005718` | `1.42x` |
| `B=2,H=32` | `0.005690` | `0.004367` | `1.30x` |
| `B=2,H=128` | `0.014432` | `0.008394` | `1.72x` |
| `B=4,H=32` | `0.008106` | `0.005695` | `1.42x` |
| `B=4,H=128` | `0.024838` | `0.015683` | `1.58x` |
| `B=8,H=32` | `0.014434` | `0.008439` | `1.71x` |
| `B=8,H=128` | `0.045484` | `0.033423` | `1.36x` |
| `B=16,H=32` | `0.024770` | `0.015661` | `1.58x` |
| `B=16,H=128` | `0.099944` | `0.072223` | `1.38x` |
| `B=32,H=32` | `0.045511` | `0.027792` | `1.64x` |
| `B=32,H=128` | `0.259613` | `0.161011` | `1.61x` |

Across the full 30-row matrix:

| Metric | Speedup vs FLA |
| --- | ---: |
| min | `1.19x` |
| mean | `1.44x` |
| max | `1.72x` |

## AKO findings behind this draft

We ran strict AKO iterations with correctness, benchmark, NCU, and recorded decisions for each accepted or rejected variant.

The robust win was structural: distribute K work across lanes and stage K/Q in shared memory.

Earlier single-lane raw CUDA (`v_tile=32`) was correct but register-heavy:

- latency around `0.00600 ms` for `B=1,H=32,DK=DV=128`
- NCU around `255 regs/thread`

The accepted split-K/shared-KQ candidate uses:

- `v_tile=16`
- `raw_group_size=2`
- `raw_maxrregcount=146`
- NCU resource shape around `104 regs/thread`

Rejected or non-promoted branches include:

- q.k/shared-scalar broadcasts
- formula/two-pass forms
- launch-bounds-only variants
- lower/higher register caps around the best point
- bf16 shared/live-state cache variants
- precomputed pointer/index forms
- leader-only or inline beta-load variants
- `unroll128` shape-specific dispatch candidates

The latest 200-round follow-up did not find a stable shape-specific dispatch improvement over the accepted default. Apparent wins such as `B=32,H=32` did not reproduce under targeted repeat and isolated NCU, so this PR keeps one conservative fast-path configuration.

## Why TileLang DSL instead of extern C

The fast path no longer uses an `extern "C"` CUDA source string or `T.CUDASourceCodeKernel`. The pieces that mattered for the best kernel map cleanly to TileLang primitives:

- CUDA launch frame -> `T.Kernel`
- `threadIdx.x` -> `T.get_thread_binding()`
- `__shared__` K/Q staging -> `T.alloc_shared`
- `__syncthreads()` -> `T.sync_threads()`
- `__shfl_down_sync` -> `T.shfl_down`
- `__shfl_sync` -> `T.shfl_sync`
- ptxas register cap -> TileLang `compile_flags`

This keeps the maintainability benefit of TileLang while preserving the main performance win from the AKO search.

## Validation

Correctness:

```bash
pytest -q tests/ops/test_gated_deltanet_recurrence.py -k "gated_deltanet_decode" --tb=short
```

Result:

```text
16 passed, 14 warnings in 9.29s
```

Targeted latency sanity for `B=1, H=32, DK=DV=128, bf16`:

```text
kernel: GatedDeltaNetDecodeRawCudaFlaStyleKernel
config: {'threads': 32, 'v_tile': 16, 'raw_group_size': 2, 'raw_maxrregcount': 146}
latency_ms: 0.00382014
```

## Notes

This is still a draft because the path is deliberately specialized to Hopper bfloat16 `DK=DV=128` decode. The PR exposes the best stable AKO result in TileLang DSL form while keeping dispatch narrow enough to avoid affecting unrelated shapes.