### PR TITLE
[Fix][Kernel] add do_not_specialize to deltanet/gated/dsa custom-autotune kernels

### DIFF
--- a/tests/ops/attention/test_deepseek_dsa_decode.py
+++ b/tests/ops/attention/test_deepseek_dsa_decode.py
@@ -62,6 +62,10 @@ class DsaDecodeFixture(FixtureBase):
                  1, 128, 1024, 2048, 512, 64, 2048, 1, 1, 1024, None, torch.float16, False,
                  marks=pytest.mark.smoke,
              ),
+             pytest.param(
+                 1, 128, 1024, 2048, 512, 64, 2048, 1, 1, 1024, None, torch.float16, True,
+                 marks=pytest.mark.full, id="full-fp16-tuned",
+             ),
          ]),
     ]
 

--- a/tests/ops/test_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_deltanet_chunkwise_bwd.py
@@ -76,6 +76,8 @@ class DeltaNetBwdFixture(FixtureBase):
             pytest.param(1, 128, 4, 64, 64, 32, torch.float32, False, marks=pytest.mark.full),
             pytest.param(1, 128, 4, 64, 64, 32, torch.float16, False, marks=pytest.mark.full),
             pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
+                         id="full-bf16-tuned"),
         ]),
     ]
 

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -119,6 +119,8 @@ class DeltaNetFwdFixture(FixtureBase):
             pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
+                         id="full-bf16-tuned"),
         ]),
     ]
 

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -141,6 +141,8 @@ class GatedDeltaNetFwdFixture(FixtureBase):
             pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
+                         id="full-bf16-tuned"),
         ]),
     ]
 

--- a/tileops/kernels/attention/deepseek_dsa_decode.py
+++ b/tileops/kernels/attention/deepseek_dsa_decode.py
@@ -603,13 +603,16 @@ class SparseMlaKernel(Kernel):
             return  # kernel doesn't support autotuning
         print(f'Start autotuning {self.__class__.__name__}...')
 
-        # Apply autotune decorator to the kernel function
-        autotuned_kernel_fn = autotune(
-            configs=self.autotune_configs, warmup=warmup, rep=rep, supply_prog=self.supply_prog)(
-                self.kernel)
+        tunable_params = list(self._autotune_initial_kwargs(self.kernel).keys())
+        # TileLang invokes supply_prog with the candidate JIT params; SparseMlaKernel.supply_prog
+        # generates inputs from instance shape attributes and takes none, so discard them.
+        autotune_kwargs = dict(
+            configs=self.autotune_configs, warmup=warmup, rep=rep,
+            supply_prog=lambda *args, **kwargs: self.supply_prog())
+        if tunable_params:
+            autotune_kwargs["do_not_specialize"] = tunable_params
+        autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)
 
-        # Seed required tunable JIT parameters for TileLang's pre-autotune
-        # validation/binding step.
         tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
 
         # Extract and store the best config

--- a/tileops/kernels/deltanet/deltanet_bwd.py
+++ b/tileops/kernels/deltanet/deltanet_bwd.py
@@ -410,8 +410,12 @@ class DeltaNetBwdKernel(Kernel):
         parallel_configs = [{"threads": t} for t in [128, 256]]
         print(f"Autotuning bwd_parallel ({len(parallel_configs)} configs)...")
         parallel_jit = _bwd_parallel_tl(B, H, S, BC, DK, DV, dt)
+        _parallel_at = dict(configs=parallel_configs, warmup=warmup, rep=rep)
+        _parallel_dns = list(self._autotune_initial_kwargs(parallel_jit, parallel_configs[0]).keys())
+        if _parallel_dns:
+            _parallel_at["do_not_specialize"] = _parallel_dns
         tuned_parallel = self._call_autotuned_kernel(
-            tl_autotune(configs=parallel_configs, warmup=warmup, rep=rep)(parallel_jit),
+            tl_autotune(**_parallel_at)(parallel_jit),
             parallel_jit,
             parallel_configs[0],
         )
