### PR TITLE
[Feat][GEMM] Add FP8 GEMM op

### DIFF
--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -1,30 +1,24 @@
+import subprocess
+import sys
 from typing import Optional
 
 import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tests.ops.test_gemm import GemmFp8Test, GemmTest
 from tileops.manifest import load_workloads
-from tileops.ops import GemmOp
-from workloads.gemm import GemmTest
+from tileops.ops import GemmFp8Op, GemmOp
 
 _OP_NAME = "GemmOp"
+_FP8_OP_NAME = "GemmFp8Op"
 
 _DTYPE_MAP = {
     "bfloat16": torch.bfloat16,
     "float16": torch.float16,
+    "float8_e4m3fn": torch.float8_e4m3fn,
+    "float8_e5m2": torch.float8_e5m2,
 }
-
-
-class _GemmTestBaseline(GemmTest):
-    """Adds baseline ref_program for benchmark profiling."""
-
-    def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        if self.trans_a:
-            a = a.T
-        if self.trans_b:
-            b = b.T
-        return torch.matmul(a, b)
 
 
 class GemmBenchmark(BenchmarkBase[GemmTest]):
@@ -37,6 +31,100 @@ class GemmBenchmark(BenchmarkBase[GemmTest]):
     _roofline_cache: Optional[tuple[float, float]] = None
 
     def __init__(self, test: GemmTest, op: GemmOp):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            flops, mem_bytes = self._op.eval_roofline()
