### PR TITLE
[Chore] Pin tilelang to main commit and adapt autotune fallback

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -694,6 +694,9 @@ jobs:
           echo "Resolved pytest targets: ${PYTEST_TARGETS}"
           read -r -a TARGETS <<< "${PYTEST_TARGETS}"
           echo "Running pytest -m \"${TEST_MARK_EXPR}\" on ${#TARGETS[@]} target(s)"
+          # Self-heal: a reused/cached venv may predate the test deps (e.g. a
+          # trusted venv built without [dev]); ensure pytest is present.
+          python -m pytest --version >/dev/null 2>&1 || pip install pytest pytest-xdist
           python -m pytest -q "${TARGETS[@]}" -m "${TEST_MARK_EXPR}" --junit-xml=gpu_smoke_results.xml | tee gpu_smoke.log
 
       - name: Generate gpu-smoke report

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -638,7 +638,7 @@ jobs:
             # seeded, so also look in the persistent trusted cache where the
             # wheel is staged.
             TILELANG_WHL=""
-            for _dir in "${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:-/data7/shared/ci-cache}/wheels" "/data7/shared/ci-cache/wheels"; do
+            for _dir in "${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:+${TRUSTED_CACHE_ROOT}/wheels}"; do
               [[ -n "$_dir" && -d "$_dir" ]] || continue
               for _whl in "$_dir"/tilelang-*.whl; do
                 [[ -e "$_whl" ]] || continue

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -625,7 +625,10 @@ jobs:
             # — find-links is bypassed for a git-URL requirement — and pull the
             # rest with --no-deps so the git ref is never built. Fall back to the
             # source build when no wheel is staged. Revert when tilelang releases.
-            TILELANG_WHL="$(ls "${WHEEL_DIR}"/tilelang-*.whl 2>/dev/null | head -1 || true)"
+            TILELANG_WHL=""
+            for _whl in "${WHEEL_DIR}"/tilelang-*.whl; do
+              [[ -e "$_whl" ]] && TILELANG_WHL="$_whl" && break
+            done
             if [[ -n "$TILELANG_WHL" ]]; then
               echo "Reusing prebuilt tilelang wheel: ${TILELANG_WHL}"
               PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install --no-deps "${TILELANG_WHL}"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -633,11 +633,17 @@ jobs:
             # in WHEEL_DIR (seeded from the trusted cache), install it instead of
             # building the git URL. Fall back to the source build when no wheel
             # is staged. Revert when tilelang releases.
-            # Pick the newest staged wheel (the shared cache may hold several).
+            # Pick the newest staged wheel. Search every cache dir the runner
+            # may use: WHEEL_DIR can be an ephemeral per-run dir that was not
+            # seeded, so also look in the persistent trusted cache where the
+            # wheel is staged.
             TILELANG_WHL=""
