### PR TITLE
[Fix][Kernel] fp8_lighting_indexer: drop block_Q=1 from autotune sweep

### DIFF
--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -10,6 +10,13 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8LightingIndexerKernel"]
 
+# Minimum block_Q (query rows per block) for the software-pipelined copy/gemm.
+# With block_Q == 1 the pipeline deadlocks: some warps never arrive at the
+# pipeline barrier and the launch spins on the GPU forever. block_Q == 1 tiles
+# run unpipelined instead. Verified on sm90 across heads in {32, 64, 128}:
+# block_Q == 1 + num_stages >= 1 hangs; block_Q >= 2 runs (any tile width).
+_MIN_PIPELINED_BLOCK_Q = 2
+
 
 @functools.lru_cache(maxsize=32)
 def _fp8_lighting_indexer_kernel(batch,
@@ -31,7 +38,12 @@ def _fp8_lighting_indexer_kernel(batch,
         block_Q=None,
     ):
         if block_Q is None:
-            block_Q = 128 // heads
+            block_Q = max(1, 128 // heads)
+        # block_Q == 1 deadlocks the pipeline barrier; run such tiles unpipelined.
+        # Guards every entry point (autotune, manual config, the default above):
+        # heads >= 65 makes the default block_Q == 1, which would otherwise hang.
+        if block_Q < _MIN_PIPELINED_BLOCK_Q:
+            num_stages = 0
         dtype = T.float8_e4m3fn
         accum_dtype = T.float32
         index_dtype = T.int32
@@ -239,12 +251,9 @@ class FP8LightingIndexerKernel(Kernel):
         block_N = [32, 64, 128]
         num_stages = [0, 1, 2]
         threads = [128, 256]
-        # Why: block_Q=1 deadlocks the pipelined copy/gemm whenever num_stages>=1
-        # (a single query row leaves threads that never arrive at the pipeline
-        # barrier), and a hung launch keeps spinning on the GPU long after the
-        # autotuner abandons it, wedging every later candidate. block_Q=1 is also
-        # the lowest-intensity tile and never wins; exclude it from the sweep.
-        block_Q = [2, 4]
+        # block_Q == 1 deadlocks the pipeline (see _MIN_PIPELINED_BLOCK_Q) and is
+        # also the lowest-arithmetic-intensity tile that never wins; omit it.
+        block_Q = [bq for bq in (1, 2, 4) if bq >= _MIN_PIPELINED_BLOCK_Q]
         _configs = list(itertools.product(block_N, num_stages, threads, block_Q))
 
         configs = [{

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -239,7 +239,12 @@ class FP8LightingIndexerKernel(Kernel):
         block_N = [32, 64, 128]
         num_stages = [0, 1, 2]
         threads = [128, 256]
-        block_Q = [1, 2, 4]
+        # Why: block_Q=1 deadlocks the pipelined copy/gemm whenever num_stages>=1
+        # (a single query row leaves threads that never arrive at the pipeline
+        # barrier), and a hung launch keeps spinning on the GPU long after the
+        # autotuner abandons it, wedging every later candidate. block_Q=1 is also
+        # the lowest-intensity tile and never wins; exclude it from the sweep.
+        block_Q = [2, 4]
         _configs = list(itertools.product(block_N, num_stages, threads, block_Q))
 
         configs = [{

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -10,11 +10,8 @@ from tileops.kernels.kernel_base import Kernel
 
 __all__ = ["FP8LightingIndexerKernel"]
 
-# Minimum block_Q (query rows per block) for the software-pipelined copy/gemm.
-# With block_Q == 1 the pipeline deadlocks: some warps never arrive at the
-# pipeline barrier and the launch spins on the GPU forever. block_Q == 1 tiles
-# run unpipelined instead. Verified on sm90 across heads in {32, 64, 128}:
-# block_Q == 1 + num_stages >= 1 hangs; block_Q >= 2 runs (any tile width).
+# block_Q == 1 deadlocks the software pipeline (some warps never reach the
+# pipeline barrier); such tiles must run unpipelined. block_Q >= 2 is safe.
 _MIN_PIPELINED_BLOCK_Q = 2
 
 
@@ -39,9 +36,7 @@ def _fp8_lighting_indexer_kernel(batch,
     ):
         if block_Q is None:
             block_Q = max(1, 128 // heads)
-        # block_Q == 1 deadlocks the pipeline barrier; run such tiles unpipelined.
-        # Guards every entry point (autotune, manual config, the default above):
-        # heads >= 65 makes the default block_Q == 1, which would otherwise hang.
+        # Guards every entry point, incl. the default block_Q == 1 for heads >= 65.
         if block_Q < _MIN_PIPELINED_BLOCK_Q:
             num_stages = 0
         dtype = T.float8_e4m3fn
@@ -251,8 +246,7 @@ class FP8LightingIndexerKernel(Kernel):
         block_N = [32, 64, 128]
         num_stages = [0, 1, 2]
         threads = [128, 256]
-        # block_Q == 1 deadlocks the pipeline (see _MIN_PIPELINED_BLOCK_Q) and is
-        # also the lowest-arithmetic-intensity tile that never wins; omit it.
+        # Omit block_Q == 1: unsafe to pipeline (above) and never wins.
         block_Q = [bq for bq in (1, 2, 4) if bq >= _MIN_PIPELINED_BLOCK_Q]
         _configs = list(itertools.product(block_N, num_stages, threads, block_Q))
 


### PR DESCRIPTION
> **Hotfix / stopgap.** Unblocks CI and closes a deadlock footgun. Does **not** fix the root design issue (`block_Q` is exposed as an independent autotune knob while it is coupled to `heads`); see Follow-up.

## Problem

`FP8LightingIndexerOp(..., tune=True)` hangs until the per-test timeout and fails the job. It surfaced on push-to-main / nightly but not on the introducing PR (#1632), because `gpu-smoke` runs `-m smoke` on PRs and `-m "smoke or full"` only on push — so the `full`-tier `tune=True` node never ran on that PR's gate.

## Root cause

Mapped on H200 across heads ∈ {32, 64, 128}: **the kernel deadlocks iff `block_Q == 1` and `num_stages >= 1`** (some warps never reach the software-pipeline barrier; the launch spins forever). An abandoned hung launch wedges the GPU, so every later autotune candidate times out too — the sweep never finishes within budget. Also a non-autotune footgun: the default `block_Q = 128 // heads` is `1` for `heads >= 65`.

## Fix

- Force `num_stages = 0` when `block_Q < 2` (guards autotune, manual config, and the default path).
- Harden default to `block_Q = max(1, 128 // heads)`.
- Drop `block_Q == 1` from `autotune_configs`.

Verified on H200: previously-hanging configs now run; `tune=True` test passes in ~9s warm / ~54s cold (was: timeout).

## Follow-up

Clean fix is to tune the q-tile and *derive* `block_Q` so degenerate configs can't be expressed (removes the guard). The silent deadlock is also a tilelang pipeline-codegen robustness bug.