### PR TITLE
[Fix][Attention] Make dense GQA uniform validation explicit

### DIFF
--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -371,8 +371,8 @@ _GQA_PREFILL_FWD_BENCH_PARAMS = manifest_params(
 
 
 @pytest.mark.parametrize(
-    "batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, backend, sm_scale, softcap, "
-    "dtype, tune",
+    "batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, backend, "
+    "validate_uniform_cu_seqlens, sm_scale, softcap, dtype, tune",
     _GQA_PREFILL_FWD_BENCH_PARAMS,
 )
 def test_gqa_prefill_fwd_bench(
@@ -384,6 +384,7 @@ def test_gqa_prefill_fwd_bench(
     dim: int,
     causal: bool,
     backend: str,
+    validate_uniform_cu_seqlens: bool,
     sm_scale: Optional[float],
     softcap: Optional[float],
     dtype: torch.dtype,
@@ -406,6 +407,7 @@ def test_gqa_prefill_fwd_bench(
         dtype=dtype,
         tune=tune,
         backend=backend,
+        validate_uniform_cu_seqlens=validate_uniform_cu_seqlens,
         sm_scale=sm_scale,
         softcap=softcap,
     )

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -21,6 +21,7 @@ class GQAFp8TensorCoreBenchCase:
     heads: int
     heads_kv: int
     dim: int
+    validate_uniform_cu_seqlens: bool
     out_dtype: torch.dtype
     label: str
 
@@ -44,6 +45,9 @@ def _manifest_cases() -> list[GQAFp8TensorCoreBenchCase]:
                     heads=heads,
                     heads_kv=heads_kv,
                     dim=dim,
+                    validate_uniform_cu_seqlens=workload.get(
+                        "validate_uniform_cu_seqlens", True
+                    ),
                     out_dtype=out_dtype,
                     label=f"{workload['label']}-{dtype_name}",
                 )
@@ -125,6 +129,7 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
         is_causal=False,
         dtype=case.out_dtype,
         backend="fp8",
+        validate_uniform_cu_seqlens=case.validate_uniform_cu_seqlens,
     )
     inputs = _make_inputs(case)
     op(*inputs)

--- a/benchmarks/ops/attention/manifest_params.py
+++ b/benchmarks/ops/attention/manifest_params.py
@@ -50,7 +50,7 @@ def gqa_qkv_args(workload: dict[str, Any]) -> tuple[int, int, int, int, int, boo
 
 def gqa_prefill_args(
     workload: dict[str, Any],
-) -> tuple[int, int, int, int, int, int, bool, str, float | None, float | None]:
+) -> tuple[int, int, int, int, int, int, bool, str, bool, float | None, float | None]:
     if "q_shape" in workload:
         batch, seq_len_q, heads, dim = workload["q_shape"]
         _, seq_len_kv, heads_kv, _ = workload["kv_shape"]
@@ -63,6 +63,7 @@ def gqa_prefill_args(
             dim,
             workload.get("is_causal", True),
             workload.get("backend", "auto"),
+            workload.get("validate_uniform_cu_seqlens", True),
             workload.get("sm_scale"),
             workload.get("softcap"),
         )
@@ -86,6 +87,7 @@ def gqa_prefill_args(
         dim,
         workload.get("is_causal", True),
         workload.get("backend", "auto"),
+        workload.get("validate_uniform_cu_seqlens", True),
         workload.get("sm_scale"),
         workload.get("softcap"),
     )

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -250,6 +250,34 @@ def test_gqa_prefill_fwd(batch: int, seq_len_q: int, seq_len_kv: int, heads: int
 
 
 @pytest.mark.smoke
+def test_gqa_prefill_fwd_dense_backend_matches_reference() -> None:
+    batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = 1, 128, 256, 8, 2, 64
+    q = torch.randn(batch, seq_len_q, heads, dim, device="cuda",
+                    dtype=torch.float16).contiguous()
+    k = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda",
+                    dtype=torch.float16).contiguous()
+    v = torch.randn(batch, seq_len_kv, heads_kv, dim, device="cuda",
+                    dtype=torch.float16).contiguous()
+    ref = _gqa_prefill_ref(q, k, v, heads=heads, heads_kv=heads_kv, is_causal=True)
+
+    packed_inputs = _uniform_packed_prefill_inputs(q, k, v)
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len_q,
+        max_seqlen_kv=seq_len_kv,
+        is_causal=True,
+        dtype=torch.float16,
+        backend="dense",
+    )
+    output = op(*packed_inputs).view(batch, seq_len_q, heads, dim)
+
+    torch.testing.assert_close(output, ref, atol=5e-3, rtol=1e-5)
+
+
+@pytest.mark.smoke
 def test_gqa_prefill_fwd_uses_bottom_right_causal_mask() -> None:
     batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = 1, 128, 256, 4, 2, 64
     q = torch.zeros(batch, seq_len_q, heads, dim, device="cuda", dtype=torch.float16)
