### PR TITLE
[Bench][Attention] Add GQA prefill scale and softcap cases

### DIFF
--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -142,6 +142,8 @@ def _flashinfer_gqa_fwd(test, q, k, v):
         num_kv_heads=Hkv,
         head_dim_qk=D,
         causal=test.is_causal,
+        logits_soft_cap=getattr(test, "softcap", None) or 0.0,
+        sm_scale=getattr(test, "sm_scale", None),
         q_data_type=q.dtype,
     )
 
@@ -200,7 +202,13 @@ def _torch_gqa_prefill_ref(test: GQAPrefillFwdTest):
         q_bhsd = q.transpose(1, 2).float()
         k_bhsd = k.repeat_interleave(groups, dim=2).transpose(1, 2).float()
         v_bhsd = v.repeat_interleave(groups, dim=2).transpose(1, 2).float()
-        scores = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1)) * (test.dim**-0.5)
+        sm_scale = getattr(test, "sm_scale", None)
+        softcap = getattr(test, "softcap", None)
+        scores = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1)) * (
+            test.dim**-0.5 if sm_scale is None else sm_scale
+        )
+        if softcap is not None and softcap > 0:
+            scores = softcap * torch.tanh(scores / softcap)
         if test.is_causal:
             offset = test.seq_len_kv - test.seq_len_q
             q_pos = torch.arange(test.seq_len_q, device=q.device)[:, None] + offset
@@ -363,7 +371,8 @@ _GQA_PREFILL_FWD_BENCH_PARAMS = manifest_params(
 
 
 @pytest.mark.parametrize(
-    "batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, dtype, tune",
+    "batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, backend, sm_scale, softcap, "
+    "dtype, tune",
     _GQA_PREFILL_FWD_BENCH_PARAMS,
 )
 def test_gqa_prefill_fwd_bench(
@@ -374,10 +383,15 @@ def test_gqa_prefill_fwd_bench(
     heads_kv: int,
     dim: int,
     causal: bool,
+    backend: str,
+    sm_scale: Optional[float],
+    softcap: Optional[float],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
     test = GQAPrefillFwdTest(batch, heads, heads_kv, seq_len_q, seq_len_kv, dim, causal, dtype)
+    test.sm_scale = sm_scale
+    test.softcap = softcap
     inputs = test.gen_inputs()
     packed_inputs = _uniform_packed_prefill_inputs(*inputs)
 
@@ -391,6 +405,9 @@ def test_gqa_prefill_fwd_bench(
         is_causal=causal,
         dtype=dtype,
         tune=tune,
+        backend=backend,
+        sm_scale=sm_scale,
+        softcap=softcap,
     )
     bm = ManifestBenchmark(_GQA_PREFILL_FWD_OP, op, test)
     result = bm.profile(op, *packed_inputs)

--- a/benchmarks/ops/attention/manifest_params.py
+++ b/benchmarks/ops/attention/manifest_params.py
@@ -48,11 +48,24 @@ def gqa_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, boo
     return batch, seq_len, heads, heads_kv, dim, workload.get("is_causal", True)
 
 
-def gqa_prefill_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, int, bool]:
+def gqa_prefill_args(
+    workload: dict[str, Any],
+) -> tuple[int, int, int, int, int, int, bool, str, float | None, float | None]:
     if "q_shape" in workload:
         batch, seq_len_q, heads, dim = workload["q_shape"]
         _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
-        return batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, workload.get("is_causal", True)
+        return (
+            batch,
+            seq_len_q,
+            seq_len_kv,
+            heads,
+            heads_kv,
+            dim,
+            workload.get("is_causal", True),
+            workload.get("backend", "auto"),
+            workload.get("sm_scale"),
+            workload.get("softcap"),
+        )
 
     batch = workload["batch"]
     q_lens = list(workload.get("q_lens") or [workload["total_q"] // batch] * batch)
@@ -64,7 +77,18 @@ def gqa_prefill_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int,
     heads = workload["heads"]
     heads_kv = workload["heads_kv"]
     dim = workload["dim"]
-    return batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, workload.get("is_causal", True)
+    return (
+        batch,
+        seq_len_q,
+        seq_len_kv,
+        heads,
+        heads_kv,
+        dim,
+        workload.get("is_causal", True),
+        workload.get("backend", "auto"),
+        workload.get("sm_scale"),
+        workload.get("softcap"),
+    )
 
 
 def gqa_prefill_paged_args(

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -182,10 +182,12 @@ GroupedQueryAttentionPrefillFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense"}
-    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense-q-lt-kv"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", sm_scale: 0.125, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-sm-scale-0.125"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-softcap50"}
+    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense-q-lt-kv"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-dense-q-lt-kv"}
+    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-dense-q-lt-kv"}
     # FP8 Tensor Core prefill through the canonical packed prefill surface.
     - {total_q: 896, total_kv: 896, batch: 1, q_lens: [896], kv_lens: [896], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 896, max_seqlen_kv: 896, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s896"}
     - {total_q: 1792, total_kv: 1792, batch: 1, q_lens: [1792], kv_lens: [1792], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 1792, max_seqlen_kv: 1792, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s1792"}


### PR DESCRIPTION
## Summary
- Add explicit dense-backend GQA prefill manifest workloads for custom sm_scale and softcap.
- Thread backend, sm_scale, and softcap from manifest workloads into the dense prefill benchmark.
- Apply the same sm_scale/softcap settings to the torch reference and FlashInfer baseline so benchmark comparisons use matching semantics.
- Pass 0.0 instead of None for FlashInfer logits_soft_cap when softcap is unset.

This PR intentionally updates only manifest/benchmark coverage. The high-performance kernel scheduling updates will be submitted separately after this lands.

## Testing
- python -m py_compile benchmarks/ops/attention/bench_gqa.py benchmarks/ops/attention/manifest_params.py
- python manifest workload expansion check for GroupedQueryAttentionPrefillFwdOp
- git diff --check
- docker/CI image: pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py --collect-only -q
- docker/CI image: pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench and softcap50'
- docker/CI image: pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench and sm and scale'
- docker/CI image: pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench and llama-3.1-8b-prefill-dense-float16'