### PR TITLE
[Perf][Attention] Warp-specialized batch=1 GQA decode kernel + workloads

### DIFF
--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -49,17 +49,16 @@ def _fa3_gqa_decode_fwd(test):
 
 
 def _flashinfer_gqa_decode_fwd(test, q, k, v):
-    """Set up FlashInfer batched paged decode for non-paged KV cache.
+    """Set up FlashInfer decode for a non-paged KV cache.
 
-    Reshapes the contiguous (B, S_kv, H_kv, D) KV into paged format with
-    page_size=256, then uses the specialized decode kernel.
-    FlashInfer decode kernel supports group_size (Q/KV head ratio) up to 8.
+    For a single request (B == 1) the KV cache is contiguous, so the
+    ``single_decode_with_kv_cache`` kernel is the apples-to-apples baseline
+    (no paging overhead). For B > 1 the contiguous (B, S_kv, H_kv, D) KV is
+    reshaped into paged format with page_size=256 and the batched paged
+    decode kernel is used.
+    FlashInfer decode kernels support group_size (Q/KV head ratio) up to 8.
     """
     if test.sm_scale != test.dim**-0.5 or test.softcap != 0.0:
-        return None
-    try:
-        from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper  # noqa: PLC0415
-    except ImportError:
         return None
 
     # Q is (B, H, D) — single token per request
@@ -68,6 +67,29 @@ def _flashinfer_gqa_decode_fwd(test, q, k, v):
     Hkv = k.shape[2]
     if H // Hkv > 8:
         return None  # FlashInfer decode kernel does not support group_size > 8
+
+    if B == 1:
+        try:
+            from flashinfer.decode import single_decode_with_kv_cache  # noqa: PLC0415
+        except ImportError:
+            return None
+
+        # single_decode expects q (H, D) and k/v (S_kv, H_kv, D) for one request.
+        q_s = q.reshape(H, D)
+        k_s = k.reshape(k.shape[1], Hkv, D)
+        v_s = v.reshape(v.shape[1], Hkv, D)
+
+        def run_fn(q, k, v):
+            return single_decode_with_kv_cache(
+                q_s, k_s, v_s, kv_layout="NHD", use_tensor_cores=True,
+            )
+
+        return run_fn
+
+    try:
+        from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper  # noqa: PLC0415
+    except ImportError:
+        return None
     Skv = k.shape[1]
     page_size = 256
     pages_per_seq = (Skv + page_size - 1) // page_size

--- a/tests/ops/attention/test_gqa_decode.py
+++ b/tests/ops/attention/test_gqa_decode.py
@@ -5,6 +5,7 @@ import torch
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.attention.gqa_decode import GQADecodeKernel
 from tileops.ops import GroupedQueryAttentionDecodeWithKVCacheFwdOp
+from tileops.utils import is_hopper
 from workloads.attention.gqa_decode import (
     GroupedQueryAttentionDecodeTest as _GroupedQueryAttentionDecodeTestWorkload,
 )
@@ -115,6 +116,60 @@ def test_gqa_decode_rejects_non_divisible_heads() -> None:
 def test_gqa_decode_rejects_non_positive_seqlen_kv() -> None:
     with pytest.raises(ValueError, match="seqlen_kv must be positive"):
         GQADecodeKernel(1, 16, 2, 0, 128, dtype="float16")
+
+
+@pytest.mark.smoke
+def test_gqa_decode_bs1_dispatch() -> None:
+    """batch=1 fp16 dim-128 requests select the WS kernel; other dtypes/shapes fall back."""
+    if not is_hopper():
+        pytest.skip("batch=1 warp-specialized decode requires Hopper")
+    op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(1, 32, 4, 8192, 128, torch.float16)
+    assert op._uses_bs1_fast_path()
+    assert op.kernel.__class__.__name__ == "GQADecodeBs1Kernel"
+    assert op.kernel._select_tier(6000) == "ctx"
+    assert op.kernel._select_tier(1024) == "ctx"
+    assert op.kernel._select_tier(512) == "no_split"
+    assert op.kernel._ctx_splits_for(8192) == 32
+    assert op.kernel._ctx_splits_for(2048) == 16
+    assert op.kernel._ctx_splits_for(3072) == 8
+
+    op_bf16 = GroupedQueryAttentionDecodeWithKVCacheFwdOp(1, 32, 4, 4096, 128, torch.bfloat16)
+    assert not op_bf16._uses_bs1_fast_path()
+    assert op_bf16.kernel.__class__.__name__ == "GQADecodeKernel"
+
+    op_batched = GroupedQueryAttentionDecodeWithKVCacheFwdOp(4, 32, 4, 4096, 128, torch.float16)
+    assert not op_batched._uses_bs1_fast_path()
+    assert op_batched.kernel.__class__.__name__ == "GQADecodeKernel"
+
+
+@pytest.mark.smoke
+def test_gqa_decode_bs1_runtime_context_switch() -> None:
+    """One op instance stays correct across the context range as the cache grows.
+
+    Covers the crossover (1024), a balanced mid split, an aligned split needing >=3 tiles
+    per slice, an unaligned length, and the sub-1024 non-split fallback.
+    """
+    if not is_hopper():
+        pytest.skip("batch=1 warp-specialized decode requires Hopper")
+    op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(1, 32, 4, 8192, 128, torch.float16)
+    assert op.kernel.__class__.__name__ == "GQADecodeBs1Kernel"
+    for real, tier in ((6000, "ctx"), (3072, "ctx"), (2048, "ctx"), (1024, "ctx"),
+                       (512, "no_split")):
+        assert op.kernel._select_tier(real) == tier
+        test = GroupedQueryAttentionDecodeTest(1, 32, 4, real, 128, torch.float16)
+        test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_gqa_decode_bs1_group4() -> None:
+    """The WS kernel generalizes to a query-per-KV-head group other than 8 (here 4)."""
+    if not is_hopper():
+        pytest.skip("batch=1 warp-specialized decode requires Hopper")
+    op = GroupedQueryAttentionDecodeWithKVCacheFwdOp(1, 32, 8, 4096, 128, torch.float16)
+    assert op._uses_bs1_fast_path()
+    assert op.kernel.__class__.__name__ == "GQADecodeBs1Kernel"
+    test = GroupedQueryAttentionDecodeTest(1, 32, 8, 4096, 128, torch.float16)
+    test.check(op, *test.gen_inputs(), atol=1e-2, rtol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/attention/__init__.py
+++ b/tileops/kernels/attention/__init__.py
@@ -13,6 +13,7 @@ from .gqa_bwd import (
     MHABwdWgmmaPipelinedKernel,
 )
 from .gqa_decode import GQADecodeKernel
+from .gqa_decode_bs1 import GQADecodeBs1Kernel
 from .gqa_decode_paged import GQADecodePagedKernel
 from .gqa_fwd import (
     GQAFwdKernel,
@@ -48,6 +49,7 @@ __all__ = [
     "FlashAttnBwdPreprocessKernel",
     "GQABwdKernel",
     "GQABwdWgmmaPipelinedKernel",
+    "GQADecodeBs1Kernel",
     "GQADecodeKernel",
     "GQADecodePagedKernel",
     "GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel",

--- a/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/tileops/kernels/attention/gqa_decode_bs1.py
@@ -1,0 +1,281 @@
+"""Warp-specialized batch=1 GQA decode kernel (Hopper), context-split.
+
+``GQADecodeBs1Kernel`` dispatches on the runtime ``real_seqlen_kv``: lengths >= 1024
+run a context-only warp-specialized split (one TMA producer warp feeding a four-warp
+wgmma consumer warpgroup, exp2-domain online softmax, fp32 partial reduce via a combine
+kernel); shorter lengths fall back to the generic non-split decode kernel. Hopper-only,
+low-level ``tma_copy`` / ``mbarrier`` / ``wgmma_gemm``.
+"""
+import functools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.attention.gqa_decode import _gqa_decode_no_split_op
+from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.online_softmax import LOG2E
+
+__all__ = ["GQADecodeBs1Kernel"]
+
+_RING = 2  # K/V shared-ring depth (double-buffered).
+
+_COMPILE_FLAGS = [
+    "-O3",
+    "--use_fast_math",
+    "-Wno-deprecated-declarations",
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-DNDEBUG",
+]
+
+
+@functools.lru_cache(maxsize=32)
+def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap, dtype):
+    score_scale = dim**-0.5 if sm_scale is None else sm_scale
+    scale = score_scale * LOG2E
+    accum_dtype = "float"
+    kv_group_num = heads // groups
+    ns = _RING
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        },
+        compile_flags=_COMPILE_FLAGS)
+    def _func(block_M, block_N, ctx_splits, threads):
+        shape_q = [batch, heads, dim]
+        shape_k = [batch, seqlen_kv, groups, dim]
+        shape_o = [batch, heads, dim]
+        part_shape = [batch, heads, ctx_splits, dim]
+        lse_shape = [batch, heads, ctx_splits]
+        policy = T.GemmWarpPolicy.FullRow
+
+        @T.macro
+        def _split(
+                Q: T.Tensor(shape_q, dtype),
+                K: T.Tensor(shape_k, dtype),
+                V: T.Tensor(shape_k, dtype),
+                real_seqlen_kv: T.int32,
+                glse: T.Tensor(lse_shape, accum_dtype),
+                Output_partial: T.Tensor(part_shape, accum_dtype),
+        ):
+            with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
+                Qs = T.alloc_shared([block_M, dim], dtype)
+                Ks = T.alloc_shared([ns, block_N, dim], dtype)
+                Vs = T.alloc_shared([ns, block_N, dim], dtype)
+                Ps = T.alloc_shared([block_M, block_N], dtype)
+                T.annotate_layout({
+                    Qs: tilelang.layout.make_swizzled_layout(Qs),
+                    Ks: tilelang.layout.make_swizzled_layout(Ks),
+                    Vs: tilelang.layout.make_swizzled_layout(Vs),
+                    Ps: tilelang.layout.make_swizzled_layout(Ps),
+                })
+                ready = T.alloc_barrier([32] * ns)   # producer -> consumer
+                free = T.alloc_barrier([128] * ns)   # consumer -> producer
+                acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
+                acc_o = T.alloc_fragment([block_M, dim], accum_dtype)
+                sm = T.alloc_fragment([block_M], accum_dtype)
+                smp = T.alloc_fragment([block_M], accum_dtype)
+                alpha = T.alloc_fragment([block_M], accum_dtype)
+                ss = T.alloc_fragment([block_M], accum_dtype)
+                logsum = T.alloc_fragment([block_M], accum_dtype)
+
+                # Redistribute over the real length so every split holds a full tile.
+                base_len = real_seqlen_kv // (ctx_splits * block_N) * block_N
+                this_len = T.if_then_else(sid == ctx_splits - 1,
+                                          real_seqlen_kv - (ctx_splits - 1) * base_len, base_len)
+                base = base_len * sid
+                loop_range = T.ceildiv(this_len, block_N)
+                tx = T.get_thread_binding()
+
+                if tx >= 128:   # producer
+                    for k in T.serial(loop_range):
+                        T.mbarrier_wait_parity(free[k % ns], ((k // ns) % ns) ^ 1)
+                        T.tma_copy(K[bid, base + k * block_N:base + (k + 1) * block_N, hid, :],
+                                   Ks[k % ns, :, :], barrier=ready[k % ns])
+                        T.tma_copy(V[bid, base + k * block_N:base + (k + 1) * block_N, hid, :],
+                                   Vs[k % ns, :, :], barrier=ready[k % ns])
+                        T.mbarrier_arrive(ready[k % ns])
+                else:   # consumer
+                    T.fill(acc_o, 0)
+                    T.fill(logsum, 0)
+                    T.fill(sm, -T.infinity(accum_dtype))
+                    T.copy(Q[bid, hid * kv_group_num:hid * kv_group_num + kv_group_num, :],
+                           Qs[0:kv_group_num, :])
+                    for k in T.serial(loop_range):
+                        T.mbarrier_wait_parity(ready[k % ns], (k // ns) % ns)
+                        T.wgmma_gemm(Qs, Ks[k % ns, :, :], acc_s, transpose_B=True, policy=policy,
+                                     clear_accum=True)
+                        T.wait_wgmma(0)
+                        for i, j in T.Parallel(block_M, block_N):
+                            acc_s[i, j] = T.if_then_else(k * block_N + j < this_len, acc_s[i, j],
+                                                         -T.infinity(accum_dtype))
+                        T.copy(sm, smp)
+                        T.reduce_max(acc_s, sm, dim=1, clear=False)
+                        for i in T.Parallel(block_M):
+                            alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
+                        for i, j in T.Parallel(block_M, block_N):
+                            acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
+                        T.reduce_sum(acc_s, ss, dim=1)
+                        for i in T.Parallel(block_M):
+                            logsum[i] = logsum[i] * alpha[i] + ss[i]
+                        for i, j in T.Parallel(block_M, dim):
+                            acc_o[i, j] *= alpha[i]
+                        T.copy(acc_s, Ps)
+                        T.wgmma_gemm(Ps, Vs[k % ns, :, :], acc_o, policy=policy, clear_accum=False)
+                        T.wait_wgmma(0)
+                        T.mbarrier_arrive(free[k % ns])
+                    for i, j in T.Parallel(block_M, dim):
+                        acc_o[i, j] /= logsum[i]
+                    for i in T.Parallel(block_M):
+                        if i < kv_group_num:
+                            glse[bid, hid * kv_group_num + i, sid] = T.log2(logsum[i]) + sm[i] * scale
+                    for i, j in T.Parallel(block_M, dim):
+                        if i < kv_group_num:
+                            Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
+
+        @T.macro
+        def _combine(
+                glse: T.Tensor(lse_shape, accum_dtype),
+                Output_partial: T.Tensor(part_shape, accum_dtype),
+                Output: T.Tensor(shape_o, dtype),
+        ):
+            with T.Kernel(heads, batch, threads=128) as (hq, bid):
+                lse_vec = T.alloc_fragment([ctx_splits], accum_dtype)
+                lse_max = T.alloc_fragment([1], accum_dtype)
+                lse_logsum = T.alloc_local([1], accum_dtype)
+                o_accum = T.alloc_fragment([dim], accum_dtype)
+
+                for s in T.Parallel(ctx_splits):
+                    lse_vec[s] = glse[bid, hq, s]
+                T.fill(lse_max, -T.infinity(accum_dtype))
+                T.reduce_max(lse_vec, lse_max, dim=0, clear=False)
+                lse_logsum[0] = 0
+                for s in T.serial(ctx_splits):
+                    lse_logsum[0] += T.exp2(glse[bid, hq, s] - lse_max[0])
+                lse_logsum[0] = T.log2(lse_logsum[0]) + lse_max[0]
+                T.clear(o_accum)
+                for s in T.serial(ctx_splits):
+                    w = T.exp2(glse[bid, hq, s] - lse_logsum[0])
+                    for j in T.Parallel(dim):
+                        o_accum[j] += Output_partial[bid, hq, s, j] * w
+                for j in T.Parallel(dim):
+                    Output[bid, hq, j] = T.cast(o_accum[j], dtype)
+
+        @T.prim_func
+        def gqa_decode_bs1_ctx(
+                Q: T.Tensor(shape_q, dtype),
+                K: T.Tensor(shape_k, dtype),
+                V: T.Tensor(shape_k, dtype),
+                real_seqlen_kv: T.int32,
+                glse: T.Tensor(lse_shape, accum_dtype),
+                Output_partial: T.Tensor(part_shape, accum_dtype),
+                Output: T.Tensor(shape_o, dtype),
+        ):
+            _split(Q, K, V, real_seqlen_kv, glse, Output_partial)
+            _combine(glse, Output_partial, Output)
+
+        return gqa_decode_bs1_ctx
+
+    return _func
+
+
+@torch.library.custom_op("top::gqa_decode_bs1_ctx_op", mutates_args=())
+def _gqa_decode_bs1_ctx_op(batch: int, heads: int, groups: int, seqlen_kv: int,
+                           real_seqlen_kv: int, dim: int, sm_scale: float, softcap: float,
+                           dtype: str, block_M: int, block_N: int, ctx_splits: int, threads: int,
+                           Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, glse: torch.Tensor,
+                           Output_partial: torch.Tensor) -> torch.Tensor:
+    return _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, softcap,
+                                      dtype)(block_M, block_N, ctx_splits, threads)(
+                                          Q, K, V, real_seqlen_kv, glse, Output_partial)
+
+
+@_gqa_decode_bs1_ctx_op.register_fake
+def _(batch: int, heads: int, groups: int, seqlen_kv: int, real_seqlen_kv: int, dim: int,
+      sm_scale: float, softcap: float, dtype: str, block_M: int, block_N: int, ctx_splits: int,
+      threads: int, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, glse: torch.Tensor,
+      Output_partial: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(Q)
+
+
+class GQADecodeBs1Kernel(Kernel):
+    """Hopper warp-specialized batch=1 GQA decode kernel with a context-length switch.
+
+    ``forward`` dispatches on the runtime ``real_seqlen_kv``: >= 1024 runs the context-only
+    split, shorter lengths run the generic non-split GQA decode kernel.
+    """
+
+    supported_archs: list[int] = [90]
+
+    _MIN_CTX = 1024
+    # Powers of two TileLang lowers cleanly; the largest dividing the KV length balances slices.
+    _CTX_SPLIT_CANDIDATES = (32, 16, 8)
+
+    def __init__(self,
+                 batch,
+                 heads,
+                 groups,
+                 seqlen_kv,
+                 dim,
+                 dtype="float16",
+                 sm_scale: Optional[float] = None,
+                 softcap: float = 0.0,
+                 config: Optional[dict] = None,
+                 tune=False):
+        super().__init__()
+        self.batch = batch
+        self.heads = heads
+        self.groups = groups
+        self.seqlen_kv = seqlen_kv
+        self.dim = dim
+        self.dtype = dtype
+        self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
+        self.softcap = softcap
+        if self.groups <= 0:
+            raise ValueError("groups must be positive")
+        if self.heads % self.groups != 0:
+            raise ValueError("heads must be divisible by groups")
+        if self.seqlen_kv <= 0:
+            raise ValueError("seqlen_kv must be positive")
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {"block_M": 64, "block_N": 128, "threads": 160}
+
+    def _select_tier(self, real_seqlen_kv: int) -> str:
+        return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
+
+    def _ctx_splits_for(self, real_seqlen_kv: int) -> int:
+        block_N = self.config["block_N"]
+        for cs in self._CTX_SPLIT_CANDIDATES:
+            if real_seqlen_kv % (cs * block_N) == 0:
+                return cs
+        return self._CTX_SPLIT_CANDIDATES[-1]
+
+    def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, real_seqlen_kv: int):
+        c = self.config
+        if real_seqlen_kv < self._MIN_CTX:
+            return _gqa_decode_no_split_op(self.batch, self.heads, self.groups, self.seqlen_kv,
+                                           real_seqlen_kv, self.dim, self.sm_scale, self.softcap,
+                                           self.dtype_str, 64, 128, 2, 128, Q, K, V)
+
+        ctx_splits = self._ctx_splits_for(real_seqlen_kv)
+        glse = torch.empty((self.batch, self.heads, ctx_splits),
+                           dtype=torch.float32,
+                           device=Q.device)
+        Output_partial = torch.empty((self.batch, self.heads, ctx_splits, self.dim),
+                                     dtype=torch.float32,
+                                     device=Q.device)
+        return _gqa_decode_bs1_ctx_op(self.batch, self.heads, self.groups, self.seqlen_kv,
+                                      real_seqlen_kv, self.dim, self.sm_scale, self.softcap,
+                                      self.dtype_str, c["block_M"], c["block_N"], ctx_splits,
+                                      c["threads"], Q, K, V, glse, Output_partial)

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -463,6 +463,15 @@ GroupedQueryAttentionDecodeWithKVCacheFwdOp:
     # Llama-3.1-70B, long KV
     - {q_shape: [4, 64, 128], kv_shape: [4, 32768, 8, 128], dtypes: [float16, bfloat16], label: "llama-3.1-70b-32k"}
     - {q_shape: [32, 32, 128], kv_shape: [32, 4096, 8, 128], softcap: 50.0, dtypes: [float16], label: "llama-3.1-8b-4k-softcap50"}
+    # Qwen3-30B-A3B (H=32, H_kv=4, D=128), batch=1 single-request decode, KV 1K..256K
+    - {q_shape: [1, 32, 128], kv_shape: [1, 1024, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-1k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 4096, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-4k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 8192, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-8k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 16384, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-16k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 32768, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-32k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 65536, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-64k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 131072, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-128k"}
+    - {q_shape: [1, 32, 128], kv_shape: [1, 262144, 4, 128], dtypes: [float16], label: "qwen3-30b-a3b-bs1-256k"}
 
   roofline:
     func: "tileops.perf.formulas.gqa_decode_roofline"

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -480,6 +480,7 @@ GroupedQueryAttentionDecodeWithKVCacheFwdOp:
     kernel: tileops/kernels/attention/gqa_decode.py
     kernel_map:
       gqa_decode_kernel: GQADecodeKernel
+      gqa_decode_bs1_kernel: GQADecodeBs1Kernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_decode.py
     bench: benchmarks/ops/attention/bench_gqa_decode.py

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -9,6 +9,7 @@ from tileops.kernels.attention import (
     FlashAttnBwdPreprocessKernel,
     GQABwdKernel,
     GQABwdWgmmaPipelinedKernel,
+    GQADecodeBs1Kernel,
     GQADecodeKernel,
     GQADecodePagedKernel,
     GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
@@ -1377,7 +1378,7 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
         self.softcap = _score_softcap(softcap)
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["gqa_decode_kernel"](
+        self.kernel = self.kernel_map[self._select_decode_kernel_key()](
             batch,
             heads,
             heads_kv,
@@ -1391,7 +1392,32 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"gqa_decode_kernel": GQADecodeKernel}
+        # The batch=1 warp-specialized decode kernel is Hopper-only; only expose it on
+        # Hopper so the op stays constructible (falling back to the architecture-agnostic
+        # GQADecodeKernel) on sm80/sm89.
+        kernel_map: Dict[str, Kernel] = {"gqa_decode_kernel": GQADecodeKernel}
+        if is_hopper():
+            kernel_map["gqa_decode_bs1_kernel"] = GQADecodeBs1Kernel
+        return kernel_map
+
+    def _uses_bs1_fast_path(self) -> bool:
+        """Ctor-time gate for the batch=1 warp-specialized decode kernel.
+
+        Any batch=1 fp16 Hopper request with dim 128 and a query-per-KV-head group that fits
+        one wgmma tile routes to GQADecodeBs1Kernel, which then switches on the runtime KV
+        length in forward().
+        """
+        if not (self.batch == 1 and is_hopper() and self.dtype == torch.float16
+                and self.dim == 128 and self.softcap == 0.0):
+            return False
+        if self.heads % self.heads_kv != 0:
+            return False
+        return 1 <= self.heads // self.heads_kv <= 64
+
+    def _select_decode_kernel_key(self) -> str:
+        if self._uses_bs1_fast_path():
+            return "gqa_decode_bs1_kernel"
+        return "gqa_decode_kernel"
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         real_seqlen_kv = k.shape[1]


### PR DESCRIPTION
## Summary

Adds a warp-specialized (Hopper) batch=1 GQA decode kernel and routes the
`GroupedQueryAttentionDecodeWithKVCacheFwdOp` to it when the fast-path
preconditions hold. Migrated from a validated PoC and hardened for production
(runtime `real_seqlen_kv` masking + split redistribution).

Includes the batch=1 workloads and a proper FlashInfer baseline needed to
benchmark it.

## What's in it

**Workloads + benchmark baseline** (`manifest`, `bench_gqa_decode.py`)
- Eight batch=1 Qwen3-30B-A3B decode workloads (KV 1K–256K).
- FlashInfer baseline now uses `single_decode_with_kv_cache` (contiguous KV,
  no paging overhead) for batch=1 — the apples-to-apples comparison; the paged
  batched wrapper is kept for batch>1.

**Kernel + dispatch** (`gqa_decode_bs1.py`, `gqa.py`, tests, `kernel_map`)
- `GQADecodeBs1Kernel` (`supported_archs=[90]`): TMA + mbarrier + wgmma
  warp-specialized producer/consumer, online softmax in exp2 domain, fp32
  accumulators, ctx-split + LSE-combine.
- Op-level ctor gate selects the fast-path kernel only for batch=1, Hopper,
  fp16, D=128, softcap=0, group in [1,64]; everything else keeps the incumbent
  `GQADecodeKernel`. sm80/89 stay constructible.
- `forward()` dispatches by runtime `real_seqlen_kv`: `no_split` below 1024,
  ctx-split above (largest of {32,16,8} that divides `real`, balanced load).
  Non-aligned lengths (e.g. 2049) go through this kernel, not a fallback.

## Correctness

14 tests pass (`tests/ops/attention/test_gqa_decode.py`), including runtime
context-switch and non-divisible-length cases; atol=rtol=1e-2 vs the fp32
reference. Hopper-only tests skip on other arches.

## Performance (H200 @ 1500MHz, CUPTI, H=32 Hkv=4 D=128, fp16)

| KV len | new (µs) | incumbent | FlashInfer single | new/incumbent | new/FI |
|-------:|---------:|----------:|------------------:|--------------:|-------:|
| 1024   | 7.97     | 16.16     | 10.35             | 0.49          | 0.77   |
| 2048   | 8.94     | 10.65     | 11.12             | 0.84          | 0.80   |
| 3072   | 11.93    | 24.07     | 11.86             | 0.50          | 1.01   |
| 4096   | 10.70    | 12.78     | 12.40             | 0.84          | 0.86   |
| 8192   | 14.00    | 16.20     | 14.81             | 0.86          | 0.95   |
| 32768  | 29.49    | 36.52     | 35.29             | 0.81          | 0.84   |
| 131072 | 77.53    | 119.36    | 83.88             | 0.65          | 0.92   |

Faster than the incumbent across the board; faster than or on par with
FlashInfer `single_decode` everywhere (roughly tied at 3072).

## Trust-model note

Kept as a single PR per request. It mixes a manifest workloads change (normally
a separate human-reviewed PR) with the implementation; the manifest edits are
the eight workloads plus one `source.kernel_map` line (the latter is within the
implementation-PR carve-out).
