### PR TITLE
[Fix][TileLang] Fix autotune do_not_specialize for mamba, softmax, logsumexp kernels under TileLang 0.1.11

### DIFF
--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -130,9 +130,17 @@ class Kernel(ABC):
                 "Set 'self.kernel' in __init__ before calling init_config with tune=True.")
         print(f'Start autotuning {self.__class__.__name__}...')
 
-        # Apply autotune decorator to the kernel function
+        # Apply autotune decorator to the kernel function.
+        # Pass do_not_specialize so TileLang 0.1.11 excludes the seeded JIT
+        # parameters from the cache key; without this, providing the default
+        # config values below would cause the autotuner to treat them as
+        # "already tuned" and skip the benchmarking sweep entirely
+        # (returning config=None).
+        tunable_params = list(self._autotune_initial_kwargs(self.kernel).keys())
         autotune_kwargs: Dict[str, Any] = dict(
             configs=self.autotune_configs, warmup=warmup, rep=rep)
+        if tunable_params:
+            autotune_kwargs["do_not_specialize"] = tunable_params
         if self.autotune_supply_prog is not None:
             autotune_kwargs["supply_prog"] = self.autotune_supply_prog
         autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -525,6 +525,9 @@ class LogSumExpKernel(Kernel):
             autotune_kwargs: dict = dict(
                 configs=group_cfgs, warmup=warmup, rep=rep,
             )
+            tunable_params = list(self._autotune_initial_kwargs(kernel, group_cfgs[0]).keys())
+            if tunable_params:
+                autotune_kwargs["do_not_specialize"] = tunable_params
             if self.autotune_supply_prog is not None:
                 autotune_kwargs["supply_prog"] = self.autotune_supply_prog
             autotuned = tl_autotune(**autotune_kwargs)(kernel)

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -795,9 +795,12 @@ class SoftmaxKernel(Kernel):
             kernel = _softmax_kernel(
                 self.M, self.N, self.op_kind, self.dtype_str, tile_n,
             )
+            tunable_params = list(self._autotune_initial_kwargs(kernel, group_cfgs[0]).keys())
             autotune_kwargs: dict = dict(
                 configs=group_cfgs, warmup=warmup, rep=rep,
             )
+            if tunable_params:
+                autotune_kwargs["do_not_specialize"] = tunable_params
             if self.autotune_supply_prog is not None:
                 autotune_kwargs["supply_prog"] = self.autotune_supply_prog
             autotuned = tl_autotune(**autotune_kwargs)(kernel)


### PR DESCRIPTION
## Summary

Fixes autotune failures under TileLang 0.1.11 for three kernel families that were not covered by PR #1619.

### Root cause

TileLang 0.1.11 changed its autotuner: when `autotuned_kernel_fn(**initial_kwargs)` is called with the tunable JIT parameters already bound, it records those params in the cache key and — on a cache hit — treats them as "already tuned," skipping the benchmarking sweep entirely and returning `config=None`.

PR #1619 added `_call_autotuned_kernel()` to seed required JIT params (fixing the `TypeError: missing N required positional arguments`), but this inadvertently triggered the new 0.1.11 skip behavior, causing:
- `SSDStatePassingFwdKernel` / `SSDChunkScanFwdKernel` / `SSDDecodeKernel`: `Best config: None`
- `SoftmaxKernel` / `LogSumExpKernel`: `TypeError: '<' not supported between instances of 'NoneType' and 'float'`

### Fix

Pass `do_not_specialize=tunable_params` to TileLang's `autotune()` decorator. This tells 0.1.11 to exclude those parameter names from the cache key, so the seeded initial values no longer trigger the skip path — the full benchmarking sweep runs as expected.

## Changes

- **`tileops/kernels/kernel_base.py`** (`Kernel.autotune()`): extract tunable param names from the JIT signature and pass as `do_not_specialize`. Fixes `SSDStatePassingFwdKernel`, `SSDChunkScanFwdKernel`, `SSDDecodeKernel`, and any future kernel that uses the base `autotune()`.

- **`tileops/kernels/reduction/softmax.py`** (`SoftmaxKernel.autotune()`): same pattern for the custom per-tile_n autotune loop.

- **`tileops/kernels/reduction/logsumexp.py`** (`LogSumExpKernel.autotune()`): same pattern for the custom per-tile_n autotune loop.

## Validation

Tested against real TileLang 0.1.11 (`0.1.11+cuda.gitcd37ed5f`) in `flashmlaenv`:

**Mamba kernels** — all run full sweeps and return valid configs:
- `SSDStatePassingFwdKernel` → `{'block_d': 64, 'threads': 128, 'vectorize': False}`
- `SSDChunkScanFwdKernel` → `{'block_l': 64, 'block_p': 64, 'block_n': 64, 'block_s': 64, 'threads': 128}`
- `SSDDecodeKernel` → `{'block_p': 4, 'block_n': 32, 'threads': 128}`

**Softmax/logsumexp** — `tests/ops/test_softmax.py`: **135 passed** (previously 3 failed with `TypeError`)

**Autotune binding unit tests** — `tests/kernels/test_kernel_autotune_binding.py`: **3 passed**

**deepseek_dsa_decode** — `tests/ops/attention/test_deepseek_dsa_decode.py`: **1 passed**

**Ruff** — all PR #1619 validation files pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)