### PR TITLE
[Refactor] Add logical GQA prefill kernel dispatch wrappers

### DIFF
--- a/tests/ops/attention/test_gqa_logical_kernels.py
+++ b/tests/ops/attention/test_gqa_logical_kernels.py
@@ -1,0 +1,181 @@
+import pytest
+import torch
+
+from tileops.kernels.attention import gqa_logical
+
+pytestmark = pytest.mark.smoke
+
+
+class _FakeKernel:
+    supported_archs = None
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def __call__(self, *args: object, **kwargs: object) -> tuple[str, tuple[object, ...]]:
+        self.calls.append((args, kwargs))
+        return type(self).__name__, args
+
+
+class _FakeDenseKernel(_FakeKernel):
+    pass
+
+
+class _FakeVarlenKernel(_FakeKernel):
+    pass
+
+
+class _FakeSlidingWindowKernel(_FakeKernel):
+    pass
+
+
+class _FakeAppendKernel(_FakeKernel):
+    pass
+
+
+class _FakeFwdKernel(_FakeKernel):
+    pass
+
+
+class _FakeFP8Kernel(_FakeKernel):
+    pass
+
+
+def test_gqa_prefill_kernel_dispatches_dense(monkeypatch) -> None:
+    monkeypatch.setattr(gqa_logical, "GQAPrefillFwdKernel", _FakeDenseKernel)
+
+    kernel = gqa_logical.GQAPrefillKernel(
+        batch=1,
+        heads=8,
+        heads_kv=2,
+        dim=64,
+        seq_len_q=32,
+        seq_len_kv=64,
+        dtype=torch.float16,
+    )
+
+    assert isinstance(kernel.impl, _FakeDenseKernel)
+    assert kernel.impl.kwargs["seq_len_q"] == 32
+    assert kernel.impl.kwargs["seq_len_kv"] == 64
+
+
+def test_gqa_prefill_kernel_dispatches_ragged(monkeypatch) -> None:
+    monkeypatch.setattr(gqa_logical, "GQAPrefillVarlenFwdKernel", _FakeVarlenKernel)
+
+    kernel = gqa_logical.GQAPrefillKernel(
+        batch=2,
+        heads=8,
+        heads_kv=2,
+        dim=64,
+        layout="ragged",
+        dtype=torch.float16,
+    )
+
+    assert isinstance(kernel.impl, _FakeVarlenKernel)
+    assert kernel.impl.kwargs["batch"] == 2
+    assert kernel.impl.kwargs["dim"] == 64
+
+
+def test_gqa_prefill_kernel_dispatches_sliding_window(monkeypatch) -> None:
+    monkeypatch.setattr(gqa_logical, "is_hopper", lambda: False)
+    monkeypatch.setattr(gqa_logical, "GQASlidingWindowFwdKernel", _FakeSlidingWindowKernel)
+
+    kernel = gqa_logical.GQAPrefillKernel(
+        batch=1,
+        heads=8,
+        heads_kv=2,
+        dim=64,
+        seq_len_q=128,
+        seq_len_kv=128,
+        use_swa=True,
+        window_size_left=64,
+        dtype=torch.float16,
+    )
+
+    assert isinstance(kernel.impl, _FakeSlidingWindowKernel)
+    assert kernel.impl.kwargs["window_size_left"] == 64
+
+
+def test_gqa_prefill_with_kv_cache_kernel_dispatches_rope_pair(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gqa_logical, "GQAPrefillWithKVCacheRopeAppendKernel", _FakeAppendKernel)
+    monkeypatch.setattr(gqa_logical, "GQAPrefillWithKVCacheRopeFwdKernel", _FakeFwdKernel)
+
+    kernel = gqa_logical.GQAPrefillWithKVCacheKernel(
+        batch=1,
+        heads=8,
+        heads_kv=2,
+        seq_len_new=32,
+        seqlen_kv=128,
+        dim=64,
+        fuse_rope=True,
+        max_position=128,
+        rotary_dim=64,
+        dtype=torch.float16,
+    )
+    result = kernel("q", "k_new", "v_new", "k_cache", "v_cache", "lens", "cos", "sin")
+
+    assert isinstance(kernel.append_impl, _FakeAppendKernel)
+    assert isinstance(kernel.impl, _FakeFwdKernel)
+    assert len(kernel.append_impl.calls) == 1
+    assert result[0] == "_FakeFwdKernel"
+
+
+def test_gqa_prefill_paged_kernel_dispatches_fp8_cache(monkeypatch) -> None:
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        return
+    monkeypatch.setattr(gqa_logical, "GQAPrefillPagedWithFP8KVCacheFwdKernel", _FakeFP8Kernel)
+
+    kernel = gqa_logical.GQAPrefillPagedKernel(
+        batch=1,
+        heads=8,
+        heads_kv=2,
+        max_pages_per_req=4,
+        page_size=64,
+        dim=64,
+        cache_dtype=fp8_dtype,
+        dtype=torch.float16,
+    )
+
+    assert isinstance(kernel.impl, _FakeFP8Kernel)
+    assert kernel.append_impl is None
+
+
+def test_gqa_prefill_paged_kernel_dispatches_rope_pair(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gqa_logical, "GQAPrefillPagedWithKVCacheRopeAppendKernel", _FakeAppendKernel)
+    monkeypatch.setattr(gqa_logical, "GQAPrefillPagedWithKVCacheRopeFwdKernel", _FakeFwdKernel)
+
+    kernel = gqa_logical.GQAPrefillPagedKernel(
+        batch=1,
+        heads=8,
+        heads_kv=2,
+        max_pages_per_req=4,
+        page_size=64,
+        dim=64,
+        fuse_rope=True,
+        max_position=128,
+        rotary_dim=64,
+        dtype=torch.float16,
+    )
+    result = kernel(
+        "q",
+        "k_new",
+        "v_new",
+        "k_pages",
+        "v_pages",
+        "cu_q",
+        "cache_lens",
+        "block_table",
+        "max_q",
+        "cos",
+        "sin",
+    )
+
+    assert isinstance(kernel.append_impl, _FakeAppendKernel)
+    assert isinstance(kernel.impl, _FakeFwdKernel)
+    assert len(kernel.append_impl.calls) == 1
+    assert result[0] == "_FakeFwdKernel"

