### PR TITLE
[Perf][Attention] Upgrade GQA prefill kernels

### DIFF
--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -25,6 +25,7 @@ from tileops.ops.attention.gqa import (
     _select_gqa_prefill_fwd_kernel_cls,
     _select_gqa_prefill_kernel_key,
 )
+from tileops.utils import is_h200
 from workloads.attention.gqa import (
     GroupedQueryAttentionBwdTest as _GroupedQueryAttentionBwdTestWorkload,
 )
@@ -275,6 +276,114 @@ def test_gqa_prefill_fwd_uses_bottom_right_causal_mask() -> None:
 
     assert output[0, 0, 0, 0] < 2
     assert output[0, -1, 0, 0] > 40
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_square_uses_square_fast_path(dtype: torch.dtype) -> None:
+    if not is_h200():
+        pytest.skip("square fast path requires H200")
+
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=4,
+        heads=32,
+        heads_kv=8,
+        dim=128,
+        max_seqlen_q=512,
+        max_seqlen_kv=512,
+        is_causal=True,
+        dtype=dtype,
+        backend="dense",
+    )
+
+    assert op._uses_square_dense_fast_path()
+    assert op._get_square_dense_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
+
+
+@pytest.mark.parametrize("sm_scale, softcap", [
+    pytest.param(0.125, None, id="custom-scale"),
+    pytest.param(None, 2.0, id="softcap"),
+])
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_square_feature_variants_use_square_fast_path(
+    sm_scale: Optional[float],
+    softcap: Optional[float],
+) -> None:
+    if not is_h200():
+        pytest.skip("square fast path requires H200")
+
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=4,
+        heads=32,
+        heads_kv=8,
+        dim=128,
+        max_seqlen_q=512,
+        max_seqlen_kv=512,
+        is_causal=True,
+        dtype=torch.float16,
+        sm_scale=sm_scale,
+        softcap=softcap,
+        backend="dense",
+    )
+
+    assert op._uses_square_dense_fast_path()
+    assert op._get_square_dense_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
+
+
+@pytest.mark.parametrize("seq_len_q, seq_len_kv, sm_scale, softcap", [
+    pytest.param(512, 4096, None, None, id="q-lt-kv"),
+])
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_q_lt_kv_uses_prefill_ws_kernel(
+    seq_len_q: int,
+    seq_len_kv: int,
+    sm_scale: Optional[float],
+    softcap: Optional[float],
+) -> None:
+    if not is_h200():
+        pytest.skip("warp-specialized dense prefill dispatch is validated on H200")
+
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=2,
+        heads=32,
+        heads_kv=8,
+        dim=128,
+        max_seqlen_q=seq_len_q,
+        max_seqlen_kv=seq_len_kv,
+        is_causal=True,
+        dtype=torch.float16,
+        sm_scale=sm_scale,
+        softcap=softcap,
+        backend="dense",
+    )
+
+    assert not op._uses_square_dense_fast_path()
+    assert op._get_dense_kernel().__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_dense_backend_rejects_ragged_packed_inputs() -> None:
+    batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = 2, 64, 128, 8, 2, 64
+    q = torch.randn(batch * seq_len_q, heads, dim, device="cuda", dtype=torch.float16)
+    k = torch.randn(batch * seq_len_kv, heads_kv, dim, device="cuda", dtype=torch.float16)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor([0, seq_len_q // 2, batch * seq_len_q], device="cuda", dtype=torch.int32)
+    cu_kv = torch.arange(batch + 1, device="cuda", dtype=torch.int32) * seq_len_kv
+    q_scale, k_scale, v_scale = _ones_prefill_scales(batch, heads_kv, device=q.device)
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len_q,
+        max_seqlen_kv=seq_len_kv,
+        is_causal=True,
+        dtype=torch.float16,
+        backend="dense",
+    )
+
+    with pytest.raises(ValueError, match="backend='dense' requires uniform"):
+        op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/attention/_math_helper.h
+++ b/tileops/kernels/attention/_math_helper.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace tl {
+
+__device__ __forceinline__ float tileops_tanh_approx_f32(float x) {
+  float y;
+  asm volatile("tanh.approx.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+
+}  // namespace tl

--- a/tileops/kernels/attention/gqa_fwd.py
+++ b/tileops/kernels/attention/gqa_fwd.py
@@ -31,6 +31,30 @@ __all__ = [
     'MHAFwdWgmmaPipelinedKernel'
 ]
 
+_FAST_COMPILE_FLAGS = [
+    "-O3",
+    "--use_fast_math",
+    "-Wno-deprecated-declarations",
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-DENABLE_BF16",
+]
+
+
+def _make_apply_softcap_no_mask_guard(score_scale, softcap, accum_dtype, block_rows, block_cols):
+    @T.macro
+    def apply_softcap(acc_s):
+        for i, j in T.Parallel(block_rows, block_cols):
+            acc_s[i, j] = T.cast(softcap, accum_dtype) * T.tanh(
+                acc_s[i, j] * T.cast(score_scale / softcap, accum_dtype))
+
+    return apply_softcap
+
+
 # MHA
 
 
@@ -1404,7 +1428,7 @@ def _gqa_prefill_with_kv_cache_rope_append_kernel(batch: int,
         raise ValueError("rotary_dim must be positive, even, and <= dim")
     half = rotary_dim // 2
 
-    @tilelang.jit(out_idx=[], compile_flags=["-O3", "-DENABLE_BF16"])
+    @tilelang.jit(out_idx=[], compile_flags=_FAST_COMPILE_FLAGS)
     def _gqa_prefill_with_kv_cache_rope_append_func(block_m: int, threads: int) -> Callable:
 
         kv_new_shape = (batch, seq_len_new, heads_kv, dim)
@@ -1518,7 +1542,7 @@ def _gqa_prefill_with_kv_cache_rope_fwd_kernel(batch: int,
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16"])
+        compile_flags=_FAST_COMPILE_FLAGS)
     def _gqa_prefill_with_kv_cache_rope_fwd_func(block_m: int, block_n: int, num_stages: int,
                                                  threads: int) -> Callable:
 
@@ -1802,13 +1826,13 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
     accum_dtype = "float"
 
     @tilelang.jit(
-        out_idx=[8, 9],
+        out_idx=[8],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16"])
+        compile_flags=_FAST_COMPILE_FLAGS)
     def _gqa_prefill_paged_with_kv_cache_fwd_func(
             block_m: int, block_n: int, num_stages: int, threads: int) -> Callable:
 
@@ -1819,7 +1843,7 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
         o_shape = (total_q, heads, dim)
         online_softmax = make_online_softmax_with_mask_guard(
             scale, accum_dtype, block_m, block_n)
-        apply_softcap = make_apply_softcap(
+        apply_softcap = _make_apply_softcap_no_mask_guard(
             score_scale, softcap, accum_dtype, block_m, block_n) if use_softcap else None
         rescale = make_rescale(block_m, dim)
         page_size_log2 = page_size.bit_length() - 1
@@ -1835,7 +1859,6 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
                 cache_seqlens: T.Tensor([batch], T.int32),  # type: ignore
                 block_table: T.Tensor(block_table_shape, T.int32),  # type: ignore
                 output: T.Tensor(o_shape, dtype),  # type: ignore
-                lse: T.Tensor([heads, total_q], accum_dtype),  # type: ignore
                 max_seqlen_q: T.int32,  # type: ignore
         ) -> None:
             with T.Kernel(
@@ -1852,6 +1875,7 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
                 scores_scale = T.alloc_fragment([block_m], accum_dtype)
                 scores_sum = T.alloc_fragment([block_m], accum_dtype)
                 logsum = T.alloc_fragment([block_m], accum_dtype)
+                inv_logsum = T.alloc_fragment([block_m], accum_dtype)
 
                 q_start = cu_seqlens_q[bz]
                 q_len = cu_seqlens_q[bz + 1] - q_start
@@ -1967,7 +1991,9 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
                             else:
                                 k_shared[j, d] = T.cast(0, dtype)
                                 v_shared[j, d] = T.cast(0, dtype)
-                    if is_causal:
+                    if use_softcap:
+                        T.clear(acc_s)
+                    elif is_causal:
                         for i, j in T.Parallel(block_m, block_n):
                             kv_pos = k_idx * block_n + j
                             q_abs_pos = old_len + bx * block_m + i
@@ -1987,18 +2013,31 @@ def _gqa_prefill_paged_with_kv_cache_fwd_kernel(batch: int,
                         policy=T.GemmWarpPolicy.FullRow)
                     if use_softcap:
                         apply_softcap(acc_s)
+                        if is_causal:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                q_abs_pos = old_len + bx * block_m + i
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len) & (
+                                    kv_pos <= q_abs_pos)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
+                        else:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale,
                                    scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
                     T.gemm(acc_s_cast, v_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
-                for i, j in T.Parallel(block_m, dim):
-                    if bx * block_m + i < q_len:
-                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] / logsum[i]
                 for i in T.Parallel(block_m):
                     if bx * block_m + i < q_len:
-                        logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
-                        lse[by, q_start + bx * block_m + i] = logsum[i]
+                        inv_logsum[i] = T.cast(1, accum_dtype) / logsum[i]
+                for i, j in T.Parallel(block_m, dim):
+                    if bx * block_m + i < q_len:
+                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] * inv_logsum[i]
 
         return _gqa_prefill_paged_with_kv_cache_fwd_main
 
@@ -2035,7 +2074,7 @@ def _gqa_prefill_paged_with_kv_cache_fwd_wrapped_kernel(
     cu_seqlens_q: torch.Tensor,
     cache_seqlens: torch.Tensor,
     block_table: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     return _gqa_prefill_paged_with_kv_cache_fwd_kernel(
         batch, heads, heads_kv, total_q, physical_tokens, max_pages_per_req, page_size, dim,
         is_causal, sm_scale, softcap, dtype)(block_m, block_n, num_stages, threads)(
@@ -2048,10 +2087,9 @@ def _(batch: int, heads: int, heads_kv: int, total_q: int, physical_tokens: int,
       max_pages_per_req: int, page_size: int, dim: int, is_causal: bool, sm_scale: float,
       softcap: float, dtype: str, block_m: int, block_n: int, num_stages: int, threads: int,
       max_seqlen_q: int,
-      *inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, torch.Tensor]:
+      *inputs: Tuple[torch.Tensor, ...]) -> torch.Tensor:
     fake_o = torch.empty_like(inputs[0])
-    fake_lse = fake_o.new_empty([heads, total_q])
-    return fake_o, fake_lse
+    return fake_o
 
 
 class GQAPrefillPagedWithKVCacheFwdKernel(Kernel):
@@ -2113,7 +2151,7 @@ class GQAPrefillPagedWithKVCacheFwdKernel(Kernel):
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, cu_seqlens_q: torch.Tensor,
                 cache_seqlens: torch.Tensor, block_table: torch.Tensor,
-                max_seqlen_q: int) -> Tuple[torch.Tensor, torch.Tensor]:
+                max_seqlen_q: int) -> torch.Tensor:
         return _gqa_prefill_paged_with_kv_cache_fwd_wrapped_kernel(
             self.batch, self.heads, self.heads_kv, q.shape[0], k_pages.shape[0],
             self.max_pages_per_req, self.page_size, self.dim, self.is_causal, self.sm_scale,
@@ -2147,13 +2185,13 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
     cache_dtype = T.float8_e4m3fn
 
     @tilelang.jit(
-        out_idx=[10, 11],
+        out_idx=[10],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16"])
+        compile_flags=_FAST_COMPILE_FLAGS)
     def _gqa_prefill_paged_with_fp8_kv_cache_fwd_func(
             block_m: int, block_n: int, num_stages: int, threads: int) -> Callable:
 
@@ -2164,7 +2202,7 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
         o_shape = (total_q, heads, dim)
         online_softmax = make_online_softmax_with_mask_guard(
             scale, accum_dtype, block_m, block_n)
-        apply_softcap = make_apply_softcap(
+        apply_softcap = _make_apply_softcap_no_mask_guard(
             score_scale, softcap, accum_dtype, block_m, block_n) if use_softcap else None
         rescale = make_rescale(block_m, dim)
         page_size_log2 = page_size.bit_length() - 1
@@ -2192,7 +2230,6 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
                 cache_seqlens: T.Tensor([batch], T.int32),  # type: ignore
                 block_table: T.Tensor(block_table_shape, T.int32),  # type: ignore
                 output: T.Tensor(o_shape, dtype),  # type: ignore
-                lse: T.Tensor([heads, total_q], accum_dtype),  # type: ignore
                 max_seqlen_q: T.int32,  # type: ignore
         ) -> None:
             with T.Kernel(
@@ -2209,6 +2246,7 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
                 scores_scale = T.alloc_fragment([block_m], accum_dtype)
                 scores_sum = T.alloc_fragment([block_m], accum_dtype)
                 logsum = T.alloc_fragment([block_m], accum_dtype)
+                inv_logsum = T.alloc_fragment([block_m], accum_dtype)
 
                 q_start = cu_seqlens_q[bz]
                 q_len = cu_seqlens_q[bz + 1] - q_start
@@ -2340,7 +2378,9 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
                             else:
                                 k_shared[j, d] = T.cast(0, dtype)
                                 v_shared[j, d] = T.cast(0, dtype)
-                    if is_causal:
+                    if use_softcap:
+                        T.clear(acc_s)
+                    elif is_causal:
                         for i, j in T.Parallel(block_m, block_n):
                             kv_pos = k_idx * block_n + j
                             q_abs_pos = old_len + bx * block_m + i
@@ -2360,18 +2400,31 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(batch: int,
                         policy=T.GemmWarpPolicy.FullRow)
                     if use_softcap:
                         apply_softcap(acc_s)
+                        if is_causal:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                q_abs_pos = old_len + bx * block_m + i
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len) & (
+                                    kv_pos <= q_abs_pos)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
+                        else:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale,
                                    scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
                     T.gemm(acc_s_cast, v_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
-                for i, j in T.Parallel(block_m, dim):
-                    if bx * block_m + i < q_len:
-                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] / logsum[i]
                 for i in T.Parallel(block_m):
                     if bx * block_m + i < q_len:
-                        logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
-                        lse[by, q_start + bx * block_m + i] = logsum[i]
+                        inv_logsum[i] = T.cast(1, accum_dtype) / logsum[i]
+                for i, j in T.Parallel(block_m, dim):
+                    if bx * block_m + i < q_len:
+                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] * inv_logsum[i]
 
         return _gqa_prefill_paged_with_fp8_kv_cache_fwd_main
 
@@ -2410,7 +2463,7 @@ def _gqa_prefill_paged_with_fp8_kv_cache_fwd_wrapped_kernel(
     cu_seqlens_q: torch.Tensor,
     cache_seqlens: torch.Tensor,
     block_table: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     return _gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel(
         batch, heads, heads_kv, total_q, physical_tokens, max_pages_per_req, page_size, dim,
         is_causal, sm_scale, softcap, dtype)(block_m, block_n, num_stages, threads)(
@@ -2423,10 +2476,9 @@ def _(batch: int, heads: int, heads_kv: int, total_q: int, physical_tokens: int,
       max_pages_per_req: int, page_size: int, dim: int, is_causal: bool, sm_scale: float,
       softcap: float, dtype: str, block_m: int, block_n: int, num_stages: int, threads: int,
       max_seqlen_q: int,
-      *inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, torch.Tensor]:
+      *inputs: Tuple[torch.Tensor, ...]) -> torch.Tensor:
     fake_o = torch.empty_like(inputs[0])
-    fake_lse = fake_o.new_empty([heads, total_q])
-    return fake_o, fake_lse
+    return fake_o
 
 
 class GQAPrefillPagedWithFP8KVCacheFwdKernel(Kernel):
@@ -2488,8 +2540,7 @@ class GQAPrefillPagedWithFP8KVCacheFwdKernel(Kernel):
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, k_scale: torch.Tensor,
                 v_scale: torch.Tensor, cu_seqlens_q: torch.Tensor, cache_seqlens: torch.Tensor,
-                block_table: torch.Tensor, max_seqlen_q: int) -> Tuple[torch.Tensor,
-                                                                       torch.Tensor]:
+                block_table: torch.Tensor, max_seqlen_q: int) -> torch.Tensor:
         return _gqa_prefill_paged_with_fp8_kv_cache_fwd_wrapped_kernel(
             self.batch, self.heads, self.heads_kv, q.shape[0], k_pages.shape[0],
             self.max_pages_per_req, self.page_size, self.dim, self.is_causal, self.sm_scale,
@@ -2689,13 +2740,13 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
     accum_dtype = "float"
 
     @tilelang.jit(
-        out_idx=[10, 11],
+        out_idx=[10],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
             tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
             tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16"])
+        compile_flags=_FAST_COMPILE_FLAGS)
     def _gqa_prefill_paged_with_kv_cache_rope_fwd_func(
             block_m: int, block_n: int, num_stages: int, threads: int) -> Callable:
 
@@ -2707,7 +2758,7 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
         o_shape = (total_q, heads, dim)
         online_softmax = make_online_softmax_with_mask_guard(
             scale, accum_dtype, block_m, block_n)
-        apply_softcap = make_apply_softcap(
+        apply_softcap = _make_apply_softcap_no_mask_guard(
             score_scale, softcap, accum_dtype, block_m, block_n) if use_softcap else None
         rescale = make_rescale(block_m, dim)
         page_size_log2 = page_size.bit_length() - 1
@@ -2725,7 +2776,6 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
                 cos_table: T.Tensor(rope_shape, dtype),  # type: ignore
                 sin_table: T.Tensor(rope_shape, dtype),  # type: ignore
                 output: T.Tensor(o_shape, dtype),  # type: ignore
-                lse: T.Tensor([heads, total_q], accum_dtype),  # type: ignore
                 max_seqlen_q: T.int32,  # type: ignore
         ) -> None:
             with T.Kernel(
@@ -2742,6 +2792,7 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
                 scores_scale = T.alloc_fragment([block_m], accum_dtype)
                 scores_sum = T.alloc_fragment([block_m], accum_dtype)
                 logsum = T.alloc_fragment([block_m], accum_dtype)
+                inv_logsum = T.alloc_fragment([block_m], accum_dtype)
 
                 q_start = cu_seqlens_q[bz]
                 q_len = cu_seqlens_q[bz + 1] - q_start
@@ -2846,7 +2897,9 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
                             else:
                                 k_shared[j, d] = T.cast(0, dtype)
                                 v_shared[j, d] = T.cast(0, dtype)
-                    if is_causal:
+                    if use_softcap:
+                        T.clear(acc_s)
+                    elif is_causal:
                         for i, j in T.Parallel(block_m, block_n):
                             kv_pos = k_idx * block_n + j
                             q_abs_pos = old_len + bx * block_m + i
@@ -2866,18 +2919,31 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(batch: int,
                         policy=T.GemmWarpPolicy.FullRow)
                     if use_softcap:
                         apply_softcap(acc_s)
+                        if is_causal:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                q_abs_pos = old_len + bx * block_m + i
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len) & (
+                                    kv_pos <= q_abs_pos)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
+                        else:
+                            for i, j in T.Parallel(block_m, block_n):
+                                kv_pos = k_idx * block_n + j
+                                valid = (bx * block_m + i < q_len) & (kv_pos < total_len)
+                                acc_s[i, j] = T.if_then_else(
+                                    valid, acc_s[i, j], -T.infinity(acc_s.dtype))
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale,
                                    scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
                     T.gemm(acc_s_cast, v_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
-                for i, j in T.Parallel(block_m, dim):
-                    if bx * block_m + i < q_len:
-                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] / logsum[i]
                 for i in T.Parallel(block_m):
                     if bx * block_m + i < q_len:
-                        logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
-                        lse[by, q_start + bx * block_m + i] = logsum[i]
+                        inv_logsum[i] = T.cast(1, accum_dtype) / logsum[i]
+                for i, j in T.Parallel(block_m, dim):
+                    if bx * block_m + i < q_len:
+                        output[q_start + bx * block_m + i, by, j] = acc_o[i, j] * inv_logsum[i]
 
         return _gqa_prefill_paged_with_kv_cache_rope_fwd_main
 
@@ -2918,7 +2984,7 @@ def _gqa_prefill_paged_with_kv_cache_rope_fwd_wrapped_kernel(
     block_table: torch.Tensor,
     cos_table: torch.Tensor,
     sin_table: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     return _gqa_prefill_paged_with_kv_cache_rope_fwd_kernel(
         batch, heads, heads_kv, total_q, physical_tokens, max_pages_per_req, page_size, dim,
         max_position, rotary_dim, is_causal, sm_scale, softcap, dtype)(
@@ -2932,10 +2998,9 @@ def _(batch: int, heads: int, heads_kv: int, total_q: int, physical_tokens: int,
       max_pages_per_req: int, page_size: int, dim: int, max_position: int,
       rotary_dim: int, is_causal: bool, sm_scale: float, softcap: float, dtype: str,
       block_m: int, block_n: int, num_stages: int, threads: int, max_seqlen_q: int,
-      *inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, torch.Tensor]:
+      *inputs: Tuple[torch.Tensor, ...]) -> torch.Tensor:
     fake_o = torch.empty_like(inputs[0])
-    fake_lse = fake_o.new_empty([heads, total_q])
-    return fake_o, fake_lse
+    return fake_o
 
 
 class GQAPrefillPagedWithKVCacheRopeFwdKernel(Kernel):
@@ -3003,8 +3068,7 @@ class GQAPrefillPagedWithKVCacheRopeFwdKernel(Kernel):
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, cu_seqlens_q: torch.Tensor,
                 cache_seqlens: torch.Tensor, block_table: torch.Tensor, max_seqlen_q: int,
-                cos_table: torch.Tensor, sin_table: torch.Tensor) -> Tuple[torch.Tensor,
-                                                                           torch.Tensor]:
+                cos_table: torch.Tensor, sin_table: torch.Tensor) -> torch.Tensor:
         return _gqa_prefill_paged_with_kv_cache_rope_fwd_wrapped_kernel(
             self.batch, self.heads, self.heads_kv, q.shape[0], k_pages.shape[0],
             self.max_pages_per_req, self.page_size, self.dim, self.max_position,

--- a/tileops/kernels/attention/gqa_fwd_ws.py
+++ b/tileops/kernels/attention/gqa_fwd_ws.py
@@ -8,6 +8,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.online_softmax import (
+    LOG2E,
     make_log2e_scale,
     make_online_softmax_with_mask_guard,
     make_rescale,
@@ -21,6 +22,36 @@ __all__ = [
 NUM_SMS = int(os.environ.get("V2P_NUM_SMS", "132"))
 _ANCHOR_HELPER_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "_anchor_helper.h"))
+_MATH_HELPER_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "_math_helper.h"))
+
+
+def _make_apply_softcap_no_mask_guard(score_scale, softcap, accum_dtype, block_rows, block_cols):
+    @T.macro
+    def apply_softcap(acc_s):
+        for i, j in T.Parallel(block_rows, block_cols):
+            acc_s[i, j] = T.cast(softcap, accum_dtype) * T.call_extern(
+                accum_dtype,
+                "tl::tileops_tanh_approx_f32",
+                acc_s[i, j] * T.cast(score_scale / softcap, accum_dtype),
+            )
+
+    return apply_softcap
+
+
+def _make_apply_softcap_causal_mask(score_scale, softcap, accum_dtype, block_rows, block_cols):
+    @T.macro
+    def apply_softcap(acc_s, row_base, col_base):
+        for i, j in T.Parallel(block_rows, block_cols):
+            if row_base + i >= col_base + j:
+                acc_s[i, j] = T.cast(softcap, accum_dtype) * T.call_extern(
+                    accum_dtype,
+                    "tl::tileops_tanh_approx_f32",
+                    acc_s[i, j] * T.cast(score_scale / softcap, accum_dtype),
+                )
+            else:
+                acc_s[i, j] = -T.infinity(accum_dtype)
+
+    return apply_softcap
 
 
 @functools.lru_cache(maxsize=32)
