### PR TITLE
[Fix][CI] Pin ci-runner UID/GID + umask 002, and fix runner stop-signal handling

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -150,6 +150,10 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     PIP_CACHE_DIR=/ci-cache/pip \
     PIP_NO_CACHE_DIR=0
 ARG RUNNER_VERSION=2.334.0
+# The /ci-cache chown below serves only the unmounted image-verification path
+# (`docker run <image> python ...`, see README): ci-runner writes the root-created cache dirs
+# directly. In the mounted CI path the host bind-mount shadows these dirs, so the chown is a
+# no-op and host ownership wins.
 # useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
 # Pin UID/GID 1000 so the account deterministically owns the shared /ci-cache bind-mount across
 # hosts (it matches the majority of existing warm-cache entries; host normalization preserves them).
@@ -162,7 +166,7 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && ./bin/installdependencies.sh \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \
-    && chown -R ci-runner:ci-runner /home/ci-runner
+    && chown -R ci-runner:ci-runner /home/ci-runner /ci-cache
 # chmod as root before the USER drop.
 COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -151,7 +151,9 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     PIP_NO_CACHE_DIR=0
 ARG RUNNER_VERSION=2.334.0
 # useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
-RUN useradd -m -s /bin/bash ci-runner
+# Pin UID/GID 1000 so the account deterministically owns the shared /ci-cache bind-mount across
+# hosts (it matches the majority of existing warm-cache entries; host normalization preserves them).
+RUN groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 -m -s /bin/bash ci-runner
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && curl -fsSL -o runner.tar.gz \
@@ -160,7 +162,7 @@ RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && ./bin/installdependencies.sh \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /ci-cache/pip /ci-cache/tilelang/tmp /ci-cache/triton \
-    && chown -R ci-runner:ci-runner /home/ci-runner /ci-cache
+    && chown -R ci-runner:ci-runner /home/ci-runner
 # chmod as root before the USER drop.
 COPY --chown=ci-runner:ci-runner .github/runner/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh

--- a/.github/runner/entrypoint.sh
+++ b/.github/runner/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Group-writable (0775 dirs / 0664 files) so compiled kernels in the shared /ci-cache are
+# reusable across runner UIDs that share the ci-runner group.
+umask 002
+
 # Ad-hoc command passthrough: `docker run <image> python ...` / `bash -c ...` runs the
 # given command directly (image verification, smoke tests; see README). With no args the
 # container registers an ephemeral self-hosted runner (below).

--- a/.github/runner/entrypoint.sh
+++ b/.github/runner/entrypoint.sh
@@ -41,4 +41,12 @@ trap cleanup EXIT INT TERM
     --disableupdate
 
 # ── Run one job, then exit ───────────────────────────────────────────────────
-./run.sh
+# Make container stop signals reach the runner so an idle ephemeral runner shuts down promptly
+# instead of waiting out docker stop's grace:
+#   - RUNNER_MANUALLY_TRAP_SIG=1 makes run.sh trap SIGTERM/SIGINT and forward SIGINT to the
+#     listener process group (its default mode does not trap, so the signal is otherwise lost).
+#   - exec makes run.sh PID 1 so docker stop's SIGTERM is delivered to it; a bash wrapper as
+#     PID 1 would ignore an untrapped SIGTERM and stall until SIGKILL.
+# Trade-off: a stop signal cancels an in-progress job rather than draining it.
+export RUNNER_MANUALLY_TRAP_SIG=1
+exec ./run.sh

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -419,15 +419,6 @@ jobs:
           # PR would otherwise reuse.
           skip-atomic-age-trim: "true"
 
-      - name: Use run-local Triton cache
-        run: |
-          set -euo pipefail
-          run_triton_cache="/ci-cache/triton/gpu-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          mkdir -p "${run_triton_cache}"
-          chmod u+rwx "${run_triton_cache}" || true
-          echo "TRITON_CACHE_DIR=${run_triton_cache}" >> "$GITHUB_ENV"
-          echo "Using TRITON_CACHE_DIR=${run_triton_cache}"
-
       - name: Validate GPU frequency
         run: |
           set -euo pipefail


### PR DESCRIPTION
Fixes #1625.

## Summary

Resolves the nightly Triton/Inductor `PermissionError` under `/ci-cache` by establishing a UID-agnostic ownership invariant for the shared CI build cache, plus a related runner stop-signal fix and the gpu-smoke cache de-namespacing.

### Cache ownership

- `.github/runner/Dockerfile`: pin `ci-runner` to a deterministic UID/GID 1000 (`groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 ...`) so the account deterministically owns the shared `/ci-cache` bind-mount across image rebuilds.
- The `chown -R ci-runner:ci-runner ... /ci-cache` line is retained but documented as serving only the **unmounted** image-verification path; in the mounted CI path the host bind-mount shadows those dirs (host ownership wins).
- `.github/runner/entrypoint.sh`: set `umask 002` before the runner agent starts so compiled kernels land group-writable (`0775`/`2775`) for cross-UID cache reuse.

### Runner stop-signal handling

- `.github/runner/entrypoint.sh`: `exec ./run.sh` + `export RUNNER_MANUALLY_TRAP_SIG=1`.
- **Why:** `docker stop` (and the launcher's `systemctl stop`) delivers SIGTERM only to PID 1. With `./run.sh` as a foreground child, PID 1 was the entrypoint bash, which defers its trap while waiting and never relays the signal; an idle ephemeral runner then ignored SIGTERM and was SIGKILLed only after docker's full stop grace (~30 min via the launcher's `docker stop -t 1800`).
- **Fix:** `exec` makes `run.sh` PID 1 so docker's SIGTERM reaches it; `RUNNER_MANUALLY_TRAP_SIG=1` makes `run.sh` trap SIGTERM/SIGINT and forward SIGINT to the listener process group for graceful shutdown.
- **Trade-off:** a stop signal now cancels an in-progress job rather than draining it.

### gpu-smoke cache de-namespacing

- `.github/workflows/gpu-smoke.yml`: drop the per-run `TRITON_CACHE_DIR=/ci-cache/triton/gpu-smoke-<run>-<attempt>` step so gpu-smoke shares the warm Triton cache like nightly. `TRITON_CACHE_DIR` falls back to the image ENV default `/ci-cache/triton`. This is safe now that ownership is UID-agnostic (above) and fork write isolation lives at the runner's overlay mount, not the workflow. It also stops the per-run dirs accumulating.
- `nightly.yml` and `scripts/ci/prepare_cache_dirs.sh` need no change: the earlier run-local-cache hotfix (PR #1618) was never merged, so nightly already uses the shared cache and `prepare_cache_dirs.sh` does not exist on `main`.

## Test plan

- [x] Dockerfile pins `ci-runner` to UID/GID 1000; `entrypoint.sh` sets `umask 002`
- [x] Image rebuilt (same tilelang commit / tag) and deployed on the runner host; verified `id ci-runner` = `1000:1000`, `umask` = `0002`
- [x] Host cache normalized (group `1000` + group-writable + setgid); a container `ci-runner` can write into a previously-foreign cache dir (was `Permission denied`)
- [x] Idle runner `docker stop` returns in ~0.3s (was ~30 min) after the signal fix
- [x] gpu-smoke.yml parses; `TRITON_CACHE_DIR` resolves to the shared `/ci-cache/triton` via image ENV
- [ ] Nightly op tests (GLA / Mamba / MoE) pass the Triton/Inductor cache step with no `PermissionError` (final end-to-end confirmation)
- [x] pre-commit passed on changed files
