### PR TITLE
[Perf][Pool] Optimize avg_pool2d kernels

### DIFF
--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool import AvgPool2dKernel, AvgPool3dKernel
+from tileops.kernels.pool import AvgPool2dKernel, AvgPool2dSpatialKernel, AvgPool3dKernel
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 
@@ -279,7 +279,7 @@ def test_avg_pool2d_dispatches_kernel() -> None:
         stride=(2, 2),
         padding=(1, 1),
     )
-    assert isinstance(op.kernel, AvgPool2dKernel)
+    assert isinstance(op.kernel, AvgPool2dSpatialKernel)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -186,6 +186,31 @@ class AvgPool2dFixture(FixtureBase):
                 marks=pytest.mark.full,
                 id="full-divisor-override-bf16",
             ),
+            pytest.param(
+                1, 7, 9, 10, (3, 3), (2, 2), (1, 1), False, False, None, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-no-ceil-no-pad-count-fp16",
+            ),
+            pytest.param(
+                1, 5, 10, 11, (3, 3), (2, 2), (1, 1), True, True, None, torch.float32, False,
+                marks=pytest.mark.full,
+                id="full-ceil-pad-count-fp32",
+            ),
+            pytest.param(
+                2, 6, 9, 13, (2, 3), (2, 2), (0, 1), True, True, 7, torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-ceil-pad-count-divisor-bf16",
+            ),
+            pytest.param(
+                1, 9, 11, 12, (3, 5), (2, 3), (1, 2), True, False, 7, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-ceil-no-pad-count-divisor-fp16",
+            ),
+            pytest.param(
+                1, 8, 9, 9, (3, 3), (2, 2), (1, 1), False, False, 7, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-no-ceil-no-pad-count-divisor-fp16",
+            ),
         ]),
     ]
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool import AvgPool2dKernel, AvgPool2dSpatialKernel, AvgPool3dKernel
+from tileops.kernels.pool import AvgPool2dSpatialKernel, AvgPool3dKernel
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 
@@ -305,6 +305,22 @@ def test_avg_pool2d_dispatches_kernel() -> None:
         padding=(1, 1),
     )
     assert isinstance(op.kernel, AvgPool2dSpatialKernel)
+
+
+@pytest.mark.smoke
+def test_avg_pool2d_rejects_non_positive_output_size() -> None:
+    with pytest.raises(ValueError, match="output size must be greater than zero"):
+        AvgPool2dFwdOp(
+            n=1,
+            c_in=1,
+            h_in=2,
+            w_in=2,
+            kernel_size=(5, 5),
+            stride=(1, 1),
+            padding=(0, 0),
+            ceil_mode=False,
+            count_include_pad=True,
+        )
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/pool/__init__.py
+++ b/tileops/kernels/pool/__init__.py
@@ -1,5 +1,10 @@
 from .avg_pool1d import AvgPool1dKernel
-from .avg_pool2d import AvgPool2dKernel
+from .avg_pool2d import AvgPool2dKernel, AvgPool2dSpatialKernel
 from .avg_pool3d import AvgPool3dKernel
 
-__all__ = ["AvgPool1dKernel", "AvgPool2dKernel", "AvgPool3dKernel"]
+__all__ = [
+    "AvgPool1dKernel",
+    "AvgPool2dKernel",
+    "AvgPool2dSpatialKernel",
+    "AvgPool3dKernel",
+]