+            self._roofline_cache = (float(flops), float(mem_bytes))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+def _flashinfer_fp8_blockscale_ref(test: GemmFp8Test, *inputs: torch.Tensor) -> torch.Tensor:
+    from flashinfer.gemm import fp8_blockscale_gemm_sm90
+
+    a, b, scale_a, scale_b = inputs[:4]
+    if len(inputs) == 5:
+        raise ValueError("FlashInfer FP8 blockscale GEMM baseline does not support bias.")
+    if a.dtype != torch.float8_e4m3fn or b.dtype != torch.float8_e4m3fn:
+        raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires float8_e4m3fn.")
+    if test.out_dtype != torch.bfloat16:
+        raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires bfloat16 output.")
+    if test.k % 128 != 0:
+        raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires k divisible by 128.")
+    if scale_a.shape != (test.m, test.k // 128) or scale_b.shape != (test.n, test.k // 128):
+        raise ValueError(
+            "FlashInfer FP8 blockscale GEMM baseline requires exact "
+            f"scale shapes {(test.m, test.k // 128)} and {(test.n, test.k // 128)}, "
+            f"got {tuple(scale_a.shape)} and {tuple(scale_b.shape)}"
+        )
+    return fp8_blockscale_gemm_sm90(a, b, scale_a, scale_b, out_dtype=test.out_dtype)
+
+
+def _prepare_flashinfer_fp8_per_tensor(
+    test: GemmFp8Test, *inputs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    import flashinfer
+
+    a, b, scale_a, scale_b = inputs[:4]
+    if len(inputs) == 5:
+        raise ValueError("FlashInfer FP8 per-tensor GEMM baseline does not support bias.")
+    if a.dtype != torch.float8_e4m3fn or b.dtype != torch.float8_e4m3fn:
+        raise ValueError("FlashInfer FP8 per-tensor GEMM baseline requires float8_e4m3fn.")
+    if test.out_dtype != torch.bfloat16:
+        raise ValueError("FlashInfer FP8 per-tensor GEMM baseline requires bfloat16 output.")
+    if scale_a.shape != (1, 1) or scale_b.shape != (1, 1):
+        raise ValueError(
+            "FlashInfer FP8 per-tensor GEMM baseline requires (1, 1) scales, "
+            f"got {tuple(scale_a.shape)} and {tuple(scale_b.shape)}"
+        )
+    prepared_b = flashinfer.prepare_low_latency_gemm_weights(b, {})
+    alpha = (scale_a * scale_b).reshape(())
+    return prepared_b, alpha
+
+
+def _flashinfer_fp8_per_tensor_probe(test: GemmFp8Test) -> Optional[str]:
+    script = f"""
+import sys
+import torch
+import flashinfer
+
+try:
+    a = torch.empty(({test.m}, {test.k}), device="cuda", dtype=torch.float8_e4m3fn)
+    b = torch.empty(({test.n}, {test.k}), device="cuda", dtype=torch.float8_e4m3fn)
+    prepared_b = flashinfer.prepare_low_latency_gemm_weights(b, {{}})
+    alpha = torch.ones((), device="cuda", dtype=torch.float32)
+    flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=torch.bfloat16)
+    torch.cuda.synchronize()
+except Exception as exc:
+    print(type(exc).__name__ + ": " + str(exc).splitlines()[0])
+    sys.exit(2)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode == 0:
+        return None
+    reason = (result.stdout or result.stderr).strip().splitlines()
+    if reason:
+        return reason[-1]
+    return f"probe exited with status {result.returncode}"
+
+
+class GemmFp8Benchmark(BenchmarkBase[GemmFp8Test]):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: GemmFp8Test, op: GemmFp8Op):
         super().__init__(test)
         self._op = op
 
@@ -68,12 +156,24 @@ def _manifest_params() -> list:
     return params
 
 
+def _manifest_fp8_params() -> list:
+    params = []
+    for w in load_workloads(_FP8_OP_NAME):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["m"], w["n"], w["k"], w["scale_mode"], dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
 @pytest.mark.parametrize("m, n, k, trans_a, trans_b, dtype_str", _manifest_params())
 def test_gemm_bench(
     m: int, n: int, k: int, trans_a: bool, trans_b: bool, dtype_str: str,
 ) -> None:
     dtype = _DTYPE_MAP[dtype_str]
-    test = _GemmTestBaseline(m, n, k, dtype, trans_a, trans_b)
+    test = GemmTest(m, n, k, dtype, trans_a, trans_b)
     a, b = test.gen_inputs()
 
     op = GemmOp(trans_a=trans_a, trans_b=trans_b)
@@ -86,6 +186,52 @@ def test_gemm_bench(
 
     result_bl = bm.profile(test.ref_program, a, b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
+
+
+@pytest.mark.parametrize("m, n, k, scale_mode, dtype_str", _manifest_fp8_params())
+def test_gemm_fp8_bench(
+    m: int, n: int, k: int, scale_mode: str, dtype_str: str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    out_dtype = torch.bfloat16
+    test = GemmFp8Test(m, n, k, dtype, scale_mode, out_dtype=out_dtype)
+    inputs = test.gen_inputs()
+
+    op = GemmFp8Op(out_dtype=out_dtype)
+    bm = GemmFp8Benchmark(test, op)
+
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-scaled-mm")
+
+    flashinfer = pytest.importorskip("flashinfer")
+    if scale_mode == "per_tensor":
+        reason = _flashinfer_fp8_per_tensor_probe(test)
+        if reason is not None:
+            print(f"  [skip] flashinfer-mm-fp8: {reason}")
+            return
+        prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(test, *inputs)
+        try:
+            result_flashinfer = bm.profile(
+                lambda a: flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=out_dtype),
+                inputs[0],
+            )
+        except RuntimeError as exc:
+            reason = str(exc).splitlines()[0]
+            print(f"  [skip] flashinfer-mm-fp8: {reason}")
+            return
+        BenchmarkReport.record(op, locals(), result_flashinfer, tag="flashinfer-mm-fp8")
+        return
+
+    if scale_mode == "block128":
+        result_flashinfer = bm.profile(
+            lambda *args: _flashinfer_fp8_blockscale_ref(test, *args), *inputs)
+        BenchmarkReport.record(op, locals(), result_flashinfer, tag="flashinfer-fp8-blockscale-sm90")
+        return
+
+    raise ValueError(f"unsupported FP8 GEMM scale_mode for benchmark: {scale_mode!r}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 from typing import Optional
 
 import pytest
@@ -90,37 +88,6 @@ def _prepare_flashinfer_fp8_per_tensor(
     return prepared_b, alpha
 
 
-def _flashinfer_fp8_per_tensor_probe(test: GemmFp8Test) -> Optional[str]:
-    script = f"""
-import sys
-import torch
-import flashinfer
-
-try:
-    a = torch.empty(({test.m}, {test.k}), device="cuda", dtype=torch.float8_e4m3fn)
-    b = torch.empty(({test.n}, {test.k}), device="cuda", dtype=torch.float8_e4m3fn)
-    prepared_b = flashinfer.prepare_low_latency_gemm_weights(b, {{}})
-    alpha = torch.ones((), device="cuda", dtype=torch.float32)
-    flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=torch.bfloat16)
-    torch.cuda.synchronize()
-except Exception as exc:
-    print(type(exc).__name__ + ": " + str(exc).splitlines()[0])
-    sys.exit(2)
-"""
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    if result.returncode == 0:
-        return None
-    reason = (result.stdout or result.stderr).strip().splitlines()
-    if reason:
-        return reason[-1]
-    return f"probe exited with status {result.returncode}"
-
-
 class GemmFp8Benchmark(BenchmarkBase[GemmFp8Test]):
     _roofline_cache: Optional[tuple[float, float]] = None
 
@@ -208,10 +175,6 @@ def test_gemm_fp8_bench(
 
     flashinfer = pytest.importorskip("flashinfer")
     if scale_mode == "per_tensor":
-        reason = _flashinfer_fp8_per_tensor_probe(test)
-        if reason is not None:
-            print(f"  [skip] flashinfer-mm-fp8: {reason}")
-            return
         prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(test, *inputs)
         try:
             result_flashinfer = bm.profile(

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -2,17 +2,33 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import GemmOp
-from workloads.gemm import GemmTest as _GemmTestWorkload
+from tileops.ops import GemmFp8Op, GemmOp
+from tileops.utils import expand_fp8_scale
+from workloads.gemm import GemmFp8Workload, GemmWorkload
 
 
-class GemmTest(_GemmTestWorkload, TestBase):
+class GemmTest(GemmWorkload, TestBase):
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         if self.trans_a:
             a = a.T
         if self.trans_b:
             b = b.T
         return torch.matmul(a, b)
+
+
+class GemmFp8Test(GemmFp8Workload, TestBase):
+    def _expand_scale(self, scale: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+        return expand_fp8_scale(scale, rows, cols)
+
+    def ref_program(self, *inputs: torch.Tensor) -> torch.Tensor:
+        a, b, scale_a, scale_b = inputs[:4]
+        bias = inputs[4] if len(inputs) == 5 else None
+        a_f = a.float() * self._expand_scale(scale_a, self.m, self.k)
+        b_f = b.float() * self._expand_scale(scale_b, self.n, self.k)
+        out = torch.matmul(a_f, b_f.T)
+        if bias is not None:
+            out = out + bias.float()
+        return out.to(self.out_dtype)
 
 
 class GemmFixture(FixtureBase):
@@ -112,6 +128,43 @@ class GemvBoundaryFixture(FixtureBase):
     ]
 
 
+class GemmFp8Fixture(FixtureBase):
+    PARAMS = [
+        ("m, n, k, dtype, scale_mode, out_dtype, bias", [
+            pytest.param(
+                128, 128, 128, torch.float8_e4m3fn, "per_tensor", torch.bfloat16, False,
+                marks=pytest.mark.smoke,
+                id="smoke-fp8-e4m3-per-tensor",
+            ),
+            pytest.param(
+                128, 256, 256, torch.float8_e4m3fn, "block128", torch.bfloat16, False,
+                marks=pytest.mark.smoke,
+                id="smoke-fp8-e4m3-block128",
+            ),
+            pytest.param(
+                128, 128, 128, torch.float8_e5m2, "per_tensor", torch.bfloat16, False,
+                marks=pytest.mark.smoke,
+                id="smoke-fp8-e5m2-per-tensor",
+            ),
+            pytest.param(
+                4096, 256, 256, torch.float8_e4m3fn, "block128", torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-fp8-e4m3-block128-large-m",
+            ),
+            pytest.param(
+                8, 256, 128, torch.float8_e4m3fn, "per_tensor", torch.float16, True,
+                marks=pytest.mark.full,
+                id="full-fp8-e4m3-per-tensor-small-m-bias",
+            ),
+            pytest.param(
+                1, 256, 128, torch.float8_e4m3fn, "per_tensor", torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-fp8-e4m3-per-tensor-gemv",
+            ),
+        ]),
+    ]
+
+
 @GemmFixture
 def test_gemm(m: int, n: int, k: int, dtype: torch.dtype, trans_a: bool, trans_b: bool,
               tune: bool) -> None:
@@ -122,6 +175,25 @@ def test_gemm(m: int, n: int, k: int, dtype: torch.dtype, trans_a: bool, trans_b
     else:
         tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
     test.check(op, *test.gen_inputs(), **tolerances)
+
+@GemmFp8Fixture
+def test_gemm_fp8(
+    m: int,
+    n: int,
+    k: int,
+    dtype: torch.dtype,
+    scale_mode: str,
+    out_dtype: torch.dtype,
+    bias: bool,
+) -> None:
+    test = GemmFp8Test(m, n, k, dtype, scale_mode, out_dtype=out_dtype, bias=bias)
+    op = GemmFp8Op(out_dtype=out_dtype)
+    inputs = test.gen_inputs()
+    if dtype != torch.float8_e4m3fn:
+        with pytest.raises(ValueError, match="only supports torch.float8_e4m3fn"):
+            op(*inputs)
+        return
+    test.check(op, *inputs, atol=2e-2, rtol=2e-2)
 
 
 @GemvBoundaryFixture

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -3,7 +3,6 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import GemmFp8Op, GemmOp
-from tileops.utils import expand_fp8_scale
 from workloads.gemm import GemmFp8Workload, GemmWorkload
 
 
@@ -18,7 +17,13 @@ class GemmTest(GemmWorkload, TestBase):
 
 class GemmFp8Test(GemmFp8Workload, TestBase):
     def _expand_scale(self, scale: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
-        return expand_fp8_scale(scale, rows, cols)
+        if tuple(scale.shape) == (1, 1):
+            return scale.expand(rows, cols)
+        scale_cols = (cols + 127) // 128
+        if tuple(scale.shape) != (rows, scale_cols):
+            raise ValueError(
+                f"unsupported FP8 scale shape {tuple(scale.shape)} for {(rows, cols)}")
+        return scale.repeat_interleave(128, dim=1)[:, :cols]
 
     def ref_program(self, *inputs: torch.Tensor) -> torch.Tensor:
         a, b, scale_a, scale_b = inputs[:4]
@@ -194,6 +199,63 @@ def test_gemm_fp8(
             op(*inputs)
         return
     test.check(op, *inputs, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.smoke
+def test_gemm_fp8_block128_single_k_block_uses_block_kernel() -> None:
+    test = GemmFp8Test(128, 256, 128, torch.float8_e4m3fn, "block128")
+    op = GemmFp8Op()
+    test.check(op, *test.gen_inputs(), atol=2e-2, rtol=2e-2)
+    assert op.kernel.__class__.__name__ == "GemmFp8BlockScaledKernel"
+
+
+@pytest.mark.smoke
+def test_gemm_fp8_rejects_unsupported_scale_grids() -> None:
+    m, n, k = 128, 256, 256
+    test = GemmFp8Test(m, n, k, torch.float8_e4m3fn, "per_tensor")
+    a, b, _, _ = test.gen_inputs()
+    op = GemmFp8Op()
+
+    with pytest.raises(ValueError, match="supports scale shapes"):
+        op(
+            a,
+            b,
+            torch.ones((1, k // 128), device="cuda", dtype=torch.float32),
+            torch.ones((1, k // 128), device="cuda", dtype=torch.float32),
+        )
+
+    with pytest.raises(ValueError, match="supports scale shapes"):
+        op(
+            a,
+            b,
+            torch.ones((m, 1), device="cuda", dtype=torch.float32),
+            torch.ones((n, 1), device="cuda", dtype=torch.float32),
+        )
+
+
+@pytest.mark.smoke
+def test_gemm_fp8_revalidates_cached_signature_dtypes() -> None:
+    test = GemmFp8Test(
+        128,
+        128,
+        128,
+        torch.float8_e4m3fn,
+        "per_tensor",
+        out_dtype=torch.bfloat16,
+        bias=True,
+    )
+    a, b, scale_a, scale_b, bias = test.gen_inputs()
+    op = GemmFp8Op(out_dtype=torch.bfloat16)
+    op(a, b, scale_a, scale_b, bias)
+
+    with pytest.raises(ValueError, match="expects b dtype"):
+        op(a, b.to(torch.float8_e5m2), scale_a, scale_b, bias)
+
+    with pytest.raises(ValueError, match="scale_a and scale_b"):
+        op(a, b, scale_a.to(torch.float16), scale_b, bias)
+
+    with pytest.raises(ValueError, match="expects bias dtype"):
+        op(a, b, scale_a, scale_b, bias.to(torch.float16))
 
 
 @GemvBoundaryFixture

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -62,7 +62,7 @@ from .gated_deltanet_recurrence import (
     GatedDeltaNetDecodeKernel,
     GatedDeltaNetDecodeRawCudaFlaStyleKernel,
 )
-from .gemm import GemmKernel, GemvKernel
+from .gemm import GemmFp8BlockScaledKernel, GemmFp8EpilogueKernel, GemmKernel, GemvKernel
 from .gla import GLABwdKernel, GLAFwdKernel
 from .gla_recurrence import GLADecodeFP32Kernel, GLADecodeKernel
 from .grouped_gemm import GroupedGemmKernel
@@ -144,6 +144,8 @@ __all__ = [
     "GatedDeltaNetDecodeRawCudaFlaStyleKernel",
     "GatedDeltaNetFwdKernel",
     "GatedDeltaNetPrefillFwdKernel",
+    "GemmFp8BlockScaledKernel",
+    "GemmFp8EpilogueKernel",
     "GemmKernel",
     "GemvKernel",
     "GroupConv1dKernel",

--- a/tileops/kernels/gemm.py
+++ b/tileops/kernels/gemm.py
@@ -10,9 +10,270 @@ from tileops.trace import trace
 from tileops.utils import get_sm_version, str2dtype
 
 __all__ = [
+    'GemmFp8BlockScaledKernel',
+    'GemmFp8EpilogueKernel',
     'GemmKernel',
     'GemvKernel',
 ]
+
+class GemmFp8EpilogueKernel(Kernel):
+    """Simple TileLang FP8 GEMM for per-tensor scales."""
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        out_dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.out_dtype = out_dtype
+        self.kernel = _gemm_fp8_kernel(
+            m, n, k, self.dtype_str, self.out_dtype_str, block_scaled=False)
+        self.init_config(config, tune)
+
+    @property
+    def out_dtype_str(self) -> str:
+        return self.dtype_to_str(self.out_dtype)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 128,
+            "block_n": 128,
+            "block_k": 128,
+            "num_stages": 3,
+            "threads": 256,
+        }
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.dtype != torch.float8_e4m3fn:
+            raise NotImplementedError(
+                f"GemmFp8EpilogueKernel only supports torch.float8_e4m3fn, got {self.dtype}")
+        compiled = _gemm_fp8_kernel(
+            self.m, self.n, self.k, self.dtype_str, self.out_dtype_str,
+            block_scaled=False, has_bias=bias is not None)(**self.config)
+        if bias is not None:
+            return compiled(a, b, scale_a, scale_b, bias)
+        return compiled(a, b, scale_a, scale_b)
+
+
+class GemmFp8BlockScaledKernel(Kernel):
+    """Simple TileLang FP8 GEMM for K-block scales."""
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        out_dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.out_dtype = out_dtype
+        self.kernel = _gemm_fp8_kernel(
+            m, n, k, self.dtype_str, self.out_dtype_str, block_scaled=True)
+        self.init_config(config, tune)
+
+    @property
+    def out_dtype_str(self) -> str:
+        return self.dtype_to_str(self.out_dtype)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 128,
+            "block_n": 128,
+            "block_k": 128,
+            "num_stages": 3,
+            "threads": 256,
+        }
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if self.dtype != torch.float8_e4m3fn:
+            raise NotImplementedError(
+                f"GemmFp8BlockScaledKernel only supports torch.float8_e4m3fn, got {self.dtype}")
+        compiled = _gemm_fp8_kernel(
+            self.m, self.n, self.k, self.dtype_str, self.out_dtype_str,
+            block_scaled=True, has_bias=bias is not None)(**self.config)
+        if bias is not None:
+            return compiled(a, b, scale_a, scale_b, bias)
+        return compiled(a, b, scale_a, scale_b)
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_fp8_kernel(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    block_scaled: bool,
+    has_bias: bool = False,
+) -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _gemm_fp8_func(
+        block_m: int = 128,
+        block_n: int = 128,
+        block_k: int = 128,
+        num_stages: int = 3,
+        threads: int = 256,
+    ) -> Callable:
+        scale_k = (k + 127) // 128 if block_scaled else 1
+        scale_a_shape = (m, scale_k) if block_scaled else (1, 1)
+        scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
+
+        @T.prim_func
+        def _gemm_fp8_main(
+            a: T.Tensor((m, k), dtype),  # type: ignore
+            b: T.Tensor((n, k), dtype),  # type: ignore
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            c: T.Tensor((m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(
+                    T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
+                a_shared = T.alloc_shared((block_m, block_k), dtype)
+                b_shared = T.alloc_shared((block_n, block_k), dtype)
+                partial = T.alloc_fragment((block_m, block_n), accum_dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout({
+                    a_shared: tilelang.layout.make_swizzled_layout(a_shared),
+                    b_shared: tilelang.layout.make_swizzled_layout(b_shared),
+                })
+
+                m_start = by * block_m
+                n_start = bx * block_n
+                T.clear(c_local)
+
+                for kk in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
+                    k_start = kk * block_k
+                    for i, j in T.Parallel(block_m, block_k):
+                        a_shared[i, j] = T.if_then_else(
+                            (m_start + i < m) & (k_start + j < k),
+                            a[m_start + i, k_start + j],
+                            T.cast(0, dtype),
+                        )
+                    for i, j in T.Parallel(block_n, block_k):
+                        b_shared[i, j] = T.if_then_else(
+                            (n_start + i < n) & (k_start + j < k),
+                            b[n_start + i, k_start + j],
+                            T.cast(0, dtype),
+                        )
+                    T.clear(partial)
+                    T.gemm(a_shared, b_shared, partial, transpose_B=True,
+                           policy=T.GemmWarpPolicy.FullRow)
+                    for i, j in T.Parallel(block_m, block_n):
+                        if m_start + i < m and n_start + j < n:
+                            if block_scaled:
+                                c_local[i, j] += (
+                                    partial[i, j]
+                                    * scale_a[m_start + i, kk]
+                                    * scale_b[n_start + j, kk]
+                                )
+                            else:
+                                c_local[i, j] += partial[i, j] * scale_a[0, 0] * scale_b[0, 0]
+
+                for i, j in T.Parallel(block_m, block_n):
+                    if m_start + i < m and n_start + j < n:
+                        c[m_start + i, n_start + j] = c_local[i, j]
+
+        @T.prim_func
+        def _gemm_fp8_bias_main(
+            a: T.Tensor((m, k), dtype),  # type: ignore
+            b: T.Tensor((n, k), dtype),  # type: ignore
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            bias: T.Tensor((n,), out_dtype),  # type: ignore
+            c: T.Tensor((m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(
+                    T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
+                a_shared = T.alloc_shared((block_m, block_k), dtype)
+                b_shared = T.alloc_shared((block_n, block_k), dtype)
+                partial = T.alloc_fragment((block_m, block_n), accum_dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout({
+                    a_shared: tilelang.layout.make_swizzled_layout(a_shared),
+                    b_shared: tilelang.layout.make_swizzled_layout(b_shared),
+                })
+
+                m_start = by * block_m
+                n_start = bx * block_n
+                T.clear(c_local)
+
+                for kk in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
+                    k_start = kk * block_k
+                    for i, j in T.Parallel(block_m, block_k):
+                        a_shared[i, j] = T.if_then_else(
+                            (m_start + i < m) & (k_start + j < k),
+                            a[m_start + i, k_start + j],
+                            T.cast(0, dtype),
+                        )
+                    for i, j in T.Parallel(block_n, block_k):
+                        b_shared[i, j] = T.if_then_else(
+                            (n_start + i < n) & (k_start + j < k),
+                            b[n_start + i, k_start + j],
+                            T.cast(0, dtype),
+                        )
+                    T.clear(partial)
+                    T.gemm(a_shared, b_shared, partial, transpose_B=True,
+                           policy=T.GemmWarpPolicy.FullRow)
+                    for i, j in T.Parallel(block_m, block_n):
+                        if m_start + i < m and n_start + j < n:
+                            if block_scaled:
+                                c_local[i, j] += (
+                                    partial[i, j]
+                                    * scale_a[m_start + i, kk]
+                                    * scale_b[n_start + j, kk]
+                                )
+                            else:
+                                c_local[i, j] += partial[i, j] * scale_a[0, 0] * scale_b[0, 0]
+
+                for i, j in T.Parallel(block_m, block_n):
+                    if m_start + i < m and n_start + j < n:
+                        c[m_start + i, n_start + j] = c_local[i, j] + bias[n_start + j]
+
+        return _gemm_fp8_bias_main if has_bias else _gemm_fp8_main
+
+    return _gemm_fp8_func
 
 
 @functools.lru_cache(maxsize=32)

--- a/tileops/kernels/gemm.py
+++ b/tileops/kernels/gemm.py
@@ -154,6 +154,11 @@ def _gemm_fp8_kernel(
         num_stages: int = 3,
         threads: int = 256,
     ) -> Callable:
+        if block_scaled:
+            if block_k > 128:
+                raise ValueError(f"block_k must be <= 128 for block128 scaling, got {block_k}")
+            if 128 % block_k != 0:
+                raise ValueError(f"128 must be divisible by block_k, got {block_k}")
         scale_k = (k + 127) // 128 if block_scaled else 1
         scale_a_shape = (m, scale_k) if block_scaled else (1, 1)
         scale_b_shape = (n, scale_k) if block_scaled else (1, 1)
@@ -170,8 +175,9 @@ def _gemm_fp8_kernel(
                     T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
                 a_shared = T.alloc_shared((block_m, block_k), dtype)
                 b_shared = T.alloc_shared((block_n, block_k), dtype)
-                partial = T.alloc_fragment((block_m, block_n), accum_dtype)
                 c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                if block_scaled:
+                    partial = T.alloc_fragment((block_m, block_n), accum_dtype)
 
                 T.annotate_layout({
                     a_shared: tilelang.layout.make_swizzled_layout(a_shared),
@@ -196,23 +202,30 @@ def _gemm_fp8_kernel(
                             b[n_start + i, k_start + j],
                             T.cast(0, dtype),
                         )
-                    T.clear(partial)
-                    T.gemm(a_shared, b_shared, partial, transpose_B=True,
-                           policy=T.GemmWarpPolicy.FullRow)
-                    for i, j in T.Parallel(block_m, block_n):
-                        if m_start + i < m and n_start + j < n:
-                            if block_scaled:
+                    if block_scaled:
+                        scale_idx = kk * block_k // 128
+                        T.clear(partial)
+                        T.gemm(a_shared, b_shared, partial, transpose_B=True,
+                               policy=T.GemmWarpPolicy.FullRow)
+                        for i, j in T.Parallel(block_m, block_n):
+                            if m_start + i < m and n_start + j < n:
                                 c_local[i, j] += (
                                     partial[i, j]
-                                    * scale_a[m_start + i, kk]
-                                    * scale_b[n_start + j, kk]
+                                    * scale_a[m_start + i, scale_idx]
+                                    * scale_b[n_start + j, scale_idx]
                                 )
-                            else:
-                                c_local[i, j] += partial[i, j] * scale_a[0, 0] * scale_b[0, 0]
+                    else:
+                        T.gemm(a_shared, b_shared, c_local, transpose_B=True,
+                               policy=T.GemmWarpPolicy.FullRow)
 
                 for i, j in T.Parallel(block_m, block_n):
                     if m_start + i < m and n_start + j < n:
-                        c[m_start + i, n_start + j] = c_local[i, j]
+                        if block_scaled:
+                            c[m_start + i, n_start + j] = c_local[i, j]
+                        else:
+                            c[m_start + i, n_start + j] = (
+                                c_local[i, j] * scale_a[0, 0] * scale_b[0, 0]
+                            )
 
         @T.prim_func
         def _gemm_fp8_bias_main(
@@ -227,8 +240,9 @@ def _gemm_fp8_kernel(
                     T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
                 a_shared = T.alloc_shared((block_m, block_k), dtype)
                 b_shared = T.alloc_shared((block_n, block_k), dtype)
-                partial = T.alloc_fragment((block_m, block_n), accum_dtype)
                 c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+                if block_scaled:
+                    partial = T.alloc_fragment((block_m, block_n), accum_dtype)
 
                 T.annotate_layout({
                     a_shared: tilelang.layout.make_swizzled_layout(a_shared),
@@ -253,23 +267,31 @@ def _gemm_fp8_kernel(
                             b[n_start + i, k_start + j],
                             T.cast(0, dtype),
                         )
-                    T.clear(partial)
-                    T.gemm(a_shared, b_shared, partial, transpose_B=True,
-                           policy=T.GemmWarpPolicy.FullRow)
-                    for i, j in T.Parallel(block_m, block_n):
-                        if m_start + i < m and n_start + j < n:
-                            if block_scaled:
+                    if block_scaled:
+                        scale_idx = kk * block_k // 128
+                        T.clear(partial)
+                        T.gemm(a_shared, b_shared, partial, transpose_B=True,
+                               policy=T.GemmWarpPolicy.FullRow)
+                        for i, j in T.Parallel(block_m, block_n):
+                            if m_start + i < m and n_start + j < n:
                                 c_local[i, j] += (
                                     partial[i, j]
-                                    * scale_a[m_start + i, kk]
-                                    * scale_b[n_start + j, kk]
+                                    * scale_a[m_start + i, scale_idx]
+                                    * scale_b[n_start + j, scale_idx]
                                 )
-                            else:
-                                c_local[i, j] += partial[i, j] * scale_a[0, 0] * scale_b[0, 0]
+                    else:
+                        T.gemm(a_shared, b_shared, c_local, transpose_B=True,
+                               policy=T.GemmWarpPolicy.FullRow)
 
                 for i, j in T.Parallel(block_m, block_n):
                     if m_start + i < m and n_start + j < n:
-                        c[m_start + i, n_start + j] = c_local[i, j] + bias[n_start + j]
+                        if block_scaled:
+                            c[m_start + i, n_start + j] = c_local[i, j] + bias[n_start + j]
+                        else:
+                            c[m_start + i, n_start + j] = (
+                                c_local[i, j] * scale_a[0, 0] * scale_b[0, 0]
+                                + bias[n_start + j]
+                            )
 
         return _gemm_fp8_bias_main if has_bias else _gemm_fp8_main
 

--- a/tileops/manifest/gemm.yaml
+++ b/tileops/manifest/gemm.yaml
@@ -70,11 +70,7 @@ GemmFp8Op:
     shape_rules:
     - "a.shape[1] == b.shape[1]"
     - "d.shape == (a.shape[0], b.shape[0])"
-    - "a.shape[0] % scale_a.shape[0] == 0"
-    - "a.shape[1] % scale_a.shape[1] == 0"
-    - "b.shape[0] % scale_b.shape[0] == 0"
-    - "b.shape[1] % scale_b.shape[1] == 0"
-    - "scale_a.shape[1] == scale_b.shape[1]"
+    - "(scale_a.shape == (1, 1) and scale_b.shape == (1, 1)) or (scale_a.shape == (a.shape[0], (a.shape[1] + 127) // 128) and scale_b.shape == (b.shape[0], (a.shape[1] + 127) // 128))"
     - "bias.shape == (b.shape[0],)"
 
   workloads:

--- a/tileops/manifest/gemm.yaml
+++ b/tileops/manifest/gemm.yaml
@@ -51,6 +51,60 @@ GemmOp:
       gemm_kernel: GemmKernel
       gemv_kernel: GemvKernel
 
+GemmFp8Op:
+  ref_api: "torch._scaled_mm"
+  family: gemm
+  status: implemented
+
+  signature:
+    inputs:
+      a: {dtype: "float8_e4m3fn", shape: "[M, K]"}
+      b: {dtype: "same_as(a)", shape: "[N, K]"}
+      scale_a: {dtype: "float32"}
+      scale_b: {dtype: "float32"}
+      bias: {dtype: "bfloat16", shape: "[N]", optional: true}
+    outputs:
+      d: {dtype: "bfloat16 | float16", shape: "[M, N]"}
+    params:
+      out_dtype: {type: dtype, default: bfloat16}
+    shape_rules:
+    - "a.shape[1] == b.shape[1]"
+    - "d.shape == (a.shape[0], b.shape[0])"
+    - "a.shape[0] % scale_a.shape[0] == 0"
+    - "a.shape[1] % scale_a.shape[1] == 0"
+    - "b.shape[0] % scale_b.shape[0] == 0"
+    - "b.shape[1] % scale_b.shape[1] == 0"
+    - "scale_a.shape[1] == scale_b.shape[1]"
+    - "bias.shape == (b.shape[0],)"
+
+  workloads:
+  - {m: 128, n: 2112, k: 7168, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "ds-v3-decode-gate-up-per-tensor"}
+  - {m: 128, n: 7168, k: 2048, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "ds-v3-decode-down-per-tensor"}
+  - {m: 4096, n: 2112, k: 7168, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "ds-v3-prefill-gate-up-per-tensor"}
+  - {m: 4096, n: 7168, k: 2048, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "ds-v3-prefill-down-per-tensor"}
+  - {m: 128, n: 2112, k: 7168, scale_mode: block128, dtypes: [float8_e4m3fn], label: "ds-v3-decode-gate-up-block128"}
+  - {m: 128, n: 7168, k: 2048, scale_mode: block128, dtypes: [float8_e4m3fn], label: "ds-v3-decode-down-block128"}
+  - {m: 4096, n: 2112, k: 7168, scale_mode: block128, dtypes: [float8_e4m3fn], label: "ds-v3-prefill-gate-up-block128"}
+  - {m: 4096, n: 7168, k: 2048, scale_mode: block128, dtypes: [float8_e4m3fn], label: "ds-v3-prefill-down-block128"}
+  - {m: 4096, n: 4096, k: 7168, scale_mode: block128, dtypes: [float8_e4m3fn], label: "ds-v3-prefill-attn-proj-block128"}
+  - {m: 4096, n: 7168, k: 16384, scale_mode: block128, dtypes: [float8_e4m3fn], label: "k-dominant-7168x16384-block128"}
+  - {m: 4096, n: 24576, k: 1536, scale_mode: block128, dtypes: [float8_e4m3fn], label: "wide-n-24576-block128"}
+  - {m: 8, n: 7168, k: 2048, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "small-batch-down-m8-per-tensor"}
+  - {m: 1, n: 7168, k: 2048, scale_mode: per_tensor, dtypes: [float8_e4m3fn], label: "gemv-down-m1-per-tensor"}
+  - {m: 1, n: 7168, k: 2048, scale_mode: block128, dtypes: [float8_e4m3fn], label: "gemv-down-m1-block128"}
+  roofline:
+    func: "tileops.perf.formulas.gemm_fp8_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/gemm.py
+    op: tileops/ops/gemm.py
+    test: tests/ops/test_gemm.py
+    bench: benchmarks/ops/bench_gemm.py
+    bench_manifest_driven: true
+    kernel_map:
+      gemm_fp8_epilogue_kernel: GemmFp8EpilogueKernel
+      gemm_fp8_block_scaled_kernel: GemmFp8BlockScaledKernel
+
 GroupedGemmOp:
   ref_api: "none"
   family: gemm

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -43,7 +43,7 @@ from .gated_deltanet import (
     GatedDeltaNetPrefillFwdOp,
 )
 from .gated_linear_attn import GLADecodeOp
-from .gemm import GemmOp
+from .gemm import GemmFp8Op, GemmOp
 from .gla import GLABwdOp, GLAFwdOp
 from .grouped_gemm import GroupedGemmOp
 from .mamba2_fwd import Mamba2FwdOp
@@ -140,6 +140,7 @@ __all__ = [
     "GLABwdOp",
     "GLADecodeOp",
     "GLAFwdOp",
+    "GemmFp8Op",
     "GemmOp",
     "GroupedQueryAttentionSlidingWindowFwdOp",
     "GroupedQueryAttentionSlidingWindowVarlenFwdOp",

--- a/tileops/ops/gemm.py
+++ b/tileops/ops/gemm.py
@@ -160,9 +160,8 @@ class GemmFp8Op(Op):
     """Dense FP8 NT GEMM, input-inferred.
 
     Public layout is ``a=[M, K]`` and ``b=[N, K]``. ``scale_a`` and
-    ``scale_b`` are 2D scale grids whose shapes encode the scaling
-    granularity. Scales with a singleton K axis use the epilogue path;
-    scales that vary along K use the block-scaled path.
+    ``scale_b`` must be either per-tensor ``(1, 1)`` scales or block128
+    scales with shapes ``(M, ceil(K / 128))`` and ``(N, ceil(K / 128))``.
     """
 
     def __init__(
@@ -181,11 +180,12 @@ class GemmFp8Op(Op):
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[Hashable, Kernel] = {}
         self._active_sig: Optional[tuple] = None
-        self._active: Optional[tuple] = None
+        self._active: Optional[Kernel] = None
         self.m: Optional[int] = None
         self.n: Optional[int] = None
         self.k: Optional[int] = None
         self.dtype: Optional[torch.dtype] = None
+        self.has_bias = False
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -202,8 +202,6 @@ class GemmFp8Op(Op):
         scale_b: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> None:
-        if a.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
-            raise ValueError(f"GemmFp8Op expects FP8 a, got {a.dtype}")
         if a.dtype != torch.float8_e4m3fn:
             raise ValueError(
                 f"GemmFp8Op only supports torch.float8_e4m3fn, got {a.dtype}")
@@ -253,31 +251,44 @@ class GemmFp8Op(Op):
                 f"GemmFp8Op expects 2D scales, got {tuple(scale_a.shape)} and "
                 f"{tuple(scale_b.shape)}"
             )
-        if a.shape[0] % scale_a.shape[0] != 0 or a.shape[1] % scale_a.shape[1] != 0:
+        per_tensor = (tuple(scale_a.shape), tuple(scale_b.shape)) == ((1, 1), (1, 1))
+        scale_k = (k + 127) // 128
+        block128 = (
+            tuple(scale_a.shape) == (m, scale_k)
+            and tuple(scale_b.shape) == (n, scale_k)
+        )
+        if not per_tensor and not block128:
             raise ValueError(
-                f"scale_a shape {tuple(scale_a.shape)} does not tile a shape {tuple(a.shape)}"
-            )
-        if b.shape[0] % scale_b.shape[0] != 0 or b.shape[1] % scale_b.shape[1] != 0:
-            raise ValueError(
-                f"scale_b shape {tuple(scale_b.shape)} does not tile b shape {tuple(b.shape)}"
-            )
-        if scale_a.shape[1] != scale_b.shape[1]:
-            raise ValueError(
-                "GemmFp8Op expects scale_a and scale_b to have the same K-block count, "
-                f"got {scale_a.shape[1]} and {scale_b.shape[1]}"
+                "GemmFp8Op supports scale shapes (1, 1)/(1, 1) or "
+                f"{(m, scale_k)}/{(n, scale_k)}, got "
+                f"{tuple(scale_a.shape)}/{tuple(scale_b.shape)}"
             )
         if bias is not None and tuple(bias.shape) != (n,):
             raise ValueError(f"GemmFp8Op bias must have shape {(n,)}, got {tuple(bias.shape)}")
         return m, n, k
 
-    def _select_mode(self, m: int, n: int, scale_a: torch.Tensor) -> str:
-        if scale_a.shape[1] > 1:
-            return "gemm_fp8_block_scaled"
-        return "gemm_fp8"
+    def _select_kernel_name(
+        self,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        m: int,
+        n: int,
+        k: int,
+    ) -> str:
+        if (tuple(scale_a.shape), tuple(scale_b.shape)) == ((1, 1), (1, 1)):
+            return "gemm_fp8_epilogue_kernel"
+        scale_k = (k + 127) // 128
+        if tuple(scale_a.shape) == (m, scale_k) and tuple(scale_b.shape) == (n, scale_k):
+            return "gemm_fp8_block_scaled_kernel"
+        raise ValueError(
+            "GemmFp8Op supports scale shapes (1, 1)/(1, 1) or "
+            f"{(m, scale_k)}/{(n, scale_k)}, got "
+            f"{tuple(scale_a.shape)}/{tuple(scale_b.shape)}"
+        )
 
     def _get_kernel(
         self,
-        mode: str,
+        kernel_name: str,
         m: int,
         n: int,
         k: int,
@@ -285,12 +296,7 @@ class GemmFp8Op(Op):
         scale_a_shape: Tuple[int, ...],
         scale_b_shape: Tuple[int, ...],
     ) -> Kernel:
-        kernel_name = (
-            "gemm_fp8_block_scaled_kernel"
-            if mode == "gemm_fp8_block_scaled"
-            else "gemm_fp8_epilogue_kernel"
-        )
-        key = (mode, m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype)
+        key = (kernel_name, m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype)
         kernel = self._kernel_cache.get(key)
         if kernel is None:
             kernel = self.kernel_map[kernel_name](
@@ -307,8 +313,16 @@ class GemmFp8Op(Op):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         sig = (
-            a.shape, b.shape, scale_a.shape, scale_b.shape, a.dtype, self.out_dtype,
-            bias.shape if bias is not None else None,
+            a.shape,
+            b.shape,
+            scale_a.shape,
+            scale_b.shape,
+            a.dtype,
+            b.dtype,
+            scale_a.dtype,
+            scale_b.dtype,
+            self.out_dtype,
+            (bias.shape, bias.dtype) if bias is not None else None,
         )
         if sig != self._active_sig:
             self._validate_dtypes(a, b, scale_a, scale_b, bias)
@@ -317,15 +331,15 @@ class GemmFp8Op(Op):
             self.dtype = a.dtype
             self.scale_a_shape = tuple(scale_a.shape)
             self.scale_b_shape = tuple(scale_b.shape)
-            mode = self._select_mode(m, n, scale_a)
+            self.has_bias = bias is not None
+            kernel_name = self._select_kernel_name(scale_a, scale_b, m, n, k)
             kernel = self._get_kernel(
-                mode, m, n, k, a.dtype, tuple(scale_a.shape), tuple(scale_b.shape))
+                kernel_name, m, n, k, a.dtype, tuple(scale_a.shape), tuple(scale_b.shape))
             self.kernel = kernel
-            self._active = (mode, kernel)
+            self._active = kernel
             self._active_sig = sig
 
-        _mode, kernel = self._active
-        return kernel(a, b, scale_a, scale_b, bias)
+        return self._active(a, b, scale_a, scale_b, bias)
 
     def autotune(self) -> None:
         for kernel in self._kernel_cache.values():

--- a/tileops/ops/gemm.py
+++ b/tileops/ops/gemm.py
@@ -2,13 +2,18 @@ from typing import Dict, Hashable, Optional, Tuple
 
 import torch
 
-from tileops.kernels.gemm import GemmKernel, GemvKernel
+from tileops.kernels.gemm import (
+    GemmFp8BlockScaledKernel,
+    GemmFp8EpilogueKernel,
+    GemmKernel,
+    GemvKernel,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import get_sm_version
 
 from .op_base import Op
 
-__all__ = ["GemmOp"]
+__all__ = ["GemmFp8Op", "GemmOp"]
 
 
 class GemmOp(Op):
@@ -147,5 +152,181 @@ class GemmOp(Op):
         direct attributes, so the base ``Op.autotune`` (which scans ``dir(self)``)
         would miss them. Tune each cached kernel instead.
         """
+        for kernel in self._kernel_cache.values():
+            kernel.autotune()
+
+
+class GemmFp8Op(Op):
+    """Dense FP8 NT GEMM, input-inferred.
+
+    Public layout is ``a=[M, K]`` and ``b=[N, K]``. ``scale_a`` and
+    ``scale_b`` are 2D scale grids whose shapes encode the scaling
+    granularity. Scales with a singleton K axis use the epilogue path;
+    scales that vary along K use the block-scaled path.
+    """
+
+    def __init__(
+        self,
+        out_dtype: torch.dtype | str = "bfloat16",
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        if isinstance(out_dtype, str):
+            out_dtype = getattr(torch, out_dtype)
+        if out_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                f"GemmFp8Op outputs torch.float16 or torch.bfloat16, got {out_dtype}")
+        self.out_dtype = out_dtype
+        self._tune = tune
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
+        self._active_sig: Optional[tuple] = None
+        self._active: Optional[tuple] = None
+        self.m: Optional[int] = None
+        self.n: Optional[int] = None
+        self.k: Optional[int] = None
+        self.dtype: Optional[torch.dtype] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "gemm_fp8_epilogue_kernel": GemmFp8EpilogueKernel,
+            "gemm_fp8_block_scaled_kernel": GemmFp8BlockScaledKernel,
+        }
+
+    def _validate_dtypes(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> None:
+        if a.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+            raise ValueError(f"GemmFp8Op expects FP8 a, got {a.dtype}")
+        if a.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"GemmFp8Op only supports torch.float8_e4m3fn, got {a.dtype}")
+        if b.dtype != a.dtype:
+            raise ValueError(f"GemmFp8Op expects b dtype {a.dtype}, got {b.dtype}")
+        if scale_a.dtype != torch.float32 or scale_b.dtype != torch.float32:
+            raise ValueError("GemmFp8Op expects scale_a and scale_b to be torch.float32")
+        out_dtype = getattr(torch, self.out_dtype) if isinstance(self.out_dtype, str) else self.out_dtype
+        if bias is not None and bias.dtype != out_dtype:
+            raise ValueError(
+                f"GemmFp8Op expects bias dtype {out_dtype}, got {bias.dtype}")
+
+    def _infer_mnk(self, a: torch.Tensor, b: torch.Tensor) -> Tuple[int, int, int]:
+        if a.ndim != 2 or b.ndim != 2:
+            raise ValueError(
+                f"GemmFp8Op expects 2D a/b, got a.ndim={a.ndim}, b.ndim={b.ndim}")
+        m, k = a.shape
+        n, k_b = b.shape
+        if k != k_b:
+            raise ValueError(
+                f"FP8 GEMM contraction dim mismatch: a.shape={tuple(a.shape)}, "
+                f"b.shape={tuple(b.shape)}"
+            )
+        return m, n, k
+
+    def _infer_output_shapes(
+        self,
+        a_shape: Tuple[int, ...],
+        b_shape: Tuple[int, ...],
+        scale_a_shape: Tuple[int, ...],
+        scale_b_shape: Tuple[int, ...],
+        bias_shape: Optional[Tuple[int, ...]] = None,
+    ) -> dict[str, Tuple[int, int]]:
+        return {"d": (a_shape[0], b_shape[0])}
+
+    def _validate_shapes(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor],
+    ) -> tuple[int, int, int]:
+        m, n, k = self._infer_mnk(a, b)
+        if scale_a.ndim != 2 or scale_b.ndim != 2:
+            raise ValueError(
+                f"GemmFp8Op expects 2D scales, got {tuple(scale_a.shape)} and "
+                f"{tuple(scale_b.shape)}"
+            )
+        if a.shape[0] % scale_a.shape[0] != 0 or a.shape[1] % scale_a.shape[1] != 0:
+            raise ValueError(
+                f"scale_a shape {tuple(scale_a.shape)} does not tile a shape {tuple(a.shape)}"
+            )
+        if b.shape[0] % scale_b.shape[0] != 0 or b.shape[1] % scale_b.shape[1] != 0:
+            raise ValueError(
+                f"scale_b shape {tuple(scale_b.shape)} does not tile b shape {tuple(b.shape)}"
+            )
+        if scale_a.shape[1] != scale_b.shape[1]:
+            raise ValueError(
+                "GemmFp8Op expects scale_a and scale_b to have the same K-block count, "
+                f"got {scale_a.shape[1]} and {scale_b.shape[1]}"
+            )
+        if bias is not None and tuple(bias.shape) != (n,):
+            raise ValueError(f"GemmFp8Op bias must have shape {(n,)}, got {tuple(bias.shape)}")
+        return m, n, k
+
+    def _select_mode(self, m: int, n: int, scale_a: torch.Tensor) -> str:
+        if scale_a.shape[1] > 1:
+            return "gemm_fp8_block_scaled"
+        return "gemm_fp8"
+
+    def _get_kernel(
+        self,
+        mode: str,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        scale_a_shape: Tuple[int, ...],
+        scale_b_shape: Tuple[int, ...],
+    ) -> Kernel:
+        kernel_name = (
+            "gemm_fp8_block_scaled_kernel"
+            if mode == "gemm_fp8_block_scaled"
+            else "gemm_fp8_epilogue_kernel"
+        )
+        key = (mode, m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map[kernel_name](
+                m, n, k, dtype, self.out_dtype, tune=self._tune)
+            self._kernel_cache[key] = kernel
+        return kernel
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        sig = (
+            a.shape, b.shape, scale_a.shape, scale_b.shape, a.dtype, self.out_dtype,
+            bias.shape if bias is not None else None,
+        )
+        if sig != self._active_sig:
+            self._validate_dtypes(a, b, scale_a, scale_b, bias)
+            m, n, k = self._validate_shapes(a, b, scale_a, scale_b, bias)
+            self.m, self.n, self.k = m, n, k
+            self.dtype = a.dtype
+            self.scale_a_shape = tuple(scale_a.shape)
+            self.scale_b_shape = tuple(scale_b.shape)
+            mode = self._select_mode(m, n, scale_a)
+            kernel = self._get_kernel(
+                mode, m, n, k, a.dtype, tuple(scale_a.shape), tuple(scale_b.shape))
+            self.kernel = kernel
+            self._active = (mode, kernel)
+            self._active_sig = sig
+
+        _mode, kernel = self._active
+        return kernel(a, b, scale_a, scale_b, bias)
+
+    def autotune(self) -> None:
         for kernel in self._kernel_cache.values():
             kernel.autotune()

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -1081,6 +1081,26 @@ def gemm_fwd_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
+def gemm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for dense FP8 ``GemmFp8Op``."""
+    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(
+            "GemmFp8Op.eval_roofline() is valid only after the first forward(); "
+            "m/n/k and dtype are inferred from the inputs."
+        )
+    m, n, k = op.m, op.n, op.k
+    input_bytes = op.dtype.itemsize
+    out_bytes = op.out_dtype.itemsize
+    scale_a_shape = getattr(op, "scale_a_shape", (1, 1))
+    scale_b_shape = getattr(op, "scale_b_shape", (1, 1))
+    scale_elems = scale_a_shape[0] * scale_a_shape[1] + scale_b_shape[0] * scale_b_shape[1]
+    flops = 2 * m * n * k
+    nbytes = (m * k + n * k) * input_bytes + m * n * out_bytes + scale_elems * 4
+    if getattr(op, "has_bias", False):
+        nbytes += n * out_bytes
+    return int(flops), int(nbytes)
+
+
 def grouped_gemm_roofline(op: "Op") -> tuple[int, int]:
     batch_sum = int(op.batch_sum)
     batch_count = int(op.batch_count)

--- a/tileops/utils/__init__.py
+++ b/tileops/utils/__init__.py
@@ -1,6 +1,7 @@
 from .utils import (
     dtype2str,
     ensure_contiguous,
+    expand_fp8_scale,
     get_sm_version,
     is_h200,
     is_hopper,
@@ -12,6 +13,7 @@ from .utils import (
 __all__ = [
     "dtype2str",
     "ensure_contiguous",
+    "expand_fp8_scale",
     "get_sm_version",
     "is_h200",
     "is_hopper",

--- a/tileops/utils/utils.py
+++ b/tileops/utils/utils.py
@@ -69,6 +69,18 @@ def ensure_contiguous(func: callable) -> callable:
     return wrapper
 
 
+def expand_fp8_scale(scale: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    if scale.ndim != 2:
+        raise ValueError(f"FP8 scales must be 2D, got shape {tuple(scale.shape)}")
+    scale_rows, scale_cols = scale.shape
+    if rows % scale_rows != 0 or cols % scale_cols != 0:
+        raise ValueError(
+            f"FP8 scale shape {tuple(scale.shape)} does not tile matrix shape {(rows, cols)}"
+        )
+    return scale.repeat_interleave(rows // scale_rows, dim=0).repeat_interleave(
+        cols // scale_cols, dim=1)
+
+
 def is_hopper():
     return torch.cuda.get_device_capability() == (9, 0)
 

--- a/workloads/gemm.py
+++ b/workloads/gemm.py
@@ -3,7 +3,7 @@ import torch
 from workloads.workload_base import WorkloadBase
 
 
-class GemmTest(WorkloadBase):
+class GemmWorkload(WorkloadBase):
 
     def __init__(self, m: int, n: int, k: int, dtype: torch.dtype, trans_a: bool = False,
                  trans_b: bool = False):
@@ -20,3 +20,48 @@ class GemmTest(WorkloadBase):
         shape_b = (self.n, self.k) if self.trans_b else (self.k, self.n)
         b = torch.randn(*shape_b, device='cuda', dtype=self.dtype)
         return a, b
+
+
+class GemmFp8Workload(WorkloadBase):
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        scale_mode: str,
+        out_dtype: torch.dtype = torch.bfloat16,
+        bias: bool = False,
+    ) -> None:
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.scale_mode = scale_mode
+        self.out_dtype = out_dtype
+        self.bias = bias
+
+    def _scale_shapes(self) -> tuple[tuple[int, int], tuple[int, int]]:
+        if self.scale_mode in ("per_tensor", "tensor"):
+            return (1, 1), (1, 1)
+        if self.scale_mode == "block128":
+            if self.k % 128 != 0:
+                raise ValueError("block128 FP8 workloads require k divisible by 128")
+            return (self.m, self.k // 128), (self.n, self.k // 128)
+        raise ValueError(f"unknown FP8 GEMM scale_mode {self.scale_mode!r}")
+
+    def gen_inputs(self) -> tuple[torch.Tensor, ...]:
+        a = (torch.randn(self.m, self.k, device='cuda') * 0.25).to(self.dtype).contiguous()
+        b = (torch.randn(self.n, self.k, device='cuda') * 0.25).to(self.dtype).contiguous()
+        scale_a_shape, scale_b_shape = self._scale_shapes()
+        scale_a = (
+            0.5 + torch.rand(*scale_a_shape, device='cuda', dtype=torch.float32)
+        ).contiguous()
+        scale_b = (
+            0.5 + torch.rand(*scale_b_shape, device='cuda', dtype=torch.float32)
+        ).contiguous()
+        if self.bias:
+            bias = torch.randn(self.n, device='cuda', dtype=self.out_dtype)
+            return a, b, scale_a, scale_b, bias
+        return a, b, scale_a, scale_b


### PR DESCRIPTION
## Summary

- Add `GemmFp8Op` with per-tensor and block128 scale modes for dense NT FP8 GEMM.
- Add simple TileLang FP8 GEMM kernels: CTA tiles split MN, every CTA loops over full K with a multi-stage `T.Pipelined` K loop.
- Add manifest workloads, roofline accounting, correctness tests, and GEMM FP8 benchmarks against torch-scaled-mm and FlashInfer where available.
- No torch fallback is used in the FP8 kernels; unsupported dtypes fail during validation.

Closes #1653

## Validation

- `ruff check benchmarks/ops/bench_gemm.py tileops/kernels/gemm.py tileops/ops/gemm.py tileops/perf/formulas.py tests/ops/test_gemm.py workloads/gemm.py tileops/utils/utils.py tileops/utils/__init__.py`
- `CUDA_VISIBLE_DEVICES=1 pytest tests/ops/test_gemm.py -q -k gemm_fp8 -s`
- `pytest tests/test_ops_manifest.py tests/test_dtype_codegen.py -q`
- `python scripts/validate_manifest.py`
- `pytest benchmarks/ops/bench_gemm.py --collect-only -q`

## Benchmark

Environment: H200, torch `2.10.0+cu129`, CUDA `12.9`, driver `575.57.08`, GPU clocks locked at 1500 MHz.

Ratios are speedups computed from benchmark latency: `baseline latency / TileOps latency`. Values greater than `1.0x` mean TileOps is faster than that baseline.

| Workload | Scale | TileOps / torch-scaled-mm | TileOps / FlashInfer |
| --- | --- | ---: | ---: |
| 128x2112x7168 | per_tensor | 1.67x | N/A |
| 128x7168x2048 | per_tensor | 9.94x | N/A |
| 4096x2112x7168 | per_tensor | 4.89x | N/A |
| 4096x7168x2048 | per_tensor | 10.15x | N/A |
| 128x2112x7168 | block128 | 0.82x | 0.04x |
| 128x7168x2048 | block128 | 7.38x | 0.24x |
| 4096x2112x7168 | block128 | 2.70x | 0.11x |
| 4096x7168x2048 | block128 | 7.50x | 0.31x |
| 4096x4096x7168 | block128 | 8.23x | 0.26x |
| 4096x7168x16384 | block128 | 7.24x | 0.21x |
| 4096x24576x1536 | block128 | 8.19x | 0.36x |
| 8x7168x2048 | per_tensor | 3.55x | N/A |
| 1x7168x2048 | per_tensor | 2.84x | N/A |
| 1x7168x2048 | block128 | 2.63x | 0.12x |

Note: FlashInfer block128 rows use `flashinfer.gemm.fp8_blockscale_gemm_sm90`. Per-tensor rows are N/A because the available FlashInfer `mm_fp8` path is TRTLLM low-latency specific and did not run reliably for these manifest shapes in this environment.
