### PR TITLE
[Refactor] Extract GQA prefill kernel selection logic

### DIFF
--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -12,6 +12,9 @@ from tileops.kernels.attention import (
     GQAFwdWgmmaPipelinedKernel,
     GQAFwdWsPersistentCausalKernel,
     GQAFwdWsPersistentKernel,
+    GQAPrefillWithKVCacheFwdKernel,
+    GQAPrefillWithKVCacheRopeAppendKernel,
+    GQAPrefillWithKVCacheRopeFwdKernel,
 )
 from tileops.ops import (
     GroupedQueryAttentionBwdOp,
@@ -21,7 +24,10 @@ from tileops.ops import (
     GroupedQueryAttentionPrefillWithKVCacheFwdOp,
     RopeNeoxPositionIdsOp,
 )
-from tileops.ops.attention.gqa import _select_gqa_fwd_kernel_cls
+from tileops.ops.attention.gqa import (
+    _select_gqa_fwd_kernel_cls,
+    _select_gqa_prefill_with_kv_cache_kernel_keys,
+)
 from workloads.attention.gqa import (
     GroupedQueryAttentionBwdTest as _GroupedQueryAttentionBwdTestWorkload,
 )
@@ -851,6 +857,34 @@ def test_gqa_fwd_dispatch_falls_back_off_h200() -> None:
     non_hopper_cls = _select_gqa_fwd_kernel_cls(
         4, 64, 4, 512, 128, False, torch.float16, hopper=False, h200=False)
     assert non_hopper_cls is GQAFwdKernel
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_with_kv_cache_selector_uses_plain_kernel_without_rope() -> None:
+    append_key, fwd_key = _select_gqa_prefill_with_kv_cache_kernel_keys(fuse_rope=False)
+
+    assert append_key is None
+    assert fwd_key == "gqa_prefill_with_kv_cache_fwd_kernel"
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_with_kv_cache_selector_uses_rope_kernels_with_rope() -> None:
+    append_key, fwd_key = _select_gqa_prefill_with_kv_cache_kernel_keys(fuse_rope=True)
+
+    assert append_key == "gqa_prefill_with_kv_cache_rope_append_kernel"
+    assert fwd_key == "gqa_prefill_with_kv_cache_rope_fwd_kernel"
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_with_kv_cache_default_map_exposes_concrete_kernels() -> None:
+    op = object.__new__(GroupedQueryAttentionPrefillWithKVCacheFwdOp)
+
+    assert op.default_kernel_map == {
+        "gqa_prefill_with_kv_cache_fwd_kernel": GQAPrefillWithKVCacheFwdKernel,
+        "gqa_prefill_with_kv_cache_rope_append_kernel":
+            GQAPrefillWithKVCacheRopeAppendKernel,
+        "gqa_prefill_with_kv_cache_rope_fwd_kernel": GQAPrefillWithKVCacheRopeFwdKernel,
+    }
 
 
 if __name__ == "__main__":

--- a/tests/ops/attention/test_gqa_prefill_paged.py
+++ b/tests/ops/attention/test_gqa_prefill_paged.py
@@ -5,11 +5,17 @@ from itertools import accumulate
 import pytest
 import torch
 
+from tileops.kernels.attention import (
+    GQAPrefillPagedWithKVCacheFwdKernel,
+    GQAPrefillPagedWithKVCacheRopeAppendKernel,
+    GQAPrefillPagedWithKVCacheRopeFwdKernel,
+)
 from tileops.ops import (
     GroupedQueryAttentionPrefillPagedWithFP8KVCacheFwdOp,
     GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp,
     RopeNeoxPositionIdsOp,
 )
+from tileops.ops.attention.gqa import _select_gqa_prefill_paged_with_kv_cache_kernel_keys
 
 _PREFILL_PAGED_TOLERANCE = {
     torch.float16: (5e-3, 1e-5),
@@ -564,3 +570,35 @@ def test_gqa_prefill_paged_with_kv_cache_page_sizes(page_size: int) -> None:
         q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens, block_table,
         max(q_lens))
     torch.testing.assert_close(output, ref, atol=5e-3, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_paged_selector_uses_plain_kernel_without_rope() -> None:
+    append_key, fwd_key = _select_gqa_prefill_paged_with_kv_cache_kernel_keys(
+        fuse_rope=False)
+
+    assert append_key is None
+    assert fwd_key == "gqa_prefill_paged_with_kv_cache_fwd_kernel"
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_paged_selector_uses_rope_kernels_with_rope() -> None:
+    append_key, fwd_key = _select_gqa_prefill_paged_with_kv_cache_kernel_keys(
+        fuse_rope=True)
+
+    assert append_key == "gqa_prefill_paged_with_kv_cache_rope_append_kernel"
+    assert fwd_key == "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel"
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_paged_default_map_exposes_concrete_kernels() -> None:
+    op = object.__new__(GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp)
+
+    assert op.default_kernel_map == {
+        "gqa_prefill_paged_with_kv_cache_fwd_kernel":
+            GQAPrefillPagedWithKVCacheFwdKernel,
+        "gqa_prefill_paged_with_kv_cache_rope_append_kernel":
+            GQAPrefillPagedWithKVCacheRopeAppendKernel,
+        "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
+            GQAPrefillPagedWithKVCacheRopeFwdKernel,
+    }

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -53,6 +53,18 @@ __all__ = [
 
 _WS_BLOCK_M = 128
 _H200_SMS = 132
+_GQA_PREFILL_WITH_KV_CACHE_FWD_KEY = "gqa_prefill_with_kv_cache_fwd_kernel"
+_GQA_PREFILL_WITH_KV_CACHE_ROPE_APPEND_KEY = (
+    "gqa_prefill_with_kv_cache_rope_append_kernel"
+)
+_GQA_PREFILL_WITH_KV_CACHE_ROPE_FWD_KEY = "gqa_prefill_with_kv_cache_rope_fwd_kernel"
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_KEY = "gqa_prefill_paged_with_kv_cache_fwd_kernel"
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_APPEND_KEY = (
+    "gqa_prefill_paged_with_kv_cache_rope_append_kernel"
+)
+_GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_FWD_KEY = (
+    "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel"
+)
 
 
 def _gqa_ws_noncausal_total_work_items(batch: int, heads: int, heads_kv: int, seq_len: int) -> int:
@@ -169,6 +181,30 @@ def _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls() -> Type[Kernel
 
 def _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls() -> Type[Kernel]:
     return GQAPrefillPagedWithKVCacheRopeAppendKernel
+
+
+def _select_gqa_prefill_with_kv_cache_kernel_keys(
+    *,
+    fuse_rope: bool,
+) -> tuple[Optional[str], str]:
+    if fuse_rope:
+        return (
+            _GQA_PREFILL_WITH_KV_CACHE_ROPE_APPEND_KEY,
+            _GQA_PREFILL_WITH_KV_CACHE_ROPE_FWD_KEY,
+        )
+    return None, _GQA_PREFILL_WITH_KV_CACHE_FWD_KEY
+
+
+def _select_gqa_prefill_paged_with_kv_cache_kernel_keys(
+    *,
+    fuse_rope: bool,
+) -> tuple[Optional[str], str]:
+    if fuse_rope:
+        return (
+            _GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_APPEND_KEY,
+            _GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_FWD_KEY,
+        )
+    return None, _GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_KEY
 
 
 def _validate_gqa_dims(heads: int, heads_kv: int, dim: int) -> None:
@@ -682,32 +718,30 @@ class GroupedQueryAttentionPrefillWithKVCacheFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self.append_kernel: Optional[Kernel] = None
-        if self.fuse_rope:
-            self.append_kernel = self.kernel_map[
-                "gqa_prefill_with_kv_cache_rope_append_kernel"](
-                    batch, heads_kv, seq_len_new, seqlen_kv, dim, self.max_position,
-                    self.rotary_dim, self.dtype, tune=tune)
-            self.kernel = self.kernel_map["gqa_prefill_with_kv_cache_rope_fwd_kernel"](
+        append_key, fwd_key = _select_gqa_prefill_with_kv_cache_kernel_keys(
+            fuse_rope=self.fuse_rope)
+        if append_key is not None:
+            self.append_kernel = self.kernel_map[append_key](
+                batch, heads_kv, seq_len_new, seqlen_kv, dim, self.max_position,
+                self.rotary_dim, self.dtype, tune=tune)
+            self.kernel = self.kernel_map[fwd_key](
                 batch, heads, heads_kv, seq_len_new, seqlen_kv, dim, self.max_position,
                 self.rotary_dim, is_causal, self.dtype, sm_scale=self.sm_scale,
                 softcap=self.softcap, tune=tune)
         else:
-            self.kernel = self.kernel_map["gqa_prefill_with_kv_cache_fwd_kernel"](
+            self.kernel = self.kernel_map[fwd_key](
                 batch, heads, heads_kv, seq_len_new, seqlen_kv, dim, is_causal, self.dtype,
                 sm_scale=self.sm_scale, softcap=self.softcap, tune=tune)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        if self.fuse_rope:
-            return {
-                "gqa_prefill_with_kv_cache_rope_append_kernel":
-                    _select_gqa_prefill_with_kv_cache_rope_append_kernel_cls(),
-                "gqa_prefill_with_kv_cache_rope_fwd_kernel":
-                    _select_gqa_prefill_with_kv_cache_rope_fwd_kernel_cls()
-            }
         return {
-            "gqa_prefill_with_kv_cache_fwd_kernel":
-                _select_gqa_prefill_with_kv_cache_fwd_kernel_cls()
+            _GQA_PREFILL_WITH_KV_CACHE_FWD_KEY:
+                _select_gqa_prefill_with_kv_cache_fwd_kernel_cls(),
+            _GQA_PREFILL_WITH_KV_CACHE_ROPE_APPEND_KEY:
+                _select_gqa_prefill_with_kv_cache_rope_append_kernel_cls(),
+            _GQA_PREFILL_WITH_KV_CACHE_ROPE_FWD_KEY:
+                _select_gqa_prefill_with_kv_cache_rope_fwd_kernel_cls(),
         }
 
     def _validate_forward_inputs(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
@@ -856,20 +890,21 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self.append_kernel: Optional[Kernel] = None
-        if self.fuse_rope:
-            self.append_kernel = self.kernel_map[
-                "gqa_prefill_paged_with_kv_cache_rope_append_kernel"](
-                    batch=batch,
-                    heads_kv=heads_kv,
-                    max_pages_per_req=max_pages_per_req,
-                    page_size=page_size,
-                    dim=dim,
-                    max_position=self.max_position,
-                    rotary_dim=self.rotary_dim,
-                    dtype=dtype,
-                    tune=tune,
-                )
-            self.kernel = self.kernel_map["gqa_prefill_paged_with_kv_cache_rope_fwd_kernel"](
+        append_key, fwd_key = _select_gqa_prefill_paged_with_kv_cache_kernel_keys(
+            fuse_rope=self.fuse_rope)
+        if append_key is not None:
+            self.append_kernel = self.kernel_map[append_key](
+                batch=batch,
+                heads_kv=heads_kv,
+                max_pages_per_req=max_pages_per_req,
+                page_size=page_size,
+                dim=dim,
+                max_position=self.max_position,
+                rotary_dim=self.rotary_dim,
+                dtype=dtype,
+                tune=tune,
+            )
+            self.kernel = self.kernel_map[fwd_key](
                 batch=batch,
                 heads=heads,
                 heads_kv=heads_kv,
@@ -885,7 +920,7 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
                 tune=tune,
             )
         else:
-            self.kernel = self.kernel_map["gqa_prefill_paged_with_kv_cache_fwd_kernel"](
+            self.kernel = self.kernel_map[fwd_key](
                 batch=batch,
                 heads=heads,
                 heads_kv=heads_kv,
@@ -901,16 +936,13 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        if self.fuse_rope:
-            return {
-                "gqa_prefill_paged_with_kv_cache_rope_append_kernel":
-                    _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls(),
-                "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
-                    _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls()
-            }
         return {
-            "gqa_prefill_paged_with_kv_cache_fwd_kernel":
-                _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls()
+            _GQA_PREFILL_PAGED_WITH_KV_CACHE_FWD_KEY:
+                _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls(),
+            _GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_APPEND_KEY:
+                _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls(),
+            _GQA_PREFILL_PAGED_WITH_KV_CACHE_ROPE_FWD_KEY:
+                _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls(),
         }
 
     def _validate_forward_inputs(


### PR DESCRIPTION
## Summary

- Extract GQA contiguous/paged prefill RoPE dispatch into local key selector helpers.
- Keep OP dispatch on the existing `self.kernel_map[key] -> concrete Kernel` path.
- Expose all concrete contiguous/paged prefill kernels from `default_kernel_map` instead of returning only the fuse_rope-selected subset.
- Add CPU-only selector/default-map tests.

## Notes

This is the first implementation step for #1611. It intentionally does not:

- add new public OPs;
- change `tileops/manifest/attention.yaml`;
- introduce logical `Kernel` wrappers;
- add a new selector module.

The goal is to keep concrete kernels visible for manifest/kernel-map override behavior while making the OP-level selection policy easier to test and discuss.

Closes #1611

## Tests

```text
ruff check tileops/ops/attention/gqa.py tests/ops/attention/test_gqa.py tests/ops/attention/test_gqa_prefill_paged.py
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-selector-pycache python -m compileall -q tileops/ops/attention/gqa.py tests/ops/attention/test_gqa.py tests/ops/attention/test_gqa_prefill_paged.py
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-selector-pycache python -m pytest tests/ops/attention/test_gqa.py tests/ops/attention/test_gqa_prefill_paged.py -q -k 'selector or default_map'
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-selector-pycache python scripts/validate_manifest.py --check-op GroupedQueryAttentionPrefillWithKVCacheFwdOp
PYTHONPYCACHEPREFIX=/tmp/codex-gqa-selector-pycache python scripts/validate_manifest.py --check-op GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp
```
