### PR TITLE
[CI] Reproducible multi-stage runner image + single dependency source

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -16,12 +16,14 @@ FROM ${BASE_IMAGE} AS runtime
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-dev python3-pip python-is-python3 git curl ca-certificates \
+        build-essential cmake ninja-build unzip xz-utils sudo \
     && rm -rf /var/lib/apt/lists/*
 COPY constraints.txt /tmp/constraints.txt
 # torch from the cu129 index → 2.10.0+cu129, aligned with the base CUDA 12.9.
 RUN python -m pip install --index-url https://download.pytorch.org/whl/cu129 \
         -c /tmp/constraints.txt "torch==2.10.0"
 RUN python -m pip install -c /tmp/constraints.txt \
+        setuptools wheel ninja \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 
@@ -80,9 +82,12 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TRITON_CACHE_DIR=/ci-cache/triton \
     PIP_CACHE_DIR=/ci-cache/pip
 ARG RUNNER_VERSION=2.334.0
+# Create the user (and its skeleton home) before WORKDIR so the home dir is owned by
+# ci-runner, not root. WORKDIR then sits inside that home and precedes the relative-path
+# runner-extraction RUN (hadolint requires WORKDIR before relative paths).
+RUN useradd -m -s /bin/bash ci-runner
 WORKDIR /home/ci-runner/runner
-RUN useradd -m -s /bin/bash ci-runner \
-    && mkdir -p /home/ci-runner/runner/_work/_tool \
+RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && curl -fsSL -o runner.tar.gz \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
     && tar xzf runner.tar.gz && rm runner.tar.gz \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -80,7 +80,8 @@ RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraint
 FROM fullstack AS final
 # Cache dirs as image ENV defaults: workflows/scripts read these env vars rather than
 # hardcoding the path. The host persistent cache dir is bind-mounted to /ci-cache at
-# container start.
+# container start; the dirs are also pre-created below (owned by ci-runner) so the
+# defaults stay writable even when the image runs without that mount.
 ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TILELANG_CACHE_DIR=/ci-cache/tilelang \
     TILELANG_TMP_DIR=/ci-cache/tilelang/tmp \
@@ -100,7 +101,8 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
     && tar xzf runner.tar.gz && rm runner.tar.gz \
     && ./bin/installdependencies.sh \
-    && chown -R ci-runner:ci-runner /home/ci-runner
+    && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \
+    && chown -R ci-runner:ci-runner /home/ci-runner /ci-cache
 # Standalone runner mode: entrypoint.sh configures an ephemeral runner (config.sh)
 # then runs one job (run.sh). chmod needs root, so set it before dropping to ci-runner.
 COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh ./entrypoint.sh

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,16 +1,27 @@
 # syntax=docker/dockerfile:1.7
 # Multi-stage CI runner image.
-ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu24.04
+ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu22.04
 
 # ── runtime ──
 # devel (not runtime) base: nvcc is needed at runtime for tilelang JIT.
 FROM ${BASE_IMAGE} AS runtime
-# python-is-python3: later stages call `python`. PIP_BREAK_SYSTEM_PACKAGES: bypass PEP 668.
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 python3-dev python3-venv python3-pip python-is-python3 git curl ca-certificates \
-        build-essential cmake ninja-build unzip xz-utils sudo \
-    && rm -rf /var/lib/apt/lists/*
+# 22.04 ships python3.10; install 3.12 from deadsnakes and make it the default python.
+# software-properties-common is purged after adding the PPA to keep the image lean.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates curl gnupg \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.12 python3.12-dev python3.12-venv \
+        git build-essential cmake ninja-build unzip xz-utils sudo \
+    && apt-get purge -y --auto-remove software-properties-common \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && python3.12 -m ensurepip --upgrade \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 \
+    && python -m pip install --upgrade pip
 COPY constraints.txt /tmp/constraints.txt
 # `+cu129` pin forces the cu129 wheel from the pytorch index; the PyPI extra-index
 # supplies torch's pure-python deps, which the pytorch index does not host.
@@ -24,14 +35,19 @@ RUN python -m pip install -c /tmp/constraints.txt \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 
 # Build tilelang once from the pinned commit; install --no-deps so pip never re-resolves it.
-ARG TILELANG_GIT_SHA=65dbc9837beedf6882a40a08e18ea571d92fd6a5
+# TILELANG_GIT_SHA is a required build-arg (no default): bump it via `--build-arg` and tag
+# the image `:<short-sha>` — the Dockerfile never carries a SHA literal.
+ARG TILELANG_GIT_SHA
 ARG MAX_JOBS=64
 ARG NVCC_THREADS=4
 # TORCH_CUDA_ARCH_LIST=9.0: the runner pool is Hopper (H200) only.
 ENV MAX_JOBS=${MAX_JOBS} NVCC_THREADS=${NVCC_THREADS} TORCH_CUDA_ARCH_LIST=9.0
-RUN git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
+RUN if [ -z "${TILELANG_GIT_SHA}" ]; then \
+        echo "ERROR: build with --build-arg TILELANG_GIT_SHA=<commit>"; exit 1; \
+    fi \
+    && git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
     && cd /tmp/tilelang \
-    && git checkout ${TILELANG_GIT_SHA} \
+    && git checkout "${TILELANG_GIT_SHA}" \
     && git submodule update --init --recursive \
     && mkdir -p /opt/tilelang-wheels \
     && python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -61,22 +61,35 @@ RUN python -c "import importlib.metadata as m, tilelang, torch, triton; \
 print('tilelang', m.version('tilelang')); print('torch', torch.__version__); print('triton', triton.__version__)"
 
 # ── post-fa3 ──
+# Bench / test layer: a future slim image (RFC §9) stops at `runtime` and skips everything
+# below. pytest/ruff are dev/test tooling; FlashAttention-3 below is a bench baseline.
 FROM runtime AS post-fa3
 RUN python -m pip install --no-cache-dir -c /tmp/constraints.txt \
         "pytest==9.0.2" "pytest-xdist>=3.0" "ruff==0.14.13"
-# Comparison baselines are best-effort: a failed install must not break the image.
-RUN python -m pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.8.3" \
-    || echo "WARNING: flash-attn-interface install failed (non-fatal)"
+# FlashAttention-3 (Hopper) has no PyPI wheel — build it from the repo's hopper/ dir
+# (--recursive pulls the csrc/cutlass submodule the build needs). Best-effort: a bench
+# baseline must not break the image. The source tree is removed whether or not the build
+# succeeds, so it never lands in the image.
+RUN git clone --depth 1 --branch v2.8.3 --recursive \
+        https://github.com/Dao-AILab/flash-attention.git /tmp/flash-attention \
+        && cd /tmp/flash-attention/hopper && python setup.py install; \
+    status=$?; rm -rf /tmp/flash-attention; \
+    [ "$status" -eq 0 ] || echo "WARNING: FlashAttention-3 (hopper) build failed (non-fatal)"
 
 # ── fullstack ──
+# Bench baselines (comparison targets), dropped wholesale by a future slim image (RFC §9).
+# Install each independently and best-effort: one missing or unbuildable package must not
+# abort the rest or fail the image (flashinfer's PyPI name is `flashinfer-python`).
 FROM post-fa3 AS fullstack
-RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraints.txt \
+RUN for pkg in \
         "flash-attn==2.8.3" \
         "flash-linear-attention==0.4.2" \
-        "flashinfer>=0.6.6" \
+        "flashinfer-python>=0.6.6" \
         "vllm==0.18.0" \
-        "sgl-kernel==0.3.21" \
-    || echo "WARNING: a bench baseline install failed (non-fatal)"
+        "sgl-kernel==0.3.21"; do \
+        python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraints.txt "$pkg" \
+            || echo "WARNING: bench baseline '$pkg' install failed (non-fatal)"; \
+    done
 
 # ── final ──
 FROM fullstack AS final

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1.7
-# Multi-stage CI runner image.
+# Multi-stage CI runner image for the self-hosted GPU runner.
 ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu22.04
 
 # ── runtime ──
-# devel (not runtime) base: nvcc is needed at runtime for tilelang JIT.
+# devel (not runtime) base: nvcc is needed both at build time (FA3 / tilelang source builds)
+# and at runtime (tilelang JIT).
 FROM ${BASE_IMAGE} AS runtime
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
 # 22.04 ships python3.10; install 3.12 from deadsnakes and make it the default python.
@@ -23,52 +24,37 @@ RUN apt-get update \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 \
     && python -m pip install --upgrade pip
 COPY constraints.txt /tmp/constraints.txt
-# `+cu129` pin forces the cu129 wheel from the pytorch index; the PyPI extra-index
-# supplies torch's pure-python deps, which the pytorch index does not host.
+# torch / torchvision / torchaudio: cu129 wheels from the pytorch index (the PyPI default is a
+# different CUDA variant, so pin +cu129). Installing torchvision/torchaudio as cu129 here means
+# vllm later finds its exact-pinned versions already satisfied and never swaps them off cu129.
 RUN python -m pip install \
         --index-url https://download.pytorch.org/whl/cu129 \
         --extra-index-url https://pypi.org/simple \
-        -c /tmp/constraints.txt "torch==2.10.0+cu129"
-# scikit-build-core + patchelf are tilelang's PEP 517 build backend (its
-# [build-system].requires); --no-build-isolation in the next stage means pip will NOT
-# auto-install them, so they must be present here. cmake from pip provides >=3.26.1
-# (tilelang's [tool.scikit-build] floor); the jammy apt cmake is 3.22, too old.
+        -c /tmp/constraints.txt \
+        "torch==2.10.0+cu129" "torchvision==0.25.0+cu129" "torchaudio==2.10.0+cu129"
+# tilelang's build backend (scikit-build-core + patchelf, its [build-system].requires) and its
+# runtime deps, installed here so the tilelang stage can build with --no-build-isolation. cmake
+# from pip provides >=3.26.1 (tilelang's [tool.scikit-build] floor); jammy apt cmake is 3.22.
 RUN python -m pip install -c /tmp/constraints.txt \
         setuptools wheel ninja scikit-build-core patchelf cmake \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
-
-# Build tilelang once from the pinned commit; install --no-deps so pip never re-resolves it.
-# TILELANG_GIT_SHA is a required build-arg (no default): bump it via `--build-arg` and tag
-# the image `:<short-sha>` — the Dockerfile never carries a SHA literal.
-ARG TILELANG_GIT_SHA
 ARG MAX_JOBS=64
 ARG NVCC_THREADS=4
-# TORCH_CUDA_ARCH_LIST=9.0: the runner pool is Hopper (H200) only.
+# TORCH_CUDA_ARCH_LIST=9.0: the runner pool is Hopper (H200) only. Drives the FA3 and tilelang
+# source builds in later stages, and runtime tilelang JIT.
 ENV MAX_JOBS=${MAX_JOBS} NVCC_THREADS=${NVCC_THREADS} TORCH_CUDA_ARCH_LIST=9.0
-RUN if [ -z "${TILELANG_GIT_SHA}" ]; then \
-        echo "ERROR: build with --build-arg TILELANG_GIT_SHA=<commit>"; exit 1; \
-    fi \
-    && git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
-    && cd /tmp/tilelang \
-    && git checkout "${TILELANG_GIT_SHA}" \
-    && git submodule update --init --recursive \
-    && mkdir -p /opt/tilelang-wheels \
-    && python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
-    && python -m pip install --no-deps /opt/tilelang-wheels/tilelang-*.whl \
-    && rm -rf /tmp/tilelang
-RUN python -c "import importlib.metadata as m, tilelang, torch, triton; \
-print('tilelang', m.version('tilelang')); print('torch', torch.__version__); print('triton', triton.__version__)"
 
 # ── post-fa3 ──
-# Bench / test layer: a future slim image (RFC §9) stops at `runtime` and skips everything
-# below. pytest/ruff are dev/test tooling; FlashAttention-3 below is a bench baseline.
+# Test tooling + FlashAttention-3 (a bench baseline). tilelang is NOT built here — it is built
+# last (the `tilelang` stage) so a SHA bump rebuilds only that layer and so it links against
+# the final post-bench stack.
 FROM runtime AS post-fa3
 RUN python -m pip install --no-cache-dir -c /tmp/constraints.txt \
         "pytest==9.0.2" "pytest-xdist>=3.0" "ruff==0.14.13"
 # FlashAttention-3 (Hopper) has no PyPI wheel — build it from the repo's hopper/ dir.
-# Fetch ONLY the csrc/cutlass submodule the build needs: a full --recursive also pulls the
-# AMD composable_kernel submodule, which the sm_90 build never uses and which is large and
+# Fetch ONLY the csrc/cutlass submodule the build needs: a full --recursive also pulls the AMD
+# composable_kernel submodule, which the sm_90 build never uses and which is large and
 # slow/timeout-prone to clone. Best-effort: a bench baseline must not break the image. The
 # source tree is removed whether or not the build succeeds, so it never lands in the image.
 RUN git clone --depth 1 --branch v2.8.3 \
@@ -79,25 +65,84 @@ RUN git clone --depth 1 --branch v2.8.3 \
     status=$?; rm -rf /tmp/flash-attention; \
     [ "$status" -eq 0 ] || echo "WARNING: FlashAttention-3 (hopper) build failed (non-fatal)"
 
+# ── fa2 ──
+# FlashAttention-2 in its OWN stage/layer: no prebuilt wheel for this torch/cu129/py, so it
+# builds from source (~minutes). Isolating it means changes to the bench-install loop
+# (fullstack) never invalidate this expensive compile. flash-attn does not re-resolve torch.
+# Best-effort: a bench baseline must not fail the image.
+FROM post-fa3 AS fa2
+RUN python -m pip install --no-cache-dir --no-build-isolation \
+        --index-url https://download.pytorch.org/whl/cu129 \
+        --extra-index-url https://pypi.org/simple \
+        -c /tmp/constraints.txt "flash-attn==2.8.3" \
+    || echo "WARNING: flash-attn (FA2) install failed (non-fatal)"
+
 # ── fullstack ──
-# Bench baselines (comparison targets), dropped wholesale by a future slim image (RFC §9).
-# Install each independently and best-effort: one missing or unbuildable package must not
-# abort the rest or fail the image (flashinfer's PyPI name is `flashinfer-python`).
-FROM post-fa3 AS fullstack
-RUN for pkg in \
-        "flash-attn==2.8.3" \
+# Remaining bench baselines (comparison targets). Best-effort. Freeze the cu129 torch trio
+# that `runtime` installed into a constraint first so a bench dep's unversioned `torch`
+# requirement cannot swap torch off the cu129 stack; constraints.txt itself stays bare so it
+# also fits the CPU preflight. vllm pulls flashinfer 0.6.6 (upgraded below) and has no
+# apache-tvm-ffi pin, so it does not conflict with tilelang. sgl-kernel is not installed.
+FROM fa2 AS fullstack
+RUN python -m pip freeze | grep -iE '^(torch|torchvision|torchaudio)==' > /tmp/torch-cu129.txt \
+    && for pkg in \
         "flash-linear-attention==0.4.2" \
-        "flashinfer-python>=0.6.6" \
-        "vllm==0.18.0" \
-        "sgl-kernel==0.3.21"; do \
-        python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraints.txt "$pkg" \
+        "vllm==0.19.1"; do \
+        python -m pip install --no-cache-dir --no-build-isolation \
+            --index-url https://download.pytorch.org/whl/cu129 \
+            --extra-index-url https://pypi.org/simple \
+            -c /tmp/constraints.txt -c /tmp/torch-cu129.txt "$pkg" \
             || echo "WARNING: bench baseline '$pkg' install failed (non-fatal)"; \
     done
+# The attention benchmarks (benchmarks/ops/attention/) need a flashinfer newer than the 0.6.6
+# vllm pulls. Upgrade flashinfer-python/-cubin with --no-deps so torch and vllm's other deps are
+# untouched; add plain cuda-tile (flashinfer>=0.6.7 needs it — the [tileiras] extra would pull a
+# CUDA-13 toolchain). vllm's flashinfer pin is left unsatisfied, which is safe: vllm's only
+# TileOPs-used path (fused_moe) does not import flashinfer.
+RUN { python -m pip install --no-cache-dir --no-deps -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
+            "flashinfer-python==0.6.11.post2" "flashinfer-cubin==0.6.11.post2" \
+        && python -m pip install --no-cache-dir -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
+            cuda-tile nvidia-cudnn-frontend "nvidia-cutlass-dsl>=4.5.0" nvidia-ml-py; } \
+    || echo "WARNING: flashinfer 0.6.11.post2 upgrade failed (non-fatal)"
+
+# ── tilelang ──
+# Built LAST (after all bench): a TILELANG_GIT_SHA bump then rebuilds only this layer (bench
+# stays cached), and tilelang compiles/links against the exact final stack so its ABI always
+# matches what ships. ARG is declared here — not earlier — so changing it never invalidates
+# the bench layers above.
+FROM fullstack AS tilelang
+ARG TILELANG_GIT_SHA
+ARG TILELANG_VERSION
+# main mode:    --build-arg TILELANG_GIT_SHA=<commit>  → clone + compile that commit
+# release mode: --build-arg TILELANG_VERSION=<version> → pip install the PyPI release
+# Either way --no-deps, so pip never re-resolves the cu129 stack.
+RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
+        mkdir -p /tmp/tilelang && cd /tmp/tilelang \
+        && git init -q \
+        && git remote add origin https://github.com/tile-ai/tilelang.git \
+        && git fetch --depth 1 origin "${TILELANG_GIT_SHA}" \
+        && git checkout -q FETCH_HEAD \
+        && git submodule update --init --depth 1 --recursive 3rdparty/cutlass 3rdparty/tvm \
+        && mkdir -p /opt/tilelang-wheels \
+        && python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
+        && python -m pip install --no-deps /opt/tilelang-wheels/tilelang-*.whl \
+        && rm -rf /tmp/tilelang; \
+    elif [ -n "${TILELANG_VERSION}" ]; then \
+        python -m pip install --no-deps "tilelang==${TILELANG_VERSION}"; \
+    else \
+        echo "ERROR: set --build-arg TILELANG_GIT_SHA=<commit> (main) or TILELANG_VERSION=<ver> (release)"; \
+        exit 1; \
+    fi
+# Guard the final stack (GPU-free, runs at build): tilelang must import, the installed
+# apache-tvm-ffi must sit in the tilelang wheel's declared ABI range, and torch must still be
+# the cu129 build.
+COPY scripts/ci/verify_runtime_stack.py /tmp/verify_runtime_stack.py
+RUN python /tmp/verify_runtime_stack.py
 
 # ── final ──
-FROM fullstack AS final
-# Cache dir defaults (host bind-mounts /ci-cache at runtime; pre-created below so they
-# stay writable when run unmounted). PIP_NO_CACHE_DIR=0 re-enables caching (build stages disable it).
+FROM tilelang AS final
+# Cache dir defaults (host bind-mounts /ci-cache at runtime; pre-created below so they stay
+# writable when run unmounted). PIP_NO_CACHE_DIR=0 re-enables caching (build stages disable it).
 ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TILELANG_CACHE_DIR=/ci-cache/tilelang \
     TILELANG_TMP_DIR=/ci-cache/tilelang/tmp \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -113,6 +113,7 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
     && tar xzf runner.tar.gz && rm runner.tar.gz \
     && ./bin/installdependencies.sh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \
     && chown -R ci-runner:ci-runner /home/ci-runner /ci-cache
 # chmod as root before the USER drop.

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,85 +1,91 @@
-FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+# syntax=docker/dockerfile:1.7
+# Multi-stage TileOPs CI runner image (RFC §5.1). Built in the image-build env;
+# published to ghcr.io. From a PUBLIC base — fully reproducible. NOT TileOPs source.
+ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu24.04
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Public base: Ubuntu 24.04 (native python3.12) + CUDA 12.9 devel toolkit (nvcc is
+# needed at runtime for tilelang JIT, so we keep devel, not runtime). torch cu129
+# matches the base CUDA 12.9 → no LD_LIBRARY_PATH hack. Driver 575.57.08 caps CUDA at
+# 12.9 (13.x needs 580+). No DOCA/IB (single-node NCCL uses NVLink/P2P).
 
-# ── System dependencies ──────────────────────────────────────────────────────
+# ── Stage: runtime — python3.12 + torch cu129 + deps under constraints (einops/PyYAML float) + tilelang built once from SHA ──
+FROM ${BASE_IMAGE} AS runtime
+# 24.04 ships python3.12 natively. `python-is-python3` gives a `python` symlink
+# (later stages call `python`); PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668 so
+# system-wide pip installs work in this single-purpose image.
+ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        curl wget git rsync jq \
-        build-essential cmake libedit-dev libxml2-dev libtinfo-dev zlib1g-dev \
-        software-properties-common ca-certificates gnupg sudo unzip tar gzip \
+        python3 python3-dev python3-pip python-is-python3 git curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+COPY constraints.txt /tmp/constraints.txt
+# torch from the cu129 index → 2.10.0+cu129, aligned with the base CUDA 12.9.
+RUN python -m pip install --index-url https://download.pytorch.org/whl/cu129 \
+        -c /tmp/constraints.txt "torch==2.10.0"
+RUN python -m pip install -c /tmp/constraints.txt \
+        triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
+        typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 
-# ── Python 3.11 ──────────────────────────────────────────────────────────────
-RUN add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        python3.11 python3.11-dev python3.11-venv python3.11-distutils \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+# tilelang: main mode builds the wheel once from the pinned commit; the wheel is
+# kept at /opt/tilelang-wheels and installed --no-deps. For release mode, build the
+# image against a release tag instead (and skip this source build).
+ARG TILELANG_GIT_SHA=65dbc9837beedf6882a40a08e18ea571d92fd6a5
+ARG MAX_JOBS=64
+ARG NVCC_THREADS=4
+ENV MAX_JOBS=${MAX_JOBS} NVCC_THREADS=${NVCC_THREADS} TORCH_CUDA_ARCH_LIST=9.0
+RUN git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
+    && cd /tmp/tilelang \
+    && git checkout ${TILELANG_GIT_SHA} \
+    && git submodule update --init --recursive \
+    && mkdir -p /opt/tilelang-wheels \
+    && python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
+    && python -m pip install --no-deps /opt/tilelang-wheels/tilelang-*.whl \
+    && rm -rf /tmp/tilelang
+RUN python -c "import importlib.metadata as m, tilelang, torch, triton; \
+print('tilelang', m.version('tilelang')); print('torch', torch.__version__); print('triton', triton.__version__)"
 
-# ── CI runner user & directories ─────────────────────────────────────────────
-RUN useradd -m -s /bin/bash ci-runner \
-    && mkdir -p /home/ci-runner/.tilelang/cache \
-               /home/ci-runner/.triton/cache \
-               /home/ci-runner/.cache/pip \
-               /home/ci-runner/.wheel-cache \
-               /home/ci-runner/runner/_work/_tool \
-    && chown -R ci-runner:ci-runner /home/ci-runner
+# ── Stage: post-fa3 — test tooling + FA3 (pip first, vendor fallback) ──
+FROM runtime AS post-fa3
+RUN python -m pip install --no-cache-dir -c /tmp/constraints.txt \
+        "pytest==9.0.2" "pytest-xdist>=3.0" "ruff==0.14.13"
+# FA3: prefer the pip wheel; if it cannot install on this stack, Task 4 replaces
+# this line with a vendored COPY + `python setup.py install` (hopper).
+RUN python -m pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.8.3" \
+    || echo "WARNING: flash-attn-interface pip install failed — see Task 4 (vendor fallback)"
 
-# ── GitHub Actions Runner ────────────────────────────────────────────────────
-ARG RUNNER_VERSION=2.333.0
-RUN curl -o /tmp/runner.tar.gz -L \
-        https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz \
-    && cd /home/ci-runner/runner \
-    && tar xzf /tmp/runner.tar.gz \
-    && rm /tmp/runner.tar.gz \
-    && ./bin/installdependencies.sh \
-    && chown -R ci-runner:ci-runner /home/ci-runner/runner
-
-ENV MAX_JOBS=64 \
-    AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool
-
-# ── Python dependencies ──────────────────────────────────────────────────────
-RUN pip install --no-cache-dir \
-        "torch>=2.1.0,<2.11.0" \
-        "tilelang==0.1.9" \
-        einops numpy "tqdm>=4.62.3" "typing_extensions>=4.10.0" \
-        cloudpickle ml_dtypes psutil Cython \
-        setuptools wheel ninja
-
-RUN pip install --no-cache-dir \
-        "pytest==9.0.2" \
-        "pytest-xdist>=3.0" \
-        "pyyaml>=6.0"
-
-RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation "flash-attn==2.8.3" \
-    || echo "WARNING: flash-attn failed to install -- non-fatal"
-
-RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.8.3" \
-    || echo "WARNING: flash-attn-interface (FA3) failed to install -- non-fatal"
-
-RUN MAX_JOBS=96 NVCC_THREADS=96 pip install --no-cache-dir --no-build-isolation \
+# ── Stage: fullstack — bench baselines (pip subset + vendored remainder) ──
+FROM post-fa3 AS fullstack
+RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraints.txt \
+        "flash-attn==2.8.3" \
         "flash-linear-attention==0.4.2" \
         "flashinfer>=0.6.6" \
         "vllm==0.18.0" \
         "sgl-kernel==0.3.21" \
-    || echo "WARNING: Some bench deps failed to install -- non-fatal for runner image"
+    || echo "WARNING: a bench pip baseline failed — see Task 4"
+# Vendored remainder (cannot pip-install): mamba-ssm, native-sparse-attention,
+# and any pip baseline that failed above. Task 4 finalizes this set and the COPY
+# lines. Build context must contain .github/runner/vendor/<dep> (Prerequisites).
+# COPY .github/runner/vendor/mamba-ssm /tmp/vendor/mamba-ssm
+# RUN MAMBA_FORCE_BUILD=TRUE python -m pip install --no-cache-dir --no-build-isolation /tmp/vendor/mamba-ssm
+# COPY .github/runner/vendor/native-sparse-attention /tmp/vendor/native-sparse-attention
+# RUN python -m pip install --no-cache-dir --no-build-isolation /tmp/vendor/native-sparse-attention
 
-RUN MAX_JOBS=32 pip install --no-cache-dir \
-        "git+https://github.com/fla-org/native-sparse-attention.git@bd67af59b90afa34b25f61d2922e612d10dba3bd" \
-    || echo "WARNING: native-sparse-attention failed to install -- non-fatal"
-
-# ── Install TileOPs (editable) ───────────────────────────────────────────────
-WORKDIR /home/ci-runner/tileops
-COPY --chown=ci-runner:ci-runner . .
-RUN pip install --no-cache-dir --no-deps -e .
-
-# ── Entrypoint (for standalone runner mode) ──────────────────────────────────
-COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh /home/ci-runner/runner/entrypoint.sh
-RUN chmod +x /home/ci-runner/runner/entrypoint.sh
-
-USER ci-runner
+# ── Stage: final — GitHub Actions runner; NO TileOPs source ──
+FROM fullstack AS final
+# Cache dirs as image ENV defaults (RFC §6.2): workflows/scripts read these, never
+# hardcode the path. The host persistent cache dir is bind-mounted to /ci-cache at
+# container start.
+ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
+    TILELANG_CACHE_DIR=/ci-cache/tilelang \
+    TILELANG_TMP_DIR=/ci-cache/tilelang/tmp \
+    TRITON_CACHE_DIR=/ci-cache/triton \
+    PIP_CACHE_DIR=/ci-cache/pip
+ARG RUNNER_VERSION=2.334.0
 WORKDIR /home/ci-runner/runner
-ENTRYPOINT ["./entrypoint.sh"]
+RUN useradd -m -s /bin/bash ci-runner \
+    && mkdir -p /home/ci-runner/runner/_work/_tool \
+    && curl -fsSL -o runner.tar.gz \
+        "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && tar xzf runner.tar.gz && rm runner.tar.gz \
+    && ./bin/installdependencies.sh \
+    && chown -R ci-runner:ci-runner /home/ci-runner
+USER ci-runner

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -29,8 +29,12 @@ RUN python -m pip install \
         --index-url https://download.pytorch.org/whl/cu129 \
         --extra-index-url https://pypi.org/simple \
         -c /tmp/constraints.txt "torch==2.10.0+cu129"
+# scikit-build-core + patchelf are tilelang's PEP 517 build backend (its
+# [build-system].requires); --no-build-isolation in the next stage means pip will NOT
+# auto-install them, so they must be present here. cmake from pip provides >=3.26.1
+# (tilelang's [tool.scikit-build] floor); the jammy apt cmake is 3.22, too old.
 RUN python -m pip install -c /tmp/constraints.txt \
-        setuptools wheel ninja \
+        setuptools wheel ninja scikit-build-core patchelf cmake \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -85,20 +85,12 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     PIP_CACHE_DIR=/ci-cache/pip \
     PIP_NO_CACHE_DIR=0
 ARG RUNNER_VERSION=2.334.0
-# Optional: pin the runner tarball's published SHA-256 to verify integrity before
-# extraction. Empty skips the check (warns); set --build-arg RUNNER_SHA256=<hash> to enforce.
-ARG RUNNER_SHA256=
 # useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
 RUN useradd -m -s /bin/bash ci-runner
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && curl -fsSL -o runner.tar.gz \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
-    && if [ -n "${RUNNER_SHA256}" ]; then \
-           echo "${RUNNER_SHA256}  runner.tar.gz" > runner.tar.gz.sha256 \
-           && sha256sum -c runner.tar.gz.sha256 \
-           && rm runner.tar.gz.sha256; \
-       else echo "WARNING: RUNNER_SHA256 unset — skipping runner tarball integrity check"; fi \
     && tar xzf runner.tar.gz && rm runner.tar.gz \
     && ./bin/installdependencies.sh \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,28 +1,19 @@
 # syntax=docker/dockerfile:1.7
-# Multi-stage TileOPs CI runner image. Built in the image-build env;
-# published to ghcr.io. From a PUBLIC base — fully reproducible. NOT TileOPs source.
+# Multi-stage CI runner image.
 ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu24.04
 
-# Public base: Ubuntu 24.04 (native python3.12) + CUDA 12.9 devel toolkit (nvcc is
-# needed at runtime for tilelang JIT, so we keep devel, not runtime). torch cu129
-# matches the base CUDA 12.9 → no LD_LIBRARY_PATH hack. Driver 575.57.08 caps CUDA at
-# 12.9 (13.x needs 580+). No DOCA/IB (single-node NCCL uses NVLink/P2P).
-
-# ── Stage: runtime — python3.12 + torch cu129 + deps under constraints (einops/PyYAML float) + tilelang built once from SHA ──
+# ── runtime ──
+# devel (not runtime) base: nvcc is needed at runtime for tilelang JIT.
 FROM ${BASE_IMAGE} AS runtime
-# 24.04 ships python3.12 natively. `python-is-python3` gives a `python` symlink
-# (later stages call `python`); PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668 so
-# system-wide pip installs work in this single-purpose image.
+# python-is-python3: later stages call `python`. PIP_BREAK_SYSTEM_PACKAGES: bypass PEP 668.
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-dev python3-venv python3-pip python-is-python3 git curl ca-certificates \
         build-essential cmake ninja-build unzip xz-utils sudo \
     && rm -rf /var/lib/apt/lists/*
 COPY constraints.txt /tmp/constraints.txt
-# torch from the cu129 index → 2.10.0+cu129, aligned with the base CUDA 12.9. The
-# `+cu129` local-version pin forces the cu129 wheel from the pytorch index; the
-# PyPI extra-index supplies torch's pure-python transitive deps (sympy, networkx,
-# jinja2, filelock, fsspec, typing_extensions), which the pytorch index does not host.
+# `+cu129` pin forces the cu129 wheel from the pytorch index; the PyPI extra-index
+# supplies torch's pure-python deps, which the pytorch index does not host.
 RUN python -m pip install \
         --index-url https://download.pytorch.org/whl/cu129 \
         --extra-index-url https://pypi.org/simple \
@@ -32,12 +23,11 @@ RUN python -m pip install -c /tmp/constraints.txt \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
         typing_extensions Cython z3-solver torch_c_dlpack_ext einops "PyYAML>=6.0"
 
-# tilelang: main mode builds the wheel once from the pinned commit; the wheel is
-# kept at /opt/tilelang-wheels and installed --no-deps. For release mode, build the
-# image against a release tag instead (and skip this source build).
+# Build tilelang once from the pinned commit; install --no-deps so pip never re-resolves it.
 ARG TILELANG_GIT_SHA=65dbc9837beedf6882a40a08e18ea571d92fd6a5
 ARG MAX_JOBS=64
 ARG NVCC_THREADS=4
+# TORCH_CUDA_ARCH_LIST=9.0: the runner pool is Hopper (H200) only.
 ENV MAX_JOBS=${MAX_JOBS} NVCC_THREADS=${NVCC_THREADS} TORCH_CUDA_ARCH_LIST=9.0
 RUN git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
     && cd /tmp/tilelang \
@@ -50,16 +40,15 @@ RUN git clone https://github.com/tile-ai/tilelang.git /tmp/tilelang \
 RUN python -c "import importlib.metadata as m, tilelang, torch, triton; \
 print('tilelang', m.version('tilelang')); print('torch', torch.__version__); print('triton', triton.__version__)"
 
-# ── Stage: post-fa3 — test tooling + FA3 (pip first, vendor fallback) ──
+# ── post-fa3 ──
 FROM runtime AS post-fa3
 RUN python -m pip install --no-cache-dir -c /tmp/constraints.txt \
         "pytest==9.0.2" "pytest-xdist>=3.0" "ruff==0.14.13"
-# FA3: prefer the pip wheel; if it cannot install on this stack, Task 4 replaces
-# this line with a vendored COPY + `python setup.py install` (hopper).
+# Comparison baselines are best-effort: a failed install must not break the image.
 RUN python -m pip install --no-cache-dir --no-build-isolation "flash-attn-interface>=2.8.3" \
-    || echo "WARNING: flash-attn-interface pip install failed — see Task 4 (vendor fallback)"
+    || echo "WARNING: flash-attn-interface install failed (non-fatal)"
 
-# ── Stage: fullstack — bench baselines (pip subset + vendored remainder) ──
+# ── fullstack ──
 FROM post-fa3 AS fullstack
 RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraints.txt \
         "flash-attn==2.8.3" \
@@ -67,33 +56,20 @@ RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraint
         "flashinfer>=0.6.6" \
         "vllm==0.18.0" \
         "sgl-kernel==0.3.21" \
-    || echo "WARNING: a bench pip baseline failed — see Task 4"
-# Vendored remainder (cannot pip-install): mamba-ssm, native-sparse-attention,
-# and any pip baseline that failed above. Task 4 finalizes this set and the COPY
-# lines. Build context must contain .github/runner/vendor/<dep> (Prerequisites).
-# COPY .github/runner/vendor/mamba-ssm /tmp/vendor/mamba-ssm
-# RUN MAMBA_FORCE_BUILD=TRUE python -m pip install --no-cache-dir --no-build-isolation /tmp/vendor/mamba-ssm
-# COPY .github/runner/vendor/native-sparse-attention /tmp/vendor/native-sparse-attention
-# RUN python -m pip install --no-cache-dir --no-build-isolation /tmp/vendor/native-sparse-attention
+    || echo "WARNING: a bench baseline install failed (non-fatal)"
 
-# ── Stage: final — GitHub Actions runner; NO TileOPs source ──
+# ── final ──
 FROM fullstack AS final
-# Cache dirs as image ENV defaults: workflows/scripts read these env vars rather than
-# hardcoding the path. The host persistent cache dir is bind-mounted to /ci-cache at
-# container start; the dirs are also pre-created below (owned by ci-runner) so the
-# defaults stay writable even when the image runs without that mount.
+# Cache dir defaults (host bind-mounts /ci-cache at runtime; pre-created below so they
+# stay writable when run unmounted). PIP_NO_CACHE_DIR=0 re-enables caching (build stages disable it).
 ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TILELANG_CACHE_DIR=/ci-cache/tilelang \
     TILELANG_TMP_DIR=/ci-cache/tilelang/tmp \
     TRITON_CACHE_DIR=/ci-cache/triton \
     PIP_CACHE_DIR=/ci-cache/pip \
     PIP_NO_CACHE_DIR=0
-# Build stages set PIP_NO_CACHE_DIR=1 to keep image layers slim; re-enable caching
-# here so CI-runtime pip installs reuse the bind-mounted PIP_CACHE_DIR.
 ARG RUNNER_VERSION=2.334.0
-# Create the user (and its skeleton home) before WORKDIR so the home dir is owned by
-# ci-runner, not root. WORKDIR then sits inside that home and precedes the relative-path
-# runner-extraction RUN (hadolint requires WORKDIR before relative paths).
+# useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
 RUN useradd -m -s /bin/bash ci-runner
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \
@@ -103,8 +79,7 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && ./bin/installdependencies.sh \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \
     && chown -R ci-runner:ci-runner /home/ci-runner /ci-cache
-# Standalone runner mode: entrypoint.sh configures an ephemeral runner (config.sh)
-# then runs one job (run.sh). chmod needs root, so set it before dropping to ci-runner.
+# chmod as root before the USER drop.
 COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 USER ci-runner

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -66,13 +66,16 @@ print('tilelang', m.version('tilelang')); print('torch', torch.__version__); pri
 FROM runtime AS post-fa3
 RUN python -m pip install --no-cache-dir -c /tmp/constraints.txt \
         "pytest==9.0.2" "pytest-xdist>=3.0" "ruff==0.14.13"
-# FlashAttention-3 (Hopper) has no PyPI wheel — build it from the repo's hopper/ dir
-# (--recursive pulls the csrc/cutlass submodule the build needs). Best-effort: a bench
-# baseline must not break the image. The source tree is removed whether or not the build
-# succeeds, so it never lands in the image.
-RUN git clone --depth 1 --branch v2.8.3 --recursive \
+# FlashAttention-3 (Hopper) has no PyPI wheel — build it from the repo's hopper/ dir.
+# Fetch ONLY the csrc/cutlass submodule the build needs: a full --recursive also pulls the
+# AMD composable_kernel submodule, which the sm_90 build never uses and which is large and
+# slow/timeout-prone to clone. Best-effort: a bench baseline must not break the image. The
+# source tree is removed whether or not the build succeeds, so it never lands in the image.
+RUN git clone --depth 1 --branch v2.8.3 \
         https://github.com/Dao-AILab/flash-attention.git /tmp/flash-attention \
-        && cd /tmp/flash-attention/hopper && python setup.py install; \
+        && cd /tmp/flash-attention \
+        && git submodule update --init --depth 1 csrc/cutlass \
+        && cd hopper && python setup.py install; \
     status=$?; rm -rf /tmp/flash-attention; \
     [ "$status" -eq 0 ] || echo "WARNING: FlashAttention-3 (hopper) build failed (non-fatal)"
 

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -85,7 +85,10 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TILELANG_CACHE_DIR=/ci-cache/tilelang \
     TILELANG_TMP_DIR=/ci-cache/tilelang/tmp \
     TRITON_CACHE_DIR=/ci-cache/triton \
-    PIP_CACHE_DIR=/ci-cache/pip
+    PIP_CACHE_DIR=/ci-cache/pip \
+    PIP_NO_CACHE_DIR=0
+# Build stages set PIP_NO_CACHE_DIR=1 to keep image layers slim; re-enable caching
+# here so CI-runtime pip installs reuse the bind-mounted PIP_CACHE_DIR.
 ARG RUNNER_VERSION=2.334.0
 # Create the user (and its skeleton home) before WORKDIR so the home dir is owned by
 # ci-runner, not root. WORKDIR then sits inside that home and precedes the relative-path

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-# Multi-stage TileOPs CI runner image (RFC §5.1). Built in the image-build env;
+# Multi-stage TileOPs CI runner image. Built in the image-build env;
 # published to ghcr.io. From a PUBLIC base — fully reproducible. NOT TileOPs source.
 ARG BASE_IMAGE=nvidia/cuda:12.9.1-devel-ubuntu24.04
 
@@ -15,13 +15,18 @@ FROM ${BASE_IMAGE} AS runtime
 # system-wide pip installs work in this single-purpose image.
 ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1 PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 python3-dev python3-pip python-is-python3 git curl ca-certificates \
+        python3 python3-dev python3-venv python3-pip python-is-python3 git curl ca-certificates \
         build-essential cmake ninja-build unzip xz-utils sudo \
     && rm -rf /var/lib/apt/lists/*
 COPY constraints.txt /tmp/constraints.txt
-# torch from the cu129 index → 2.10.0+cu129, aligned with the base CUDA 12.9.
-RUN python -m pip install --index-url https://download.pytorch.org/whl/cu129 \
-        -c /tmp/constraints.txt "torch==2.10.0"
+# torch from the cu129 index → 2.10.0+cu129, aligned with the base CUDA 12.9. The
+# `+cu129` local-version pin forces the cu129 wheel from the pytorch index; the
+# PyPI extra-index supplies torch's pure-python transitive deps (sympy, networkx,
+# jinja2, filelock, fsspec, typing_extensions), which the pytorch index does not host.
+RUN python -m pip install \
+        --index-url https://download.pytorch.org/whl/cu129 \
+        --extra-index-url https://pypi.org/simple \
+        -c /tmp/constraints.txt "torch==2.10.0+cu129"
 RUN python -m pip install -c /tmp/constraints.txt \
         setuptools wheel ninja \
         triton apache-tvm-ffi cloudpickle ml_dtypes numpy psutil tqdm \
@@ -73,8 +78,8 @@ RUN python -m pip install --no-cache-dir --no-build-isolation -c /tmp/constraint
 
 # ── Stage: final — GitHub Actions runner; NO TileOPs source ──
 FROM fullstack AS final
-# Cache dirs as image ENV defaults (RFC §6.2): workflows/scripts read these, never
-# hardcode the path. The host persistent cache dir is bind-mounted to /ci-cache at
+# Cache dirs as image ENV defaults: workflows/scripts read these env vars rather than
+# hardcoding the path. The host persistent cache dir is bind-mounted to /ci-cache at
 # container start.
 ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TILELANG_CACHE_DIR=/ci-cache/tilelang \
@@ -93,4 +98,9 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && tar xzf runner.tar.gz && rm runner.tar.gz \
     && ./bin/installdependencies.sh \
     && chown -R ci-runner:ci-runner /home/ci-runner
+# Standalone runner mode: entrypoint.sh configures an ephemeral runner (config.sh)
+# then runs one job (run.sh). chmod needs root, so set it before dropping to ci-runner.
+COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 USER ci-runner
+ENTRYPOINT ["./entrypoint.sh"]

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -85,12 +85,20 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     PIP_CACHE_DIR=/ci-cache/pip \
     PIP_NO_CACHE_DIR=0
 ARG RUNNER_VERSION=2.334.0
+# Optional: pin the runner tarball's published SHA-256 to verify integrity before
+# extraction. Empty skips the check (warns); set --build-arg RUNNER_SHA256=<hash> to enforce.
+ARG RUNNER_SHA256=
 # useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
 RUN useradd -m -s /bin/bash ci-runner
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && curl -fsSL -o runner.tar.gz \
         "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && if [ -n "${RUNNER_SHA256}" ]; then \
+           echo "${RUNNER_SHA256}  runner.tar.gz" > runner.tar.gz.sha256 \
+           && sha256sum -c runner.tar.gz.sha256 \
+           && rm runner.tar.gz.sha256; \
+       else echo "WARNING: RUNNER_SHA256 unset — skipping runner tarball integrity check"; fi \
     && tar xzf runner.tar.gz && rm runner.tar.gz \
     && ./bin/installdependencies.sh \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -34,14 +34,13 @@ add a numeric suffix (`:65dbc98-2`).
 
 ### Build args
 
-| Arg                | Default                                | Purpose                                                                                                                                                                                           |
-| ------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                                                                                                                                                              |
-| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes).                                                                                                                                            |
-| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.                                                                                                                                                  |
-| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                                                                                                                                                               |
-| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.                                                                                                                                                 |
-| `RUNNER_SHA256`    | *(empty → skipped)*                    | Optional: published SHA-256 of the runner tarball; when set, the build verifies the download before extracting. Find it on the [runner release page](https://github.com/actions/runner/releases). |
+| Arg                | Default                                | Purpose                                                |
+| ------------------ | -------------------------------------- | ------------------------------------------------------ |
+| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                   |
+| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes). |
+| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.       |
+| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                    |
+| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.      |
 
 ### Stages (`--target`)
 

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -1,8 +1,8 @@
 # CI runner image
 
-Multi-stage image for the self-hosted GPU runner. It bakes a tilelang wheel (compiled
-once from a pinned commit) plus the test/benchmark stack onto a public CUDA base, so CI
-never recompiles tilelang per PR.
+Multi-stage image for the self-hosted GPU runner. It bakes a tilelang wheel (compiled once
+from a pinned commit, or installed from a PyPI release) plus the test/benchmark stack onto a
+public CUDA base, so CI never recompiles tilelang per PR.
 
 Built **manually on a GPU host** (needs `nvcc`), then pushed to `ghcr.io`. It is **not**
 built in CI.
@@ -11,16 +11,21 @@ built in CI.
 
 - An NVIDIA GPU host with a CUDA 12.9-capable driver and `nvcc`.
 - Docker with BuildKit enabled (`DOCKER_BUILDKIT=1`).
-- Run from the **repository root** — the build context must contain `constraints.txt`
-  and `.github/runner/entrypoint.sh` (the Dockerfile copies both).
+- Run from the **repository root** — the build context must contain `constraints.txt`,
+  `scripts/ci/verify_runtime_stack.py`, and `.github/runner/entrypoint.sh` (the Dockerfile
+  copies all three).
 
 ## Build
 
-`TILELANG_GIT_SHA` is **required** (no default). The Dockerfile carries no commit literal;
-the commit you pass is the single source of truth, and the image tag records it.
+Provide tilelang one of two ways — pass **exactly one** of these build-args:
+
+- **main commit**: `--build-arg TILELANG_GIT_SHA=<commit>` — shallow-fetches and compiles that
+  commit. The Dockerfile carries no commit literal; the commit you pass is the single source
+  of truth, and the image tag records it.
+- **release**: `--build-arg TILELANG_VERSION=<version>` — `pip install tilelang==<version>`.
 
 ```bash
-# from the repository root
+# from the repository root (main-commit mode)
 DOCKER_BUILDKIT=1 docker build \
   -f .github/runner/Dockerfile \
   --target final \
@@ -34,31 +39,40 @@ add a numeric suffix (`:65dbc98-2`).
 
 ### Build args
 
-| Arg                | Default                                | Purpose                                                |
-| ------------------ | -------------------------------------- | ------------------------------------------------------ |
-| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                   |
-| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes). |
-| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.       |
-| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                    |
-| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.      |
+| Arg                | Default                                | Purpose                                                   |
+| ------------------ | -------------------------------------- | --------------------------------------------------------- |
+| `TILELANG_GIT_SHA` | *(none)*                               | tilelang commit to shallow-clone and compile (main mode). |
+| `TILELANG_VERSION` | *(none)*                               | tilelang PyPI version to `pip install` (release mode).    |
+| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes).    |
+| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / FA2 / FA3 source builds.   |
+| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                       |
+| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.         |
+
+Set exactly one of `TILELANG_GIT_SHA` / `TILELANG_VERSION`; the build fails fast if neither is set.
 
 ### Stages (`--target`)
 
-| Stage       | Contents                                                                                   |
-| ----------- | ------------------------------------------------------------------------------------------ |
-| `runtime`   | Python 3.12 + torch `2.10.0+cu129` + tilelang runtime deps + tilelang wheel (`--no-deps`). |
-| `post-fa3`  | `runtime` + pytest/ruff + FlashAttention-3.                                                |
-| `fullstack` | `post-fa3` + vLLM / flashinfer / sgl-kernel / FLA.                                         |
-| `final`     | `fullstack` + the GitHub Actions runner (no TileOPs source baked).                         |
+| Stage       | Contents                                                                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.** |
+| `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                           |
+| `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                       |
+| `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed.      |
+| `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                        |
+| `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                        |
 
 Build an earlier stage for debugging with `--target runtime` (etc.).
+
+The `tilelang` stage ends by running `scripts/ci/verify_runtime_stack.py` (GPU-free): it fails
+the build unless tilelang imports, the installed `apache-tvm-ffi` sits inside the tilelang
+wheel's declared range, and torch is still the cu129 build.
 
 ## Verify the built image
 
 ```bash
 docker run --rm --gpus all ghcr.io/tile-ai/tileops-runner:65dbc98 python - <<'PY'
 import torch
-print("torch", torch.__version__, "cuda", torch.version.cuda)   # expect cuda 12.9
+print("torch", torch.__version__, "cuda", torch.version.cuda)   # expect 2.10.0+cu129, cuda 12.9
 import tilelang; print("tilelang", tilelang.__version__)
 
 # cuBLAS probe: matmul / bmm / einsum on the GPU
@@ -80,8 +94,8 @@ docker run --rm --gpus all -v "$PWD:/src" -w /src \
   bash -c 'scripts/ci/install_tileops.sh && pytest -m smoke'
 ```
 
-`install_tileops.sh` installs TileOPs `--no-deps` against the baked stack; it fails fast
-if tilelang is missing (the image provides it).
+`install_tileops.sh` installs TileOPs `--no-deps` against the baked stack; it fails fast if
+tilelang is missing (the image provides it).
 
 ## Run as a self-hosted runner
 
@@ -92,7 +106,7 @@ exit. Provide a registration token and the target URL; bind-mount the host cache
 docker run -d --gpus all \
   -e RUNNER_URL=https://github.com/tile-ai/TileOPs \
   -e RUNNER_TOKEN=<registration-token> \
-  -e RUNNER_LABELS=self-hosted,tile-ops \
+  -e RUNNER_LABELS=self-hosted,tile-ops,venv \
   -v <host-cache-dir>:/ci-cache \
   ghcr.io/tile-ai/tileops-runner:65dbc98
 ```
@@ -102,7 +116,9 @@ under `/ci-cache`; the directories are pre-created so the container also works u
 
 ## Bumping the tilelang commit
 
-A commit bump always rebuilds (the wheel is baked), but **never edits the Dockerfile**:
-rebuild with a new `--build-arg TILELANG_GIT_SHA=<commit>` and a new `:<short-sha>` tag,
-push to `ghcr.io`, then point the runner at the new tag. Switching between a release and a
-main commit is the same — only the image tag changes.
+A commit (or release) bump always rebuilds, but **never edits the Dockerfile**: rebuild with a
+new `--build-arg TILELANG_GIT_SHA=<commit>` (or `TILELANG_VERSION=<version>`) and a new
+`:<short-sha>` tag, push to `ghcr.io`, then point the runner at the new tag. Because tilelang
+is the last stage, only its layer recompiles — the bench layers (FA2 / FA3 / vLLM / …) stay
+cached. Switching between a release and a main commit is the same — only the build-arg and tag
+change.

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -1,0 +1,108 @@
+# CI runner image
+
+Multi-stage image for the self-hosted GPU runner. It bakes a tilelang wheel (compiled
+once from a pinned commit) plus the test/benchmark stack onto a public CUDA base, so CI
+never recompiles tilelang per PR.
+
+Built **manually on a GPU host** (needs `nvcc`), then pushed to `ghcr.io`. It is **not**
+built in CI.
+
+## Prerequisites
+
+- An NVIDIA GPU host with a CUDA 12.9-capable driver and `nvcc`.
+- Docker with BuildKit enabled (`DOCKER_BUILDKIT=1`).
+- Run from the **repository root** — the build context must contain `constraints.txt`
+  and `.github/runner/entrypoint.sh` (the Dockerfile copies both).
+
+## Build
+
+`TILELANG_GIT_SHA` is **required** (no default). The Dockerfile carries no commit literal;
+the commit you pass is the single source of truth, and the image tag records it.
+
+```bash
+# from the repository root
+DOCKER_BUILDKIT=1 docker build \
+  -f .github/runner/Dockerfile \
+  --target final \
+  --build-arg TILELANG_GIT_SHA=65dbc9837beedf6882a40a08e18ea571d92fd6a5 \
+  -t ghcr.io/tile-ai/tileops-runner:65dbc98 \
+  .
+```
+
+Tag with the tilelang commit's **short SHA** (`:65dbc98`). If you rebuild the same commit,
+add a numeric suffix (`:65dbc98-2`).
+
+### Build args
+
+| Arg                | Default                                | Purpose                                                |
+| ------------------ | -------------------------------------- | ------------------------------------------------------ |
+| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                   |
+| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes). |
+| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.       |
+| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                    |
+| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.      |
+
+### Stages (`--target`)
+
+| Stage       | Contents                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| `runtime`   | Python 3.12 + torch `2.10.0+cu129` + tilelang runtime deps + tilelang wheel (`--no-deps`). |
+| `post-fa3`  | `runtime` + pytest/ruff + FlashAttention-3.                                                |
+| `fullstack` | `post-fa3` + vLLM / flashinfer / sgl-kernel / FLA.                                         |
+| `final`     | `fullstack` + the GitHub Actions runner (no TileOPs source baked).                         |
+
+Build an earlier stage for debugging with `--target runtime` (etc.).
+
+## Verify the built image
+
+```bash
+docker run --rm --gpus all ghcr.io/tile-ai/tileops-runner:65dbc98 python - <<'PY'
+import torch
+print("torch", torch.__version__, "cuda", torch.version.cuda)   # expect cuda 12.9
+import tilelang; print("tilelang", tilelang.__version__)
+
+# cuBLAS probe: matmul / bmm / einsum on the GPU
+a = torch.randn(512, 512, device="cuda", dtype=torch.float16)
+b = torch.randn(512, 512, device="cuda", dtype=torch.float16)
+assert torch.matmul(a, b).isfinite().all()
+ab = torch.randn(8, 128, 128, device="cuda", dtype=torch.float16)
+assert torch.bmm(ab, ab).isfinite().all()
+assert torch.einsum("bik,bkj->bij", ab, ab).isfinite().all()
+print("cuBLAS probe OK")
+PY
+```
+
+Then run the smoke tests against a checkout of this repo:
+
+```bash
+docker run --rm --gpus all -v "$PWD:/src" -w /src \
+  ghcr.io/tile-ai/tileops-runner:65dbc98 \
+  bash -c 'scripts/ci/install_tileops.sh && pytest -m smoke'
+```
+
+`install_tileops.sh` installs TileOPs `--no-deps` against the baked stack; it fails fast
+if tilelang is missing (the image provides it).
+
+## Run as a self-hosted runner
+
+`entrypoint.sh` registers an ephemeral runner (one job per container), then deregisters on
+exit. Provide a registration token and the target URL; bind-mount the host cache.
+
+```bash
+docker run -d --gpus all \
+  -e RUNNER_URL=https://github.com/tile-ai/TileOPs \
+  -e RUNNER_TOKEN=<registration-token> \
+  -e RUNNER_LABELS=self-hosted,tile-ops \
+  -v <host-cache-dir>:/ci-cache \
+  ghcr.io/tile-ai/tileops-runner:65dbc98
+```
+
+The image sets cache env vars (`TILELANG_CACHE_DIR`, `TRITON_CACHE_DIR`, `PIP_CACHE_DIR`, …)
+under `/ci-cache`; the directories are pre-created so the container also works unmounted.
+
+## Bumping the tilelang commit
+
+A commit bump always rebuilds (the wheel is baked), but **never edits the Dockerfile**:
+rebuild with a new `--build-arg TILELANG_GIT_SHA=<commit>` and a new `:<short-sha>` tag,
+push to `ghcr.io`, then point the runner at the new tag. Switching between a release and a
+main commit is the same — only the image tag changes.

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -34,13 +34,14 @@ add a numeric suffix (`:65dbc98-2`).
 
 ### Build args
 
-| Arg                | Default                                | Purpose                                                |
-| ------------------ | -------------------------------------- | ------------------------------------------------------ |
-| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                   |
-| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes). |
-| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.       |
-| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                    |
-| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.      |
+| Arg                | Default                                | Purpose                                                                                                                                                                                           |
+| ------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TILELANG_GIT_SHA` | *(required)*                           | tilelang commit to compile and bake.                                                                                                                                                              |
+| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes).                                                                                                                                            |
+| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / extension builds.                                                                                                                                                  |
+| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                                                                                                                                                               |
+| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.                                                                                                                                                 |
+| `RUNNER_SHA256`    | *(empty → skipped)*                    | Optional: published SHA-256 of the runner tarball; when set, the build verifies the download before extracting. Find it on the [runner release page](https://github.com/actions/runner/releases). |
 
 ### Stages (`--target`)
 

--- a/.github/runner/entrypoint.sh
+++ b/.github/runner/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ad-hoc command passthrough: `docker run <image> python ...` / `bash -c ...` runs the
+# given command directly (image verification, smoke tests; see README). With no args the
+# container registers an ephemeral self-hosted runner (below).
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
 # ── Validate required environment variables ──────────────────────────────────
 : "${RUNNER_TOKEN:?Environment variable RUNNER_TOKEN is required}"
 : "${RUNNER_URL:?Environment variable RUNNER_URL is required}"

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,19 @@
+# Cross-layer version lock for CI / runner builds (RFC §4.1).
+# Pins ONLY versions; never defines dependency membership (that is pyproject's job).
+# torch: bare `==2.10.0` is intentional — per PEP 440 it matches any local build
+# (`2.10.0+cu129` on the GPU image, the default build on CPU preflight). The CUDA
+# variant is chosen by the install index (`--index-url .../cu129` at base-image
+# build), NOT by this pin; adding `+cu129` here would break installs resolving
+# from PyPI (CPU preflight), so this single file works for both.
+torch==2.10.0
+triton==3.6.0
+apache-tvm-ffi==0.1.8.post2
+cloudpickle==3.1.2
+ml_dtypes==0.5.4
+numpy==2.4.4
+psutil==7.2.2
+tqdm==4.67.3
+typing_extensions==4.15.0
+Cython==3.2.4
+z3-solver==4.15.4.0
+torch_c_dlpack_ext==0.1.5

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,10 +1,6 @@
-# Cross-layer version lock for CI / runner builds.
-# Pins ONLY versions; never defines dependency membership (that is pyproject's job).
-# torch: bare `==2.10.0` is intentional — per PEP 440 it matches any local build
-# (`2.10.0+cu129` on the GPU image, the default build on CPU preflight). The CUDA
-# variant is chosen by the install index (`--index-url .../cu129` at base-image
-# build), NOT by this pin; adding `+cu129` here would break installs resolving
-# from PyPI (CPU preflight), so this single file works for both.
+# Version lock for CI / runner builds. Pins versions only; membership lives in pyproject.
+# torch `==2.10.0` (bare) matches any local build (`+cu129` GPU image, default CPU
+# preflight); the CUDA variant comes from the install index, not this pin. Do not add `+cu129`.
 torch==2.10.0
 triton==3.6.0
 apache-tvm-ffi==0.1.8.post2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,20 @@
 # Version lock for CI / runner builds. Pins versions only; membership lives in pyproject.
-# torch `==2.10.0` (bare) matches any local build (`+cu129` GPU image, default CPU
-# preflight); the CUDA variant comes from the install index, not this pin. Do not add `+cu129`.
+# torch/torchvision/torchaudio bare (no `+cu129`): the CUDA variant comes from the install
+# index, not this pin, so the same lock also fits the CPU preflight. Do not add `+cu129`.
+# torchvision/torchaudio are pinned to vllm 0.19.1's exact requirements (the newest vllm on
+# the torch 2.10 / CUDA-12 line — vllm 0.20+ are CUDA-13 builds, unrunnable on a 12.9 driver).
 torch==2.10.0
+torchvision==0.25.0
+torchaudio==2.10.0
 triton==3.6.0
-apache-tvm-ffi==0.1.8.post2
+# apache-tvm-ffi is ABI-coupled to the baked tilelang wheel: it MUST sit inside the range
+# tilelang's own metadata declares for the pinned commit (verified at build time by
+# scripts/ci/verify_runtime_stack.py). Re-confirm this pin whenever TILELANG_GIT_SHA changes.
+apache-tvm-ffi==0.1.11
 cloudpickle==3.1.2
 ml_dtypes==0.5.4
-numpy==2.4.4
+# numpy<2.3 required by vllm 0.19.1's numba dep; 2.2.6 also satisfies tilelang (>=1.23.5).
+numpy==2.2.6
 psutil==7.2.2
 tqdm==4.67.3
 typing_extensions==4.15.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
-# Cross-layer version lock for CI / runner builds (RFC §4.1).
+# Cross-layer version lock for CI / runner builds.
 # Pins ONLY versions; never defines dependency membership (that is pyproject's job).
 # torch: bare `==2.10.0` is intentional — per PEP 440 it matches any local build
 # (`2.10.0+cu129` on the GPU image, the default build on CPU preflight). The CUDA

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install tileops without letting pip re-resolve tilelang.
 #
-# Contract (RFC §4.2): tilelang must already be present — baked into
+# Contract: tilelang must already be present — baked into
 # the runner image (CI), or installed by the developer (local) — BEFORE this runs.
 # tileops is then installed --no-deps under the version lock. pip must never resolve
 # tilelang transitively: it would drift the cu129 stack.
@@ -12,7 +12,7 @@ CONSTRAINTS="${REPO_ROOT}/constraints.txt"
 if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   {
     echo "::error::tilelang is not importable. Provision it first, then re-run:"
-    echo "  release:  pip install --no-deps -c constraints.txt tilelang==0.1.9"
+    echo "  release:  pip install --no-deps -c \"${CONSTRAINTS}\" tilelang==0.1.9"
     echo "  main:     pip install --no-deps <prebuilt main-commit tilelang wheel>"
     echo "(the CI runner image bakes tilelang; this script never installs it)"
   } >&2

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install tileops without letting pip re-resolve tilelang.
+#
+# Contract (RFC §4.2): tilelang must already be present — baked into
+# the runner image (CI), or installed by the developer (local) — BEFORE this runs.
+# tileops is then installed --no-deps under the version lock. pip must never resolve
+# tilelang transitively: it would drift the cu129 stack.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONSTRAINTS="${REPO_ROOT}/constraints.txt"
+
+if ! python -c "import tilelang" >/dev/null 2>&1; then
+  {
+    echo "::error::tilelang is not importable. Provision it first, then re-run:"
+    echo "  release:  pip install --no-deps -c constraints.txt tilelang==0.1.9"
+    echo "  main:     pip install --no-deps <prebuilt main-commit tilelang wheel>"
+    echo "(the CI runner image bakes tilelang; this script never installs it)"
+  } >&2
+  exit 1
+fi
+
+# tileops itself only. Its runtime deps (torch/einops/pyyaml) and any dev/bench
+# extras are provided by the runner image (or installed separately for local dev),
+# pinned by constraints.txt. --no-deps keeps pip away from tilelang.
+pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
+
+python -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONSTRAINTS="${REPO_ROOT}/constraints.txt"
 
-if ! python -c "import tilelang" >/dev/null 2>&1; then
+if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   {
     echo "::error::tilelang is not importable. Provision it first, then re-run:"
     echo "  release:  pip install --no-deps -c constraints.txt tilelang==0.1.9"
@@ -22,6 +22,6 @@ fi
 # tileops itself only. Its runtime deps (torch/einops/pyyaml) and any dev/bench
 # extras are provided by the runner image (or installed separately for local dev),
 # pinned by constraints.txt. --no-deps keeps pip away from tilelang.
-pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
+python3 -m pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
 
-python -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"
+python3 -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -9,7 +9,7 @@ CONSTRAINTS="${REPO_ROOT}/constraints.txt"
 if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   {
     echo "::error::tilelang is not importable. Provision it first, then re-run:"
-    echo "  release:  python3 -m pip install --no-deps -c \"${CONSTRAINTS}\" tilelang==0.1.9"
+    echo "  release:  python3 -m pip install --no-deps -c \"${CONSTRAINTS}\" tilelang==<version>"
     echo "  main:     python3 -m pip install --no-deps <prebuilt main-commit tilelang wheel>"
     echo "(the CI runner image bakes tilelang; this script never installs it)"
   } >&2

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -20,8 +20,9 @@ if ! python3 -c "import tilelang" >/dev/null 2>&1; then
 fi
 
 # tileops itself only. Its runtime deps (torch/einops/pyyaml) and any dev/bench
-# extras are provided by the runner image (or installed separately for local dev),
-# pinned by constraints.txt. --no-deps keeps pip away from tilelang.
+# extras are provided by the runner image (or installed separately for local dev).
+# constraints.txt version-locks the CI/runner stack it covers (torch, triton,
+# apache-tvm-ffi, and tilelang's runtime deps); --no-deps keeps pip away from tilelang.
 python3 -m pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
 
 python3 -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Install tileops without letting pip re-resolve tilelang.
-#
-# Contract: tilelang must already be present — baked into
-# the runner image (CI), or installed by the developer (local) — BEFORE this runs.
-# tileops is then installed --no-deps under the version lock. pip must never resolve
-# tilelang transitively: it would drift the cu129 stack.
+# Install tileops with --no-deps so pip never re-resolves tilelang (which would drift the
+# cu129 stack). tilelang must already be present — baked into the runner image, or
+# installed by the developer locally — before this runs.
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONSTRAINTS="${REPO_ROOT}/constraints.txt"
@@ -19,10 +16,7 @@ if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   exit 1
 fi
 
-# tileops itself only. Its runtime deps (torch/einops/pyyaml) and any dev/bench
-# extras are provided by the runner image (or installed separately for local dev).
-# constraints.txt version-locks the CI/runner stack it covers (torch, triton,
-# apache-tvm-ffi, and tilelang's runtime deps); --no-deps keeps pip away from tilelang.
+# tileops only; its runtime deps come from the runner image.
 python3 -m pip install -e "${REPO_ROOT}" --no-deps -c "${CONSTRAINTS}"
 
 python3 -c "import tileops, tilelang; print('install_tileops: tileops + tilelang import OK')"

--- a/scripts/ci/install_tileops.sh
+++ b/scripts/ci/install_tileops.sh
@@ -12,8 +12,8 @@ CONSTRAINTS="${REPO_ROOT}/constraints.txt"
 if ! python3 -c "import tilelang" >/dev/null 2>&1; then
   {
     echo "::error::tilelang is not importable. Provision it first, then re-run:"
-    echo "  release:  pip install --no-deps -c \"${CONSTRAINTS}\" tilelang==0.1.9"
-    echo "  main:     pip install --no-deps <prebuilt main-commit tilelang wheel>"
+    echo "  release:  python3 -m pip install --no-deps -c \"${CONSTRAINTS}\" tilelang==0.1.9"
+    echo "  main:     python3 -m pip install --no-deps <prebuilt main-commit tilelang wheel>"
     echo "(the CI runner image bakes tilelang; this script never installs it)"
   } >&2
   exit 1

--- a/scripts/ci/verify_runtime_stack.py
+++ b/scripts/ci/verify_runtime_stack.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Build-time guard for the runner image: fail the build unless the baked stack is coherent.
+
+Runs GPU-free, so it works during `docker build` (no GPU attached). Catches the failure
+modes that a plain `import tilelang` smoke check misses:
+
+  1. tilelang imports at all — catches gross ABI breakage that aborts on import (e.g. an
+     apache-tvm-ffi too new for the baked wheel, which double-registers and calls abort()).
+  2. the installed apache-tvm-ffi satisfies tilelang's own declared requirement — catches
+     the case that imports lazily here but crashes the first time a kernel compiles under
+     GPU (apache-tvm-ffi too old: `undefined symbol: tvm::ffi::ReprPrint`). A no-GPU import
+     does not load the compiler library, so only the version range exposes this at build.
+  3. torch is still the cu129 build — a bench baseline that pulls torch from PyPI silently
+     swaps it to cu128, which breaks prebuilt c10-ABI extensions (e.g. vllm's `_C`:
+     `undefined symbol: c10::cuda::c10_cuda_check_implementation`).
+"""
+import importlib.metadata as md
+import sys
+
+import tilelang
+import torch
+from packaging.requirements import Requirement
+
+# Matches the cu129 base image; bump together with the base/torch CUDA major.minor.
+EXPECTED_TORCH_CUDA = "12.9"
+
+installed = md.version("apache-tvm-ffi")
+ffi_req = next(
+    (Requirement(r) for r in (md.requires("tilelang") or [])
+     if Requirement(r).name == "apache-tvm-ffi"),
+    None,
+)
+if ffi_req is None:
+    sys.exit("FAIL: tilelang declares no apache-tvm-ffi requirement; cannot verify the ABI pin")
+if not ffi_req.specifier.contains(installed, prereleases=True):
+    sys.exit(
+        f"FAIL: apache-tvm-ffi {installed} violates tilelang's requirement {ffi_req.specifier}. "
+        "Pin a version inside that range in constraints.txt."
+    )
+
+if torch.version.cuda != EXPECTED_TORCH_CUDA:
+    sys.exit(
+        f"FAIL: torch CUDA is {torch.version.cuda}, expected {EXPECTED_TORCH_CUDA} (cu129). "
+        "A bench baseline pulled torch from PyPI; reinstall torch from the cu129 index in "
+        "that layer so the c10 ABI stays consistent."
+    )
+
+print(
+    f"runtime-stack OK: tilelang {tilelang.__version__} | "
+    f"torch {torch.__version__} (cuda {torch.version.cuda}) | "
+    f"apache-tvm-ffi {installed} satisfies {ffi_req.specifier}"
+)


### PR DESCRIPTION
Closes #1599

## Summary

- Repo-side foundation of the CI dependency / cache redesign — additive and files-only; nothing consumes these files yet (the workflow cutover is a separate follow-up).
- `constraints.txt`: single source of exact version pins for the CI/runner stack (torch, triton, apache-tvm-ffi, and tilelang runtime deps).
- `scripts/ci/install_tileops.sh`: requires `tilelang` already present, then `pip install -e . --no-deps -c constraints.txt`; fails clearly if tilelang is missing (so pip cannot drift torch / apache-tvm-ffi).
- `.github/runner/Dockerfile`: rewritten as a multi-stage build from the public `nvidia/cuda:12.9.1-devel-ubuntu22.04` base (`runtime` builds python3.12 via the deadsnakes PPA → `post-fa3` → `fullstack` → `final`); bakes no TileOPs source and no runner credentials.

## Test plan

- [x] AC-1: `constraints.txt`, `scripts/ci/install_tileops.sh`, and the rewritten multi-stage `.github/runner/Dockerfile` exist with the requested structure (stages runtime/post-fa3/fullstack/final, public CUDA 12.9.1 base, constraints-only Docker COPY, tilelang preflight, `--no-deps` install).
- [x] AC-2: `scripts/ci/install_tileops.sh` passes `shellcheck` (0.11.0, no diagnostics).
- [x] AC-3: `.github/runner/Dockerfile` passes `hadolint --failure-threshold error` (2.12.0; only warning/info findings).
- [ ] AC-4: **DEFERRED-TO-MANUAL on a GPU build host.** The image is intentionally NOT built in CI by this issue. Manual validation (image builds; `torch.version.cuda == "12.9"`; `tilelang` imports; cuBLAS matmul/bmm/einsum probe passes; `pytest -m smoke` passes) is performed by a maintainer on a host with an NVIDIA GPU + nvcc. Reviewers should not expect a CI image build here.
