### PR TITLE
[Feat][Manifest] Add Linear Attention decode contracts

### DIFF
--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -3,10 +3,14 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import DeltaNetDecodeOp
 from workloads.deltanet import DeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
+
+_OP_NAME = "DeltaNetDecodeOp"
 
 
 def deltanet_decode_torch(
@@ -71,21 +75,14 @@ class DeltaNetDecodeBenchmark(BenchmarkBase[DeltaNetDecodeTest]):
 
 class DeltaNetDecodeBenchFixture(FixtureBase):
     PARAMS = [
-        ("batch, heads, dim_k, dim_v, dtype", [
-            pytest.param(1, 32, 128, 128, torch.float32, marks=pytest.mark.smoke),
-            pytest.param(1, 32, 128, 128, torch.bfloat16, marks=pytest.mark.full),
-            pytest.param(8, 32, 128, 128, torch.float32, marks=pytest.mark.full),
-            pytest.param(8, 32, 128, 128, torch.bfloat16, marks=pytest.mark.full),
-            pytest.param(16, 32, 128, 128, torch.float32, marks=pytest.mark.full),
-            pytest.param(16, 32, 128, 128, torch.bfloat16, marks=pytest.mark.full),
-            pytest.param(32, 32, 128, 128, torch.float32, marks=pytest.mark.full),
-            pytest.param(32, 32, 128, 128, torch.bfloat16, marks=pytest.mark.full),
-            pytest.param(1, 32, 64, 64, torch.float32, marks=pytest.mark.full),
-            pytest.param(8, 32, 64, 64, torch.float32, marks=pytest.mark.full),
-            pytest.param(32, 32, 64, 64, torch.float32, marks=pytest.mark.full),
-            pytest.param(64, 32, 128, 128, torch.float32, marks=pytest.mark.nightly),
-            pytest.param(64, 32, 128, 128, torch.bfloat16, marks=pytest.mark.nightly),
-        ]),
+        (
+            "batch, heads, dim_k, dim_v, dtype, tune",
+            manifest_params(
+                load_workloads(_OP_NAME),
+                lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
+                tune=False,
+            ),
+        ),
     ]
 
 
@@ -96,12 +93,13 @@ def test_deltanet_decode_bench(
     dim_k: int,
     dim_v: int,
     dtype: torch.dtype,
+    tune: bool,
 ) -> None:
     test = _DeltaNetDecodeTestBaseline(batch, heads, dim_k, dim_v, dtype)
-    bm = DeltaNetDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = DeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype)
+    op = DeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -3,10 +3,14 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import GatedDeltaNetDecodeOp
 from workloads.gated_deltanet import GatedDeltaNetDecodeTest
 from workloads.workload_base import FixtureBase
+
+_OP_NAME = "GatedDeltaNetDecodeOp"
 
 
 def gated_deltanet_decode_torch(
@@ -81,21 +85,14 @@ class GatedDeltaNetDecodeBenchmark(BenchmarkBase[GatedDeltaNetDecodeTest]):
 
 class GatedDeltaNetDecodeBenchFixture(FixtureBase):
     PARAMS = [
-        ("batch, heads, dim_k, dim_v, dtype", [
-            (1, 32, 128, 128, torch.float32),
-            (1, 32, 128, 128, torch.bfloat16),
-            (8, 32, 128, 128, torch.float32),
-            (8, 32, 128, 128, torch.bfloat16),
-            (16, 32, 128, 128, torch.float32),
-            (16, 32, 128, 128, torch.bfloat16),
-            (32, 32, 128, 128, torch.float32),
-            (32, 32, 128, 128, torch.bfloat16),
-            (1, 32, 64, 64, torch.float32),
-            (8, 32, 64, 64, torch.float32),
-            (32, 32, 64, 64, torch.float32),
-            (64, 32, 128, 128, torch.float32),
-            (64, 32, 128, 128, torch.bfloat16),
-        ]),
+        (
+            "batch, heads, dim_k, dim_v, dtype, tune",
+            manifest_params(
+                load_workloads(_OP_NAME),
+                lambda w: (w["q_shape"][0], w["q_shape"][1], w["q_shape"][2], w["v_shape"][2]),
+                tune=False,
+            ),
+        ),
     ]
 
 
@@ -106,12 +103,13 @@ def test_gated_deltanet_decode_bench(
     dim_k: int,
     dim_v: int,
     dtype: torch.dtype,
+    tune: bool,
 ) -> None:
     test = _GatedDeltaNetDecodeTestBaseline(batch, heads, dim_k, dim_v, dtype)
-    bm = GatedDeltaNetDecodeBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GatedDeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype)
+    op = GatedDeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -10,10 +10,14 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.ops.attention.manifest_params import manifest_params
+from tileops.manifest import load_workloads
 from tileops.ops import GLADecodeOp
 from workloads.gla import GLADecodeTest
 from workloads.workload_base import FixtureBase
