### PR TITLE
[Fix][MHC] Fix post shared-buffer stride

### DIFF
--- a/tileops/kernels/mhc/mhc_post.py
+++ b/tileops/kernels/mhc/mhc_post.py
@@ -49,9 +49,10 @@ def _mhc_post_kernel(batch: int, n_expand: int, c_x: int, x_dtype: str = 'bfloat
                     x_res_shared[i, j] = x_res[bx, i * c_x + by * block_C + j]
 
                 for i, j in T.Parallel(n_expand, block_C):
-                    x_out_shared[i * n_expand +
-                                 j] = h_post_shared[i] * x_layer_out_shared[j] + x_res_shared[i, j]
-                    x_out[bx, i * c_x + block_C * by + j] = x_out_shared[i * n_expand + j]
+                    x_out_shared[i * block_C + j] = (
+                        h_post_shared[i] * x_layer_out_shared[j] + x_res_shared[i, j]
+                    )
+                    x_out[bx, i * c_x + block_C * by + j] = x_out_shared[i * block_C + j]
 
         @T.prim_func
         def mhc_post(


### PR DESCRIPTION
## Summary

- fix `MHCPostKernel` shared-memory indexing to use `block_C` as the row stride for `x_out_shared`
- avoid overlapping writes across `n_expand` rows in the default `n_expand=4, block_C=64` configuration

Fixes #1584.

## Tests

- `python -m py_compile tileops/kernels/mhc/mhc_post.py tileops/ops/mhc.py tests/ops/test_mhc_post.py`
- `python -m ruff check tileops/kernels/mhc/mhc_post.py tests/ops/test_mhc_post.py`
- Docker runner: `python -m pytest tests/ops/test_mhc_post.py -vvs -k smoke`
- Docker runner: `compute-sanitizer --tool racecheck python -m pytest tests/ops/test_mhc_post.py -q -k smoke`
  - `RACECHECK SUMMARY: 0 hazards displayed (0 errors, 0 warnings)`
- Docker runner: `python -m pytest tests/ops/test_mhc_post.py -q`

Host pytest was not used for validation because the host environment is missing `tvm.tirx`; the Docker runner image includes the TileOps CI dependencies.
