### PR TITLE
[Bench][MOE] Reduce nightly benchmark OOM risk

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,6 +78,10 @@ jobs:
     needs: [cache-warmup]
     timeout-minutes: 120
     runs-on: [self-hosted, tile-ops, nightly]
+    env:
+      # Keep the long benchmark suite from fragmenting CUDA allocator segments
+      # before late large MoE input tensors allocate 14-21 GiB weight blocks.
+      PYTORCH_ALLOC_CONF: expandable_segments:True
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 import torch
 
@@ -64,6 +66,13 @@ def _is_fp8_e4m3_benchmark(item: pytest.Item) -> bool:
     return callspec.params.get("dtype") == torch.float8_e4m3fn
 
 
+def _release_cuda_cache_after_case() -> None:
+    """Drop per-case Python references and cached CUDA blocks between benchmarks."""
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 @pytest.fixture(autouse=True)
 def setup() -> None:
     torch.manual_seed(1235)
@@ -116,65 +125,67 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 def pytest_runtest_call(item):
     """After bench test execution, attach perf data to the item as properties."""
     _bench_results.entries = []
-    yield
-    entries = getattr(_bench_results, "entries", [])
-    if not entries:
-        return
+    try:
+        yield
+        entries = getattr(_bench_results, "entries", [])
+        if not entries:
+            return
 
-    # Separate tileops entry (tag starts with "tileops") from baselines.
-    tileops_entry = None
-    baseline_entries = []
-    for e in entries:
-        if e["tag"].startswith("tileops"):
-            if tileops_entry is None:
-                tileops_entry = e
-        else:
-            baseline_entries.append(e)
+        # Separate tileops entry (tag starts with "tileops") from baselines.
+        tileops_entry = None
+        baseline_entries = []
+        for e in entries:
+            if e["tag"].startswith("tileops"):
+                if tileops_entry is None:
+                    tileops_entry = e
+            else:
+                baseline_entries.append(e)
 
-    if tileops_entry:
-        item.user_properties.append(("op", tileops_entry["op"]))
-        if "op_module" in tileops_entry:
-            item.user_properties.append(("op_module", tileops_entry["op_module"]))
-        tag = tileops_entry["tag"]
-        if tag != "tileops" and tag.startswith("tileops_"):
-            item.user_properties.append(("tileops_variant", tag[len("tileops_"):]))
-        item.user_properties.append(("tileops_latency_ms",
-                                     f"{tileops_entry.get('latency_ms', 0):.4f}"))
-        tflops = tileops_entry.get("tflops")
-        if tflops is not None:
-            item.user_properties.append(("tileops_tflops", f"{tflops:.2f}"))
-        bw = tileops_entry.get("bandwidth_tbs")
-        if bw is not None:
-            item.user_properties.append(("tileops_bandwidth_tbs", f"{bw:.2f}"))
+        if tileops_entry:
+            item.user_properties.append(("op", tileops_entry["op"]))
+            if "op_module" in tileops_entry:
+                item.user_properties.append(("op_module", tileops_entry["op_module"]))
+            tag = tileops_entry["tag"]
+            if tag != "tileops" and tag.startswith("tileops_"):
+                item.user_properties.append(("tileops_variant", tag[len("tileops_"):]))
+            item.user_properties.append(("tileops_latency_ms",
+                                         f"{tileops_entry.get('latency_ms', 0):.4f}"))
+            tflops = tileops_entry.get("tflops")
+            if tflops is not None:
+                item.user_properties.append(("tileops_tflops", f"{tflops:.2f}"))
+            bw = tileops_entry.get("bandwidth_tbs")
+            if bw is not None:
+                item.user_properties.append(("tileops_bandwidth_tbs", f"{bw:.2f}"))
 
