### PR TITLE
[Fix][TileLang] seed autotune JIT parameters

### DIFF
--- a/tests/kernels/test_kernel_autotune_binding.py
+++ b/tests/kernels/test_kernel_autotune_binding.py
@@ -1,0 +1,92 @@
+import inspect
+
+import pytest
+
+import tileops.kernels.kernel_base as kernel_base
+from tileops.kernels.kernel_base import Kernel
+
+pytestmark = pytest.mark.smoke
+
+
+class _FakeJit:
+    signature = inspect.signature(lambda block_m, threads: None)
+
+
+class _FakeAliasedJit:
+    signature = inspect.signature(lambda threads_arg, npt_arg: None)
+
+
+class _TunedKernel:
+    config = {"block_m": 64, "threads": 128}
+
+
+class _KernelWithRequiredTunables(Kernel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.kernel = _FakeJit()
+
+    @property
+    def default_config(self) -> dict:
+        return {"block_m": 128, "threads": 256, "tile_n": 0}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": 64, "threads": 128},
+            {"block_m": 128, "threads": 256},
+        ]
+
+    def forward(self):  # pragma: no cover - not needed for this unit test
+        raise NotImplementedError
+
+
+def test_autotune_seeds_required_jit_params_from_default_config(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_autotune(**autotune_kwargs):
+        calls["autotune_kwargs"] = autotune_kwargs
+
+        def decorate(kernel):
+            calls["kernel"] = kernel
+
+            def wrapped(**kwargs):
+                calls["initial_kwargs"] = kwargs
+                kernel.signature.bind(**kwargs)
+                return _TunedKernel()
+
+            return wrapped
+
+        return decorate
+
+    monkeypatch.setattr(kernel_base, "autotune", fake_autotune)
+
+    kernel = _KernelWithRequiredTunables()
+    kernel.autotune()
+
+    assert calls["initial_kwargs"] == {"block_m": 128, "threads": 256}
+    assert "tile_n" not in calls["initial_kwargs"]
+    assert kernel.config == _TunedKernel.config
+
+
+def test_autotune_group_seed_is_filtered_to_jit_signature():
+    kernel = _KernelWithRequiredTunables()
+
+    captured = kernel._call_autotuned_kernel(
+        lambda **kwargs: kwargs,
+        kernel.kernel,
+        {"block_m": 1, "threads": 128, "tile_n": 4096},
+    )
+
+    assert captured == {"block_m": 1, "threads": 128}
+
+
+def test_autotune_initial_kwargs_support_common_jit_param_aliases():
+    kernel = _KernelWithRequiredTunables()
+
+    captured = kernel._call_autotuned_kernel(
+        lambda **kwargs: kwargs,
+        _FakeAliasedJit(),
+        {"threads": 128, "num_per_thread": 4},
+    )
+
+    assert captured == {"threads_arg": 128, "npt_arg": 4}

--- a/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -608,8 +608,9 @@ class SparseMlaKernel(Kernel):
             configs=self.autotune_configs, warmup=warmup, rep=rep, supply_prog=self.supply_prog)(
                 self.kernel)
 
-        # Call without config parameters to trigger autotuning, returns the tuned kernel
-        tuned_kernel = autotuned_kernel_fn()
+        # Seed required tunable JIT parameters for TileLang's pre-autotune
+        # validation/binding step.
+        tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
         # Extract and store the best config
         self.config = tuned_kernel.config

--- a/tileops/kernels/deltanet/deltanet_bwd.py
+++ b/tileops/kernels/deltanet/deltanet_bwd.py
@@ -410,7 +410,11 @@ class DeltaNetBwdKernel(Kernel):
         parallel_configs = [{"threads": t} for t in [128, 256]]
         print(f"Autotuning bwd_parallel ({len(parallel_configs)} configs)...")
         parallel_jit = _bwd_parallel_tl(B, H, S, BC, DK, DV, dt)
-        tuned_parallel = tl_autotune(configs=parallel_configs, warmup=warmup, rep=rep)(parallel_jit)()
+        tuned_parallel = self._call_autotuned_kernel(
+            tl_autotune(configs=parallel_configs, warmup=warmup, rep=rep)(parallel_jit),
+            parallel_jit,
+            parallel_configs[0],
+        )
         parallel_best = tuned_parallel.config
         print(f"  Best: {parallel_best}")
 
@@ -421,7 +425,11 @@ class DeltaNetBwdKernel(Kernel):
         ]
         print(f"Autotuning dh_recurrence_bwd ({len(recurrence_configs)} configs)...")
         recurrence_jit = _dh_recurrence_bwd_tl(B, H, S, BC, DK, DV, dt)
-        tuned_recurrence = tl_autotune(configs=recurrence_configs, warmup=warmup, rep=rep)(recurrence_jit)()
+        tuned_recurrence = self._call_autotuned_kernel(
+            tl_autotune(configs=recurrence_configs, warmup=warmup, rep=rep)(recurrence_jit),
+            recurrence_jit,
+            recurrence_configs[0],
+        )
         recurrence_best = tuned_recurrence.config
         print(f"  Best: {recurrence_best}")
 
