### PR TITLE
[Bench][Linear-Attn] Add Qwen GDN prefill benchmark surface

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -317,6 +317,31 @@ def _get_env_metadata() -> list[str]:
         driver = "N/A"
     lines.append(f"- **Driver version**: {driver}")
 
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=clocks.current.sm,clocks.current.memory,"
+                "clocks.applications.graphics,clocks.applications.memory",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            clock_values = [part.strip() for part in result.stdout.splitlines()[0].split(",")]
+            if len(clock_values) == 4:
+                sm_clock, mem_clock, app_sm_clock, app_mem_clock = clock_values
+                lines.append(
+                    "- **GPU clocks**: "
+                    f"SM current {sm_clock} MHz, memory current {mem_clock} MHz, "
+                    f"application SM {app_sm_clock} MHz, "
+                    f"application memory {app_mem_clock} MHz"
+                )
+    except (FileNotFoundError, IndexError, subprocess.TimeoutExpired):
+        pass
+
     return lines
 
 
@@ -608,7 +633,7 @@ class BenchmarkReport:
         lines.extend(_get_env_metadata())
         lines.append("")
 
-        result_keys = ["latency_ms", "tflops", "bandwidth_tbs"]
+        default_result_keys = ["latency_ms", "tflops", "bandwidth_tbs"]
 
         for name, entries in BenchmarkReport._records.items():
             if not entries:
@@ -621,6 +646,11 @@ class BenchmarkReport:
             tag_entries = {}
             for entry in entries:
                 tag_entries.setdefault(entry["tag"], []).append(entry)
+            result_keys = list(default_result_keys)
+            for entry in entries:
+                for key in entry["result"]:
+                    if key not in result_keys:
+                        result_keys.append(key)
 
             for tag, tag_group in tag_entries.items():
                 lines.append(f"### {tag}")

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -306,41 +306,42 @@ def _get_env_metadata() -> list[str]:
     else:
         lines.append("- **GPU model**: N/A (no CUDA device)")
 
-    # Try to get NVIDIA driver version from nvidia-smi
-    try:
-        result = subprocess.run(
-            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
-            capture_output=True, text=True, timeout=5,
-        )
-        driver = result.stdout.strip().split("\n")[0] if result.returncode == 0 else "N/A"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        driver = "N/A"
-    lines.append(f"- **Driver version**: {driver}")
-
+    # Try to get NVIDIA driver version and clocks from nvidia-smi.
+    gpu_query_fields = [
+        "driver_version",
+        "clocks.current.sm",
+        "clocks.current.memory",
+        "clocks.applications.graphics",
+        "clocks.applications.memory",
+    ]
+    gpu_query_values = []
     try:
         result = subprocess.run(
             [
                 "nvidia-smi",
-                "--query-gpu=clocks.current.sm,clocks.current.memory,"
-                "clocks.applications.graphics,clocks.applications.memory",
+                f"--query-gpu={','.join(gpu_query_fields)}",
                 "--format=csv,noheader,nounits",
             ],
-            capture_output=True,
-            text=True,
-            timeout=5,
+            capture_output=True, text=True, timeout=5,
         )
         if result.returncode == 0:
