### PR TITLE
[Feat][Pool] Align avg pool forward ops with manifest

### DIFF
--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -1,3 +1,11 @@
+"""Average-pooling benchmarks.
+
+Workloads are loaded from ``tileops/manifest/pool.yaml``. The 2D cases model
+vision-backbone downsampling patterns such as ResNet/ConvNeXt feature stages.
+The 3D cases model video CNN spatiotemporal pooling patterns such as
+I3D/SlowFast-style feature stages.
+"""
+
 from typing import Optional
 
 import pytest
@@ -7,9 +15,11 @@ import torch.nn.functional as F
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.manifest import load_workloads
-from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
+from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 _AVG_POOL1D_OP_NAME = "AvgPool1dFwdOp"
+_AVG_POOL2D_OP_NAME = "AvgPool2dFwdOp"
+_AVG_POOL3D_OP_NAME = "AvgPool3dFwdOp"
 
 
 class AvgPool1dBenchCase:
@@ -169,7 +179,9 @@ class AvgPool2dBenchCase:
         self.dtype = dtype
 
     def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(self.n, self.h_in, self.w_in, self.c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(
+            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
+        ).contiguous()
         return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
@@ -186,29 +198,62 @@ class AvgPool2dBenchCase:
 
 class AvgPool2dBenchmark(BenchmarkBase[AvgPool2dBenchCase]):
 
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: AvgPool2dBenchCase, op: AvgPool2dFwdOp) -> None:
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        out_h = pool_output_dim(t.h_in, t.kernel_size[0], t.stride[0], t.padding[0], t.ceil_mode)
-        out_w = pool_output_dim(t.w_in, t.kernel_size[1], t.stride[1], t.padding[1], t.ceil_mode)
-        return t.n * t.c_in * out_h * out_w * t.kernel_size[0] * t.kernel_size[1]
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        out_h = pool_output_dim(t.h_in, t.kernel_size[0], t.stride[0], t.padding[0], t.ceil_mode)
-        out_w = pool_output_dim(t.w_in, t.kernel_size[1], t.stride[1], t.padding[1], t.ceil_mode)
-        return (t.n * t.c_in * t.h_in * t.w_in + t.n * t.c_in * out_h * out_w) * t.dtype.itemsize
+        return self._get_roofline()[1]
 
 
-_AVG_POOL2D_BENCH_PARAMS = [
-    pytest.param(2, 64, 112, 112, (3, 3), (2, 2), (1, 1), False, True, None, torch.float16, True, id="vision-3x3-s2"),
-    pytest.param(2, 128, 56, 56, (5, 5), (2, 2), (2, 2), False, True, None, torch.float16, True, id="vision-5x5-s2"),
-    pytest.param(3, 96, 55, 57, (3, 5), (2, 2), (1, 2), True, False, 7, torch.bfloat16, True, id="ceil-divisor-bf16"),
-]
+def _avg_pool2d_bench_params() -> list:
+    params = []
+    for workload in load_workloads(_AVG_POOL2D_OP_NAME):
+        n, c_in, h_in, w_in = workload["input_shape"]
+        kernel_size = tuple(workload["kernel_size"])
+        stride = workload.get("stride")
+        if stride is not None:
+            stride = tuple(stride)
+        padding = tuple(workload.get("padding", (0, 0)))
+        ceil_mode = workload.get("ceil_mode", False)
+        count_include_pad = workload.get("count_include_pad", True)
+        divisor_override = workload.get("divisor_override")
+        label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
+        for dtype_str in workload["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(
+                pytest.param(
+                    n,
+                    c_in,
+                    h_in,
+                    w_in,
+                    kernel_size,
+                    stride,
+                    padding,
+                    ceil_mode,
+                    count_include_pad,
+                    divisor_override,
+                    dtype,
+                    True,
+                    id=f"{label}-{dtype_str}",
+                )
+            )
+    return params
 
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override, dtype, tune",
-    _AVG_POOL2D_BENCH_PARAMS,
+    _avg_pool2d_bench_params(),
 )
 def test_avg_pool2d_bench(
     n: int,
@@ -237,12 +282,9 @@ def test_avg_pool2d_bench(
         divisor_override,
         dtype,
     )
-    bm = AvgPool2dBenchmark(test)
     inputs = test.gen_inputs()
-    (x,) = inputs
-    x_nchw = x.permute(0, 3, 1, 2).contiguous()
 
-    op = AvgPool2dOp(
+    op = AvgPool2dFwdOp(
         n=n,
         c_in=c_in,
         h_in=h_in,
@@ -256,10 +298,11 @@ def test_avg_pool2d_bench(
         dtype=dtype,
         tune=tune,
     )
+    bm = AvgPool2dBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("avg_pool2d", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x_nchw)
+    result_bl = bm.profile(test.ref_program, *inputs)
     BenchmarkReport.record("avg_pool2d", locals(), result_bl, tag="torch-ref")
 
 
@@ -295,7 +338,13 @@ class AvgPool3dBenchCase:
 
     def gen_inputs(self) -> tuple[torch.Tensor]:
         x = torch.randn(
-            self.n, self.d_in, self.h_in, self.w_in, self.c_in, device="cuda", dtype=self.dtype
+            self.n,
+            self.c_in,
+            self.d_in,
+            self.h_in,
+            self.w_in,
+            device="cuda",
+            dtype=self.dtype,
         ).contiguous()
         return (x,)
 
@@ -313,33 +362,63 @@ class AvgPool3dBenchCase:
 
 class AvgPool3dBenchmark(BenchmarkBase[AvgPool3dBenchCase]):
 
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: AvgPool3dBenchCase, op: AvgPool3dFwdOp) -> None:
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            self._roofline_cache = self._op.eval_roofline()
+        return self._roofline_cache
+
     def calculate_flops(self) -> Optional[float]:
-        t = self.workload
-        out_d = pool_output_dim(t.d_in, t.kernel_size[0], t.stride[0], t.padding[0], t.ceil_mode)
-        out_h = pool_output_dim(t.h_in, t.kernel_size[1], t.stride[1], t.padding[1], t.ceil_mode)
-        out_w = pool_output_dim(t.w_in, t.kernel_size[2], t.stride[2], t.padding[2], t.ceil_mode)
-        return t.n * t.c_in * out_d * out_h * out_w * t.kernel_size[0] * t.kernel_size[1] * t.kernel_size[2]
+        return self._get_roofline()[0]
 
     def calculate_memory(self) -> Optional[float]:
-        t = self.workload
-        out_d = pool_output_dim(t.d_in, t.kernel_size[0], t.stride[0], t.padding[0], t.ceil_mode)
-        out_h = pool_output_dim(t.h_in, t.kernel_size[1], t.stride[1], t.padding[1], t.ceil_mode)
-        out_w = pool_output_dim(t.w_in, t.kernel_size[2], t.stride[2], t.padding[2], t.ceil_mode)
-        return (
-            t.n * t.c_in * t.d_in * t.h_in * t.w_in + t.n * t.c_in * out_d * out_h * out_w
-        ) * t.dtype.itemsize
+        return self._get_roofline()[1]
 
 
-_AVG_POOL3D_BENCH_PARAMS = [
-    pytest.param(1, 32, 16, 56, 56, (2, 2, 2), (2, 2, 2), (0, 0, 0), False, True, None, torch.float16, True, id="video-2x2x2"),
-    pytest.param(2, 64, 8, 28, 28, (2, 3, 3), (2, 2, 2), (1, 1, 1), True, False, None, torch.float16, True, id="ceil-video"),
-    pytest.param(2, 24, 10, 20, 22, (2, 2, 3), (2, 2, 2), (0, 1, 1), False, True, 7, torch.bfloat16, True, id="divisor-bf16"),
-]
+def _avg_pool3d_bench_params() -> list:
+    params = []
+    for workload in load_workloads(_AVG_POOL3D_OP_NAME):
+        n, c_in, d_in, h_in, w_in = workload["input_shape"]
+        kernel_size = tuple(workload["kernel_size"])
+        stride = workload.get("stride")
+        if stride is not None:
+            stride = tuple(stride)
+        padding = tuple(workload.get("padding", (0, 0, 0)))
+        ceil_mode = workload.get("ceil_mode", False)
+        count_include_pad = workload.get("count_include_pad", True)
+        divisor_override = workload.get("divisor_override")
+        label = workload.get("label", f"{n}x{c_in}x{d_in}x{h_in}x{w_in}")
+        for dtype_str in workload["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(
+                pytest.param(
+                    n,
+                    c_in,
+                    d_in,
+                    h_in,
+                    w_in,
+                    kernel_size,
+                    stride,
+                    padding,
+                    ceil_mode,
+                    count_include_pad,
+                    divisor_override,
+                    dtype,
+                    True,
+                    id=f"{label}-{dtype_str}",
+                )
+            )
+    return params
 
 
 @pytest.mark.parametrize(
     "n, c_in, d_in, h_in, w_in, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override, dtype, tune",
-    _AVG_POOL3D_BENCH_PARAMS,
+    _avg_pool3d_bench_params(),
 )
 def test_avg_pool3d_bench(
     n: int,
@@ -370,12 +449,9 @@ def test_avg_pool3d_bench(
         divisor_override,
         dtype,
     )
-    bm = AvgPool3dBenchmark(test)
     inputs = test.gen_inputs()
-    (x,) = inputs
-    x_ncdhw = x.permute(0, 4, 1, 2, 3).contiguous()
 
-    op = AvgPool3dOp(
+    op = AvgPool3dFwdOp(
         n=n,
         c_in=c_in,
         d_in=d_in,
@@ -390,8 +466,9 @@ def test_avg_pool3d_bench(
         dtype=dtype,
         tune=tune,
     )
+    bm = AvgPool3dBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record("avg_pool3d", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x_ncdhw)
+    result_bl = bm.profile(test.ref_program, *inputs)
     BenchmarkReport.record("avg_pool3d", locals(), result_bl, tag="torch-ref")

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import AvgPool2dKernel, AvgPool3dKernel
-from tileops.ops import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
+from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 
 class _DummyKernel(Kernel):
@@ -158,13 +158,6 @@ def test_avg_pool1d_rejects_non_3d_input(monkeypatch: pytest.MonkeyPatch) -> Non
         op(x)
 
 
-class _DummyKernel(Kernel):
-    supported_archs = [80]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x
-
-
 class AvgPool2dFixture(FixtureBase):
     PARAMS = [
         ("n, c_in, h_in, w_in, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override, dtype, tune", [
@@ -177,6 +170,11 @@ class AvgPool2dFixture(FixtureBase):
                 2, 64, 56, 56, (3, 3), None, (1, 1), False, True, None, torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-3x3-default-stride-bf16",
+            ),
+            pytest.param(
+                1, 32, 28, 28, (3, 3), None, (1, 1), False, True, None, torch.float32, False,
+                marks=pytest.mark.smoke,
+                id="smoke-3x3-default-stride-fp32",
             ),
             pytest.param(
                 1, 128, 55, 57, (3, 5), (2, 2), (1, 2), True, False, None, torch.float16, False,
@@ -213,12 +211,12 @@ class AvgPool2dTest(TestBase):
         self.dtype = dtype
 
     def gen_inputs(self, n: int, c_in: int, h_in: int, w_in: int) -> tuple[torch.Tensor]:
-        x = torch.randn(n, h_in, w_in, c_in, device="cuda", dtype=self.dtype).contiguous()
+        x = torch.randn(n, c_in, h_in, w_in, device="cuda", dtype=self.dtype).contiguous()
         return (x,)
 
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        out = F.avg_pool2d(
-            x.permute(0, 3, 1, 2).contiguous(),
+    def ref_program(self, input: torch.Tensor) -> torch.Tensor:
+        return F.avg_pool2d(
+            input,
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
@@ -226,7 +224,6 @@ class AvgPool2dTest(TestBase):
             count_include_pad=self.count_include_pad,
             divisor_override=self.divisor_override,
         )
-        return out.permute(0, 2, 3, 1).contiguous()
 
 
 @AvgPool2dFixture
@@ -253,7 +250,7 @@ def test_avg_pool2d(
         divisor_override,
         dtype,
     )
-    op = AvgPool2dOp(
+    op = AvgPool2dFwdOp(
         n=n,
         c_in=c_in,
         h_in=h_in,
@@ -273,14 +270,22 @@ def test_avg_pool2d(
 
 @pytest.mark.smoke
 def test_avg_pool2d_dispatches_kernel() -> None:
-    op = AvgPool2dOp(n=1, c_in=32, h_in=28, w_in=28, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))
+    op = AvgPool2dFwdOp(
+        n=1,
+        c_in=32,
+        h_in=28,
+        w_in=28,
+        kernel_size=(3, 3),
+        stride=(2, 2),
+        padding=(1, 1),
+    )
     assert isinstance(op.kernel, AvgPool2dKernel)
 
 
 @pytest.mark.smoke
 def test_avg_pool2d_rejects_zero_divisor_override() -> None:
     with pytest.raises(ValueError, match="divisor_override must not be zero"):
-        AvgPool2dOp(
+        AvgPool2dFwdOp(
             n=1,
             c_in=8,
             h_in=16,
@@ -293,7 +298,7 @@ def test_avg_pool2d_rejects_zero_divisor_override() -> None:
 @pytest.mark.smoke
 def test_avg_pool2d_rejects_non_positive_stride() -> None:
     with pytest.raises(ValueError, match="stride must be greater than zero"):
-        AvgPool2dOp(
+        AvgPool2dFwdOp(
             n=1,
             c_in=8,
             h_in=16,
@@ -306,7 +311,7 @@ def test_avg_pool2d_rejects_non_positive_stride() -> None:
 @pytest.mark.smoke
 def test_avg_pool2d_rejects_invalid_padding() -> None:
     with pytest.raises(ValueError, match="padding must be at most half"):
-        AvgPool2dOp(
+        AvgPool2dFwdOp(
             n=1,
             c_in=8,
             h_in=16,
@@ -338,14 +343,14 @@ def test_avg_pool2d_rejects_invalid_param_types(kwargs: dict[str, object], match
     }
     base_kwargs.update(kwargs)
     with pytest.raises(TypeError, match=match):
-        AvgPool2dOp(**base_kwargs)
+        AvgPool2dFwdOp(**base_kwargs)
 
 
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_avg_pool2d_negative_divisor_override_matches_torch() -> None:
-    x = torch.randn(1, 8, 8, 4, device="cuda", dtype=torch.float16).contiguous()
-    op = AvgPool2dOp(
+    x = torch.randn(1, 4, 8, 8, device="cuda", dtype=torch.float16).contiguous()
+    op = AvgPool2dFwdOp(
         n=1,
         c_in=4,
         h_in=8,
@@ -358,55 +363,51 @@ def test_avg_pool2d_negative_divisor_override_matches_torch() -> None:
     )
     out = op(x)
     ref = F.avg_pool2d(
-        x.permute(0, 3, 1, 2).contiguous(),
+        x,
         kernel_size=(2, 2),
         stride=(2, 2),
         padding=(0, 0),
         divisor_override=-1,
-    ).permute(0, 2, 3, 1).contiguous()
+    )
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
-def test_avg_pool2d_forward_rejects_nchw_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_avg_pool2d_rejects_non_4d_input(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
-    op = AvgPool2dOp(
-        n=1,
-        c_in=4,
-        h_in=8,
-        w_in=8,
-        kernel_size=(2, 2),
-        stride=(2, 2),
+    op = AvgPool2dFwdOp(
+        n=2,
+        c_in=8,
+        h_in=16,
+        w_in=16,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        dtype=torch.float32,
         kernel_map={"avg_pool2d_kernel": _DummyKernel},
     )
-    x = torch.randn(1, 4, 8, 8)
-    with pytest.raises(ValueError, match="NHWC"):
+    x = torch.randn(2, 8, 16)
+    with pytest.raises(ValueError, match="expects input to be a 4D NCHW tensor"):
         op(x)
 
 
 @pytest.mark.smoke
-def test_avg_pool2d_forward_warns_on_ambiguous_nhwc_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_avg_pool2d_rejects_wrong_nchw_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
-    op = AvgPool2dOp(
-        n=1,
+    op = AvgPool2dFwdOp(
+        n=2,
         c_in=8,
-        h_in=8,
-        w_in=8,
-        kernel_size=(2, 2),
-        stride=(2, 2),
+        h_in=16,
+        w_in=16,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        dtype=torch.float32,
         kernel_map={"avg_pool2d_kernel": _DummyKernel},
     )
-    x = torch.randn(1, 8, 8, 8)
-    with pytest.warns(UserWarning, match="ambiguous NHWC shape"):
-        out = op(x)
-    assert out is x
-
-
-class _DummyKernel(Kernel):
-    supported_archs = [80]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x
+    x = torch.randn(2, 16, 16, 8)
+    with pytest.raises(ValueError, match=r"expects input shape \(2, 8, 16, 16\)"):
+        op(x)
 
 
 class AvgPool3dFixture(FixtureBase):
@@ -421,6 +422,11 @@ class AvgPool3dFixture(FixtureBase):
                 1, 32, 16, 28, 28, (2, 2, 2), None, (0, 0, 0), False, True, None, torch.bfloat16, False,
                 marks=pytest.mark.smoke,
                 id="smoke-2x2x2-default-stride-bf16",
+            ),
+            pytest.param(
+                1, 16, 8, 14, 14, (2, 2, 2), None, (0, 0, 0), False, True, None, torch.float32, False,
+                marks=pytest.mark.smoke,
+                id="smoke-2x2x2-default-stride-fp32",
             ),
             pytest.param(
                 1, 48, 15, 25, 27, (2, 3, 3), (2, 2, 2), (1, 1, 1), True, False, None, torch.float16, False,
@@ -456,13 +462,28 @@ class AvgPool3dTest(TestBase):
         self.divisor_override = divisor_override
         self.dtype = dtype
 
-    def gen_inputs(self, n: int, c_in: int, d_in: int, h_in: int, w_in: int) -> tuple[torch.Tensor]:
-        x = torch.randn(n, d_in, h_in, w_in, c_in, device="cuda", dtype=self.dtype).contiguous()
+    def gen_inputs(
+        self,
+        n: int,
+        c_in: int,
+        d_in: int,
+        h_in: int,
+        w_in: int,
+    ) -> tuple[torch.Tensor]:
+        x = torch.randn(
+            n,
+            c_in,
+            d_in,
+            h_in,
+            w_in,
+            device="cuda",
+            dtype=self.dtype,
+        ).contiguous()
         return (x,)
 
-    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        out = F.avg_pool3d(
-            x.permute(0, 4, 1, 2, 3).contiguous(),
+    def ref_program(self, input: torch.Tensor) -> torch.Tensor:
+        return F.avg_pool3d(
+            input,
             kernel_size=self.kernel_size,
             stride=self.stride,
             padding=self.padding,
@@ -470,7 +491,6 @@ class AvgPool3dTest(TestBase):
             count_include_pad=self.count_include_pad,
             divisor_override=self.divisor_override,
         )
-        return out.permute(0, 2, 3, 4, 1).contiguous()
 
 
 @AvgPool3dFixture
@@ -498,7 +518,7 @@ def test_avg_pool3d(
         divisor_override,
         dtype,
     )
-    op = AvgPool3dOp(
+    op = AvgPool3dFwdOp(
         n=n,
         c_in=c_in,
         d_in=d_in,
@@ -519,7 +539,7 @@ def test_avg_pool3d(
 
 @pytest.mark.smoke
 def test_avg_pool3d_dispatches_kernel() -> None:
-    op = AvgPool3dOp(
+    op = AvgPool3dFwdOp(
         n=1,
         c_in=16,
         d_in=8,
@@ -535,7 +555,7 @@ def test_avg_pool3d_dispatches_kernel() -> None:
 @pytest.mark.smoke
 def test_avg_pool3d_rejects_zero_divisor_override() -> None:
     with pytest.raises(ValueError, match="divisor_override must not be zero"):
-        AvgPool3dOp(
+        AvgPool3dFwdOp(
             n=1,
             c_in=8,
             d_in=8,
@@ -549,7 +569,7 @@ def test_avg_pool3d_rejects_zero_divisor_override() -> None:
 @pytest.mark.smoke
 def test_avg_pool3d_rejects_non_positive_stride() -> None:
     with pytest.raises(ValueError, match="stride must be greater than zero"):
-        AvgPool3dOp(
+        AvgPool3dFwdOp(
             n=1,
             c_in=8,
             d_in=8,
@@ -583,14 +603,14 @@ def test_avg_pool3d_rejects_invalid_param_types(kwargs: dict[str, object], match
     }
     base_kwargs.update(kwargs)
     with pytest.raises(TypeError, match=match):
-        AvgPool3dOp(**base_kwargs)
+        AvgPool3dFwdOp(**base_kwargs)
 
 
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_avg_pool3d_negative_divisor_override_matches_torch() -> None:
-    x = torch.randn(1, 4, 6, 6, 3, device="cuda", dtype=torch.float16).contiguous()
-    op = AvgPool3dOp(
+    x = torch.randn(1, 3, 4, 6, 6, device="cuda", dtype=torch.float16).contiguous()
+    op = AvgPool3dFwdOp(
         n=1,
         c_in=3,
         d_in=4,
@@ -604,50 +624,53 @@ def test_avg_pool3d_negative_divisor_override_matches_torch() -> None:
     )
     out = op(x)
     ref = F.avg_pool3d(
-        x.permute(0, 4, 1, 2, 3).contiguous(),
+        x,
         kernel_size=(2, 2, 2),
         stride=(2, 2, 2),
         padding=(0, 0, 0),
         divisor_override=-1,
-    ).permute(0, 2, 3, 4, 1).contiguous()
+    )
     torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.smoke
-def test_avg_pool3d_forward_rejects_ncdhw_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_avg_pool3d_rejects_non_5d_input(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
-    op = AvgPool3dOp(
+    op = AvgPool3dFwdOp(
         n=1,
-        c_in=3,
-        d_in=4,
-        h_in=6,
-        w_in=6,
+        c_in=4,
+        d_in=8,
+        h_in=8,
+        w_in=8,
         kernel_size=(2, 2, 2),
         stride=(2, 2, 2),
+        padding=(0, 0, 0),
+        dtype=torch.float32,
         kernel_map={"avg_pool3d_kernel": _DummyKernel},
     )
-    x = torch.randn(1, 3, 4, 6, 6)
-    with pytest.raises(ValueError, match="NDHWC"):
+    x = torch.randn(1, 4, 8, 8)
+    with pytest.raises(ValueError, match="expects input to be a 5D NCDHW tensor"):
         op(x)
 
 
 @pytest.mark.smoke
-def test_avg_pool3d_forward_warns_on_ambiguous_ndhwc_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_avg_pool3d_rejects_wrong_ncdhw_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tileops.ops.op_base.get_sm_version", lambda: 80)
-    op = AvgPool3dOp(
+    op = AvgPool3dFwdOp(
         n=1,
         c_in=4,
-        d_in=4,
-        h_in=4,
-        w_in=4,
+        d_in=8,
+        h_in=8,
+        w_in=8,
         kernel_size=(2, 2, 2),
         stride=(2, 2, 2),
+        padding=(0, 0, 0),
+        dtype=torch.float32,
         kernel_map={"avg_pool3d_kernel": _DummyKernel},
     )
-    x = torch.randn(1, 4, 4, 4, 4)
-    with pytest.warns(UserWarning, match="ambiguous NDHWC shape"):
-        out = op(x)
-    assert out is x
+    x = torch.randn(1, 8, 8, 8, 4)
+    with pytest.raises(ValueError, match=r"expects input shape \(1, 4, 8, 8, 8\)"):
+        op(x)
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/pool/avg_pool2d.py
+++ b/tileops/kernels/pool/avg_pool2d.py
@@ -38,57 +38,97 @@ def _avg_pool2d_kernel(
     def _avg_pool2d_func(block_m: int, block_c: int, threads: int):
         @T.prim_func
         def _avg_pool2d_main(
-            x: T.Tensor((n, h_in, w_in, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, out_h, out_w, c_in), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
         ):
             with T.Kernel(
+                T.ceildiv(out_h * out_w, block_m),
                 T.ceildiv(c_in, block_c),
-                T.ceildiv(n * out_h * out_w, block_m),
+                n,
                 threads=threads,
-            ) as (bx, by):
-                out_flat = T.Tensor((n * out_h * out_w, c_in), dtype, out.data)
+            ) as (bx, by, bz):
+                T.use_swizzle(10)
+                tile_spatial_start = bx * block_m
+                tile_spatial_end = tile_spatial_start + block_m - 1
+                tile_oh_start = tile_spatial_start // out_w
+                tile_oh_end = tile_spatial_end // out_w
+                tile_spatial_same_row = tile_oh_start == tile_oh_end
+                tile_ow_start = tile_spatial_start % out_w
+                tile_ow_end = tile_spatial_end % out_w
+                tile_input_h_start = tile_oh_start * stride_h - pad_h
+                tile_input_h_end = tile_oh_end * stride_h + kernel_h - 1 - pad_h
+                tile_input_w_start = tile_ow_start * stride_w - pad_w
+                tile_input_w_end = tile_ow_end * stride_w + kernel_w - 1 - pad_w
+                tile_spatial_full = (
+                    tile_spatial_same_row
+                    & (tile_input_h_start >= 0)
+                    & (tile_input_h_end < h_in)
+                    & (tile_input_w_start >= 0)
+                    & (tile_input_w_end < w_in)
+                )
+                use_fixed_kernel_divisor = count_include_pad and not use_divisor_override
 
                 for i, j in T.Parallel(block_m, block_c):
-                    m_idx = by * block_m + i
-                    c_idx = bx * block_c + j
-                    if m_idx < n * out_h * out_w and c_idx < c_in:
-                        batch = m_idx // (out_h * out_w)
-                        out_idx = m_idx % (out_h * out_w)
-                        oh = out_idx // out_w
-                        ow = out_idx % out_w
+                    out_spatial = bx * block_m + i
+                    oh = out_spatial // out_w
+                    ow = out_spatial % out_w
+                    c_idx = by * block_c + j
+                    batch = bz
+                    if out_spatial < out_h * out_w and c_idx < c_in:
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
 
-                        for kh in T.serial(kernel_h):
-                            for kw in T.serial(kernel_w):
-                                ih = oh * stride_h + kh - pad_h
-                                iw = ow * stride_w + kw - pad_w
-                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
-                                    sum_val += T.cast(x[batch, ih, iw, c_idx], accum_dtype)
+                        if tile_spatial_full and use_fixed_kernel_divisor:
+                            for kh in T.serial(kernel_h):
+                                for kw in T.serial(kernel_w):
+                                    ih = oh * stride_h + kh - pad_h
+                                    iw = ow * stride_w + kw - pad_w
+                                    sum_val += T.cast(
+                                        x[batch, c_idx, ih, iw], accum_dtype
+                                    )
+                            out[batch, c_idx, oh, ow] = T.cast(
+                                sum_val / T.cast(kernel_h * kernel_w, accum_dtype),
+                                dtype,
+                            )
+                        else:
+                            for kh in T.serial(kernel_h):
+                                for kw in T.serial(kernel_w):
+                                    ih = oh * stride_h + kh - pad_h
+                                    iw = ow * stride_w + kw - pad_w
+                                    if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
+                                        sum_val += T.cast(
+                                            x[batch, c_idx, ih, iw], accum_dtype
+                                        )
 
-                        start_h = oh * stride_h - pad_h
-                        start_w = ow * stride_w - pad_w
-                        end_h = start_h + kernel_h
-                        end_w = start_w + kernel_w
-                        valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
-                        valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
-                        valid_count = valid_h * valid_w
-                        padded_h = T.max(T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0)
-                        padded_w = T.max(T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0)
-                        padded_count = padded_h * padded_w
-                        auto_divisor = T.max(
-                            T.if_then_else(count_include_pad, padded_count, valid_count),
-                            1,
-                        )
-                        divisor = T.if_then_else(
-                            use_divisor_override,
-                            divisor_override,
-                            auto_divisor,
-                        )
-                        out_flat[m_idx, c_idx] = T.cast(
-                            sum_val / T.cast(divisor, accum_dtype),
-                            dtype,
-                        )
+                            start_h = oh * stride_h - pad_h
+                            start_w = ow * stride_w - pad_w
+                            end_h = start_h + kernel_h
+                            end_w = start_w + kernel_w
+                            valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
+                            valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
+                            valid_count = valid_h * valid_w
+                            padded_h = T.max(
+                                T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0
+                            )
+                            padded_w = T.max(
+                                T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0
+                            )
+                            padded_count = padded_h * padded_w
+                            auto_divisor = T.max(
+                                T.if_then_else(
+                                    count_include_pad, padded_count, valid_count
+                                ),
+                                1,
+                            )
+                            divisor = T.if_then_else(
+                                use_divisor_override,
+                                divisor_override,
+                                auto_divisor,
+                            )
+                            out[batch, c_idx, oh, ow] = T.cast(
+                                sum_val / T.cast(divisor, accum_dtype),
+                                dtype,
+                            )
 
         return _avg_pool2d_main
 
@@ -158,10 +198,18 @@ def _(
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    _ = (count_include_pad, use_divisor_override, divisor_override, dtype, block_m, block_c, threads)
+    _ = (
+        count_include_pad,
+        use_divisor_override,
+        divisor_override,
+        dtype,
+        block_m,
+        block_c,
+        threads,
+    )
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
-    return torch.empty((n, out_h, out_w, c_in), dtype=x.dtype, device=x.device)
+    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class AvgPool2dKernel(Kernel):

--- a/tileops/kernels/pool/avg_pool3d.py
+++ b/tileops/kernels/pool/avg_pool3d.py
@@ -43,71 +43,144 @@ def _avg_pool3d_kernel(
     def _avg_pool3d_func(block_m: int, block_c: int, threads: int):
         @T.prim_func
         def _avg_pool3d_main(
-            x: T.Tensor((n, d_in, h_in, w_in, c_in), dtype),  # type: ignore
-            out: T.Tensor((n, out_d, out_h, out_w, c_in), dtype),  # type: ignore
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_d, out_h, out_w), dtype),  # type: ignore
         ):
             with T.Kernel(
+                T.ceildiv(out_d * out_h * out_w, block_m),
                 T.ceildiv(c_in, block_c),
-                T.ceildiv(n * out_d * out_h * out_w, block_m),
+                n,
                 threads=threads,
-            ) as (bx, by):
-                out_flat = T.Tensor((n * out_d * out_h * out_w, c_in), dtype, out.data)
+            ) as (bx, by, bz):
+                T.use_swizzle(10)
+                tile_spatial_start = bx * block_m
+                tile_spatial_end = tile_spatial_start + block_m - 1
+                tile_od_start = tile_spatial_start // (out_h * out_w)
+                tile_od_end = tile_spatial_end // (out_h * out_w)
+                tile_spatial_same_plane = tile_od_start == tile_od_end
+                tile_input_d_start = tile_od_start * stride_d - pad_d
+                tile_input_d_end = tile_od_end * stride_d + kernel_d - 1 - pad_d
+
+                rem_start = tile_spatial_start % (out_h * out_w)
+                rem_end = tile_spatial_end % (out_h * out_w)
+                tile_oh_start = rem_start // out_w
+                tile_oh_end = rem_end // out_w
+                tile_spatial_same_row = tile_oh_start == tile_oh_end
+                tile_ow_start = rem_start % out_w
+                tile_ow_end = rem_end % out_w
+
+                tile_input_h_start = tile_oh_start * stride_h - pad_h
+                tile_input_h_end = tile_oh_end * stride_h + kernel_h - 1 - pad_h
+                tile_input_w_start = tile_ow_start * stride_w - pad_w
+                tile_input_w_end = tile_ow_end * stride_w + kernel_w - 1 - pad_w
+
+                tile_spatial_full = (
+                    tile_spatial_same_plane
+                    & tile_spatial_same_row
+                    & (tile_input_d_start >= 0)
+                    & (tile_input_d_end < d_in)
+                    & (tile_input_h_start >= 0)
+                    & (tile_input_h_end < h_in)
+                    & (tile_input_w_start >= 0)
+                    & (tile_input_w_end < w_in)
+                )
+                use_fixed_kernel_divisor = count_include_pad and not use_divisor_override
 
                 for i, j in T.Parallel(block_m, block_c):
-                    m_idx = by * block_m + i
-                    c_idx = bx * block_c + j
-                    if m_idx < n * out_d * out_h * out_w and c_idx < c_in:
-                        batch = m_idx // (out_d * out_h * out_w)
-                        out_idx = m_idx % (out_d * out_h * out_w)
-                        od = out_idx // (out_h * out_w)
-                        oh = (out_idx // out_w) % out_h
-                        ow = out_idx % out_w
+                    out_spatial = bx * block_m + i
+                    od = out_spatial // (out_h * out_w)
+                    oh = (out_spatial // out_w) % out_h
+                    ow = out_spatial % out_w
+                    c_idx = by * block_c + j
+                    batch = bz
+                    if out_spatial < out_d * out_h * out_w and c_idx < c_in:
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
 
-                        for kd in T.serial(kernel_d):
-                            for kh in T.serial(kernel_h):
-                                for kw in T.serial(kernel_w):
-                                    id_ = od * stride_d + kd - pad_d
-                                    ih = oh * stride_h + kh - pad_h
-                                    iw = ow * stride_w + kw - pad_w
-                                    if (
-                                        id_ >= 0
-                                        and id_ < d_in
-                                        and ih >= 0
-                                        and ih < h_in
-                                        and iw >= 0
-                                        and iw < w_in
-                                    ):
-                                        sum_val += T.cast(x[batch, id_, ih, iw, c_idx], accum_dtype)
+                        if tile_spatial_full and use_fixed_kernel_divisor:
+                            for kd in T.serial(kernel_d):
+                                for kh in T.serial(kernel_h):
+                                    for kw in T.serial(kernel_w):
+                                        id_ = od * stride_d + kd - pad_d
+                                        ih = oh * stride_h + kh - pad_h
+                                        iw = ow * stride_w + kw - pad_w
+                                        sum_val += T.cast(
+                                            x[batch, c_idx, id_, ih, iw], accum_dtype
+                                        )
+                            out[batch, c_idx, od, oh, ow] = T.cast(
+                                sum_val
+                                / T.cast(
+                                    kernel_d * kernel_h * kernel_w, accum_dtype
+                                ),
+                                dtype,
+                            )
+                        else:
+                            for kd in T.serial(kernel_d):
+                                for kh in T.serial(kernel_h):
+                                    for kw in T.serial(kernel_w):
+                                        id_ = od * stride_d + kd - pad_d
+                                        ih = oh * stride_h + kh - pad_h
+                                        iw = ow * stride_w + kw - pad_w
+                                        if (
+                                            id_ >= 0
+                                            and id_ < d_in
+                                            and ih >= 0
+                                            and ih < h_in
+                                            and iw >= 0
+                                            and iw < w_in
+                                        ):
+                                            sum_val += T.cast(
+                                                x[batch, c_idx, id_, ih, iw],
+                                                accum_dtype,
+                                            )
 
-                        start_d = od * stride_d - pad_d
-                        start_h = oh * stride_h - pad_h
-                        start_w = ow * stride_w - pad_w
-                        end_d = start_d + kernel_d
-                        end_h = start_h + kernel_h
-                        end_w = start_w + kernel_w
-                        valid_d = T.max(T.min(end_d, d_in) - T.max(start_d, 0), 0)
-                        valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
-                        valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
-                        valid_count = valid_d * valid_h * valid_w
-                        padded_d = T.max(T.min(end_d, d_in + pad_d) - T.max(start_d, -pad_d), 0)
-                        padded_h = T.max(T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0)
-                        padded_w = T.max(T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0)
-                        padded_count = padded_d * padded_h * padded_w
-                        auto_divisor = T.max(
-                            T.if_then_else(count_include_pad, padded_count, valid_count),
-                            1,
-                        )
-                        divisor = T.if_then_else(
-                            use_divisor_override,
-                            divisor_override,
-                            auto_divisor,
-                        )
-                        out_flat[m_idx, c_idx] = T.cast(
-                            sum_val / T.cast(divisor, accum_dtype),
-                            dtype,
-                        )
+                            start_d = od * stride_d - pad_d
+                            start_h = oh * stride_h - pad_h
+                            start_w = ow * stride_w - pad_w
+                            end_d = start_d + kernel_d
+                            end_h = start_h + kernel_h
+                            end_w = start_w + kernel_w
+                            valid_d = T.max(
+                                T.min(end_d, d_in) - T.max(start_d, 0), 0
+                            )
+                            valid_h = T.max(
+                                T.min(end_h, h_in) - T.max(start_h, 0), 0
+                            )
+                            valid_w = T.max(
+                                T.min(end_w, w_in) - T.max(start_w, 0), 0
+                            )
+                            valid_count = valid_d * valid_h * valid_w
+                            padded_d = T.max(
+                                T.min(end_d, d_in + pad_d)
+                                - T.max(start_d, -pad_d),
+                                0,
+                            )
+                            padded_h = T.max(
+                                T.min(end_h, h_in + pad_h)
+                                - T.max(start_h, -pad_h),
+                                0,
+                            )
+                            padded_w = T.max(
+                                T.min(end_w, w_in + pad_w)
+                                - T.max(start_w, -pad_w),
+                                0,
+                            )
+                            padded_count = padded_d * padded_h * padded_w
+                            auto_divisor = T.max(
+                                T.if_then_else(
+                                    count_include_pad, padded_count, valid_count
+                                ),
+                                1,
+                            )
+                            divisor = T.if_then_else(
+                                use_divisor_override,
+                                divisor_override,
+                                auto_divisor,
+                            )
+                            out[batch, c_idx, od, oh, ow] = T.cast(
+                                sum_val / T.cast(divisor, accum_dtype),
+                                dtype,
+                            )
 
         return _avg_pool3d_main
 
@@ -189,11 +262,19 @@ def _(
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    _ = (count_include_pad, use_divisor_override, divisor_override, dtype, block_m, block_c, threads)
+    _ = (
+        count_include_pad,
+        use_divisor_override,
+        divisor_override,
+        dtype,
+        block_m,
+        block_c,
+        threads,
+    )
     out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode)
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
-    return torch.empty((n, out_d, out_h, out_w, c_in), dtype=x.dtype, device=x.device)
+    return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 class AvgPool3dKernel(Kernel):

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -56,7 +56,7 @@ AvgPool1dFwdOp:
 AvgPool2dFwdOp:
   ref_api: "torch.nn.functional.avg_pool2d"
   family: pool
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -85,7 +85,10 @@ AvgPool2dFwdOp:
       - "W_out == max(((W_in + 2 * _pW - _kW + (_sW - 1 if ceil_mode else 0)) // _sW + 1) - (1 if ceil_mode and ((W_in + 2 * _pW - _kW + _sW - 1) // _sW + 1) > 0 and (((W_in + 2 * _pW - _kW + _sW - 1) // _sW + 1) - 1) * _sW >= W_in + _pW else 0), 0)"
 
   workloads:
-    # Vision backbone pooling cases, expressed in PyTorch NCHW layout.
+    # Real-model sources: ResNet-style and ConvNeXt-style vision backbones use
+    # 2D average-pooling/downsampling over NCHW feature maps at early and middle
+    # feature stages. The asymmetric ceil/divisor case is a stress workload for
+    # PyTorch avg_pool2d semantics, not a separate model family.
     - {input_shape: [2, 64, 112, 112], kernel_size: [3, 3], stride: [2, 2], padding: [1, 1], dtypes: [float16], label: "vision-3x3-s2"}
     - {input_shape: [2, 128, 56, 56], kernel_size: [5, 5], stride: [2, 2], padding: [2, 2], dtypes: [float16], label: "vision-5x5-s2"}
     - {input_shape: [3, 96, 55, 57], kernel_size: [3, 5], stride: [2, 2], padding: [1, 2], ceil_mode: true, count_include_pad: false, divisor_override: 7, dtypes: [bfloat16], label: "ceil-divisor-bf16"}
@@ -110,12 +113,12 @@ AvgPool2dFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 AvgPool3dFwdOp:
   ref_api: "torch.nn.functional.avg_pool3d"
   family: pool
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -148,7 +151,9 @@ AvgPool3dFwdOp:
       - "W_out == max(((W_in + 2 * _pW - _kW + (_sW - 1 if ceil_mode else 0)) // _sW + 1) - (1 if ceil_mode and ((W_in + 2 * _pW - _kW + _sW - 1) // _sW + 1) > 0 and (((W_in + 2 * _pW - _kW + _sW - 1) // _sW + 1) - 1) * _sW >= W_in + _pW else 0), 0)"
 
   workloads:
-    # Video/spatiotemporal pooling cases, expressed in PyTorch NCDHW layout.
+    # Real-model sources: I3D/SlowFast-style video CNNs use 3D spatiotemporal
+    # pooling over NCDHW activations. The ceil and divisor workloads stress
+    # PyTorch avg_pool3d semantics on video-like feature volumes.
     - {input_shape: [1, 32, 16, 56, 56], kernel_size: [2, 2, 2], stride: [2, 2, 2], padding: [0, 0, 0], dtypes: [float16], label: "video-2x2x2"}
     - {input_shape: [2, 64, 8, 28, 28], kernel_size: [2, 3, 3], stride: [2, 2, 2], padding: [1, 1, 1], ceil_mode: true, count_include_pad: false, dtypes: [float16], label: "ceil-video"}
     - {input_shape: [2, 24, 10, 20, 22], kernel_size: [2, 2, 3], stride: [2, 2, 2], padding: [0, 1, 1], divisor_override: 7, dtypes: [bfloat16], label: "divisor-bf16"}
@@ -177,7 +182,7 @@ AvgPool3dFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 MaxPool1dFwdOp:
   ref_api: "torch.nn.functional.max_pool1d"

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -64,7 +64,7 @@ from .norm import (
     RMSNormFwdOp,
 )
 from .op_base import Op
-from .pool import AvgPool1dFwdOp, AvgPool2dOp, AvgPool3dOp
+from .pool import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 # --- Reduction ops (uncomment as sub-category PRs land) ---
 from .reduction import (
@@ -109,8 +109,8 @@ from .topk_selector import TopkSelectorOp
 __all__ = [
     "BinaryOp",
     "AvgPool1dFwdOp",
-    "AvgPool2dOp",
-    "AvgPool3dOp",
+    "AvgPool2dFwdOp",
+    "AvgPool3dFwdOp",
     "AdaLayerNormFwdOp",
     "AdaLayerNormZeroFwdOp",
     "BatchNormBwdOp",

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -7,13 +7,12 @@ from tileops.kernels.pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKern
 from tileops.kernels.pool.common import (
     _normalize_pool_dims,
     pool_output_dim,
-    validate_channels_last_input,
     validate_pool_params,
 )
 
 from .op_base import Op
 
-__all__ = ["AvgPool1dFwdOp", "AvgPool2dOp", "AvgPool3dOp"]
+__all__ = ["AvgPool1dFwdOp", "AvgPool2dFwdOp", "AvgPool3dFwdOp"]
 
 
 def _validate_positive_int(name: str, value: int, op_name: str) -> None:
@@ -64,7 +63,9 @@ class AvgPool1dFwdOp(Op):
         )
         self.dispatch_kernel(kernel_map)
         if "avg_pool1d_kernel" not in self.kernel_map:
-            raise NotImplementedError("AvgPool1dFwdOp requires 'avg_pool1d_kernel' in kernel_map")
+            raise NotImplementedError(
+                "AvgPool1dFwdOp requires 'avg_pool1d_kernel' in kernel_map"
+            )
         self.out_l = pool_output_dim(
             self.l_in,
             self.kernel_size,
@@ -80,8 +81,8 @@ class AvgPool1dFwdOp(Op):
             kernel_l=self.kernel_size,
             stride_l=self.stride,
             pad_l=self.padding,
-            ceil_mode=self.ceil_mode,
-            count_include_pad=self.count_include_pad,
+            ceil_mode=ceil_mode,
+            count_include_pad=count_include_pad,
             dtype=dtype,
             tune=tune,
         )
@@ -90,7 +91,9 @@ class AvgPool1dFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"avg_pool1d_kernel": AvgPool1dKernel}
 
-    def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:
+    def _infer_output_shapes(
+        self, input_shape: tuple[int, ...]
+    ) -> Dict[str, tuple[int, ...]]:
         if len(input_shape) != 3:
             raise ValueError("AvgPool1dFwdOp expects input_shape to be 3D NCL")
         n, c_in, l_in = input_shape
@@ -110,7 +113,9 @@ class AvgPool1dFwdOp(Op):
                 f"got {input.dtype}"
             )
         if input.dtype != self.dtype:
-            raise ValueError(f"input.dtype must match op dtype {self.dtype}, got {input.dtype}")
+            raise ValueError(
+                f"input.dtype must match op dtype {self.dtype}, got {input.dtype}"
+            )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         self._validate_dtypes(input)
@@ -132,17 +137,14 @@ class AvgPool1dFwdOp(Op):
     def eval_roofline(self) -> tuple[int, int]:
         elem_bytes = torch.empty((), dtype=self.dtype).element_size()
         flops = self.n * self.c_in * self.out_l * self.kernel_size
-        bytes_ = (self.n * self.c_in * self.l_in + self.n * self.c_in * self.out_l) * elem_bytes
+        bytes_ = (
+            self.n * self.c_in * self.l_in + self.n * self.c_in * self.out_l
+        ) * elem_bytes
         return flops, bytes_
 
 
-class AvgPool2dOp(Op):
-    """Average pooling over channels-last `NHWC` inputs.
-
-    This op is API-compatible with PyTorch pooling parameters, but the tensor
-    layout contract is channels-last rather than `NCHW`. Ambiguous shapes
-    where `NHWC` and `NCHW` would be indistinguishable are rejected eagerly.
-    """
+class AvgPool2dFwdOp(Op):
+    """Average pooling over PyTorch-compatible NCHW inputs."""
 
     def __init__(
         self,
@@ -160,6 +162,10 @@ class AvgPool2dOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        _validate_positive_int("n", n, "AvgPool2dFwdOp")
+        _validate_positive_int("c_in", c_in, "AvgPool2dFwdOp")
+        _validate_positive_int("h_in", h_in, "AvgPool2dFwdOp")
+        _validate_positive_int("w_in", w_in, "AvgPool2dFwdOp")
         self.n = n
         self.c_in = c_in
         self.h_in = h_in
@@ -175,6 +181,7 @@ class AvgPool2dOp(Op):
         self.count_include_pad = count_include_pad
         self.divisor_override = divisor_override
         self.dtype = dtype
+        self.tune = tune
         validate_pool_params(
             ndim=2,
             kernel_size=self.kernel_size,
@@ -185,7 +192,15 @@ class AvgPool2dOp(Op):
 
         self.dispatch_kernel(kernel_map)
         if "avg_pool2d_kernel" not in self.kernel_map:
-            raise NotImplementedError("AvgPool2dOp requires 'avg_pool2d_kernel' in kernel_map")
+            raise NotImplementedError(
+                "AvgPool2dFwdOp requires 'avg_pool2d_kernel' in kernel_map"
+            )
+        self.out_h = pool_output_dim(
+            self.h_in, self.kernel_size[0], self.stride[0], self.padding[0], self.ceil_mode
+        )
+        self.out_w = pool_output_dim(
+            self.w_in, self.kernel_size[1], self.stride[1], self.padding[1], self.ceil_mode
+        )
         self.kernel = self.kernel_map["avg_pool2d_kernel"](
             n=n,
             c_in=c_in,
@@ -208,23 +223,79 @@ class AvgPool2dOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"avg_pool2d_kernel": AvgPool2dKernel}
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        validate_channels_last_input(
-            op_name=type(self).__name__,
-            x_shape=tuple(x.shape),
-            expected_shape=(self.n, self.h_in, self.w_in, self.c_in),
-            layout="NHWC",
-            ambiguous_layout_shape=(self.n, self.c_in, self.h_in, self.w_in),
+    def _infer_output_shapes(
+        self, input_shape: tuple[int, ...]
+    ) -> Dict[str, tuple[int, ...]]:
+        if len(input_shape) != 4:
+            raise ValueError("AvgPool2dFwdOp expects input_shape to be 4D NCHW")
+        n, c_in, h_in, w_in = input_shape
+        kernel_size = getattr(self, "kernel_size", None)
+        stride = getattr(self, "stride", None)
+        padding = getattr(self, "padding", None)
+        ceil_mode = getattr(self, "ceil_mode", False)
+        if kernel_size is None or stride is None or padding is None:
+            return {"output": (n, c_in, 0, 0)}
+        out_h = pool_output_dim(h_in, kernel_size[0], stride[0], padding[0], ceil_mode)
+        out_w = pool_output_dim(w_in, kernel_size[1], stride[1], padding[1], ceil_mode)
+        return {"output": (n, c_in, out_h, out_w)}
+
+    def _validate_dtypes(self, input: torch.Tensor) -> None:
+        if input.dtype not in {torch.float16, torch.bfloat16, torch.float32}:
+            raise ValueError(
+                "input.dtype must be float16, bfloat16, or float32, "
+                f"got {input.dtype}"
+            )
+        if input.dtype != self.dtype:
+            raise ValueError(
+                f"input.dtype must match op dtype {self.dtype}, got {input.dtype}"
+            )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self._validate_dtypes(input)
+        if input.ndim != 4:
+            raise ValueError("AvgPool2dFwdOp expects input to be a 4D NCHW tensor")
+
+        expected_shape = (self.n, self.c_in, self.h_in, self.w_in)
+        actual_shape = tuple(input.shape)
+        if actual_shape != expected_shape:
+            raise ValueError(
+                f"AvgPool2dFwdOp expects input shape {expected_shape}, "
+                f"but got {actual_shape}"
+            )
+        if not input.is_cuda:
+            raise ValueError("input must be a CUDA tensor")
+
+        input = input.contiguous()
+        return self.kernel(input)
+
+    def eval_roofline(self) -> tuple[int, int]:
+        elem_bytes = torch.empty((), dtype=self.dtype).element_size()
+        out_h = pool_output_dim(
+            self.h_in,
+            self.kernel_size[0],
+            self.stride[0],
+            self.padding[0],
+            self.ceil_mode,
         )
-        return self.kernel(x)
+        out_w = pool_output_dim(
+            self.w_in,
+            self.kernel_size[1],
+            self.stride[1],
+            self.padding[1],
+            self.ceil_mode,
+        )
+        flops = (
+            self.n * self.c_in * out_h * out_w * self.kernel_size[0] * self.kernel_size[1]
+        )
+        bytes_ = (
+            self.n * self.c_in * self.h_in * self.w_in
+            + self.n * self.c_in * out_h * out_w
+        ) * elem_bytes
+        return flops, bytes_
 
 
-class AvgPool3dOp(Op):
-    """Average pooling over channels-last `NDHWC` inputs.
-
-    Ambiguous shapes where `NDHWC` and `NCDHW` would be indistinguishable are
-    rejected eagerly.
-    """
+class AvgPool3dFwdOp(Op):
+    """Average pooling over PyTorch-compatible NCDHW inputs."""
 
     def __init__(
         self,
@@ -243,6 +314,11 @@ class AvgPool3dOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        _validate_positive_int("n", n, "AvgPool3dFwdOp")
+        _validate_positive_int("c_in", c_in, "AvgPool3dFwdOp")
+        _validate_positive_int("d_in", d_in, "AvgPool3dFwdOp")
+        _validate_positive_int("h_in", h_in, "AvgPool3dFwdOp")
+        _validate_positive_int("w_in", w_in, "AvgPool3dFwdOp")
         self.n = n
         self.c_in = c_in
         self.d_in = d_in
@@ -259,6 +335,7 @@ class AvgPool3dOp(Op):
         self.count_include_pad = count_include_pad
         self.divisor_override = divisor_override
         self.dtype = dtype
+        self.tune = tune
         validate_pool_params(
             ndim=3,
             kernel_size=self.kernel_size,
@@ -269,7 +346,18 @@ class AvgPool3dOp(Op):
 
         self.dispatch_kernel(kernel_map)
         if "avg_pool3d_kernel" not in self.kernel_map:
-            raise NotImplementedError("AvgPool3dOp requires 'avg_pool3d_kernel' in kernel_map")
+            raise NotImplementedError(
+                "AvgPool3dFwdOp requires 'avg_pool3d_kernel' in kernel_map"
+            )
+        self.out_d = pool_output_dim(
+            self.d_in, self.kernel_size[0], self.stride[0], self.padding[0], self.ceil_mode
+        )
+        self.out_h = pool_output_dim(
+            self.h_in, self.kernel_size[1], self.stride[1], self.padding[1], self.ceil_mode
+        )
+        self.out_w = pool_output_dim(
+            self.w_in, self.kernel_size[2], self.stride[2], self.padding[2], self.ceil_mode
+        )
         self.kernel = self.kernel_map["avg_pool3d_kernel"](
             n=n,
             c_in=c_in,
@@ -296,12 +384,87 @@ class AvgPool3dOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"avg_pool3d_kernel": AvgPool3dKernel}
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        validate_channels_last_input(
-            op_name=type(self).__name__,
-            x_shape=tuple(x.shape),
-            expected_shape=(self.n, self.d_in, self.h_in, self.w_in, self.c_in),
-            layout="NDHWC",
-            ambiguous_layout_shape=(self.n, self.c_in, self.d_in, self.h_in, self.w_in),
+    def _infer_output_shapes(
+        self, input_shape: tuple[int, ...]
+    ) -> Dict[str, tuple[int, ...]]:
+        if len(input_shape) != 5:
+            raise ValueError("AvgPool3dFwdOp expects input_shape to be 5D NCDHW")
+        n, c_in, d_in, h_in, w_in = input_shape
+        kernel_size = getattr(self, "kernel_size", None)
+        stride = getattr(self, "stride", None)
+        padding = getattr(self, "padding", None)
+        ceil_mode = getattr(self, "ceil_mode", False)
+        if kernel_size is None or stride is None or padding is None:
+            return {"output": (n, c_in, 0, 0, 0)}
+        out_d = pool_output_dim(d_in, kernel_size[0], stride[0], padding[0], ceil_mode)
+        out_h = pool_output_dim(h_in, kernel_size[1], stride[1], padding[1], ceil_mode)
+        out_w = pool_output_dim(w_in, kernel_size[2], stride[2], padding[2], ceil_mode)
+        return {"output": (n, c_in, out_d, out_h, out_w)}
+
+    def _validate_dtypes(self, input: torch.Tensor) -> None:
+        if input.dtype not in {torch.float16, torch.bfloat16, torch.float32}:
+            raise ValueError(
+                "input.dtype must be float16, bfloat16, or float32, "
+                f"got {input.dtype}"
+            )
+        if input.dtype != self.dtype:
+            raise ValueError(
+                f"input.dtype must match op dtype {self.dtype}, got {input.dtype}"
+            )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        self._validate_dtypes(input)
+        if input.ndim != 5:
+            raise ValueError("AvgPool3dFwdOp expects input to be a 5D NCDHW tensor")
+
+        expected_shape = (self.n, self.c_in, self.d_in, self.h_in, self.w_in)
+        actual_shape = tuple(input.shape)
+        if actual_shape != expected_shape:
+            raise ValueError(
+                f"AvgPool3dFwdOp expects input shape {expected_shape}, "
+                f"but got {actual_shape}"
+            )
+        if not input.is_cuda:
+            raise ValueError("input must be a CUDA tensor")
+
+        input = input.contiguous()
+        return self.kernel(input)
+
+    def eval_roofline(self) -> tuple[int, int]:
+        elem_bytes = torch.empty((), dtype=self.dtype).element_size()
+        out_d = pool_output_dim(
+            self.d_in,
+            self.kernel_size[0],
+            self.stride[0],
+            self.padding[0],
+            self.ceil_mode,
         )
-        return self.kernel(x)
+        out_h = pool_output_dim(
+            self.h_in,
+            self.kernel_size[1],
+            self.stride[1],
+            self.padding[1],
+            self.ceil_mode,
+        )
+        out_w = pool_output_dim(
+            self.w_in,
+            self.kernel_size[2],
+            self.stride[2],
+            self.padding[2],
+            self.ceil_mode,
+        )
+        flops = (
+            self.n
+            * self.c_in
+            * out_d
+            * out_h
+            * out_w
+            * self.kernel_size[0]
+            * self.kernel_size[1]
+            * self.kernel_size[2]
+        )
+        bytes_ = (
+            self.n * self.c_in * self.d_in * self.h_in * self.w_in
+            + self.n * self.c_in * out_d * out_h * out_w
+        ) * elem_bytes
+        return flops, bytes_

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -270,26 +270,17 @@ class AvgPool2dFwdOp(Op):
 
     def eval_roofline(self) -> tuple[int, int]:
         elem_bytes = torch.empty((), dtype=self.dtype).element_size()
-        out_h = pool_output_dim(
-            self.h_in,
-            self.kernel_size[0],
-            self.stride[0],
-            self.padding[0],
-            self.ceil_mode,
-        )
-        out_w = pool_output_dim(
-            self.w_in,
-            self.kernel_size[1],
-            self.stride[1],
-            self.padding[1],
-            self.ceil_mode,
-        )
         flops = (
-            self.n * self.c_in * out_h * out_w * self.kernel_size[0] * self.kernel_size[1]
+            self.n
+            * self.c_in
+            * self.out_h
+            * self.out_w
+            * self.kernel_size[0]
+            * self.kernel_size[1]
         )
         bytes_ = (
             self.n * self.c_in * self.h_in * self.w_in
-            + self.n * self.c_in * out_h * out_w
+            + self.n * self.c_in * self.out_h * self.out_w
         ) * elem_bytes
         return flops, bytes_
 
@@ -432,39 +423,18 @@ class AvgPool3dFwdOp(Op):
 
     def eval_roofline(self) -> tuple[int, int]:
         elem_bytes = torch.empty((), dtype=self.dtype).element_size()
-        out_d = pool_output_dim(
-            self.d_in,
-            self.kernel_size[0],
-            self.stride[0],
-            self.padding[0],
-            self.ceil_mode,
-        )
-        out_h = pool_output_dim(
-            self.h_in,
-            self.kernel_size[1],
-            self.stride[1],
-            self.padding[1],
-            self.ceil_mode,
-        )
-        out_w = pool_output_dim(
-            self.w_in,
-            self.kernel_size[2],
-            self.stride[2],
-            self.padding[2],
-            self.ceil_mode,
-        )
         flops = (
             self.n
             * self.c_in
-            * out_d
-            * out_h
-            * out_w
+            * self.out_d
+            * self.out_h
+            * self.out_w
             * self.kernel_size[0]
             * self.kernel_size[1]
             * self.kernel_size[2]
         )
         bytes_ = (
             self.n * self.c_in * self.d_in * self.h_in * self.w_in
-            + self.n * self.c_in * out_d * out_h * out_w
+            + self.n * self.c_in * self.out_d * self.out_h * self.out_w
         ) * elem_bytes
         return flops, bytes_


### PR DESCRIPTION
Closes #1585

## Summary

- Align `AvgPool2dFwdOp` and `AvgPool3dFwdOp` with the `pool.yaml` manifest contract.
- Replace the old `AvgPool2dOp`/`AvgPool3dOp` public surface with the manifest-declared FwdOp classes.
- Rewrite 2D/3D avg-pool kernels to consume native `NCHW`/`NCDHW` layouts without Op-level permutation.
- Drive 2D/3D pool benchmarks from manifest workloads and document workload provenance.
- Promote both manifest entries to `status: implemented` with `source.bench_manifest_driven: true`.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `python -m pytest tests/ops/test_pool.py -k "avg_pool2d or avg_pool3d" -vvs`
- [x] `python -m pytest tests/ops/test_pool.py -vvs`
- [x] `python scripts/validate_manifest.py --check-op AvgPool2dFwdOp --strict`
- [x] `python scripts/validate_manifest.py --check-op AvgPool3dFwdOp --strict`
- [x] `python scripts/validate_manifest.py`

## Benchmark

- [x] `python -m pytest benchmarks/ops/bench_pool.py -k "avg_pool2d or avg_pool3d" -vvs`
  - 6 selected benchmark tests passed.

## Test node delta triage

- Ran `python scripts/test_node_delta.py --base upstream/main`.
- Result:
  - `tests/ops/test_pool.py`: `0 -> 46`, `+46`
  - `TOTAL`: `0 -> 46`, `+46`
- Root cause for the `0` base count: `test_node_delta.py` collects the base-version test file inside the current PR checkout. The base-version `tests/ops/test_pool.py` imports `AvgPool2dOp` and `AvgPool3dOp`, but this PR intentionally removes those names from `tileops.ops` and keeps only `AvgPool2dFwdOp` / `AvgPool3dFwdOp`. That makes base-side collection fail with `ImportError`, so the script records the base count as `0`.
- Manual diff triage: this PR does not add 46 new pool test cases. The parameter matrix adds two smoke cases only:
  - `smoke-3x3-default-stride-fp32` for `AvgPool2dFwdOp`
  - `smoke-2x2x2-default-stride-fp32` for `AvgPool3dFwdOp`
- The remaining `tests/ops/test_pool.py` changes update existing tests for the intentional API/layout migration: `AvgPool2dOp` / `AvgPool3dOp` to `AvgPool2dFwdOp` / `AvgPool3dFwdOp`, and NHWC/NDHWC inputs to native NCHW/NCDHW inputs.
- The two new fp32 smoke cases are kept to complete smoke dtype coverage for the promoted implemented ops, matching the existing fp16/bf16 smoke coverage and the 1D avg-pool pattern.

## Additional context

- This intentionally removes the old `AvgPool2dOp` and `AvgPool3dOp` names to match the manifest-declared public API.
- `scripts/validate_manifest.py` still emits existing advisory shape-rule warnings for temporary manifest variables, including pool entries, but targeted strict validation exits successfully for both promoted ops.