@@ -432,7 +440,11 @@ class DeltaNetBwdKernel(Kernel):
         ]
         print(f"Autotuning compute_w_u_bwd ({len(wu_bwd_configs)} configs)...")
         wu_bwd_jit = compute_w_u_bwd_tl(B, H, S, BC, DK, DV, dt)
-        tuned_wu_bwd = tl_autotune(configs=wu_bwd_configs, warmup=warmup, rep=rep)(wu_bwd_jit)()
+        tuned_wu_bwd = self._call_autotuned_kernel(
+            tl_autotune(configs=wu_bwd_configs, warmup=warmup, rep=rep)(wu_bwd_jit),
+            wu_bwd_jit,
+            wu_bwd_configs[0],
+        )
         wu_bwd_best = tuned_wu_bwd.config
         print(f"  Best: {wu_bwd_best}")
 

--- a/tileops/kernels/deltanet/deltanet_fwd.py
+++ b/tileops/kernels/deltanet/deltanet_fwd.py
@@ -307,7 +307,11 @@ class DeltaNetFwdKernel(Kernel):
         ]
         print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
         fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
-        tuned_fused = tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit)()
+        tuned_fused = self._call_autotuned_kernel(
+            tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit),
+            fused_jit,
+            fused_configs[0],
+        )
         fused_best = tuned_fused.config
         print(f"  Best: {fused_best}")
 
@@ -323,7 +327,11 @@ class DeltaNetFwdKernel(Kernel):
             label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
             print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
             h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
-            tuned_h = tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit)()
+            tuned_h = self._call_autotuned_kernel(
+                tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit),
+                h_jit,
+                h_configs[0],
+            )
             if tuned_h.config is not None:
                 lat = _do_bench(tuned_h, warmup=warmup, rep=rep)
                 print(f"  Best: {tuned_h.config}, latency={lat:.4f} ms")
@@ -337,7 +345,11 @@ class DeltaNetFwdKernel(Kernel):
         o_configs = [{"threads": t} for t in [64, 128, 256]]
         print(f"Autotuning output_o ({len(o_configs)} configs)...")
         o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
-        tuned_o = tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit)()
+        tuned_o = self._call_autotuned_kernel(
+            tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit),
+            o_jit,
+            o_configs[0],
+        )
         o_best = tuned_o.config
         print(f"  Best: {o_best}")
 

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -306,8 +306,9 @@ class FP8LightingIndexerKernel(Kernel):
             configs=self.autotune_configs, warmup=warmup, rep=rep, supply_prog=self.supply_prog)(
                 self.kernel)
 
-        # Call without config parameters to trigger autotuning, returns the tuned kernel
-        tuned_kernel = autotuned_kernel_fn()
+        # Seed required tunable JIT parameters for TileLang's pre-autotune
+        # validation/binding step.
+        tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
         # Extract and store the best config
         self.config = tuned_kernel.config

--- a/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -326,7 +326,11 @@ class GatedDeltaNetFwdKernel(Kernel):
         ]
         print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
         fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
-        tuned_fused = tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit)()
+        tuned_fused = self._call_autotuned_kernel(
+            tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit),
+            fused_jit,
+            fused_configs[0],
+        )
         fused_best = tuned_fused.config
         print(f"  Best: {fused_best}")
 
@@ -342,7 +346,11 @@ class GatedDeltaNetFwdKernel(Kernel):
             label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
             print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
             h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
-            tuned_h = tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit)()
+            tuned_h = self._call_autotuned_kernel(
+                tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit),
+                h_jit,
+                h_configs[0],
+            )
             if tuned_h.config is not None:
                 lat = _do_bench(tuned_h, warmup=warmup, rep=rep)
                 print(f"  Best: {tuned_h.config}, latency={lat:.4f} ms")
@@ -356,7 +364,11 @@ class GatedDeltaNetFwdKernel(Kernel):
         o_configs = [{"threads": t} for t in [64, 128, 256]]
         print(f"Autotuning output_o ({len(o_configs)} configs)...")
         o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
-        tuned_o = tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit)()
+        tuned_o = self._call_autotuned_kernel(
+            tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit),
+            o_jit,
+            o_configs[0],
+        )
         o_best = tuned_o.config
         print(f"  Best: {o_best}")
 

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -11,6 +11,11 @@ class Kernel(ABC):
     autotune_configs: Optional[list[dict]] = None
     supported_archs: Optional[list[int]] = None
     kernel: Callable[[dict], Callable]
+    _AUTOTUNE_PARAM_ALIASES = {
+        "threads_arg": "threads",
+        "npt_arg": "num_per_thread",
+        "num_per_thread_arg": "num_per_thread",
+    }
 
     def __init__(self, *args, **kwargs) -> None:
         self.config = {}
