### PR TITLE
[CI] use 1500 MHz GPU clock validation for H200 runners

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -542,7 +542,7 @@ jobs:
       - name: Validate GPU frequency
         run: |
           set -euo pipefail
-          TARGET_CLOCK_MHZ=1830
+          TARGET_CLOCK_MHZ=1500
           RETRIES=5
           SLEEP_SECONDS=2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
           source "${VENV_PATH}/bin/activate"
 
           # Validate GPU frequency
-          TARGET_CLOCK_MHZ=1830
+          TARGET_CLOCK_MHZ=1500
           RETRIES=5
           for i in $(seq 1 "${RETRIES}"); do
             gpu_clock=$(nvidia-smi --query-gpu=clocks.current.graphics --format=csv,noheader,nounits | xargs)
@@ -362,7 +362,7 @@ jobs:
           source "${VENV_PATH}/bin/activate"
 
           # Validate GPU frequency
-          TARGET_CLOCK_MHZ=1830
+          TARGET_CLOCK_MHZ=1500
           RETRIES=5
           for i in $(seq 1 "${RETRIES}"); do
             gpu_clock=$(nvidia-smi --query-gpu=clocks.current.graphics --format=csv,noheader,nounits | xargs)


### PR DESCRIPTION
## Summary

- lower the GPU clock validation target from `1830 MHz` to `1500 MHz`
- update both nightly validation points and the gpu-smoke validation point

## Context

H200 runners on the current 700W power limit cannot reliably sustain a locked `1830 MHz` graphics/SM clock under full load. A nominal `1830 MHz` lock can still be pulled down by power limiting, which defeats the goal of stable benchmark/control frequency validation.

`1500 MHz` is a more realistic sustained locked-clock target for these H200 self-hosted runners.

Fixes #1587

## Testing

- Verified the workflow files no longer contain `TARGET_CLOCK_MHZ=1830`.
- Not run: CI workflow execution, because this is a YAML target-value-only change.
