### PR TITLE
[Test][Manifest] Skip spec-only ops in source path validation

### DIFF
--- a/tests/test_ops_manifest.py
+++ b/tests/test_ops_manifest.py
@@ -199,6 +199,9 @@ class TestSourcePaths:
 
     def test_all_source_paths_exist(self, all_ops):
         for op_name, entry in all_ops.items():
+            # Skip spec-only ops — source paths are placeholders until implementation
+            if entry.get("status") == "spec-only":
+                continue
             source = entry["source"]
             for key, rel_path in source.items():
                 if not isinstance(rel_path, str):


### PR DESCRIPTION
## Summary
- Skip ops with `status=spec-only` in `test_all_source_paths_exist`
- Spec-only entries are design specs without implementations yet
- Their source paths are placeholders and don't exist until the op is implemented

## Context
The test was failing on `GatedDeltaNetPrefillFwdOp` which is marked as `spec-only` in `tileops/manifest/linear_attention.yaml`. According to the trust model, spec-only ops declare future implementations and their source paths point to where files will eventually go.

## Test plan
- [x] Pre-commit hooks pass
- [x] Fixes the failing test for `GatedDeltaNetPrefillFwdOp`
- [x] Still validates source paths for all implemented ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)