--- a/tileops/kernels/pool/avg_pool2d.py
+++ b/tileops/kernels/pool/avg_pool2d.py
@@ -33,102 +33,66 @@ def _avg_pool2d_kernel(
     accum_dtype = "float"
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
+    total_output = n * c_in * out_h * out_w
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool2d_func(block_m: int, block_c: int, threads: int):
+    def _avg_pool2d_func(block_m: int, threads: int):
         @T.prim_func
         def _avg_pool2d_main(
             x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
             out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
         ):
-            with T.Kernel(
-                T.ceildiv(out_h * out_w, block_m),
-                T.ceildiv(c_in, block_c),
-                n,
-                threads=threads,
-            ) as (bx, by, bz):
-                T.use_swizzle(10)
-                tile_spatial_start = bx * block_m
-                tile_spatial_end = tile_spatial_start + block_m - 1
-                tile_oh_start = tile_spatial_start // out_w
-                tile_oh_end = tile_spatial_end // out_w
-                tile_spatial_same_row = tile_oh_start == tile_oh_end
-                tile_ow_start = tile_spatial_start % out_w
-                tile_ow_end = tile_spatial_end % out_w
-                tile_input_h_start = tile_oh_start * stride_h - pad_h
-                tile_input_h_end = tile_oh_end * stride_h + kernel_h - 1 - pad_h
-                tile_input_w_start = tile_ow_start * stride_w - pad_w
-                tile_input_w_end = tile_ow_end * stride_w + kernel_w - 1 - pad_w
-                tile_spatial_full = (
-                    tile_spatial_same_row
-                    & (tile_input_h_start >= 0)
-                    & (tile_input_h_end < h_in)
-                    & (tile_input_w_start >= 0)
-                    & (tile_input_w_end < w_in)
-                )
-                use_fixed_kernel_divisor = count_include_pad and not use_divisor_override
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        channel_batch_idx = spatial_idx // out_h
+                        c_idx = channel_batch_idx % c_in
+                        batch = channel_batch_idx // c_in
 
-                for i, j in T.Parallel(block_m, block_c):
-                    out_spatial = bx * block_m + i
-                    oh = out_spatial // out_w
-                    ow = out_spatial % out_w
-                    c_idx = by * block_c + j
-                    batch = bz
-                    if out_spatial < out_h * out_w and c_idx < c_in:
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full and use_fixed_kernel_divisor:
-                            for kh in T.serial(kernel_h):
-                                for kw in T.serial(kernel_w):
-                                    ih = oh * stride_h + kh - pad_h
-                                    iw = ow * stride_w + kw - pad_w
+                        for kh in T.serial(kernel_h):
+                            for kw in T.serial(kernel_w):
+                                ih = oh * stride_h + kh - pad_h
+                                iw = ow * stride_w + kw - pad_w
+                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
                                     sum_val += T.cast(
                                         x[batch, c_idx, ih, iw], accum_dtype
                                     )
-                            out[batch, c_idx, oh, ow] = T.cast(
-                                sum_val / T.cast(kernel_h * kernel_w, accum_dtype),
-                                dtype,
-                            )
-                        else:
-                            for kh in T.serial(kernel_h):
-                                for kw in T.serial(kernel_w):
-                                    ih = oh * stride_h + kh - pad_h
-                                    iw = ow * stride_w + kw - pad_w
-                                    if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
-                                        sum_val += T.cast(
-                                            x[batch, c_idx, ih, iw], accum_dtype
-                                        )
 
-                            start_h = oh * stride_h - pad_h
-                            start_w = ow * stride_w - pad_w
-                            end_h = start_h + kernel_h
-                            end_w = start_w + kernel_w
-                            valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
-                            valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
-                            valid_count = valid_h * valid_w
-                            padded_h = T.max(
-                                T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0
-                            )
-                            padded_w = T.max(
-                                T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0
-                            )
-                            padded_count = padded_h * padded_w
-                            auto_divisor = T.max(
-                                T.if_then_else(
-                                    count_include_pad, padded_count, valid_count
-                                ),
-                                1,
-                            )
-                            divisor = T.if_then_else(
-                                use_divisor_override,
-                                divisor_override,
-                                auto_divisor,
-                            )
-                            out[batch, c_idx, oh, ow] = T.cast(
-                                sum_val / T.cast(divisor, accum_dtype),
-                                dtype,
-                            )
+                        start_h = oh * stride_h - pad_h
+                        start_w = ow * stride_w - pad_w
+                        end_h = start_h + kernel_h
+                        end_w = start_w + kernel_w
+                        valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
+                        valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
+                        valid_count = valid_h * valid_w
+                        padded_h = T.max(
+                            T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0
+                        )
+                        padded_w = T.max(
+                            T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0
+                        )
+                        padded_count = padded_h * padded_w
+                        auto_divisor = T.max(
+                            T.if_then_else(
+                                count_include_pad, padded_count, valid_count
+                            ),
+                            1,
+                        )
+                        divisor = T.if_then_else(
+                            use_divisor_override,
+                            divisor_override,
+                            auto_divisor,
+                        )
+                        out[batch, c_idx, oh, ow] = T.cast(
+                            sum_val / T.cast(divisor, accum_dtype),
+                            dtype,
+                        )
 
         return _avg_pool2d_main
 
@@ -270,7 +234,6 @@ def _avg_pool2d_wrapped_kernel(
     divisor_override: int,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -290,7 +253,7 @@ def _avg_pool2d_wrapped_kernel(
         use_divisor_override,
         divisor_override,
         dtype,
-    )(block_m, block_c, threads)(x)
+    )(block_m, threads)(x)
 
 
 @_avg_pool2d_wrapped_kernel.register_fake
@@ -311,7 +274,6 @@ def _(
     divisor_override: int,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -321,7 +283,6 @@ def _(
         divisor_override,
         dtype,
         block_m,
-        block_c,
         threads,
     )
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
@@ -475,21 +436,15 @@ class AvgPool2dKernel(Kernel):
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 128,
-            "block_c": 64,
-            "threads": 128,
+            "block_m": 256,
+            "threads": 256,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        configs = itertools.product([64, 128, 256], [32, 64, 128], [128, 256])
         return [
-            {
-                "block_m": block_m,
-                "block_c": block_c,
-                "threads": threads,
-            }
-            for block_m, block_c, threads in configs
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -510,7 +465,6 @@ class AvgPool2dKernel(Kernel):
             self.divisor_override,
             self.dtype_str,
             self.config["block_m"],
-            self.config["block_c"],
             self.config["threads"],
             x,
         )

--- a/tileops/kernels/pool/avg_pool2d.py
+++ b/tileops/kernels/pool/avg_pool2d.py
@@ -9,7 +9,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool.common import pool_output_dim
 
-__all__ = ["AvgPool2dKernel"]
+__all__ = ["AvgPool2dKernel", "AvgPool2dSpatialKernel"]
 
 
 @functools.lru_cache(maxsize=64)
@@ -135,6 +135,123 @@ def _avg_pool2d_kernel(
     return _avg_pool2d_func
 
 
+@functools.lru_cache(maxsize=64)
+def _avg_pool2d_spatial_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+    total_output = n * c_in * out_h * out_w
+
+    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _avg_pool2d_spatial_func(block_m: int, threads: int):
+        @T.prim_func
+        def _avg_pool2d_spatial_main(
+            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        channel_batch_idx = spatial_idx // out_h
+                        c_idx = channel_batch_idx % c_in
+                        batch = channel_batch_idx // c_in
+
+                        sum_val = T.alloc_var(T.float32)
+                        sum_val = T.cast(0.0, accum_dtype)
+                        for kh in T.serial(kernel_h):
+                            for kw in T.serial(kernel_w):
+                                ih = oh * stride_h + kh - pad_h
+                                iw = ow * stride_w + kw - pad_w
+                                if ih >= 0 and ih < h_in and iw >= 0 and iw < w_in:
+                                    sum_val += T.cast(
+                                        x[batch, c_idx, ih, iw], accum_dtype
+                                    )
+
+                        out[batch, c_idx, oh, ow] = T.cast(
+                            sum_val / T.cast(kernel_h * kernel_w, accum_dtype),
+                            dtype,
+                        )
+
+        return _avg_pool2d_spatial_main
+
+    return _avg_pool2d_spatial_func
+
+
+@torch.library.custom_op("top::avg_pool2d_spatial_wrapped_kernel", mutates_args=())
+def _avg_pool2d_spatial_wrapped_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _avg_pool2d_spatial_kernel(
+        n,
+        c_in,
+        h_in,
+        w_in,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        dtype,
+    )(block_m, threads)(x)
+
+
+@_avg_pool2d_spatial_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    _ = (
+        dtype,
+        block_m,
+        threads,
+    )
+    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
+
+
 @torch.library.custom_op("top::avg_pool2d_wrapped_kernel", mutates_args=())
 def _avg_pool2d_wrapped_kernel(
     n: int,
@@ -210,6 +327,89 @@ def _(
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
     return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
+
+
+class AvgPool2dSpatialKernel(Kernel):
+    """Fast path for common NCHW avg_pool2d workloads."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        kernel_h: int,
+        kernel_w: int,
+        stride_h: int,
+        stride_w: int,
+        pad_h: int,
+        pad_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.kernel_h = kernel_h
+        self.kernel_w = kernel_w
+        self.stride_h = stride_h
+        self.stride_w = stride_w
+        self.pad_h = pad_h
+        self.pad_w = pad_w
+        self.dtype = dtype
+        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+        self.kernel = _avg_pool2d_spatial_kernel(
+            n,
+            c_in,
+            h_in,
+            w_in,
+            kernel_h,
+            kernel_w,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 256,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _avg_pool2d_spatial_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.h_in,
+            self.w_in,
+            self.kernel_h,
+            self.kernel_w,
+            self.stride_h,
+            self.stride_w,
+            self.pad_h,
+            self.pad_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )
 
 
 class AvgPool2dKernel(Kernel):

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -3,7 +3,12 @@ from typing import Dict, Optional, Tuple
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
+from tileops.kernels.pool import (
+    AvgPool1dKernel,
+    AvgPool2dKernel,
+    AvgPool2dSpatialKernel,
+    AvgPool3dKernel,
+)
 from tileops.kernels.pool.common import (
     _normalize_pool_dims,
     pool_output_dim,
@@ -191,9 +196,13 @@ class AvgPool2dFwdOp(Op):
         )
 
         self.dispatch_kernel(kernel_map)
-        if "avg_pool2d_kernel" not in self.kernel_map:
+        if (
+            "avg_pool2d_kernel" not in self.kernel_map
+            and "avg_pool2d_spatial_kernel" not in self.kernel_map
+        ):
             raise NotImplementedError(
-                "AvgPool2dFwdOp requires 'avg_pool2d_kernel' in kernel_map"
+                "AvgPool2dFwdOp requires 'avg_pool2d_kernel' or "
+                "'avg_pool2d_spatial_kernel' in kernel_map"
             )
         self.out_h = pool_output_dim(
             self.h_in, self.kernel_size[0], self.stride[0], self.padding[0], self.ceil_mode
@@ -201,7 +210,8 @@ class AvgPool2dFwdOp(Op):
         self.out_w = pool_output_dim(
             self.w_in, self.kernel_size[1], self.stride[1], self.padding[1], self.ceil_mode
         )
-        self.kernel = self.kernel_map["avg_pool2d_kernel"](
+
+        kernel_kwargs = dict(
             n=n,
             c_in=c_in,
             h_in=h_in,
@@ -212,16 +222,36 @@ class AvgPool2dFwdOp(Op):
             stride_w=self.stride[1],
             pad_h=self.padding[0],
             pad_w=self.padding[1],
-            ceil_mode=ceil_mode,
-            count_include_pad=count_include_pad,
-            divisor_override=divisor_override,
             dtype=dtype,
             tune=tune,
         )
+        use_spatial_fast_path = (
+            not ceil_mode
+            and count_include_pad
+            and divisor_override is None
+            and "avg_pool2d_spatial_kernel" in self.kernel_map
+        )
+        if use_spatial_fast_path:
+            self.kernel = self.kernel_map["avg_pool2d_spatial_kernel"](**kernel_kwargs)
+        elif "avg_pool2d_kernel" in self.kernel_map:
+            self.kernel = self.kernel_map["avg_pool2d_kernel"](
+                **kernel_kwargs,
+                ceil_mode=ceil_mode,
+                count_include_pad=count_include_pad,
+                divisor_override=divisor_override,
+            )
+        else:
+            raise NotImplementedError(
+                "AvgPool2dFwdOp requires 'avg_pool2d_kernel' or "
+                "'avg_pool2d_spatial_kernel' in kernel_map"
+            )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"avg_pool2d_kernel": AvgPool2dKernel}
+        return {
+            "avg_pool2d_kernel": AvgPool2dKernel,
+            "avg_pool2d_spatial_kernel": AvgPool2dSpatialKernel,
+        }
 
     def _infer_output_shapes(
         self, input_shape: tuple[int, ...]

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -210,6 +210,11 @@ class AvgPool2dFwdOp(Op):
         self.out_w = pool_output_dim(
             self.w_in, self.kernel_size[1], self.stride[1], self.padding[1], self.ceil_mode
         )
+        if self.out_h <= 0 or self.out_w <= 0:
+            raise ValueError(
+                "AvgPool2dFwdOp calculated output size must be greater than zero, "
+                f"got ({self.out_h}, {self.out_w})"
+            )
 
         kernel_kwargs = dict(
             n=n,


### PR DESCRIPTION
Closes #1654

## Summary

- Add an `AvgPool2dSpatialKernel` fast path for the common NCHW case with `ceil_mode=False`, `count_include_pad=True`, and no `divisor_override`.
- Rewrite the general `AvgPool2dKernel` fallback to use a flat `N*C*H_out*W_out` launch grid and remove the `block_c` tuning dimension.
- Extend `AvgPool2dFixture` coverage for `ceil_mode`, `count_include_pad`, and `divisor_override` combinations.

## Test plan

- [x] Cleared TileLang caches before the final benchmark/profiling run:

```bash
rm -rf /home/lyc/.tilelang \
  /home/lyc/Project/TileOps-workspace2/.tmp/tilelang_clear_sync_cache \
  /home/lyc/Project/TileOps-workspace2/.tmp/tilelang_ifelse_cache
```

- [x] Functional tests:

```bash
CUDA_VISIBLE_DEVICES=1 conda run -n tileops-dev \
  python -m pytest tests/ops/test_pool.py -k avg_pool2d -vvs
```

Result:

```text
23 passed, 28 deselected, 14 warnings in 57.08s
```

- [x] Benchmark:

```bash
CUDA_VISIBLE_DEVICES=1 conda run -n tileops-dev \
  python -m pytest benchmarks/ops/bench_pool.py::test_avg_pool2d_bench -vvs
```

Result:

```text
3 passed, 15 warnings in 34.03s
```

- [x] Whitespace check:

```bash
git diff --check
```

## Benchmark

Final benchmark on NVIDIA H200:

| workload | kernel path | before TileOps ms | after TileOps ms | torch-ref ms | after vs before | after vs torch |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `vision-3x3-s2` | `AvgPool2dSpatialKernel` | `0.0505` | `0.0046` | `0.0094` | `10.98x faster` | `2.04x faster` |
| `vision-5x5-s2` | `AvgPool2dSpatialKernel` | `0.0372` | `0.0045` | `0.0102` | `8.27x faster` | `2.27x faster` |
| `ceil-divisor-bf16` | `AvgPool2dKernel` flat general | `0.0149` | `0.0038` | `0.0080` | `3.92x faster` | `2.11x faster` |

Autotune best configs from the final run:

| workload | kernel | best config |
| --- | --- | --- |
| `vision-3x3-s2` | `AvgPool2dSpatialKernel` | `{"block_m": 256, "threads": 256}` |
| `vision-5x5-s2` | `AvgPool2dSpatialKernel` | `{"block_m": 512, "threads": 256}` |
| `ceil-divisor-bf16` | `AvgPool2dKernel` | `{"block_m": 256, "threads": 256}` |

Notes on the baseline values:

- The `vision-3x3-s2` and `vision-5x5-s2` "before" values are from the original TileOps kernel measured during the avg_pool2d performance investigation.
- The `ceil-divisor-bf16` "before" value is the local pre-flat-general fallback re-run used for the review comparison.

### Profiling summary

The benchmark improvement is consistent with fixed-config `nsys` and `ncu` data.

For `vision-3x3-s2`, `ncu` shows that TileOps executes much less work than torch:

| metric | TileOps | torch |
| --- | ---: | ---: |
| Duration | `5.12 us` | `10.05 us` |
| Waves/SM | `1.48` | `1.48` |
| Achieved Occupancy | `73.61%` | `79.44%` |
| SM Busy | `44.53%` | `67.92%` |
| Memory Throughput | `628.30 GB/s` | `321.45 GB/s` |
| Issued Instructions | `1.09M` | `4.24M` |

Torch has higher SM busy, but it issues about `3.9x` more instructions. The TileOps fast path avoids the general pooling divisor/control path and reaches about `2x` higher effective memory throughput.

For `vision-5x5-s2`, fixed-config `nsys` reports:

| metric | TileOps | torch |
| --- | ---: | ---: |
| nsys median | `3.808 us` | `9.664 us` |
| nsys avg | `3.822 us` | `9.672 us` |
| Grid / Block | `392 x 256` | `196 x 1024` |
| Registers/thread | `29` | `32` |

For `ceil-divisor-bf16`, the new flat general fallback is also faster than torch:

| metric | TileOps | torch |
| --- | ---: | ---: |
| nsys median | `3.456 us` | `7.488 us` |
| ncu Duration | `4.48 us` | `8.96 us` |
| Grid / Block | `914 x 256` | `229 x 1024` |
| Waves/SM | `0.87` | `0.87` |
| Achieved Occupancy | `68.44%` | `73.10%` |
| SM Busy | `43.02%` | `65.50%` |
| Eligible Warps/Scheduler | `1.42` | `3.65` |
| Memory Throughput | `404.46 GB/s` | `203.60 GB/s` |
| Issued Instructions | `875K` | `3.28M` |

Torch again keeps the SMs busier, but it issues about `3.75x` more instructions. The flat general kernel removes the old `block_c` split, launches over `N*C*H_out*W_out`, and completes the same workload with a shorter instruction path and higher effective memory throughput.

