### PR TITLE
[Perf][moe] Speed up MoE permute-gather and unpermute kernels

### DIFF
--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -102,6 +102,11 @@ class MoePermuteNopadFixture(FixtureBase):
             pytest.param(4,  2, 4, 64,  torch.bfloat16, marks=pytest.mark.smoke, id="tiny-bf16"),
             pytest.param(4,  2, 4, 64,  torch.float16,  marks=pytest.mark.smoke, id="tiny-fp16"),
             pytest.param(16, 2, 8, 128, torch.bfloat16, marks=pytest.mark.full,  id="small"),
+            # numel = total_tokens * top_k = 10 is NOT a multiple of the gather
+            # kernel's ROWS_PER_BLOCK (8), so the last block's `if slot < numel`
+            # out-of-bounds guard is actually exercised — every other shape here
+            # has numel divisible by 8 and never hits the partial tail.
+            pytest.param(5,  2, 4, 64,  torch.bfloat16, marks=pytest.mark.full,  id="partial-tail-numel10"),
         ]),
     ]
 

--- a/tests/ops/test_moe_unpermute.py
+++ b/tests/ops/test_moe_unpermute.py
@@ -68,6 +68,13 @@ class MoeUnpermuteFixture(FixtureBase):
             pytest.param(1,    2,   64,  torch.bfloat16, marks=pytest.mark.full,  id="single-token"),
             pytest.param(8,    1,   64,  torch.bfloat16, marks=pytest.mark.full,  id="top-k-1"),
             pytest.param(32,   4,   64,  torch.bfloat16, marks=pytest.mark.full,  id="skewed"),
+            # Large H (8x the next-biggest case) with top_k=8 so the K-loop is
+            # actually pipelined (T.Pipelined num_stages=2): asserts correctness
+            # at a production-scale hidden size, where the framework must
+            # double-buffer the reused `src` fragment to avoid a WAR race
+            # between load(k+1) and accumulate(k). Smaller cases (H<=256) leave
+            # that on the benchmark path only.
+            pytest.param(64,   8,   2048, torch.bfloat16, marks=pytest.mark.full, id="large-h-pipeline"),
         ]),
     ]
 
@@ -115,6 +122,41 @@ def test_moe_unpermute_skewed():
         f"skewed mismatch: max_err={(output.float() - output_ref.float()).abs().max()}"
     )
     print("PASS skewed (all slots → first K padded positions)")
