### PR TITLE
[Feat][Manifest] Promote special elementwise ops

### DIFF
--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -66,6 +66,28 @@ def test_silu_and_mul_op(m: int, n: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+def test_silu_and_mul_infers_manifest_shape_contract() -> None:
+    """Manifest path binds shape and dtype from x instead of ctor args."""
+    m, n, dtype = 64, 128, torch.float16
+    test = SiluAndMulTest(m, n, dtype)
+    op = SiluAndMulFwdOp()
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    assert (op.M, op.N, op.dtype) == (m, n, dtype)
+
+
+@pytest.mark.smoke
+def test_silu_and_mul_lazy_op_rebinds_shape() -> None:
+    """Lazy construction should not lock the op to the first runtime shape."""
+    op = SiluAndMulFwdOp()
+    for m, n in [(32, 64), (16, 128)]:
+        test = SiluAndMulTest(m, n, torch.float16)
+        atol, rtol = _get_tolerances(torch.float16)
+        test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+        assert (op.M, op.N, op.dtype) == (m, n, torch.float16)
+
+
 # ---------------------------------------------------------------------------
 # GeluAndMul
 # ---------------------------------------------------------------------------

--- a/tileops/manifest/elementwise_fused_gated.yaml
+++ b/tileops/manifest/elementwise_fused_gated.yaml
@@ -14,7 +14,7 @@ SiluAndMulFwdOp:
   # the last dim, x.shape == (M, 2*N). No single torch.* symbol.
   ref_api: "none"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -56,7 +56,7 @@ GeluAndMulFwdOp:
   # (erf-based). No single torch.* symbol.
   ref_api: "none"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:
@@ -96,7 +96,7 @@ GeluTanhAndMulFwdOp:
   # GELU approximation. No single torch.* symbol.
   ref_api: "none"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs:

--- a/tileops/manifest/elementwise_generative.yaml
+++ b/tileops/manifest/elementwise_generative.yaml
@@ -5,7 +5,7 @@ AlibiFwdOp:
   # construction-time integer parameters.
   ref_api: "none"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs: {}
@@ -14,15 +14,17 @@ AlibiFwdOp:
     params:
       seq_len: {type: int}
       num_heads: {type: int}
-      dtype: {type: torch.dtype, default: float16}
+      dtype: {type: torch.dtype}
     shape_rules:
     - "seq_len > 0"
     - "num_heads > 0"
 
   workloads:
     # Llama-style attention bias dimensions
-  - {seq_len: 2048, num_heads: 32, dtypes: [float16, bfloat16], label: "llama-prefill-2k"}
-  - {seq_len: 4096, num_heads: 32, dtypes: [float16, bfloat16], label: "llama-prefill-4k"}
+  - {seq_len: 2048, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-2k-fp16"}
+  - {seq_len: 2048, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-2k-bf16"}
+  - {seq_len: 4096, num_heads: 32, dtype: float16, dtypes: [float16], label: "llama-prefill-4k-fp16"}
+  - {seq_len: 4096, num_heads: 32, dtype: bfloat16, dtypes: [bfloat16], label: "llama-prefill-4k-bf16"}
 
   roofline:
     vars:
@@ -52,7 +54,7 @@ SinusoidalFwdOp:
   # from the construction-time integer parameters. d_model must be even.
   ref_api: "none"
   family: elementwise
-  status: spec-only
+  status: implemented
 
   signature:
     inputs: {}
@@ -61,7 +63,7 @@ SinusoidalFwdOp:
     params:
       seq_len: {type: int}
       d_model: {type: int}
-      dtype: {type: torch.dtype, default: float16}
+      dtype: {type: torch.dtype}
     shape_rules:
     - "seq_len > 0"
     - "d_model > 0"
@@ -69,8 +71,10 @@ SinusoidalFwdOp:
 
   workloads:
     # Transformer-style positional encodings
-  - {seq_len: 2048, d_model: 4096, dtypes: [float16, bfloat16], label: "transformer-2k-4k"}
-  - {seq_len: 4096, d_model: 4096, dtypes: [float16, bfloat16], label: "transformer-4k-4k"}
+  - {seq_len: 2048, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-2k-4k-fp16"}
+  - {seq_len: 2048, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-2k-4k-bf16"}
+  - {seq_len: 4096, d_model: 4096, dtype: float16, dtypes: [float16], label: "transformer-4k-4k-fp16"}
+  - {seq_len: 4096, d_model: 4096, dtype: bfloat16, dtypes: [bfloat16], label: "transformer-4k-4k-bf16"}
 
   roofline:
     vars:

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -869,9 +869,10 @@ class FusedGatedOp(Op):
     to enable torch.compile support.
 
     Args:
-        M: Number of rows.
-        N: Half column dim (output width).
-        dtype: Torch dtype.
+        M: Optional number of rows. Inferred from ``x`` when omitted.
+        N: Optional half column dim (output width). Inferred from ``x`` when
+            omitted.
+        dtype: Optional torch dtype. Inferred from ``x`` when omitted.
         strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
@@ -880,31 +881,33 @@ class FusedGatedOp(Op):
     kernel_cls: type
     _op_name: str
     _wrapped = None  # Set by _register_fused_gated_custom_op at class definition
+    FLOPS_PER_ELEM: int = 6
 
     def __init__(
         self,
-        M: int,
-        N: int,
-        dtype: torch.dtype,
+        M: Optional[int] = None,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        supported = self.kernel_cls.SUPPORTED_DTYPES
-        if supported is not None and dtype not in supported:
-            names = ", ".join(str(dt) for dt in supported)
-            raise ValueError(
-                f"{self._op_name} does not support dtype {dtype}. "
-                f"Supported: [{names}]"
-            )
+        if (M is None) != (N is None):
+            raise ValueError("M and N must be provided together")
+        if dtype is not None:
+            self._validate_dtype(dtype)
+        self._explicit_shape = M is not None and N is not None
+        self._explicit_dtype = dtype is not None
         self.M = M
         self.N = N
         self.dtype = dtype
         self.strategy = strategy
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            M, N, dtype, strategy=strategy, tune=tune,
-        )
+        self.kernel = None
+        self._kernel_key = None
+        if M is not None and N is not None and dtype is not None:
+            self._ensure_kernel(M, N, dtype)
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -916,26 +919,77 @@ class FusedGatedOp(Op):
     @property
     def total_memory(self) -> float:
         """Read x (M*2N) + write y (M*N)."""
+        if self.M is None or self.N is None or self.dtype is None:
+            raise RuntimeError(
+                "Fused gated dimensions are available after first forward"
+            )
         in_elem = self.dtype.itemsize
-        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
+        fp8_out = (
+            getattr(self.kernel, "_fp8_output_dtype", None)
+            if self.kernel is not None
+            else None
+        )
         out_elem = fp8_out.itemsize if fp8_out is not None else in_elem
         return self.M * 2 * self.N * in_elem + self.M * self.N * out_elem
 
+    def eval_roofline(self) -> tuple[int, int]:
+        if self.M is None or self.N is None or self.dtype is None:
+            raise RuntimeError(
+                "Fused gated roofline is available after first forward"
+            )
+        flops = self.FLOPS_PER_ELEM * self.M * self.N
+        return flops, int(self.total_memory)
+
+    def _validate_dtype(self, dtype: torch.dtype) -> None:
+        supported = self.kernel_cls.SUPPORTED_DTYPES
+        if supported is not None and dtype not in supported:
+            names = ", ".join(str(dt) for dt in supported)
+            raise ValueError(
+                f"{self._op_name} does not support dtype {dtype}. "
+                f"Supported: [{names}]"
+            )
+
+    def _ensure_kernel(self, M: int, N: int, dtype: torch.dtype) -> None:
+        self._validate_dtype(dtype)
+        key = (M, N, dtype)
+        if self._kernel_key == key and self.kernel is not None:
+            return
+        self.M = M
+        self.N = N
+        self.dtype = dtype
+        self.kernel = self.kernel_map[self._op_name](
+            M, N, dtype, strategy=self.strategy, tune=self.tune,
+        )
+        self._kernel_key = key
+
+    def _validate_runtime_input(self, x: torch.Tensor) -> tuple[int, int]:
+        if not x.is_cuda:
+            raise ValueError("Input must be a CUDA tensor")
+        if x.ndim != 2:
+            raise ValueError(f"Expected x to be 2D, got {x.ndim}D")
+        if x.shape[1] % 2 != 0:
+            raise ValueError(f"Expected x.shape[1] to be even, got {x.shape[1]}")
+        M = x.shape[0]
+        N = x.shape[1] // 2
+        if self._explicit_shape and (M, N) != (self.M, self.N):
+            raise ValueError(
+                f"Expected shape ({self.M}, {2 * self.N}), got {tuple(x.shape)}"
+            )
+        if self._explicit_dtype and x.dtype != self.dtype:
+            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        return M, N
+
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
         """Direct kernel call for use inside custom_op implementation."""
+        M, N = self._validate_runtime_input(x)
+        self._ensure_kernel(M, N, x.dtype)
         x = x.contiguous()
         result = self.kernel(x)
         return _apply_fp8_post_cast(result, self.kernel)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
-            raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.shape != (self.M, 2 * self.N):
-            raise ValueError(
-                f"Expected shape ({self.M}, {2 * self.N}), got {tuple(x.shape)}"
-            )
+        M, N = self._validate_runtime_input(x)
+        self._ensure_kernel(M, N, x.dtype)
         wrapped = type(self)._wrapped
         if wrapped is not None:
             return wrapped(x, self.M, self.N, self._instance_key)

--- a/tileops/ops/elementwise/alibi.py
+++ b/tileops/ops/elementwise/alibi.py
@@ -51,6 +51,20 @@ class AlibiFwdOp(Op):
     def default_kernel_map(self):
         return {"alibi": AlibiFwdKernel}
 
+    def _infer_output_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {"output": (self.num_heads, self.seq_len, self.seq_len)}
+
+    def _validate_dtypes(self) -> None:
+        return None
+
+    @property
+    def total_memory(self) -> int:
+        return self.num_heads * self.seq_len * self.seq_len * self.dtype.itemsize
+
+    def eval_roofline(self) -> tuple[int, int]:
+        n_elem = self.num_heads * self.seq_len * self.seq_len
+        return 3 * n_elem, self.total_memory
+
     def forward(self) -> torch.Tensor:
         out = self.kernel()
         result = out.reshape(self.num_heads, self.seq_len, self.seq_len)

--- a/tileops/ops/elementwise/fused_gated.py
+++ b/tileops/ops/elementwise/fused_gated.py
@@ -28,3 +28,4 @@ class GeluTanhAndMulFwdOp(FusedGatedOp):
 
     _op_name = "gelu_tanh_and_mul"
     kernel_cls = GeluTanhAndMulFwdKernel
+    FLOPS_PER_ELEM = 10

--- a/tileops/ops/elementwise/sinusoidal.py
+++ b/tileops/ops/elementwise/sinusoidal.py
@@ -51,6 +51,20 @@ class SinusoidalFwdOp(Op):
     def default_kernel_map(self):
         return {"sinusoidal": SinusoidalFwdKernel}
 
+    def _infer_output_shapes(self) -> dict[str, tuple[int, ...]]:
+        return {"output": (self.seq_len, self.d_model)}
+
+    def _validate_dtypes(self) -> None:
+        return None
+
+    @property
+    def total_memory(self) -> int:
+        return self.seq_len * self.d_model * self.dtype.itemsize
+
+    def eval_roofline(self) -> tuple[int, int]:
+        n_elem = self.seq_len * self.d_model
+        return 6 * n_elem, self.total_memory
+
     def forward(self) -> torch.Tensor:
         out = self.kernel()
         result = out.reshape(self.seq_len, self.d_model)


### PR DESCRIPTION
## Summary

Closes #1659. Refs #1650.

Promotes implemented special elementwise ops from `spec-only` to `implemented`:

- `SiluAndMulFwdOp`, `GeluAndMulFwdOp`, `GeluTanhAndMulFwdOp`
- `AlibiFwdOp`, `SinusoidalFwdOp`

This is a code/manifest cleanup PR, not a release-plan doc update. #1659 is tracked as a sub-issue of the broader #1650 release-facing manifest coverage tracker.

## Changes

- Allow fused gated ops to bind `M`, `N`, and `dtype` from the runtime input tensor, while preserving the old explicit ctor path.
- Keep lazy fused gated ops reusable across runtime shapes/dtypes by separating explicit ctor contracts from the last runtime-bound kernel specialization.
- Ensure `_eager_forward` validates the runtime input and calls `_ensure_kernel(M, N, x.dtype)` before launch.
- Add fused gated `eval_roofline()` support and the correct GELU-tanh FLOPs coefficient.
- Add zero-input `_validate_dtypes()`, `_infer_output_shapes()`, `total_memory`, and `eval_roofline()` for `AlibiFwdOp` and `SinusoidalFwdOp`.
- Keep generative op `dtype` explicit in the manifest because these ops have no input tensor to infer dtype from.
- Add smoke tests for manifest-style fused gated lazy binding and shape rebinding.

## Validation

Ran in `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`:

```bash
python -m pytest tests/test_ops_manifest.py -q
# 21 passed

python -m pytest tests/test_ops_manifest.py::TestOpSchema::test_workloads_include_all_required_params -q
# 1 passed

for op in SiluAndMulFwdOp GeluAndMulFwdOp GeluTanhAndMulFwdOp AlibiFwdOp SinusoidalFwdOp; do
  python scripts/validate_manifest.py --check-op "$op" --strict
done
# all targeted checks passed

python -m pytest \
  tests/ops/test_fused_gated.py::test_silu_and_mul_infers_manifest_shape_contract \
  tests/ops/test_fused_gated.py::test_silu_and_mul_lazy_op_rebinds_shape \
  tests/ops/test_fused_gated.py::test_fused_gated_rejects_integer_dtype -q
# 3 passed

python -m ruff check \
  tileops/ops/elementwise/_base.py \
  tileops/ops/elementwise/fused_gated.py \
  tileops/ops/elementwise/alibi.py \
  tileops/ops/elementwise/sinusoidal.py \
  tests/ops/test_fused_gated.py
# All checks passed
```

GitHub CI is green, including `validate-manifest`, `benchmark-contract-tests`, and `gpu-smoke`.