### PR TITLE
[Feat][Linear-Attn] Update GDN prefill manifest contract

### DIFF
--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -23,7 +23,8 @@ GatedDeltaNetPrefillFwdOp:
       o: {dtype: "same_as(q)"}
       final_state: {dtype: "same_as(q)"}
     params:
-      chunk_size: {type: int, default: 64}
+      chunk_size: {type: "int | None", default: null}
+      layout: {type: str, default: "bhtd"}
     shape_rules:
       - "q.shape == (B, H, S, DK)"
       - "k.shape == (B, H, S, DK)"
@@ -32,13 +33,14 @@ GatedDeltaNetPrefillFwdOp:
       - "beta.shape == (B, H, S)"
       - "o.shape == (B, H, S, DV)"
       - "final_state.shape == (B, H, DK, DV)"
-      - "S % chunk_size == 0"
+      - "chunk_size is None or S % chunk_size == 0"
 
   workloads:
     # Inference-oriented BHSD rows. Unit tests should use smaller
     # branch-covering shapes in tests/ops, not these benchmark workloads.
     - {q_shape: [1, 16, 512, 128], k_shape: [1, 16, 512, 128], v_shape: [1, 16, 512, 128], g_shape: [1, 16, 512], beta_shape: [1, 16, 512], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s512-h16-d128"}
     - {q_shape: [4, 16, 2048, 64], k_shape: [4, 16, 2048, 64], v_shape: [4, 16, 2048, 128], g_shape: [4, 16, 2048], beta_shape: [4, 16, 2048], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b4-s2k-h16-dk64-dv128"}
+    - {q_shape: [1, 16, 2048, 128], k_shape: [1, 16, 2048, 128], v_shape: [1, 16, 2048, 128], g_shape: [1, 16, 2048], beta_shape: [1, 16, 2048], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s2k-h16-d128"}
     - {q_shape: [1, 16, 8192, 128], k_shape: [1, 16, 8192, 128], v_shape: [1, 16, 8192, 128], g_shape: [1, 16, 8192], beta_shape: [1, 16, 8192], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s8k-h16-d128"}
 
   roofline:


### PR DESCRIPTION
## Summary
- update the GatedDeltaNetPrefillFwdOp spec-only manifest contract to allow chunk_size=None
- add the layout parameter used by the implementation path
- add an H16/S2K manifest workload row for the target prefill shape family

## Notes
- This is a manifest-only precursor for PR #1596.
- It intentionally keeps status: spec-only and leaves source paths null; the implementation PR should flip status/source/roofline once the kernel code lands.

## Validation
- python scripts/validate_manifest.py --check-op GatedDeltaNetPrefillFwdOp
