### PR TITLE
[Design][Linear-Attn] Complete GDN prefill manifest contract

### DIFF
--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -14,24 +14,31 @@ GatedDeltaNetPrefillFwdOp:
 
   signature:
     inputs:
-      q: {dtype: "float16 | bfloat16 | float32"}
-      k: {dtype: "same_as(q)"}
-      v: {dtype: "same_as(q)"}
-      g: {dtype: "same_as(q)"}
-      beta: {dtype: "same_as(q)"}
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, S, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, S, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, H, S]"}
+      beta: {dtype: "same_as(q)", shape: "[B, H, S]"}
     outputs:
-      o: {dtype: "same_as(q)"}
-      final_state: {dtype: "same_as(q)"}
+      o: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      final_state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
     params:
       chunk_size: {type: "int | None", default: null}
       layout: {type: str, default: "bhtd"}
     shape_rules:
-      - "q.shape == (B, H, S, DK)"
-      - "k.shape == (B, H, S, DK)"
-      - "v.shape == (B, H, S, DV)"
-      - "g.shape == (B, H, S)"
-      - "beta.shape == (B, H, S)"
-      - "o.shape == (B, H, S, DV)"
+      - "layout in ('bhtd', 'bhsd', 'bthd')"
+      - "layout == 'bthd' or q.shape == (B, H, S, DK)"
+      - "layout == 'bthd' or k.shape == (B, H, S, DK)"
+      - "layout == 'bthd' or v.shape == (B, H, S, DV)"
+      - "layout == 'bthd' or g.shape == (B, H, S)"
+      - "layout == 'bthd' or beta.shape == (B, H, S)"
+      - "layout == 'bthd' or o.shape == (B, H, S, DV)"
+      - "layout != 'bthd' or q.shape == (B, S, H, DK)"
+      - "layout != 'bthd' or k.shape == (B, S, H, DK)"
+      - "layout != 'bthd' or v.shape == (B, S, H, DV)"
+      - "layout != 'bthd' or g.shape == (B, S, H)"
+      - "layout != 'bthd' or beta.shape == (B, S, H)"
+      - "layout != 'bthd' or o.shape == (B, S, H, DV)"
       - "final_state.shape == (B, H, DK, DV)"
       - "chunk_size is None or S % chunk_size == 0"
 
@@ -44,15 +51,13 @@ GatedDeltaNetPrefillFwdOp:
     - {q_shape: [1, 16, 8192, 128], k_shape: [1, 16, 8192, 128], v_shape: [1, 16, 8192, 128], g_shape: [1, 16, 8192], beta_shape: [1, 16, 8192], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s8k-h16-d128"}
 
   roofline:
-    # Placeholder while this entry is spec-only. The implementation PR should
-    # replace this with gated_deltanet_prefill_fwd_roofline.
-    flops: "0"
-    bytes: "0"
+    func: "tileops.perf.formulas.gated_deltanet_prefill_fwd_roofline"
 
   source:
-    # No concrete implementation files yet. The implementation PR should fill
-    # these paths and flip status to implemented.
-    kernel: null
-    op: null
-    test: null
-    bench: null
+    kernel: tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+    kernel_map:
+      GatedDeltaNetPrefillFwdKernel: GatedDeltaNetPrefillFwdKernel
+    op: tileops/ops/gated_deltanet.py
+    test: tests/ops/test_gated_deltanet_prefill.py
+    bench: benchmarks/ops/bench_gated_deltanet_prefill.py
+    bench_manifest_driven: true


### PR DESCRIPTION
## Summary
- encode the GatedDeltaNetPrefillFwdOp BHTD/BHSD and BTHD layout shape contracts in the manifest
- add fixed-rank shape metadata for the manifest tensors
- fill the planned roofline/source metadata while keeping the entry spec-only

## Notes
- This is a manifest-only prerequisite for PR #1596.
- The implementation PR should only flip status and keep any remaining manifest edit within the status-flip carve-out.

## Validation
- python scripts/validate_manifest.py
