### PR TITLE
[Doc][Trace] Doc-ready docstrings + in-kernel timeline tutorial

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -22,3 +22,9 @@ All conclusions are scoped to this configuration. Re-validate when any component
 | Category    | Checklist                        | Evidence                                           |
 | ----------- | -------------------------------- | -------------------------------------------------- |
 | Elementwise | [elementwise.md](elementwise.md) | [elementwise-evidence.md](elementwise-evidence.md) |
+
+## Tools & Guides
+
+| Guide                                  | What it covers                                            |
+| -------------------------------------- | --------------------------------------------------------- |
+| [trace-timeline.md](trace-timeline.md) | In-kernel timeline tracer: annotate, build, run, and read |

--- a/docs/perf/trace-timeline.md
+++ b/docs/perf/trace-timeline.md
@@ -1,0 +1,168 @@
+# In-Kernel Timeline Trace
+
+[`tileops.trace`](../api/trace.md) is an in-kernel timeline tracer for diagnosing kernel performance.
+It records per-CTA timestamps from inside the kernel and renders a timeline you
+can scroll through — showing execution, gaps, and producer/consumer overlap that
+per-kernel profilers (e.g. `ncu`) do not surface. It is most useful for
+warp-specialized kernels, where overlapping the producer (TMA) and consumer
+(WGMMA) warpgroups is the whole point.
+
+## How it works
+
+1. You annotate the kernel body with markers (`trace.range`, `trace.group`, …).
+1. Markers are **always emitted** as placeholders. At build time the kernel is
+   either **lowered** (markers become real `clock64()`-recording code plus a
+   trailing `slots` output) or **stripped** (markers become no-ops — the
+   generated CUDA is identical to an un-instrumented build).
+1. At runtime, `trace.run` executes the kernel, decodes the `slots` buffer, and
+   writes a self-contained Plotly HTML timeline.
+1. A process-local switch (`trace.enable()`) decides lowered-vs-stripped, so
+   tracing is **zero cost when off** — you can leave markers in production code.
+
+The timestamp source is `clock64()` (the per-SM cycle counter).
+
+## Write a traced kernel
+
+Below is a complete (illustrative, single-buffer) warp-specialized GEMM with
+tracing wired in. The numbered markers `(1)`–`(7)` are the only trace-specific
+additions; each is explained below, linked to its API doc. The production
+multi-stage version lives in
+[`tileops/kernels/gemm.py`](https://github.com/tile-ai/TileOPs/blob/main/tileops/kernels/gemm.py).
+
+```{ .python .annotate }
+import functools
+import tilelang
+import tilelang.language as T
+from tileops.trace import trace  # (1)!
+
+
+@functools.lru_cache(maxsize=32)
+def build_gemm(m, n, k, dtype="float16", traced=False):
+    @tilelang.jit(out_idx=trace.out_idx(1, traced))  # (2)!
+    def factory(block_m=128, block_n=128, block_k=64):
+        @T.prim_func
+        def main(a: T.Tensor((m, k), dtype), b: T.Tensor((n, k), dtype),
+                 c: T.Tensor((m, n), dtype)):
+            with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m),
+                          threads=256) as (bx, by):
+                a_smem = T.alloc_shared((block_m, block_k), dtype)
+                b_smem = T.alloc_shared((block_n, block_k), dtype)
+                c_local = T.alloc_fragment((block_m, block_n), "float")
+                full = T.alloc_barrier(128)
+                tx = T.get_thread_binding()
+
+                if tx < 128:
+                    with trace.group("producer", lead=0):  # (3)!
+                        for ki in T.serial(T.ceildiv(k, block_k)):
+                            with trace.range("tma", lane="tma"):  # (4)!
+                                T.tma_copy(a[by * block_m, ki * block_k], a_smem, barrier=full)
+                                T.tma_copy(b[bx * block_n, ki * block_k], b_smem, barrier=full)
+                            with trace.range("arrive", lane="barrier"):
+                                T.barrier_arrive(full)
+                else:
+                    with trace.group("consumer", lead=128):
+                        T.clear(c_local)
+                        for ki in T.serial(T.ceildiv(k, block_k)):
+                            with trace.range("wait", lane="barrier"):
+                                T.barrier_wait(full, ki % 2)
+                            with trace.range("mma", lane="wgmma"):  # (5)!
+                                T.wgmma_gemm(a_smem, b_smem, c_local, transpose_B=True)
+                        with trace.range("epilogue"):
+                            T.copy(c_local, c[by * block_m, bx * block_n])
+
+                trace.dag("arrive", "wait")  # (6)!
+        return trace.finalize(main, traced=traced, max_events=1024)  # (7)!
+    return factory
+```
+
+1. Import the trace namespace — every call below is a method on this single
+   `trace` object (full [API reference](../api/trace.md)).
+1. [`trace.out_idx(n_outputs, traced)`](../api/trace.md#tileops.trace.api._Trace.out_idx) — the
+   `@tilelang.jit` `out_idx`. It grows by one (for the trailing `slots` output)
+   only when `traced`, so the same builder works on or off.
+1. [`trace.group(name, lead)`](../api/trace.md#tileops.trace.api._Trace.group) — declares which
+   warpgroup records. `lead` is the elected writer thread (`tx == lead`);
+   compute still runs on all threads, only the timestamps are written by `lead`.
+1. [`trace.range(name, lane)`](../api/trace.md#tileops.trace.api._Trace.range) — a `with` block
+   timed from enter to exit, drawn as a bar on sub-lane `lane`. For control flow
+   that does not fit a `with`, use
+   [`trace.range_start`](../api/trace.md#tileops.trace.api._Trace.range_start) /
+   [`trace.range_end`](../api/trace.md#tileops.trace.api._Trace.range_end); for a zero-width mark
+   use [`trace.record`](../api/trace.md#tileops.trace.api._Trace.record).
+1. Lane names (`"tma"`, `"barrier"`, `"wgmma"`, the default `"main"`) become the
+   rows in the timeline.
+1. [`trace.dag(src, dst)`](../api/trace.md#tileops.trace.api._Trace.dag) — declares a dependency
+   arrow from one named range to another (`arrive` → `wait`), drawn once per
+   occurrence.
+1. [`trace.finalize(func, traced, max_events)`](../api/trace.md#tileops.trace.api._Trace.finalize)
+   — lowers the markers (adding the `slots` output) when `traced`, else strips
+   them to zero cost. `traced` **must be part of the builder's cache key** so a
+   traced and an untraced build for the same shape do not collide.
+
+## Running a traced kernel
+
+Call the builder with `traced=trace.enabled` and hand the compiled kernel to
+`trace.run`. The same `forward` works in both modes: with tracing off it returns
+the outputs unchanged; with tracing on it dumps the timeline and returns the real
+outputs only — so you never branch on the switch yourself.
+
+```{ .python .annotate }
+def forward(self, a, b):
+    compiled = build_gemm(self.m, self.n, self.k, self.dtype_str,
+                          traced=trace.enabled)(**self.config)  # (1)!
+    return trace.run(compiled, (a, b), stem="gemm_128x256x512")  # (2)!
+```
+
+1. Build the kernel matching the switch — [`trace.enabled`](../api/trace.md#tileops.trace.api._Trace.enabled)
+   picks the traced or stripped variant (and is part of the cache key from
+   marker `(7)`).
+1. [`trace.run(compiled, inputs, stem=...)`](../api/trace.md#tileops.trace.api._Trace.run) — runs
+   the kernel; when traced, splits the trailing `slots` off, decodes it, and
+   writes `debug/<stem>.html` (a fresh, non-colliding file each call). Under the
+   hood it is [`decode`](../api/trace.md#tileops.trace.api._Trace.decode) +
+   [`dump`](../api/trace.md#tileops.trace.api._Trace.dump), which you can also call directly.
+
+## Enabling tracing
+
+Tracing is off by default. Flip the process-local switch once at startup, then
+run as usual:
+
+```{ .python .annotate }
+from tileops.trace import trace
+
+trace.enable()  # (1)!
+c = op.forward(a, b)  # (2)!
+```
+
+1. [`trace.enable(output="debug")`](../api/trace.md#tileops.trace.api._Trace.enable) — turn
+   tracing on and choose the dump directory (default `debug/`, gitignored). The
+   switch is process-local — no environment variable, and `tilelang` is not
+   monkeypatched. See also [`trace.disable()`](../api/trace.md#tileops.trace.api._Trace.disable),
+   [`trace.enabled`](../api/trace.md#tileops.trace.api._Trace.enabled),
+   [`trace.output`](../api/trace.md#tileops.trace.api._Trace.output).
+1. Any traced kernel that now runs writes `debug/<stem>.html`.
+
+From a pytest run, `--trace-kernel` calls `trace.enable()` from `pytest_configure`
+before any kernel is built:
+
+```bash
+pytest tests/ops/test_gemm.py --trace-kernel
+```
+
+## Reading the timeline
+
+<iframe src="../gemm-trace.html" title="GEMM timeline" width="100%" height="540"
+        style="border:1px solid var(--md-default-fg-color--lightest);border-radius:4px;"></iframe>
+
+- **CTA tabs** at the top — one timeline per CTA (block).
+- **Lanes** (rows) come from your `group` and `lane` names — e.g. `producer / tma`,
+  `consumer / wgmma`. Each `range` is a bar; hover for its name and cycle span.
+- **X axis** is raw SM cycles (`clock64()`), zeroed per CTA.
+- **Arrows** are your `dag` edges (e.g. producer `arrive` → consumer `wait`), one
+  per occurrence — so you can read the handoff latency and whether the consumer
+  is starved.
+- Zoom and pan are horizontal-only.
+
+What to look for: gaps on the `wgmma` lane (consumer stalled waiting on a TMA
+load), `dag` arrows that do not overlap across iterations (no pipelining), or one
+lane dominating the others (imbalance).

--- a/tileops/trace/__init__.py
+++ b/tileops/trace/__init__.py
@@ -1,6 +1,6 @@
 """In-kernel timeline trace tool: annotate, build, run, and export a timeline.
 
-The whole surface is the :data:`trace` namespace (see :mod:`tileops.trace.api`
+The whole surface is the ``trace`` namespace (see ``tileops.trace.api``
 for the full, example-driven reference). In short: ``trace.enable()`` turns
 tracing on, ``with trace.range(...)`` / ``trace.group(...)`` mark up a kernel
 body, ``trace.out_idx`` + ``trace.finalize`` wire it into a vanilla

--- a/tileops/trace/api.py
+++ b/tileops/trace/api.py
@@ -57,10 +57,10 @@ __all__ = ["trace"]
 
 
 class _Trace:
-    """The ``trace`` namespace (use the singleton :data:`trace`, do not instantiate).
+    """The ``trace`` namespace (use the singleton ``trace``, do not instantiate).
 
-    Stateless except for the process-local run switch (:attr:`enabled` /
-    :attr:`output`); all annotation state lives in the per-build registry.
+    Stateless except for the process-local run switch (``enabled`` /
+    ``output``); all annotation state lives in the per-build registry.
     """
 
     def __init__(self) -> None:
@@ -93,10 +93,10 @@ class _Trace:
         """Turn tracing on for this process and set the output directory.
 
         Call once at startup, before any traced kernel is built — a builder reads
-        :attr:`enabled` at build time and is typically cached.
+        ``enabled`` at build time and is typically cached.
 
         Args:
-            output: Directory for dumped artifacts (created on first :meth:`dump`).
+            output: Directory for dumped artifacts (created on first ``dump``).
                 Defaults to ``"debug"`` (gitignored).
 
         Example:
@@ -160,7 +160,7 @@ class _Trace:
             lane: Render sub-lane, interned dynamically (default ``"main"``).
 
         Returns:
-            A token to pass to :meth:`range_end`.
+            A token to pass to ``range_end``.
 
         Example:
             >>> tok = trace.range_start("phase")
@@ -173,7 +173,7 @@ class _Trace:
         """Close the range opened for ``tok`` (``None`` no-ops).
 
         Args:
-            tok: The token returned by :meth:`range_start`.
+            tok: The token returned by ``range_start``.
 
         Example:
             >>> trace.range_end(tok)
@@ -215,13 +215,13 @@ class _Trace:
     def out_idx(self, n_outputs: int, traced: bool | None = None) -> list[int]:
         """Return the ``out_idx`` for a kernel with ``n_outputs`` real outputs.
 
-        Grows by one (for the trailing ``slots`` output that :meth:`finalize`
+        Grows by one (for the trailing ``slots`` output that ``finalize``
         appends) when traced, so the same builder works either way.
 
         Args:
             n_outputs: Number of real (non-``slots``) outputs.
             traced: Whether this build is traced. ``None`` (default) reads the
-                process switch :attr:`enabled`. **A cached builder must pass an
+                process switch ``enabled``. **A cached builder must pass an
                 explicit value** and include it in its cache key — otherwise the
                 ``out_idx`` baked into the cached kernel ignores later switch flips.
 
@@ -243,13 +243,13 @@ class _Trace:
         """Lower the markers when traced, else strip them — return either.
 
         The one line a builder returns instead of branching. Pairs with
-        :meth:`out_idx`; pass the same ``traced`` to both.
+        ``out_idx``; pass the same ``traced`` to both.
 
         Args:
             primfunc: The built kernel; its body carries ``trace.*`` markers.
             traced: Whether this build is traced. ``None`` (default) reads the
-                process switch :attr:`enabled`. A cached builder must pass an
-                explicit value (see :meth:`out_idx`).
+                process switch ``enabled``. A cached builder must pass an
+                explicit value (see ``out_idx``).
             max_events: Per-slot event capacity when lowering.
 
         Returns:
@@ -268,7 +268,7 @@ class _Trace:
     def lower(self, primfunc, max_events: int = MAX_EVENTS_DEFAULT):
         """Primitive: materialize the markers and append the ``slots`` output.
 
-        Prefer :meth:`finalize` unless you need to lower unconditionally.
+        Prefer ``finalize`` unless you need to lower unconditionally.
 
         Args:
             primfunc: The built kernel; its body carries ``trace.*`` markers.
@@ -285,7 +285,7 @@ class _Trace:
     def strip(self, primfunc):
         """Primitive: no-op every marker so the kernel compiles without tracing.
 
-        Prefer :meth:`finalize` unless you need to strip unconditionally. The
+        Prefer ``finalize`` unless you need to strip unconditionally. The
         generated CUDA is identical to an un-instrumented build.
 
         Args:
@@ -308,15 +308,15 @@ class _Trace:
         so the caller does not. With tracing **off** it just returns the kernel's
         outputs unchanged. With tracing **on** the kernel is the traced build
         (returns ``(*real_outputs, slots)``): this splits the trailing ``slots``
-        tensor off, decodes it, writes the timeline via :meth:`dump` (a fresh file
+        tensor off, decodes it, writes the timeline via ``dump`` (a fresh file
         each call), and returns the real outputs only.
 
         Args:
             compiled: A compiled kernel. Build it with ``traced=trace.enabled``
-                (via :meth:`out_idx` / :meth:`finalize`) so its outputs match the
+                (via ``out_idx`` / ``finalize``) so its outputs match the
                 switch.
             inputs: Tuple of positional tensors to pass to ``compiled``.
-            stem: Descriptive file stem (op name + shape); see :meth:`dump`.
+            stem: Descriptive file stem (op name + shape); see ``dump``.
 
         Returns:
             The kernel's real outputs: a single tensor, or a tuple in order.
@@ -357,13 +357,13 @@ class _Trace:
                        max_events=maps["max_events"], num_groups=maps["num_groups"])
 
     def dump(self, events: list, compiled, *, stem: str) -> str:
-        """Write events as an HTML timeline under :attr:`output`, never overwriting.
+        """Write events as an HTML timeline under ``output``, never overwriting.
 
         Picks a collision-free base name: ``{output}/{stem}`` when free, else
         ``{output}/{stem}_1``, ``_2``, ... so repeated dumps accumulate.
 
         Args:
-            events: Event list from :meth:`decode`.
+            events: Event list from ``decode``.
             compiled: The compiled traced kernel (carries the host maps).
             stem: File stem (no directory, no extension), e.g. op name + shape.
 
@@ -390,7 +390,7 @@ class _Trace:
         """Write events as a self-contained Plotly HTML timeline.
 
         Args:
-            events: Event list from :meth:`decode`.
+            events: Event list from ``decode``.
             path: Destination ``.html`` path.
             compiled: The compiled traced kernel (carries the host maps).
             title: Base figure title; the CTA index is appended per tab.

--- a/tileops/trace/decode.py
+++ b/tileops/trace/decode.py
@@ -2,7 +2,7 @@
 
 After readback the device emits one ``slots`` int64 tensor of shape
 ``(num_cta, num_groups, (max_events + 1) * 2)`` (the layout
-:func:`tileops.trace.passes.lower` writes). Each ``(cta, gid)`` slot row
+``tileops.trace.passes.lower`` writes). Each ``(cta, gid)`` slot row
 is a flat run of int64 words:
 
 * ``word[0]`` = event count (header), saturated at ``max_events``.
@@ -15,15 +15,15 @@ is a flat run of int64 words:
 This module turns those raw words into render-ready objects: per ``(cta, gid)``
 slot it reads the header count, unpacks each ``w1`` word, zeroes timestamps per
 **CTA**, and stack-matches RANGE_BEGIN/RANGE_END pairs per ``(cta, gid, lane)``
-track into :class:`Slice` objects. INSTANT records become :class:`Instant`
+track into ``Slice`` objects. INSTANT records become ``Instant``
 objects. The ``lane`` in each track is the interned lane id; exporters resolve it
 to a name via the ``lane_id_to_name`` map.
 
 Flow arrows are NOT decoded from records: ``trace.dag`` is a build-time
-declaration, so no flow record exists on the device. Instead :func:`compute_flows`
-takes the decoded :class:`Slice` list plus the declared ``(src_name, dst_name)``
+declaration, so no flow record exists on the device. Instead ``compute_flows``
+takes the decoded ``Slice`` list plus the declared ``(src_name, dst_name)``
 pairs and, per CTA, pairs the i-th ``src_name`` slice with the i-th ``dst_name``
-slice (both in timestamp order) into :class:`FlowEdge` objects.
+slice (both in timestamp order) into ``FlowEdge`` objects.
 
 Per-CTA timestamp zeroing:
     ``clock64`` is a per-SM counter, so timestamps are only comparable within a
@@ -80,7 +80,7 @@ class Instant:
 class FlowEdge:
     """One resolved flow arrow connecting a source slice to a destination slice.
 
-    Built by :func:`compute_flows` from a declared ``(src_name, dst_name)`` flow:
+    Built by ``compute_flows`` from a declared ``(src_name, dst_name)`` flow:
     per CTA, the i-th ``src_name`` slice (by start timestamp) pairs with the i-th
     ``dst_name`` slice. The arrow runs from the source slice's END to the
     destination slice's START.
@@ -137,7 +137,7 @@ def decode(slots, *, id_to_name: dict[int, str], group_id_to_name: dict[int, str
     Walks every ``(cta, gid)`` slot, reads the header count, unpacks each event's
     ``w1`` word, zeroes timestamps against the owning **CTA**'s minimum, and
     stack-matches range pairs per ``(cta, gid, lane)`` track in stored program
-    order. Flow arrows are not decoded here; :func:`compute_flows` derives them
+    order. Flow arrows are not decoded here; ``compute_flows`` derives them
     from the returned slices and the declared flow pairs.
 
     Tracks are always the full 3-tuple ``(cta, gid, lane)`` with ``lane`` the
@@ -243,23 +243,23 @@ def decode(slots, *, id_to_name: dict[int, str], group_id_to_name: dict[int, str
 
 
 def compute_flows(events: list, flows: list) -> list:
-    """Resolve declared flow pairs into per-CTA :class:`FlowEdge` arrows.
+    """Resolve declared flow pairs into per-CTA ``FlowEdge`` arrows.
 
     For each declared ``(src_name, dst_name)`` flow and each CTA, collects that
-    CTA's :class:`Slice` objects named ``src_name`` and named ``dst_name`` (each
+    CTA's ``Slice`` objects named ``src_name`` and named ``dst_name`` (each
     sorted by start timestamp), then pairs the i-th source with the i-th
     destination for ``i`` in ``[0, min(len_src, len_dst))``. Each pair becomes one
-    :class:`FlowEdge` whose arrow runs from the source slice END to the
+    ``FlowEdge`` whose arrow runs from the source slice END to the
     destination slice START. Distinct occurrences therefore yield distinct edges
     with distinct endpoints — never collapsing onto a single anchor.
 
     Args:
-        events: Flat event list from :func:`decode` (only :class:`Slice` objects
+        events: Flat event list from ``decode`` (only ``Slice`` objects
             participate; other kinds are ignored).
         flows: Declared ``(src_name, dst_name)`` pairs (``host_maps["flows"]``).
 
     Returns:
-        A flat list of :class:`FlowEdge` objects across all flows and CTAs.
+        A flat list of ``FlowEdge`` objects across all flows and CTAs.
     """
     slices = [e for e in events if isinstance(e, Slice)]
     ctas = sorted({s.track[0] for s in slices})

--- a/tileops/trace/markers.py
+++ b/tileops/trace/markers.py
@@ -2,7 +2,7 @@
 
 Holds the device-side ``tl_trace_marker`` emitter plus the scope / token types
 that ``trace.group`` and ``trace.range`` return. Not part of the public API —
-import :data:`tileops.trace.trace`, never this module.
+import ``tileops.trace.trace``, never this module.
 """
 
 import tilelang.language as T

--- a/tileops/trace/passes.py
+++ b/tileops/trace/passes.py
@@ -1,14 +1,14 @@
 """Frontend ``trace.lower`` transform: materialize trace placeholders.
 
 This is the build-time half of the trace tool. It pairs with the module-level
-:data:`tileops.trace.api.trace` annotation API: that API emits zero-cost
+``tileops.trace.api.trace`` annotation API: that API emits zero-cost
 ``tl_trace_marker`` placeholders into a kernel body as it is built; ``trace.lower``
 then rewrites every placeholder into real emit code and appends a ``slots`` output
 param, returning a plain ``PrimFunc`` that a *vanilla* ``@tilelang.jit`` compiles.
 
 There is no monkeypatch of ``tilelang``: importing this module leaves
 ``tilelang.compile`` / ``tilelang.jit.compile`` untouched. The whole surface is
-the explicit :func:`lower` transform.
+the explicit ``lower`` transform.
 
 Module name note:
     ``pass`` is a Python keyword, so the file is named ``passes.py`` to stay a
@@ -42,9 +42,9 @@ kernel prologue before any marker fires.
 Host-map registry
 ------------------
 ``trace.lower`` stashes the host-side decode maps in the module-level
-:data:`_META_REGISTRY` dict, keyed by an integer meta id stamped onto the
+``_META_REGISTRY`` dict, keyed by an integer meta id stamped onto the
 returned ``PrimFunc`` as the ``tl.trace_meta_id`` attr. The attr rides through
-``tilelang.jit`` onto ``kernel.prim_func``, so :func:`lookup_meta` resolves a
+``tilelang.jit`` onto ``kernel.prim_func``, so ``lookup_meta`` resolves a
 compiled kernel back to its maps without relying on object identity.
 """
 
@@ -215,7 +215,7 @@ def _strip_markers(primfunc):
 
     The always-emit markers are no-opped before codegen so the generated CUDA is
     byte-identical to an un-instrumented build (no ``slots`` param, no
-    ``__tl_now``). Backs the public :func:`strip` escape hatch.
+    ``__tl_now``). Backs the public ``strip`` escape hatch.
 
     Args:
         primfunc: A built kernel whose body may contain marker placeholders.
@@ -248,21 +248,21 @@ def lower(primfunc, max_events: int = MAX_EVENTS_DEFAULT):
     ``out_idx`` already accounts for the trailing ``slots`` param (e.g.
     ``out_idx=[-2, -1]`` when the kernel has one own output ``C`` and ``slots``).
 
-    Reads the per-build trace registry (:func:`tileops.trace.state.build_state`),
+    Reads the per-build trace registry (``tileops.trace.state.build_state``),
     derives ``num_groups`` from the distinct interned groups, runs
-    :func:`_transform` to rewrite each marker into writer-gated clamped emit code
+    ``_transform`` to rewrite each marker into writer-gated clamped emit code
     (deriving ``num_cta`` from the launch grid), then stashes the host decode maps
-    in :data:`_META_REGISTRY` under a fresh integer meta id and stamps that id
+    in ``_META_REGISTRY`` under a fresh integer meta id and stamps that id
     onto the returned func as the ``tl.trace_meta_id`` attr. The attr rides
-    through ``tilelang.jit`` onto ``kernel.prim_func`` so :func:`lookup_meta`
+    through ``tilelang.jit`` onto ``kernel.prim_func`` so ``lookup_meta``
     resolves the compiled kernel back to its maps. It then retires the build epoch
-    (:func:`tileops.trace.state.begin_build_epoch`) so the next build starts
+    (``tileops.trace.state.begin_build_epoch``) so the next build starts
     fresh.
 
     Args:
         primfunc: The built kernel; its body carries ``tl_trace_marker`` markers.
         max_events: Per-slot event capacity (compile-time cursor bound). Defaults
-            to :data:`tileops.trace.record.MAX_EVENTS_DEFAULT`.
+            to ``tileops.trace.record.MAX_EVENTS_DEFAULT``.
 
     Returns:
         The lowered ``PrimFunc`` with the trailing ``slots`` int64 output param
@@ -303,7 +303,7 @@ def strip(primfunc):
     """No-op the always-emit markers so ``primfunc`` compiles WITHOUT tracing.
 
     The escape hatch: a kernel written with ``trace.*`` markers can be compiled
-    zero-cost by passing it through ``strip`` instead of :func:`lower`. The
+    zero-cost by passing it through ``strip`` instead of ``lower``. The
     returned func has no ``slots`` param and emits no ``__tl_now``, so the
     generated CUDA is byte-identical to an un-instrumented build.
 
@@ -319,13 +319,13 @@ def strip(primfunc):
 def lookup_meta(kernel) -> dict:
     """Resolve a compiled kernel back to its host decode maps.
 
-    Reads the ``tl.trace_meta_id`` attr that :func:`lower` stamped onto the
+    Reads the ``tl.trace_meta_id`` attr that ``lower`` stamped onto the
     transformed ``PrimFunc`` (exposed as ``kernel.prim_func``) and looks the maps
-    up in :data:`_META_REGISTRY`.
+    up in ``_META_REGISTRY``.
 
     Args:
         kernel: A compiled kernel from a vanilla ``@tilelang.jit`` over a builder
-            that returned :func:`lower`'s result.
+            that returned ``lower``'s result.
 
     Returns:
         The host-map dict (``id_to_name`` / ``group_id_to_name`` /
@@ -334,7 +334,7 @@ def lookup_meta(kernel) -> dict:
 
     Raises:
         ValueError: If the kernel's ``prim_func`` carries no ``tl.trace_meta_id``
-            attr (it was not produced by :func:`lower`), or the id is unknown.
+            attr (it was not produced by ``lower``), or the id is unknown.
     """
     prim_func = getattr(kernel, "prim_func", None)
     attrs = getattr(prim_func, "attrs", None)

--- a/tileops/trace/record.py
+++ b/tileops/trace/record.py
@@ -60,7 +60,7 @@ def pack_w1(event_id: int, kind: int, lane: int, payload: int) -> int:
 
     Args:
         event_id: Interned event id, must fit 24 bits (0..2**24-1).
-        kind: Event kind, must fit 4 bits (an :class:`EventKind` or its int).
+        kind: Event kind, must fit 4 bits (an ``EventKind`` or its int).
         lane: Interned lane id, must fit 4 bits.
         payload: Raw unsigned 32-bit bit-pattern of an i32/f32 payload. Must fit
             32 bits; no silent truncation.
@@ -88,7 +88,7 @@ def pack_w1(event_id: int, kind: int, lane: int, payload: int) -> int:
 def unpack_w1(w1: int) -> tuple[int, int, int, int]:
     """Unpack a ``w1`` word into ``(event_id, kind, lane, payload)``.
 
-    Inverse of :func:`pack_w1` over the full field ranges.
+    Inverse of ``pack_w1`` over the full field ranges.
 
     Args:
         w1: A packed 64-bit word.
@@ -114,7 +114,7 @@ def pack_w1_tir(event_id: int, kind: int, lane: int, payload_expr: PrimExpr) -> 
 
     Args:
         event_id: Interned event id, must fit 24 bits.
-        kind: Event kind, must fit 4 bits (an :class:`EventKind` or its int).
+        kind: Event kind, must fit 4 bits (an ``EventKind`` or its int).
         lane: Interned lane id, must fit 4 bits.
         payload_expr: TIR i32 PrimExpr carrying the raw payload bits.
 

--- a/tileops/trace/state.py
+++ b/tileops/trace/state.py
@@ -2,17 +2,17 @@
 
 The trace tool splits responsibilities:
 
-* The module-level :data:`tileops.trace.api.trace` namespace emits lightweight
+* The module-level ``tileops.trace.api.trace`` namespace emits lightweight
   *placeholders* (``tl_trace_marker`` ``call_extern`` nodes) into the kernel body
   and interns the human-readable names referenced by those placeholders into id
   tables.
-* The :func:`tileops.trace.passes.lower` transform reads those same intern tables
+* The ``tileops.trace.passes.lower`` transform reads those same intern tables
   back out (to build the host-side decode maps) after the kernel is built.
 
 The two halves never call each other directly; they communicate through the
 build registry installed here. The ``trace.*`` markers populate a fresh
-:class:`TraceState` per build epoch (:func:`build_state`); ``trace.lower`` reads
-it, then retires the epoch (:func:`begin_build_epoch`) so the next build starts
+``TraceState`` per build epoch (``build_state``); ``trace.lower`` reads
+it, then retires the epoch (``begin_build_epoch``) so the next build starts
 clean.
 
 This is process-global, single-threaded build state: TileLang kernels are built
@@ -42,7 +42,7 @@ _DEFAULT_LANE = "main"
 class TraceState:
     """Build-global intern tables + the active group stack for one build.
 
-    A fresh instance backs each build epoch (see :func:`build_state`). The
+    A fresh instance backs each build epoch (see ``build_state``). The
     annotation API mutates it as it emits placeholders; the transform reads the
     reverse maps to label the host-side decode.
 
@@ -99,11 +99,11 @@ class TraceState:
         return self._group_stack[-1][1]
 
     def push_group(self, name: str, lead: int) -> None:
-        """Make ``(name, lead)`` the live group until the matching :meth:`pop_group`."""
+        """Make ``(name, lead)`` the live group until the matching ``pop_group``."""
         self._group_stack.append((name, lead))
 
     def pop_group(self) -> None:
-        """Restore the previously live group (undo one :meth:`push_group`)."""
+        """Restore the previously live group (undo one ``push_group``)."""
         self._group_stack.pop()
 
     # -- intern tables ----------------------------------------------------
@@ -175,7 +175,7 @@ class TraceState:
 
         The declaration emits no runtime record; the host renders it by pairing
         each CTA's ``src_name`` slices with its ``dst_name`` slices in timestamp
-        order (see :func:`tileops.trace.decode.compute_flows`).
+        order (see ``tileops.trace.decode.compute_flows``).
 
         Args:
             src_name: Source (producer) range name.
@@ -200,9 +200,9 @@ _BUILD_STATE: TraceState | None = None
 def begin_build_epoch() -> None:
     """Retire the current build registry so the next marker starts a fresh one.
 
-    Called by :func:`tileops.trace.passes.lower` after it has consumed a build's
-    interned maps. The next :func:`build_state` lookup installs a new empty
-    :class:`TraceState`.
+    Called by ``tileops.trace.passes.lower`` after it has consumed a build's
+    interned maps. The next ``build_state`` lookup installs a new empty
+    ``TraceState``.
     """
     global _BUILD_STATE
     _BUILD_STATE = None
@@ -215,7 +215,7 @@ def build_state() -> TraceState:
     which emits no markers never allocates one.
 
     Returns:
-        The current build epoch's :class:`TraceState`.
+        The current build epoch's ``TraceState``.
     """
     global _BUILD_STATE
     if _BUILD_STATE is None:

--- a/tileops/trace/ui.py
+++ b/tileops/trace/ui.py
@@ -1,7 +1,7 @@
 """Self-contained Plotly HTML timeline viewer for decoded trace events.
 
 Turns the flat ``Slice`` / ``Instant`` list from
-:func:`tileops.trace.decode.decode` into a single, self-contained ``.html`` file
+``tileops.trace.decode.decode`` into a single, self-contained ``.html`` file
 that renders one horizontal-bar Gantt timeline per CTA. The viewer matches the
 look of the reference GPU-pipeline timeline in ``docs/plans/reference_fa3_pipeline.html``:
 warm ``#f3ede1`` paper, monospace fonts, overlaid bars with light separator lines,
@@ -25,8 +25,8 @@ Layout per CTA (``_figure_for_cta``):
       sorted name, so a name keeps its color across CTAs. ``Instant`` markers are
       grouped likewise into thin (1% of span) bar traces.
     * **Flows** (declared ``(src_name, dst_name)`` pairs resolved per CTA by
-      :func:`tileops.trace.decode.compute_flows`) become one ``annotations`` arrow
-      per :class:`~tileops.trace.decode.FlowEdge`, from the source slice's end lane
+      ``tileops.trace.decode.compute_flows``) become one ``annotations`` arrow
+      per ``FlowEdge``, from the source slice's end lane
       to the destination slice's start lane.
 
 Interaction is horizontal-only zoom + pan: ``dragmode:"pan"`` with
@@ -189,7 +189,7 @@ def _figure_for_cta(cta, events, group_id_to_name, lane_id_to_name, flows, color
         group_id_to_name: ``gid -> name`` map for lane labels.
         lane_id_to_name: ``lane_id -> name`` map for lane labels.
         flows: Declared ``(src_name, dst_name)`` pairs, resolved to per-edge arrows
-            for this CTA via :func:`tileops.trace.decode.compute_flows`.
+            for this CTA via ``tileops.trace.decode.compute_flows``.
         color_map: Global ``name -> color`` assignment (stable across CTAs).
         title: Base figure title; the CTA index is appended.
         sm_clock_ghz: Locked SM clock in GHz.
@@ -290,7 +290,7 @@ def _figure_for_cta(cta, events, group_id_to_name, lane_id_to_name, flows, color
         "font": {"family": _FONT_FAMILY, "color": _INK, "size": 13},
         "dragmode": "pan",
         "xaxis": {
-            "title": "SM cycles (clock64)",
+            "title": {"text": "SM cycles (clock64)", "standoff": 10},
             "gridcolor": _GRID_COLOR,
             "zeroline": False,
             "range": [0, span * 1.02],
@@ -307,8 +307,9 @@ def _figure_for_cta(cta, events, group_id_to_name, lane_id_to_name, flows, color
             "tickfont": {"size": 13, "family": _FONT_FAMILY},
             "automargin": True,
         },
-        "legend": {"orientation": "h", "y": -0.16, "x": 0, "font": {"size": 12}},
-        "margin": {"l": 200, "r": 30, "t": 80, "b": 120},
+        "legend": {"orientation": "h", "y": -0.30, "yanchor": "top", "x": 0,
+                   "font": {"size": 12}},
+        "margin": {"l": 200, "r": 30, "t": 80, "b": 170},
         "hoverlabel": {"font": {"family": _FONT_FAMILY, "size": 12}},
         "annotations": annotations,
     }
@@ -379,7 +380,7 @@ def export_timeline_html(events: list, path: str, *, group_id_to_name: dict,
 
     Args:
         events: Flat list of ``Slice`` / ``Instant`` objects from
-            :func:`tileops.trace.decode.decode`.
+            ``tileops.trace.decode.decode``.
         path: Destination ``.html`` path.
         group_id_to_name: ``gid -> name`` map (resolved from the compiled kernel),
             used to label each lane.


### PR DESCRIPTION
## What

Makes the `tileops.trace` module documentation-ready and adds a usage tutorial,
so the trace tool renders cleanly on the docs site (mkdocstrings + Material).

- **Docstrings: Sphinx roles → plain code spans.** Across the whole
  `tileops/trace/` package (`__init__`, `api`, `decode`, `markers`, `passes`,
  `record`, `state`, `ui`), replace `:func:` / `:class:` / `:mod:` / `:data:`
  cross-reference roles with double-backtick code spans. The project is
  Google-docstring-only; mkdocstrings does not resolve Sphinx roles, so they
  rendered as literal `:func:`...`` text on the site.
- **`ui.py` timeline legend fix.** The horizontal legend overlapped the x-axis
  title. Give the x-axis title a `standoff`, anchor the legend below it
  (`y: -0.30`, `yanchor: top`), and grow the bottom margin (120 → 170).
- **New tutorial: `docs/perf/trace-timeline.md`.** End-to-end walkthrough —
  write a traced warp-specialized GEMM, run it, enable tracing, read the
  timeline. Each code block uses Material code annotations (the `+` markers)
  linked to the auto-generated API reference.
- **`docs/perf/README.md`**: add a "Tools & Guides" entry pointing at the tutorial.

## Why

The trace tool shipped in #1638 with no rendered API docs or guide; this makes
its public surface (`tileops.trace.api`) render correctly and gives users a
single walkthrough.

## Notes

- No behavior change: docstring text and one Plotly layout dict only.
- The site-side wiring (mkdocstrings page, nav, embedded timeline) is a separate
  PR against `tile-ai/TileOPs.github.io`.

Closes #1639
