### PR TITLE
[Fix][Kernel] restore autotuning on TileLang 0.1.11

### DIFF
--- a/tests/kernels/test_kernel_autotune_binding.py
+++ b/tests/kernels/test_kernel_autotune_binding.py
@@ -8,12 +8,28 @@ from tileops.kernels.kernel_base import Kernel
 pytestmark = pytest.mark.smoke
 
 
+class _FakeBinder:
+    """Mimics TileLang's _JITArgumentBinder fields used by _seed_autotune_binder."""
+
+    def __init__(self, param_names):
+        self.param_names = tuple(param_names)
+        self.defaults = ()
+        self.required_indices = tuple(range(len(param_names)))
+
+
+class _FakeFunc:
+    def __init__(self, param_names):
+        self._argument_binder = _FakeBinder(param_names)
+
+
 class _FakeJit:
-    signature = inspect.signature(lambda block_m, threads: None)
+    """Stand-in for a @tilelang.jit kernel: exposes .func._argument_binder and .signature."""
 
-
-class _FakeAliasedJit:
-    signature = inspect.signature(lambda threads_arg, npt_arg: None)
+    def __init__(self, param_names):
+        self.func = _FakeFunc(param_names)
+        self.signature = inspect.Signature(
+            [inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD) for n in param_names]
+        )
 
 
 class _TunedKernel:
@@ -21,9 +37,9 @@ class _TunedKernel:
 
 
 class _KernelWithRequiredTunables(Kernel):
-    def __init__(self) -> None:
+    def __init__(self, param_names=("block_m", "threads")) -> None:
         super().__init__()
-        self.kernel = _FakeJit()
+        self.kernel = _FakeJit(param_names)
 
     @property
     def default_config(self) -> dict:
@@ -40,18 +56,16 @@ class _KernelWithRequiredTunables(Kernel):
         raise NotImplementedError
 
 
-def test_autotune_seeds_required_jit_params_from_default_config(monkeypatch):
+def test_autotune_runs_wrapper_with_no_args_and_seeds_binder(monkeypatch):
+    """autotune() must NOT pass tunable args (that makes TileLang 0.1.11 skip
+    tuning); it seeds the JIT binder defaults from default_config instead."""
     calls: dict[str, object] = {}
 
     def fake_autotune(**autotune_kwargs):
-        calls["autotune_kwargs"] = autotune_kwargs
-
         def decorate(kernel):
-            calls["kernel"] = kernel
-
-            def wrapped(**kwargs):
-                calls["initial_kwargs"] = kwargs
-                kernel.signature.bind(**kwargs)
+            def wrapped(*args, **kwargs):
+                calls["args"] = args
+                calls["kwargs"] = kwargs
                 return _TunedKernel()
 
             return wrapped
@@ -63,30 +77,31 @@ def test_autotune_seeds_required_jit_params_from_default_config(monkeypatch):
     kernel = _KernelWithRequiredTunables()
     kernel.autotune()
 
-    assert calls["initial_kwargs"] == {"block_m": 128, "threads": 256}
-    assert "tile_n" not in calls["initial_kwargs"]
+    # The autotuned wrapper is called with no tunable arguments ...
+    assert calls["args"] == ()
+    assert calls["kwargs"] == {}
+    # ... and the binder defaults were seeded from default_config (signature-filtered).
+    binder = kernel.kernel.func._argument_binder
+    assert binder.defaults == (128, 256)  # block_m, threads; tile_n is not a JIT param
+    assert binder.required_indices == ()
     assert kernel.config == _TunedKernel.config
 
 
-def test_autotune_group_seed_is_filtered_to_jit_signature():
+def test_seed_binder_uses_passed_config_filtered_to_signature():
     kernel = _KernelWithRequiredTunables()
 
-    captured = kernel._call_autotuned_kernel(
-        lambda **kwargs: kwargs,
-        kernel.kernel,
-        {"block_m": 1, "threads": 128, "tile_n": 4096},
-    )
+    Kernel._seed_autotune_binder(kernel.kernel, {"block_m": 1, "threads": 128, "tile_n": 4096})
 
-    assert captured == {"block_m": 1, "threads": 128}
+    binder = kernel.kernel.func._argument_binder
+    assert binder.defaults == (1, 128)  # tile_n filtered out (not in signature)
+    assert binder.required_indices == ()
 
 
-def test_autotune_initial_kwargs_support_common_jit_param_aliases():
-    kernel = _KernelWithRequiredTunables()
+def test_seed_binder_supports_common_jit_param_aliases():
+    kernel = _KernelWithRequiredTunables(param_names=("threads_arg", "npt_arg"))
 