@@ -74,6 +79,48 @@ class Kernel(ABC):
         """
         return None
 
+    def _autotune_initial_kwargs(
+        self,
+        kernel: Optional[Callable] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return initial JIT kwargs for TileLang autotuner binding.
+
+        TileLang 0.1.11 validates/binds the JIT signature before candidate
+        configs are applied. Passing the kernel's default config keeps required
+        tunable parameters bindable while the autotuner still overrides them
+        with each candidate config during benchmarking.
+        """
+        source = self.default_config if config is None else config
+        if not source:
+            return {}
+
+        jit_kernel = getattr(self, "kernel", None) if kernel is None else kernel
+        signature = getattr(jit_kernel, "signature", None)
+        parameters = getattr(signature, "parameters", None)
+        if parameters is None:
+            return dict(source)
+
+        kwargs = {}
+        for name in parameters:
+            if name in source:
+                kwargs[name] = source[name]
+                continue
+            alias = self._AUTOTUNE_PARAM_ALIASES.get(name)
+            if alias is not None and alias in source:
+                kwargs[name] = source[alias]
+        return kwargs
+
+    def _call_autotuned_kernel(
+        self,
+        autotuned_kernel_fn: Callable,
+        kernel: Optional[Callable] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        return autotuned_kernel_fn(
+            **self._autotune_initial_kwargs(kernel=kernel, config=config)
+        )
+
     def autotune(self, warmup: int = 25, rep: int = 50) -> None:
         if self.autotune_configs is None:
             return  # kernel doesn't support autotuning
@@ -90,8 +137,10 @@ class Kernel(ABC):
             autotune_kwargs["supply_prog"] = self.autotune_supply_prog
         autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)
 
-        # Call without config parameters to trigger autotuning, returns the tuned kernel
-        tuned_kernel = autotuned_kernel_fn()
+        # Seed required tunable JIT parameters for TileLang's pre-autotune
+        # validation/binding step. Candidate configs still override these
+        # initial values during the actual autotune run.
+        tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
         # Extract and store the best config
         self.config = tuned_kernel.config

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -528,7 +528,7 @@ class LogSumExpKernel(Kernel):
             if self.autotune_supply_prog is not None:
                 autotune_kwargs["supply_prog"] = self.autotune_supply_prog
             autotuned = tl_autotune(**autotune_kwargs)(kernel)
-            tuned = autotuned()
+            tuned = self._call_autotuned_kernel(autotuned, kernel, group_cfgs[0])
             latency = tuned.latency
             if latency < best_time:
                 best_time = latency

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -801,7 +801,7 @@ class SoftmaxKernel(Kernel):
             if self.autotune_supply_prog is not None:
                 autotune_kwargs["supply_prog"] = self.autotune_supply_prog
             autotuned = tl_autotune(**autotune_kwargs)(kernel)
-            tuned = autotuned()
+            tuned = self._call_autotuned_kernel(autotuned, kernel, group_cfgs[0])
             latency = tuned.latency
             if latency < best_time:
                 best_time = latency


### PR DESCRIPTION
## Summary

Fixes #1613.

TileLang 0.1.11 validates/binds autotuned JIT signatures before candidate configs are applied. Several TileOPs kernels expose tunable JIT parameters such as `block_m`, `block_n`, and `bdim` as required arguments, so calling the autotuned wrapper with no kwargs can fail before autotuning starts.

This seeds the autotuned wrapper call with bindable config values while preserving the existing autotune search space.

## Changes

- Add shared `Kernel._call_autotuned_kernel()` / `_autotune_initial_kwargs()` helpers.
- Seed base `Kernel.autotune()` with `default_config`, filtered to the JIT signature.
- Support common JIT parameter aliases such as `threads_arg` and `npt_arg`.
- Update custom autotune overrides that previously called autotuned wrappers with no kwargs:
  - `SoftmaxKernel`
  - `LogSumExpKernel`
  - `SparseMlaKernel`
  - `FP8LightingIndexerKernel`
  - DeltaNet / GatedDeltaNet sub-kernel autotune paths
- Add unit coverage for required tunable binding, signature filtering, and alias mapping.

## Validation

- `python3 -m pytest -q tests/kernels/test_kernel_autotune_binding.py`
- `python3 -m ruff check tileops/kernels/kernel_base.py tileops/kernels/reduction/softmax.py tileops/kernels/reduction/logsumexp.py tileops/kernels/attention/deepseek_dsa_decode.py tileops/kernels/fp8_lighting_indexer.py tileops/kernels/deltanet/deltanet_fwd.py tileops/kernels/deltanet/deltanet_bwd.py tileops/kernels/gated_deltanet/gated_deltanet_fwd.py tests/kernels/test_kernel_autotune_binding.py`
- `python3 -m compileall -q ...` on changed Python files
- commit hooks / pre-commit checks

Note: local environment has TileLang 0.1.9, so the regression test mocks the TileLang 0.1.11-style binding requirement instead of running the exact 0.1.11 autotuner.