@@ -45,7 +76,22 @@ def _gqa_fwd_ws_persistent_kernel(
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
             tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16", "-include", _ANCHOR_HELPER_PATH],
+        compile_flags=[
+            "-O3",
+            "--use_fast_math",
+            "-Wno-deprecated-declarations",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "-DENABLE_BF16",
+            "-include",
+            _MATH_HELPER_PATH,
+            "-include",
+            _ANCHOR_HELPER_PATH,
+        ],
     )
     def func(block_m: int, block_n: int):
         q_shape = (batch, seq_len, heads, dim)
@@ -350,6 +396,8 @@ def _gqa_fwd_ws_persistent_causal_kernel(
     heads_kv: int,
     seq_len: int,
     dim: int,
+    sm_scale: Optional[float] = None,
+    softcap: float = 0.0,
     dtype: str = "float16",
 ) -> Callable:
     assert heads % heads_kv == 0 and dim == 128
@@ -357,7 +405,9 @@ def _gqa_fwd_ws_persistent_causal_kernel(
     half_m = block_m // 2
     groups = heads // heads_kv
     hkv_sections = heads_kv
-    scale = make_log2e_scale(dim)
+    score_scale = dim**-0.5 if sm_scale is None else sm_scale
+    use_softcap = softcap > 0.0
+    scale = LOG2E if use_softcap else score_scale * LOG2E
     accum_dtype = "float"
     m_blocks = (seq_len + block_m - 1) // block_m
     if m_blocks % 2 != 0:
@@ -365,12 +415,27 @@ def _gqa_fwd_ws_persistent_causal_kernel(
     half_m_blocks = m_blocks // 2
 
     @tilelang.jit(
-        out_idx=[3, 4],
+        out_idx=[3],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
             tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
         },
-        compile_flags=["-O3", "-DENABLE_BF16", "-include", _ANCHOR_HELPER_PATH],
+        compile_flags=[
+            "-O3",
+            "--use_fast_math",
+            "-Wno-deprecated-declarations",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "-DENABLE_BF16",
+            "-include",
+            _MATH_HELPER_PATH,
+            "-include",
+            _ANCHOR_HELPER_PATH,
+        ],
     )
     def func(block_m: int, block_n: int):
         q_shape = (batch, seq_len, heads, dim)
@@ -378,6 +443,12 @@ def _gqa_fwd_ws_persistent_causal_kernel(
 
         softmax_1 = make_online_softmax_with_mask_guard(scale, accum_dtype, half_m, block_n)
         softmax_2 = make_online_softmax_with_mask_guard(scale, accum_dtype, half_m, block_n)
+        apply_softcap_1 = _make_apply_softcap_no_mask_guard(
+            score_scale, softcap, accum_dtype, half_m, block_n) if use_softcap else None
+        apply_softcap_2 = _make_apply_softcap_no_mask_guard(
+            score_scale, softcap, accum_dtype, half_m, block_n) if use_softcap else None
+        apply_softcap_causal_mask = _make_apply_softcap_causal_mask(
+            score_scale, softcap, accum_dtype, half_m, block_n) if use_softcap else None
         rescale_1 = make_rescale(half_m, dim)
         rescale_2 = make_rescale(half_m, dim)
 
@@ -387,7 +458,6 @@ def _gqa_fwd_ws_persistent_causal_kernel(
             k: T.Tensor(kv_shape, dtype),
             v: T.Tensor(kv_shape, dtype),
             output: T.Tensor(q_shape, dtype),
-            lse: T.Tensor([batch, heads, seq_len], accum_dtype),
         ) -> None:
             with T.Kernel(NUM_SMS, 1, 1, threads=384) as (bx, _by, _bz):
                 q_shared_1 = T.alloc_shared([half_m, dim], dtype)
@@ -539,7 +609,12 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                                     T.wait_wgmma(0)
                                     T.warpgroup_fence_operand(acc_s_1, num_regs=64)
                                     T.barrier_arrive(k_empty)
-                                    if n_idx == loop_range - 1:
+                                    if use_softcap and n_idx == loop_range - 1:
+                                        apply_softcap_causal_mask(
+                                            acc_s_1, row_base, n_idx * block_n)
+                                    elif use_softcap:
+                                        apply_softcap_1(acc_s_1)
+                                    elif n_idx == loop_range - 1:
                                         for i, j in T.Parallel(half_m, block_n):
                                             acc_s_1[i, j] = T.if_then_else(
                                                 row_base + i >= n_idx * block_n + j,
@@ -562,7 +637,12 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                                     T.call_extern("handle", "tl::wait_wgmma_anchor<1>", T.address_of(anchor_sink[0]), gi_kc1)
                                     T.warpgroup_fence_operand(acc_s_1, num_regs=64)
                                     T.barrier_arrive(k_empty)
-                                    if n_idx == loop_range - 1:
+                                    if use_softcap and n_idx == loop_range - 1:
+                                        apply_softcap_causal_mask(
+                                            acc_s_1, row_base, n_idx * block_n)
+                                    elif use_softcap:
+                                        apply_softcap_1(acc_s_1)
+                                    elif n_idx == loop_range - 1:
                                         for i, j in T.Parallel(half_m, block_n):
                                             acc_s_1[i, j] = T.if_then_else(
                                                 row_base + i >= n_idx * block_n + j,
@@ -593,9 +673,6 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=3, arrive_count=128)
                             T.copy(q_shared_1, output[tile_b, row_base:row_base + half_m, tile_h, :])
-                            for i in T.Parallel(half_m):
-                                ls_1[i] = T.log2(ls_1[i]) + sm_1[i] * scale
-                            T.copy(ls_1, lse[tile_b, tile_h, row_base:row_base + half_m])
 
                 else:
                     T.inc_max_nreg(240)
@@ -637,7 +714,12 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                                     T.wait_wgmma(0)
                                     T.warpgroup_fence_operand(acc_s_2, num_regs=64)
                                     T.barrier_arrive(k_empty)
-                                    if n_idx == loop_range - 1:
+                                    if use_softcap and n_idx == loop_range - 1:
+                                        apply_softcap_causal_mask(
+                                            acc_s_2, row_base + half_m, n_idx * block_n)
+                                    elif use_softcap:
+                                        apply_softcap_2(acc_s_2)
+                                    elif n_idx == loop_range - 1:
                                         for i, j in T.Parallel(half_m, block_n):
                                             acc_s_2[i, j] = T.if_then_else(
                                                 row_base + half_m + i >= n_idx * block_n + j,
@@ -660,7 +742,12 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                                     T.call_extern("handle", "tl::wait_wgmma_anchor<1>", T.address_of(anchor_sink[1]), gi_kc2)
                                     T.warpgroup_fence_operand(acc_s_2, num_regs=64)
                                     T.barrier_arrive(k_empty)
-                                    if n_idx == loop_range - 1:
+                                    if use_softcap and n_idx == loop_range - 1:
+                                        apply_softcap_causal_mask(
+                                            acc_s_2, row_base + half_m, n_idx * block_n)
+                                    elif use_softcap:
+                                        apply_softcap_2(acc_s_2)
+                                    elif n_idx == loop_range - 1:
                                         for i, j in T.Parallel(half_m, block_n):
                                             acc_s_2[i, j] = T.if_then_else(
                                                 row_base + half_m + i >= n_idx * block_n + j,
@@ -691,9 +778,6 @@ def _gqa_fwd_ws_persistent_causal_kernel(
                             T.fence_proxy_async()
                             T.sync_threads(barrier_id=4, arrive_count=128)
                             T.copy(q_shared_2, output[tile_b, row_base + half_m:row_base + block_m, tile_h, :])
-                            for i in T.Parallel(half_m):
-                                ls_2[i] = T.log2(ls_2[i]) + sm_2[i] * scale
-                            T.copy(ls_2, lse[tile_b, tile_h, row_base + half_m:row_base + block_m])
 
         return main
 
@@ -750,14 +834,16 @@ class GQAFwdWsPersistentCausalKernel(Kernel):
         dim: int,
         is_causal: bool,
         dtype: torch.dtype,
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
         config: Optional[dict] = None,
         tune: bool = False,
     ) -> None:
         super().__init__()
         if not is_causal:
             raise ValueError("GQAFwdWsPersistentCausalKernel only supports causal forward.")
-        if dtype != torch.float16:
-            raise ValueError("GQAFwdWsPersistentCausalKernel currently supports float16 only.")
+        if dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("GQAFwdWsPersistentCausalKernel currently supports float16/bfloat16 only.")
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -765,12 +851,15 @@ class GQAFwdWsPersistentCausalKernel(Kernel):
         self.dim = dim
         self.is_causal = is_causal
         self.dtype = dtype
-        self.kernel = _gqa_fwd_ws_persistent_causal_kernel(batch, heads, heads_kv, seq_len, dim, self.dtype_str)
+        self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
+        self.softcap = softcap
+        self.kernel = _gqa_fwd_ws_persistent_causal_kernel(
+            batch, heads, heads_kv, seq_len, dim, self.sm_scale, self.softcap, self.dtype_str)
         self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
         return {"block_m": 128, "block_n": 128}
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         return self.kernel(self.config["block_m"], self.config["block_n"])(q, k, v)

--- a/tileops/kernels/attention/gqa_prefill_fwd_ws.py
+++ b/tileops/kernels/attention/gqa_prefill_fwd_ws.py
@@ -140,9 +140,11 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                     T.named_barrier_arrive(nxt_bar, NMMA)
                     T.wait_wgmma(0)
                     T.mbarrier_arrive(kfree[0])
-                    for i, j in T.Parallel(half, block_N):
-                        acc_s[i, j] = T.if_then_else(
-                            q0 + r0 + i + co >= j, acc_s[i, j], -T.infinity(accum))
+                    if q0 + r0 + co < block_N - 1:
+                        mask_limit = q0 + r0 + co
+                        for i, j in T.Parallel(half, block_N):
+                            acc_s[i, j] = T.if_then_else(
+                                mask_limit + i >= j, acc_s[i, j], -T.infinity(accum))
                     if use_softcap:
                         apply_softcap(acc_s, half, block_N)
                     T.reduce_max(acc_s, sm, dim=1, clear=False)
@@ -167,10 +169,6 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                         T.named_barrier_arrive(nxt_bar, NMMA)
                         T.wait_wgmma(1)
                         T.mbarrier_arrive(kfree[sk])
-                        for i, j in T.Parallel(half, block_N):
-                            acc_s[i, j] = T.if_then_else(
-                                q0 + r0 + i + co >= k * block_N + j, acc_s[i, j],
-                                -T.infinity(accum))
                         if use_softcap:
                             apply_softcap(acc_s, half, block_N)
                         T.copy(sm, smp)
@@ -198,9 +196,10 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                         T.named_barrier_arrive(nxt_bar, NMMA)
                         T.wait_wgmma(1)
                         T.mbarrier_arrive(kfree[sk])
+                        mask_limit_tail = q0 + r0 + co - k * block_N
                         for i, j in T.Parallel(half, block_N):
                             acc_s[i, j] = T.if_then_else(
-                                q0 + r0 + i + co >= k * block_N + j, acc_s[i, j], -T.infinity(accum))
+                                mask_limit_tail + i >= j, acc_s[i, j], -T.infinity(accum))
                         if use_softcap:
                             apply_softcap(acc_s, half, block_N)
                         T.copy(sm, smp)
@@ -223,8 +222,10 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                     T.wgmma_gemm(pcast, Vs[svp, :, :], acc_o, policy=Pol, clear_accum=False)
                     T.wait_wgmma(0)
                     T.mbarrier_arrive(vfree[svp])
+                    for i in T.Parallel(half):
+                        alpha[i] = 1.0 / logsum[i]
                     for i, j in T.Parallel(half, D):
-                        acc_o[i, j] /= logsum[i]
+                        acc_o[i, j] *= alpha[i]
                     T.copy(acc_o, Os[0, :, :])                                  # registers -> smem
                     T.copy(Os[0, :, :], O[bz, q0 + r0:q0 + r0 + half, by, :])  # smem -> global (coalesced)
 
@@ -256,9 +257,11 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                     T.named_barrier_arrive(nxt_bar, NMMA)
                     T.wait_wgmma(0)
                     T.mbarrier_arrive(kfree[0])
-                    for i, j in T.Parallel(half, block_N):
-                        acc_s[i, j] = T.if_then_else(
-                            q0 + r0 + i + co >= j, acc_s[i, j], -T.infinity(accum))
+                    if q0 + r0 + co < block_N - 1:
+                        mask_limit_wg1 = q0 + r0 + co
+                        for i, j in T.Parallel(half, block_N):
+                            acc_s[i, j] = T.if_then_else(
+                                mask_limit_wg1 + i >= j, acc_s[i, j], -T.infinity(accum))
                     if use_softcap:
                         apply_softcap(acc_s, half, block_N)
                     T.reduce_max(acc_s, sm, dim=1, clear=False)
@@ -269,24 +272,20 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                         logsum[i] = ss[i]
                     T.copy(acc_s, pcast)
 
-                    nu = T.max(1, T.min(eff, T.floordiv(q0 + r0 + co + 1, block_N)))
-                    for k in T.serial(1, nu):
+                    nu_wg1 = T.max(1, T.min(eff, T.floordiv(q0 + r0 + co + 1, block_N)))
+                    for k in T.serial(1, nu_wg1):
                         sk = k % nsK
-                        svp = (k - 1) % nsV
+                        svp_wg1 = (k - 1) % nsV
                         T.sync_threads(my_bar, NMMA)
                         T.mbarrier_wait_parity(kready[sk], (k // nsK) % 2)
                         T.wgmma_gemm(Qs[1, :, :], Ks[sk, :, :], acc_s, transpose_B=True, policy=Pol, clear_accum=True)
                         for i, j in T.Parallel(half, D):  # pipelined rescale (prev alpha) covers QK latency
                             acc_o[i, j] *= alpha[i]
-                        T.mbarrier_wait_parity(vready[svp], ((k - 1) // nsV) % 2)
-                        T.wgmma_gemm(pcast, Vs[svp, :, :], acc_o, policy=Pol, clear_accum=False)
+                        T.mbarrier_wait_parity(vready[svp_wg1], ((k - 1) // nsV) % 2)
+                        T.wgmma_gemm(pcast, Vs[svp_wg1, :, :], acc_o, policy=Pol, clear_accum=False)
                         T.named_barrier_arrive(nxt_bar, NMMA)
                         T.wait_wgmma(1)
                         T.mbarrier_arrive(kfree[sk])
-                        for i, j in T.Parallel(half, block_N):
-                            acc_s[i, j] = T.if_then_else(
-                                q0 + r0 + i + co >= k * block_N + j, acc_s[i, j],
-                                -T.infinity(accum))
                         if use_softcap:
                             apply_softcap(acc_s, half, block_N)
                         T.copy(sm, smp)
@@ -297,26 +296,27 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                             acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
                         T.reduce_sum(acc_s, ss, dim=1)
                         T.wait_wgmma(0)
-                        T.mbarrier_arrive(vfree[svp])
+                        T.mbarrier_arrive(vfree[svp_wg1])
                         for i in T.Parallel(half):
                             logsum[i] = logsum[i] * alpha[i] + ss[i]
                         T.copy(acc_s, pcast)
-                    for k in T.serial(nu, eff):
+                    for k in T.serial(nu_wg1, eff):
                         sk = k % nsK
-                        svp = (k - 1) % nsV
+                        svp_wg1_tail = (k - 1) % nsV
                         T.sync_threads(my_bar, NMMA)
                         T.mbarrier_wait_parity(kready[sk], (k // nsK) % 2)
                         T.wgmma_gemm(Qs[1, :, :], Ks[sk, :, :], acc_s, transpose_B=True, policy=Pol, clear_accum=True)
                         for i, j in T.Parallel(half, D):  # pipelined rescale (prev alpha)
                             acc_o[i, j] *= alpha[i]
-                        T.mbarrier_wait_parity(vready[svp], ((k - 1) // nsV) % 2)
-                        T.wgmma_gemm(pcast, Vs[svp, :, :], acc_o, policy=Pol, clear_accum=False)
+                        T.mbarrier_wait_parity(vready[svp_wg1_tail], ((k - 1) // nsV) % 2)
+                        T.wgmma_gemm(pcast, Vs[svp_wg1_tail, :, :], acc_o, policy=Pol, clear_accum=False)
                         T.named_barrier_arrive(nxt_bar, NMMA)
                         T.wait_wgmma(1)
                         T.mbarrier_arrive(kfree[sk])
+                        mask_limit_wg1_tail = q0 + r0 + co - k * block_N
                         for i, j in T.Parallel(half, block_N):
                             acc_s[i, j] = T.if_then_else(
-                                q0 + r0 + i + co >= k * block_N + j, acc_s[i, j], -T.infinity(accum))
+                                mask_limit_wg1_tail + i >= j, acc_s[i, j], -T.infinity(accum))
                         if use_softcap:
                             apply_softcap(acc_s, half, block_N)
                         T.copy(sm, smp)
@@ -327,20 +327,22 @@ def _gqa_prefill_fwd_fa3_kernel(B, H, Hkv, Sq, Skv, D, sm_scale, softcap, dtype,
                             acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
                         T.reduce_sum(acc_s, ss, dim=1)
                         T.wait_wgmma(0)
-                        T.mbarrier_arrive(vfree[svp])
+                        T.mbarrier_arrive(vfree[svp_wg1_tail])
                         for i in T.Parallel(half):
                             logsum[i] = logsum[i] * alpha[i] + ss[i]
                         T.copy(acc_s, pcast)
 
-                    svp = (eff - 1) % nsV
+                    svp_wg1_final = (eff - 1) % nsV
                     for i, j in T.Parallel(half, D):  # pipelined rescale: final alpha before last PV
                         acc_o[i, j] *= alpha[i]
-                    T.mbarrier_wait_parity(vready[svp], ((eff - 1) // nsV) % 2)
-                    T.wgmma_gemm(pcast, Vs[svp, :, :], acc_o, policy=Pol, clear_accum=False)
+                    T.mbarrier_wait_parity(vready[svp_wg1_final], ((eff - 1) // nsV) % 2)
+                    T.wgmma_gemm(pcast, Vs[svp_wg1_final, :, :], acc_o, policy=Pol, clear_accum=False)
                     T.wait_wgmma(0)
-                    T.mbarrier_arrive(vfree[svp])
+                    T.mbarrier_arrive(vfree[svp_wg1_final])
+                    for i in T.Parallel(half):
+                        alpha[i] = 1.0 / logsum[i]
                     for i, j in T.Parallel(half, D):
-                        acc_o[i, j] /= logsum[i]
+                        acc_o[i, j] *= alpha[i]
                     T.copy(acc_o, Os[1, :, :])                                  # registers -> smem
                     T.copy(Os[1, :, :], O[bz, q0 + r0:q0 + r0 + half, by, :])  # smem -> global (coalesced)
 
@@ -355,9 +357,8 @@ class GQAPrefillFwdWsPersistentCausalKernel(Kernel):
     fp16/bf16 causal dim-128 path; other cases fall back to ``GQAPrefillFwdKernel``. Causal
     uses bottom-right alignment (``co = seq_len_kv - seq_len_q``).
 
-    Note: like FlashInfer's forward kernel, this does not emit log-sum-exp; the
-    op's ``(output, lse)`` contract is satisfied with ``lse=None``. A backward
-    pass that needs lse must compute it separately.
+    Note: like FlashInfer's forward inference kernel, this emits output only. A
+    backward pass that needs log-sum-exp must compute it separately.
     """
 
     supported_archs: list[int] = [90]

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -200,7 +200,8 @@ GroupedQueryAttentionPrefillFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
       gqa_prefill_varlen_fwd_kernel: GQAPrefillVarlenFwdKernel
       gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdKernel
       gqa_prefill_fp8_tensor_core_fwd_kernel: GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -29,7 +29,7 @@ from tileops.kernels.attention import (
     GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
 )
 from tileops.kernels.kernel_base import Kernel
-from tileops.utils import is_hopper
+from tileops.utils import is_h200, is_hopper
 
 from ..op_base import Op
 from ..rope import _base_freqs
@@ -244,7 +244,9 @@ def _rope_rotary_dim(dim: int, rotary_dim: Optional[int]) -> int:
     return rotary_dim
 
 
-def _attention_output(result: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+def _attention_output(result: torch.Tensor | tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+    if isinstance(result, torch.Tensor):
+        return result
     output, _ = result
     return output
 
@@ -394,6 +396,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         self.backend = backend
         self.tune = tune
         self._dense_kernel = None
+        self._square_dense_kernel = None
         self._varlen_kernel = None
         self._sliding_window_varlen_kernel = None
         self._fp8_kernel = None
@@ -419,6 +422,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         )
         return {
             "gqa_prefill_fwd_kernel": dense_kernel_cls,
+            "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
             "gqa_prefill_varlen_fwd_kernel": _select_gqa_prefill_varlen_fwd_kernel_cls(),
             "gqa_sliding_window_varlen_fwd": sliding_kernel_cls,
             "gqa_prefill_fp8_tensor_core_fwd_kernel":
@@ -550,6 +554,40 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             )
         return self._dense_kernel
 
+    def _uses_square_dense_fast_path(self) -> bool:
+        if self.dtype not in (torch.float16, torch.bfloat16):
+            return False
+        if not is_h200() or self.dim != 128:
+            return False
+        if self.heads % self.heads_kv != 0 or self.max_seqlen_q % _WS_BLOCK_M != 0:
+            return False
+        m_blocks = math.ceil(self.max_seqlen_q / _WS_BLOCK_M)
+        if m_blocks % 2 != 0:
+            return False
+        return (
+            self.is_causal
+            and self.max_seqlen_q == self.max_seqlen_kv
+            and _gqa_ws_causal_total_work_items(
+                self.batch, self.heads, self.heads_kv, self.max_seqlen_q
+            ) >= _H200_SMS
+        )
+
+    def _get_square_dense_kernel(self) -> Kernel:
+        if self._square_dense_kernel is None:
+            self._square_dense_kernel = self.kernel_map["gqa_prefill_square_fwd_kernel"](
+                self.batch,
+                self.heads,
+                self.heads_kv,
+                self.max_seqlen_q,
+                self.dim,
+                self.is_causal,
+                self.dtype,
+                sm_scale=self.sm_scale,
+                softcap=self.softcap,
+                tune=self.tune,
+            )
+        return self._square_dense_kernel
+
     def _get_varlen_kernel(self) -> Kernel:
         if self._varlen_kernel is None:
             self._varlen_kernel = self.kernel_map["gqa_prefill_varlen_fwd_kernel"](
@@ -666,7 +704,12 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             q_bshd = q.view(self.batch, self.max_seqlen_q, self.heads, self.dim)
             k_bshd = k.view(self.batch, self.max_seqlen_kv, self.heads_kv, self.dim)
             v_bshd = v.view(self.batch, self.max_seqlen_kv, self.heads_kv, self.dim)
-            out = _attention_output(self._get_dense_kernel()(q_bshd, k_bshd, v_bshd))
+            kernel = (
+                self._get_square_dense_kernel()
+                if self._uses_square_dense_fast_path()
+                else self._get_dense_kernel()
+            )
+            out = _attention_output(kernel(q_bshd, k_bshd, v_bshd))
             self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
             return out.reshape(q.shape)
 


### PR DESCRIPTION
## Summary
- Dispatch dense GQA prefill to Hopper warp-specialized kernels for H200 fp16/bf16 causal dim-128 paths.
- Add a square dense prefill fast path that reuses the high-performance square GQA WS kernel and supports custom `sm_scale` / `softcap`.
- Avoid timed CUDA `torch.equal` checks for explicit dense backend inputs by validating fixed packed lengths directly.
- Make paged prefill forward kernels output-only for inference paths and keep RoPE / FP8-cache / softcap variants on the canonical paged OP.
- Add focused tests for dense dispatch, feature variants, and dense backend packed-input validation.

This follows #1641, which added the manifest/benchmark coverage for scale and softcap cases.

## Performance Notes
H200, torch 2.10.0+cu129, CUDA 12.9, driver 575.57.08.

Dense prefill benchmark (`test_gqa_prefill_fwd_bench`):
- B4 S512 H32/Hkv8 D128 fp16: TileOps 0.0394 ms vs FlashInfer 0.0397 ms
- B4 S512 H32/Hkv8 D128 bf16: TileOps 0.0393 ms vs FlashInfer 0.0398 ms
- B2 Sq512 Skv4096 H32/Hkv8 D128 fp16: TileOps 0.1247 ms vs FlashInfer 0.1266 ms
- B2 Sq512 Skv4096 H32/Hkv8 D128 bf16: TileOps 0.1240 ms vs FlashInfer 0.1258 ms
- B1 Sq512 Skv4096 H64/Hkv8 D128 fp16: TileOps 0.1233 ms vs FlashInfer 0.1245 ms
- B1 Sq512 Skv4096 H64/Hkv8 D128 bf16: TileOps 0.1223 ms vs FlashInfer 0.1239 ms

Focused feature benchmarks:
- sm_scale=0.125: TileOps 0.0391 ms vs FlashInfer 0.0395 ms
- softcap=50.0: TileOps 0.0455 ms vs FlashInfer 0.0459 ms

Paged representative benchmarks:
- Llama3.1 paged RoPE: 1.9863 ms
- paged softcap: 0.1759 ms
- Llama3.1 FP8 KV cache: 2.0418 ms
- FP8 KV cache softcap: 0.2440 ms

## Testing
- `python -m py_compile tileops/kernels/attention/gqa_prefill_fwd_ws.py tileops/kernels/attention/gqa_fwd_ws.py tileops/kernels/attention/gqa_fwd.py tileops/ops/attention/gqa.py tests/ops/attention/test_gqa.py`
- `git diff --check`
- docker/CI image: `pytest /workspace/TileOPs/tests/ops/attention/test_gqa.py -q -k 'prefill_fwd'` -> 19 passed
- docker/CI image: `pytest /workspace/TileOPs/tests/ops/attention/test_gqa_prefill_paged.py -q` -> 27 passed
- docker/CI image: `pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py --collect-only -q` -> 34 collected
- docker/CI image: `python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict`
- docker/CI image: `python -m pytest -q benchmarks/tests` -> 8 passed
- docker/CI image: `pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench'` -> 8 passed
- docker/CI image: `pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench and sm and scale'` -> 1 passed
- docker/CI image: `pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_fwd_bench and softcap50'` -> 1 passed
- docker/CI image: `pytest /workspace/TileOPs/benchmarks/ops/attention/bench_gqa.py -q -k 'test_gqa_prefill_paged_with_kv_cache_fwd_bench and (llama31 or softcap50)'` -> 4 passed