-    captured = kernel._call_autotuned_kernel(
-        lambda **kwargs: kwargs,
-        _FakeAliasedJit(),
-        {"threads": 128, "num_per_thread": 4},
-    )
+    Kernel._seed_autotune_binder(kernel.kernel, {"threads": 128, "num_per_thread": 4})
 
-    assert captured == {"threads_arg": 128, "npt_arg": 4}
+    binder = kernel.kernel.func._argument_binder
+    assert binder.defaults == (128, 4)  # threads_arg<-threads, npt_arg<-num_per_thread
+    assert binder.required_indices == ()

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional
 
@@ -11,6 +12,7 @@ class Kernel(ABC):
     autotune_configs: Optional[list[dict]] = None
     supported_archs: Optional[list[int]] = None
     kernel: Callable[[dict], Callable]
+    # JIT parameter names that differ from their autotune config key.
     _AUTOTUNE_PARAM_ALIASES = {
         "threads_arg": "threads",
         "npt_arg": "num_per_thread",
@@ -79,37 +81,48 @@ class Kernel(ABC):
         """
         return None
 
-    def _autotune_initial_kwargs(
-        self,
-        kernel: Optional[Callable] = None,
-        config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
-        """Return initial JIT kwargs for TileLang autotuner binding.
+    @staticmethod
+    def _seed_autotune_binder(kernel: Optional[Callable], source: Optional[Dict[str, Any]]) -> None:
+        """Make a kernel's tunable JIT params bindable from ``source`` defaults.
 
-        TileLang 0.1.11 validates/binds the JIT signature before candidate
-        configs are applied. Passing the kernel's default config keeps required
-        tunable parameters bindable while the autotuner still overrides them
-        with each candidate config during benchmarking.
+        TileLang 0.1.11 binds the JIT signature before autotuning, so a tunable
+        parameter with no default and no supplied value raises at bind time;
+        but supplying the value on the call makes the autotuner skip tuning
+        entirely (returning ``config=None``). To get neither, seed the JIT
+        argument binder's per-parameter defaults from a single source of truth
+        (the kernel's ``default_config``, or the per-sub-kernel config a custom
+        autotune override passes), so binding succeeds with no args while the
+        autotuner still overrides every tunable parameter per candidate.
+
+        ``source`` values are bind-time placeholders only; they are never the
+        executed config (the search overrides them, and ``forward`` always
+        passes the chosen config explicitly).
         """
-        source = self.default_config if config is None else config
         if not source:
-            return {}
-
-        jit_kernel = getattr(self, "kernel", None) if kernel is None else kernel
-        signature = getattr(jit_kernel, "signature", None)
-        parameters = getattr(signature, "parameters", None)
-        if parameters is None:
-            return dict(source)
-
-        kwargs = {}
-        for name in parameters:
-            if name in source:
-                kwargs[name] = source[name]
+            return
+        binder = getattr(getattr(kernel, "func", None), "_argument_binder", None)
+        if binder is None:
+            return
+        names = getattr(binder, "param_names", None)
+        if not names:
+            return
+        sig = getattr(kernel, "signature", None)
+        params = sig.parameters if sig is not None else {}
+        defaults: list[Any] = []
+        required: list[int] = []
+        for i, name in enumerate(names):
+            key = name if name in source else Kernel._AUTOTUNE_PARAM_ALIASES.get(name)
+            if key in source:
+                defaults.append(source[key])
                 continue
-            alias = self._AUTOTUNE_PARAM_ALIASES.get(name)
-            if alias is not None and alias in source:
-                kwargs[name] = source[alias]
-        return kwargs
+            existing = params.get(name)
+            if existing is not None and existing.default is not inspect.Parameter.empty:
+                defaults.append(existing.default)  # keep a pre-existing signature default
+            else:
+                defaults.append(None)  # genuinely required (not a tunable config key)
+                required.append(i)
+        binder.defaults = tuple(defaults)
+        binder.required_indices = tuple(required)
 
     def _call_autotuned_kernel(
         self,
@@ -117,9 +130,16 @@ class Kernel(ABC):
         kernel: Optional[Callable] = None,
         config: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        return autotuned_kernel_fn(
-            **self._autotune_initial_kwargs(kernel=kernel, config=config)
-        )
+        """Run the TileLang autotuner search and return its tuned kernel.
+
+        The autotuned wrapper is invoked with no tunable arguments (supplying
+        them makes TileLang 0.1.11 skip tuning and return ``config=None``).
+        Binding without args is made possible by seeding the JIT binder defaults
+        from the kernel's ``default_config`` (or the ``config`` a custom override
+        passes) -- see ``_seed_autotune_binder``.
+        """
+        self._seed_autotune_binder(kernel, config if config is not None else self.default_config)
+        return autotuned_kernel_fn()
 
     def autotune(self, warmup: int = 25, rep: int = 50) -> None:
         if self.autotune_configs is None:
@@ -137,9 +157,9 @@ class Kernel(ABC):
             autotune_kwargs["supply_prog"] = self.autotune_supply_prog
         autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)
 
-        # Seed required tunable JIT parameters for TileLang's pre-autotune
-        # validation/binding step. Candidate configs still override these
-        # initial values during the actual autotune run.
+        # Run the autotuner search (no tunable args passed; see
+        # _call_autotuned_kernel). Tunable JIT parameters are bindable via
+        # defaults on the kernel @tilelang.jit signatures.
         tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
         # Extract and store the best config


### PR DESCRIPTION
## Summary

Autotuned ops (`tune=True`) crash on the TileLang 0.1.11 stack:

```
TypeError: 'NoneType' object is not subscriptable          # self.config["num_split"], ...
TypeError: '<' not supported between 'NoneType' and 'float'
```

Surfaced by nightly: `op_test` had 9 failures (all `-tuned`/`True` variants), `benchmark` had 168 (gemm/rms_norm/softmax/pool/deepseek_mla_decode). Non-tuned variants pass.

## Root cause

`Kernel.autotune()` set `self.config = tuned_kernel.config`, which came back **None**. TileLang 0.1.11 short-circuits the autotuner — logging `"Tunable parameters [...] already provided during auto-tuning. Skipping compilation and using direct JIT"` and returning an `AutotuneResult` with no `config` — whenever the **tunable** JIT parameters are supplied on the autotuned call. The base class supplied them (seeding `default_config`) to satisfy TileLang 0.1.11's eager signature binding. So tuning never ran and `self.config` was `None`, and the first `self.config[...]` in `forward()` raised.

## Fix — one central change in `kernel_base`

Decouple the two needs (bind the signature vs. don't trip the skip), with a single source of truth and no per-kernel edits:

- **Don't pass tunable args** on the autotuned call (so the autotuner is not skipped); invoke the wrapper with no arguments.
- **Seed the JIT argument binder's per-parameter defaults** from the kernel's `default_config` (or the per-sub-kernel config a custom autotune override passes), via `Kernel._seed_autotune_binder`. Binding then succeeds with no args, and the autotuner overrides every tunable parameter per candidate during the search.

These seeded values are **bind-time placeholders only** — never the executed config (the search overrides them; `forward` always passes the chosen config explicitly). Because they come straight from `default_config`, there is **no second source of default values and no inconsistency**, including shape-computed entries (e.g. deepseek MLA-decode's `block_H = min(64, heads // kv)` is seeded with its real per-instance value).

`Kernel._call_autotuned_kernel` is the single call point used by both the base `autotune()` and the custom autotune overrides (softmax, logsumexp, deltanet, gated_deltanet, fp8 indexer, deepseek DSA), so the fix covers all of them without touching individual kernels.

## Test plan

Verified on H200 (TileLang `0.1.11+cu129.git65dbc98`):

- [x] gemm (`tune=True`): autotuner runs the candidate space (no "Skipping"), returns a real best config, op forward correct — was `config=None` -> crash.
- [x] deepseek MLA-decode warp-specialized (the op that surfaced the bug): autotunes; `config` populated; seeded `block_H` matches `default_config` (consistency check).
- [x] All kernel modules import; `tests/kernels/test_kernel_autotune_binding.py` updated to the new behavior (no seeded kwargs; binder defaults seeded from `default_config`; signature filtering; aliases) and passes.
- [x] ruff + pre-commit pass.
- [ ] Full nightly `op_test` + `benchmark` rerun (broad check across all tuned ops).

## Notes

Implementation seeds TileLang's `_JITArgumentBinder` defaults/`required_indices` directly. This couples to a TileLang internal, but fails loudly (not silently) on a TileLang change, and TileLang is pinned by the runner image. The underlying "silent `config=None` on skip" is arguably a TileLang issue worth reporting upstream.