@@ -362,28 +390,216 @@ def test_gqa_prefill_fwd_q_lt_kv_uses_prefill_ws_kernel(
 
 
 @pytest.mark.smoke
-def test_gqa_prefill_fwd_dense_backend_rejects_ragged_packed_inputs() -> None:
-    batch, seq_len_q, seq_len_kv, heads, heads_kv, dim = 2, 64, 128, 8, 2, 64
-    q = torch.randn(batch * seq_len_q, heads, dim, device="cuda", dtype=torch.float16)
-    k = torch.randn(batch * seq_len_kv, heads_kv, dim, device="cuda", dtype=torch.float16)
-    v = torch.randn_like(k)
-    cu_q = torch.tensor([0, seq_len_q // 2, batch * seq_len_q], device="cuda", dtype=torch.int32)
-    cu_kv = torch.arange(batch + 1, device="cuda", dtype=torch.int32) * seq_len_kv
+@pytest.mark.parametrize("backend", ["varlen", "sliding_window"])
+def test_gqa_prefill_fwd_explicit_varlen_backends_skip_uniform_cu_seqlens_check(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
+    q = torch.empty(batch * seq_len, heads, dim, dtype=torch.float16)
+    k = torch.empty(batch * seq_len, heads_kv, dim, dtype=torch.float16)
+    v = torch.empty_like(k)
+    cu_q = torch.tensor([0, seq_len // 2, batch * seq_len], dtype=torch.int32)
+    cu_kv = torch.arange(batch + 1, dtype=torch.int32) * seq_len
     q_scale, k_scale, v_scale = _ones_prefill_scales(batch, heads_kv, device=q.device)
     op = GroupedQueryAttentionPrefillFwdOp(
         batch=batch,
         heads=heads,
         heads_kv=heads_kv,
         dim=dim,
-        max_seqlen_q=seq_len_q,
-        max_seqlen_kv=seq_len_kv,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+        is_causal=backend != "fp8",
+        dtype=torch.float16,
+        backend=backend,
+        window_size_left=16 if backend == "sliding_window" else -1,
+    )
+
+    def fail_uniform_check(*args: object, **kwargs: object) -> bool:
+        pytest.fail("_uniform_cu_seqlens should not run for explicit varlen backends")
+
+    def fake_varlen_kernel(*args: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return torch.empty_like(q), None
+
+    monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_uniform_cu_seqlens", fail_uniform_check)
+    monkeypatch.setattr(op, "_get_varlen_kernel", lambda: fake_varlen_kernel)
+    monkeypatch.setattr(op, "_get_sliding_window_varlen_kernel", lambda: fake_varlen_kernel)
+
+    out = op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
+    assert out.shape == q.shape
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("backend", ["dense", "fp8"])
+def test_gqa_prefill_fwd_explicit_dense_backends_validate_uniform_cu_seqlens(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
+    q = torch.empty(batch * seq_len, heads, dim, dtype=torch.float16)
+    k = torch.empty(batch * seq_len, heads_kv, dim, dtype=torch.float16)
+    v = torch.empty_like(k)
+    cu_q = torch.tensor([0, seq_len // 2, batch * seq_len], dtype=torch.int32)
+    cu_kv = torch.arange(batch + 1, dtype=torch.int32) * seq_len
+    q_scale, k_scale, v_scale = _ones_prefill_scales(batch, heads_kv, device=q.device)
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+        is_causal=backend != "fp8",
+        dtype=torch.float16,
+        backend=backend,
+    )
+
+    uniform_checks = 0
+
+    def ragged_uniform_check(cu_seqlens: torch.Tensor, seq: int) -> bool:
+        nonlocal uniform_checks
+        uniform_checks += 1
+        return torch.equal(cu_seqlens, cu_kv)
+
+    monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_uniform_cu_seqlens", ragged_uniform_check)
+    if backend == "fp8":
+        monkeypatch.setattr(op, "_is_fp8_tensor", lambda tensor: True)
+
+    expected_error = (
+        "FP8 Tensor Core prefill requires uniform packed cu_seqlens"
+        if backend == "fp8"
+        else "backend='dense' requires uniform"
+    )
+    with pytest.raises(ValueError, match=expected_error):
+        op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
+    assert uniform_checks == 2
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_explicit_dense_can_skip_uniform_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
+    q = torch.empty(batch * seq_len, heads, dim, dtype=torch.float16)
+    k = torch.empty(batch * seq_len, heads_kv, dim, dtype=torch.float16)
+    v = torch.empty_like(k)
+    cu = torch.arange(batch + 1, dtype=torch.int32) * seq_len
+    q_scale, k_scale, v_scale = _ones_prefill_scales(batch, heads_kv, device=q.device)
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
         is_causal=True,
         dtype=torch.float16,
         backend="dense",
+        validate_uniform_cu_seqlens=False,
     )
 
-    with pytest.raises(ValueError, match="backend='dense' requires uniform"):
-        op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
+    def fail_uniform_check(*args: object, **kwargs: object) -> bool:
+        pytest.fail("validate_uniform_cu_seqlens=False should skip value checks")
+
+    def fake_dense_kernel(*args: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(args[0])
+
+    monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_uniform_cu_seqlens", fail_uniform_check)
+    monkeypatch.setattr(op, "_uses_square_dense_fast_path", lambda: False)
+    monkeypatch.setattr(op, "_get_dense_kernel", lambda: fake_dense_kernel)
+
+    out = op(q, k, v, cu, cu, q_scale, k_scale, v_scale)
+    assert out.shape == q.shape
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_auto_backend_requires_uniform_validation() -> None:
+    with pytest.raises(ValueError, match="backend='auto' requires validate_uniform_cu_seqlens=True"):
+        GroupedQueryAttentionPrefillFwdOp(
+            batch=2,
+            heads=8,
+            heads_kv=2,
+            dim=64,
+            max_seqlen_q=64,
+            max_seqlen_kv=64,
+            dtype=torch.float16,
+            backend="auto",
+            validate_uniform_cu_seqlens=False,
+        )
+
+
+@pytest.mark.smoke
+def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
+    q = torch.empty(batch, seq_len, heads, dim, dtype=torch.float16)
+    k = torch.empty(batch, seq_len, heads_kv, dim, dtype=torch.float16)
+    v = torch.empty_like(k)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True, torch.float16)
+
+    def fail_uniform_check(*args: object, **kwargs: object) -> bool:
+        pytest.fail("BSHD wrapper should not inspect packed cu_seqlens")
+
+    def fake_dense_kernel(*args: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(args[0])
+
+    monkeypatch.setattr(op._prefill_op, "_uniform_cu_seqlens", fail_uniform_check)
+    monkeypatch.setattr(op._prefill_op, "_uses_square_dense_fast_path", lambda: False)
+    monkeypatch.setattr(op._prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
+
+    out = op(q, k, v)
+    assert out.shape == q.shape
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_fwd_auto_backend_checks_uniform_cu_seqlens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
+    q = torch.empty(batch * seq_len, heads, dim, dtype=torch.float16)
+    k = torch.empty(batch * seq_len, heads_kv, dim, dtype=torch.float16)
+    v = torch.empty_like(k)
+    cu_q = torch.arange(batch + 1, dtype=torch.int32) * seq_len
+    cu_kv = torch.arange(batch + 1, dtype=torch.int32) * seq_len
+    q_scale, k_scale, v_scale = _ones_prefill_scales(batch, heads_kv, device=q.device)
+    op = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+        is_causal=True,
+        dtype=torch.float16,
+        backend="auto",
+    )
+
+    uniform_checks = 0
+
+    def count_uniform_check(*args: object, **kwargs: object) -> bool:
+        nonlocal uniform_checks
+        uniform_checks += 1
+        return True
+
+    def fake_dense_kernel(*args: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(args[0])
+
+    monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(op, "_uniform_cu_seqlens", count_uniform_check)
+    monkeypatch.setattr(op, "_uses_square_dense_fast_path", lambda: False)
+    monkeypatch.setattr(op, "_get_dense_kernel", lambda: fake_dense_kernel)
+
+    out = op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
+    assert out.shape == q.shape
+    assert uniform_checks == 2
 
 
 @pytest.mark.smoke

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -163,6 +163,7 @@ GroupedQueryAttentionPrefillFwdOp:
       window_size_left: {type: int, default: -1}
       window_size_right: {type: int, default: -1}
       backend: {type: str, default: "auto"}
+      validate_uniform_cu_seqlens: {type: bool, default: true}
     dtype_combos:
       - {q: float16, k: float16, v: float16, cu_seqlens_q: int32, cu_seqlens_kv: int32, q_scale: float32, k_scale: float32, v_scale: float32, o: float16}
       - {q: bfloat16, k: bfloat16, v: bfloat16, cu_seqlens_q: int32, cu_seqlens_kv: int32, q_scale: float32, k_scale: float32, v_scale: float32, o: bfloat16}
@@ -182,17 +183,17 @@ GroupedQueryAttentionPrefillFwdOp:
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense"}
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", sm_scale: 0.125, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-sm-scale-0.125"}
-    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-softcap50"}
-    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense-q-lt-kv"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, sm_scale: 0.125, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-sm-scale-0.125"}
+    - {total_q: 2048, total_kv: 2048, batch: 4, q_lens: [512, 512, 512, 512], kv_lens: [512, 512, 512, 512], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 512, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-prefill-dense-softcap50"}
+    - {total_q: 1024, total_kv: 8192, batch: 2, q_lens: [512, 512], kv_lens: [4096, 4096], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-dense-q-lt-kv"}
     # Llama-3.1-70B (H=64, H_kv=8, D=128)
-    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-dense-q-lt-kv"}
+    - {total_q: 512, total_kv: 4096, batch: 1, q_lens: [512], kv_lens: [4096], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 512, max_seqlen_kv: 4096, is_causal: true, backend: "dense", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-dense-q-lt-kv"}
     # FP8 Tensor Core prefill through the canonical packed prefill surface.
-    - {total_q: 896, total_kv: 896, batch: 1, q_lens: [896], kv_lens: [896], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 896, max_seqlen_kv: 896, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s896"}
-    - {total_q: 1792, total_kv: 1792, batch: 1, q_lens: [1792], kv_lens: [1792], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 1792, max_seqlen_kv: 1792, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s1792"}
-    - {total_q: 3584, total_kv: 3584, batch: 1, q_lens: [3584], kv_lens: [3584], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 3584, max_seqlen_kv: 3584, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s3584"}
-    - {total_q: 7168, total_kv: 7168, batch: 1, q_lens: [7168], kv_lens: [7168], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 7168, max_seqlen_kv: 7168, is_causal: false, backend: "fp8", dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s7168"}
+    - {total_q: 896, total_kv: 896, batch: 1, q_lens: [896], kv_lens: [896], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 896, max_seqlen_kv: 896, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s896"}
+    - {total_q: 1792, total_kv: 1792, batch: 1, q_lens: [1792], kv_lens: [1792], heads: 32, heads_kv: 8, dim: 128, max_seqlen_q: 1792, max_seqlen_kv: 1792, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill-fp8tc-bn224-s1792"}
+    - {total_q: 3584, total_kv: 3584, batch: 1, q_lens: [3584], kv_lens: [3584], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 3584, max_seqlen_kv: 3584, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s3584"}
+    - {total_q: 7168, total_kv: 7168, batch: 1, q_lens: [7168], kv_lens: [7168], heads: 64, heads_kv: 8, dim: 128, max_seqlen_q: 7168, max_seqlen_kv: 7168, is_causal: false, backend: "fp8", validate_uniform_cu_seqlens: false, dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill-fp8tc-bn224-s7168"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_prefill_varlen_fwd_roofline"

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -291,8 +291,6 @@ class GroupedQueryAttentionFwdOp(Op):
             kernel_map=self.kernel_map,
             tune=tune,
         )
-        self._cu_seqlens_cache: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
-        self._scale_cache: dict[torch.device, torch.Tensor] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -311,27 +309,26 @@ class GroupedQueryAttentionFwdOp(Op):
         return self._prefill_op._get_dense_kernel()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
-        cu_cache_key = (q.device, torch.int32)
-        cu_seqlens = self._cu_seqlens_cache.get(cu_cache_key)
-        if cu_seqlens is None:
-            cu_seqlens = torch.arange(
-                self.batch + 1, device=q.device, dtype=torch.int32) * self.seq_len
-            self._cu_seqlens_cache[cu_cache_key] = cu_seqlens
-        scale = self._scale_cache.get(q.device)
-        if scale is None:
-            scale = torch.ones((self.batch, self.heads_kv), device=q.device, dtype=torch.float32)
-            self._scale_cache[q.device] = scale
-        output = self._prefill_op(
-            q.reshape(self.batch * self.seq_len, self.heads, self.dim).contiguous(),
-            k.reshape(self.batch * self.seq_len, self.heads_kv, self.dim).contiguous(),
-            v.reshape(self.batch * self.seq_len, self.heads_kv, self.dim).contiguous(),
-            cu_seqlens,
-            cu_seqlens,
-            scale,
-            scale,
-            scale,
+        expected_q = (self.batch, self.seq_len, self.heads, self.dim)
+        expected_kv = (self.batch, self.seq_len, self.heads_kv, self.dim)
+        if tuple(q.shape) != expected_q:
+            raise ValueError(f"q must have shape {expected_q}, got {tuple(q.shape)}")
+        if tuple(k.shape) != expected_kv:
+            raise ValueError(f"k must have shape {expected_kv}, got {tuple(k.shape)}")
+        if tuple(v.shape) != expected_kv:
+            raise ValueError(f"v must have shape {expected_kv}, got {tuple(v.shape)}")
+        if q.dtype != self.dtype or k.dtype != self.dtype or v.dtype != self.dtype:
+            raise ValueError(f"q/k/v dtype must match op dtype {self.dtype}.")
+
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        kernel = (
+            self._prefill_op._get_square_dense_kernel()
+            if self._prefill_op._uses_square_dense_fast_path()
+            else self._prefill_op._get_dense_kernel()
         )
-        return output.reshape(self.batch, self.seq_len, self.heads, self.dim)
+        return _attention_output(kernel(q, k, v))
 
 
 class GroupedQueryAttentionPrefillFwdOp(Op):
@@ -357,6 +354,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         window_size_left: int = -1,
         window_size_right: int = -1,
         backend: str = "auto",
+        validate_uniform_cu_seqlens: bool = True,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -379,6 +377,8 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             raise ValueError(
                 "backend must be one of 'auto', 'dense', 'varlen', 'fp8', or 'sliding_window'"
             )
+        if backend == "auto" and not validate_uniform_cu_seqlens:
+            raise ValueError("backend='auto' requires validate_uniform_cu_seqlens=True.")
         _validate_attention_dtype(dtype)
 
         self.batch = batch
@@ -394,6 +394,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         self.window_size_left = window_size_left
         self.window_size_right = window_size_right
         self.backend = backend
+        self.validate_uniform_cu_seqlens = validate_uniform_cu_seqlens
         self.tune = tune
         self._dense_kernel = None
         self._square_dense_kernel = None
@@ -666,9 +667,14 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         self._validate_dtypes(q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
         self._validate_common_shapes(q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale,
                                      v_scale)
-        q_uniform = self._uniform_cu_seqlens(cu_seqlens_q, self.max_seqlen_q)
-        kv_uniform = self._uniform_cu_seqlens(cu_seqlens_kv, self.max_seqlen_kv)
-        is_uniform = q_uniform and kv_uniform
+        if self.backend == "auto" or (
+            self.backend in ("dense", "fp8") and self.validate_uniform_cu_seqlens
+        ):
+            q_uniform = self._uniform_cu_seqlens(cu_seqlens_q, self.max_seqlen_q)
+            kv_uniform = self._uniform_cu_seqlens(cu_seqlens_kv, self.max_seqlen_kv)
+            is_uniform = q_uniform and kv_uniform
+        else:
+            is_uniform = True
 
         kernel_key = _select_gqa_prefill_kernel_key(
             backend=self.backend,


### PR DESCRIPTION
## Summary
- keep public packed `backend="dense"` and `backend="fp8"` GQA prefill safe by validating uniform `cu_seqlens` by default before reshaping to BSHD
- add an explicit public `validate_uniform_cu_seqlens` switch so high-performance callers with known-uniform packed metadata can skip the CUDA value check without using a separate benchmark-only path
- keep `backend="auto"` requiring uniform validation because auto dispatch needs the `cu_seqlens` values to choose dense vs varlen
- declare `validate_uniform_cu_seqlens` in the op manifest and mark known-uniform dense/fp8 manifest workloads with `validate_uniform_cu_seqlens=False`
- update dense and fp8 prefill benchmarks to consume the manifest setting and call the same public op path users call
- add tests covering default dense/fp8 ragged rejection, explicit dense validation skip, auto validation requirements, varlen-style skip behavior, and the BSHD wrapper path

This addresses the dense packed-input contract concern from review while keeping benchmark and user calls on the same public API.

## Testing
- `python -m ruff check tileops/ops/attention/gqa.py tests/ops/attention/test_gqa.py benchmarks/ops/attention/bench_gqa.py benchmarks/ops/attention/bench_gqa_fp8.py benchmarks/ops/attention/manifest_params.py`
- `python -m py_compile tileops/ops/attention/gqa.py tests/ops/attention/test_gqa.py benchmarks/ops/attention/bench_gqa.py benchmarks/ops/attention/bench_gqa_fp8.py benchmarks/ops/attention/manifest_params.py`
- `git diff --check`
- Docker (`ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`): `python scripts/validate_manifest.py --check-op GroupedQueryAttentionPrefillFwdOp --levels schema,signature,shape,dtype,bench --strict`
- Docker (`ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`): `python -m pytest tests/ops/attention/test_gqa.py -q -k "explicit_varlen_backends or explicit_dense_backends or explicit_dense_can_skip or auto_backend_requires or bshd_wrapper or auto_backend_checks"`
- Docker as root for writable TileLang cache/benchmark log: `python -m pytest benchmarks/ops/attention/bench_gqa.py::test_gqa_prefill_fwd_bench[llama-3.1-8b-prefill-dense-float16] -q -s`

Host pytest was not used for validation because the host environment is missing `tvm.tirx`; the Docker runner image includes the TileOps CI dependencies.