+
+_OP_NAME = "GLADecodeOp"
 
 
 def gla_decode_torch(
@@ -81,24 +85,20 @@ class GLADecodeBenchmark(BenchmarkBase[GLADecodeTest]):
 
 class GLADecodeBenchFixture(FixtureBase):
     PARAMS = [
-        ("batch, heads, dim_k, dim_v, dtype", [
-            (1, 32, 64, 64, torch.float32),
-            (1, 32, 128, 128, torch.float32),
-            (1, 32, 128, 128, torch.float16),
-            (1, 32, 128, 128, torch.bfloat16),
-            (8, 32, 128, 128, torch.float32),
-            (8, 32, 128, 128, torch.float16),
-            (8, 32, 128, 128, torch.bfloat16),
-            (16, 32, 128, 128, torch.float32),
-            (16, 32, 128, 128, torch.float16),
-            (16, 32, 128, 128, torch.bfloat16),
-            (32, 32, 128, 128, torch.float32),
-            (32, 32, 128, 128, torch.float16),
-            (32, 32, 128, 128, torch.bfloat16),
-            (64, 32, 128, 128, torch.float32),
-            (64, 32, 128, 128, torch.float16),
-            (64, 32, 128, 128, torch.bfloat16),
-        ]),
+        (
+            "batch, heads, dim_k, dim_v, scale, dtype, tune",
+            manifest_params(
+                load_workloads(_OP_NAME),
+                lambda w: (
+                    w["q_shape"][0],
+                    w["q_shape"][1],
+                    w["q_shape"][2],
+                    w["v_shape"][2],
+                    w.get("scale", w["q_shape"][2] ** -0.5),
+                ),
+                tune=False,
+            ),
+        ),
     ]
 
 
@@ -108,15 +108,16 @@ def test_gla_decode_bench(
     heads: int,
     dim_k: int,
     dim_v: int,
+    scale: float,
     dtype: torch.dtype,
+    tune: bool,
 ) -> None:
-    scale = dim_k ** -0.5
     test = _GLADecodeTestBaseline(batch, heads, dim_k, dim_v, dtype, scale=scale)
-    bm = GLADecodeBenchmark(test)
     inputs = test.gen_inputs()
 
     # --- TileOPs ---
-    op = GLADecodeOp(batch, heads, dim_k, dim_v, scale=scale, dtype=dtype)
+    op = GLADecodeOp(batch, heads, dim_k, dim_v, scale=scale, dtype=dtype, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -133,5 +133,24 @@ def test_deltanet_decode_multi_step(
         torch.testing.assert_close(state_op, state_ref, **tols)
 
 
+@pytest.mark.smoke
+def test_deltanet_decode_rejects_manifest_shape_mismatch() -> None:
+    op = object.__new__(DeltaNetDecodeOp)
+    op.batch = 2
+    op.heads = 3
+    op.dim_k = 4
+    op.dim_v = 5
+    op.dtype = torch.float32
+
+    q = torch.empty(2, 3, 5)
+    k = torch.empty(2, 3, 4)
+    v = torch.empty(2, 3, 5)
+    beta = torch.empty(2, 3)
+    state = torch.empty(2, 3, 4, 5)
+
+    with pytest.raises(ValueError, match="q must have shape"):
+        op.forward(q, k, v, beta, state)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -231,5 +231,25 @@ def test_gated_deltanet_decode_raw_cuda_dispatch_rejects_unsupported_sm100(
     )
 
 
+@pytest.mark.smoke
+def test_gated_deltanet_decode_rejects_manifest_shape_mismatch() -> None:
+    op = object.__new__(GatedDeltaNetDecodeOp)
+    op.batch = 2
+    op.heads = 3
+    op.dim_k = 4
+    op.dim_v = 5
+    op.dtype = torch.float32
+
+    q = torch.empty(2, 3, 4)
+    k = torch.empty(2, 3, 4)
+    v = torch.empty(2, 3, 5)
+    g = torch.empty(2, 4)
+    beta = torch.empty(2, 3)
+    state = torch.empty(2, 3, 4, 5)
+
+    with pytest.raises(ValueError, match="g must have shape"):
+        op.forward(q, k, v, g, beta, state)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -183,5 +183,25 @@ def test_gla_decode_vs_fla(
     torch.testing.assert_close(s_tile, s_fla.to(dtype), **tols)
 
 
+@pytest.mark.smoke
+def test_gla_decode_rejects_manifest_shape_mismatch() -> None:
+    op = object.__new__(GLADecodeOp)
+    op.batch = 2
+    op.heads = 3
+    op.dim_k = 4
+    op.dim_v = 5
+    op.scale = -1.0
+    op.dtype = torch.float32
+
+    q = torch.empty(2, 3, 4)
+    k = torch.empty(2, 3, 4)
+    v = torch.empty(2, 3, 5)
+    gk = torch.empty(2, 3, 5)
+    state = torch.empty(2, 3, 4, 5)
+
+    with pytest.raises(ValueError, match="gk must have shape"):
+        op.forward(q, k, v, gk, state)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/test_ops_manifest.py
+++ b/tests/test_ops_manifest.py
@@ -212,6 +212,17 @@ class TestSourcePaths:
                 )
 
 
+class TestManifestRegressions:
+    """Focused checks for manifest/code contract bugs caught in review."""
+
+    def test_gdn_decode_manifest_lists_raw_cuda_kernel(self, all_ops):
+        kernel_map = all_ops["GatedDeltaNetDecodeOp"]["source"]["kernel_map"]
+        assert (
+            kernel_map["GatedDeltaNetDecodeRawCudaFlaStyleKernel"]
+            == "GatedDeltaNetDecodeRawCudaFlaStyleKernel"
+        )
+
+
 class TestManifestAPI:
     """Tests for the programmatic manifest API (tileops.manifest)."""
 

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -103,6 +103,7 @@ GatedDeltaNetDecodeOp:
     kernel_map:
       GatedDeltaNetDecodeKernel: GatedDeltaNetDecodeKernel
       GatedDeltaNetDecodeFP32Kernel: GatedDeltaNetDecodeFP32Kernel
+      GatedDeltaNetDecodeRawCudaFlaStyleKernel: GatedDeltaNetDecodeRawCudaFlaStyleKernel
     op: tileops/ops/gated_deltanet.py
     test: tests/ops/test_gated_deltanet_recurrence.py
     bench: benchmarks/ops/bench_gated_deltanet_recurrence.py

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -60,3 +60,337 @@ GatedDeltaNetPrefillFwdOp:
     test: tests/ops/test_gated_deltanet_prefill.py
     bench: benchmarks/ops/bench_gated_deltanet_prefill.py
     bench_manifest_driven: true
+
+GatedDeltaNetDecodeOp:
+  # Single-token serving decode. The input state is read-only from the public
+  # contract perspective; the op returns a fresh new_state tensor.
+  ref_api: "none"
+  family: linear_attention
+  status: implemented
+
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, H]"}
+      beta: {dtype: "same_as(q)", shape: "[B, H]"}
+      state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      new_state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    params: {}
+    shape_rules:
+      - "q.shape == (B, H, DK)"
+      - "k.shape == (B, H, DK)"
+      - "v.shape == (B, H, DV)"
+      - "g.shape == (B, H)"
+      - "beta.shape == (B, H)"
+      - "state.shape == (B, H, DK, DV)"
+      - "o.shape == (B, H, DV)"
+      - "new_state.shape == (B, H, DK, DV)"
+
+  workloads:
+    - {q_shape: [1, 4, 64], k_shape: [1, 4, 64], v_shape: [1, 4, 64], g_shape: [1, 4], beta_shape: [1, 4], state_shape: [1, 4, 64, 64], dtypes: [float16, bfloat16, float32], label: "gdn-decode-smoke-d64"}
+    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], g_shape: [1, 32], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [bfloat16, float32], label: "gdn-decode-b1-h32-d128"}
+    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], g_shape: [8, 32], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [bfloat16, float32], label: "gdn-decode-b8-h32-d128"}
+
+  roofline:
+    func: "tileops.perf.formulas.gated_deltanet_decode_roofline"
+
+  source:
+    kernel: tileops/kernels/gated_deltanet_recurrence.py
+    kernel_map:
+      GatedDeltaNetDecodeKernel: GatedDeltaNetDecodeKernel
+      GatedDeltaNetDecodeFP32Kernel: GatedDeltaNetDecodeFP32Kernel
+    op: tileops/ops/gated_deltanet.py
+    test: tests/ops/test_gated_deltanet_recurrence.py
+    bench: benchmarks/ops/bench_gated_deltanet_recurrence.py
+    bench_manifest_driven: true
+
+DeltaNetDecodeOp:
+  # Single-token ungated DeltaNet decode. Like GDN decode, state ownership is
+  # functional: state is read and new_state is returned.
+  ref_api: "none"
+  family: linear_attention
+  status: implemented
+
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      beta: {dtype: "same_as(q)", shape: "[B, H]"}
+      state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      new_state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    params: {}
+    shape_rules:
+      - "q.shape == (B, H, DK)"
+      - "k.shape == (B, H, DK)"
+      - "v.shape == (B, H, DV)"
+      - "beta.shape == (B, H)"
+      - "state.shape == (B, H, DK, DV)"
+      - "o.shape == (B, H, DV)"
+      - "new_state.shape == (B, H, DK, DV)"
+
+  workloads:
+    - {q_shape: [1, 4, 64], k_shape: [1, 4, 64], v_shape: [1, 4, 64], beta_shape: [1, 4], state_shape: [1, 4, 64, 64], dtypes: [float16, bfloat16, float32], label: "delta-decode-smoke-d64"}
+    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b1-h32-d128"}
+    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b8-h32-d128"}
+
+  roofline:
+    func: "tileops.perf.formulas.deltanet_decode_roofline"
+
+  source:
+    kernel: tileops/kernels/deltanet_recurrence.py
+    kernel_map:
+      DeltaNetDecodeKernel: DeltaNetDecodeKernel
+      DeltaNetDecodeFP32Kernel: DeltaNetDecodeFP32Kernel
+    op: tileops/ops/deltanet_recurrence.py
+    test: tests/ops/test_deltanet_recurrence.py
+    bench: benchmarks/ops/bench_deltanet_recurrence.py
+    bench_manifest_driven: true
+
+GLADecodeOp:
+  # Single-token GLA decode. The scale parameter is semantic and fixed at op
+  # construction; state is returned functionally as new_state.
+  ref_api: "none"
+  family: linear_attention
+  status: implemented
+
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      gk: {dtype: "same_as(q)", shape: "[B, H, DK]"}
+      state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, H, DV]"}
+      new_state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    params:
+      scale: {type: float, default: -1.0}
+    shape_rules:
+      - "q.shape == (B, H, DK)"
+      - "k.shape == (B, H, DK)"
+      - "v.shape == (B, H, DV)"
+      - "gk.shape == (B, H, DK)"
+      - "state.shape == (B, H, DK, DV)"
+      - "o.shape == (B, H, DV)"
+      - "new_state.shape == (B, H, DK, DV)"
+
+  workloads:
+    - {q_shape: [1, 4, 64], k_shape: [1, 4, 64], v_shape: [1, 4, 64], gk_shape: [1, 4, 64], state_shape: [1, 4, 64, 64], scale: 0.125, dtypes: [float16, bfloat16, float32], label: "gla-decode-smoke-d64"}
+    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], gk_shape: [1, 32, 128], state_shape: [1, 32, 128, 128], scale: 0.08838834764831845, dtypes: [float16, bfloat16, float32], label: "gla-decode-b1-h32-d128"}
+    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], gk_shape: [8, 32, 128], state_shape: [8, 32, 128, 128], scale: 0.08838834764831845, dtypes: [float16, bfloat16, float32], label: "gla-decode-b8-h32-d128"}
+
+  roofline:
+    func: "tileops.perf.formulas.gla_decode_roofline"
+
+  source:
+    kernel: tileops/kernels/gla_recurrence.py
+    kernel_map:
+      GLADecodeKernel: GLADecodeKernel
+      GLADecodeFP32Kernel: GLADecodeFP32Kernel
+    op: tileops/ops/gated_linear_attn.py
+    test: tests/ops/test_gla_recurrence.py
+    bench: benchmarks/ops/bench_gla_recurrence.py
+    bench_manifest_driven: true
+
+# The remaining code-present chunkwise/training Linear Attention surfaces are
+# intentionally spec-only for this pass. They expose backward-only artifacts
+# (Aw/Au/w/u/h) or optional initial/final state choices that need a separate
+# release-facing wrapper before they should count as implemented manifest ops.
+
+GatedDeltaNetFwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, S, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, S, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, H, S]"}
+      beta: {dtype: "same_as(q)", shape: "[B, H, S]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+    params:
+      chunk_size: {type: int, default: 64}
+    shape_rules:
+      - "S % chunk_size == 0"
+      - "NC == S // chunk_size"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+    op: tileops/ops/gated_deltanet.py
+    test: tests/ops/test_gated_deltanet_fwd.py
+    bench: benchmarks/ops/bench_gated_deltanet.py
+    bench_manifest_driven: false
+
+GatedDeltaNetBwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      do: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, S, DV]"}
+      q: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      k: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      v: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
+      g: {dtype: "same_as(do)", shape: "[B, H, S]"}
+      beta: {dtype: "same_as(do)", shape: "[B, H, S]"}
+      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+    outputs:
+      dq: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      dk: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      dv: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
+      dg: {dtype: "same_as(do)", shape: "[B, H, S]"}
+      dbeta: {dtype: "same_as(do)", shape: "[B, H, S]"}
+    params:
+      chunk_size: {type: int, default: 64}
+    shape_rules:
+      - "S % chunk_size == 0"
+      - "NC == S // chunk_size"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/gated_deltanet/gated_deltanet_bwd.py
+    op: tileops/ops/gated_deltanet.py
+    test: tests/ops/test_gated_deltanet_chunkwise_bwd.py
+    bench: benchmarks/ops/bench_gated_deltanet.py
+    bench_manifest_driven: false
+
+DeltaNetFwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, S, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, H, S, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      beta: {dtype: "same_as(q)", shape: "[B, H, S]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, H, S, DV]"}
+      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      w: {dtype: "float32", shape: "[B, H, S, DK]"}
+      u: {dtype: "float32", shape: "[B, H, S, DV]"}
+    params:
+      chunk_size: {type: int, default: 64}
+    shape_rules:
+      - "S % chunk_size == 0"
+      - "NC == S // chunk_size"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/deltanet/deltanet_fwd.py
+    op: tileops/ops/deltanet.py
+    test: tests/ops/test_deltanet_fwd.py
+    bench: benchmarks/ops/bench_deltanet.py
+    bench_manifest_driven: false
+
+DeltaNetBwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      do: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, S, DV]"}
+      q: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      k: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      v: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
+      beta: {dtype: "same_as(do)", shape: "[B, H, S]"}
+      S: {dtype: "float32", shape: "[B, H, NC + 1, DK, DV]"}
+      Aw: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      Au: {dtype: "float32", shape: "[B, H, S, chunk_size]"}
+      w: {dtype: "float32", shape: "[B, H, S, DK]"}
+      u: {dtype: "float32", shape: "[B, H, S, DV]"}
+    outputs:
+      dq: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      dk: {dtype: "same_as(do)", shape: "[B, H, S, DK]"}
+      dv: {dtype: "same_as(do)", shape: "[B, H, S, DV]"}
+      dbeta: {dtype: "same_as(do)", shape: "[B, H, S]"}
+    params:
+      chunk_size: {type: int, default: 64}
+    shape_rules:
+      - "S % chunk_size == 0"
+      - "NC == S // chunk_size"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/deltanet/deltanet_bwd.py
+    op: tileops/ops/deltanet.py
+    test: tests/ops/test_deltanet_chunkwise_bwd.py
+    bench: benchmarks/ops/bench_deltanet.py
+    bench_manifest_driven: false
+
+GLAFwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, S, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+    outputs:
+      o: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      final_state: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    params:
+      chunk_size: {type: int, default: 64}
+      scale: {type: float, default: -1.0}
+      output_final_state: {type: bool, default: false}
+    shape_rules:
+      - "S % chunk_size == 0"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/gla/gla_fwd.py
+    op: tileops/ops/gla.py
+    test: tests/ops/test_gla_chunkwise_fwd.py
+    bench: benchmarks/ops/bench_gla_chunkwise.py
+    bench_manifest_driven: false
+
+GLABwdOp:
+  ref_api: "none"
+  family: linear_attention
+  status: spec-only
+  signature:
+    inputs:
+      q: {dtype: "float16 | bfloat16 | float32", shape: "[B, S, H, DK]"}
+      k: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      v: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      g: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      h: {dtype: "float32", shape: "[B, NC + 1, H, DK, DV]"}
+      do: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      dht: {dtype: "same_as(q)", shape: "[B, H, DK, DV]"}
+    outputs:
+      dq: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      dk: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+      dv: {dtype: "same_as(q)", shape: "[B, S, H, DV]"}
+      dg: {dtype: "same_as(q)", shape: "[B, S, H, DK]"}
+    params:
+      chunk_size: {type: int, default: 64}
+      scale: {type: float, default: -1.0}
+      has_initial_state: {type: bool, default: false}
+    shape_rules:
+      - "S % chunk_size == 0"
+      - "NC == S // chunk_size"
+  workloads: []
+  roofline: {flops: 0, bytes: 0}
+  source:
+    kernel: tileops/kernels/gla/gla_bwd.py
+    op: tileops/ops/gla.py
+    test: tests/ops/test_gla_chunkwise_bwd.py
+    bench: benchmarks/ops/bench_gla_chunkwise.py
+    bench_manifest_driven: false

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -93,6 +93,47 @@ class DeltaNetDecodeOp(Op):
             if tensor.dtype != self.dtype:
                 raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
 
