### PR TITLE
[CI] Publish nightly benchmark data to nightly-bench branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -334,6 +334,75 @@ jobs:
         shell: bash
 
   # =========================================================================
+  # Phase 3b — Publish benchmark data to the nightly-bench orphan branch
+  # Consumed by tile-ai/TileOPs.github.io to render the docs Benchmarks page.
+  # Runs on a github-hosted runner (no GPU needed) and uses the default token
+  # to force-push the day's XML snapshot, mirroring the manifest-stats pattern.
+  # =========================================================================
+  publish-bench-data:
+    if: ${{ always() && github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
+    needs: [op_test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Download benchmark artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tileops_benchmark_${{ github.run_id }}
+          path: _bench
+        continue-on-error: true
+
+      - name: Download op test artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tileops_op_test_${{ github.run_id }}
+          path: _optest
+        continue-on-error: true
+
+      - name: Assemble publish payload
+        id: assemble
+        run: |
+          set -euo pipefail
+          mkdir -p _publish
+          ok=1
+          if [ -f _bench/bench_results.xml ]; then
+            cp _bench/bench_results.xml _publish/bench_results.xml
+          else
+            echo "::warning::bench_results.xml missing; skipping nightly-bench publish"
+            ok=0
+          fi
+          if [ -f _optest/test_results.xml ]; then
+            cp _optest/test_results.xml _publish/test_results.xml
+          else
+            echo "::warning::test_results.xml missing; page will render without test status"
+          fi
+          if [ "$ok" -eq 1 ]; then
+            run_date="$(date -u +%Y-%m-%d)"
+            printf '{\n  "commit": "%s",\n  "date": "%s",\n  "gpu": "NVIDIA H200",\n  "run_id": "%s"\n}\n' \
+              "${GITHUB_SHA}" "${run_date}" "${GITHUB_RUN_ID}" > _publish/meta.json
+          fi
+          echo "ok=${ok}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Publish to nightly-bench branch
+        if: ${{ steps.assemble.outputs.ok == '1' }}
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: nightly-bench
+          publish_dir: _publish
+          force_orphan: true
+          commit_message: "chore(bench): nightly benchmark data from ${{ github.sha }}"
+          user_name: "github-actions[bot]"
+          user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+
+  # =========================================================================
   # Phase 4 — Packaging and smoke test
   # =========================================================================
   packaging:


### PR DESCRIPTION
## Summary

- Add a `publish-bench-data` job to the nightly workflow that collects the run's `bench_results.xml` + `test_results.xml` and a small `meta.json` (commit/date/gpu/run_id), then force-pushes them to a new `nightly-bench` orphan branch.
- Uses the default `GITHUB_TOKEN` and `peaceiris/actions-gh-pages@v4 force_orphan` — the same pattern as the existing manifest-stats publish job. No PAT/secret required.
- Runs on a github-hosted `ubuntu-latest` runner (`needs: [op_test]`), so it never occupies the GPU nightly runner.

This branch is the public data contract consumed by `tile-ai/TileOPs.github.io` to render the docs Benchmarks page; the docs site fetches it over public `raw.githubusercontent.com`, so no cross-repo token is needed in either direction.

## Test plan

- [x] pre-commit passed
- [x] `nightly.yml` validated with `yaml.safe_load`
- [ ] After merge: `workflow_dispatch` one nightly run and confirm the `nightly-bench` branch is created with the three files