### PR TITLE
[Feat][GEMM] Warp-specialized GEMM kernel (Hopper) + in-kernel timeline trace tool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,35 @@ def _under_repo_tests(item: pytest.Item) -> bool:
     return "tests/" in path and "benchmarks/tests/" not in path
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the opt-in in-kernel timeline-trace flag.
+
+    Off by default: when ``--trace-kernel`` is absent the process-local trace
+    switch stays off, so trace-dump tests no-op and normal runs are zero cost.
+    (``--trace`` itself is reserved by pytest for its pdb tracer.)
+    """
+    parser.addoption(
+        "--trace-kernel",
+        action="store_true",
+        default=False,
+        help="Build instrumented kernels with in-kernel tracing and dump their "
+             "timeline (HTML + Chrome JSON) for the trace-dump tests.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Flip the in-process trace switch on when ``--trace-kernel`` is passed.
+
+    Runs once at startup, before any kernel is built, so the traced build is the
+    one that gets cached. No environment variable is involved — the switch lives
+    in this pytest process only.
+    """
+    if config.getoption("--trace-kernel"):
+        from tileops.trace import trace
+
+        trace.enable()  # dumps to debug/ (gitignored)
+
+
 @pytest.fixture(autouse=True)
 def setup() -> None:
     torch.manual_seed(1235)

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -1,4 +1,3 @@
-
 import pytest
 import torch
 
@@ -33,6 +32,11 @@ class GemmFixture(FixtureBase):
                 1, 1024, 1024, torch.float16, False, True, False,
                 marks=pytest.mark.full,
                 id="full-fp16-trans-b-small-m",