@@ -425,8 +429,12 @@ class DeltaNetBwdKernel(Kernel):
         ]
         print(f"Autotuning dh_recurrence_bwd ({len(recurrence_configs)} configs)...")
         recurrence_jit = _dh_recurrence_bwd_tl(B, H, S, BC, DK, DV, dt)
+        _recurrence_at = dict(configs=recurrence_configs, warmup=warmup, rep=rep)
+        _recurrence_dns = list(self._autotune_initial_kwargs(recurrence_jit, recurrence_configs[0]).keys())
+        if _recurrence_dns:
+            _recurrence_at["do_not_specialize"] = _recurrence_dns
         tuned_recurrence = self._call_autotuned_kernel(
-            tl_autotune(configs=recurrence_configs, warmup=warmup, rep=rep)(recurrence_jit),
+            tl_autotune(**_recurrence_at)(recurrence_jit),
             recurrence_jit,
             recurrence_configs[0],
         )
@@ -440,8 +448,12 @@ class DeltaNetBwdKernel(Kernel):
         ]
         print(f"Autotuning compute_w_u_bwd ({len(wu_bwd_configs)} configs)...")
         wu_bwd_jit = compute_w_u_bwd_tl(B, H, S, BC, DK, DV, dt)
+        _wu_bwd_at = dict(configs=wu_bwd_configs, warmup=warmup, rep=rep)
+        _wu_bwd_dns = list(self._autotune_initial_kwargs(wu_bwd_jit, wu_bwd_configs[0]).keys())
+        if _wu_bwd_dns:
+            _wu_bwd_at["do_not_specialize"] = _wu_bwd_dns
         tuned_wu_bwd = self._call_autotuned_kernel(
-            tl_autotune(configs=wu_bwd_configs, warmup=warmup, rep=rep)(wu_bwd_jit),
+            tl_autotune(**_wu_bwd_at)(wu_bwd_jit),
             wu_bwd_jit,
             wu_bwd_configs[0],
         )

--- a/tileops/kernels/deltanet/deltanet_fwd.py
+++ b/tileops/kernels/deltanet/deltanet_fwd.py
@@ -307,8 +307,12 @@ class DeltaNetFwdKernel(Kernel):
         ]
         print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
         fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
+        _fused_at = dict(configs=fused_configs, warmup=warmup, rep=rep)
+        _fused_dns = list(self._autotune_initial_kwargs(fused_jit, fused_configs[0]).keys())
+        if _fused_dns:
+            _fused_at["do_not_specialize"] = _fused_dns
         tuned_fused = self._call_autotuned_kernel(
-            tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit),
+            tl_autotune(**_fused_at)(fused_jit),
             fused_jit,
             fused_configs[0],
         )
@@ -327,8 +331,12 @@ class DeltaNetFwdKernel(Kernel):
             label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
             print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
             h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
+            _h_at = dict(configs=h_configs, warmup=warmup, rep=rep)
+            _h_dns = list(self._autotune_initial_kwargs(h_jit, h_configs[0]).keys())
+            if _h_dns:
+                _h_at["do_not_specialize"] = _h_dns
             tuned_h = self._call_autotuned_kernel(
-                tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit),
+                tl_autotune(**_h_at)(h_jit),
                 h_jit,
                 h_configs[0],
             )
@@ -345,8 +353,12 @@ class DeltaNetFwdKernel(Kernel):
         o_configs = [{"threads": t} for t in [64, 128, 256]]
         print(f"Autotuning output_o ({len(o_configs)} configs)...")
         o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
+        _o_at = dict(configs=o_configs, warmup=warmup, rep=rep)
+        _o_dns = list(self._autotune_initial_kwargs(o_jit, o_configs[0]).keys())
+        if _o_dns:
+            _o_at["do_not_specialize"] = _o_dns
         tuned_o = self._call_autotuned_kernel(
-            tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit),
+            tl_autotune(**_o_at)(o_jit),
             o_jit,
             o_configs[0],
         )

--- a/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -326,8 +326,12 @@ class GatedDeltaNetFwdKernel(Kernel):
         ]
         print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
         fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
