### PR TITLE
[Feat][Ops] Infer shape metadata from op inputs

### DIFF
--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -76,7 +76,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = AdaLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormFwdOp(dtype=dtype)
     bm = AdaLayerNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -95,7 +95,7 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroTest(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = AdaLayerNormZeroFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(dtype=dtype)
     bm = AdaLayerNormZeroBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_fused_add_layer_norm.py
+++ b/benchmarks/ops/bench_fused_add_layer_norm.py
@@ -49,7 +49,7 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
     test = FusedAddLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = FusedAddLayerNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = FusedAddLayerNormFwdOp(dtype=dtype, tune=tune)
     bm = FusedAddLayerNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_fused_add_rms_norm.py
+++ b/benchmarks/ops/bench_fused_add_rms_norm.py
@@ -55,7 +55,7 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
     test = FusedAddRMSNormTest(m, n, dtype)
     inputs = test.gen_inputs()
 
-    op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype, tune=tune)
+    op = FusedAddRMSNormFwdOp(dtype=dtype, tune=tune)
     bm = FusedAddRMSNormBenchmark(test, op)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -221,7 +221,7 @@ def _run_bench(
     else:
         # torch-ref baseline: memory-efficient per-expert GEMM loop.
         fk = FusedTopKOp(
-            num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
+            top_k=top_k,
             scoring_func=scoring_func, renormalize=renormalize,
             with_correction_bias=with_correction_bias,
         )

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -102,7 +102,11 @@ def test_fused_topk_bench(
     (gating_output,) = test.gen_inputs()
 
     # TileOPs
-    op = FusedTopKOp(num_tokens, num_experts, top_k, scoring_func, renormalize)
+    op = FusedTopKOp(
+        top_k=top_k,
+        scoring_func=scoring_func,
+        renormalize=renormalize,
+    )
     op(gating_output)  # warmup / JIT compile
     torch.cuda.synchronize()
 

--- a/benchmarks/ops/bench_moe_kernel_breakdown.py
+++ b/benchmarks/ops/bench_moe_kernel_breakdown.py
@@ -90,8 +90,10 @@ def profile_nopad(T, E, K, H, F, scoring_func, renormalize):
     hidden, gating, w_gu, w_down = gen_inputs(T, E, K, H, F)
 
     # Build ops
-    topk_op    = FusedTopKOp(T, E, K, scoring_func, renormalize)
-    permute_op = MoePermuteNopadFwdOp(T, K, E, H, DTYPE)
+    topk_op    = FusedTopKOp(
+        top_k=K, scoring_func=scoring_func, renormalize=renormalize,
+    )
+    permute_op = MoePermuteNopadFwdOp(num_experts=E, dtype=DTYPE)
     unp_op     = MoeUnpermuteFwdOp(T, K, H, DTYPE, padded_batch_sum=numel)
     silu_op    = SiluAndMulFwdOp(M=numel, N=F, dtype=DTYPE)
 
@@ -153,7 +155,9 @@ def profile_nopad(T, E, K, H, F, scoring_func, renormalize):
 def profile_vllm(T, E, K, H, F, scoring_func, renormalize, iters=5):
     """Run vLLM fused_experts under torch.profiler; return sorted CUDA kernel table."""
     hidden, gating, w_gu, w_down = gen_inputs(T, E, K, H, F)
-    topk_op = FusedTopKOp(T, E, K, scoring_func, renormalize)
+    topk_op = FusedTopKOp(
+        top_k=K, scoring_func=scoring_func, renormalize=renormalize,
+    )
     tw, tids = topk_op(gating)
     # vLLM expects int64 topk_ids
     tids_i64 = tids.to(torch.int64)

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -89,9 +89,12 @@ def _manifest_params():
     params = []
     for w in load_workloads(_OP_NAME):
         label = w.get("label", "unlabeled")
+        total_tokens, hidden_size = w["hidden_states_shape"]
+        topk_tokens, top_k = w["topk_ids_shape"]
+        assert topk_tokens == total_tokens
         for dtype_str in w["dtypes"]:
             params.append(pytest.param(
-                w["total_tokens"], w["top_k"], w["num_experts"], w["hidden_size"],
+                total_tokens, top_k, w["num_experts"], hidden_size,
                 id=f"{label}-{dtype_str}",
             ))
     return params
@@ -114,7 +117,7 @@ def test_moe_permute_nopad_bench(
     hidden_states, topk_ids = test.gen_inputs()
 
     # TileOPs
-    op = MoePermuteNopadFwdOp(total_tokens, top_k, num_experts, hidden_size, dtype)
+    op = MoePermuteNopadFwdOp(num_experts=num_experts, dtype=dtype)
     bm = MoePermuteNopadBenchmark(test, op)
     op(hidden_states, topk_ids)  # warmup / JIT compile
     torch.cuda.synchronize()

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -253,7 +253,7 @@ def test_shared_fused_moe_bench(
     else:
         # torch-ref: per-expert GEMM loop + manual shared MLP
         fk = FusedTopKOp(
-            num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
+            top_k=top_k,
             scoring_func=scoring_func, renormalize=renormalize,
             with_correction_bias=with_correction_bias,
         )

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -282,6 +282,10 @@ signature:
 | `layout`      | no       | Memory format when non-default (R19).                                                                                                    |
 
 **Param fields:** `type` (string: `int`, `float`, `bool`, `"list[int]"`) + optional `default`.
+`compat_default` is reserved for legacy Python constructor compatibility:
+it may match an `__init__` default without making the parameter optional in
+the manifest contract. Manifest-driven callers must still provide params that
+omit `default`.
 
 #### Shape Decision Tree
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3304,10 +3304,16 @@ def check_c3_ctor_signature_parity(
         # Default-value parity: when the manifest declares a default the
         # ctor default must match it value-for-value. Manifest sentinel
         # ``REQUIRED`` (or absent ``default``) means the param has no
-        # default; the ctor must omit one too.
+        # manifest default. A narrow ``compat_default`` escape hatch lets
+        # legacy ctor signatures keep a Python default without advertising
+        # that value to manifest-driven callers.
         manifest_default = pattrs.get("default", _MISSING)
         manifest_has_default = (
             manifest_default is not _MISSING and manifest_default != "REQUIRED"
+        )
+        compat_default = pattrs.get("compat_default", _MISSING)
+        manifest_has_compat_default = (
+            compat_default is not _MISSING and not manifest_has_default
         )
         code_has_default = code_p.default is not inspect.Parameter.empty
         if manifest_has_default and not code_has_default:
@@ -3316,10 +3322,14 @@ def check_c3_ctor_signature_parity(
                 f"{manifest_default!r} but no default on __init__"
             )
         elif (not manifest_has_default) and code_has_default:
-            errors.append(
-                f"[ctor] {op_name}: param {pname!r} has __init__ default "
-                f"{code_p.default!r} but no manifest default"
-            )
+            if (
+                not manifest_has_compat_default
+                or code_p.default != compat_default
+            ):
+                errors.append(
+                    f"[ctor] {op_name}: param {pname!r} has __init__ default "
+                    f"{code_p.default!r} but no manifest default"
+                )
         elif (
             manifest_has_default
             and code_has_default

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -56,7 +56,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @AdaLayerNormFixture
 def test_ada_layer_norm_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormTest(m, n, dtype)
-    op = AdaLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormFwdOp(dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -78,8 +78,7 @@ def test_ada_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype
     scale = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     shift = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = AdaLayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = AdaLayerNormFwdOp(dtype=dtype)
 
     # Reference: scale * LayerNorm(x) + shift
     eps = 1e-5

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -58,7 +58,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @AdaLayerNormZeroFixture
 def test_ada_layer_norm_zero_op(m: int, n: int, dtype: torch.dtype) -> None:
     test = AdaLayerNormZeroTest(m, n, dtype)
-    op = AdaLayerNormZeroFwdOp(M=m, N=n, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -81,8 +81,7 @@ def test_ada_layer_norm_zero_3d(batch: int, seq: int, hidden: int, dtype: torch.
     shift = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
     gate = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
 
-    M = batch * seq
-    op = AdaLayerNormZeroFwdOp(M=M, N=hidden, dtype=dtype)
+    op = AdaLayerNormZeroFwdOp(dtype=dtype)
 
     # Reference: gate * (scale * LayerNorm(x) + shift)
     eps = 1e-5

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -146,7 +146,7 @@ def test_cumsum_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     test = CumulativeTest(m, n, dtype, "cumsum")
-    op = CumsumFwdOp(N=n, dtype=dtype)
+    op = CumsumFwdOp(dtype=dtype)
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
@@ -156,7 +156,7 @@ def test_cumsum_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
-    op = CumsumFwdOp(N=n, dtype=dtype)
+    op = CumsumFwdOp(dtype=dtype)
     ref = x.contiguous().float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -168,7 +168,7 @@ def test_cumsum_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(batch, seq, hidden, dtype=dtype, device="cuda")
-    op = CumsumFwdOp(N=hidden, dtype=dtype)
+    op = CumsumFwdOp(dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -180,7 +180,7 @@ def test_cumsum_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> Non
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(b0, b1, b2, n, dtype=dtype, device="cuda")
-    op = CumsumFwdOp(N=n, dtype=dtype)
+    op = CumsumFwdOp(dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
@@ -192,11 +192,37 @@ def test_cumsum_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = CumsumFwdOp(N=n, dtype=dtype)
+    op = CumsumFwdOp(dtype=dtype)
     ref = x.float().cumsum(dim=-1).to(dtype)
     y = op(x)
     tol = _tol(dtype)
     assert torch.allclose(y, ref, **tol), f"1D cumsum max err: {(y - ref).abs().max()}"
+
+
+@pytest.mark.smoke
+def test_cumsum_explicit_n_mismatch_raises() -> None:
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    x = torch.randn(4, 8, dtype=torch.float16, device="cuda")
+    op = CumsumFwdOp(N=9, dtype=torch.float16)
+    with pytest.raises(ValueError, match="Expected x.shape"):
+        op(x)
+
+
+@pytest.mark.smoke
+def test_cumsum_dynamic_shape_kernel_cache() -> None:
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    op = CumsumFwdOp()
+    x1 = torch.randn(4, 8, dtype=torch.float16, device="cuda")
+    x2 = torch.randn(5, 8, dtype=torch.float16, device="cuda")
+
+    op(x1)
+    assert len(op._kernel_cache) == 1
+    op(x1)
+    assert len(op._kernel_cache) == 1
+    op(x2)
+    assert len(op._kernel_cache) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +235,7 @@ def test_cumprod_op(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     test = CumulativeTest(m, n, dtype, "cumprod", use_small_range=True)
-    op = CumprodFwdOp(N=n, dtype=dtype)
+    op = CumprodFwdOp(dtype=dtype)
     test.check(op, *test.gen_inputs(), **_cumprod_tol(dtype))
 
 
@@ -219,7 +245,7 @@ def test_cumprod_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
 
     x_full = torch.rand(m, n * 2, dtype=dtype, device="cuda") * 0.01 + 0.99
     x = x_full[:, :n]
-    op = CumprodFwdOp(N=n, dtype=dtype)
+    op = CumprodFwdOp(dtype=dtype)
     ref = x.contiguous().float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -231,7 +257,7 @@ def test_cumprod_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype) -> No
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(batch, seq, hidden, dtype=dtype, device="cuda") * 0.01 + 0.99
-    op = CumprodFwdOp(N=hidden, dtype=dtype)
+    op = CumprodFwdOp(dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -243,7 +269,7 @@ def test_cumprod_4d(b0: int, b1: int, b2: int, n: int, dtype: torch.dtype) -> No
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(b0, b1, b2, n, dtype=dtype, device="cuda") * 0.01 + 0.99
-    op = CumprodFwdOp(N=n, dtype=dtype)
+    op = CumprodFwdOp(dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -255,7 +281,7 @@ def test_cumprod_1d(n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.cumprod import CumprodFwdOp
 
     x = torch.rand(n, dtype=dtype, device="cuda") * 0.01 + 0.99
-    op = CumprodFwdOp(N=n, dtype=dtype)
+    op = CumprodFwdOp(dtype=dtype)
     ref = x.float().cumprod(dim=-1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)
@@ -279,7 +305,7 @@ def test_cumsum_dim_axis1(
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     x = torch.randn(batch, hidden, seq, dtype=dtype, device="cuda")
-    op = CumsumFwdOp(N=hidden, dtype=dtype, dim=1)
+    op = CumsumFwdOp(dtype=dtype, dim=1)
     ref = x.float().cumsum(dim=1).to(dtype)
     y = op(x)
     atol = 1e-2 if dtype == torch.float16 else 1.6e-2
@@ -296,7 +322,7 @@ def test_cumprod_dim_axis1(
 
     # Values close to 1 to avoid over/underflow in cumprod over hidden dim.
     x = torch.rand(batch, hidden, seq, dtype=dtype, device="cuda") * 0.01 + 0.99
-    op = CumprodFwdOp(N=hidden, dtype=dtype, dim=1)
+    op = CumprodFwdOp(dtype=dtype, dim=1)
     ref = x.float().cumprod(dim=1).to(dtype)
     y = op(x)
     tol = _cumprod_tol(dtype)

--- a/tests/ops/test_fused_add_layer_norm.py
+++ b/tests/ops/test_fused_add_layer_norm.py
@@ -63,7 +63,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @FusedAddLayerNormFixture
 def test_fused_add_layer_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddLayerNormTest(m, n, dtype)
-    op = FusedAddLayerNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddLayerNormFwdOp(dtype=dtype, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -121,7 +121,7 @@ def test_fused_add_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch
     bias = torch.randn(hidden, dtype=dtype, device="cuda")
 
     M = batch * seq
-    op = FusedAddLayerNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = FusedAddLayerNormFwdOp(dtype=dtype)
 
     test = FusedAddLayerNormTest(M, hidden, dtype)
     y_ref, add_ref = test.ref_program(x, residual, weight, bias)

--- a/tests/ops/test_fused_add_rms_norm.py
+++ b/tests/ops/test_fused_add_rms_norm.py
@@ -51,7 +51,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 @FusedAddRMSNormFixture
 def test_fused_add_rms_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     test = FusedAddRMSNormTest(m, n, dtype)
-    op = FusedAddRMSNormFwdOp(M=m, N=n, dtype=dtype)
+    op = FusedAddRMSNormFwdOp(dtype=dtype, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -105,7 +105,7 @@ def test_fused_add_rms_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.d
     weight = torch.randn(hidden, dtype=dtype, device="cuda")
 
     M = batch * seq
-    op = FusedAddRMSNormFwdOp(M=M, N=hidden, dtype=dtype)
+    op = FusedAddRMSNormFwdOp(dtype=dtype)
 
     test = FusedAddRMSNormTest(M, hidden, dtype)
     y_ref, add_ref = test.ref_program(x, residual, weight)

--- a/tests/ops/test_moe_fused_topk.py
+++ b/tests/ops/test_moe_fused_topk.py
@@ -83,8 +83,6 @@ class FusedTopKFixture(FixtureBase):
 def _check(test: FusedTopKTest) -> None:
     (gating,) = test.gen_inputs()
     op = FusedTopKOp(
-        num_tokens=test.num_tokens,
-        num_experts=test.num_experts,
         top_k=test.top_k,
         scoring_func=test.scoring_func,
         renormalize=test.renormalize,
@@ -140,3 +138,57 @@ def test_fused_topk(
 ) -> None:
     test = FusedTopKTest(num_tokens, num_experts, top_k, scoring_func, renormalize, dtype)
     _check(test)
+
+
+@pytest.mark.smoke
+def test_fused_topk_explicit_shape_mismatch_raises() -> None:
+    gating = torch.randn(4, 8, dtype=torch.float16, device="cuda")
+    op = FusedTopKOp(num_tokens=5, num_experts=8, top_k=2)
+    with pytest.raises(ValueError, match="Expected num_tokens"):
+        op(gating)
+
+
+@pytest.mark.smoke
+def test_fused_topk_cpu_input_raises() -> None:
+    gating = torch.randn(4, 8, dtype=torch.float16)
+    op = FusedTopKOp(top_k=2)
+    with pytest.raises(ValueError, match="gating_output must be a CUDA tensor"):
+        op(gating)
+
+
+@pytest.mark.smoke
+def test_fused_topk_invalid_dtype_raises() -> None:
+    gating = torch.randint(0, 8, (4, 8), dtype=torch.int32, device="cuda")
+    op = FusedTopKOp(top_k=2)
+    with pytest.raises(ValueError, match="Expected gating_output.dtype"):
+        op(gating)
+
+
+@pytest.mark.smoke
+def test_fused_topk_correction_bias_requires_sigmoid() -> None:
+    with pytest.raises(ValueError, match="requires scoring_func='sigmoid'"):
+        FusedTopKOp(top_k=2, scoring_func="softmax", with_correction_bias=True)
+
+
+@pytest.mark.smoke
+def test_fused_topk_correction_bias_device_check() -> None:
+    gating = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+    correction_bias = torch.randn(8, dtype=torch.float32)
+    op = FusedTopKOp(top_k=2, scoring_func="sigmoid", with_correction_bias=True)
+    with pytest.raises(ValueError, match="correction_bias must be a CUDA tensor"):
+        op(gating, correction_bias)
+
+
+@pytest.mark.smoke
+def test_fused_topk_dynamic_shape_kernel_cache() -> None:
+    op = FusedTopKOp(top_k=2)
+    gating1 = torch.randn(4, 8, dtype=torch.float16, device="cuda")
+    gating2 = torch.randn(5, 8, dtype=torch.float16, device="cuda")
+
+    op(gating1)
+    assert op.dtype == torch.float16
+    assert len(op._kernel_cache) == 1
+    op(gating1)
+    assert len(op._kernel_cache) == 1
+    op(gating2)
+    assert len(op._kernel_cache) == 2

--- a/tests/ops/test_moe_permute_nopad.py
+++ b/tests/ops/test_moe_permute_nopad.py
@@ -114,13 +114,49 @@ class MoePermuteNopadFixture(FixtureBase):
 @MoePermuteNopadFixture
 def test_moe_permute_nopad_op(total_tokens, top_k, num_experts, hidden_size, dtype):
     test = MoePermuteNopadTest(total_tokens, top_k, num_experts, hidden_size, dtype)
-    op = MoePermuteNopadFwdOp(total_tokens, top_k, num_experts, hidden_size, dtype)
+    op = MoePermuteNopadFwdOp(num_experts=num_experts, dtype=dtype)
     hidden_states, topk_ids = test.gen_inputs()
 
     outputs = op(hidden_states, topk_ids)
     outputs_ref = test.ref_program(hidden_states, topk_ids)
 
     _compare(hidden_states, topk_ids, outputs, outputs_ref, num_experts)
+    flops, nbytes = op.eval_roofline()
+    assert flops == 0
+    assert nbytes > 0
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_explicit_shape_mismatch_raises() -> None:
+    hidden_states = torch.randn(4, 16, dtype=torch.float16, device="cuda")
+    topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadFwdOp(
+        total_tokens=5,
+        top_k=2,
+        num_experts=4,
+        hidden_size=16,
+        dtype=torch.float16,
+    )
+    with pytest.raises(ValueError, match="Expected total_tokens"):
+        op(hidden_states, topk_ids)
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_cpu_input_raises() -> None:
+    hidden_states = torch.randn(4, 16, dtype=torch.float16)
+    topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32)
+    op = MoePermuteNopadFwdOp(num_experts=4)
+    with pytest.raises(ValueError, match="hidden_states must be a CUDA tensor"):
+        op(hidden_states, topk_ids)
+
+
+@pytest.mark.smoke
+def test_moe_permute_nopad_invalid_dtype_raises() -> None:
+    hidden_states = torch.randn(4, 16, dtype=torch.float32, device="cuda")
+    topk_ids = torch.randint(0, 4, (4, 2), dtype=torch.int32, device="cuda")
+    op = MoePermuteNopadFwdOp(num_experts=4)
+    with pytest.raises(ValueError, match="Expected hidden_states.dtype"):
+        op(hidden_states, topk_ids)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -4503,6 +4503,43 @@ class TestStrictParityC3Ctor:
         errs = validator.check_c3_ctor_signature_parity("Op2", entry, Op2)
         assert any("no default on __init__" in e for e in errs), errs
 
+    def test_compat_default_allows_required_manifest_param(self, validator):
+        from tileops.ops.op_base import Op
+
+        class OpCompat(Op):
+            def __init__(self, num_experts=None, kernel_map=None): pass
+            def forward(self, x): return None
+            @property
+            def default_kernel_map(self): return {}
+
+        entry = {"signature": {
+            "params": {
+                "num_experts": {"type": "int", "compat_default": None},
+            },
+        }}
+        assert validator.check_c3_ctor_signature_parity(
+            "OpCompat", entry, OpCompat
+        ) == []
+
+    def test_compat_default_mismatch_fails(self, validator):
+        from tileops.ops.op_base import Op
+
+        class OpCompatMismatch(Op):
+            def __init__(self, num_experts=0, kernel_map=None): pass
+            def forward(self, x): return None
+            @property
+            def default_kernel_map(self): return {}
+
+        entry = {"signature": {
+            "params": {
+                "num_experts": {"type": "int", "compat_default": None},
+            },
+        }}
+        errs = validator.check_c3_ctor_signature_parity(
+            "OpCompatMismatch", entry, OpCompatMismatch
+        )
+        assert any("no manifest default" in e for e in errs), errs
+
     def test_kw_only_mismatch_fails(self, validator):
         from tileops.ops.op_base import Op
 

--- a/tileops/manifest/moe.yaml
+++ b/tileops/manifest/moe.yaml
@@ -66,40 +66,48 @@ MoePermuteNopadFwdOp:
       expert_first_token_offset: {dtype: "int64"}
       fwd_idx: {dtype: "int32"}
     params:
-      total_tokens: {type: int}
-      top_k: {type: int}
-      num_experts: {type: int}
-      hidden_size: {type: int}
+      num_experts: {type: int, compat_default: null}
     shape_rules:
-    - "hidden_states.shape == (total_tokens, hidden_size)"
+    - "hidden_states.ndim == 2"
+    - "topk_ids.ndim == 2"
+    - "topk_ids.shape[0] == hidden_states.shape[0]"
+    - "perm_h.shape == (hidden_states.shape[0] * topk_ids.shape[1], hidden_states.shape[1])"
+    - "true_offsets.shape == (num_experts,)"
+    - "true_sizes.shape == (num_experts,)"
+    - "expert_first_token_offset.shape == (num_experts + 1,)"
+    - "fwd_idx.shape == (hidden_states.shape[0] * topk_ids.shape[1],)"
 
   workloads:
     # Kimi K2: H=7168, E=384, K=8
-  - {total_tokens: 1, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-decode"}
-  - {total_tokens: 32, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-small"}
-  - {total_tokens: 512, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-medium"}
-  - {total_tokens: 4096, top_k: 8, num_experts: 384, hidden_size: 7168, dtypes: [bfloat16], label: "kimi-k2-prefill"}
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 384, dtypes: [bfloat16], label: "kimi-k2-prefill"}
     # DeepSeek-V3: H=7168, E=256, K=8
-  - {total_tokens: 1, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-decode"}
-  - {total_tokens: 32, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-small"}
-  - {total_tokens: 512, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-medium"}
-  - {total_tokens: 4096, top_k: 8, num_experts: 256, hidden_size: 7168, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 256, dtypes: [bfloat16], label: "deepseek-v3-prefill"}
     # Qwen3-235B-A22B: H=7168, E=128, K=8
-  - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-decode"}
-  - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-small"}
-  - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-medium"}
-  - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 7168, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
+  - {hidden_states_shape: [1, 7168], topk_ids_shape: [1, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-decode"}
+  - {hidden_states_shape: [32, 7168], topk_ids_shape: [32, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-small"}
+  - {hidden_states_shape: [512, 7168], topk_ids_shape: [512, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-medium"}
+  - {hidden_states_shape: [4096, 7168], topk_ids_shape: [4096, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-235b-prefill"}
     # Qwen3-30B-A3B: H=3072, E=128, K=8
-  - {total_tokens: 1, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-decode"}
-  - {total_tokens: 32, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-small"}
-  - {total_tokens: 512, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-medium"}
-  - {total_tokens: 4096, top_k: 8, num_experts: 128, hidden_size: 3072, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
+  - {hidden_states_shape: [1, 3072], topk_ids_shape: [1, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-decode"}
+  - {hidden_states_shape: [32, 3072], topk_ids_shape: [32, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-small"}
+  - {hidden_states_shape: [512, 3072], topk_ids_shape: [512, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-medium"}
+  - {hidden_states_shape: [4096, 3072], topk_ids_shape: [4096, 8], num_experts: 128, dtypes: [bfloat16], label: "qwen3-30b-prefill"}
 
   roofline:
+    vars:
+      T: "hidden_states_shape[0]"
+      K: "topk_ids_shape[1]"
+      H: "hidden_states_shape[1]"
     # Permute is memory-bound; flops = 0
     flops: "0"
     # hidden_states read [T, H] + perm_h write [T*K, H] + metadata
-    bytes: "(total_tokens * hidden_size + total_tokens * top_k * hidden_size) * elem_bytes + (num_experts + 1) * 8 + 2 * total_tokens * top_k * 4 + num_experts * 8"
+    bytes: "(T * H + T * K * H) * elem_bytes + (num_experts + 1) * 8 + 2 * T * K * 4 + num_experts * 8"
 
   source:
     kernel: tileops/kernels/moe/permute_nopad.py

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -118,8 +118,6 @@ AdaLayerNormFwdOp:
       output: {dtype: "same_as(x)"}
     params:
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      N: "x.shape[-1]"
     shape_rules:
       - "scale.shape == x.shape"
       - "shift.shape == x.shape"
@@ -165,8 +163,6 @@ AdaLayerNormZeroFwdOp:
       output: {dtype: "same_as(x)"}
     params:
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      N: "x.shape[-1]"
     shape_rules:
       - "scale.shape == x.shape"
       - "shift.shape == x.shape"
@@ -214,8 +210,6 @@ FusedAddLayerNormFwdOp:
       residual_out: {dtype: "same_as(x)"}
     params:
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      N: "x.shape[-1]"
     shape_rules:
       - "residual.shape == x.shape"
       - "weight.shape == (x.shape[-1],)"
@@ -264,8 +258,6 @@ FusedAddRMSNormFwdOp:
       residual_out: {dtype: "same_as(x)"}
     params:
       eps: {type: float, default: 1.0e-6}
-    static_dims:
-      N: "x.shape[-1]"
     shape_rules:
       - "residual.shape == x.shape"
       - "weight.shape == (x.shape[-1],)"

--- a/tileops/manifest/scan.yaml
+++ b/tileops/manifest/scan.yaml
@@ -16,8 +16,6 @@ CumsumFwdOp:
       y: {dtype: "same_as(x)"}
     params:
       dim: {type: int, default: -1}
-    static_dims:
-      N: "x.shape[dim]"
     shape_rules:
       - "-x.ndim <= dim < x.ndim"
       - "y.shape == x.shape"
@@ -58,8 +56,6 @@ CumprodFwdOp:
       y: {dtype: "same_as(x)"}
     params:
       dim: {type: int, default: -1}
-    static_dims:
-      N: "x.shape[dim]"
     shape_rules:
       - "-x.ndim <= dim < x.ndim"
       - "y.shape == x.shape"

--- a/tileops/ops/moe/fused_moe.py
+++ b/tileops/ops/moe/fused_moe.py
@@ -92,8 +92,6 @@ class FusedMoe(Op):
         self.dispatch_kernel(kernel_map)
 
         self._fused_topk = FusedTopKOp(
-            num_tokens=num_tokens,
-            num_experts=num_experts,
             top_k=top_k,
             scoring_func=scoring_func,
             renormalize=renormalize,

--- a/tileops/ops/moe/fused_topk.py
+++ b/tileops/ops/moe/fused_topk.py
@@ -19,8 +19,10 @@ class FusedTopKOp(Op):
     top-k experts per token.
 
     Args:
-        num_tokens: Number of input tokens T.
-        num_experts: Number of experts E.
+        num_tokens: Optional committed number of input tokens T. Preferred
+            API infers it from ``gating_output.shape[0]``.
+        num_experts: Optional committed number of experts E. Preferred API
+            infers it from ``gating_output.shape[1]``.
         top_k: Number of experts to select per token K.
         scoring_func: "softmax" (Qwen3/Qwen2) or "sigmoid" (DeepSeek-V3/GLM-4/Kimi K2).
         renormalize: If True, normalize top-k weights to sum to 1.
@@ -31,7 +33,7 @@ class FusedTopKOp(Op):
         config: Optional kernel config dict.
 
     Example:
-        >>> op = FusedTopKOp(num_tokens=512, num_experts=128, top_k=8)
+        >>> op = FusedTopKOp(top_k=8)
         >>> topk_weights, topk_ids = op(gating_output)
         >>> # topk_weights: [512, 8] float32
         >>> # topk_ids:     [512, 8] int32
@@ -39,9 +41,9 @@ class FusedTopKOp(Op):
 
     def __init__(
         self,
-        num_tokens: int,
-        num_experts: int,
-        top_k: int,
+        num_tokens: Optional[int] = None,
+        num_experts: Optional[int] = None,
+        top_k: Optional[int] = None,
         scoring_func: str = "softmax",
         renormalize: bool = False,
         with_correction_bias: bool = False,
@@ -51,24 +53,38 @@ class FusedTopKOp(Op):
         self.num_tokens = num_tokens
         self.num_experts = num_experts
         self.top_k = top_k
+        self._committed_num_tokens = num_tokens
+        self._committed_num_experts = num_experts
         self.scoring_func = scoring_func
         self.renormalize = renormalize
         self.with_correction_bias = with_correction_bias
+        if with_correction_bias and scoring_func != "sigmoid":
+            raise ValueError("with_correction_bias=True requires scoring_func='sigmoid'")
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fused_topk_kernel"](
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            top_k=top_k,
-            scoring_func=scoring_func,
-            renormalize=renormalize,
-            with_correction_bias=with_correction_bias,
-            config=config,
-        )
+        self.config = config
+        self._kernel_cache: Dict[tuple[int, int, int, int | None], Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fused_topk_kernel": FusedTopKKernel}
+
+    def _get_kernel(
+        self, num_tokens: int, num_experts: int, top_k: int,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (num_tokens, num_experts, top_k, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fused_topk_kernel"](
+                num_tokens=num_tokens,
+                num_experts=num_experts,
+                top_k=top_k,
+                scoring_func=self.scoring_func,
+                renormalize=self.renormalize,
+                with_correction_bias=self.with_correction_bias,
+                config=self.config,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -86,4 +102,64 @@ class FusedTopKOp(Op):
             topk_weights: [T, K] float32.
             topk_ids:     [T, K] int32.
         """
-        return self.kernel(gating_output, correction_bias)
+        if not gating_output.is_cuda:
+            raise ValueError("gating_output must be a CUDA tensor")
+        if correction_bias is not None and not correction_bias.is_cuda:
+            raise ValueError("correction_bias must be a CUDA tensor")
+        if correction_bias is not None and gating_output.device != correction_bias.device:
+            raise ValueError(
+                f"Expected gating_output and correction_bias to be on the same device, "
+                f"got {gating_output.device} and {correction_bias.device}"
+            )
+        if gating_output.ndim != 2:
+            raise ValueError(
+                f"Expected gating_output to be 2D [T, E], got {gating_output.ndim}D"
+            )
+        if gating_output.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise ValueError(
+                "Expected gating_output.dtype to be torch.float16, "
+                f"torch.bfloat16, or torch.float32, got {gating_output.dtype}"
+            )
+        num_tokens, num_experts = gating_output.shape
+        if (
+            self._committed_num_tokens is not None
+            and num_tokens != self._committed_num_tokens
+        ):
+            raise ValueError(
+                f"Expected num_tokens={self._committed_num_tokens}, got {num_tokens}"
+            )
+        if (
+            self._committed_num_experts is not None
+            and num_experts != self._committed_num_experts
+        ):
+            raise ValueError(
+                f"Expected num_experts={self._committed_num_experts}, got {num_experts}"
+            )
+        if self.top_k is None:
+            raise ValueError("top_k must be provided at construction time")
+        if self.top_k > num_experts:
+            raise ValueError(
+                f"top_k={self.top_k} cannot exceed num_experts={num_experts}"
+            )
+        if self.with_correction_bias:
+            if correction_bias is None:
+                raise ValueError("correction_bias is required when with_correction_bias=True")
+            if correction_bias.shape != (num_experts,):
+                raise ValueError(
+                    f"Expected correction_bias shape {(num_experts,)}, "
+                    f"got {tuple(correction_bias.shape)}"
+                )
+            if correction_bias.dtype != torch.float32:
+                raise ValueError(
+                    f"Expected correction_bias.dtype torch.float32, got {correction_bias.dtype}"
+                )
+        elif correction_bias is not None:
+            raise ValueError("correction_bias must be None when with_correction_bias=False")
+
+        self.num_tokens = num_tokens
+        self.num_experts = num_experts
+        self.dtype = gating_output.dtype
+        kernel = self._get_kernel(
+            num_tokens, num_experts, self.top_k, gating_output.device.index,
+        )
+        return kernel(gating_output, correction_bias)

--- a/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -182,8 +182,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
                 self.use_fused_activation = False
 
         self._permute = MoePermuteNopadFwdOp(
-            total_tokens=num_tokens, top_k=top_k, num_experts=num_experts,
-            hidden_size=hidden_size, dtype=dtype, expert_map=expert_map,
+            num_experts=num_experts, dtype=dtype, expert_map=expert_map,
             kernel_map=kernel_map,
         )
         self.activation = activation

--- a/tileops/ops/moe/routed_expert/permute_nopad.py
+++ b/tileops/ops/moe/routed_expert/permute_nopad.py
@@ -20,28 +20,32 @@ class MoePermuteNopadFwdOp(Op):
     the MoE pipeline.
 
     Args:
-        total_tokens: Number of input tokens T.
-        top_k: Number of experts selected per token K.
+        total_tokens: Optional committed number of input tokens T. Preferred
+            API infers it from ``hidden_states.shape[0]``.
+        top_k: Optional committed number of experts selected per token K.
+            Preferred API infers it from ``topk_ids.shape[1]``.
         num_experts: Total number of experts E (global count).
-        hidden_size: Hidden dimension H.
-        dtype: Data type of hidden_states (bf16 or fp16).
+        hidden_size: Optional committed hidden dimension H. Preferred API
+            infers it from ``hidden_states.shape[1]``.
+        dtype: Data type of hidden_states (bf16 or fp16). If omitted,
+            inferred from ``hidden_states``.
         expert_map: Optional [E_global] int32 tensor mapping global expert ids
             to local ids (-1 = not on this rank).  When provided, only local
             token-expert pairs are counted; non-local positions get fwd_idx = -1.
         kernel_map: Optional kernel override dict.
 
     Example:
-        >>> op = MoePermuteNopadFwdOp(total_tokens=4, top_k=2, num_experts=8, hidden_size=128)
+        >>> op = MoePermuteNopadFwdOp(num_experts=8)
         >>> perm_h, offsets, sizes, expert_offset, fwd_idx = op(hidden_states, topk_ids)
     """
 
     def __init__(
         self,
-        total_tokens: int,
-        top_k: int,
-        num_experts: int,
-        hidden_size: int,
-        dtype: torch.dtype = torch.bfloat16,
+        total_tokens: Optional[int] = None,
+        top_k: Optional[int] = None,
+        num_experts: Optional[int] = None,
+        hidden_size: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         expert_map: Optional[torch.Tensor] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ) -> None:
@@ -50,18 +54,57 @@ class MoePermuteNopadFwdOp(Op):
         self.num_experts = num_experts
         self.hidden_size = hidden_size
         self.dtype = dtype
+        self._committed_total_tokens = total_tokens
+        self._committed_top_k = top_k
+        self._committed_hidden_size = hidden_size
+        self._committed_dtype = dtype
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["permute_nopad_kernel"](
-            total_tokens, top_k, num_experts, hidden_size, dtype, expert_map
+        self.expert_map = expert_map
+        self._kernel_cache: Dict[tuple[int, int, int, int, torch.dtype, int | None], Kernel] = {}
+
+    def eval_roofline(self) -> tuple[int, int]:
+        if (
+            not hasattr(self, "hidden_states_shape")
+            or not hasattr(self, "topk_ids_shape")
+            or self.dtype is None
+            or self.num_experts is None
+        ):
+            raise ValueError(
+                "MoePermuteNopadFwdOp.eval_roofline() requires a prior forward() "
+                "to bind hidden_states_shape, topk_ids_shape, dtype, and num_experts"
+            )
+        total_tokens, hidden_size = self.hidden_states_shape
+        top_k = self.topk_ids_shape[1]
+        elem_bytes = self.dtype.itemsize
+        nbytes = (
+            (total_tokens * hidden_size + total_tokens * top_k * hidden_size)
+            * elem_bytes
+            + (self.num_experts + 1) * 8
+            + 2 * total_tokens * top_k * 4
+            + self.num_experts * 8
         )
+        return 0, int(nbytes)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"permute_nopad_kernel": MoePermuteNopadKernel}
 
-    # eval_roofline is installed by tileops.ops._roofline_codegen from the
-    # manifest roofline.bytes / roofline.flops expressions; no manual override.
+    def _get_kernel(
+        self,
+        total_tokens: int,
+        top_k: int,
+        num_experts: int,
+        hidden_size: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (total_tokens, top_k, num_experts, hidden_size, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["permute_nopad_kernel"](
+                total_tokens, top_k, num_experts, hidden_size, dtype, self.expert_map
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -82,4 +125,72 @@ class MoePermuteNopadFwdOp(Op):
             fwd_idx:                   [T*K] int32 forward mapping: flat_idx → tight slot
                                        (-1 for non-local pairs when expert_map is set)
         """
-        return self.kernel(hidden_states, topk_ids)
+        if not hidden_states.is_cuda:
+            raise ValueError("hidden_states must be a CUDA tensor")
+        if not topk_ids.is_cuda:
+            raise ValueError("topk_ids must be a CUDA tensor")
+        if hidden_states.device != topk_ids.device:
+            raise ValueError(
+                f"Expected hidden_states and topk_ids to be on the same device, "
+                f"got {hidden_states.device} and {topk_ids.device}"
+            )
+        if hidden_states.ndim != 2:
+            raise ValueError(
+                f"Expected hidden_states to be 2D [T, H], got {hidden_states.ndim}D"
+            )
+        if topk_ids.ndim != 2:
+            raise ValueError(
+                f"Expected topk_ids to be 2D [T, K], got {topk_ids.ndim}D"
+            )
+        total_tokens, hidden_size = hidden_states.shape
+        topk_tokens, top_k = topk_ids.shape
+        if topk_tokens != total_tokens:
+            raise ValueError(
+                f"Expected topk_ids.shape[0] == hidden_states.shape[0] "
+                f"({total_tokens}), got {topk_tokens}"
+            )
+        if (
+            self._committed_total_tokens is not None
+            and total_tokens != self._committed_total_tokens
+        ):
+            raise ValueError(
+                f"Expected total_tokens={self._committed_total_tokens}, got {total_tokens}"
+            )
+        if self._committed_top_k is not None and top_k != self._committed_top_k:
+            raise ValueError(f"Expected top_k={self._committed_top_k}, got {top_k}")
+        if (
+            self._committed_hidden_size is not None
+            and hidden_size != self._committed_hidden_size
+        ):
+            raise ValueError(
+                f"Expected hidden_size={self._committed_hidden_size}, got {hidden_size}"
+            )
+        if self.num_experts is None:
+            raise ValueError("num_experts must be provided at construction time")
+        if (
+            self._committed_dtype is not None
+            and hidden_states.dtype != self._committed_dtype
+        ):
+            raise ValueError(
+                f"Expected hidden_states.dtype {self._committed_dtype}, got {hidden_states.dtype}"
+            )
+        if hidden_states.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "Expected hidden_states.dtype to be torch.float16 or "
+                f"torch.bfloat16, got {hidden_states.dtype}"
+            )
+        if topk_ids.dtype != torch.int32:
+            raise ValueError(f"Expected topk_ids.dtype torch.int32, got {topk_ids.dtype}")
+
+        dtype = hidden_states.dtype
+        self.total_tokens = total_tokens
+        self.top_k = top_k
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+        self.hidden_states_shape = tuple(hidden_states.shape)
+        self.topk_ids_shape = tuple(topk_ids.shape)
+        kernel = self._get_kernel(
+            total_tokens, top_k, self.num_experts, hidden_size, dtype,
+            hidden_states.device.index,
+        )
+        return kernel(hidden_states, topk_ids)

--- a/tileops/ops/norm/ada_layer_norm.py
+++ b/tileops/ops/norm/ada_layer_norm.py
@@ -36,8 +36,10 @@ class AdaLayerNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        M: Optional committed row count for strict compatibility. Preferred
+            API infers it from ``x.shape[:-1]``.
+        N: Optional committed hidden dimension. Preferred API infers it from
+            ``x.shape[-1]``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -47,9 +49,9 @@ class AdaLayerNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
+        M: Optional[int] = None,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -57,20 +59,38 @@ class AdaLayerNormFwdOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
+        self._committed_M = M
+        self._committed_N = N
+        self._committed_dtype = dtype
         self.eps = eps
-        self.N_padded = align_up(N, ALIGNMENT)
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ada_layer_norm"](
-            M, N, eps, dtype, has_gate=False, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
+        self._last_roofline_mn: Optional[tuple[int, int]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ada_layer_norm": AdaLayerNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
+        if self._last_roofline_mn is None or self.dtype is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind input shape and dtype"
+            )
+        M, N = self._last_roofline_mn
         elem_bytes = self.dtype.itemsize
-        return 5 * self.M * self.N, 4 * self.M * self.N * elem_bytes
+        return 5 * M * N, 4 * M * N * elem_bytes
+
+    def _get_kernel(
+        self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
+    ) -> Kernel:
+        key = (M, N, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ada_layer_norm"](
+                M, N, self.eps, dtype, has_gate=False, tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor,
@@ -95,43 +115,59 @@ class AdaLayerNormFwdOp(Op):
             raise ValueError("scale must be a CUDA tensor")
         if not shift.is_cuda:
             raise ValueError("shift must be a CUDA tensor")
-        if x.dtype != self.dtype:
+        expected_dtype = self._committed_dtype
+        if expected_dtype is not None and x.dtype != expected_dtype:
             raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+                f"Expected x.dtype {expected_dtype}, got {x.dtype}"
             )
-        if scale.dtype != self.dtype:
+        if expected_dtype is None:
+            expected_dtype = x.dtype
+        if scale.dtype != expected_dtype:
             raise ValueError(
-                f"Expected scale.dtype {self.dtype}, got {scale.dtype}"
+                f"Expected scale.dtype {expected_dtype}, got {scale.dtype}"
             )
-        if shift.dtype != self.dtype:
+        if shift.dtype != expected_dtype:
             raise ValueError(
-                f"Expected shift.dtype {self.dtype}, got {shift.dtype}"
+                f"Expected shift.dtype {expected_dtype}, got {shift.dtype}"
             )
-        if x.shape[-1] != self.N:
+        if scale.shape != x.shape:
+            raise ValueError(f"Expected scale shape {x.shape}, got {scale.shape}")
+        if shift.shape != x.shape:
+            raise ValueError(f"Expected shift shape {x.shape}, got {shift.shape}")
+        N = x.shape[-1]
+        if self._committed_N is not None and self._committed_N != N:
             raise ValueError(
-                f"Expected hidden dim {self.N}, got {x.shape[-1]}"
+                f"Expected hidden dim {self._committed_N}, got {N}"
             )
 
         orig_shape = x.shape
-        x = x.contiguous().reshape(-1, self.N)
-        scale = scale.contiguous().reshape(-1, self.N)
-        shift = shift.contiguous().reshape(-1, self.N)
+        x = x.contiguous().reshape(-1, N)
+        scale = scale.contiguous().reshape(-1, N)
+        shift = shift.contiguous().reshape(-1, N)
         M_actual = x.shape[0]
-        if M_actual != self.M:
+        if self._committed_M is not None and M_actual != self._committed_M:
             raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
+                f"Expected M={self._committed_M} (product of leading dims), got {M_actual}"
             )
+        self.M = M_actual
+        self.N = N
+        dtype = expected_dtype
+        assert dtype is not None
+        self.dtype = dtype
+        N_padded = align_up(N, ALIGNMENT)
 
         # Pad hidden dim to 256-element alignment if needed
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-            scale = F.pad(scale, (0, self.N_padded - self.N))
-            shift = F.pad(shift, (0, self.N_padded - self.N))
+        if N_padded != N:
+            x = F.pad(x, (0, N_padded - N))
+            scale = F.pad(scale, (0, N_padded - N))
+            shift = F.pad(shift, (0, N_padded - N))
 
-        y = self.kernel(x, scale, shift)
+        kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
+        y = kernel(x, scale, shift)
+        self._last_roofline_mn = (M_actual, N)
 
         # Trim padding
-        if self.N_padded != self.N:
-            y = y[:, :self.N]
+        if N_padded != N:
+            y = y[:, :N]
 
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/tileops/ops/norm/ada_layer_norm_zero.py
@@ -37,8 +37,10 @@ class AdaLayerNormZeroFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        M: Optional committed row count for strict compatibility. Preferred
+            API infers it from ``x.shape[:-1]``.
+        N: Optional committed hidden dimension. Preferred API infers it from
+            ``x.shape[-1]``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -48,9 +50,9 @@ class AdaLayerNormZeroFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
+        M: Optional[int] = None,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -58,20 +60,38 @@ class AdaLayerNormZeroFwdOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
+        self._committed_M = M
+        self._committed_N = N
+        self._committed_dtype = dtype
         self.eps = eps
-        self.N_padded = align_up(N, ALIGNMENT)
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ada_layer_norm"](
-            M, N, eps, dtype, has_gate=True, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
+        self._last_roofline_mn: Optional[tuple[int, int]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ada_layer_norm": AdaLayerNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
+        if self._last_roofline_mn is None or self.dtype is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind input shape and dtype"
+            )
+        M, N = self._last_roofline_mn
         elem_bytes = self.dtype.itemsize
-        return 6 * self.M * self.N, 5 * self.M * self.N * elem_bytes
+        return 6 * M * N, 5 * M * N * elem_bytes
+
+    def _get_kernel(
+        self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
+    ) -> Kernel:
+        key = (M, N, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ada_layer_norm"](
+                M, N, self.eps, dtype, has_gate=True, tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -103,49 +123,67 @@ class AdaLayerNormZeroFwdOp(Op):
             raise ValueError("shift must be a CUDA tensor")
         if not gate.is_cuda:
             raise ValueError("gate must be a CUDA tensor")
-        if x.dtype != self.dtype:
+        expected_dtype = self._committed_dtype
+        if expected_dtype is not None and x.dtype != expected_dtype:
             raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+                f"Expected x.dtype {expected_dtype}, got {x.dtype}"
             )
-        if scale.dtype != self.dtype:
+        if expected_dtype is None:
+            expected_dtype = x.dtype
+        if scale.dtype != expected_dtype:
             raise ValueError(
-                f"Expected scale.dtype {self.dtype}, got {scale.dtype}"
+                f"Expected scale.dtype {expected_dtype}, got {scale.dtype}"
             )
-        if shift.dtype != self.dtype:
+        if shift.dtype != expected_dtype:
             raise ValueError(
-                f"Expected shift.dtype {self.dtype}, got {shift.dtype}"
+                f"Expected shift.dtype {expected_dtype}, got {shift.dtype}"
             )
-        if gate.dtype != self.dtype:
+        if gate.dtype != expected_dtype:
             raise ValueError(
-                f"Expected gate.dtype {self.dtype}, got {gate.dtype}"
+                f"Expected gate.dtype {expected_dtype}, got {gate.dtype}"
             )
-        if x.shape[-1] != self.N:
+        if scale.shape != x.shape:
+            raise ValueError(f"Expected scale shape {x.shape}, got {scale.shape}")
+        if shift.shape != x.shape:
+            raise ValueError(f"Expected shift shape {x.shape}, got {shift.shape}")
+        if gate.shape != x.shape:
+            raise ValueError(f"Expected gate shape {x.shape}, got {gate.shape}")
+        N = x.shape[-1]
+        if self._committed_N is not None and self._committed_N != N:
             raise ValueError(
-                f"Expected hidden dim {self.N}, got {x.shape[-1]}"
+                f"Expected hidden dim {self._committed_N}, got {N}"
             )
 
         orig_shape = x.shape
-        x = x.contiguous().reshape(-1, self.N)
-        scale = scale.contiguous().reshape(-1, self.N)
-        shift = shift.contiguous().reshape(-1, self.N)
-        gate = gate.contiguous().reshape(-1, self.N)
+        x = x.contiguous().reshape(-1, N)
+        scale = scale.contiguous().reshape(-1, N)
+        shift = shift.contiguous().reshape(-1, N)
+        gate = gate.contiguous().reshape(-1, N)
         M_actual = x.shape[0]
-        if M_actual != self.M:
+        if self._committed_M is not None and M_actual != self._committed_M:
             raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
+                f"Expected M={self._committed_M} (product of leading dims), got {M_actual}"
             )
+        self.M = M_actual
+        self.N = N
+        dtype = expected_dtype
+        assert dtype is not None
+        self.dtype = dtype
+        N_padded = align_up(N, ALIGNMENT)
 
         # Pad hidden dim to 256-element alignment if needed
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-            scale = F.pad(scale, (0, self.N_padded - self.N))
-            shift = F.pad(shift, (0, self.N_padded - self.N))
-            gate = F.pad(gate, (0, self.N_padded - self.N))
+        if N_padded != N:
+            x = F.pad(x, (0, N_padded - N))
+            scale = F.pad(scale, (0, N_padded - N))
+            shift = F.pad(shift, (0, N_padded - N))
+            gate = F.pad(gate, (0, N_padded - N))
 
-        y = self.kernel(x, scale, shift, gate)
+        kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
+        y = kernel(x, scale, shift, gate)
+        self._last_roofline_mn = (M_actual, N)
 
         # Trim padding
-        if self.N_padded != self.N:
-            y = y[:, :self.N]
+        if N_padded != N:
+            y = y[:, :N]
 
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/fused_add_layer_norm.py
+++ b/tileops/ops/norm/fused_add_layer_norm.py
@@ -38,8 +38,10 @@ class FusedAddLayerNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        M: Optional committed row count for strict compatibility. Preferred
+            API infers it from ``x.shape[:-1]``.
+        N: Optional committed hidden dimension. Preferred API infers it from
+            ``x.shape[-1]``.
         dtype: Data type (``torch.float32``, ``torch.float16``, or
             ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
@@ -49,9 +51,9 @@ class FusedAddLayerNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
+        M: Optional[int] = None,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -59,23 +61,41 @@ class FusedAddLayerNormFwdOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
+        self._committed_M = M
+        self._committed_N = N
+        self._committed_dtype = dtype
         self.eps = eps
-        self.N_padded = align_up(N, ALIGNMENT)
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fused_add_layer_norm"](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
+        self._last_roofline_mn: Optional[tuple[int, int]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fused_add_layer_norm": FusedAddLayerNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
+        if self._last_roofline_mn is None or self.dtype is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind input shape and dtype"
+            )
+        M, N = self._last_roofline_mn
         elem_bytes = self.dtype.itemsize
         return (
-            6 * self.M * self.N,
-            (4 * self.M * self.N + 2 * self.N) * elem_bytes,
+            6 * M * N,
+            (4 * M * N + 2 * N) * elem_bytes,
         )
+
+    def _get_kernel(
+        self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
+    ) -> Kernel:
+        key = (M, N, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fused_add_layer_norm"](
+                M, N, self.eps, dtype, tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -101,13 +121,16 @@ class FusedAddLayerNormFwdOp(Op):
             ValueError: If tensors are not on CUDA, dtypes mismatch,
                 or shapes are incompatible with the configured dimensions.
         """
+        expected_dtype = self._committed_dtype
         for name, tensor in [("x", x), ("residual", residual), ("weight", weight), ("bias", bias)]:
             if not tensor.is_cuda:
                 raise ValueError(f"{name} must be a CUDA tensor")
-            if tensor.dtype != self.dtype:
+            if expected_dtype is not None and tensor.dtype != expected_dtype:
                 raise ValueError(
-                    f"Expected {name}.dtype {self.dtype}, got {tensor.dtype}"
+                    f"Expected {name}.dtype {expected_dtype}, got {tensor.dtype}"
                 )
+            if expected_dtype is None:
+                expected_dtype = tensor.dtype
         if weight.ndim != 1:
             raise ValueError(
                 f"Expected weight to be 1D, got {weight.ndim}D"
@@ -116,44 +139,53 @@ class FusedAddLayerNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias to be 1D, got {bias.ndim}D"
             )
-        if x.shape[-1] != self.N:
+        N = x.shape[-1]
+        if self._committed_N is not None and self._committed_N != N:
             raise ValueError(
-                f"Expected hidden dim {self.N}, got {x.shape[-1]}"
+                f"Expected hidden dim {self._committed_N}, got {N}"
             )
         if residual.shape != x.shape:
             raise ValueError(
                 f"Expected residual shape {x.shape}, got {residual.shape}"
             )
-        if weight.shape[0] != self.N:
+        if weight.shape[0] != N:
             raise ValueError(
-                f"Expected weight dim {self.N}, got {weight.shape[0]}"
+                f"Expected weight dim {N}, got {weight.shape[0]}"
             )
-        if bias.shape[0] != self.N:
+        if bias.shape[0] != N:
             raise ValueError(
-                f"Expected bias dim {self.N}, got {bias.shape[0]}"
+                f"Expected bias dim {N}, got {bias.shape[0]}"
             )
 
         orig_shape = x.shape
-        x = x.contiguous().reshape(-1, self.N)
-        residual = residual.contiguous().reshape(-1, self.N)
+        x = x.contiguous().reshape(-1, N)
+        residual = residual.contiguous().reshape(-1, N)
         M_actual = x.shape[0]
-        if M_actual != self.M:
+        if self._committed_M is not None and M_actual != self._committed_M:
             raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
+                f"Expected M={self._committed_M} (product of leading dims), got {M_actual}"
             )
+        self.M = M_actual
+        self.N = N
+        dtype = expected_dtype
+        assert dtype is not None
+        self.dtype = dtype
+        N_padded = align_up(N, ALIGNMENT)
 
         # Pad hidden dim to 256-element alignment if needed
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-            residual = F.pad(residual, (0, self.N_padded - self.N))
-            weight = F.pad(weight, (0, self.N_padded - self.N))
-            bias = F.pad(bias, (0, self.N_padded - self.N))
+        if N_padded != N:
+            x = F.pad(x, (0, N_padded - N))
+            residual = F.pad(residual, (0, N_padded - N))
+            weight = F.pad(weight, (0, N_padded - N))
+            bias = F.pad(bias, (0, N_padded - N))
 
-        y, residual_out = self.kernel(x, residual, weight, bias)
+        kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
+        y, residual_out = kernel(x, residual, weight, bias)
+        self._last_roofline_mn = (M_actual, N)
 
         # Trim padding
-        if self.N_padded != self.N:
-            y = y[:, :self.N]
-            residual_out = residual_out[:, :self.N]
+        if N_padded != N:
+            y = y[:, :N]
+            residual_out = residual_out[:, :N]
 
         return y.reshape(orig_shape), residual_out.reshape(orig_shape)

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -37,8 +37,10 @@ class FusedAddRMSNormFwdOp(Op):
         by padding to 256-element alignment.
 
     Args:
-        M: Number of rows (product of all dims except the last).
-        N: Hidden dimension (last dim).
+        M: Optional committed row count for strict compatibility. Preferred
+            API infers it from ``x.shape[:-1]``.
+        N: Optional committed hidden dimension. Preferred API infers it from
+            ``x.shape[-1]``.
         dtype: Data type (``torch.float16`` or ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
         kernel_map: Optional kernel override dictionary.
@@ -47,9 +49,9 @@ class FusedAddRMSNormFwdOp(Op):
 
     def __init__(
         self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
+        M: Optional[int] = None,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-6,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -57,23 +59,41 @@ class FusedAddRMSNormFwdOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
+        self._committed_M = M
+        self._committed_N = N
+        self._committed_dtype = dtype
         self.eps = eps
-        self.N_padded = align_up(N, ALIGNMENT)
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fused_add_rms_norm"](
-            M, N, eps, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
+        self._last_roofline_mn: Optional[tuple[int, int]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fused_add_rms_norm": FusedAddRMSNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
+        if self._last_roofline_mn is None or self.dtype is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind input shape and dtype"
+            )
+        M, N = self._last_roofline_mn
         elem_bytes = self.dtype.itemsize
         return (
-            5 * self.M * self.N,
-            (4 * self.M * self.N + self.N) * elem_bytes,
+            5 * M * N,
+            (4 * M * N + N) * elem_bytes,
         )
+
+    def _get_kernel(
+        self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
+    ) -> Kernel:
+        key = (M, N, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fused_add_rms_norm"](
+                M, N, self.eps, dtype, tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -97,50 +117,62 @@ class FusedAddRMSNormFwdOp(Op):
             ValueError: If tensors are not on CUDA, dtypes mismatch,
                 or shapes are incompatible with the configured dimensions.
         """
+        expected_dtype = self._committed_dtype
         for name, tensor in [("x", x), ("residual", residual), ("weight", weight)]:
             if not tensor.is_cuda:
                 raise ValueError(f"{name} must be a CUDA tensor")
-            if tensor.dtype != self.dtype:
+            if expected_dtype is not None and tensor.dtype != expected_dtype:
                 raise ValueError(
-                    f"Expected {name}.dtype {self.dtype}, got {tensor.dtype}"
+                    f"Expected {name}.dtype {expected_dtype}, got {tensor.dtype}"
                 )
+            if expected_dtype is None:
+                expected_dtype = tensor.dtype
         if weight.ndim != 1:
             raise ValueError(
                 f"Expected weight to be 1D, got {weight.ndim}D"
             )
-        if x.shape[-1] != self.N:
+        N = x.shape[-1]
+        if self._committed_N is not None and self._committed_N != N:
             raise ValueError(
-                f"Expected hidden dim {self.N}, got {x.shape[-1]}"
+                f"Expected hidden dim {self._committed_N}, got {N}"
             )
         if residual.shape != x.shape:
             raise ValueError(
                 f"Expected residual shape {x.shape}, got {residual.shape}"
             )
-        if weight.shape[0] != self.N:
+        if weight.shape[0] != N:
             raise ValueError(
-                f"Expected weight dim {self.N}, got {weight.shape[0]}"
+                f"Expected weight dim {N}, got {weight.shape[0]}"
             )
 
         orig_shape = x.shape
-        x = x.contiguous().reshape(-1, self.N)
-        residual = residual.contiguous().reshape(-1, self.N)
+        x = x.contiguous().reshape(-1, N)
+        residual = residual.contiguous().reshape(-1, N)
         M_actual = x.shape[0]
-        if M_actual != self.M:
+        if self._committed_M is not None and M_actual != self._committed_M:
             raise ValueError(
-                f"Expected M={self.M} (product of leading dims), got {M_actual}"
+                f"Expected M={self._committed_M} (product of leading dims), got {M_actual}"
             )
+        self.M = M_actual
+        self.N = N
+        dtype = expected_dtype
+        assert dtype is not None
+        self.dtype = dtype
+        N_padded = align_up(N, ALIGNMENT)
 
         # Pad hidden dim to 256-element alignment if needed
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-            residual = F.pad(residual, (0, self.N_padded - self.N))
-            weight = F.pad(weight, (0, self.N_padded - self.N))
+        if N_padded != N:
+            x = F.pad(x, (0, N_padded - N))
+            residual = F.pad(residual, (0, N_padded - N))
+            weight = F.pad(weight, (0, N_padded - N))
 
-        y, residual_out = self.kernel(x, residual, weight)
+        kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
+        y, residual_out = kernel(x, residual, weight)
+        self._last_roofline_mn = (M_actual, N)
 
         # Trim padding
-        if self.N_padded != self.N:
-            y = y[:, :self.N]
-            residual_out = residual_out[:, :self.N]
+        if N_padded != N:
+            y = y[:, :N]
+            residual_out = residual_out[:, :N]
 
         return y.reshape(orig_shape), residual_out.reshape(orig_shape)

--- a/tileops/ops/reduction/cumprod.py
+++ b/tileops/ops/reduction/cumprod.py
@@ -21,16 +21,17 @@ class CumprodFwdOp(CumulativeOp):
     handled inside the kernel via masked loads.
 
     Args:
-        N: Reduction dimension size (statically committed at ctor;
-            corresponds to manifest ``static_dims.N = "x.shape[dim]"``).
-        dtype: Data type (float32, float16, or bfloat16).
+        N: Optional committed reduction dimension size for compatibility.
+            Preferred API infers it from ``x.shape[dim]``.
+        dtype: Optional data type (float32, float16, or bfloat16).
+            Preferred API infers it from ``x``.
         dim: Reduction axis (default -1). Negative values are normalized
             at forward time.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
 
     Example:
-        >>> op = CumprodFwdOp(N=4096, dtype=torch.float16)
+        >>> op = CumprodFwdOp()
         >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda") * 0.01 + 0.99
         >>> y = op(x)  # shape: (1024, 4096)
     """

--- a/tileops/ops/reduction/cumsum.py
+++ b/tileops/ops/reduction/cumsum.py
@@ -21,16 +21,17 @@ class CumsumFwdOp(CumulativeOp):
     handled inside the kernel via masked loads.
 
     Args:
-        N: Reduction dimension size (statically committed at ctor;
-            corresponds to manifest ``static_dims.N = "x.shape[dim]"``).
-        dtype: Data type (float32, float16, or bfloat16).
+        N: Optional committed reduction dimension size for compatibility.
+            Preferred API infers it from ``x.shape[dim]``.
+        dtype: Optional data type (float32, float16, or bfloat16).
+            Preferred API infers it from ``x``.
         dim: Reduction axis (default -1). Negative values are normalized
             at forward time.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
 
     Example:
-        >>> op = CumsumFwdOp(N=4096, dtype=torch.float16)
+        >>> op = CumsumFwdOp()
         >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
         >>> y = op(x)  # shape: (1024, 4096)
     """

--- a/tileops/ops/reduction/cumulative_base.py
+++ b/tileops/ops/reduction/cumulative_base.py
@@ -1,9 +1,9 @@
 """CumulativeOp base class for scan operators (cumsum, cumprod).
 
-Implements the canonical static_dims pattern from docs/design/ops-design.md § Step 3:
-ctor binds only `static_dims` (`N`) + `signature.params` (`dim`); `M` (the
-leading-dims product) is derived at forward time, kernels are built lazily
-and cached by `M`.
+Implements manifest-driven dynamic shape binding: ctor binds only
+semantic/config params (`dim`, optional committed `N` for strict
+compatibility); `M` and the effective `N` are derived at forward time, kernels
+are built lazily and cached by `(M, N, dtype, device)`.
 
 Forward pipeline: validate -> movedim(dim → -1) -> reshape (M, N) -> kernel
 (handles alignment via masked loads) -> trim -> reshape -> movedim(-1 → dim).
@@ -30,8 +30,10 @@ class CumulativeOp(Op):
     op-kind dispatch string (`"sum"` or `"prod"`).
 
     Args:
-        N: Reduction dimension size (statically committed at ctor).
-        dtype: Data type (float32, float16, or bfloat16).
+        dtype: Data type (float32, float16, or bfloat16). If omitted,
+            inferred from the first input tensor.
+        N: Optional reduction dimension size. When provided, forward validates
+            it against ``x.shape[dim]`` for backward compatibility.
         dim: Reduction axis (default -1). Negative values are normalized at
             forward time (`dim % x.ndim`).
         kernel_map: Optional kernel override dict.
@@ -47,8 +49,8 @@ class CumulativeOp(Op):
 
     def __init__(
         self,
-        N: int,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         dim: int = -1,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -56,11 +58,12 @@ class CumulativeOp(Op):
     ) -> None:
         self.N = N
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_dtype = dtype
         self.dim = dim
         self.tune = tune
-        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self.dispatch_kernel(kernel_map)
-        self._kernel_cache: Dict[int, Kernel] = {}
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
         self._last_roofline_mn: Optional[Tuple[int, int]] = None
 
     @property
@@ -74,39 +77,52 @@ class CumulativeOp(Op):
                 "forward() call to bind dynamic input shape (M)"
             )
         M, N = self._last_roofline_mn
+        if self.dtype is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.eval_roofline() requires a prior "
+                "forward() call to bind dtype"
+            )
         elem_bytes = self.dtype.itemsize
         # Per row: N-1 ops (running sum/prod) ≈ M*N flops total.
         # Read x + write y = 2 * M * N elements.
         return (M * N, 2 * M * N * elem_bytes)
 
-    def _get_kernel(self, M: int) -> Kernel:
-        """Return a kernel built for (M, self.N), caching by M."""
-        if M not in self._kernel_cache:
-            self._kernel_cache[M] = self.kernel_map["cumulative_fwd"](
-                M, self.N, self._op_kind, self.dtype, tune=self.tune,
+    def _get_kernel(
+        self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
+    ) -> Kernel:
+        """Return a kernel built for (M, N, dtype), caching by specialization."""
+        key = (M, N, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["cumulative_fwd"](
+                M, N, self._op_kind, dtype, tune=self.tune,
             )
-        return self._kernel_cache[M]
+        return self._kernel_cache[key]
 
-    def _validate_and_normalize_dim(self, x: torch.Tensor) -> int:
+    def _validate_and_normalize_dim(self, x: torch.Tensor) -> tuple[int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
+            )
         ndim = x.ndim
         if not (-ndim <= self.dim < ndim):
             raise ValueError(
                 f"dim={self.dim} out of range for {ndim}-D input"
             )
         dim_norm = self.dim % ndim
-        if x.shape[dim_norm] != self.N:
+        N = x.shape[dim_norm]
+        if self._committed_N is not None and self._committed_N != N:
             raise ValueError(
-                f"Expected x.shape[{self.dim}]={self.N}, "
-                f"got {x.shape[dim_norm]}"
+                f"Expected x.shape[{self.dim}]={self._committed_N}, "
+                f"got {N}"
             )
+        self.N = N
+        self.dtype = x.dtype
         # Bind the dynamic static-axis (param-dependent N axis) so
         # Op-layer cache-key / introspection consumers see the committed axis.
         self._static_axes = frozenset({(0, dim_norm)})
-        return dim_norm
+        return dim_norm, N, x.dtype
 
     @abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -116,21 +132,22 @@ class CumulativeOp(Op):
     def _run(self, x: torch.Tensor) -> torch.Tensor:
         """Shared forward implementation. Subclasses call this from `forward`."""
         ndim = x.ndim
-        dim_norm = self._validate_and_normalize_dim(x)
+        dim_norm, N, dtype = self._validate_and_normalize_dim(x)
 
         if dim_norm != ndim - 1:
             x = x.movedim(dim_norm, -1)
         post_move_shape = tuple(x.shape)
-        x = x.contiguous().reshape(-1, self.N)
+        x = x.contiguous().reshape(-1, N)
         M = x.shape[0]
 
         # Alignment padding is handled inside the kernel via masked loads.
-        y = self._get_kernel(M)(x)
-        self._last_roofline_mn = (M, self.N)
+        y = self._get_kernel(M, N, dtype, x.device.index)(x)
+        self._last_roofline_mn = (M, N)
 
         # Kernel output is N_padded-wide along last dim; trim to N.
-        if self.N_padded != self.N:
-            y = y[:, : self.N]
+        N_padded = align_up(N, DEFAULT_ALIGNMENT)
+        if N_padded != N:
+            y = y[:, :N]
         y = y.reshape(post_move_shape)
         if dim_norm != ndim - 1:
             y = y.movedim(-1, dim_norm)


### PR DESCRIPTION
## Summary

Closes #1648.

This updates the initial #1648 scope so derivable shape metadata is inferred from op inputs instead of being required as constructor arguments:

- Norm family: `FusedAddLayerNormFwdOp`, `FusedAddRMSNormFwdOp`, `AdaLayerNormFwdOp`, `AdaLayerNormZeroFwdOp`
- Scan family: `CumsumFwdOp`, `CumprodFwdOp`
- MoE leaf ops: `FusedTopKOp`, `MoePermuteNopadFwdOp`

The old explicit constructor arguments remain supported as compatibility/strict-validation commitments, while the preferred API derives `M`, `N`, token counts, top-k shape, hidden size, and dtype from the input tensors at `forward()` time. Kernels are built lazily and cached by the inferred specialization.

## Manifest / callers

- Removed input-derivable `static_dims` from the affected norm and scan manifest entries.
- Updated `MoePermuteNopadFwdOp` manifest params/workloads/roofline to treat `hidden_states` and `topk_ids` shapes as the source of truth, keeping `num_experts` explicit.
- Updated direct benchmarks and composite call sites to use the preferred input-inferred APIs.
- Added compatibility and cache-reuse/changing-shape test coverage.

## Testing

Using the TileOpsGov runner image `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10` on H200 GPU:

- `python -m pytest -q tests/ops/test_cumulative.py tests/ops/test_fused_add_layer_norm.py tests/ops/test_fused_add_rms_norm.py tests/ops/test_ada_layer_norm.py tests/ops/test_ada_layer_norm_zero.py tests/ops/test_moe_fused_topk.py tests/ops/test_moe_permute_nopad.py -m smoke --tb=short --timeout=900 --timeout-method=thread`
  - `67 passed, 52 deselected, 14 warnings`
- `python -m pytest -q tests/ops/test_cumulative.py tests/ops/test_fused_add_layer_norm.py tests/ops/test_fused_add_rms_norm.py tests/ops/test_ada_layer_norm.py tests/ops/test_ada_layer_norm_zero.py tests/ops/test_moe_fused_topk.py tests/ops/test_moe_permute_nopad.py --tb=short --timeout=900 --timeout-method=thread`
  - `119 passed, 14 warnings`
- `python scripts/validate_manifest.py`
  - `All manifest checks passed`

Note: the validator reports an advisory warning that `MoePermuteNopadFwdOp.num_experts` has an `__init__` default of `None` while the manifest has no default. This is intentional to preserve old positional construction compatibility; `forward()` still requires `num_experts` to be provided.