+
+
+@pytest.mark.smoke
+def test_moe_unpermute_ep_masking():
+    """EP mode: fwd_idx == -1 (non-local expert) must contribute zero, even
+    inside the pipelined K-loop (the slot-0 dummy read is zeroed by weight=0).
+
+    The shared `_ref_moe_unpermute` would index `mm2_pad[-1]` for a -1 slot, so
+    this test uses a reference that skips -1 — matching the kernel's masking.
+    """
+    torch.manual_seed(0)
+    T, K, H = 16, 4, 256
+    numel = T * K
+    dev = "cuda"
+    mm2_pad = torch.randn(numel, H, dtype=torch.bfloat16, device=dev) * 0.02
+    fwd_idx = torch.randperm(numel, device=dev).to(torch.int32)
+    fwd_idx[::3] = -1  # mark every 3rd slot non-local
+    assert (fwd_idx < 0).any(), "test must actually inject -1 slots"
+    topk_weights = torch.rand(T, K, dtype=torch.float32, device=dev)
+
+    op = MoeUnpermuteFwdOp(T, K, H, torch.bfloat16, padded_batch_sum=numel)
+    output = op(mm2_pad, fwd_idx, topk_weights)
+
+    # Reference matching the kernel's -1 semantics: skip non-local slots.
+    ref = torch.zeros(T, H, dtype=torch.float32, device=dev)
+    for i in range(T):
+        for k in range(K):
+            slot = int(fwd_idx[i * K + k].item())
+            if slot >= 0:
+                ref[i] += mm2_pad[slot].float() * topk_weights[i, k].item()
+
+    assert torch.allclose(output.float(), ref, atol=1e-2), (
+        f"EP -1 masking mismatch: max_err={(output.float() - ref).abs().max()}"
+    )
+    print("PASS ep-masking (fwd_idx=-1 contributes zero inside pipeline)")
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/moe/permute_nopad.py
+++ b/tileops/kernels/moe/permute_nopad.py
@@ -205,14 +205,22 @@ def _make_scan_kernel_nopad_ep(
 def _make_gather_kernel_nopad(num_tokens: int, numel: int, hidden_size: int, dtype: str):
     """Phase 2: gather hidden_states rows into perm_h at tight positions.
 
-    One block per slot. Each thread handles 8 elements (128-bit uint4 load/store).
-    threads = hidden_size // 8, capped at 1024.
+    ``ROWS_PER_BLOCK`` slots per block (each thread handles 8 elements via a
+    128-bit uint4 load/store). Grouping slots per block amortizes the launch /
+    scheduling overhead of the one-block-per-slot layout, which dominated at
+    prefill scale (numel up to ~32K blocks): on H200 this cut the gather from
+    1.30x to 1.06x the HBM-bandwidth floor (~17% faster, matching torch's
+    advanced-index gather). ROWS_PER_BLOCK=8 is the sweep optimum; >=32 degrades
+    (too few blocks). threads = hidden_size // 8, capped at 1024.
     """
     VEC = 8
     threads = min(1024, hidden_size // VEC)
     while threads > 0 and hidden_size % threads != 0:
         threads -= 1
     threads = max(threads, 1)
+
+    ROWS_PER_BLOCK = 8
+    grid = (numel + ROWS_PER_BLOCK - 1) // ROWS_PER_BLOCK
 
     @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
     def _gather():
@@ -223,10 +231,14 @@ def _make_gather_kernel_nopad(num_tokens: int, numel: int, hidden_size: int, dty
             permuted_idx: T.Tensor([numel], "int32"),                   # noqa: F821
             perm_h: T.Tensor([numel, hidden_size], dtype),              # noqa: F821
         ):
-            with T.Kernel(numel, threads=threads) as (slot,):
-                frag = T.alloc_fragment([hidden_size], dtype)
-                T.copy(hidden_states[permuted_idx[slot], 0:hidden_size], frag)
-                T.copy(frag, perm_h[slot, 0:hidden_size])
+            with T.Kernel(grid, threads=threads) as (bid,):
+                for r in T.serial(ROWS_PER_BLOCK):
+                    slot = bid * ROWS_PER_BLOCK + r
+                    if slot < numel:
+                        # Direct global->global vectorized copy (no register-fragment
+                        # round-trip; TileLang lowers both identically).
+                        T.copy(hidden_states[permuted_idx[slot], 0:hidden_size],
+                               perm_h[slot, 0:hidden_size])
 
         return _gather_main
 

--- a/tileops/kernels/moe/unpermute.py
+++ b/tileops/kernels/moe/unpermute.py
@@ -43,11 +43,10 @@ def _make_unpermute_kernel(
     Each thread handles VEC=8 elements (128-bit uint4 load/store).
     Accumulation in float32, cast to dtype on store.
     """
-    VEC = 8  # 8 x bf16/fp16 = 128 bits
-    threads = min(1024, hidden_size // VEC)
-    if threads > 0:
-        threads = 1 << (threads.bit_length() - 1)
-    threads = max(threads, 1)
+    # threads=256 is the sweep optimum for the per-token-block reduction: it
+    # balances per-thread ILP against occupancy. 512 is ~3% slower and 1024
+    # spills the fp32 acc[H] accumulator into local memory (H200, H=7168).
+    threads = min(256, hidden_size)
 
     numel = num_tokens * top_k
 
@@ -69,8 +68,10 @@ def _make_unpermute_kernel(
                 # zero accumulator
                 T.fill(acc, 0.0)
 
-                # accumulate K expert contributions
-                for k in T.serial(top_k):
+                # accumulate K expert contributions. Software-pipeline the
+                # gathers (num_stages=2) so each scattered row load overlaps the
+                # previous slot's accumulate — the K loads are latency-bound.
+                for k in T.Pipelined(top_k, num_stages=2):
                     flat_idx = token_idx * T.int32(top_k) + k
                     raw_slot = fwd_idx[flat_idx]
                     # EP mode: fwd_idx == -1 marks non-local expert → zero contribution.

--- a/tileops/kernels/moe/unpermute.py
+++ b/tileops/kernels/moe/unpermute.py
@@ -38,10 +38,13 @@ def _make_unpermute_kernel(
     dtype: str,
     scaling: float = 1.0,
 ):
-    """One block per token. Threads cooperate over H dimension.
+    """One block per token; threads cooperate over the H dimension.
 
-    Each thread handles VEC=8 elements (128-bit uint4 load/store).
-    Accumulation in float32, cast to dtype on store.
+    Threads are capped at 256 (see below), so each thread handles ceil(H /
+    threads) elements: a clean multiple of VEC=8 (128-bit uint4 load/store)
+    when H // threads is, otherwise partially vectorized (e.g. H=7168 -> 256
+    threads -> 28 elems/thread = 3.5x VEC). Accumulation is in float32, cast to
+    dtype on store.
     """
     # Cap threads at 256 (the sweep optimum at H=7168: 512 is ~3% slower and
     # 1024 spills the fp32 acc[H] accumulator to local memory) but scale with

--- a/tileops/kernels/moe/unpermute.py
+++ b/tileops/kernels/moe/unpermute.py
@@ -43,10 +43,16 @@ def _make_unpermute_kernel(
     Each thread handles VEC=8 elements (128-bit uint4 load/store).
     Accumulation in float32, cast to dtype on store.
     """
-    # threads=256 is the sweep optimum for the per-token-block reduction: it
-    # balances per-thread ILP against occupancy. 512 is ~3% slower and 1024
-    # spills the fp32 acc[H] accumulator into local memory (H200, H=7168).
-    threads = min(256, hidden_size)
+    # Cap threads at 256 (the sweep optimum at H=7168: 512 is ~3% slower and
+    # 1024 spills the fp32 acc[H] accumulator to local memory) but scale with
+    # hidden_size // VEC and keep power-of-2 alignment, so small hidden sizes
+    # retain 128-bit (VEC=8) vectorized load/store instead of slow scalar 16-bit
+    # ops (e.g. H=512 -> 64 threads of 8 elems each, ~14% faster than 256).
+    VEC = 8  # 8 x bf16/fp16 = 128 bits
+    threads = min(256, hidden_size // VEC)
+    if threads > 0:
+        threads = 1 << (threads.bit_length() - 1)
+    threads = max(threads, 1)
 
     numel = num_tokens * top_k
 
@@ -71,7 +77,9 @@ def _make_unpermute_kernel(
                 # accumulate K expert contributions. Software-pipeline the
                 # gathers (num_stages=2) so each scattered row load overlaps the
                 # previous slot's accumulate — the K loads are latency-bound.
-                for k in T.Pipelined(top_k, num_stages=2):
+                # Serial fallback when top_k < 2 (pipeline depth > trip count).
+                for k in (T.Pipelined(top_k, num_stages=2)
+                          if top_k >= 2 else T.serial(top_k)):
                     flat_idx = token_idx * T.int32(top_k) + k
                     raw_slot = fwd_idx[flat_idx]
                     # EP mode: fwd_idx == -1 marks non-local expert → zero contribution.


### PR DESCRIPTION
## Summary

Optimizes two memory-bound MoE token-movement kernels — the permute **gather**
(phase 2 of `MoePermuteNopadKernel`) and **unpermute** (`MoeUnpermuteKernel`).
Both are pure data movement; the goal is to push each toward the HBM-bandwidth
floor. Kernel logic is unchanged (EP `-1` masking and `routed_scaling_factor`
preserved) — only the launch/iteration structure changes.

## What changed

**1. permute gather — group rows per block (`ROWS_PER_BLOCK = 8`)**

The baseline launched one block per output slot (`numel` blocks, ~32K at prefill
scale), each copying a single 14 KB row. That left the kernel dominated by block
launch/scheduling overhead rather than bandwidth. Grouping 8 slots per block
amortizes it (and a sweep confirms 8 is the optimum; ≥32 degrades as blocks get
too few). The register-fragment round-trip was also dropped for a direct
`global→global` copy (TileLang lowers both identically).

**2. unpermute — pipeline the K gathers + `threads=256`**

Each token block does `top_k` scattered row gathers then an fp32 weighted reduce;
the gathers are latency-bound. Software-pipelining them (`T.Pipelined`,
`num_stages=2`) overlaps each load with the previous slot's accumulate.
`threads=256` is the sweep optimum — 512 is ~3% slower and 1024 spills the
`fp32 acc[H]` accumulator into local memory.

## Benchmark (H200, SM clock-locked 1500 MHz, bf16, T=4096, H=7168)

| kernel | before | after | speedup | vs HBM floor |
| --- | --- | --- | --- | --- |
| permute gather | 0.255 ms | **0.212 ms** | **1.20×** | 1.30× → **1.08×** |
| permute (full: scan+gather) | 0.317 ms | **0.276 ms** | 1.15× | — |
| unpermute | 0.150 ms | **0.138 ms** | **1.09×** | 1.25× (1.06–1.17× random-access-adjusted) |

HBM floor = bytes moved / 4.8 TB/s. For unpermute the naive floor (0.110 ms)
understates the real one: a measured **1.20× random-access penalty** on the
scattered row reads puts the achievable floor at ~0.118–0.130 ms, so 0.138 ms is
already 1.06–1.17× of it.

## Comparison vs PyTorch

- **gather** — reference is `hidden[permuted_idx]` (torch advanced-index gather),
  which sits at ~0.206 ms (1.05× floor). The baseline kernel was **0.82×** torch
  (slower); after grouping rows it **matches torch** (0.212 vs 0.206 ms) and the
  output is bit-exact (`torch.equal`).
- **unpermute** — the torch reference (`mm2[fwd_idx].view(T,K,H) * w` then
  `.sum(1)`) materializes the `[T, K, H]` gather and runs ~2.09 ms, i.e. the
  kernel is **~14× faster**; that reference is only a correctness oracle, so the
  kernel is ranked against the bandwidth floor rather than torch.

## Correctness

Logic is unchanged. Verified:
- `tests/ops/test_moe_permute_nopad.py` + `tests/ops/test_moe_unpermute.py` — 15 passed (incl. EP `expert_map` and `scaling` paths).
- Full MoE sweep (`test_fused_moe_experts`, `test_moe_fused_moe`, `test_moe_shared_fused_moe`, + the two above) — 77 passed, no hang.
- Pre-commit (gitleaks/ruff/codespell), `validate_manifest`, and a no-CJK scan on the changed files all pass.

## Test coverage (review follow-up)

Added cases for the new logic that the existing shapes never exercised:

- **gather OOB guard** — permute shape `numel=10` (not a multiple of `ROWS_PER_BLOCK=8`), so the last block's `if slot < numel` guard actually runs (all prior shapes had `numel % 8 == 0`).
- **pipeline correctness at scale** — unpermute `H=2048, top_k=8` so `T.Pipelined`'s `src` double-buffering is asserted at a production-scale hidden size (prior max H was 256; H=7168 was benchmark-only).
- **EP masking inside the pipeline** — unpermute `fwd_idx=-1` injection with a reference that skips `-1`, covering the masked dummy-read path now running in the pipelined K-loop.

`scripts/test_node_delta.py` vs `origin/main`:

| File | Base | HEAD | Delta |
| --- | --- | --- | --- |
| tests/ops/test_moe_permute_nopad.py | 3 | 4 | +1 |
| tests/ops/test_moe_unpermute.py | 12 | 14 | +2 |
| **TOTAL** | 15 | 18 | **+3 (+20%)** |

Each new node traces to a specific new code path (tail OOB guard / pipeline `src` buffering at production H / EP `-1` mask) — not combinatorial padding.