+        _fused_at = dict(configs=fused_configs, warmup=warmup, rep=rep)
+        _fused_dns = list(self._autotune_initial_kwargs(fused_jit, fused_configs[0]).keys())
+        if _fused_dns:
+            _fused_at["do_not_specialize"] = _fused_dns
         tuned_fused = self._call_autotuned_kernel(
-            tl_autotune(configs=fused_configs, warmup=warmup, rep=rep)(fused_jit),
+            tl_autotune(**_fused_at)(fused_jit),
             fused_jit,
             fused_configs[0],
         )
@@ -346,8 +350,12 @@ class GatedDeltaNetFwdKernel(Kernel):
             label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
             print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
             h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
+            _h_at = dict(configs=h_configs, warmup=warmup, rep=rep)
+            _h_dns = list(self._autotune_initial_kwargs(h_jit, h_configs[0]).keys())
+            if _h_dns:
+                _h_at["do_not_specialize"] = _h_dns
             tuned_h = self._call_autotuned_kernel(
-                tl_autotune(configs=h_configs, warmup=warmup, rep=rep)(h_jit),
+                tl_autotune(**_h_at)(h_jit),
                 h_jit,
                 h_configs[0],
             )
@@ -364,8 +372,12 @@ class GatedDeltaNetFwdKernel(Kernel):
         o_configs = [{"threads": t} for t in [64, 128, 256]]
         print(f"Autotuning output_o ({len(o_configs)} configs)...")
         o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
+        _o_at = dict(configs=o_configs, warmup=warmup, rep=rep)
+        _o_dns = list(self._autotune_initial_kwargs(o_jit, o_configs[0]).keys())
+        if _o_dns:
+            _o_at["do_not_specialize"] = _o_dns
         tuned_o = self._call_autotuned_kernel(
-            tl_autotune(configs=o_configs, warmup=warmup, rep=rep)(o_jit),
+            tl_autotune(**_o_at)(o_jit),
             o_jit,
             o_configs[0],
         )


### PR DESCRIPTION
## Summary

Follow-up to #1627, which fixed the TileLang 0.1.11 autotune-skip bug (seeded tunable params recorded in the cache key → treated as "already tuned" → sweep skipped, `config=None` → crash) in the base `Kernel.autotune()` and in `SoftmaxKernel` / `LogSumExpKernel`.

These custom-autotune kernels build the TileLang `autotune(...)` decorator directly and were not covered:
- `deltanet_fwd` / `deltanet_bwd` (per sub-kernel)
- `gated_deltanet_fwd` (per sub-kernel)
- `deepseek_dsa_decode` (`SparseMlaKernel`)

## Fix

- At each autotuned call site, derive the seeded tunable parameter names via `_autotune_initial_kwargs` and pass them as `do_not_specialize` so TileLang excludes them from the cache key and runs the full sweep (guarded so it's only passed when non-empty).
- `deepseek_dsa_decode` also passes `supply_prog`: TileLang calls it with the candidate JIT params, but `SparseMlaKernel.supply_prog` takes none (it builds inputs from instance attrs), so it's wrapped (`lambda *args, **kwargs: self.supply_prog()`) to discard the extra arg.

## Test coverage

Added one `tune=True` (`full` tier) regression case to `test_deltanet_fwd.py`, `test_deltanet_chunkwise_bwd.py`, `test_gated_deltanet_fwd.py`, and `test_deepseek_dsa_decode.py` so these autotune paths are covered by CI.

## Not included — fp8_lighting_indexer

`fp8_lighting_indexer` was in scope initially but is **reverted**: its `supply_prog(q, kv, ...)` needs tensors not available at tune time and requires an instance-attr fallback (a separate change). Deferred to a follow-up.

## Test plan

- [x] H200: `DeltaNetFwdKernel(tune=True)` and `SparseMlaKernel(tune=True)` autotune and return a populated config (were `None` / crash).
- [x] New tuned cases collect cleanly and satisfy the conftest tier validator.
- [x] `ruff` + pre-commit pass.

### Test node delta
4 new nodes (one `tune=True` `full` case per touched test file). `scripts/test_node_delta.py` could not run in the runner image (host-owned workspace not writable by the container user); the growth is exactly those 4 cases.