-    # Write all baselines into JUnit XML properties.
-    # The first baseline uses the legacy unprefixed names (baseline_tag, etc.)
-    # for backward compatibility.  Additional baselines use "{tag}_latency_ms",
-    # "{tag}_tflops", "{tag}_ratio" so the report can display multiple columns.
-    for idx, be in enumerate(baseline_entries):
-        tag = be["tag"]
-        bl_latency = be.get("latency_ms", 0)
-        bl_tflops = be.get("tflops")
+        # Write all baselines into JUnit XML properties.
+        # The first baseline uses the legacy unprefixed names (baseline_tag, etc.)
+        # for backward compatibility.  Additional baselines use "{tag}_latency_ms",
+        # "{tag}_tflops", "{tag}_ratio" so the report can display multiple columns.
+        for idx, be in enumerate(baseline_entries):
+            tag = be["tag"]
+            bl_latency = be.get("latency_ms", 0)
+            bl_tflops = be.get("tflops")
 
-        if idx == 0:
-            # Legacy unprefixed keys — consumed by existing nightly_report.py
-            item.user_properties.append(("baseline_tag", tag))
-            item.user_properties.append(("baseline_latency_ms", f"{bl_latency:.4f}"))
+            if idx == 0:
+                # Legacy unprefixed keys — consumed by existing nightly_report.py
+                item.user_properties.append(("baseline_tag", tag))
+                item.user_properties.append(("baseline_latency_ms", f"{bl_latency:.4f}"))
+                if bl_tflops is not None:
+                    item.user_properties.append(("baseline_tflops", f"{bl_tflops:.2f}"))
+                if tileops_entry:
+                    tl = tileops_entry.get("latency_ms", 0)
+                    if tl > 0 and bl_latency > 0:
+                        item.user_properties.append(("baseline_ratio",
+                                                     f"{bl_latency / tl:.4f}"))
+
+            # Tag-prefixed keys — always written for every baseline
+            item.user_properties.append((f"{tag}_latency_ms", f"{bl_latency:.4f}"))
             if bl_tflops is not None:
-                item.user_properties.append(("baseline_tflops", f"{bl_tflops:.2f}"))
+                item.user_properties.append((f"{tag}_tflops", f"{bl_tflops:.2f}"))
             if tileops_entry:
                 tl = tileops_entry.get("latency_ms", 0)
                 if tl > 0 and bl_latency > 0:
-                    item.user_properties.append(("baseline_ratio",
-                                                 f"{bl_latency / tl:.4f}"))
-
-        # Tag-prefixed keys — always written for every baseline
-        item.user_properties.append((f"{tag}_latency_ms", f"{bl_latency:.4f}"))
-        if bl_tflops is not None:
-            item.user_properties.append((f"{tag}_tflops", f"{bl_tflops:.2f}"))
-        if tileops_entry:
-            tl = tileops_entry.get("latency_ms", 0)
-            if tl > 0 and bl_latency > 0:
-                item.user_properties.append((f"{tag}_ratio", f"{bl_latency / tl:.4f}"))
-
-    _bench_results.entries = []
+                    item.user_properties.append((f"{tag}_ratio", f"{bl_latency / tl:.4f}"))
+    finally:
+        _bench_results.entries = []
+        _release_cuda_cache_after_case()


### PR DESCRIPTION
## Summary

- Set `PYTORCH_ALLOC_CONF=expandable_segments:True` for the nightly benchmark job so PyTorch can grow CUDA allocator segments during the long benchmark suite.
- Release Python references and cached CUDA blocks after each benchmark case in `benchmarks/conftest.py` to reduce accumulated memory pressure before large MoE input tensors allocate.

Closes #1592

## Test plan

- [x] `python -m py_compile benchmarks/conftest.py`
- [x] `python - <<'PY' ... yaml.safe_load('.github/workflows/nightly.yml') ... PY`
- [x] commit/push hooks passed: yaml, python ast, ruff, codespell, and related pre-commit checks
- [ ] Nightly workflow dispatch on this PR/head branch validates full benchmark behavior on CI

## Benchmark

Not run locally by request. The intended validation is a manually dispatched Nightly workflow on the self-hosted H200 runner.

## Regression

This keeps the existing single-process nightly benchmark command and only changes allocator configuration plus post-case cleanup. The main residual risk is that the OOM is caused by truly live allocations rather than allocator fragmentation/cache retention; the manually dispatched Nightly run should confirm whether this mitigation is sufficient.