+    def _validate_shapes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        q_shape = (self.batch, self.heads, self.dim_k)
+        v_shape = (self.batch, self.heads, self.dim_v)
+        beta_shape = (self.batch, self.heads)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        expected_shapes = (
+            ("q", q, q_shape),
+            ("k", k, q_shape),
+            ("v", v, v_shape),
+            ("beta", beta, beta_shape),
+            ("state", state, state_shape),
+        )
+        for name, tensor, expected in expected_shapes:
+            if tuple(tensor.shape) != expected:
+                raise ValueError(
+                    f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
+                )
+        if not all(tensor.is_cuda for tensor in (q, k, v, beta, state)):
+            raise ValueError("q, k, v, beta, and state must be CUDA tensors")
+
+    def _validate_output_shapes(
+        self,
+        o: torch.Tensor,
+        new_state: torch.Tensor,
+    ) -> None:
+        o_shape = (self.batch, self.heads, self.dim_v)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if tuple(o.shape) != o_shape:
+            raise ValueError(f"o must have shape {o_shape}, got {tuple(o.shape)}")
+        if tuple(new_state.shape) != state_shape:
+            raise ValueError(
+                f"new_state must have shape {state_shape}, got {tuple(new_state.shape)}"
+            )
+
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import deltanet_decode_roofline
 