--- a/tileops/kernels/attention/__init__.py
+++ b/tileops/kernels/attention/__init__.py
@@ -30,6 +30,7 @@ from .gqa_fwd import (
 )
 from .gqa_fwd_fp8 import GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel
 from .gqa_fwd_ws import GQAFwdWsPersistentCausalKernel, GQAFwdWsPersistentKernel
+from .gqa_logical import GQAPrefillKernel, GQAPrefillPagedKernel, GQAPrefillWithKVCacheKernel
 from .gqa_prefill_varlen_fwd import GQAPrefillVarlenFwdKernel
 from .gqa_sliding_window_fwd import (
     GQASlidingWindowFwdKernel,
@@ -55,12 +56,15 @@ __all__ = [
     "GQAFwdWsPersistentCausalKernel",
     "GQAFwdWsPersistentKernel",
     "GQAPrefillFwdKernel",
+    "GQAPrefillKernel",
+    "GQAPrefillPagedKernel",
     "GQAPrefillPagedWithFP8KVCacheFwdKernel",
     "GQAPrefillPagedWithKVCacheFwdKernel",
     "GQAPrefillPagedWithKVCacheRopeAppendKernel",
     "GQAPrefillPagedWithKVCacheRopeFwdKernel",
     "GQAPrefillVarlenFwdKernel",
     "GQAPrefillWithKVCacheFwdKernel",
+    "GQAPrefillWithKVCacheKernel",
     "GQAPrefillWithKVCacheRopeAppendKernel",
     "GQAPrefillWithKVCacheRopeFwdKernel",
     "GQASlidingWindowFwdKernel",

--- a/tileops/kernels/attention/gqa_logical.py
+++ b/tileops/kernels/attention/gqa_logical.py
@@ -1,0 +1,320 @@
+from typing import Literal, Optional
+
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+from tileops.utils import is_hopper
+
+from .gqa_fwd import (
+    GQAPrefillFwdKernel,
+    GQAPrefillPagedWithFP8KVCacheFwdKernel,
+    GQAPrefillPagedWithKVCacheFwdKernel,
+    GQAPrefillPagedWithKVCacheRopeAppendKernel,
+    GQAPrefillPagedWithKVCacheRopeFwdKernel,
+    GQAPrefillWithKVCacheFwdKernel,
+    GQAPrefillWithKVCacheRopeAppendKernel,
+    GQAPrefillWithKVCacheRopeFwdKernel,
+)
+from .gqa_fwd_fp8 import GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel
+from .gqa_prefill_varlen_fwd import GQAPrefillVarlenFwdKernel
+from .gqa_sliding_window_fwd import (
+    GQASlidingWindowFwdKernel,
+    GQASlidingWindowFwdWgmmaPipelinedKernel,
+)
+from .gqa_sliding_window_varlen_fwd import (
+    GQASlidingWindowVarlenFwdKernel,
+    GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
+)
+
+__all__ = [
+    "GQAPrefillKernel",
+    "GQAPrefillPagedKernel",
+    "GQAPrefillWithKVCacheKernel",
+]
+
+
+class GQAPrefillKernel(Kernel):
+    """Logical no-cache GQA prefill kernel.
+
+    This wrapper keeps current concrete kernels intact and dispatches to the
+    implementation that matches the requested layout/features. It is an internal
+    stepping stone for the GQA taxonomy refactor; public OP contracts stay
+    manifest-owned.
+    """
+
+    supported_archs: list[int] = [80, 89, 90]
+
+    def __init__(
+        self,
+        *,
+        batch: int,
+        heads: int,
+        heads_kv: int,
+        dim: int,
+        dtype: torch.dtype = torch.float16,
+        layout: Literal["dense", "ragged"] = "dense",
+        seq_len_q: Optional[int] = None,
+        seq_len_kv: Optional[int] = None,
+        is_causal: bool = True,
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
+        use_swa: bool = False,
+        window_size_left: int = -1,
+        window_size_right: int = -1,
+        fp8_tensor_core: bool = False,
+        backend: Literal["auto", "basic", "wgmma", "ws", "fa3"] = "auto",
+        accum_dtype: torch.dtype = torch.float32,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.layout = layout
+        self.use_swa = use_swa
+        self.fp8_tensor_core = fp8_tensor_core
+        self.backend = backend
+        self.dtype = dtype
+
+        if fp8_tensor_core:
+            if seq_len_q is None:
+                raise ValueError("seq_len_q is required for fp8_tensor_core=True")
+            if seq_len_kv is not None and seq_len_kv != seq_len_q:
+                raise ValueError("FP8 Tensor Core prefill currently requires seq_len_q == seq_len_kv")
+            self.impl = GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel(
+                batch, heads, heads_kv, seq_len_q, dim, dtype, tune=tune)
+        elif layout == "ragged":
+            if use_swa:
+                kernel_cls = (
+                    GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
+                    if is_hopper() else GQASlidingWindowVarlenFwdKernel)
+                self.impl = kernel_cls(
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    dim=dim,
+                    is_causal=is_causal,
+                    window_size_left=window_size_left,
+                    window_size_right=window_size_right,
+                    dtype=dtype,
+                    accum_dtype=accum_dtype,
+                    tune=tune,
+                )
+            else:
+                self.impl = GQAPrefillVarlenFwdKernel(
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    dim=dim,
+                    is_causal=is_causal,
+                    dtype=dtype,
+                    sm_scale=sm_scale,
+                    softcap=softcap,
+                    tune=tune,
+                )
+        elif layout == "dense":
+            if seq_len_q is None or seq_len_kv is None:
+                raise ValueError("seq_len_q and seq_len_kv are required for dense prefill")
+            if use_swa:
+                if seq_len_q != seq_len_kv:
+                    raise ValueError("sliding-window dense prefill currently requires seq_len_q == seq_len_kv")
+                kernel_cls = GQASlidingWindowFwdWgmmaPipelinedKernel if is_hopper() else GQASlidingWindowFwdKernel
+                self.impl = kernel_cls(
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    seq_len=seq_len_q,
+                    dim=dim,
+                    is_causal=is_causal,
+                    window_size_left=window_size_left,
+                    window_size_right=window_size_right,
+                    dtype=dtype,
+                    tune=tune,
+                )
+            else:
+                if backend not in {"auto", "basic", "wgmma", "ws", "fa3"}:
+                    raise ValueError(f"unsupported backend {backend!r}")
+                self.impl = GQAPrefillFwdKernel(
+                    batch=batch,
+                    heads=heads,
+                    heads_kv=heads_kv,
+                    seq_len_q=seq_len_q,
+                    seq_len_kv=seq_len_kv,
+                    dim=dim,
+                    is_causal=is_causal,
+                    dtype=dtype,
+                    sm_scale=sm_scale,
+                    softcap=softcap,
+                    tune=tune,
+                )
+        else:
+            raise ValueError(f"unsupported GQA prefill layout {layout!r}")
+
+    def forward(self, *args: object, **kwargs: object) -> object:
+        return self.impl(*args, **kwargs)
+
+
+class GQAPrefillWithKVCacheKernel(Kernel):
+    """Logical contiguous KV-cache GQA prefill kernel."""
+
+    supported_archs: list[int] = [80, 89, 90]
+
+    def __init__(
+        self,
+        *,
+        batch: int,
+        heads: int,
+        heads_kv: int,
+        seq_len_new: int,
+        seqlen_kv: int,
+        dim: int,
+        is_causal: bool = True,
+        dtype: torch.dtype = torch.float16,
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
+        fuse_rope: bool = False,
+        max_position: Optional[int] = None,
+        rotary_dim: Optional[int] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.fuse_rope = fuse_rope
+        self.dtype = dtype
+        if fuse_rope:
+            if max_position is None or rotary_dim is None:
+                raise ValueError("max_position and rotary_dim are required when fuse_rope=True")
+            self.append_impl = GQAPrefillWithKVCacheRopeAppendKernel(
+                batch, heads_kv, seq_len_new, seqlen_kv, dim, max_position, rotary_dim, dtype,
+                tune=tune)
+            self.impl = GQAPrefillWithKVCacheRopeFwdKernel(
+                batch, heads, heads_kv, seq_len_new, seqlen_kv, dim, max_position, rotary_dim,
+                is_causal, dtype, sm_scale=sm_scale, softcap=softcap, tune=tune)
+        else:
+            self.append_impl = None
+            self.impl = GQAPrefillWithKVCacheFwdKernel(
+                batch, heads, heads_kv, seq_len_new, seqlen_kv, dim, is_causal, dtype,
+                sm_scale=sm_scale, softcap=softcap, tune=tune)
+
+    def forward(self, *args: object, **kwargs: object) -> object:
+        if not self.fuse_rope:
+            return self.impl(*args, **kwargs)
+        if len(args) < 8:
+            raise ValueError(
+                "fused RoPE contiguous KV-cache prefill expects cos_table and sin_table")
+        q, k_new, v_new, k_cache, v_cache, cache_seqlens, cos_table, sin_table = args[:8]
+        self.append_impl(k_new, v_new, k_cache, v_cache, cache_seqlens, cos_table, sin_table)
+        return self.impl(q, k_new, v_new, k_cache, v_cache, cache_seqlens, cos_table, sin_table)
+
+
+class GQAPrefillPagedKernel(Kernel):
+    """Logical paged KV-cache GQA prefill kernel."""
+
+    supported_archs: list[int] = [80, 89, 90]
+
+    def __init__(
+        self,
+        *,
+        batch: int,
+        heads: int,
+        heads_kv: int,
+        max_pages_per_req: int,
+        page_size: int,
+        dim: int,
+        is_causal: bool = True,
+        dtype: torch.dtype = torch.float16,
+        cache_dtype: Optional[torch.dtype] = None,
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
+        fuse_rope: bool = False,
+        max_position: Optional[int] = None,
+        rotary_dim: Optional[int] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.fuse_rope = fuse_rope
+        self.cache_dtype = cache_dtype
+        self.dtype = dtype
+        fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+        if cache_dtype is not None and cache_dtype == fp8_dtype:
+            if fuse_rope:
+                raise ValueError("paged FP8 KV-cache prefill does not support fused RoPE yet")
+            self.append_impl = None
+            self.impl = GQAPrefillPagedWithFP8KVCacheFwdKernel(
+                batch=batch,
+                heads=heads,
+                heads_kv=heads_kv,
+                max_pages_per_req=max_pages_per_req,
+                page_size=page_size,
+                dim=dim,
+                is_causal=is_causal,
+                dtype=dtype,
+                sm_scale=sm_scale,
+                softcap=softcap,
+                tune=tune,
+            )
+        elif fuse_rope:
+            if max_position is None or rotary_dim is None:
+                raise ValueError("max_position and rotary_dim are required when fuse_rope=True")
+            self.append_impl = GQAPrefillPagedWithKVCacheRopeAppendKernel(
+                batch=batch,
+                heads_kv=heads_kv,
+                max_pages_per_req=max_pages_per_req,
+                page_size=page_size,
+                dim=dim,
+                max_position=max_position,
+                rotary_dim=rotary_dim,
+                dtype=dtype,
+                tune=tune,
+            )
+            self.impl = GQAPrefillPagedWithKVCacheRopeFwdKernel(
+                batch=batch,
+                heads=heads,
+                heads_kv=heads_kv,
+                max_pages_per_req=max_pages_per_req,
+                page_size=page_size,
+                dim=dim,
+                max_position=max_position,
+                rotary_dim=rotary_dim,
+                is_causal=is_causal,
+                dtype=dtype,
+                sm_scale=sm_scale,
+                softcap=softcap,
+                tune=tune,
+            )
+        else:
+            self.append_impl = None
+            self.impl = GQAPrefillPagedWithKVCacheFwdKernel(
+                batch=batch,
+                heads=heads,
+                heads_kv=heads_kv,
+                max_pages_per_req=max_pages_per_req,
+                page_size=page_size,
+                dim=dim,
+                is_causal=is_causal,
+                dtype=dtype,
+                sm_scale=sm_scale,
+                softcap=softcap,
+                tune=tune,
+            )
+
+    def forward(self, *args: object, **kwargs: object) -> object:
+        if not self.fuse_rope:
+            return self.impl(*args, **kwargs)
+        if len(args) < 11:
+            raise ValueError("fused RoPE paged prefill expects cos_table and sin_table")
+        (
+            q,
+            k_new,
+            v_new,
+            k_pages,
+            v_pages,
+            cu_seqlens_q,
+            cache_seqlens,
+            block_table,
+            max_seqlen_q,
+            cos_table,
+            sin_table,
+        ) = args[:11]
+        self.append_impl(
+            k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens, block_table,
+            max_seqlen_q, cos_table, sin_table)
+        return self.impl(
+            q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens, block_table,
+            max_seqlen_q, cos_table, sin_table)


### PR DESCRIPTION
## Summary

- Add logical GQA prefill dispatch wrappers:
  - `GQAPrefillKernel`
  - `GQAPrefillWithKVCacheKernel`
  - `GQAPrefillPagedKernel`
- Keep existing concrete TileLang kernels intact and available.
- Add lightweight dispatch tests using fake implementations, so the wrapper selection logic is covered without compiling GPU kernels.

## Notes

This is the first kernel-internal step for #1610. It does not add public OPs and does not change `tileops/manifest/attention.yaml`.

Closes #1611

## Tests

```text
ruff check tileops/kernels/attention/gqa_logical.py tileops/kernels/attention/__init__.py tests/ops/attention/test_gqa_logical_kernels.py
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-logical-pycache python -m compileall -q tileops/kernels/attention/gqa_logical.py tests/ops/attention/test_gqa_logical_kernels.py
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-logical-pycache python -m pytest tests/ops/attention/test_gqa_logical_kernels.py -q
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-logical-pycache python - <<'PY'
from tileops.kernels.attention import GQAPrefillKernel, GQAPrefillPagedKernel, GQAPrefillWithKVCacheKernel
print(GQAPrefillKernel.__name__, GQAPrefillPagedKernel.__name__, GQAPrefillWithKVCacheKernel.__name__)
PY
```