+            ),
+            pytest.param(
+                128, 2112, 4096, torch.float16, False, True, False,
+                marks=pytest.mark.full,
+                id="full-fp16-nt-dense-ws",
             ),
             pytest.param(
                 1, 7168, 16384, torch.float16, False, True, True,

--- a/tileops/kernels/gemm.py
+++ b/tileops/kernels/gemm.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 from typing import Callable, Optional
 
 import tilelang
@@ -7,6 +6,7 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.trace import trace
 from tileops.utils import get_sm_version, str2dtype
 
 __all__ = [
@@ -21,17 +21,66 @@ def _gemm_kernel(m: int,
                  k: int,
                  trans_a: bool,
                  trans_b: bool,
-                 dtype: str = 'float16') -> Callable:
+                 dtype: str = "float16",
+                 traced: bool = False) -> Callable:
+    """Hand-written warp-specialized GEMM ``C = op(A) @ op(B)`` for Hopper (SM90).
+
+    One producer warpgroup (128 threads) issues TMA loads into a double-buffered
+    SMEM ring; one consumer warpgroup (128 threads) runs the WGMMA and accumulates
+    over K. All four layouts are covered by ``trans_a`` / ``trans_b`` (forwarded to
+    the WGMMA transpose flags): ``A`` is ``[M,K]`` (or ``[K,M]`` transposed), ``B``
+    is ``[K,N]`` (or ``[N,K]`` transposed), ``C`` is ``[M,N]``. fp16 / bf16 inputs,
+    fp32 accumulation. The auto warp-specialization pass is disabled so it does not
+    fire on top of this manual layout.
+
+    TMA constraint: each input's innermost (contiguous) dimension must be a
+    multiple of 8 elements (16-byte alignment). That dim is ``K`` for a
+    non-transposed ``A`` and a transposed ``B``, ``M`` for a transposed ``A``, and
+    ``N`` for a non-transposed ``B``. So NT (``A@Bᵀ``) only requires ``K % 8 == 0``;
+    other layouts additionally require the relevant ``M`` / ``N`` to be aligned.
+
+    Args:
+        m: Rows of ``op(A)`` / ``C``.
+        n: Columns of ``op(B)`` / ``C``.
+        k: Contraction dim.
+        trans_a: Whether ``A`` is stored transposed (``[K, M]``).
+        trans_b: Whether ``B`` is stored transposed (``[N, K]``).
+        dtype: Activation / weight dtype string (``"float16"`` or ``"bfloat16"``).
+        traced: Build with in-kernel timeline markers materialized (``True``) or
+            stripped to zero cost (``False``). **Part of the cache key**: traced
+            and untraced builds are distinct cached kernels, so flipping the
+            process trace switch never returns a stale variant. Callers pass
+            ``trace.enabled`` explicitly rather than letting the build read the
+            global switch.
+
+    Returns:
+        A ``@tilelang.jit`` factory; calling it with ``(block_m, block_n,
+        block_k, num_stages)`` returns the compiled ``prim_func``. When ``traced``
+        it materializes the markers and appends a trailing ``slots`` output (so
+        ``out_idx`` returns ``(C, slots)``); otherwise ``C`` is the lone output.
+    """
     accum_dtype = "float"
+    a_shape = (k, m) if trans_a else (m, k)
+    b_shape = (n, k) if trans_b else (k, n)
 
-    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _gemm_func(block_m: int = 128, block_n: int = 256, block_k: int = 64, threads: int = 256,
-                   num_stages: int = 3, enable_rasterization: bool = True) -> Callable:
-
-        a_shape = (k, m) if trans_a else (m, k)
-        b_shape = (n, k) if trans_b else (k, n)
-        a_shared_shape = (block_k, block_m) if trans_a else (block_m, block_k)
-        b_shared_shape = (block_n, block_k) if trans_b else (block_k, block_n)
+    @tilelang.jit(
+        out_idx=trace.out_idx(1, traced),
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _gemm_func(block_m: int = 128,
+                   block_n: int = 128,
+                   block_k: int = 64,
+                   num_stages: int = 3) -> Callable:
+        # Manual 2-warpgroup WS: 1 producer WG (128 threads) issues TMA, 1
+        # consumer WG (128 threads) runs WGMMA. Barrier arrive_counts (128) are
+        # bound to this layout, so threads is fixed at 256.
+        threads = 256
+        k_iters = T.ceildiv(k, block_k)
+        # SMEM tile shapes follow the storage layout; the WGMMA transpose flags
+        # reconcile them with the logical (M,K) x (K,N) contraction.
+        a_tile = (block_k, block_m) if trans_a else (block_m, block_k)
+        b_tile = (block_n, block_k) if trans_b else (block_k, block_n)
 
         @T.prim_func
         def _gemm_main(
@@ -41,38 +90,122 @@ def _gemm_kernel(m: int,
         ) -> None:
             with T.Kernel(
                     T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
-                a_shared = T.alloc_shared(a_shared_shape, dtype)
-                b_shared = T.alloc_shared(b_shared_shape, dtype)
+                # Multi-stage ring of A/B SMEM buffers. Indexed by stage = gi %
+                # num_stages; the phase bit flips every num_stages iterations.
+                a_smem = T.alloc_shared((num_stages,) + a_tile, dtype)
+                b_smem = T.alloc_shared((num_stages,) + b_tile, dtype)
                 c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
-                c_shared = T.alloc_shared((block_m, block_n), dtype)
 
                 T.annotate_layout({
-                    c_shared: tilelang.layout.make_swizzled_layout(c_shared),
+                    a_smem: tilelang.layout.make_swizzled_layout(a_smem),
+                    b_smem: tilelang.layout.make_swizzled_layout(b_smem),
                 })
-                T.use_swizzle(10, enable=enable_rasterization)
 
-                T.clear(c_local)
+                # Producer→consumer (buffer full) and consumer→producer (buffer
+                # empty) barriers, one per ring slot. Each is arrived by exactly
+                # one warpgroup (128 threads). Allocated as length-num_stages
+                # barrier arrays and indexed by the static slot id.
+                ab_full = T.alloc_barrier([128] * num_stages)
+                ab_empty = T.alloc_barrier([128] * num_stages)
 
-                for _k in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
-                    if not trans_a:
-                        # a: (m, k)
-                        T.copy(a[by * block_m, _k * block_k], a_shared)  # [block_m, block_k]
-                    else:
-                        # a: (k, m)
-                        T.copy(a[_k * block_k, by * block_m], a_shared)  # [block_k, block_m]
+                # Monotonic per-warpgroup iteration counters; stage = gi %
+                # num_stages, phase = (gi // num_stages) % 2.
+                gi_prod = T.alloc_var("int32", init=0)
+                gi_cons = T.alloc_var("int32", init=0)
 
-                    if not trans_b:
-                        # b: (k, n)
-                        T.copy(b[_k * block_k, bx * block_n], b_shared)  # [block_k, block_n]
-                    else:
-                        # b: (n, k)
-                        T.copy(b[bx * block_n, _k * block_k], b_shared)  # [block_n, block_k]
-                    T.gemm(a_shared, b_shared, c_local, trans_a, trans_b)
+                m_start = by * block_m
+                n_start = bx * block_n
 
-                T.copy(c_local, c_shared)
-                T.copy(c_shared, c[by * block_m, bx * block_n])
+                tx = T.get_thread_binding()
 
-        return _gemm_main
+                if tx < 128:
+                    # ── Producer warpgroup: issue TMA loads of A and B tiles. ──
+                    # Intern the "producer" group first so it gets gid 0.
+                    T.dec_max_nreg(24)
+                    with trace.group("producer", lead=0):
+                        for ki in T.serial(k_iters):
+                            stage = gi_prod % num_stages
+                            phase = (gi_prod // num_stages) % 2
+                            k_start = ki * block_k
+                            # Unroll the ring-slot dispatch at trace time: each
+                            # slot gets a static SMEM/barrier index under a
+                            # dynamic `stage == s` guard.
+                            for s in range(num_stages):
+                                if stage == s:
+                                    # Wait for this slot to be drained before
+                                    # reuse. The consumer leaves the slot in
+                                    # empty-phase (phase ^ 1) for the round the
+                                    # producer is about to refill; rounds
+                                    # 0..num_stages-1 see the init-0 state (phase
+                                    # ^ 1 == 1) which is already satisfied by the
+                                    # barrier's initial parity.
+                                    T.barrier_wait(ab_empty[s], phase ^ 1)
+                                    with trace.range("tma", lane="tma"):
+                                        if trans_a:
+                                            T.tma_copy(
+                                                a[k_start:k_start + block_k,
+                                                  m_start:m_start + block_m],
+                                                a_smem[s, :, :], barrier=ab_full[s])
+                                        else:
+                                            T.tma_copy(
+                                                a[m_start:m_start + block_m,
+                                                  k_start:k_start + block_k],
+                                                a_smem[s, :, :], barrier=ab_full[s])
+                                        if trans_b:
+                                            T.tma_copy(
+                                                b[n_start:n_start + block_n,
+                                                  k_start:k_start + block_k],
+                                                b_smem[s, :, :], barrier=ab_full[s])
+                                        else:
+                                            T.tma_copy(
+                                                b[k_start:k_start + block_k,
+                                                  n_start:n_start + block_n],
+                                                b_smem[s, :, :], barrier=ab_full[s])
+                                    with trace.range("arrive", lane="barrier"):
+                                        T.barrier_arrive(ab_full[s])
+                            gi_prod = gi_prod + 1
+                else:
+                    # ── Consumer warpgroup: run WGMMA, accumulate over K. ──
+                    T.inc_max_nreg(240)
+                    T.clear(c_local)
+                    with trace.group("consumer", lead=128):
+                        for ki in T.serial(k_iters):
+                            stage = gi_cons % num_stages
+                            phase = (gi_cons // num_stages) % 2
+                            for s in range(num_stages):
+                                if stage == s:
+                                    with trace.range("wait", lane="barrier"):
+                                        T.barrier_wait(ab_full[s], phase)
+                                    with trace.range("mma", lane="wgmma"):
+                                        T.wgmma_gemm(
+                                            a_smem[s, :, :],
+                                            b_smem[s, :, :],
+                                            c_local,
+                                            transpose_A=trans_a,
+                                            transpose_B=trans_b,
+                                            policy=T.GemmWarpPolicy.FullRow,
+                                            clear_accum=(ki == 0),
+                                        )
+                                        T.wait_wgmma(0)
+                                    T.warpgroup_fence_operand(c_local, num_regs=64)
+                                    T.barrier_arrive(ab_empty[s])
+                            gi_cons = gi_cons + 1
+
+                        # Epilogue: guard the M/N tail so partial tiles don't
+                        # write out of bounds (m / n need not be multiples of the
+                        # block sizes; K tails are zero-filled by TMA).
+                        with trace.range("epilogue"):
+                            for i, j in T.Parallel(block_m, block_n):
+                                if m_start + i < m and n_start + j < n:
+                                    c[m_start + i, n_start + j] = c_local[i, j]
+
+                # Build-time flow declaration: producer "arrive" → consumer
+                # "wait" (fixed per-iter pairing).
+                trace.dag("arrive", "wait")
+
+        # Materialize markers + append ``slots`` when traced; no-op them (identical
+        # CUDA to an un-instrumented build) otherwise. Pairs with ``out_idx`` above.
+        return trace.finalize(_gemm_main, traced=traced, max_events=1024)
 
     return _gemm_func
 
@@ -89,26 +222,36 @@ def _gemm_wrapped_kernel(
     block_n: int,
     block_k: int,
     num_stages: int,
-    threads: int,
-    enable_rasterization: bool,
     a: torch.Tensor,
     b: torch.Tensor,
 ) -> torch.Tensor:
-    return _gemm_kernel(m, n, k, trans_a, trans_b, dtype)(block_m, block_n, block_k, threads,
-                                                          num_stages, enable_rasterization)(a, b)
+    """Run the warp-specialized GEMM ``C = op(A) @ op(B)`` (torch custom op).
+
+    Kept for ``torch.compile`` compatibility (registered op + ``register_fake``).
+    ``GemmKernel.forward`` calls the compiled JIT directly (cf. ``GemvKernel``),
+    so this wrapper is not on the eager forward path.
+    """
+    return _gemm_kernel(m, n, k, trans_a, trans_b, dtype)(
+        block_m, block_n, block_k, num_stages)(a, b)
 
 
 @_gemm_wrapped_kernel.register_fake
-def _(m: int, n: int, k: int,
-      trans_a: bool, trans_b: bool,
-      dtype: str, block_m: int, block_n: int, block_k: int,
-      num_stages: int, threads: int, enable_rasterization: bool,
+def _(m: int, n: int, k: int, trans_a: bool, trans_b: bool, dtype: str,
+      block_m: int, block_n: int, block_k: int, num_stages: int,
       *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
     return torch.empty((m, n), dtype=inputs[0].dtype, device=inputs[0].device)
 
 
 class GemmKernel(Kernel):
-    supported_archs: list[int] = [80, 89, 90]
+    """Dense GEMM kernel: a hand-written warp-specialized implementation (SM90).
+
+    Computes ``C = op(A) @ op(B)`` for any ``(trans_a, trans_b)`` layout. One
+    producer warpgroup issues TMA loads into a double-buffered SMEM ring; one
+    consumer warpgroup runs the WGMMA over K. fp16 / bf16 inputs, fp32
+    accumulation. Hopper-only — TMA + WGMMA require SM90.
+    """
+
+    supported_archs: list[int] = [90]
 
     def __init__(self,
                  m: int,
@@ -133,63 +276,24 @@ class GemmKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # From tilelang/examples/gemm/example_gemm_autotune.py
-        sm_version = get_sm_version()
-
-        if sm_version in {80}:
-            return {
-                "block_m": 128,
-                "block_n": 256,
-                "block_k": 32,
-                "num_stages": 2,
-                "threads": 128,
-                "enable_rasterization": True
-            }
-        if sm_version in {90}:
-            return {
-                "block_m": 128,
-                "block_n": 256,
-                "block_k": 64,
-                "num_stages": 3,
-                "threads": 256,
-                "enable_rasterization": True
-            }
-
         return {
             "block_m": 128,
-            "block_n": 256,
-            "block_k": 32,
-            "num_stages": 0,
-            "threads": 128,
-            "enable_rasterization": True
+            "block_n": 128,
+            "block_k": 64,
+            "num_stages": 3,
         }
 
-    @property
-    def autotune_configs(self) -> list[dict]:
-        # From tilelang/examples/gemm/example_gemm_autotune.py
-        block_m = [64, 128, 256]
-        block_n = [64, 128, 256]
-        block_k = [32, 64]
-        num_stages = [0, 1, 2, 3]
-        threads = [128, 256]
-        enable_rasterization = [True, False]
-        _configs = list(
-            itertools.product(block_m, block_n, block_k, num_stages, threads, enable_rasterization))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'block_k': c[2],
-            'num_stages': c[3],
-            'threads': c[4],
-            'enable_rasterization': c[5]
-        } for c in _configs]
-
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        return _gemm_wrapped_kernel(self.m, self.n, self.k, self.trans_a, self.trans_b,
-                                    self.dtype_str, self.config["block_m"], self.config["block_n"],
-                                    self.config["block_k"], self.config["num_stages"],
-                                    self.config["threads"], self.config["enable_rasterization"], a, b)
+        # Call the compiled JIT directly (cf. GemvKernel); _gemm_wrapped_kernel is
+        # kept only for torch.compile compatibility. trace.run dumps the timeline
+        # when tracing is on and otherwise just returns C — so no branch here.
+        compiled = _gemm_kernel(
+            self.m, self.n, self.k, self.trans_a, self.trans_b, self.dtype_str,
+            traced=trace.enabled)(**self.config)
+        layout = f"{'T' if self.trans_a else 'N'}{'T' if self.trans_b else 'N'}"
+        return trace.run(
+            compiled, (a, b),
+            stem=f"gemm_{self.m}x{self.n}x{self.k}_{layout}_{self.dtype_str}")
 
 
 # TODO: add persistent, split-k, steam-k...

--- a/tileops/ops/gemm.py
+++ b/tileops/ops/gemm.py
@@ -89,7 +89,8 @@ class GemmOp(Op):
         """Return ``(mode, kernel)`` for the given dims, building/caching lazily.
 
         ``mode`` is ``"lhs_row"``/``"rhs_col"`` for the GEMV fast path, else
-        ``"gemm"``.
+        ``"gemm"`` — the hand-written warp-specialized ``GemmKernel`` (SM90),
+        covering all four ``(trans_a, trans_b)`` layouts.
         """
         gemv_lhs_row = (m == 1 and not self.trans_a and self.trans_b)
         gemv_rhs_col = (n == 1 and not self.trans_a and not self.trans_b)

--- a/tileops/trace/__init__.py
+++ b/tileops/trace/__init__.py
@@ -1,0 +1,35 @@
+"""In-kernel timeline trace tool: annotate, build, run, and export a timeline.
+
+The whole surface is the :data:`trace` namespace (see :mod:`tileops.trace.api`
+for the full, example-driven reference). In short: ``trace.enable()`` turns
+tracing on, ``with trace.range(...)`` / ``trace.group(...)`` mark up a kernel
+body, ``trace.out_idx`` + ``trace.finalize`` wire it into a vanilla
+``@tilelang.jit`` builder, and ``trace.run`` executes the kernel and dumps the
+timeline. With tracing off, markers are stripped and the generated CUDA is
+identical to an un-instrumented build.
+
+Lane names are interned dynamically at build time (default ``"main"``); at most
+16 distinct lanes fit the packed 4-bit lane field.
+
+Importing this package does **not** touch ``tilelang``: there is no monkeypatch,
+and ``tilelang.compile`` / ``tilelang.jit.compile`` stay the originals.
+"""
+
+from .api import trace
+from .decode import FlowEdge, Instant, Slice, compute_flows, decode
+from .record import MAX_EVENTS_DEFAULT, EventKind, pack_w1, unpack_w1
+from .ui import export_timeline_html
+
+__all__ = [
+    "MAX_EVENTS_DEFAULT",
+    "EventKind",
+    "FlowEdge",
+    "Instant",
+    "Slice",
+    "compute_flows",
+    "decode",
+    "export_timeline_html",
+    "pack_w1",
+    "trace",
+    "unpack_w1",
+]

--- a/tileops/trace/api.py
+++ b/tileops/trace/api.py
@@ -1,0 +1,410 @@
+"""Public API for the in-kernel timeline trace tool.
+
+``trace`` is a single namespace object. Import it and use four groups of methods:
+
+- **Switch** — ``enable`` / ``disable`` / ``enabled`` / ``output``: turn tracing on
+  for this process and choose where dumps land.
+- **Annotate** — ``group`` / ``range`` / ``range_start`` / ``range_end`` / ``record``
+  / ``dag``: mark up a kernel body. Markers are *always* emitted; a build either
+  lowers them (traced) or strips them (zero cost).
+- **Build** — ``out_idx`` / ``finalize`` (and the ``lower`` / ``strip`` primitives):
+  call inside a ``@tilelang.jit`` builder so the right ``out_idx`` and marker
+  handling apply automatically based on the switch.
+- **Run & export** — ``run`` (one call: execute, dump, return outputs), or the
+  ``decode`` / ``dump`` / ``export_html`` building blocks.
+
+End-to-end::
+
+    import functools, tilelang
+    import tilelang.language as T
+    from tileops.trace import trace
+
+    @functools.lru_cache
+    def build():
+        @tilelang.jit(out_idx=trace.out_idx(1))      # +1 output (slots) when tracing
+        def factory(block=128):
+            @T.prim_func
+            def main(a: T.Tensor(...), b: T.Tensor(...), c: T.Tensor(...)):
+                with T.Kernel(...):
+                    with trace.range("compute"):
+                        ...
+            return trace.finalize(main, max_events=1024)   # lower if on, else strip
+        return factory
+
+    trace.enable()                                     # dumps to debug/ (gitignored)
+    compiled = build()(block=128)
+    c = trace.run(compiled, (a, b), stem="my_kernel")  # writes debug/my_kernel.html
+"""
+
+import os
+
+from . import passes
+from .decode import decode as _decode
+from .markers import (
+    DEFAULT_LANE,
+    AnnoToken,
+    GroupScope,
+    RangeScope,
+    close_range,
+    declare_flow,
+    emit_instant,
+    open_range,
+)
+from .record import MAX_EVENTS_DEFAULT
+from .ui import export_timeline_html as _export_timeline_html
+
+__all__ = ["trace"]
+
+
+class _Trace:
+    """The ``trace`` namespace (use the singleton :data:`trace`, do not instantiate).
+
+    Stateless except for the process-local run switch (:attr:`enabled` /
+    :attr:`output`); all annotation state lives in the per-build registry.
+    """
+
+    def __init__(self) -> None:
+        self._enabled = False
+        self._output = "debug"
+
+    # == Switch =============================================================
+
+    @property
+    def enabled(self) -> bool:
+        """Whether tracing is on for this process (default ``False``).
+
+        Example:
+            >>> trace.enabled
+            False
+        """
+        return self._enabled
+
+    @property
+    def output(self) -> str:
+        """Output directory for dumped artifacts (default ``"debug"``).
+
+        Example:
+            >>> trace.output
+            'debug'
+        """
+        return self._output
+
+    def enable(self, output: str = "debug") -> None:
+        """Turn tracing on for this process and set the output directory.
+
+        Call once at startup, before any traced kernel is built — a builder reads
+        :attr:`enabled` at build time and is typically cached.
+
+        Args:
+            output: Directory for dumped artifacts (created on first :meth:`dump`).
+                Defaults to ``"debug"`` (gitignored).
+
+        Example:
+            >>> trace.enable()              # dumps under debug/
+            >>> trace.enable("out/traces")  # or a directory of your choosing
+        """
+        self._enabled = True
+        self._output = output
+
+    def disable(self) -> None:
+        """Turn tracing off for this process.
+
+        Example:
+            >>> trace.disable()
+        """
+        self._enabled = False
+
+    # == Annotate (inside a kernel body) ====================================
+
+    def group(self, name: str, lead: int) -> GroupScope:
+        """Declare the logical work-group enclosed markers belong to.
+
+        Governs only *who records* (the elected writer is ``tx == lead``); the
+        enclosed compute still runs on all threads.
+
+        Args:
+            name: Work-group name, interned to a stable group id.
+            lead: Branch-baseline thread id of the electing writer.
+
+        Returns:
+            A ``with`` context manager.
+
+        Example:
+            >>> with trace.group("producer", lead=0):
+            ...     with trace.range("tma"):
+            ...         ...  # only thread 0 records
+        """
+        return GroupScope(name, lead)
+
+    def range(self, name: str, lane: str = DEFAULT_LANE) -> RangeScope:
+        """Time a span: RANGE_BEGIN on enter, RANGE_END on exit.
+
+        Args:
+            name: Range name, interned to a stable event id.
+            lane: Render sub-lane, interned dynamically (default ``"main"``).
+
+        Returns:
+            A ``with`` context manager.
+
+        Example:
+            >>> with trace.range("mma", lane="wgmma"):
+            ...     T.wgmma_gemm(...)
+        """
+        return RangeScope(name, lane)
+
+    def range_start(self, name: str, lane: str = DEFAULT_LANE) -> "AnnoToken":
+        """Open a range explicitly (use when ``with`` does not fit the control flow).
+
+        Args:
+            name: Range name, interned to a stable event id.
+            lane: Render sub-lane, interned dynamically (default ``"main"``).
+
+        Returns:
+            A token to pass to :meth:`range_end`.
+
+        Example:
+            >>> tok = trace.range_start("phase")
+            >>> ...  # work
+            >>> trace.range_end(tok)
+        """
+        return open_range(name, lane)
+
+    def range_end(self, tok: "AnnoToken | None") -> None:
+        """Close the range opened for ``tok`` (``None`` no-ops).
+
+        Args:
+            tok: The token returned by :meth:`range_start`.
+
+        Example:
+            >>> trace.range_end(tok)
+        """
+        close_range(tok)
+
+    def record(self, name: str, payload=None, lane: str = DEFAULT_LANE) -> None:
+        """Emit a single instant event (a zero-width mark).
+
+        Args:
+            name: Event name, interned to a stable event id.
+            payload: Optional 32-bit i32 payload — a Python ``int`` or a runtime
+                PrimExpr (e.g. a loop index). ``None`` records 0.
+            lane: Render sub-lane, interned dynamically (default ``"main"``).
+
+        Example:
+            >>> trace.record("iter", payload=ki)  # tag the mark with the loop index
+        """
+        emit_instant(name, payload, lane)
+
+    def dag(self, src_name: str, dst_name: str) -> None:
+        """Declare a dependency arrow from one named range to another.
+
+        Call once in the kernel body. Emits no device marker; at render time each
+        CTA's ``src_name`` slices are paired with its ``dst_name`` slices in
+        timestamp order, drawing one arrow per pair.
+
+        Args:
+            src_name: Source (producer-side) range name.
+            dst_name: Destination (consumer-side) range name.
+
+        Example:
+            >>> trace.dag("arrive", "wait")  # producer "arrive" -> consumer "wait"
+        """
+        declare_flow(src_name, dst_name)
+
+    # == Build (inside a @tilelang.jit builder) =============================
+
+    def out_idx(self, n_outputs: int, traced: bool | None = None) -> list[int]:
+        """Return the ``out_idx`` for a kernel with ``n_outputs`` real outputs.
+
+        Grows by one (for the trailing ``slots`` output that :meth:`finalize`
+        appends) when traced, so the same builder works either way.
+
+        Args:
+            n_outputs: Number of real (non-``slots``) outputs.
+            traced: Whether this build is traced. ``None`` (default) reads the
+                process switch :attr:`enabled`. **A cached builder must pass an
+                explicit value** and include it in its cache key — otherwise the
+                ``out_idx`` baked into the cached kernel ignores later switch flips.
+
+        Returns:
+            Negative output indices for ``@tilelang.jit``.
+
+        Example:
+            >>> @tilelang.jit(out_idx=trace.out_idx(1))          # follows the switch
+            ... def factory(): ...
+            >>> @tilelang.jit(out_idx=trace.out_idx(1, traced))  # cached builder
+            ... def factory(): ...
+        """
+        enabled = self._enabled if traced is None else traced
+        n = n_outputs + 1 if enabled else n_outputs
+        return list(range(-n, 0))
+
+    def finalize(self, primfunc, traced: bool | None = None,
+                 max_events: int = MAX_EVENTS_DEFAULT):
+        """Lower the markers when traced, else strip them — return either.
+
+        The one line a builder returns instead of branching. Pairs with
+        :meth:`out_idx`; pass the same ``traced`` to both.
+
+        Args:
+            primfunc: The built kernel; its body carries ``trace.*`` markers.
+            traced: Whether this build is traced. ``None`` (default) reads the
+                process switch :attr:`enabled`. A cached builder must pass an
+                explicit value (see :meth:`out_idx`).
+            max_events: Per-slot event capacity when lowering.
+
+        Returns:
+            A ``PrimFunc`` ready for ``@tilelang.jit`` (with a trailing ``slots``
+            output when traced).
+
+        Example:
+            >>> def factory():
+            ...     @T.prim_func
+            ...     def main(...): ...
+            ...     return trace.finalize(main, traced, max_events=1024)
+        """
+        enabled = self._enabled if traced is None else traced
+        return self.lower(primfunc, max_events) if enabled else self.strip(primfunc)
+
+    def lower(self, primfunc, max_events: int = MAX_EVENTS_DEFAULT):
+        """Primitive: materialize the markers and append the ``slots`` output.
+
+        Prefer :meth:`finalize` unless you need to lower unconditionally.
+
+        Args:
+            primfunc: The built kernel; its body carries ``trace.*`` markers.
+            max_events: Per-slot event capacity (compile-time cursor bound).
+
+        Returns:
+            The lowered ``PrimFunc`` with a trailing ``slots`` int64 output.
+
+        Example:
+            >>> return trace.lower(main, max_events=1024)
+        """
+        return passes.lower(primfunc, max_events=max_events)
+
+    def strip(self, primfunc):
+        """Primitive: no-op every marker so the kernel compiles without tracing.
+
+        Prefer :meth:`finalize` unless you need to strip unconditionally. The
+        generated CUDA is identical to an un-instrumented build.
+
+        Args:
+            primfunc: The built kernel; its body may carry ``trace.*`` markers.
+
+        Returns:
+            A ``PrimFunc`` with markers no-opped, signature unchanged.
+
+        Example:
+            >>> return trace.strip(main)
+        """
+        return passes.strip(primfunc)
+
+    # == Run & export =======================================================
+
+    def run(self, compiled, inputs: tuple, *, stem: str):
+        """Run a kernel and, when tracing is on, dump its timeline.
+
+        The one call a ``forward`` needs — it branches on the switch internally,
+        so the caller does not. With tracing **off** it just returns the kernel's
+        outputs unchanged. With tracing **on** the kernel is the traced build
+        (returns ``(*real_outputs, slots)``): this splits the trailing ``slots``
+        tensor off, decodes it, writes the timeline via :meth:`dump` (a fresh file
+        each call), and returns the real outputs only.
+
+        Args:
+            compiled: A compiled kernel. Build it with ``traced=trace.enabled``
+                (via :meth:`out_idx` / :meth:`finalize`) so its outputs match the
+                switch.
+            inputs: Tuple of positional tensors to pass to ``compiled``.
+            stem: Descriptive file stem (op name + shape); see :meth:`dump`.
+
+        Returns:
+            The kernel's real outputs: a single tensor, or a tuple in order.
+
+        Example:
+            >>> compiled = build()(block=128)
+            >>> c = trace.run(compiled, (a, b), stem="gemm_128x256x512")
+        """
+        out = compiled(*inputs)
+        if not self._enabled:
+            return out
+        real = list(out) if isinstance(out, (tuple, list)) else [out]
+        slots = real.pop()
+        base = self.dump(self.decode(compiled, slots), compiled, stem=stem)
+        print(f"[trace] wrote timeline {base}.html")
+        return real[0] if len(real) == 1 else tuple(real)
+
+    def decode(self, compiled, slots) -> list:
+        """Decode a returned ``slots`` tensor into render-ready events.
+
+        Resolves the host decode maps from the compiled kernel.
+
+        Args:
+            compiled: The compiled traced kernel (carries the host maps).
+            slots: The trailing ``slots`` int64 tensor the kernel returned.
+
+        Returns:
+            A flat list of ``Slice`` / ``Instant`` events.
+
+        Example:
+            >>> *_, slots = compiled(a, b)
+            >>> events = trace.decode(compiled, slots)
+        """
+        maps = passes.lookup_meta(compiled)
+        return _decode(slots, id_to_name=maps["id_to_name"],
+                       group_id_to_name=maps["group_id_to_name"],
+                       lane_id_to_name=maps["lane_id_to_name"],
+                       max_events=maps["max_events"], num_groups=maps["num_groups"])
+
+    def dump(self, events: list, compiled, *, stem: str) -> str:
+        """Write events as an HTML timeline under :attr:`output`, never overwriting.
+
+        Picks a collision-free base name: ``{output}/{stem}`` when free, else
+        ``{output}/{stem}_1``, ``_2``, ... so repeated dumps accumulate.
+
+        Args:
+            events: Event list from :meth:`decode`.
+            compiled: The compiled traced kernel (carries the host maps).
+            stem: File stem (no directory, no extension), e.g. op name + shape.
+
+        Returns:
+            The base path written (no extension); ``{base}.html`` exists.
+
+        Example:
+            >>> base = trace.dump(events, compiled, stem="gemm_128x256x512")
+            >>> base
+            'debug/gemm_128x256x512'
+        """
+        os.makedirs(self._output, exist_ok=True)
+        base = os.path.join(self._output, stem)
+        if os.path.exists(f"{base}.html"):
+            i = 1
+            while os.path.exists(f"{base}_{i}.html"):
+                i += 1
+            base = f"{base}_{i}"
+        self.export_html(events, f"{base}.html", compiled=compiled)
+        return base
+
+    def export_html(self, events: list, path: str, *, compiled,
+                    title: str = "", sm_clock_ghz: float = 1.5) -> None:
+        """Write events as a self-contained Plotly HTML timeline.
+
+        Args:
+            events: Event list from :meth:`decode`.
+            path: Destination ``.html`` path.
+            compiled: The compiled traced kernel (carries the host maps).
+            title: Base figure title; the CTA index is appended per tab.
+            sm_clock_ghz: Locked SM clock in GHz for the ``~ns`` hover column.
+
+        Example:
+            >>> trace.export_html(events, "timeline.html", compiled=compiled)
+        """
+        maps = passes.lookup_meta(compiled)
+        _export_timeline_html(events, path, group_id_to_name=maps["group_id_to_name"],
+                              lane_id_to_name=maps["lane_id_to_name"],
+                              flows=maps["flows"], title=title,
+                              sm_clock_ghz=sm_clock_ghz)
+
+
+# The singleton namespace: ``from tileops.trace import trace``.
+trace = _Trace()

--- a/tileops/trace/decode.py
+++ b/tileops/trace/decode.py
@@ -1,0 +1,284 @@
+"""Host-side decode of the single ``slots`` buffer into ``Slice`` / ``Instant``.
+
+After readback the device emits one ``slots`` int64 tensor of shape
+``(num_cta, num_groups, (max_events + 1) * 2)`` (the layout
+:func:`tileops.trace.passes.lower` writes). Each ``(cta, gid)`` slot row
+is a flat run of int64 words:
+
+* ``word[0]`` = event count (header), saturated at ``max_events``.
+* ``word[1]`` = reserved (garbage from ``torch.empty``; ignored).
+* event ``e`` in ``[0, count)`` occupies words ``[(e + 1) * 2, (e + 1) * 2 + 1]``::
+
+      word[(e + 1) * 2]      = clock64 timestamp (int64)
+      word[(e + 1) * 2 + 1]  = pack_w1(event_id, kind, lane, payload)
+
+This module turns those raw words into render-ready objects: per ``(cta, gid)``
+slot it reads the header count, unpacks each ``w1`` word, zeroes timestamps per
+**CTA**, and stack-matches RANGE_BEGIN/RANGE_END pairs per ``(cta, gid, lane)``
+track into :class:`Slice` objects. INSTANT records become :class:`Instant`
+objects. The ``lane`` in each track is the interned lane id; exporters resolve it
+to a name via the ``lane_id_to_name`` map.
+
+Flow arrows are NOT decoded from records: ``trace.dag`` is a build-time
+declaration, so no flow record exists on the device. Instead :func:`compute_flows`
+takes the decoded :class:`Slice` list plus the declared ``(src_name, dst_name)``
+pairs and, per CTA, pairs the i-th ``src_name`` slice with the i-th ``dst_name``
+slice (both in timestamp order) into :class:`FlowEdge` objects.
+
+Per-CTA timestamp zeroing:
+    ``clock64`` is a per-SM counter, so timestamps are only comparable within a
+    single CTA (all of a CTA's groups run on the same SM). Each CTA subtracts the
+    minimum timestamp across all of its groups and events, giving the producer and
+    consumer warpgroups of one CTA a shared origin while keeping different CTAs
+    independent.
+"""
+
+from dataclasses import dataclass
+
+from .record import EventKind, unpack_w1
+
+__all__ = ["FlowEdge", "Instant", "Slice", "compute_flows", "cycles_to_us", "decode"]
+
+
+@dataclass
+class Slice:
+    """A completed RANGE_BEGIN/RANGE_END span on one render track.
+
+    Attributes:
+        track: Render track ``(cta, gid, lane)``.
+        name: Human-readable event name from ``id_to_name``.
+        ts_cy: Per-CTA-zeroed start timestamp in ``clock64`` cycles.
+        dur_cy: Span duration in cycles (end minus start, non-negative).
+        payload: Raw 32-bit payload from the RANGE_BEGIN record, or ``None``.
+    """
+
+    track: tuple
+    name: str
+    ts_cy: int
+    dur_cy: int
+    payload: int | None
+
+
+@dataclass
+class Instant:
+    """A point-in-time INSTANT marker on one render track.
+
+    Attributes:
+        track: Render track ``(cta, gid, lane)``.
+        name: Human-readable event name from ``id_to_name``.
+        ts_cy: Per-CTA-zeroed timestamp in ``clock64`` cycles.
+        payload: Raw 32-bit payload from the record, or ``None``.
+    """
+
+    track: tuple
+    name: str
+    ts_cy: int
+    payload: int | None
+
+
+@dataclass
+class FlowEdge:
+    """One resolved flow arrow connecting a source slice to a destination slice.
+
+    Built by :func:`compute_flows` from a declared ``(src_name, dst_name)`` flow:
+    per CTA, the i-th ``src_name`` slice (by start timestamp) pairs with the i-th
+    ``dst_name`` slice. The arrow runs from the source slice's END to the
+    destination slice's START.
+
+    Attributes:
+        src_track: Source render track ``(cta, gid, lane)``.
+        src_ts_cy: Per-CTA-zeroed source endpoint (source slice end) in cycles.
+        dst_track: Destination render track ``(cta, gid, lane)``.
+        dst_ts_cy: Per-CTA-zeroed destination endpoint (dest slice start) in cycles.
+        src_name: Source range name.
+        dst_name: Destination range name.
+    """
+
+    src_track: tuple
+    src_ts_cy: int
+    dst_track: tuple
+    dst_ts_cy: int
+    src_name: str
+    dst_name: str
+
+
+def cycles_to_us(cy: int, sm_clock_ghz: float = 1.5) -> float:
+    """Convert a ``clock64`` cycle count to microseconds at a fixed SM clock.
+
+    Args:
+        cy: Cycle count (e.g. a ``Slice.dur_cy`` or zeroed ``ts_cy``).
+        sm_clock_ghz: Locked SM clock in GHz (1.5 GHz on the bench rig).
+
+    Returns:
+        The duration in microseconds (``cy / (sm_clock_ghz * 1e3)``).
+    """
+    return cy / (sm_clock_ghz * 1e3)
+
+
+def _to_numpy(arr):
+    """Return ``arr`` as a host numpy array, accepting torch tensors or numpy.
+
+    Args:
+        arr: A torch tensor (any device) or a numpy array.
+
+    Returns:
+        The same data as a CPU numpy array.
+    """
+    if hasattr(arr, "cpu"):
+        return arr.cpu().numpy()
+    return arr
+
+
+def decode(slots, *, id_to_name: dict[int, str], group_id_to_name: dict[int, str] | None = None,
+           lane_id_to_name: dict[int, str] | None = None, max_events: int, num_groups: int,
+           sm_clock_ghz: float = 1.5) -> list:
+    """Decode the ``slots`` buffer into a flat list of ``Slice`` / ``Instant``.
+
+    Walks every ``(cta, gid)`` slot, reads the header count, unpacks each event's
+    ``w1`` word, zeroes timestamps against the owning **CTA**'s minimum, and
+    stack-matches range pairs per ``(cta, gid, lane)`` track in stored program
+    order. Flow arrows are not decoded here; :func:`compute_flows` derives them
+    from the returned slices and the declared flow pairs.
+
+    Tracks are always the full 3-tuple ``(cta, gid, lane)`` with ``lane`` the
+    interned lane id; exporters resolve it to a name via ``lane_id_to_name``.
+
+    Robustness:
+        * RANGE_END without a matching open begin on its track is skipped.
+        * If the track stack top mismatches the end's ``event_id``, the matching
+          begin is searched deeper in the stack; intervening begins are kept open.
+        * Begins still open at end of a slot are dropped (e.g. when ``max_events``
+          clamps the row before a RANGE_END is recorded).
+
+    Args:
+        slots: ``(num_cta, num_groups, (max_events + 1) * 2)`` int64 buffer.
+            Accepts a torch tensor or numpy array.
+        id_to_name: Maps interned event id to a human-readable name.
+        group_id_to_name: Unused for decode (gid stays numeric in the track);
+            accepted for symmetry with the host maps. ``None`` is fine.
+        lane_id_to_name: Unused for decode (lane stays numeric in the track);
+            accepted for symmetry with the host maps. ``None`` is fine.
+        max_events: Per-slot event capacity; the header count is clamped to it.
+        num_groups: Logical groups per CTA (the ``gid`` axis length).
+        sm_clock_ghz: Locked SM clock in GHz; carried for downstream consumers.
+
+    Returns:
+        A flat list of ``Slice`` and ``Instant`` objects across all
+        ``(cta, gid)`` slots.
+    """
+    del group_id_to_name  # gid stays numeric in the track; accepted for symmetry.
+    del lane_id_to_name  # lane stays numeric in the track; accepted for symmetry.
+    del sm_clock_ghz  # carried for API symmetry; conversion happens downstream.
+
+    slots_np = _to_numpy(slots)
+    num_cta = slots_np.shape[0]
+
+    events: list = []
+
+    # Per-CTA clock origin: a CTA's group rows share one SM, so they zero against
+    # a common minimum taken across all of that CTA's groups and events.
+    cta_ts_min: dict[int, int] = {}
+    for cta in range(num_cta):
+        for gid in range(num_groups):
+            row = slots_np[cta, gid]
+            count = min(int(row[0]), max_events)
+            if count <= 0:
+                continue
+            ts_words = [int(row[(e + 1) * 2]) for e in range(count)]
+            slot_min = min(ts_words)
+            prev = cta_ts_min.get(cta)
+            cta_ts_min[cta] = slot_min if prev is None else min(prev, slot_min)
+
+    for cta in range(num_cta):
+        if cta not in cta_ts_min:
+            continue
+        ts_min = cta_ts_min[cta]
+        for gid in range(num_groups):
+            row = slots_np[cta, gid]
+            count = min(int(row[0]), max_events)
+            if count <= 0:
+                continue
+
+            # Open RANGE_BEGIN stacks keyed by lane; each entry is (event_id, ts0,
+            # payload). Program order is the stored event order within the slot.
+            open_stacks: dict[int, list[tuple[int, int, int]]] = {}
+
+            for e in range(count):
+                ts = int(row[(e + 1) * 2]) - ts_min
+                event_id, kind, lane, payload = unpack_w1(int(row[(e + 1) * 2 + 1]))
+                name = id_to_name.get(event_id, str(event_id))
+
+                if kind == EventKind.RANGE_BEGIN:
+                    open_stacks.setdefault(lane, []).append((event_id, ts, payload))
+
+                elif kind == EventKind.RANGE_END:
+                    stack = open_stacks.get(lane)
+                    if not stack:
+                        continue  # end without any open begin on this track.
+                    # Match by event_id; tolerate a mismatched top by searching down.
+                    match_idx = None
+                    for i in range(len(stack) - 1, -1, -1):
+                        if stack[i][0] == event_id:
+                            match_idx = i
+                            break
+                    if match_idx is None:
+                        continue  # no matching begin; skip this end.
+                    begin_id, ts0, begin_payload = stack.pop(match_idx)
+                    events.append(
+                        Slice(
+                            track=(cta, gid, lane),
+                            name=id_to_name.get(begin_id, str(begin_id)),
+                            ts_cy=ts0,
+                            dur_cy=ts - ts0,
+                            payload=begin_payload,
+                        ))
+
+                elif kind == EventKind.INSTANT:
+                    events.append(
+                        Instant(track=(cta, gid, lane), name=name, ts_cy=ts, payload=payload))
+
+            # Begins still open at slot end (e.g. clamped RANGE_END) are dropped.
+
+    return events
+
+
+def compute_flows(events: list, flows: list) -> list:
+    """Resolve declared flow pairs into per-CTA :class:`FlowEdge` arrows.
+
+    For each declared ``(src_name, dst_name)`` flow and each CTA, collects that
+    CTA's :class:`Slice` objects named ``src_name`` and named ``dst_name`` (each
+    sorted by start timestamp), then pairs the i-th source with the i-th
+    destination for ``i`` in ``[0, min(len_src, len_dst))``. Each pair becomes one
+    :class:`FlowEdge` whose arrow runs from the source slice END to the
+    destination slice START. Distinct occurrences therefore yield distinct edges
+    with distinct endpoints — never collapsing onto a single anchor.
+
+    Args:
+        events: Flat event list from :func:`decode` (only :class:`Slice` objects
+            participate; other kinds are ignored).
+        flows: Declared ``(src_name, dst_name)`` pairs (``host_maps["flows"]``).
+
+    Returns:
+        A flat list of :class:`FlowEdge` objects across all flows and CTAs.
+    """
+    slices = [e for e in events if isinstance(e, Slice)]
+    ctas = sorted({s.track[0] for s in slices})
+
+    edges: list = []
+    for src_name, dst_name in flows:
+        for cta in ctas:
+            srcs = sorted((s for s in slices if s.track[0] == cta and s.name == src_name),
+                          key=lambda s: s.ts_cy)
+            dsts = sorted((s for s in slices if s.track[0] == cta and s.name == dst_name),
+                          key=lambda s: s.ts_cy)
+            for src, dst in zip(srcs, dsts, strict=False):
+                edges.append(
+                    FlowEdge(
+                        src_track=src.track,
+                        src_ts_cy=src.ts_cy + src.dur_cy,
+                        dst_track=dst.track,
+                        dst_ts_cy=dst.ts_cy,
+                        src_name=src_name,
+                        dst_name=dst_name,
+                    ))
+    return edges

--- a/tileops/trace/device.py
+++ b/tileops/trace/device.py
@@ -1,0 +1,32 @@
+"""Device-side timing helper injection for the in-kernel trace.
+
+The timestamp source is ``clock64()`` (a CUDA builtin, per-SM cycle counter),
+wrapped in a ``__device__`` helper that the emit path calls via
+``T.call_extern("uint64", "__tl_now")``. The helper is injected with
+``T.import_source``, which must run inside a ``with T.Kernel(...)`` scope.
+"""
+
+import tilelang.language as T
+
+__all__ = ["inject_helper"]
+
+# clock64() is a CUDA builtin (no inline asm); the cast keeps the return type a
+# plain u64.
+_HELPER = r"""
+__device__ __forceinline__ unsigned long long __tl_now() {
+    return (unsigned long long)clock64();  // per-SM cycle counter (CUDA builtin)
+}
+"""
+
+
+def inject_helper() -> None:
+    """Inject the ``__tl_now()`` device timer helper into the current kernel.
+
+    Emits the ``clock64()`` wrapper via ``T.import_source`` so that
+    ``T.call_extern("uint64", "__tl_now")`` resolves at codegen.
+
+    Note:
+        MUST be called inside a ``with T.Kernel(...)`` scope. Calling it before
+        the kernel block raises "No builder in current scope".
+    """
+    T.import_source(_HELPER)

--- a/tileops/trace/markers.py
+++ b/tileops/trace/markers.py
@@ -1,0 +1,110 @@
+"""Internal marker-emission machinery backing the ``trace`` annotation methods.
+
+Holds the device-side ``tl_trace_marker`` emitter plus the scope / token types
+that ``trace.group`` and ``trace.range`` return. Not part of the public API —
+import :data:`tileops.trace.trace`, never this module.
+"""
+
+import tilelang.language as T
+
+from .record import EventKind
+from .state import MARKER, build_state
+
+# Default render sub-lane for records that do not name one.
+DEFAULT_LANE = "main"
+
+
+def _emit(event_id: int, kind: int, lane: int, payload) -> None:
+    """Emit one ``tl_trace_marker`` placeholder for the active group.
+
+    ``event_id`` / ``kind`` / ``lane`` / ``gid`` are compile-time-constant ints;
+    ``payload`` is the lone runtime arg, carried through as a PrimExpr so a loop
+    index survives into the lowered ``pack_w1_tir`` call.
+    """
+    state = build_state()
+    if payload is None:
+        payload_expr = T.int32(0)
+    elif isinstance(payload, int):
+        payload_expr = T.int32(payload)
+    else:
+        payload_expr = payload
+    T.evaluate(
+        T.call_extern("handle", MARKER, event_id, int(kind), lane, state.active_gid,
+                      payload_expr))
+
+
+class AnnoToken:
+    """Opaque handle naming an open range; pairs a RANGE_END with its RANGE_BEGIN.
+
+    Returned by ``trace.range_start`` and consumed by ``trace.range_end``. Holds
+    no device state.
+    """
+
+    __slots__ = ("name", "event_id", "lane")
+
+    def __init__(self, name: str, event_id: int, lane: int):
+        self.name = name
+        self.event_id = event_id
+        self.lane = lane
+
+
+def open_range(name: str, lane: str) -> AnnoToken:
+    """Intern ``name`` / ``lane``, emit a RANGE_BEGIN, and return its token."""
+    state = build_state()
+    event_id = state.intern_event(name)
+    lane_id = state.intern_lane(lane)
+    _emit(event_id, EventKind.RANGE_BEGIN, lane_id, 0)
+    return AnnoToken(name, event_id, lane_id)
+
+
+def close_range(tok: AnnoToken | None) -> None:
+    """Emit the RANGE_END matching ``tok`` (``None`` no-ops)."""
+    if tok is None:
+        return
+    _emit(tok.event_id, EventKind.RANGE_END, tok.lane, 0)
+
+
+def emit_instant(name: str, payload, lane: str) -> None:
+    """Intern ``name`` / ``lane`` and emit a single INSTANT marker."""
+    state = build_state()
+    event_id = state.intern_event(name)
+    lane_id = state.intern_lane(lane)
+    _emit(event_id, EventKind.INSTANT, lane_id, payload)
+
+
+def declare_flow(src_name: str, dst_name: str) -> None:
+    """Record a build-time ``(src_name, dst_name)`` flow pair (no device marker)."""
+    build_state().declare_flow(src_name, dst_name)
+
+
+class GroupScope:
+    """Context manager that makes a declared group live for its body."""
+
+    def __init__(self, name: str, lead: int):
+        self._name = name
+        self._lead = lead
+
+    def __enter__(self) -> "GroupScope":
+        build_state().push_group(self._name, self._lead)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        build_state().pop_group()
+        return False
+
+
+class RangeScope:
+    """Context manager emitting RANGE_BEGIN on enter, RANGE_END on exit."""
+
+    def __init__(self, name: str, lane: str):
+        self._name = name
+        self._lane = lane
+        self._tok: AnnoToken | None = None
+
+    def __enter__(self) -> AnnoToken | None:
+        self._tok = open_range(self._name, self._lane)
+        return self._tok
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        close_range(self._tok)
+        return False

--- a/tileops/trace/passes.py
+++ b/tileops/trace/passes.py
@@ -1,0 +1,349 @@
+"""Frontend ``trace.lower`` transform: materialize trace placeholders.
+
+This is the build-time half of the trace tool. It pairs with the module-level
+:data:`tileops.trace.api.trace` annotation API: that API emits zero-cost
+``tl_trace_marker`` placeholders into a kernel body as it is built; ``trace.lower``
+then rewrites every placeholder into real emit code and appends a ``slots`` output
+param, returning a plain ``PrimFunc`` that a *vanilla* ``@tilelang.jit`` compiles.
+
+There is no monkeypatch of ``tilelang``: importing this module leaves
+``tilelang.compile`` / ``tilelang.jit.compile`` untouched. The whole surface is
+the explicit :func:`lower` transform.
+
+Module name note:
+    ``pass`` is a Python keyword, so the file is named ``passes.py`` to stay a
+    normal importable submodule.
+
+slots buffer layout (the contract decode reads against)
+--------------------------------------------------------
+One injected output param, the LAST output::
+
+    slots : T.Tensor((num_cta, num_groups, (max_events + 1) * 2), "int64")
+
+Per ``(cta, gid)`` slot (a flat row of ``(max_events + 1) * 2`` int64 words):
+
+* ``word[0]``  = event count (header), saturated at ``max_events``.
+* ``word[1]``  = reserved (unused garbage; decoders ignore it).
+* event ``e`` in ``[0, max_events)`` occupies words ``[(e + 1) * 2, (e + 1) * 2 + 1]``::
+
+      word[(e + 1) * 2]      = w0 = clock64() timestamp (int64)
+      word[(e + 1) * 2 + 1]  = w1 = pack_w1(event_id, kind, lane, payload)
+
+NO-STOMP guarantee: the write offset uses ``idx = min(cursor, max_events - 1)``
+and the header count saturates with ``count = min(cursor + 1, max_events)``, so a
+writer can never address a word past its own slot's event region — this holds
+even though TileLang's simplifier collapses a plain ``if cursor < max_events``
+guard. The clamp, not the guard, is the contract.
+
+Header zeroing: the output buffer is adapter-allocated via ``torch.empty`` (not
+zeroed), so the elected writer of each group zeroes its header ``word[0]`` in the
+kernel prologue before any marker fires.
+
+Host-map registry
+------------------
+``trace.lower`` stashes the host-side decode maps in the module-level
+:data:`_META_REGISTRY` dict, keyed by an integer meta id stamped onto the
+returned ``PrimFunc`` as the ``tl.trace_meta_id`` attr. The attr rides through
+``tilelang.jit`` onto ``kernel.prim_func``, so :func:`lookup_meta` resolves a
+compiled kernel back to its maps without relying on object identity.
+"""
+
+# Importing tilelang first populates sys.path for the bundled tvm package.
+import tilelang  # noqa: F401  (loads tvm before the tvm imports below)
+import tilelang.language as T  # noqa: F401
+import tvm.tirx as tx
+from tvm.tirx.stmt_functor import ir_transform, post_order_visit
+
+from .device import _HELPER
+from .record import MAX_EVENTS_DEFAULT, pack_w1_tir
+from .state import MARKER, begin_build_epoch, build_state
+
+__all__ = ["MAX_EVENTS_DEFAULT", "lookup_meta", "lower", "strip"]
+
+# Header words per slot: word[0] = count, word[1] = reserved. Events follow.
+HEADER_WORDS = 2
+
+# PrimFunc attr that carries the host-map registry key onto the lowered func; it
+# rides through tilelang.jit onto kernel.prim_func so lookup_meta resolves a
+# compiled kernel back to its decode maps.
+_META_ATTR = "tl.trace_meta_id"
+
+# Module-level host-map registry: meta_id (int) -> host_maps dict. Populated by
+# lower(), read by lookup_meta().
+_META_REGISTRY: dict[int, dict] = {}
+_NEXT_META_ID = 0
+
+
+def _is_marker(node) -> bool:
+    """True if ``node`` is a ``tl_trace_marker`` placeholder Call (StringImm arg0)."""
+    if not isinstance(node, tx.Call):
+        return False
+    args = list(node.args)
+    return bool(args) and isinstance(args[0], tx.StringImm) and args[0].value == MARKER
+
+
+def _transform(primfunc, max_events: int, num_groups: int, lead_fn):
+    """Rewrite trace placeholders into emit code; append the ``slots`` output param.
+
+    See the module docstring for the slots layout and the no-stomp clamp
+    contract. The flat CTA count is derived from the kernel's launch config (the
+    product of the blockIdx extents); the buffer's CTA dimension uses it.
+
+    Args:
+        primfunc: The built kernel; body may contain ``tl_trace_marker`` markers.
+        max_events: Compile-time per-slot event capacity (cursor bound).
+        num_groups: Logical groups per CTA (gid range).
+        lead_fn: ``gid -> lead`` lookup electing each group's writer (``tx == lead``).
+
+    Returns:
+        A ``(primfunc, num_cta)`` pair: the new ``PrimFunc`` with a trailing
+        ``slots`` int64 param and every marker rewritten into writer-gated,
+        clamped emit code, plus the derived flat CTA count.
+    """
+    slot_words = (max_events + HEADER_WORDS) * 2
+
+    # 1) Collect thread/block binding For nodes (the loop var IS the blockIdx /
+    #    threadIdx, the For extent IS the grid / block dimension). Every blockIdx
+    #    and threadIdx axis appears, even when its extent is 1; the extent is a
+    #    concrete IntImm at transform time (build-time-known launch config).
+    bind = {}
+
+    def collect(n):
+        if isinstance(n, tx.For) and n.thread_binding is not None:
+            bind[n.thread_binding.thread_tag] = n
+
+    post_order_visit(primfunc.body, collect)
+    tx_ = bind["threadIdx.x"].loop_var
+
+    # Flatten the full grid: read each present blockIdx axis's var + extent and
+    # build cta_flat = bx + by*gx + bz*gx*gy (only the axes that exist), with
+    # num_cta = gx * gy * gz. A multi-dim grid (gy/gz > 1) would otherwise collide
+    # every block sharing a (bx) row on the same slot.
+    gx = gy = gz = 1
+    cta_flat = tx.IntImm("int32", 0)
+    stride = 1
+    for tag in ("blockIdx.x", "blockIdx.y", "blockIdx.z"):
+        node = bind.get(tag)
+        if node is None:
+            continue
+        extent = int(node.extent)
+        cta_flat = cta_flat + node.loop_var * stride if stride != 1 else node.loop_var
+        stride *= extent
+        if tag == "blockIdx.x":
+            gx = extent
+        elif tag == "blockIdx.y":
+            gy = extent
+        else:
+            gz = extent
+    num_cta = gx * gy * gz
+
+    # 2) New slots param Var + Buffer: [num_cta, num_groups, slot_words] int64.
+    slots_buf = tx.decl_buffer((num_cta, num_groups, slot_words), "int64",
+                               name="slots", scope="global")
+    slots_var = tx.Var("slots_handle", "handle")
+
+    # 3) Cursor lives in the slot HEADER word (slots[cta,gid,0]), read-modify-write
+    #    per marker. A global header RMW stays opaque to the simplifier (a local
+    #    int32 cursor gets const-folded and its guards collapse). Single writer
+    #    (tx==lead) => no atomics.
+    def emit_for_marker(call):
+        # event_id / kind / lane / gid are compile-time-constant interned ids;
+        # payload is the one runtime arg, kept as-is for pack_w1_tir.
+        event_id, kind, lane, gid = (int(a) for a in call.args[1:5])
+        payload_expr = call.args[5]
+        is_writer = tx_ == lead_fn(gid)
+        i = tx.Cast("int32", tx.BufferLoad(slots_buf, [cta_flat, gid, 0]))
+        in_room = i < max_events
+        # No-stomp #1: hard-clamp the write index to the last legal event slot
+        # so a collapsed guard can never address past this slot's event region.
+        idx = tx.Min(i, max_events - 1)
+        base = HEADER_WORDS + idx * 2
+        ts = T.call_extern("uint64", "__tl_now")
+        w1 = pack_w1_tir(event_id, kind, lane, payload_expr)
+        store_w0 = tx.BufferStore(slots_buf, tx.Cast("int64", ts), [cta_flat, gid, base])
+        store_w1 = tx.BufferStore(slots_buf, w1, [cta_flat, gid, base + 1])
+        # No-stomp #2: saturate the header count so the decoder never reads more
+        # events than the slot physically holds.
+        new_cnt = tx.Min(i + 1, max_events)
+        store_cnt = tx.BufferStore(slots_buf, tx.Cast("int64", new_cnt), [cta_flat, gid, 0])
+        body = tx.SeqStmt([store_w0, store_w1, store_cnt])
+        guarded = tx.IfThenElse(in_room, body, None)
+        return tx.IfThenElse(is_writer, guarded, None)
+
+    # 4) Rewrite pass: replace each Evaluate(marker) with emit code; on the root
+    #    SBlock inject the helper + zero each group's header word (writer only).
+    def post(node):
+        if isinstance(node, tx.Evaluate) and _is_marker(node.value):
+            return emit_for_marker(node.value)
+        if isinstance(node, tx.SBlock) and node.name_hint == "tilelang_root":
+            anns = dict(node.annotations) if node.annotations else {}
+            anns["pragma_import_c"] = _HELPER
+            # torch.empty output is NOT pre-zeroed; each group's elected writer
+            # zeroes its header count before any marker fires.
+            zero_stores = []
+            for g in range(num_groups):
+                lead_g = lead_fn(g)
+                zero = tx.BufferStore(slots_buf, tx.IntImm("int64", 0), [cta_flat, g, 0])
+                zero_stores.append(tx.IfThenElse(tx_ == lead_g, zero, None))
+            zero_body = zero_stores[0] if len(zero_stores) == 1 else tx.SeqStmt(zero_stores)
+            new_body = tx.SeqStmt([zero_body, node.body])
+            return tx.SBlock(
+                iter_vars=node.iter_vars, reads=node.reads, writes=node.writes,
+                name_hint=node.name_hint, body=new_body, init=node.init,
+                alloc_buffers=node.alloc_buffers, match_buffers=node.match_buffers,
+                annotations=anns,
+            )
+        return node
+
+    new_body = ir_transform(primfunc.body, None, post)
+
+    # 5) Append the slots param + buffer_map.
+    new_bmap = dict(primfunc.buffer_map)
+    new_bmap[slots_var] = slots_buf
+    lowered = tx.PrimFunc(
+        params=list(primfunc.params) + [slots_var],
+        body=new_body,
+        ret_type=primfunc.ret_type,
+        buffer_map=new_bmap,
+        attrs=primfunc.attrs,
+    )
+    return lowered, num_cta
+
+
+def _strip_markers(primfunc):
+    """Drop every ``tl_trace_marker`` placeholder from ``primfunc`` (zero-cost path).
+
+    The always-emit markers are no-opped before codegen so the generated CUDA is
+    byte-identical to an un-instrumented build (no ``slots`` param, no
+    ``__tl_now``). Backs the public :func:`strip` escape hatch.
+
+    Args:
+        primfunc: A built kernel whose body may contain marker placeholders.
+
+    Returns:
+        A ``PrimFunc`` with every ``Evaluate(tl_trace_marker)`` replaced by a
+        no-op ``Evaluate(0)``; unchanged in every other respect.
+    """
+
+    def post(node):
+        if isinstance(node, tx.Evaluate) and _is_marker(node.value):
+            return tx.Evaluate(tx.IntImm("int32", 0))
+        return node
+
+    new_body = ir_transform(primfunc.body, None, post)
+    return tx.PrimFunc(
+        params=list(primfunc.params),
+        body=new_body,
+        ret_type=primfunc.ret_type,
+        buffer_map=dict(primfunc.buffer_map),
+        attrs=primfunc.attrs,
+    )
+
+
+def lower(primfunc, max_events: int = MAX_EVENTS_DEFAULT):
+    """Lower the always-emit markers in ``primfunc`` and append the ``slots`` output.
+
+    The explicit build-time transform: call it inside a builder, return its
+    result, and decorate the builder with a *vanilla* ``@tilelang.jit`` whose
+    ``out_idx`` already accounts for the trailing ``slots`` param (e.g.
+    ``out_idx=[-2, -1]`` when the kernel has one own output ``C`` and ``slots``).
+
+    Reads the per-build trace registry (:func:`tileops.trace.state.build_state`),
+    derives ``num_groups`` from the distinct interned groups, runs
+    :func:`_transform` to rewrite each marker into writer-gated clamped emit code
+    (deriving ``num_cta`` from the launch grid), then stashes the host decode maps
+    in :data:`_META_REGISTRY` under a fresh integer meta id and stamps that id
+    onto the returned func as the ``tl.trace_meta_id`` attr. The attr rides
+    through ``tilelang.jit`` onto ``kernel.prim_func`` so :func:`lookup_meta`
+    resolves the compiled kernel back to its maps. It then retires the build epoch
+    (:func:`tileops.trace.state.begin_build_epoch`) so the next build starts
+    fresh.
+
+    Args:
+        primfunc: The built kernel; its body carries ``tl_trace_marker`` markers.
+        max_events: Per-slot event capacity (compile-time cursor bound). Defaults
+            to :data:`tileops.trace.record.MAX_EVENTS_DEFAULT`.
+
+    Returns:
+        The lowered ``PrimFunc`` with the trailing ``slots`` int64 output param
+        and the ``tl.trace_meta_id`` attr set. A vanilla ``@tilelang.jit`` over a
+        builder returning this func compiles it; ``extract_params`` then sees
+        ``slots`` as the last param.
+    """
+    global _NEXT_META_ID
+
+    state = build_state()
+    begin_build_epoch()
+
+    num_groups = max(len(state.group_id_to_name), 1)
+
+    def lead_fn(gid: int) -> int:
+        return state.group_id_to_lead.get(gid, 0)
+
+    lowered, num_cta = _transform(primfunc, max_events, num_groups, lead_fn)
+
+    host_maps = {
+        "id_to_name": dict(state.id_to_name),
+        "group_id_to_name": dict(state.group_id_to_name),
+        "group_id_to_lead": dict(state.group_id_to_lead),
+        "lane_id_to_name": dict(state.lane_id_to_name),
+        "flows": list(state.declared_flows),
+        "max_events": max_events,
+        "num_groups": num_groups,
+        "num_cta": num_cta,
+    }
+
+    meta_id = _NEXT_META_ID
+    _NEXT_META_ID += 1
+    _META_REGISTRY[meta_id] = host_maps
+    return lowered.with_attr(_META_ATTR, meta_id)
+
+
+def strip(primfunc):
+    """No-op the always-emit markers so ``primfunc`` compiles WITHOUT tracing.
+
+    The escape hatch: a kernel written with ``trace.*`` markers can be compiled
+    zero-cost by passing it through ``strip`` instead of :func:`lower`. The
+    returned func has no ``slots`` param and emits no ``__tl_now``, so the
+    generated CUDA is byte-identical to an un-instrumented build.
+
+    Args:
+        primfunc: A built kernel whose body may contain ``trace.*`` markers.
+
+    Returns:
+        A ``PrimFunc`` with every marker replaced by a no-op; otherwise unchanged.
+    """
+    return _strip_markers(primfunc)
+
+
+def lookup_meta(kernel) -> dict:
+    """Resolve a compiled kernel back to its host decode maps.
+
+    Reads the ``tl.trace_meta_id`` attr that :func:`lower` stamped onto the
+    transformed ``PrimFunc`` (exposed as ``kernel.prim_func``) and looks the maps
+    up in :data:`_META_REGISTRY`.
+
+    Args:
+        kernel: A compiled kernel from a vanilla ``@tilelang.jit`` over a builder
+            that returned :func:`lower`'s result.
+
+    Returns:
+        The host-map dict (``id_to_name`` / ``group_id_to_name`` /
+        ``group_id_to_lead`` / ``lane_id_to_name`` / ``flows`` /
+        ``max_events`` / ``num_groups`` / ``num_cta``).
+
+    Raises:
+        ValueError: If the kernel's ``prim_func`` carries no ``tl.trace_meta_id``
+            attr (it was not produced by :func:`lower`), or the id is unknown.
+    """
+    prim_func = getattr(kernel, "prim_func", None)
+    attrs = getattr(prim_func, "attrs", None)
+    meta_id = attrs.get(_META_ATTR) if attrs is not None else None
+    if meta_id is None:
+        raise ValueError(
+            "kernel was not produced by trace.lower (no tl.trace_meta_id attr on "
+            "kernel.prim_func); cannot resolve host decode maps")
+    meta_id = int(meta_id)
+    if meta_id not in _META_REGISTRY:
+        raise ValueError(f"unknown trace meta id {meta_id}; host maps not registered")
+    return _META_REGISTRY[meta_id]

--- a/tileops/trace/record.py
+++ b/tileops/trace/record.py
@@ -1,0 +1,139 @@
+"""In-kernel trace ``EventRecord`` packing (16-byte / 2x u64 layout).
+
+Each record is two 64-bit words: ``w0`` holds the ``clock64()`` timestamp and
+``w1`` packs ``event_id`` / ``kind`` / ``lane`` / ``payload``. This module owns
+the host-side pack/unpack helpers plus a device-side (TIR) packer for the emit
+path.
+"""
+
+from enum import IntEnum
+
+# Importing tilelang first populates sys.path for the bundled tvm package.
+import tilelang.language as T
+from tvm.ir import PrimExpr
+
+__all__ = [
+    "MAX_EVENTS_DEFAULT",
+    "EventKind",
+    "pack_w1",
+    "pack_w1_tir",
+    "unpack_w1",
+]
+
+
+class EventKind(IntEnum):
+    """Event kind packed into ``w1`` bits 24..27."""
+
+    RANGE_BEGIN = 0
+    RANGE_END = 1
+    INSTANT = 2
+    # Reserved: ``trace.dag`` is now a build-time declaration (no runtime record),
+    # so no DAG record is ever emitted. Kept to keep the enum value stable.
+    DAG = 3
+
+
+# Per-slot record capacity (config default; callers may override).
+MAX_EVENTS_DEFAULT = 768
+
+# Field widths and bit offsets within w1.
+_EVENT_ID_BITS = 24
+_KIND_BITS = 4
+_LANE_BITS = 4
+_PAYLOAD_BITS = 32
+
+_EVENT_ID_SHIFT = 0
+_KIND_SHIFT = 24
+_LANE_SHIFT = 28
+_PAYLOAD_SHIFT = 32
+
+_EVENT_ID_MASK = (1 << _EVENT_ID_BITS) - 1
+_KIND_MASK = (1 << _KIND_BITS) - 1
+_LANE_MASK = (1 << _LANE_BITS) - 1
+_PAYLOAD_MASK = (1 << _PAYLOAD_BITS) - 1
+
+# Max distinct lanes that fit the 4-bit lane field.
+MAX_LANES = 1 << _LANE_BITS
+
+
+def pack_w1(event_id: int, kind: int, lane: int, payload: int) -> int:
+    """Pack the four ``w1`` fields into a single unsigned 64-bit word.
+
+    Args:
+        event_id: Interned event id, must fit 24 bits (0..2**24-1).
+        kind: Event kind, must fit 4 bits (an :class:`EventKind` or its int).
+        lane: Interned lane id, must fit 4 bits.
+        payload: Raw unsigned 32-bit bit-pattern of an i32/f32 payload. Must fit
+            32 bits; no silent truncation.
+
+    Returns:
+        The packed 64-bit word as a Python int.
+
+    Raises:
+        ValueError: If any field is negative or exceeds its bit width.
+    """
+    kind = int(kind)
+    if not 0 <= event_id <= _EVENT_ID_MASK:
+        raise ValueError(f"event_id {event_id} does not fit {_EVENT_ID_BITS} bits")
+    if not 0 <= kind <= _KIND_MASK:
+        raise ValueError(f"kind {kind} does not fit {_KIND_BITS} bits")
+    if not 0 <= lane <= _LANE_MASK:
+        raise ValueError(f"lane {lane} does not fit {_LANE_BITS} bits")
+    if not 0 <= payload <= _PAYLOAD_MASK:
+        raise ValueError(f"payload {payload} does not fit {_PAYLOAD_BITS} bits")
+
+    return ((event_id << _EVENT_ID_SHIFT) | (kind << _KIND_SHIFT) | (lane << _LANE_SHIFT) |
+            (payload << _PAYLOAD_SHIFT))
+
+
+def unpack_w1(w1: int) -> tuple[int, int, int, int]:
+    """Unpack a ``w1`` word into ``(event_id, kind, lane, payload)``.
+
+    Inverse of :func:`pack_w1` over the full field ranges.
+
+    Args:
+        w1: A packed 64-bit word.
+
+    Returns:
+        Tuple of ``(event_id, kind, lane, payload)``.
+    """
+    event_id = (w1 >> _EVENT_ID_SHIFT) & _EVENT_ID_MASK
+    kind = (w1 >> _KIND_SHIFT) & _KIND_MASK
+    lane = (w1 >> _LANE_SHIFT) & _LANE_MASK
+    payload = (w1 >> _PAYLOAD_SHIFT) & _PAYLOAD_MASK
+    return event_id, kind, lane, payload
+
+
+def pack_w1_tir(event_id: int, kind: int, lane: int, payload_expr: PrimExpr) -> PrimExpr:
+    """Build the device-side ``w1`` packed word as an int64 TIR expression.
+
+    The ``event_id`` / ``kind`` / ``lane`` fields are compile-time Python ints
+    and fold into a constant base occupying the low 32 bits. ``payload_expr`` is a
+    runtime i32 PrimExpr whose raw bits are shifted into bits 32..63. The i32 is
+    reinterpreted as uint32 before widening so a negative i32 does not
+    sign-extend into the high half.
+
+    Args:
+        event_id: Interned event id, must fit 24 bits.
+        kind: Event kind, must fit 4 bits (an :class:`EventKind` or its int).
+        lane: Interned lane id, must fit 4 bits.
+        payload_expr: TIR i32 PrimExpr carrying the raw payload bits.
+
+    Returns:
+        An int64 PrimExpr equal to the packed ``w1`` word.
+
+    Raises:
+        ValueError: If ``event_id`` / ``kind`` / ``lane`` exceed their widths.
+    """
+    kind = int(kind)
+    if not 0 <= event_id <= _EVENT_ID_MASK:
+        raise ValueError(f"event_id {event_id} does not fit {_EVENT_ID_BITS} bits")
+    if not 0 <= kind <= _KIND_MASK:
+        raise ValueError(f"kind {kind} does not fit {_KIND_BITS} bits")
+    if not 0 <= lane <= _LANE_MASK:
+        raise ValueError(f"lane {lane} does not fit {_LANE_BITS} bits")
+
+    base = (event_id << _EVENT_ID_SHIFT) | (kind << _KIND_SHIFT) | (lane << _LANE_SHIFT)
+    payload_u32 = T.reinterpret(payload_expr, "uint32")
+    payload_i64 = T.Cast("int64", payload_u32)
+    payload_hi = T.shift_left(payload_i64, T.Cast("int64", _PAYLOAD_SHIFT))
+    return T.bitwise_or(T.Cast("int64", base), payload_hi)

--- a/tileops/trace/state.py
+++ b/tileops/trace/state.py
@@ -1,0 +1,224 @@
+"""Build-global trace state shared between the annotation API and the transform.
+
+The trace tool splits responsibilities:
+
+* The module-level :data:`tileops.trace.api.trace` namespace emits lightweight
+  *placeholders* (``tl_trace_marker`` ``call_extern`` nodes) into the kernel body
+  and interns the human-readable names referenced by those placeholders into id
+  tables.
+* The :func:`tileops.trace.passes.lower` transform reads those same intern tables
+  back out (to build the host-side decode maps) after the kernel is built.
+
+The two halves never call each other directly; they communicate through the
+build registry installed here. The ``trace.*`` markers populate a fresh
+:class:`TraceState` per build epoch (:func:`build_state`); ``trace.lower`` reads
+it, then retires the epoch (:func:`begin_build_epoch`) so the next build starts
+clean.
+
+This is process-global, single-threaded build state: TileLang kernels are built
+eagerly on the calling thread, so one build epoch brackets exactly one build.
+"""
+
+from .record import MAX_LANES
+
+__all__ = [
+    "MARKER",
+    "TraceState",
+    "begin_build_epoch",
+    "build_state",
+]
+
+# Placeholder symbol name. A trace placeholder is
+# ``T.evaluate(T.call_extern("handle", MARKER, event_id, kind, lane, gid, payload))``.
+# The id args are compile-time-constant interned ids; ``payload`` is the one
+# runtime arg (a PrimExpr). The transform locates the placeholder by matching
+# ``StringImm`` arg0 == MARKER.
+MARKER = "tl_trace_marker"
+
+_DEFAULT_LEAD = 0
+_DEFAULT_LANE = "main"
+
+
+class TraceState:
+    """Build-global intern tables + the active group stack for one build.
+
+    A fresh instance backs each build epoch (see :func:`build_state`). The
+    annotation API mutates it as it emits placeholders; the transform reads the
+    reverse maps to label the host-side decode.
+
+    Event names, group names, and lane names each live in a **separate** intern
+    namespace: an event name interns to a 24-bit ``event_id`` packed into the
+    record, a group name interns to a ``gid`` that selects the slot row, and a
+    lane name interns to a 4-bit ``lane_id`` packed into the record.
+
+    Attributes:
+        enabled: Whether placeholders are emitted.
+        id_to_name: Reverse event-id map (``event_id -> name``).
+        group_id_to_name: Reverse group-id map (``gid -> name``).
+        group_id_to_lead: Group-id to elected lead lane (``gid -> lead``).
+        lane_id_to_name: Reverse lane-id map (``lane_id -> name``).
+        declared_flows: Build-time-declared ``(src_name, dst_name)`` flow pairs.
+    """
+
+    def __init__(self) -> None:
+        self.enabled = False
+
+        # event-name -> event_id (sequential from 0) + reverse for the host.
+        self._name_to_id: dict[str, int] = {}
+        self.id_to_name: dict[int, str] = {}
+
+        # group-name -> gid (sequential from 0) + reverses for host/transform.
+        self._group_to_id: dict[str, int] = {}
+        self.group_id_to_name: dict[int, str] = {}
+        self.group_id_to_lead: dict[int, int] = {}
+
+        # lane-name -> lane_id (sequential from 0) + reverse for the host.
+        self._lane_to_id: dict[str, int] = {}
+        self.lane_id_to_name: dict[int, str] = {}
+
+        # Build-time-declared flows: each a (src_name, dst_name) pair. The host
+        # pairs same-named slices per CTA in timestamp order to draw arrows.
+        self.declared_flows: list[tuple[str, str]] = []
+
+        # Active-group stack of (name, lead); the live group is the top. gids are
+        # assigned lazily on first emit (see active_gid) so a kernel that declares
+        # its own groups gets a contiguous gid range.
+        self._group_stack: list[tuple[str, int]] = [("default", _DEFAULT_LEAD)]
+
+    # -- group stack ------------------------------------------------------
+
+    @property
+    def active_gid(self) -> int:
+        """Group id of the live group, interning its name on first use."""
+        name, lead = self._group_stack[-1]
+        return self._intern_group(name, lead)
+
+    @property
+    def active_lead(self) -> int:
+        """Elected lead lane of the live group (top of the stack)."""
+        return self._group_stack[-1][1]
+
+    def push_group(self, name: str, lead: int) -> None:
+        """Make ``(name, lead)`` the live group until the matching :meth:`pop_group`."""
+        self._group_stack.append((name, lead))
+
+    def pop_group(self) -> None:
+        """Restore the previously live group (undo one :meth:`push_group`)."""
+        self._group_stack.pop()
+
+    # -- intern tables ----------------------------------------------------
+
+    def intern_event(self, name: str) -> int:
+        """Intern an event ``name`` to a stable 24-bit event id.
+
+        Args:
+            name: Human-readable event name.
+
+        Returns:
+            The interned event id; stable across repeated lookups of ``name``.
+        """
+        eid = self._name_to_id.get(name)
+        if eid is None:
+            eid = len(self._name_to_id)
+            self._name_to_id[name] = eid
+            self.id_to_name[eid] = name
+        return eid
+
+    def intern_lane(self, name: str) -> int:
+        """Intern a lane ``name`` to a stable 4-bit lane id.
+
+        Args:
+            name: Render sub-lane name (e.g. ``"main"``, ``"tma"``).
+
+        Returns:
+            The interned lane id; stable across repeated lookups of ``name``.
+
+        Raises:
+            ValueError: If interning ``name`` would exceed the 16-lane cap of the
+                4-bit packed lane field.
+        """
+        lane_id = self._lane_to_id.get(name)
+        if lane_id is None:
+            if len(self._lane_to_id) >= MAX_LANES:
+                raise ValueError(
+                    f"too many distinct lanes: the packed lane field holds at most "
+                    f"{MAX_LANES}; cannot intern {name!r} (have "
+                    f"{sorted(self._lane_to_id)})")
+            lane_id = len(self._lane_to_id)
+            self._lane_to_id[name] = lane_id
+            self.lane_id_to_name[lane_id] = name
+        return lane_id
+
+    def intern_group(self, name: str, lead: int) -> int:
+        """Intern a group ``name`` (with its ``lead``) to a stable gid.
+
+        Args:
+            name: Work-group name.
+            lead: Elected lead lane for the group's writer (``tx == lead``).
+
+        Returns:
+            The interned gid; stable across repeated lookups of ``name``.
+        """
+        return self._intern_group(name, lead)
+
+    def _intern_group(self, name: str, lead: int) -> int:
+        gid = self._group_to_id.get(name)
+        if gid is None:
+            gid = len(self._group_to_id)
+            self._group_to_id[name] = gid
+            self.group_id_to_name[gid] = name
+            self.group_id_to_lead[gid] = lead
+        return gid
+
+    def declare_flow(self, src_name: str, dst_name: str) -> None:
+        """Record a build-time flow declaration between two named ranges.
+
+        The declaration emits no runtime record; the host renders it by pairing
+        each CTA's ``src_name`` slices with its ``dst_name`` slices in timestamp
+        order (see :func:`tileops.trace.decode.compute_flows`).
+
+        Args:
+            src_name: Source (producer) range name.
+            dst_name: Destination (consumer) range name.
+        """
+        self.declared_flows.append((src_name, dst_name))
+
+
+# ---------------------------------------------------------------------------
+# Always-emit build registry.
+#
+# ``trace.*`` markers always emit their placeholder into the kernel body and
+# intern the referenced names into a per-build registry. TileLang builds
+# eagerly and single-threaded, so one build = one registry epoch: ``trace.lower``
+# reads the registry right after the build it transforms, then retires it via
+# begin_build_epoch(). The next marker lazily installs a fresh registry.
+# ---------------------------------------------------------------------------
+
+_BUILD_STATE: TraceState | None = None
+
+
+def begin_build_epoch() -> None:
+    """Retire the current build registry so the next marker starts a fresh one.
+
+    Called by :func:`tileops.trace.passes.lower` after it has consumed a build's
+    interned maps. The next :func:`build_state` lookup installs a new empty
+    :class:`TraceState`.
+    """
+    global _BUILD_STATE
+    _BUILD_STATE = None
+
+
+def build_state() -> TraceState:
+    """Return the live build registry, installing a fresh one if none is active.
+
+    Lazily creates the registry on the first marker of a build epoch so a kernel
+    which emits no markers never allocates one.
+
+    Returns:
+        The current build epoch's :class:`TraceState`.
+    """
+    global _BUILD_STATE
+    if _BUILD_STATE is None:
+        _BUILD_STATE = TraceState()
+        _BUILD_STATE.enabled = True
+    return _BUILD_STATE

--- a/tileops/trace/ui.py
+++ b/tileops/trace/ui.py
@@ -1,0 +1,423 @@
+"""Self-contained Plotly HTML timeline viewer for decoded trace events.
+
+Turns the flat ``Slice`` / ``Instant`` list from
+:func:`tileops.trace.decode.decode` into a single, self-contained ``.html`` file
+that renders one horizontal-bar Gantt timeline per CTA. The viewer matches the
+look of the reference GPU-pipeline timeline in ``docs/plans/reference_fa3_pipeline.html``:
+warm ``#f3ede1`` paper, monospace fonts, overlaid bars with light separator lines,
+a categorical lane axis, an x axis labelled in SM cycles, and a horizontal legend
+pinned at the bottom.
+
+This module is pure Python — it emits the Plotly figure dicts as embedded JSON
+plus a small JS shim and loads Plotly itself from a CDN. It imports neither torch
+nor plotly, so it stays importable in any environment.
+
+Layout per CTA (``_figure_for_cta``):
+    * **Lanes** are auto-derived from the data: the distinct ``(gid, lane)`` pairs
+      that carry events in the CTA, sorted by ``(gid, lane)``. Each lane's label is
+      ``"<group> / <lane>"``. Plotly draws a categorical ``categoryarray``
+      bottom-up, so the array is the lane labels in **reverse** sorted order — the
+      first ``(gid, lane)`` (producer / group 0, ``main`` lane) lands last in the
+      array and therefore renders at the top, matching the reference (its
+      ``categoryarray`` likewise lists the visually-bottom lane first).
+    * **Traces** are grouped by event ``name`` across all lanes — one bar trace per
+      name, each with a stable color picked deterministically from a warm palette by
+      sorted name, so a name keeps its color across CTAs. ``Instant`` markers are
+      grouped likewise into thin (1% of span) bar traces.
+    * **Flows** (declared ``(src_name, dst_name)`` pairs resolved per CTA by
+      :func:`tileops.trace.decode.compute_flows`) become one ``annotations`` arrow
+      per :class:`~tileops.trace.decode.FlowEdge`, from the source slice's end lane
+      to the destination slice's start lane.
+
+Interaction is horizontal-only zoom + pan: ``dragmode:"pan"`` with
+``xaxis.fixedrange:false`` and ``yaxis.fixedrange:true``, plus a Plotly config that
+keeps ``scrollZoom`` on and strips the vertical/box zoom buttons. With the y axis
+fixed, scroll-zoom only stretches x and pan only moves x.
+"""
+
+import json
+
+from .decode import Instant, Slice, compute_flows
+
+__all__ = ["export_timeline_html"]
+
+# Warm palette seeded from the reference timeline, then extended with further warm
+# / muted tones. Colors are assigned to event names deterministically by sorted
+# order so a name keeps its color across CTAs.
+_PALETTE = [
+    "#c43c19",  # red-orange (reference: softmax)
+    "#2f5d8c",  # steel blue (reference: QK wgmma)
+    "#1a6e63",  # teal (reference: PV wgmma)
+    "#d8a13a",  # amber (reference: rescale)
+    "#7d5ba6",  # violet (reference: wait peer / barrier)
+    "#7f97a6",  # slate (reference: TMA load)
+    "#9a8f7a",  # taupe (reference: wgmma drain)
+    "#5f6d76",  # gunmetal (reference: store)
+    "#b5651d",  # ochre
+    "#4a7c59",  # moss
+    "#8c4a6b",  # plum
+    "#3d6b8c",  # denim
+    "#a6803a",  # bronze
+    "#6b6f5f",  # olive grey
+    "#9c5d3a",  # terracotta
+    "#5a6b8c",  # dusty blue
+]
+
+# Annotation arrow color for dag / barrier dependency edges (reference violet).
+_ARROW_COLOR = "#7d5ba6"
+
+# Shared aesthetic constants (match the reference).
+_PAPER_BG = "#f3ede1"
+_GRID_COLOR = "#d8cfbb"
+_BAR_LINE_COLOR = "#f3ede1"
+_FONT_FAMILY = "ui-monospace, SFMono-Regular, monospace"
+_INK = "#191a16"
+
+
+def _lane_label(gid: int, lane: int, group_id_to_name: dict, lane_id_to_name: dict) -> str:
+    """Build a lane's y-axis label ``"<group> / <lane>"``.
+
+    Args:
+        gid: Logical work-group id of the lane.
+        lane: Interned render sub-lane id.
+        group_id_to_name: ``gid -> name`` map; falls back to ``g<gid>``.
+        lane_id_to_name: ``lane_id -> name`` map; falls back to the id.
+
+    Returns:
+        The lane label string.
+    """
+    gname = group_id_to_name.get(gid, f"g{gid}")
+    lname = lane_id_to_name.get(lane, str(lane))
+    return f"{gname} / {lname}"
+
+
+def _assign_colors(names: list) -> dict:
+    """Map each event name to a stable palette color by sorted order.
+
+    Args:
+        names: All distinct event names appearing across every CTA.
+
+    Returns:
+        ``name -> hex color`` dict; the same name always gets the same color.
+    """
+    return {name: _PALETTE[i % len(_PALETTE)] for i, name in enumerate(sorted(names))}
+
+
+def _text_color(hex_color: str) -> str:
+    """Pick black or white inside-bar text for legible contrast on ``hex_color``.
+
+    Args:
+        hex_color: A ``#rrggbb`` bar fill color.
+
+    Returns:
+        ``"#191a16"`` on light fills, ``"#ffffff"`` on dark fills.
+    """
+    r = int(hex_color[1:3], 16)
+    g = int(hex_color[3:5], 16)
+    b = int(hex_color[5:7], 16)
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255.0
+    return _INK if luminance > 0.6 else "#ffffff"
+
+
+def _ns(cy: float, sm_clock_ghz: float) -> float:
+    """Convert a cycle count to nanoseconds at the locked SM clock.
+
+    ``cycles / GHz == ns`` (a GHz clock advances one cycle per ns).
+
+    Args:
+        cy: Cycle count.
+        sm_clock_ghz: Locked SM clock in GHz.
+
+    Returns:
+        The duration in nanoseconds, rounded to one decimal.
+    """
+    return round(cy / sm_clock_ghz, 1)
+
+
+def _bar_trace(name, color, lane_labels, bases, durs, texts, payloads, sm_clock_ghz,
+               *, width, textangle):
+    """Build one Plotly horizontal-bar trace for an event name.
+
+    Args:
+        name: Event name (legend entry).
+        color: Bar fill color.
+        lane_labels: y category per bar.
+        bases: ``base`` (start cycle) per bar.
+        durs: ``x`` (duration cycle) per bar.
+        texts: Inside-bar text per bar.
+        payloads: Raw payload per bar (for the hover ``customdata``).
+        sm_clock_ghz: Locked SM clock in GHz (for the ~ns hover column).
+        width: Bar thickness (Plotly y-units).
+        textangle: Inside-text rotation in degrees.
+
+    Returns:
+        A Plotly trace dict.
+    """
+    customdata = [[name, "" if p is None else p, d, _ns(d, sm_clock_ghz)]
+                  for d, p in zip(durs, payloads, strict=True)]
+    return {
+        "type": "bar",
+        "orientation": "h",
+        "name": name,
+        "base": bases,
+        "x": durs,
+        "y": lane_labels,
+        "text": texts,
+        "textposition": "inside",
+        "insidetextanchor": "middle",
+        "constraintext": "inside",
+        "cliponaxis": False,
+        "textangle": textangle,
+        "textfont": {"color": _text_color(color), "size": 11, "family": _FONT_FAMILY},
+        "marker": {"color": color, "line": {"color": _BAR_LINE_COLOR, "width": 1.2}},
+        "width": width,
+        "showlegend": True,
+        "customdata": customdata,
+        "hovertemplate": ("<b>%{customdata[0]}</b>  payload %{customdata[1]}<br>"
+                          "start %{base} cyc   dur %{x} cyc "
+                          "(~%{customdata[3]} ns)<extra></extra>"),
+    }
+
+
+def _figure_for_cta(cta, events, group_id_to_name, lane_id_to_name, flows, color_map,
+                    title, sm_clock_ghz):
+    """Build the Plotly ``{data, layout}`` figure dict for one CTA.
+
+    Args:
+        cta: The flat CTA index.
+        events: This CTA's ``Slice`` / ``Instant`` objects.
+        group_id_to_name: ``gid -> name`` map for lane labels.
+        lane_id_to_name: ``lane_id -> name`` map for lane labels.
+        flows: Declared ``(src_name, dst_name)`` pairs, resolved to per-edge arrows
+            for this CTA via :func:`tileops.trace.decode.compute_flows`.
+        color_map: Global ``name -> color`` assignment (stable across CTAs).
+        title: Base figure title; the CTA index is appended.
+        sm_clock_ghz: Locked SM clock in GHz.
+
+    Returns:
+        A ``{"data": [...], "layout": {...}}`` dict ready for ``Plotly.react``.
+    """
+    slices = [e for e in events if isinstance(e, Slice)]
+    instants = [e for e in events if isinstance(e, Instant)]
+    # compute_flows pairs same-named slices in timestamp order; events are already
+    # restricted to this CTA, so each declared flow yields its per-occurrence edges.
+    edges = compute_flows(events, flows or [])
+
+    # Lanes auto-derived: distinct (gid, lane) with events, sorted by (gid, lane).
+    lane_pairs = sorted({(e.track[1], e.track[2]) for e in events})
+    lane_labels = {(g, l): _lane_label(g, l, group_id_to_name, lane_id_to_name)
+                   for (g, l) in lane_pairs}
+
+    # x span for instant-bar width and the initial range.
+    span = 0
+    for s in slices:
+        span = max(span, s.ts_cy + s.dur_cy)
+    for e in instants:
+        span = max(span, e.ts_cy)
+    for edge in edges:
+        span = max(span, edge.src_ts_cy, edge.dst_ts_cy)
+    span = span or 1
+    instant_w = max(1, span * 0.01)
+
+    data = []
+
+    # Slice traces, grouped by name.
+    by_name: dict = {}
+    for s in slices:
+        by_name.setdefault(s.name, []).append(s)
+    for name in sorted(by_name):
+        items = by_name[name]
+        text = [(f"{s.name}<br>{s.payload}" if s.payload is not None else s.name)
+                for s in items]
+        data.append(_bar_trace(
+            name, color_map[name],
+            [lane_labels[(s.track[1], s.track[2])] for s in items],
+            [s.ts_cy for s in items],
+            [s.dur_cy for s in items],
+            text,
+            [s.payload for s in items],
+            sm_clock_ghz, width=0.62, textangle=0))
+
+    # Instant traces (thin bars), grouped by name.
+    inst_by_name: dict = {}
+    for inst in instants:
+        inst_by_name.setdefault(inst.name, []).append(inst)
+    for name in sorted(inst_by_name):
+        items = inst_by_name[name]
+        data.append(_bar_trace(
+            name, color_map[name],
+            [lane_labels[(i.track[1], i.track[2])] for i in items],
+            [i.ts_cy for i in items],
+            [instant_w] * len(items),
+            [name] * len(items),
+            [i.payload for i in items],
+            sm_clock_ghz, width=0.34, textangle=0))
+
+    # Plotly draws categoryarray bottom-up; reverse the sorted lane order so the
+    # first (gid, lane) — producer / group0 main — renders at the TOP.
+    category_array = [lane_labels[p] for p in reversed(lane_pairs)]
+
+    # Flow edges -> one annotation arrow each, from the source slice's end lane to
+    # the destination slice's start lane. Each FlowEdge is a distinct occurrence,
+    # so the arrows fan out instead of collapsing onto a shared endpoint.
+    annotations = []
+    for edge in edges:
+        src_label = _lane_label(edge.src_track[1], edge.src_track[2], group_id_to_name,
+                                lane_id_to_name)
+        dst_label = _lane_label(edge.dst_track[1], edge.dst_track[2], group_id_to_name,
+                                lane_id_to_name)
+        src_ts = edge.src_ts_cy
+        dst_ts = edge.dst_ts_cy
+        # Arrow only, no text label: the line from src to dst already says it all.
+        annotations.append({
+            "x": dst_ts, "y": dst_label,
+            "ax": src_ts, "ay": src_label,
+            "xref": "x", "yref": "y", "axref": "x", "ayref": "y",
+            "showarrow": True, "arrowhead": 2, "arrowwidth": 1.5, "arrowsize": 1.1,
+            "arrowcolor": _ARROW_COLOR, "opacity": 0.85, "text": "",
+        })
+
+    layout = {
+        "title": {
+            "text": f"<b>{title} · CTA {cta}</b>",
+            "font": {"size": 20, "family": _FONT_FAMILY},
+            "x": 0.02, "xanchor": "left",
+        },
+        "barmode": "overlay",
+        "bargap": 0.35,
+        "paper_bgcolor": _PAPER_BG,
+        "plot_bgcolor": _PAPER_BG,
+        "font": {"family": _FONT_FAMILY, "color": _INK, "size": 13},
+        "dragmode": "pan",
+        "xaxis": {
+            "title": "SM cycles (clock64)",
+            "gridcolor": _GRID_COLOR,
+            "zeroline": False,
+            "range": [0, span * 1.02],
+            "fixedrange": False,
+            "showspikes": True,
+            "spikemode": "across",
+            "spikecolor": "#7c7565",
+            "spikethickness": 1,
+        },
+        "yaxis": {
+            "categoryorder": "array",
+            "categoryarray": category_array,
+            "fixedrange": True,
+            "tickfont": {"size": 13, "family": _FONT_FAMILY},
+            "automargin": True,
+        },
+        "legend": {"orientation": "h", "y": -0.16, "x": 0, "font": {"size": 12}},
+        "margin": {"l": 200, "r": 30, "t": 80, "b": 120},
+        "hoverlabel": {"font": {"family": _FONT_FAMILY, "size": 12}},
+        "annotations": annotations,
+    }
+    return {"data": data, "layout": layout}
+
+
+# Plotly config: horizontal-only zoom + pan. With yaxis.fixedrange set, scrollZoom
+# stretches only x and pan moves only x; the vertical / box / autoscale buttons are
+# stripped so the y axis can never be rescaled.
+_CONFIG = {
+    "scrollZoom": True,
+    "displaylogo": False,
+    "responsive": True,
+    "modeBarButtonsToRemove": [
+        "zoom2d", "select2d", "lasso2d", "zoomIn2d", "zoomOut2d", "autoScale2d",
+    ],
+}
+
+_PLOTLY_CDN = "https://cdn.plot.ly/plotly-2.35.2.min.js"
+
+_HTML_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title}</title>
+<script src="{cdn}" charset="utf-8"></script>
+<style>
+ html,body{{margin:0;height:100%;background:#f3ede1;font-family:ui-monospace,monospace;}}
+ #tabs{{display:flex;gap:6px;padding:8px 14px 4px;overflow-x:auto;white-space:nowrap;
+   border-bottom:1px solid #d8cfbb;}}
+ #tabs button{{font:600 13px ui-monospace,monospace;background:#e8e1d1;color:#191a16;
+   border:1px solid #c9c0b0;border-radius:5px;padding:5px 12px;cursor:pointer;}}
+ #tabs button:hover{{background:#dcd3bf;}}
+ #tabs button.active{{background:#7d5ba6;color:#fff;border-color:#7d5ba6;}}
+ #plot{{width:100vw;height:calc(100vh - 56px);}}
+</style></head><body>
+<div id="tabs">{tab_buttons}</div>
+<div id="plot"></div>
+<script>
+ const figs = {figs_json};
+ const ctas = {ctas_json};
+ const config = {config_json};
+ const plot = document.getElementById('plot');
+ function show(cta){{
+   const f = figs[cta];
+   Plotly.react(plot, f.data, f.layout, config);
+   document.querySelectorAll('#tabs button').forEach(function(b){{
+     b.classList.toggle('active', b.dataset.cta === String(cta));
+   }});
+ }}
+ document.querySelectorAll('#tabs button').forEach(function(b){{
+   b.onclick = function(){{ show(b.dataset.cta); }};
+ }});
+ show(ctas[0]);
+ window.addEventListener('resize', function(){{ Plotly.Plots.resize(plot); }});
+</script></body></html>"""
+
+
+def export_timeline_html(events: list, path: str, *, group_id_to_name: dict,
+                         lane_id_to_name: dict | None = None,
+                         flows: list | None = None, title: str = "",
+                         sm_clock_ghz: float = 1.5) -> None:
+    """Write decoded trace events as a self-contained Plotly HTML timeline.
+
+    Groups the events by CTA (``track[0]``), builds one horizontal-bar Gantt figure
+    per CTA, and emits a single ``.html`` file with a top tab strip switching CTAs
+    via ``Plotly.react``. Colors are assigned per event name globally (stable
+    across CTAs). The viewer loads Plotly from a CDN, so opening the file needs
+    internet access (or a locally cached Plotly).
+
+    Args:
+        events: Flat list of ``Slice`` / ``Instant`` objects from
+            :func:`tileops.trace.decode.decode`.
+        path: Destination ``.html`` path.
+        group_id_to_name: ``gid -> name`` map (resolved from the compiled kernel),
+            used to label each lane.
+        lane_id_to_name: ``lane_id -> name`` map (resolved from the kernel), used
+            to label each lane.
+        flows: Optional declared ``(src_name, dst_name)`` pairs
+            (``host_maps["flows"]``), resolved per CTA to flow arrows.
+        title: Base figure title; the CTA index is appended per tab.
+        sm_clock_ghz: Locked SM clock in GHz, used for the ``~ns`` hover column.
+
+    Returns:
+        None. Writes the HTML document to ``path``.
+    """
+    lane_id_to_name = lane_id_to_name or {}
+
+    # All distinct event names across every CTA -> stable color assignment.
+    all_names = {e.name for e in events if isinstance(e, (Slice, Instant))}
+    color_map = _assign_colors(list(all_names))
+
+    by_cta: dict = {}
+    for e in events:
+        by_cta.setdefault(e.track[0], []).append(e)
+
+    ctas = sorted(by_cta)
+    figs = {
+        str(cta): _figure_for_cta(cta, by_cta[cta], group_id_to_name, lane_id_to_name,
+                                  flows, color_map, title, sm_clock_ghz)
+        for cta in ctas
+    }
+
+    tab_buttons = "".join(f'<button data-cta="{cta}">CTA {cta}</button>' for cta in ctas)
+    html = _HTML_TEMPLATE.format(
+        title=title or "trace timeline",
+        cdn=_PLOTLY_CDN,
+        tab_buttons=tab_buttons,
+        figs_json=json.dumps(figs),
+        ctas_json=json.dumps([str(c) for c in ctas]),
+        config_json=json.dumps(_CONFIG),
+    )
+    with open(path, "w") as f:
+        f.write(html)


### PR DESCRIPTION
## Summary

- **Warp-specialized GEMM kernel.** Rewrites the dense `GemmKernel` as a hand-written two-warpgroup warp-specialized implementation for Hopper (SM90): a producer warpgroup issues TMA loads into a double-buffered SMEM ring, a consumer warpgroup runs WGMMA over K. Covers all four `(trans_a, trans_b)` layouts via the WGMMA transpose flags. fp16/bf16 in, fp32 accumulate. The `GemvKernel` fast path (m==1 / n==1) is unchanged.
- **In-kernel timeline trace tool (`tileops/trace/`).** Annotate a kernel body with `trace.group` / `range` / `record` / `dag`; `trace.out_idx` + `trace.finalize` wire the markers into a vanilla `@tilelang.jit` builder (lowered when tracing is on, stripped to zero cost when off); `trace.run` executes the kernel and dumps a self-contained Plotly HTML timeline. Process-local switch via `trace.enable()` — no monkeypatch, no env var. `GemmKernel` is annotated; opt in per pytest run with `--trace-kernel`.

## Motivation

Small-m dense NT GEMM (e.g. 128×2112×7168) was running well under cuBLAS. The WS kernel targets that regime, and the trace tool provides a timeline view (kernel execution / gaps / producer–consumer overlap) to diagnose it.

## Notes / tradeoffs

- **SM90-only.** WS relies on TMA + WGMMA, so `GemmKernel.supported_archs = [90]`.
- **TMA alignment.** Each input's innermost (contiguous) dimension must be a multiple of 8 fp16 elements (16-byte). For NT (`A @ Bᵀ`) that is `K` only; other layouts additionally require the relevant `M` / `N` to be aligned. Documented on the kernel.
- `_gemm_wrapped_kernel` (torch custom op) is kept for `torch.compile` compatibility; the eager forward calls the compiled JIT directly (cf. `GemvKernel`).

## Tests

- All four layouts (NN/NT/TN/TT) verified numerically against torch (max abs err 0.0), including the `transpose_A` paths.
- Added an NT dense numerics case to `tests/ops/test_gemm.py`; suite passes (23 passed).

## Follow-ups (not in this PR)

- Unit tests for the `tileops/trace/` package.
- Promote the trace-tool design doc into `docs/design/`.