@@ -107,4 +148,7 @@ class DeltaNetDecodeOp(Op):
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         self._validate_dtypes(q, k, v, beta, state)
-        return self.kernel(q, k, v, beta, state)
+        self._validate_shapes(q, k, v, beta, state)
+        o, new_state = self.kernel(q, k, v, beta, state)
+        self._validate_output_shapes(o, new_state)
+        return o, new_state

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -106,4 +106,5 @@ class DeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self._validate_dtypes(q, k, v, beta, state)
         return self.kernel(q, k, v, beta, state)

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -65,6 +65,39 @@ class DeltaNetDecodeOp(Op):
             "DeltaNetDecodeFP32Kernel": DeltaNetDecodeFP32Kernel,
         }
 
+    def _infer_output_shapes(
+        self,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+        beta_shape: tuple[int, ...],
+        state_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        del k_shape, beta_shape
+        return {
+            "o": (q_shape[0], q_shape[1], v_shape[-1]),
+            "new_state": state_shape,
+        }
+
+    def _validate_dtypes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        for name, tensor in (("q", q), ("k", k), ("v", v), ("beta", beta), ("state", state)):
+            if tensor.dtype != self.dtype:
+                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+
+    def eval_roofline(self) -> tuple[int, int]:
+        from tileops.perf.formulas import deltanet_decode_roofline
+
+        return deltanet_decode_roofline(self)
+
     def forward(
         self,
         q: torch.Tensor,

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -633,4 +633,5 @@ class GatedDeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self._validate_dtypes(q, k, v, g, beta, state)
         return self.kernel(q, k, v, g, beta, state)

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -582,6 +582,48 @@ class GatedDeltaNetDecodeOp(Op):
             )
         return kernels
 
+    def _infer_output_shapes(
+        self,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+        g_shape: tuple[int, ...],
+        beta_shape: tuple[int, ...],
+        state_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        del k_shape, g_shape, beta_shape
+        return {
+            "o": (q_shape[0], q_shape[1], v_shape[-1]),
+            "new_state": state_shape,
+        }
+
+    def _validate_dtypes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        for name, tensor in (
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("g", g),
+            ("beta", beta),
+            ("state", state),
+        ):
+            if tensor.dtype != self.dtype:
+                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+
+    def eval_roofline(self) -> tuple[int, int]:
+        from tileops.perf.formulas import gated_deltanet_decode_roofline
+
+        return gated_deltanet_decode_roofline(self)
+
     def forward(
         self,
         q: torch.Tensor,

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -619,6 +619,49 @@ class GatedDeltaNetDecodeOp(Op):
             if tensor.dtype != self.dtype:
                 raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
 
+    def _validate_shapes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        q_shape = (self.batch, self.heads, self.dim_k)
+        v_shape = (self.batch, self.heads, self.dim_v)
+        gate_shape = (self.batch, self.heads)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        expected_shapes = (
+            ("q", q, q_shape),
+            ("k", k, q_shape),
+            ("v", v, v_shape),
+            ("g", g, gate_shape),
+            ("beta", beta, gate_shape),
+            ("state", state, state_shape),
+        )
+        for name, tensor, expected in expected_shapes:
+            if tuple(tensor.shape) != expected:
+                raise ValueError(
+                    f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
+                )
+        if not all(tensor.is_cuda for tensor in (q, k, v, g, beta, state)):
+            raise ValueError("q, k, v, g, beta, and state must be CUDA tensors")
+
+    def _validate_output_shapes(
+        self,
+        o: torch.Tensor,
+        new_state: torch.Tensor,
+    ) -> None:
+        o_shape = (self.batch, self.heads, self.dim_v)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if tuple(o.shape) != o_shape:
+            raise ValueError(f"o must have shape {o_shape}, got {tuple(o.shape)}")
+        if tuple(new_state.shape) != state_shape:
+            raise ValueError(
+                f"new_state must have shape {state_shape}, got {tuple(new_state.shape)}"
+            )
+
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import gated_deltanet_decode_roofline
 
@@ -634,4 +677,7 @@ class GatedDeltaNetDecodeOp(Op):
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         self._validate_dtypes(q, k, v, g, beta, state)
-        return self.kernel(q, k, v, g, beta, state)
+        self._validate_shapes(q, k, v, g, beta, state)
+        o, new_state = self.kernel(q, k, v, g, beta, state)
+        self._validate_output_shapes(o, new_state)
+        return o, new_state

--- a/tileops/ops/gated_linear_attn.py
+++ b/tileops/ops/gated_linear_attn.py
@@ -92,6 +92,46 @@ class GLADecodeOp(Op):
             if tensor.dtype != self.dtype:
                 raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
 
+    def _validate_shapes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        gk: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        q_shape = (self.batch, self.heads, self.dim_k)
+        v_shape = (self.batch, self.heads, self.dim_v)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        expected_shapes = (
+            ("q", q, q_shape),
+            ("k", k, q_shape),
+            ("v", v, v_shape),
+            ("gk", gk, q_shape),
+            ("state", state, state_shape),
+        )
+        for name, tensor, expected in expected_shapes:
+            if tuple(tensor.shape) != expected:
+                raise ValueError(
+                    f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
+                )
+        if not all(tensor.is_cuda for tensor in (q, k, v, gk, state)):
+            raise ValueError("q, k, v, gk, and state must be CUDA tensors")
+
+    def _validate_output_shapes(
+        self,
+        o: torch.Tensor,
+        new_state: torch.Tensor,
+    ) -> None:
+        o_shape = (self.batch, self.heads, self.dim_v)
+        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if tuple(o.shape) != o_shape:
+            raise ValueError(f"o must have shape {o_shape}, got {tuple(o.shape)}")
+        if tuple(new_state.shape) != state_shape:
+            raise ValueError(
+                f"new_state must have shape {state_shape}, got {tuple(new_state.shape)}"
+            )
+
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import gla_decode_roofline
 
@@ -106,4 +146,7 @@ class GLADecodeOp(Op):
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         self._validate_dtypes(q, k, v, gk, state)
-        return self.kernel(q, k, v, gk, state)
+        self._validate_shapes(q, k, v, gk, state)
+        o, new_state = self.kernel(q, k, v, gk, state)
+        self._validate_output_shapes(o, new_state)
+        return o, new_state

--- a/tileops/ops/gated_linear_attn.py
+++ b/tileops/ops/gated_linear_attn.py
@@ -105,4 +105,5 @@ class GLADecodeOp(Op):
         gk: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self._validate_dtypes(q, k, v, gk, state)
         return self.kernel(q, k, v, gk, state)

--- a/tileops/ops/gated_linear_attn.py
+++ b/tileops/ops/gated_linear_attn.py
@@ -64,6 +64,39 @@ class GLADecodeOp(Op):
             "GLADecodeFP32Kernel": GLADecodeFP32Kernel,
         }
 
+    def _infer_output_shapes(
+        self,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+        gk_shape: tuple[int, ...],
+        state_shape: tuple[int, ...],
+    ) -> dict[str, tuple[int, ...]]:
+        del k_shape, gk_shape
+        return {
+            "o": (q_shape[0], q_shape[1], v_shape[-1]),
+            "new_state": state_shape,
+        }
+
+    def _validate_dtypes(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        gk: torch.Tensor,
+        state: torch.Tensor,
+    ) -> None:
+        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        for name, tensor in (("q", q), ("k", k), ("v", v), ("gk", gk), ("state", state)):
+            if tensor.dtype != self.dtype:
+                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+
+    def eval_roofline(self) -> tuple[int, int]:
+        from tileops.perf.formulas import gla_decode_roofline
+
+        return gla_decode_roofline(self)
+
     def forward(
         self,
         q: torch.Tensor,

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -28,6 +28,7 @@ __all__ = [
     "clamp_min_fwd_roofline",
     "deepseek_dsa_decode_roofline",
     "deepseek_mla_decode_roofline",
+    "deltanet_decode_roofline",
     "div_fwd_roofline",
     "dropout_roofline",
     "engram_decode_roofline",
@@ -39,9 +40,11 @@ __all__ = [
     "fp8_lighting_indexer_roofline",
     "fp8_quant_roofline",
     "fused_moe_fwd_bytes",
+    "gated_deltanet_decode_roofline",
     "gated_deltanet_prefill_fwd_roofline",
     "ge_fwd_roofline",
     "gemm_fwd_roofline",
+    "gla_decode_roofline",
     "gqa_bwd_roofline",
     "gqa_decode_paged_roofline",
     "gqa_decode_roofline",
@@ -282,6 +285,50 @@ def gated_deltanet_prefill_fwd_roofline(op: Any | None = None, **kwargs: Any) ->
     output_elems = batch * heads * seq_len * dim_v + batch * heads * dim_k * dim_v
     nbytes = (input_elems + output_elems) * elem_bytes
     return int(flops), int(nbytes)
+
+
+def _linear_attention_decode_dims(data: dict[str, Any]) -> tuple[int, int, int, int]:
+    if "q_shape" in data:
+        batch, heads, dim_k = data["q_shape"]
+        state_shape = data["state_shape"]
+        _, state_heads, state_dim_k, dim_v = state_shape
+        if state_heads != heads or state_dim_k != dim_k:
+            raise ValueError("decode q_shape and state_shape must share heads and dim_k")
+        return batch, heads, dim_k, dim_v
+    return data["batch"], data["heads"], data["dim_k"], data["dim_v"]
+
+
+def deltanet_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for single-step DeltaNet recurrence decode."""
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, dim_k, dim_v = _linear_attention_decode_dims(data)
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 2 * batch * heads * (3 * dim_k * dim_v + dim_k)
+    nbytes = batch * heads * (2 * dim_k + 2 * dim_v + 1 + 2 * dim_k * dim_v)
+    return int(flops), int(nbytes * elem_bytes)
+
+
+def gated_deltanet_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for single-step Gated DeltaNet recurrence decode."""
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, dim_k, dim_v = _linear_attention_decode_dims(data)
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 2 * batch * heads * (3 * dim_k * dim_v + dim_k)
+    nbytes = batch * heads * (2 * dim_k + 2 * dim_v + 2 + 2 * dim_k * dim_v)
+    return int(flops), int(nbytes * elem_bytes)
+
+
+def gla_decode_roofline(op: Any | None = None, **kwargs: Any) -> tuple[int, int]:
+    """Roofline for single-step GLA recurrence decode."""
+    data = _shape_or_attrs(op, kwargs)
+    batch, heads, dim_k, dim_v = _linear_attention_decode_dims(data)
+    elem_bytes = _dtype_itemsize(data.get("dtype", data.get("dtypes", "float16")))
+
+    flops = 2 * batch * heads * (2 * dim_k * dim_v + dim_k)
+    nbytes = batch * heads * (3 * dim_k + 2 * dim_v + 2 * dim_k * dim_v)
+    return int(flops), int(nbytes * elem_bytes)
 
 
 def gqa_prefill_fp8_tensor_core_roofline(


### PR DESCRIPTION
## Summary

- promote `GatedDeltaNetDecodeOp`, `DeltaNetDecodeOp`, and `GLADecodeOp` into `linear_attention` manifest as implemented stateful decode contracts
- define decode state ownership as functional `state -> new_state` for all three entries
- add decode roofline formulas and op-side shape/dtype/roofline helpers
- switch the corresponding recurrence benchmarks to manifest workloads
- explicitly defer chunkwise/training fwd/bwd surfaces as `spec-only` because they still expose training artifacts or optional state contracts

Closes #1667.

## Validation

Local static checks:

```text
ruff check tileops/perf/formulas.py tileops/ops/deltanet_recurrence.py tileops/ops/gated_linear_attn.py tileops/ops/gated_deltanet.py benchmarks/ops/bench_deltanet_recurrence.py benchmarks/ops/bench_gated_deltanet_recurrence.py benchmarks/ops/bench_gla_recurrence.py
python -m py_compile tileops/perf/formulas.py tileops/ops/deltanet_recurrence.py tileops/ops/gated_linear_attn.py tileops/ops/gated_deltanet.py benchmarks/ops/bench_deltanet_recurrence.py benchmarks/ops/bench_gated_deltanet_recurrence.py benchmarks/ops/bench_gla_recurrence.py
git diff --check
```

TileOpsGov runner image (`ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`, GPU 2):

```text
bash scripts/ci/install_tileops.sh
python3 scripts/validate_manifest.py --strict --levels schema,signature,shape,dtype,bench --check-op GatedDeltaNetDecodeOp
python3 scripts/validate_manifest.py --strict --levels schema,signature,shape,dtype,bench --check-op DeltaNetDecodeOp
python3 scripts/validate_manifest.py --strict --levels schema,signature,shape,dtype,bench --check-op GLADecodeOp
python3 -m pytest -q tests/ops/test_gated_deltanet_recurrence.py tests/ops/test_deltanet_recurrence.py tests/ops/test_gla_recurrence.py -m smoke --tb=short --disable-warnings
python3 -m pytest -q benchmarks/ops/bench_gated_deltanet_recurrence.py benchmarks/ops/bench_deltanet_recurrence.py benchmarks/ops/bench_gla_recurrence.py --collect-only
```

Results:

```text
All targeted strict manifest checks passed.
26 passed, 30 deselected, 14 warnings in 6.40s
23 benchmark tests collected in 4.70s
```