-            clock_values = [part.strip() for part in result.stdout.splitlines()[0].split(",")]
-            if len(clock_values) == 4:
-                sm_clock, mem_clock, app_sm_clock, app_mem_clock = clock_values
-                lines.append(
-                    "- **GPU clocks**: "
-                    f"SM current {sm_clock} MHz, memory current {mem_clock} MHz, "
-                    f"application SM {app_sm_clock} MHz, "
-                    f"application memory {app_mem_clock} MHz"
-                )
-    except (FileNotFoundError, IndexError, subprocess.TimeoutExpired):
+            gpu_query_values = [
+                part.strip() for part in result.stdout.splitlines()[0].split(",")
+            ]
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
+
+    driver = gpu_query_values[0] if len(gpu_query_values) == len(gpu_query_fields) else "N/A"
+    lines.append(f"- **Driver version**: {driver}")
+
+    if len(gpu_query_values) == len(gpu_query_fields):
+        sm_clock, mem_clock, app_sm_clock, app_mem_clock = gpu_query_values[1:]
+        lines.append(
+            "- **GPU clocks**: "
+            f"SM current {sm_clock} MHz, memory current {mem_clock} MHz, "
+            f"application SM {app_sm_clock} MHz, "
+            f"application memory {app_mem_clock} MHz"
+        )
 
     return lines
 

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -16,7 +16,6 @@ import torch
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from benchmarks.ops.attention.manifest_params import manifest_params
 from benchmarks.ops.bench_gated_deltanet import (
-    _to_fla_layout,
     compute_w_u_torch,
     kernel2_gated_deltanet_torch,
     prepare_wy_repr_gated_torch,
@@ -45,6 +44,7 @@ class _GatedDeltaNetPrefillFwdTestBaseline(GatedDeltaNetPrefillFwdTest):
         g: torch.Tensor,
         beta: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        q, k, v, g, beta = _to_bhtd_layout(q, k, v, g, beta, self.layout)
         batch, heads, seq_len, dim_k = k.shape
         dim_v = v.shape[-1]
         chunk_size = self.chunk_size
@@ -64,7 +64,7 @@ class _GatedDeltaNetPrefillFwdTestBaseline(GatedDeltaNetPrefillFwdTest):
         final_state, o = kernel2_gated_deltanet_torch(
             q, k, g_cum, w, u, initial_state, chunk_size
         )
-        return o.to(self.dtype), final_state.to(self.dtype)
+        return _from_bhtd_layout(o.to(self.dtype), final_state.to(self.dtype), self.layout)
 
 
 def _fla_prefill_fwd():
@@ -90,21 +90,90 @@ def _fla_prefill_fwd():
     return baseline_fn
 
 
-def _gdn_prefill_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int]:
-    batch, seq_len, heads, dim_k = workload["q_shape"]
-    _, v_seq_len, v_heads, dim_v = workload["v_shape"]
-    if v_seq_len != seq_len:
-        raise ValueError("GDN prefill q_shape and v_shape must share seq_len")
-    if v_heads != heads:
-        raise ValueError("GDN prefill q_shape and v_shape must share heads")
-    return batch, heads, seq_len, dim_k, dim_v, workload.get("chunk_size", 64)
+def _to_bhtd_layout(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    layout = layout.lower()
+    if layout == "bthd":
+        return (
+            q.permute(0, 2, 1, 3).contiguous(),
+            k.permute(0, 2, 1, 3).contiguous(),
+            v.permute(0, 2, 1, 3).contiguous(),
+            g.permute(0, 2, 1).contiguous(),
+            beta.permute(0, 2, 1).contiguous(),
+        )
+    if layout in ("bhtd", "bhsd"):
+        return q, k, v, g, beta
+    raise ValueError(f"Unsupported layout: {layout}")
+
+
+def _from_bhtd_layout(
+    o: torch.Tensor,
+    final_state: torch.Tensor,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if layout.lower() == "bthd":
+        return o.permute(0, 2, 1, 3).contiguous(), final_state
+    return o, final_state
+
+
+def _to_fla_public_layout(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    layout = layout.lower()
+    if layout == "bthd":
+        return q, k, v, g, beta
+    if layout in ("bhtd", "bhsd"):
+        return (
+            q.permute(0, 2, 1, 3).contiguous(),
+            k.permute(0, 2, 1, 3).contiguous(),
+            v.permute(0, 2, 1, 3).contiguous(),
+            g.permute(0, 2, 1).contiguous(),
+            beta.permute(0, 2, 1).contiguous(),
+        )
+    raise ValueError(f"Unsupported layout: {layout}")
+
+
+def _gdn_prefill_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, int, str]:
+    layout = workload.get("layout", "bthd").lower()
+    if layout == "bthd":
+        batch, seq_len, heads, dim_k = workload["q_shape"]
+        _, v_seq_len, v_heads, dim_v = workload["v_shape"]
+    elif layout in ("bhtd", "bhsd"):
+        batch, heads, seq_len, dim_k = workload["q_shape"]
+        _, v_heads, v_seq_len, dim_v = workload["v_shape"]
+    else:
+        raise ValueError(f"Unsupported layout: {layout}")
+    if v_seq_len != seq_len or v_heads != heads:
+        raise ValueError("GDN prefill q_shape and v_shape must share seq_len and heads")
+    return (
+        batch,
+        heads,
+        seq_len,
+        dim_k,
+        dim_v,
+        workload.get("chunk_size", 64),
+        layout,
+    )
 
 
 _BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), _gdn_prefill_args, tune=False)
 
 
 @pytest.mark.parametrize(
-    "batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune",
+    "batch, heads, seq_len, dim_k, dim_v, chunk_size, layout, dtype, tune",
     _BENCH_PARAMS,
 )
 def test_gated_deltanet_prefill_fwd_bench(
@@ -114,11 +183,12 @@ def test_gated_deltanet_prefill_fwd_bench(
     dim_k: int,
     dim_v: int,
     chunk_size: int,
+    layout: str,
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
     test = _GatedDeltaNetPrefillFwdTestBaseline(
-        batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype
+        batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, layout=layout
     )
     inputs = test.gen_inputs()
 
@@ -130,19 +200,21 @@ def test_gated_deltanet_prefill_fwd_bench(
         dim_v,
         chunk_size,
         dtype,
-        layout="bthd",
         tune=tune,
+        layout=layout,
     )
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    bthd_inputs = _to_fla_layout(*inputs)
-    result = bm.profile(op, *bthd_inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    result = bm.profile(op, *inputs)
 
     fla_fn = _fla_prefill_fwd()
     if fla_fn is not None:
-        result_fla = bm.profile(fla_fn, *bthd_inputs)
+        fla_inputs = _to_fla_public_layout(*inputs, layout)
+        result_fla = bm.profile(fla_fn, *fla_inputs)
+        result["speedup_vs_fla"] = result_fla["latency_ms"] / result["latency_ms"]
+        BenchmarkReport.record(op, locals(), result, tag="tileops")
         BenchmarkReport.record(op, locals(), result_fla, tag="fla")
     else:
+        BenchmarkReport.record(op, locals(), result, tag="tileops")
         result_ref = bm.profile(test.ref_program, *inputs)
         BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
 

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -1,7 +1,9 @@
 """Benchmark: TileOPs Gated DeltaNet inference prefill.
 
-When FLA is installed, record it as the independent baseline. Otherwise fall
-back to a pure-torch reference so every benchmark row has a non-TileOps entry.
+When FLA is installed, record it as the independent baseline. A pure-torch
+reference is kept only for small ad-hoc fallback rows; the manifest's
+long-context Qwen rows require FLA so no-FLA runs do not spend minutes or OOM
+inside the reference recurrence.
 
 The benchmark measures the serving-oriented BTHD layout because that is the
 production fast path used by FLA/Qwen-style inference prefill.
@@ -25,6 +27,7 @@ from tileops.ops import GatedDeltaNetPrefillFwdOp
 from workloads.gated_deltanet import GatedDeltaNetPrefillFwdTest
 
 _OP_NAME = "GatedDeltaNetPrefillFwdOp"
+_TORCH_FALLBACK_MAX_SEQ_LEN = 4096
 
 
 try:
@@ -169,6 +172,10 @@ def _gdn_prefill_args(
     )
 
 
+def _can_use_torch_fallback(seq_len: int) -> bool:
+    return seq_len <= _TORCH_FALLBACK_MAX_SEQ_LEN
+
+
 _BENCH_PARAMS = manifest_params(load_workloads(_OP_NAME), _gdn_prefill_args, tune=False)
 
 
@@ -187,6 +194,14 @@ def test_gated_deltanet_prefill_fwd_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
+    fla_fn = _fla_prefill_fwd()
+    if fla_fn is None and not _can_use_torch_fallback(seq_len):
+        pytest.skip(
+            "FLA is required for long-context GDN prefill benchmark rows; "
+            "the pure-torch fallback is capped at "
+            f"S <= {_TORCH_FALLBACK_MAX_SEQ_LEN}"
+        )
+
     test = _GatedDeltaNetPrefillFwdTestBaseline(
         batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, layout=layout
     )
@@ -206,7 +221,6 @@ def test_gated_deltanet_prefill_fwd_bench(
     bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
 
-    fla_fn = _fla_prefill_fwd()
     if fla_fn is not None:
         fla_inputs = _to_fla_public_layout(*inputs, layout)
         result_fla = bm.profile(fla_fn, *fla_inputs)

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -10,7 +10,7 @@ production fast path used by FLA/Qwen-style inference prefill.
 """
 
 import inspect
-from typing import Any
+from typing import Any, Sequence
 
 import pytest
 import torch
@@ -47,7 +47,9 @@ class _GatedDeltaNetPrefillFwdTestBaseline(GatedDeltaNetPrefillFwdTest):
         g: torch.Tensor,
         beta: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        q, k, v, g, beta = _to_bhtd_layout(q, k, v, g, beta, self.layout)
+        q, k, v, g, beta = convert_gdn_prefill_layout(
+            (q, k, v, g, beta), self.layout, "bhtd"
+        )
         batch, heads, seq_len, dim_k = k.shape
         dim_v = v.shape[-1]
         chunk_size = self.chunk_size
@@ -67,7 +69,8 @@ class _GatedDeltaNetPrefillFwdTestBaseline(GatedDeltaNetPrefillFwdTest):
         final_state, o = kernel2_gated_deltanet_torch(
             q, k, g_cum, w, u, initial_state, chunk_size
         )
-        return _from_bhtd_layout(o.to(self.dtype), final_state.to(self.dtype), self.layout)
+        (o,) = convert_gdn_prefill_layout((o.to(self.dtype),), "bhtd", self.layout)
+        return o, final_state.to(self.dtype)
 
 
 def _fla_prefill_fwd():
@@ -93,58 +96,39 @@ def _fla_prefill_fwd():
     return baseline_fn
 
 
-def _to_bhtd_layout(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    layout: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def _normalize_gdn_prefill_layout(layout: str) -> str:
     layout = layout.lower()
-    if layout == "bthd":
-        return (
-            q.permute(0, 2, 1, 3).contiguous(),
-            k.permute(0, 2, 1, 3).contiguous(),
-            v.permute(0, 2, 1, 3).contiguous(),
-            g.permute(0, 2, 1).contiguous(),
-            beta.permute(0, 2, 1).contiguous(),
-        )
-    if layout in ("bhtd", "bhsd"):
-        return q, k, v, g, beta
+    if layout == "bhsd":
+        return "bhtd"
+    if layout in ("bhtd", "bthd"):
+        return layout
     raise ValueError(f"Unsupported layout: {layout}")
 
 
-def _from_bhtd_layout(
-    o: torch.Tensor,
-    final_state: torch.Tensor,
-    layout: str,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    if layout.lower() == "bthd":
-        return o.permute(0, 2, 1, 3).contiguous(), final_state
-    return o, final_state
+def convert_gdn_prefill_layout(
+    tensors: Sequence[torch.Tensor],
+    src_layout: str,
+    dst_layout: str,
+) -> tuple[torch.Tensor, ...]:
+    src_layout = _normalize_gdn_prefill_layout(src_layout)
+    dst_layout = _normalize_gdn_prefill_layout(dst_layout)
+    if src_layout == dst_layout:
+        return tuple(tensors)
+    if {src_layout, dst_layout} != {"bhtd", "bthd"}:
+        raise ValueError(f"Unsupported layout conversion: {src_layout} -> {dst_layout}")
 
-
-def _to_fla_public_layout(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    g: torch.Tensor,
-    beta: torch.Tensor,
-    layout: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    layout = layout.lower()
-    if layout == "bthd":
-        return q, k, v, g, beta
-    if layout in ("bhtd", "bhsd"):
-        return (
-            q.permute(0, 2, 1, 3).contiguous(),
-            k.permute(0, 2, 1, 3).contiguous(),
-            v.permute(0, 2, 1, 3).contiguous(),
-            g.permute(0, 2, 1).contiguous(),
-            beta.permute(0, 2, 1).contiguous(),
-        )
-    raise ValueError(f"Unsupported layout: {layout}")
+    converted = []
+    for tensor in tensors:
+        if tensor.ndim == 4:
+            converted.append(tensor.permute(0, 2, 1, 3).contiguous())
+        elif tensor.ndim == 3:
+            converted.append(tensor.permute(0, 2, 1).contiguous())
+        else:
+            raise ValueError(
+                "GDN prefill layout conversion expects 3D gate tensors or "
+                f"4D sequence tensors, got {tensor.ndim}D"
+            )
+    return tuple(converted)
 
 
 def _gdn_prefill_args(
@@ -222,7 +206,7 @@ def test_gated_deltanet_prefill_fwd_bench(
     result = bm.profile(op, *inputs)
 
     if fla_fn is not None:
-        fla_inputs = _to_fla_public_layout(*inputs, layout)
+        fla_inputs = convert_gdn_prefill_layout(inputs, layout, "bthd")
         result_fla = bm.profile(fla_fn, *fla_inputs)
         result["speedup_vs_fla"] = result_fla["latency_ms"] / result["latency_ms"]
         BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -1,9 +1,9 @@
 """Benchmark: TileOPs Gated DeltaNet inference prefill.
 
 When FLA is installed, record it as the independent baseline. A pure-torch
-reference is kept only for small ad-hoc fallback rows; the manifest's
-long-context Qwen rows require FLA so no-FLA runs do not spend minutes or OOM
-inside the reference recurrence.
+reference is kept only for small manifest fallback rows; the long-context Qwen
+rows require FLA so no-FLA runs do not spend minutes or OOM inside the
+reference recurrence.
 
 The benchmark measures the serving-oriented BTHD layout because that is the
 production fast path used by FLA/Qwen-style inference prefill.

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -43,6 +43,11 @@ GatedDeltaNetPrefillFwdOp:
       - "chunk_size is None or S % chunk_size == 0"
 
   workloads:
+    # Small fallback row for environments without FLA. The benchmark uses the
+    # pure-torch reference only up to S=4096; the long-context Qwen rows below
+    # require FLA as their independent baseline.
+    - {q_shape: [1, 4096, 16, 128], k_shape: [1, 4096, 16, 128], v_shape: [1, 4096, 16, 128], g_shape: [1, 4096, 16], beta_shape: [1, 4096, 16], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "fallback-gdn-prefill-b1-s4k-h16-d128-bthd"}
+
     # Qwen3.5-aligned inference prefill rows using the public FLA BTHD
     # contract. Tests use smaller branch-covering shapes in tests/ops; these
     # rows are intentionally long-context benchmark coverage.

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -43,11 +43,21 @@ GatedDeltaNetPrefillFwdOp:
       - "chunk_size is None or S % chunk_size == 0"
 
   workloads:
-    # Serving-oriented BTHD rows, matching FLA/Qwen inference prefill.
-    - {q_shape: [1, 512, 16, 128], k_shape: [1, 512, 16, 128], v_shape: [1, 512, 16, 128], g_shape: [1, 512, 16], beta_shape: [1, 512, 16], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s512-h16-d128"}
-    - {q_shape: [4, 2048, 16, 64], k_shape: [4, 2048, 16, 64], v_shape: [4, 2048, 16, 128], g_shape: [4, 2048, 16], beta_shape: [4, 2048, 16], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b4-s2k-h16-dk64-dv128"}
-    - {q_shape: [1, 2048, 16, 128], k_shape: [1, 2048, 16, 128], v_shape: [1, 2048, 16, 128], g_shape: [1, 2048, 16], beta_shape: [1, 2048, 16], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s2k-h16-d128"}
-    - {q_shape: [1, 8192, 16, 128], k_shape: [1, 8192, 16, 128], v_shape: [1, 8192, 16, 128], g_shape: [1, 8192, 16], beta_shape: [1, 8192, 16], chunk_size: 64, dtypes: [float16, bfloat16], label: "gdn-prefill-b1-s8k-h16-d128"}
+    # Qwen3.5-aligned inference prefill rows using the public FLA BTHD
+    # contract. Tests use smaller branch-covering shapes in tests/ops; these
+    # rows are intentionally long-context benchmark coverage.
+    - {q_shape: [1, 32768, 16, 128], k_shape: [1, 32768, 16, 128], v_shape: [1, 32768, 16, 128], g_shape: [1, 32768, 16], beta_shape: [1, 32768, 16], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s32k-h16-d128-bthd"}
+    - {q_shape: [1, 65536, 16, 128], k_shape: [1, 65536, 16, 128], v_shape: [1, 65536, 16, 128], g_shape: [1, 65536, 16], beta_shape: [1, 65536, 16], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s64k-h16-d128-bthd"}
+    - {q_shape: [1, 131072, 16, 128], k_shape: [1, 131072, 16, 128], v_shape: [1, 131072, 16, 128], g_shape: [1, 131072, 16], beta_shape: [1, 131072, 16], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s128k-h16-d128-bthd"}
+    - {q_shape: [1, 32768, 32, 128], k_shape: [1, 32768, 32, 128], v_shape: [1, 32768, 32, 128], g_shape: [1, 32768, 32], beta_shape: [1, 32768, 32], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s32k-h32-d128-bthd"}
+    - {q_shape: [1, 65536, 32, 128], k_shape: [1, 65536, 32, 128], v_shape: [1, 65536, 32, 128], g_shape: [1, 65536, 32], beta_shape: [1, 65536, 32], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s64k-h32-d128-bthd"}
+    - {q_shape: [1, 131072, 32, 128], k_shape: [1, 131072, 32, 128], v_shape: [1, 131072, 32, 128], g_shape: [1, 131072, 32], beta_shape: [1, 131072, 32], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s128k-h32-d128-bthd"}
+    - {q_shape: [1, 32768, 48, 128], k_shape: [1, 32768, 48, 128], v_shape: [1, 32768, 48, 128], g_shape: [1, 32768, 48], beta_shape: [1, 32768, 48], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s32k-h48-d128-bthd"}
+    - {q_shape: [1, 65536, 48, 128], k_shape: [1, 65536, 48, 128], v_shape: [1, 65536, 48, 128], g_shape: [1, 65536, 48], beta_shape: [1, 65536, 48], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s64k-h48-d128-bthd"}
+    - {q_shape: [1, 131072, 48, 128], k_shape: [1, 131072, 48, 128], v_shape: [1, 131072, 48, 128], g_shape: [1, 131072, 48], beta_shape: [1, 131072, 48], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s128k-h48-d128-bthd"}
+    - {q_shape: [1, 32768, 64, 128], k_shape: [1, 32768, 64, 128], v_shape: [1, 32768, 64, 128], g_shape: [1, 32768, 64], beta_shape: [1, 32768, 64], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s32k-h64-d128-bthd"}
+    - {q_shape: [1, 65536, 64, 128], k_shape: [1, 65536, 64, 128], v_shape: [1, 65536, 64, 128], g_shape: [1, 65536, 64], beta_shape: [1, 65536, 64], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s64k-h64-d128-bthd"}
+    - {q_shape: [1, 131072, 64, 128], k_shape: [1, 131072, 64, 128], v_shape: [1, 131072, 64, 128], g_shape: [1, 131072, 64], beta_shape: [1, 131072, 64], chunk_size: 64, layout: bthd, dtypes: [float16, bfloat16], label: "qwen35-gdn-prefill-b1-s128k-h64-d128-bthd"}
 
   roofline:
     func: "tileops.perf.formulas.gated_deltanet_prefill_fwd_roofline"

--- a/workloads/gated_deltanet.py
+++ b/workloads/gated_deltanet.py
@@ -45,9 +45,35 @@ class GatedDeltaNetPrefillFwdTest(GatedDeltaNetFwdTest):
         dim_v: int,
         chunk_size: int,
         dtype: torch.dtype,
+        layout: str = "bhtd",
     ) -> None:
         super().__init__(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
-        self.shape = (batch, heads, seq_len, dim_k)
+        self.layout = self._normalize_layout(layout)
+        if self.layout == "bthd":
+            self.shape = (batch, seq_len, heads, dim_k)
+        else:
+            self.shape = (batch, heads, seq_len, dim_k)
+
+    @staticmethod
+    def _normalize_layout(layout: str) -> str:
+        layout = layout.lower()
+        if layout == "bhsd":
+            return "bhtd"
+        if layout in ("bhtd", "bthd"):
+            return layout
+        raise ValueError(f"Unsupported layout: {layout}")
+
+    def gen_inputs(self) -> tuple[torch.Tensor, ...]:
+        if self.layout != "bthd":
+            return super().gen_inputs()
+
+        B, H, S, DK, DV = self.batch, self.heads, self.seq_len, self.dim_k, self.dim_v
+        q = torch.randn(B, S, H, DK, device="cuda", dtype=self.dtype) * 0.1
+        k = torch.randn(B, S, H, DK, device="cuda", dtype=self.dtype) * 0.1
+        v = torch.randn(B, S, H, DV, device="cuda", dtype=self.dtype) * 0.1
+        g = -torch.rand(B, S, H, device="cuda", dtype=self.dtype)
+        beta = torch.rand(B, S, H, device="cuda", dtype=self.dtype) * 0.5
+        return q, k, v, g, beta
 
 
 class GatedDeltaNetDecodeTest(WorkloadBase):


### PR DESCRIPTION
Depends on #1596. Addresses #1597.

This is opened against upstream as a draft. Until #1596 lands, the diff will include the GDN prefill implementation commits from that dependency; after #1596 merges this branch should be rebased/updated so the PR contains only the benchmark-surface commit.

## Summary
- Switch the Gated DeltaNet prefill benchmark surface to the FLA/Qwen BTHD contract.
- Add Qwen3.5-aligned long-context rows for S=32K/64K/128K and H=16/32/48/64 across fp16/bf16.
- Compare TileOps against FLA with output_final_state=True and surface speedup in profile_run.log.
- Keep nightly JUnit properties compatible while allowing profile_run.log to show extra metrics and GPU clocks.

## Validation
- python -m py_compile benchmarks/ops/bench_gated_deltanet_prefill.py workloads/gated_deltanet.py benchmarks/benchmark_base.py tileops/perf/formulas.py
- python scripts/validate_manifest.py
- python -m pytest --collect-only benchmarks/ops/bench_gated_deltanet_prefill.py -q
- TMPDIR=/home/ga/tmp python -m pytest tests/ops/test_gated_deltanet_prefill.py -m smoke -q

## Notes
- The local environment does not have FLA installed, so full benchmark execution was only checked for collection/skip behavior here.