### PR TITLE
[Fix][Attention] Fix GQA sliding-window fwd WGMMA output shared-memory race

### DIFF
--- a/tileops/kernels/attention/gqa_fwd.py
+++ b/tileops/kernels/attention/gqa_fwd.py
@@ -309,10 +309,10 @@ def _mha_fwd_wgmma_pipelined_kernel(batch: int,
                     mma1(v, v_shared, acc_s_cast, acc_o, k_idx, by, bz)
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
-                # Barriers guard the swizzled o_shared round-trip: without them
-                # warps read o_shared before peer warps finish writing it, a
-                # shared-memory race that can corrupt the output under WGMMA
-                # pipelining (num_stages >= 2).
+                # Guard the swizzled o_shared round-trip against a shared-memory
+                # race under WGMMA pipelining. Any non-zero barrier slot works;
+                # a bare T.sync_threads() aliases the implicit barrier-0 and is
+                # elided.
                 T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
                 T.sync_threads(3, threads)
@@ -693,10 +693,10 @@ def _gqa_fwd_wgmma_pipelined_kernel(batch: int,
                     mma1(v, v_shared, acc_s_cast, acc_o, k_idx, by, bz)
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
-                # Barriers guard the swizzled o_shared round-trip: without them
-                # warps read o_shared before peer warps finish writing it, a
-                # shared-memory race that can corrupt the output under WGMMA
-                # pipelining (num_stages >= 2).
+                # Guard the swizzled o_shared round-trip against a shared-memory
+                # race under WGMMA pipelining. Any non-zero barrier slot works;
+                # a bare T.sync_threads() aliases the implicit barrier-0 and is
+                # elided.
                 T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
                 T.sync_threads(3, threads)

--- a/tileops/kernels/attention/gqa_fwd.py
+++ b/tileops/kernels/attention/gqa_fwd.py
@@ -309,7 +309,13 @@ def _mha_fwd_wgmma_pipelined_kernel(batch: int,
                     mma1(v, v_shared, acc_s_cast, acc_o, k_idx, by, bz)
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
+                # Barriers guard the swizzled o_shared round-trip: without them
+                # warps read o_shared before peer warps finish writing it, a
+                # shared-memory race that can corrupt the output under WGMMA
+                # pipelining (num_stages >= 2).
+                T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
+                T.sync_threads(3, threads)
                 T.copy(o_shared, output[bz, bx * block_m:(bx + 1) * block_m, by, :])
                 for i in T.Parallel(block_m):
                     logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
@@ -687,7 +693,13 @@ def _gqa_fwd_wgmma_pipelined_kernel(batch: int,
                     mma1(v, v_shared, acc_s_cast, acc_o, k_idx, by, bz)
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
+                # Barriers guard the swizzled o_shared round-trip: without them
+                # warps read o_shared before peer warps finish writing it, a
+                # shared-memory race that can corrupt the output under WGMMA
+                # pipelining (num_stages >= 2).
+                T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
+                T.sync_threads(3, threads)
                 T.copy(o_shared, output[bz, bx * block_m:(bx + 1) * block_m, by, :])
                 for i in T.Parallel(block_m):
                     logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale

--- a/tileops/kernels/attention/gqa_sliding_window_fwd.py
+++ b/tileops/kernels/attention/gqa_sliding_window_fwd.py
@@ -413,7 +413,13 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
 
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
+                # Barriers guard the swizzled o_shared round-trip: without them
+                # warps read o_shared before peer warps finish writing it, a
+                # shared-memory race that corrupts the output under WGMMA
+                # pipelining (num_stages >= 2).
+                T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
+                T.sync_threads(3, threads)
                 T.copy(o_shared, output[bz, bx * block_m:(bx + 1) * block_m, by, :])
                 for i in T.Parallel(block_m):
                     logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale

--- a/tileops/kernels/attention/gqa_sliding_window_fwd.py
+++ b/tileops/kernels/attention/gqa_sliding_window_fwd.py
@@ -413,10 +413,10 @@ def _gqa_sw_fwd_wgmma_pipelined_kernel(
 
                 for i, j in T.Parallel(block_m, dim):
                     acc_o[i, j] /= logsum[i]
-                # Barriers guard the swizzled o_shared round-trip: without them
-                # warps read o_shared before peer warps finish writing it, a
-                # shared-memory race that corrupts the output under WGMMA
-                # pipelining (num_stages >= 2).
+                # Guard the swizzled o_shared round-trip against a shared-memory
+                # race under WGMMA pipelining. Any non-zero barrier slot works;
+                # a bare T.sync_threads() aliases the implicit barrier-0 and is
+                # elided.
                 T.sync_threads(3, threads)
                 T.copy(acc_o, o_shared)
                 T.sync_threads(3, threads)


### PR DESCRIPTION
## Summary

Fixes #1616, plus a defensive fix for the same latent race in the plain MHA/GQA forward WGMMA kernels.

The fixed-length `GQASlidingWindowFwdWgmmaPipelinedKernel` (selected on H200) miscomputed non-causal right-window cases — up to ~19% of elements wrong, max abs diff ~0.47 (tolerance 0.01), reproduced deterministically across recent `main` gpu-smoke runs.

## Root cause

The kernel writes the output accumulator through a **swizzled** `o_shared` buffer (`acc_o -> o_shared -> output`) with **no barrier** around the round-trip. Across warps this is a shared-memory race: a warp reads `o_shared` before peer warps finish writing it, corrupting the output under WGMMA pipelining (`num_stages >= 2`).

The varlen sibling already guards the identical round-trip with `T.sync_threads(3, threads)` (added in the closed #1404 "wgmma varlen output shared-memory race"); that guard was never ported to the fixed-length kernel. This PR ports it.

**Why a named barrier (slot 3, not bare `T.sync_threads()`):** verified on H200 — a bare `T.sync_threads()` (slot 0) aliases the implicit `__syncthreads()` the surrounding `T.copy` lowering already emits, gets elided, and the race survives. Any non-zero slot works.

**Why non-causal right-window specifically:** some query rows have a fully-masked trailing KV tile, which shifts warp scheduling enough to expose the race. Causal / left-only / no-window paths and `num_stages=1` happened to avoid the timing window — which is why those passed and masked the latent bug.

## Commits

1. `gqa_sliding_window_fwd.py` — the #1616 fix.
2. `gqa_fwd.py` — defensive fix: `_mha_fwd_wgmma_pipelined_main` / `_gqa_fwd_wgmma_pipelined_main` have the identical unguarded write-back. Plain attention has no masked-tile trigger so it is latent (tests pass), but the hazard is real; barriers only add synchronization.
3. comment clarifying the named-barrier requirement.

## Correctness verification (CI image `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10-dev`, torch 2.10.0+cu129, H200)

| suite | result |
|---|---|
| `tests/ops/attention/test_gqa_sliding_window.py` | **21/21 passed** (incl. the two previously-failing cases) |
| `tests/ops/attention/test_mha.py` + `test_gqa.py` | **55 passed, 4 skipped** (no regression from commit 2) |

## Barrier perf impact — before/after latency (median over 100 iters, same image)

The two `T.sync_threads` run once per block at the end (not in the KV loop), so the cost is below run-to-run noise.

| kernel | shape | latency before (ms) | latency after (ms) |
|---|---|---|---|
| GQASlidingWindowFwdWgmmaPipelined | fp16 wl=-1 wr=64 | 0.0167 | 0.0164 |
| GQASlidingWindowFwdWgmmaPipelined | bf16 wl=64 wr=64 | 0.0149 | 0.0146 |
| MHAFwdWgmmaPipelined | causal fp16 | 0.0162 | 0.0159 |
| GQAFwdWgmmaPipelined | causal fp16 | 0.0160 | 0.0157 |
| MHAFwdWgmmaPipelined | causal bf16 | 0.0161 | 0.0159 |
| GQAFwdWgmmaPipelined | causal bf16 | 0.0158 | 0.0158 |

> "before" = the unguarded `origin/main` kernels (temporarily reverted, then restored). The sliding-window "before" output is numerically wrong (the bug); only latency is comparable.

## GQA forward vs reference baselines (`bench_gqa.py`, same image, H200)

Metric is **throughput in TFLOPS (higher is better)** — not latency. TileOPs = `GroupedQueryAttentionFwdOp` (kernel variant in parens). Baselines = FlashAttention-3 and FlashInfer. Bold = fastest in the row.

### Compute-bound (S=2048, causal, autotuned) — the representative comparison

| model | dtype | TileOPs (TFLOPS) | FA3 (TFLOPS) | FlashInfer (TFLOPS) |
|---|---|---|---|---|
| Llama-3.1-8B  (B=2, H=32, Hkv=8, D=128) | fp16 | 412 (ws_causal) | **508** | 215 |
| Llama-3.1-8B  (B=2, H=32, Hkv=8, D=128) | bf16 | 107 (wgmma_pipelined) | **288** | 186 |
| Llama-3.1-70B (B=1, H=64, Hkv=8, D=128) | fp16 | 212 (ws_causal) | **236** | 216 |
| Llama-3.1-70B (B=1, H=64, Hkv=8, D=128) | bf16 | 146 (wgmma_pipelined) | **236** | 186 |

### Small / overhead-bound (S=512, causal) — latency-dominated, not throughput-representative

| model | dtype | TileOPs (TFLOPS) | FA3 (TFLOPS) | FlashInfer (TFLOPS) |
|---|---|---|---|---|
| Llama-3.1-8B  (B=4, H=32, Hkv=8, D=128) | fp16 | 215 (ws_causal) | **249** | 88 |
| Llama-3.1-8B  (B=4, H=32, Hkv=8, D=128) | bf16 | 81 (wgmma_pipelined) | **94** | 92 |
| Llama-3.1-70B (B=2, H=64, Hkv=8, D=128) | fp16 | 92 (ws_causal) | 94 | **196** |
| Llama-3.1-70B (B=2, H=64, Hkv=8, D=128) | bf16 | 86 (wgmma_pipelined) | 94 | **198** |

**Reading the compute-bound numbers:**
- **fp16 (ws_causal)** reaches **81–90% of FA3** and matches/beats FlashInfer — TileOPs' strong path.
- **bf16 (wgmma_pipelined)** is markedly weaker (**37–62% of FA3**), even behind FlashInfer. For the same causal shape fp16 dispatches to `ws_causal` but bf16 falls back to `wgmma_pipelined`, a separate perf gap unrelated to this fix (the barrier change has no measurable latency impact, see above). Worth a follow-up (bf16 support in the persistent kernel, or better wgmma bf16 autotune).

## Acceptance criteria (#1616)

- [x] Both failing fixed-length GQA sliding-window cases pass at `atol=1e-2, rtol=1e-2`.
- [x] Causal, left-window-only, no-window, and varlen cases remain green.
- [x] Right-window masking covered by the existing (now-passing) parametrizations in `test_gqa_sliding_window.py`.