-            for _whl in "${WHEEL_DIR}"/tilelang-*.whl; do
-              [[ -e "$_whl" ]] || continue
-              [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"
+            for _dir in "${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:-/data7/shared/ci-cache}/wheels" "/data7/shared/ci-cache/wheels"; do
+              [[ -n "$_dir" && -d "$_dir" ]] || continue
+              for _whl in "$_dir"/tilelang-*.whl; do
+                [[ -e "$_whl" ]] || continue
+                [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"
+              done
             done
             if [[ -n "$TILELANG_WHL" ]]; then
               echo "Reusing prebuilt tilelang wheel: ${TILELANG_WHL}"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -608,8 +608,17 @@ jobs:
           fi
 
           if [[ "$VENV_REUSED" == "true" ]]; then
-            echo "Using cached venv at ${VENV_PATH}"
-            exit 0
+            # Validate the cached venv before trusting it. A prior run that
+            # failed mid-install (e.g. a tilelang source build that aborted on a
+            # submodule clone) can leave a bare/incomplete venv cached here;
+            # reusing it skips install and breaks tests. Rebuild if key imports
+            # are missing.
+            if "${VENV_PATH}/bin/python" -c "import torch, tilelang, pytest" >/dev/null 2>&1; then
+              echo "Using cached venv at ${VENV_PATH}"
+              exit 0
+            fi
+            echo "Cached venv at ${VENV_PATH} is incomplete; rebuilding from scratch"
+            rm -rf "${VENV_PATH}"
           fi
 
           echo "Creating fresh venv at ${VENV_PATH}"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -618,12 +618,22 @@ jobs:
           source "${VENV_PATH}/bin/activate"
           python -m pip install --upgrade pip setuptools wheel --no-user
           if [[ "$IS_FORK" == "true" ]]; then
-            FIND_LINKS_FLAG=""
-            if [[ -d "${WHEEL_DIR}" ]] && ls "${WHEEL_DIR}"/*.whl >/dev/null 2>&1; then
-              FIND_LINKS_FLAG="--find-links ${WHEEL_DIR}"
+            # TEMPORARY (while tilelang is pinned to a git commit): building it
+            # from source clones large submodules from github, which is
+            # unreliable on this runner. If a prebuilt tilelang wheel is staged
+            # in WHEEL_DIR (seeded from the trusted cache), install it directly
+            # — find-links is bypassed for a git-URL requirement — and pull the
+            # rest with --no-deps so the git ref is never built. Fall back to the
+            # source build when no wheel is staged. Revert when tilelang releases.
+            TILELANG_WHL="$(ls "${WHEEL_DIR}"/tilelang-*.whl 2>/dev/null | head -1 || true)"
+            if [[ -n "$TILELANG_WHL" ]]; then
+              echo "Reusing prebuilt tilelang wheel: ${TILELANG_WHL}"
+              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install --no-deps "${TILELANG_WHL}"
+              PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' --no-deps
+              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install "apache-tvm-ffi>=0.1.10,<=0.1.11" "torch>=2.1.0,<2.11.0" einops pyyaml pytest pytest-xdist
+            else
+              PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]'
             fi
-            # shellcheck disable=SC2086
-            PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' ${FIND_LINKS_FLAG}
 
             # Sync libtilelang.so mtime with trusted venv so compile cache keys match.
             # TileLang cache keys include the library's mtime (kernel_cache.py); a fresh

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -637,16 +637,19 @@ jobs:
             # may use: WHEEL_DIR can be an ephemeral per-run dir that was not
             # seeded, so also look in the persistent trusted cache where the
             # wheel is staged.
+            SEARCH_DIRS=("${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:+${TRUSTED_CACHE_ROOT}/wheels}")
+            echo "[tilelang] searching for a prebuilt wheel in: ${SEARCH_DIRS[*]}"
             TILELANG_WHL=""
-            for _dir in "${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:+${TRUSTED_CACHE_ROOT}/wheels}"; do
-              [[ -n "$_dir" && -d "$_dir" ]] || continue
+            for _dir in "${SEARCH_DIRS[@]}"; do
+              [[ -n "$_dir" && -d "$_dir" ]] || { echo "[tilelang]   - $_dir : (missing dir)"; continue; }
+              echo "[tilelang]   - $_dir :"; ls -la "$_dir" 2>&1 | sed 's/^/[tilelang]       /'
               for _whl in "$_dir"/tilelang-*.whl; do
                 [[ -e "$_whl" ]] || continue
                 [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"
               done
             done
             if [[ -n "$TILELANG_WHL" ]]; then
-              echo "Reusing prebuilt tilelang wheel: ${TILELANG_WHL}"
+              echo "::notice::[tilelang] FOUND prebuilt wheel ${TILELANG_WHL} — installing it, SKIPPING git source build"
               # Install the wheel WITH its runtime deps (numpy, cloudpickle,
               # psutil, ml-dtypes, ...) but pin torch/apache-tvm-ffi to our
               # ranges. Then install TileOPs editable --no-deps so the git
@@ -656,6 +659,7 @@ jobs:
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' --no-deps
               PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install einops pyyaml pytest pytest-xdist
             else
+              echo "::warning::[tilelang] NO prebuilt wheel found in [${SEARCH_DIRS[*]}] — FALLING BACK to git source build (clone + compile)"
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]'
             fi
 

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -642,7 +642,7 @@ jobs:
             TILELANG_WHL=""
             for _dir in "${SEARCH_DIRS[@]}"; do
               [[ -n "$_dir" && -d "$_dir" ]] || { echo "[tilelang]   - $_dir : (missing dir)"; continue; }
-              echo "[tilelang]   - $_dir :"; ls -la "$_dir" 2>&1 | sed 's/^/[tilelang]       /'
+              echo "[tilelang]   - $_dir :"; find "$_dir" -maxdepth 1 -type f -printf '[tilelang]       %f\n' 2>/dev/null || true
               for _whl in "$_dir"/tilelang-*.whl; do
                 [[ -e "$_whl" ]] || continue
                 [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -621,19 +621,25 @@ jobs:
             # TEMPORARY (while tilelang is pinned to a git commit): building it
             # from source clones large submodules from github, which is
             # unreliable on this runner. If a prebuilt tilelang wheel is staged
-            # in WHEEL_DIR (seeded from the trusted cache), install it directly
-            # — find-links is bypassed for a git-URL requirement — and pull the
-            # rest with --no-deps so the git ref is never built. Fall back to the
-            # source build when no wheel is staged. Revert when tilelang releases.
+            # in WHEEL_DIR (seeded from the trusted cache), install it instead of
+            # building the git URL. Fall back to the source build when no wheel
+            # is staged. Revert when tilelang releases.
+            # Pick the newest staged wheel (the shared cache may hold several).
             TILELANG_WHL=""
             for _whl in "${WHEEL_DIR}"/tilelang-*.whl; do
-              [[ -e "$_whl" ]] && TILELANG_WHL="$_whl" && break
+              [[ -e "$_whl" ]] || continue
+              [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"
             done
             if [[ -n "$TILELANG_WHL" ]]; then
               echo "Reusing prebuilt tilelang wheel: ${TILELANG_WHL}"
-              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install --no-deps "${TILELANG_WHL}"
+              # Install the wheel WITH its runtime deps (numpy, cloudpickle,
+              # psutil, ml-dtypes, ...) but pin torch/apache-tvm-ffi to our
+              # ranges. Then install TileOPs editable --no-deps so the git
+              # tilelang URL is never built, and add TileOPs' own deps + test
+              # tools (not pulled by --no-deps).
+              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install --find-links "${WHEEL_DIR}" "${TILELANG_WHL}" "apache-tvm-ffi>=0.1.10,<=0.1.11" "torch>=2.1.0,<2.11.0"
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' --no-deps
-              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install "apache-tvm-ffi>=0.1.10,<=0.1.11" "torch>=2.1.0,<2.11.0" einops pyyaml pytest pytest-xdist
+              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install einops pyyaml pytest pytest-xdist
             else
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]'
             fi

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -608,17 +608,8 @@ jobs:
           fi
 
           if [[ "$VENV_REUSED" == "true" ]]; then
-            # Validate the cached venv before trusting it. A prior run that
-            # failed mid-install (e.g. a tilelang source build that aborted on a
-            # submodule clone) can leave a bare/incomplete venv cached here;
-            # reusing it skips install and breaks tests. Rebuild if key imports
-            # are missing.
-            if "${VENV_PATH}/bin/python" -c "import torch, tilelang, pytest" >/dev/null 2>&1; then
-              echo "Using cached venv at ${VENV_PATH}"
-              exit 0
-            fi
-            echo "Cached venv at ${VENV_PATH} is incomplete; rebuilding from scratch"
-            rm -rf "${VENV_PATH}"
+            echo "Using cached venv at ${VENV_PATH}"
+            exit 0
           fi
 
           echo "Creating fresh venv at ${VENV_PATH}"
@@ -627,39 +618,19 @@ jobs:
           source "${VENV_PATH}/bin/activate"
           python -m pip install --upgrade pip setuptools wheel --no-user
           if [[ "$IS_FORK" == "true" ]]; then
-            # TEMPORARY (while tilelang is pinned to a git commit): building it
-            # from source clones large submodules from github, which is
-            # unreliable on this runner. If a prebuilt tilelang wheel is staged
-            # in WHEEL_DIR (seeded from the trusted cache), install it instead of
-            # building the git URL. Fall back to the source build when no wheel
-            # is staged. Revert when tilelang releases.
-            # Pick the newest staged wheel. Search every cache dir the runner
-            # may use: WHEEL_DIR can be an ephemeral per-run dir that was not
-            # seeded, so also look in the persistent trusted cache where the
-            # wheel is staged.
-            SEARCH_DIRS=("${WHEEL_DIR:-}" "${TRUSTED_CACHE_ROOT:+${TRUSTED_CACHE_ROOT}/wheels}")
-            echo "[tilelang] searching for a prebuilt wheel in: ${SEARCH_DIRS[*]}"
-            TILELANG_WHL=""
-            for _dir in "${SEARCH_DIRS[@]}"; do
-              [[ -n "$_dir" && -d "$_dir" ]] || { echo "[tilelang]   - $_dir : (missing dir)"; continue; }
-              echo "[tilelang]   - $_dir :"; find "$_dir" -maxdepth 1 -type f -printf '[tilelang]       %f\n' 2>/dev/null || true
-              for _whl in "$_dir"/tilelang-*.whl; do
-                [[ -e "$_whl" ]] || continue
-                [[ -z "$TILELANG_WHL" || "$_whl" -nt "$TILELANG_WHL" ]] && TILELANG_WHL="$_whl"
-              done
-            done
-            if [[ -n "$TILELANG_WHL" ]]; then
-              echo "::notice::[tilelang] FOUND prebuilt wheel ${TILELANG_WHL} — installing it, SKIPPING git source build"
-              # Install the wheel WITH its runtime deps (numpy, cloudpickle,
-              # psutil, ml-dtypes, ...) but pin torch/apache-tvm-ffi to our
-              # ranges. Then install TileOPs editable --no-deps so the git
-              # tilelang URL is never built, and add TileOPs' own deps + test
-              # tools (not pulled by --no-deps).
-              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install --find-links "${WHEEL_DIR}" "${TILELANG_WHL}" "apache-tvm-ffi>=0.1.10,<=0.1.11" "torch>=2.1.0,<2.11.0"
+            # tilelang is pinned to a git commit and is prebuilt into the runner
+            # image at /opt/tilelang-wheels (built with the image's own toolchain,
+            # so ABI-native; lives in the image layer, so it survives cache
+            # cleanup and container restart). Install it from there and never
+            # build the git URL. Fall back to a source build only if absent.
+            TL_WHL=$(compgen -G "/opt/tilelang-wheels/tilelang-*.whl" | head -1 || true)
+            if [[ -n "$TL_WHL" ]]; then
+              echo "Installing prebuilt tilelang wheel: $TL_WHL (skipping git source build)"
+              PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install "$TL_WHL" "apache-tvm-ffi>=0.1.10,<=0.1.11" "torch>=2.1.0,<2.11.0"
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]' --no-deps
               PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install einops pyyaml pytest pytest-xdist
             else
-              echo "::warning::[tilelang] NO prebuilt wheel found in [${SEARCH_DIRS[*]}] — FALLING BACK to git source build (clone + compile)"
+              echo "No prebuilt tilelang wheel in /opt/tilelang-wheels; building from source"
               PIP_NO_BUILD_ISOLATION=1 PIP_CACHE_DIR="${PIP_CACHE_DIR}" pip install -e '.[dev]'
             fi
 
@@ -719,9 +690,6 @@ jobs:
           echo "Resolved pytest targets: ${PYTEST_TARGETS}"
           read -r -a TARGETS <<< "${PYTEST_TARGETS}"
           echo "Running pytest -m \"${TEST_MARK_EXPR}\" on ${#TARGETS[@]} target(s)"
-          # Self-heal: a reused/cached venv may predate the test deps (e.g. a
-          # trusted venv built without [dev]); ensure pytest is present.
-          python -m pytest --version >/dev/null 2>&1 || pip install pytest pytest-xdist
           python -m pytest -q "${TARGETS[@]}" -m "${TEST_MARK_EXPR}" --junit-xml=gpu_smoke_results.xml | tee gpu_smoke.log
 
       - name: Generate gpu-smoke report

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -253,7 +253,10 @@ jobs:
         # --no-deps and skip the git build.
         run: |
           pip install -e . --no-deps
-          pip install "tilelang==0.1.9" "torch>=2.1.0,<2.11.0" einops pyyaml
+          # Released tilelang 0.1.9 declares apache-tvm-ffi~=0.1.0, which pulls
+          # an incompatible 0.1.1x; cap it (the pin tileops carried before this
+          # PR) so the released wheel imports.
+          pip install "tilelang==0.1.9" "apache-tvm-ffi>=0.1.2,<0.1.10" "torch>=2.1.0,<2.11.0" einops pyyaml
 
       - name: Validate ops manifest
         run: python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict
@@ -311,7 +314,10 @@ jobs:
         # skip the git build.
         run: |
           pip install -e . --no-deps
-          pip install "tilelang==0.1.9" "torch>=2.1.0,<2.11.0" einops pyyaml pytest pytest-xdist
+          # Released tilelang 0.1.9 declares apache-tvm-ffi~=0.1.0, which pulls
+          # an incompatible 0.1.1x; cap it (the pin tileops carried before this
+          # PR) so the released wheel imports.
+          pip install "tilelang==0.1.9" "apache-tvm-ffi>=0.1.2,<0.1.10" "torch>=2.1.0,<2.11.0" einops pyyaml pytest pytest-xdist
 
       - name: Run benchmark contract tests
         run: python -m pytest -q benchmarks/tests

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -247,7 +247,13 @@ jobs:
           python-version: "3.10"
 
       - name: Install TileOPs and validator dependencies
-        run: pip install -e .
+        # tilelang is pinned to a git commit (built from source); a CPU-only
+        # runner has no CUDA toolkit to compile it. Manifest validation only
+        # needs tilelang importable, so install the released wheel with
+        # --no-deps and skip the git build.
+        run: |
+          pip install -e . --no-deps
+          pip install "tilelang==0.1.9" "torch>=2.1.0,<2.11.0" einops pyyaml
 
       - name: Validate ops manifest
         run: python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict
@@ -299,7 +305,13 @@ jobs:
           python-version: "3.10"
 
       - name: Install TileOPs (with dev extras)
-        run: pip install -e ".[dev]"
+        # tilelang is pinned to a git commit (built from source); a CPU-only
+        # runner has no CUDA toolkit to compile it. Contract tests only need
+        # tilelang importable, so install the released wheel with --no-deps and
+        # skip the git build.
+        run: |
+          pip install -e . --no-deps
+          pip install "tilelang==0.1.9" "torch>=2.1.0,<2.11.0" einops pyyaml pytest pytest-xdist
 
       - name: Run benchmark contract tests
         run: python -m pytest -q benchmarks/tests

--- a/README.md
+++ b/README.md
@@ -51,13 +51,12 @@ TileOPs can be installed from PyPI or built from source. A CUDA-capable GPU is r
 - NVIDIA GPU: **Hopper** (SM_90)
 - [TileLang](https://github.com/tile-ai/tilelang) — pinned to a `main` commit, built from source (see the note below)
 
-### From PyPI
-
-```bash
-pip install tileops
-```
-
 ### From source
+
+> [!NOTE]
+> Installing from PyPI (`pip install tileops`) is temporarily unavailable: TileOPs
+> pins TileLang to a `main` commit (see the note below), and a published package
+> cannot carry a git dependency. Build from source until TileLang has a release again.
 
 ```bash
 git clone https://github.com/tile-ai/TileOPs

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TileOPs can be installed from PyPI or built from source. A CUDA-capable GPU is r
 - PyTorch >= 2.1
 - CUDA Toolkit
 - NVIDIA GPU: **Hopper** (SM_90)
-- [TileLang](https://github.com/tile-ai/tilelang) == 0.1.9
+- [TileLang](https://github.com/tile-ai/tilelang) — pinned to a `main` commit, built from source (see the note below)
 
 ### From PyPI
 
@@ -68,6 +68,23 @@ make install    # dev dependencies + pre-commit hooks
 > [!NOTE]
 > If CUDA and TileLang are already installed system-wide and you encounter build issues:
 > `PIP_NO_BUILD_ISOLATION=1 pip install -e '.[dev]' -v && pre-commit install`
+
+> [!IMPORTANT]
+> **TileOPs currently pins TileLang to a `main` commit** because it depends on a fix not
+> yet in a TileLang release. While this holds:
+>
+> - Installing **compiles TileLang from source** — a git commit has no prebuilt wheel, so
+>   `pip` builds TileLang and its submodules. A CUDA build toolchain is required and the
+>   first build is slow; the pinned commit is cached and reused afterward.
+> - **`pip install tileops` from PyPI is unavailable** during this phase: a published
+>   package cannot carry a git dependency. Install from source.
+> - On import, TileOPs preloads the CUDA driver (`libcuda.so.1`) into the global symbol
+>   namespace, working around a TileLang source-build gap where `libtvm_runtime.so` leaves
+>   driver symbols (e.g. `cuModuleLoadData`) unresolved. If you `import tilelang` **directly**
+>   (not via `tileops`) and hit `undefined symbol: cuModuleLoadData`, run with
+>   `LD_PRELOAD=/path/to/libcuda.so.1`.
+>
+> This reverts to a normal version pin once TileLang cuts a release.
 
 Verify:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This separation keeps user-facing behavior independent of GPU strategy, allowing
 
 ## Installation
 
-TileOPs can be installed from PyPI or built from source. A CUDA-capable GPU is required.
+TileOPs is currently built from source (PyPI install is temporarily unavailable — see the note below). A CUDA-capable GPU is required.
 
 ### Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,13 @@ readme = "README.md"
 authors = [{ name="Tile-AI"}]
 dependencies = [
     "torch>=2.1.0,<2.11.0",
-    "tilelang==0.1.9",
-    # FIXME(apache-tvm-ffi-pin): Remove once tilelang carries its own
-    # apache-tvm-ffi<0.1.10 pin (already on tilelang main, not yet released).
-    # Tracking: https://github.com/tile-ai/TileOPs/issues/969
-    "apache-tvm-ffi>=0.1.2,<0.1.10",
+    # Tracking tilelang main until its next release (see issue #969). Pinned to
+    # a commit for reproducibility and so pip can cache the built wheel — never
+    # float @main. tilelang main carries its own apache-tvm-ffi pin, so we no
+    # longer restate it here.
+    # FLIP PLAN: when tilelang cuts a release, replace this with
+    # `tilelang>=<version>` (the project becomes PyPI-publishable then).
+    "tilelang @ git+https://github.com/tile-ai/tilelang.git@65dbc9837beedf6882a40a08e18ea571d92fd6a5",
     "einops",
     "pyyaml>=6.0",
 ]

--- a/tileops/__init__.py
+++ b/tileops/__init__.py
@@ -1,1 +1,44 @@
+"""TileOPs package initialization.
+
+Hotfix: preload the CUDA driver into the global symbol namespace before any
+submodule imports tilelang's native runtime. See ``_preload_cuda_driver``.
+"""
+from __future__ import annotations
+
+
+def _preload_cuda_driver() -> None:
+    """Load libcuda into the global symbol scope before tilelang's runtime.
+
+    tilelang built from source (we pin a main commit) ships ``libtvm_runtime.so``
+    with unresolved CUDA *driver* symbols such as ``cuModuleLoadData``: it links
+    the CUDA *runtime* stub (``libcudart_stub.so``) but not the *driver* stub
+    (``libcuda_stub.so``), and assumes the driver is already present in the
+    global symbol scope. When nothing else loads it globally — e.g. torch's CUDA
+    libraries are opened ``RTLD_LOCAL`` — importing tilelang fails with
+    ``OSError: undefined symbol: cuModuleLoadData``.
+
+    Loading the real driver with ``RTLD_GLOBAL`` here makes those symbols
+    resolvable, exactly as an external ``LD_PRELOAD=libcuda.so.1`` would. This is
+    best effort: on non-Linux or CPU-only hosts the driver is absent, so we leave
+    the import to proceed (and surface tilelang's own error if one is raised).
+
+    Stopgap for a tilelang source-build packaging gap — remove once tilelang
+    links the driver stub (or preloads it) itself.
+    """
+    import ctypes
+    import sys
+
+    if not sys.platform.startswith("linux"):
+        return
+    for soname in ("libcuda.so.1", "libcuda.so"):
+        try:
+            ctypes.CDLL(soname, mode=ctypes.RTLD_GLOBAL)
+            return
+        except OSError:
+            continue
+
+
+_preload_cuda_driver()
+del _preload_cuda_driver
+
 __all__: list[str] = []

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -760,28 +760,22 @@ class UnaryKernel(Kernel):
         ]
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Override to handle serialization failures in the TileLang autotuner.
+        """Autotuning is unsupported for this kernel — fall back to default_config.
 
-        UnaryKernel JIT functions capture op_func closures that the autotuner
-        subprocess cannot serialize.  Catch the error and fall back to the
-        default config so that ``tune=True`` never crashes.
+        UnaryKernel captures a Python op_func closure the TileLang autotuner
+        cannot drive (older versions fail to serialize it for subprocess
+        compilation; tilelang main fails to bind the tunable params), so a tune
+        is guaranteed to fail. Skip it and fall back immediately so ``tune=True``
+        degrades gracefully without wasting time on a failing autotune.
         """
         import warnings
 
-        try:
-            super().autotune(warmup=warmup, rep=rep)
-        except Exception as exc:
-            # This kernel captures a Python op_func closure the TileLang
-            # autotuner cannot drive: older versions fail to serialize it for
-            # subprocess compilation ("not serializable"); tilelang main fails
-            # to bind the tunable params. Autotuning is unsupported here — fall
-            # back to default_config so tune=True degrades gracefully.
-            warnings.warn(
-                f"{self.__class__.__name__} autotuning unsupported "
-                f"({type(exc).__name__}: {exc}); falling back to default_config.",
-                stacklevel=2,
-            )
-            self.config = dict(self.default_config)
+        warnings.warn(
+            f"{self.__class__.__name__} autotuning unsupported "
+            f"(captures a Python closure); falling back to default_config.",
+            stacklevel=2,
+        )
+        self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -974,28 +968,22 @@ class BinaryKernel(Kernel):
         ]
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Override to handle serialization failures in the TileLang autotuner.
+        """Autotuning is unsupported for this kernel — fall back to default_config.
 
-        BinaryKernel JIT functions capture op_func closures that the autotuner
-        subprocess cannot serialize.  Catch the error and fall back to the
-        default config so that ``tune=True`` never crashes.
+        BinaryKernel captures a Python op_func closure the TileLang autotuner
+        cannot drive (older versions fail to serialize it for subprocess
+        compilation; tilelang main fails to bind the tunable params), so a tune
+        is guaranteed to fail. Skip it and fall back immediately so ``tune=True``
+        degrades gracefully without wasting time on a failing autotune.
         """
         import warnings
 
-        try:
-            super().autotune(warmup=warmup, rep=rep)
-        except Exception as exc:
-            # This kernel captures a Python op_func closure the TileLang
-            # autotuner cannot drive: older versions fail to serialize it for
-            # subprocess compilation ("not serializable"); tilelang main fails
-            # to bind the tunable params. Autotuning is unsupported here — fall
-            # back to default_config so tune=True degrades gracefully.
-            warnings.warn(
-                f"{self.__class__.__name__} autotuning unsupported "
-                f"({type(exc).__name__}: {exc}); falling back to default_config.",
-                stacklevel=2,
-            )
-            self.config = dict(self.default_config)
+        warnings.warn(
+            f"{self.__class__.__name__} autotuning unsupported "
+            f"(captures a Python closure); falling back to default_config.",
+            stacklevel=2,
+        )
+        self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -1132,28 +1120,22 @@ class FusedGatedKernel(Kernel):
         ]
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Override to handle serialization failures in the TileLang autotuner.
+        """Autotuning is unsupported for this kernel — fall back to default_config.
 
-        FusedGatedKernel JIT functions capture activation_func closures that
-        the autotuner subprocess cannot serialize.  Catch the error and fall
-        back to the default config so that ``tune=True`` never crashes.
+        FusedGatedKernel captures a Python activation_func closure the TileLang
+        autotuner cannot drive (older versions fail to serialize it for
+        subprocess compilation; tilelang main fails to bind the tunable params),
+        so a tune is guaranteed to fail. Skip it and fall back immediately so
+        ``tune=True`` degrades gracefully without wasting time on a failing tune.
         """
         import warnings
 
-        try:
-            super().autotune(warmup=warmup, rep=rep)
-        except Exception as exc:
-            # This kernel captures a Python activation_func closure the TileLang
-            # autotuner cannot drive: older versions fail to serialize it for
-            # subprocess compilation ("not serializable"); tilelang main fails
-            # to bind the tunable params. Autotuning is unsupported here — fall
-            # back to default_config so tune=True degrades gracefully.
-            warnings.warn(
-                f"{self.__class__.__name__} autotuning unsupported "
-                f"({type(exc).__name__}: {exc}); falling back to default_config.",
-                stacklevel=2,
-            )
-            self.config = dict(self.default_config)
+        warnings.warn(
+            f"{self.__class__.__name__} autotuning unsupported "
+            f"(captures a Python closure); falling back to default_config.",
+            stacklevel=2,
+        )
+        self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -776,6 +776,12 @@ class UnaryKernel(Kernel):
             stacklevel=2,
         )
         self.config = dict(self.default_config)
+        # If autotune() runs after init_config() (e.g. a post-init re-tune),
+        # rebuild the cached kernel so forward() matches self.config. During the
+        # normal init flow _compiled_fn does not exist yet, so this is skipped
+        # and init_config() compiles it afterward.
+        if getattr(self, "_compiled_fn", None) is not None:
+            self.init_config(self.config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -984,6 +990,12 @@ class BinaryKernel(Kernel):
             stacklevel=2,
         )
         self.config = dict(self.default_config)
+        # If autotune() runs after init_config() (e.g. a post-init re-tune),
+        # rebuild the cached kernel so forward() matches self.config. During the
+        # normal init flow _compiled_fn does not exist yet, so this is skipped
+        # and init_config() compiles it afterward.
+        if getattr(self, "_compiled_fn", None) is not None:
+            self.init_config(self.config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -1136,6 +1148,12 @@ class FusedGatedKernel(Kernel):
             stacklevel=2,
         )
         self.config = dict(self.default_config)
+        # If autotune() runs after init_config() (e.g. a post-init re-tune),
+        # rebuild the cached kernel so forward() matches self.config. During the
+        # normal init flow _compiled_fn does not exist yet, so this is skipped
+        # and init_config() compiles it afterward.
+        if getattr(self, "_compiled_fn", None) is not None:
+            self.init_config(self.config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -770,17 +770,18 @@ class UnaryKernel(Kernel):
 
         try:
             super().autotune(warmup=warmup, rep=rep)
-        except (AssertionError, Exception) as exc:
-            if "not serializable" in str(exc) or "pickle" in str(exc).lower():
-                warnings.warn(
-                    f"{self.__class__.__name__} autotuning failed "
-                    f"(op_func is not serializable); falling back to "
-                    f"default_config.",
-                    stacklevel=2,
-                )
-                self.config = dict(self.default_config)
-            else:
-                raise
+        except Exception as exc:
+            # This kernel captures a Python op_func closure the TileLang
+            # autotuner cannot drive: older versions fail to serialize it for
+            # subprocess compilation ("not serializable"); tilelang main fails
+            # to bind the tunable params. Autotuning is unsupported here — fall
+            # back to default_config so tune=True degrades gracefully.
+            warnings.warn(
+                f"{self.__class__.__name__} autotuning unsupported "
+                f"({type(exc).__name__}: {exc}); falling back to default_config.",
+                stacklevel=2,
+            )
+            self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -983,15 +984,18 @@ class BinaryKernel(Kernel):
 
         try:
             super().autotune(warmup=warmup, rep=rep)
-        except (AssertionError, Exception) as exc:
-            if "not serializable" in str(exc) or "pickle" in str(exc).lower():
-                warnings.warn(  # noqa: B028
-                    f"{self.__class__.__name__} autotuning failed "
-                    f"(op_func is not serializable); falling back to "
-                    f"default_config.")
-                self.config = dict(self.default_config)
-            else:
-                raise
+        except Exception as exc:
+            # This kernel captures a Python op_func closure the TileLang
+            # autotuner cannot drive: older versions fail to serialize it for
+            # subprocess compilation ("not serializable"); tilelang main fails
+            # to bind the tunable params. Autotuning is unsupported here — fall
+            # back to default_config so tune=True degrades gracefully.
+            warnings.warn(
+                f"{self.__class__.__name__} autotuning unsupported "
+                f"({type(exc).__name__}: {exc}); falling back to default_config.",
+                stacklevel=2,
+            )
+            self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
@@ -1138,17 +1142,18 @@ class FusedGatedKernel(Kernel):
 
         try:
             super().autotune(warmup=warmup, rep=rep)
-        except (AssertionError, Exception) as exc:
-            if "not serializable" in str(exc) or "pickle" in str(exc).lower():
-                warnings.warn(
-                    f"{self.__class__.__name__} autotuning failed "
-                    f"(activation_func is not serializable); falling back to "
-                    f"default_config.",
-                    stacklevel=2,
-                )
-                self.config = dict(self.default_config)
-            else:
-                raise
+        except Exception as exc:
+            # This kernel captures a Python activation_func closure the TileLang
+            # autotuner cannot drive: older versions fail to serialize it for
+            # subprocess compilation ("not serializable"); tilelang main fails
+            # to bind the tunable params. Autotuning is unsupported here — fall
+            # back to default_config so tune=True degrades gracefully.
+            warnings.warn(
+                f"{self.__class__.__name__} autotuning unsupported "
+                f"({type(exc).__name__}: {exc}); falling back to default_config.",
+                stacklevel=2,
+            )
+            self.config = dict(self.default_config)
 
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""


### PR DESCRIPTION
## Summary

- Depend on tilelang via a git reference pinned to commit `65dbc98` (main) instead of released `0.1.9` — tileops needs fixes only on main. Pinned to a commit (not `@main`) for reproducibility and so pip can cache the built wheel.
- Drop the manual `apache-tvm-ffi<0.1.10` pin. tilelang main carries its own pin (now `>=0.1.10,<=0.1.11`), which conflicted with ours; it now resolves transitively. Relates to #969.
- Adapt the elementwise Unary/Binary/Activation autotune overrides to fall back to `default_config` on **any** autotune failure. These kernels capture Python `op_func`/`activation_func` closures the TileLang autotuner cannot drive; tilelang main now fails with `TypeError: missing a required argument: 'threads'` (tunable-param binding changed), which the old "not serializable"-only filter let crash `tune=True`.
- Preload `libcuda.so.1` (`RTLD_GLOBAL`) in `tileops/__init__` so the source-built tilelang imports without a manual `LD_PRELOAD` (see below). Document the source-build + preload situation in the README.

## Test plan

- [x] pre-commit passed (ruff, codespell, mdformat)
- [x] `import tileops; import tilelang` succeeds with **no** `LD_PRELOAD`
- [x] `tests/ops/test_binary_arith.py` — **147 passed** (previously 1 failed: `test_binary_tune_true_does_not_crash`)
- [x] representative cross-family smoke sample (activation / gemm / rms_norm / binary / argreduce) — passing
- [ ] full suite (3602 tests) not run locally — single-GPU serial, hours

## Additional context

Consequences of the git pin that reviewers should weigh:

- **`pip install` now compiles tilelang from source** — a git SHA has no prebuilt wheel, so pip clones tilelang + TVM/cutlass/composable_kernel submodules and builds them. CI that previously pulled the `0.1.9` wheel will now need a build toolchain + wheel caching (the immutable SHA lets pip reuse the cached build).
- **Import gap (now worked around here, root cause upstream):** the source-built tilelang ships `libtvm_runtime.so` with unresolved CUDA **driver** symbols (`cuModuleLoadData` …) — it links `libcudart_stub` but not `libcuda_stub`. This PR preloads the driver in `tileops/__init__`; a proper fix belongs in tilelang's source build.
- **FLIP PLAN**: when tilelang cuts a release, replace the git reference with a version spec, drop the driver preload, and the project becomes PyPI-publishable again.