### PR TITLE
[Feat][BMM] Add FP16 BF16 BMM op

### DIFF
--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -4,9 +4,9 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tests.ops.test_bmm import BmmTest
 from tileops.manifest import load_workloads
 from tileops.ops import BmmFwdOp
-from workloads.bmm import BmmTest
 
 _OP_NAME = "BmmFwdOp"
 
@@ -14,13 +14,6 @@ _DTYPE_MAP = {
     "bfloat16": torch.bfloat16,
     "float16": torch.float16,
 }
-
-
-class _BmmTestBaseline(BmmTest):
-    """Adds baseline ref_program for benchmark profiling."""
-
-    def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        return torch.bmm(a, b)
 
 
 class BmmBenchmark(BenchmarkBase[BmmTest]):
@@ -66,7 +59,7 @@ def _manifest_params() -> list:
 @pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_params())
 def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     dtype = _DTYPE_MAP[dtype_str]
-    test = _BmmTestBaseline(batch, m, n, k, dtype)
+    test = BmmTest(batch, m, n, k, dtype)
     a, b = test.gen_inputs()
 
     op = BmmFwdOp(tune=True)

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -1,0 +1,85 @@
+from typing import Optional
+
+import pytest
+import torch
+
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tileops.manifest import load_workloads
+from tileops.ops import BmmFwdOp
+from workloads.bmm import BmmTest
+
+_OP_NAME = "BmmFwdOp"
+
+_DTYPE_MAP = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+class _BmmTestBaseline(BmmTest):
+    """Adds baseline ref_program for benchmark profiling."""
+
+    def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.bmm(a, b)
+
+
+class BmmBenchmark(BenchmarkBase[BmmTest]):
+    """Reads FLOP/byte counts from the Op's manifest-derived roofline.
+
+    ``BmmFwdOp`` is input-inferred, so ``eval_roofline()`` is valid only
+    after a forward has bound ``batch/m/n/k/dtype``; the benchmark calls it
+    lazily.
+    """
+
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: BmmTest, op: BmmFwdOp):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            flops, mem_bytes = self._op.eval_roofline()
+            self._roofline_cache = (float(flops), float(mem_bytes))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
+def _manifest_params() -> list:
+    """Convert manifest workloads to pytest params (batch, m, n, k, dtype)."""
+    params = []
+    for w in load_workloads(_OP_NAME):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["b"], w["m"], w["n"], w["k"], dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+@pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_params())
+def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    test = _BmmTestBaseline(batch, m, n, k, dtype)
+    a, b = test.gen_inputs()
+
+    op = BmmFwdOp(tune=True)
+    bm = BmmBenchmark(test, op)
+
+    # eval_roofline() is read lazily after profiling, by which point
+    # forward() has bound the dims.
+    result = bm.profile(op, a, b)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, a, b)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -3,10 +3,10 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import BmmFwdOp
-from workloads.bmm import BmmTest as _BmmTestWorkload
+from workloads.bmm import BmmWorkload
 
 
-class BmmTest(_BmmTestWorkload, TestBase):
+class BmmTest(BmmWorkload, TestBase):
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return torch.bmm(a, b)
 

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -1,0 +1,124 @@
+import pytest
+import torch
+
+from tests.test_base import FixtureBase, TestBase
+from tileops.ops import BmmFwdOp
+from workloads.bmm import BmmTest as _BmmTestWorkload
+
+
+class BmmTest(_BmmTestWorkload, TestBase):
+    def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.bmm(a, b)
+
+
+class BmmFixture(FixtureBase):
+    PARAMS = [
+        ("batch, m, n, k, dtype, tune", [
+            pytest.param(
+                4, 128, 128, 128, torch.float16, False,
+                marks=[pytest.mark.smoke, pytest.mark.packaging],
+                id="smoke-fp16-b4-128",
+            ),
+            pytest.param(
+                4, 128, 128, 128, torch.bfloat16, False,
+                marks=pytest.mark.smoke,
+                id="smoke-bf16-b4-128",
+            ),
+            pytest.param(
+                8, 512, 512, 512, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b8-512",
+            ),
+            pytest.param(
+                8, 512, 512, 512, torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-bf16-b8-512",
+            ),
+            pytest.param(
+                16, 256, 256, 256, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b16-256",
+            ),
+            pytest.param(
+                1, 1024, 1024, 1024, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b1-1k",
+            ),
+            pytest.param(
+                32, 128, 512, 128, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b32-mha-qk",
+            ),
+            pytest.param(
+                8, 128, 128, 2048, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b8-mha-pv",
+            ),
+            pytest.param(
+                8, 128, 128, 2048, torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-bf16-b8-mha-pv",
+            ),
+            pytest.param(
+                32, 256, 256, 1024, torch.bfloat16, False,
+                marks=pytest.mark.full,
+                id="full-bf16-b32-moe",
+            ),
+            pytest.param(
+                4, 200, 300, 128, torch.float16, False,
+                marks=pytest.mark.full,
+                id="full-fp16-b4-mn-nonaligned",
+            ),
+        ]),
+    ]
+
+
+@BmmFixture
+def test_bmm(batch: int, m: int, n: int, k: int, dtype: torch.dtype, tune: bool) -> None:
+    test = BmmTest(batch, m, n, k, dtype)
+    op = BmmFwdOp(tune=tune)
+    if dtype == torch.float16:
+        tolerances = {"atol": 1e-3, "rtol": 1e-3}
+    else:
+        tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
+    test.check(op, *test.gen_inputs(), **tolerances)
+
+
+@pytest.mark.smoke
+def test_bmm_batch_mismatch_raises() -> None:
+    op = BmmFwdOp()
+    a = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    b = torch.randn(5, 16, 16, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="batch dim mismatch"):
+        op(a, b)
+
+
+@pytest.mark.smoke
+def test_bmm_contraction_mismatch_raises() -> None:
+    op = BmmFwdOp()
+    a = torch.randn(4, 16, 32, device="cuda", dtype=torch.float16)
+    b = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="contraction dim mismatch"):
+        op(a, b)
+
+
+@pytest.mark.smoke
+def test_bmm_rank_mismatch_raises() -> None:
+    op = BmmFwdOp()
+    a = torch.randn(16, 16, device="cuda", dtype=torch.float16)
+    b = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="strict 3D"):
+        op(a, b)
+
+
+@pytest.mark.smoke
+def test_bmm_dtype_mismatch_raises() -> None:
+    op = BmmFwdOp()
+    a = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    b = torch.randn(4, 16, 16, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError):
+        op(a, b)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -120,5 +120,26 @@ def test_bmm_dtype_mismatch_raises() -> None:
         op(a, b)
 
 
+@pytest.mark.smoke
+def test_bmm_b_dtype_change_after_valid_call_raises() -> None:
+    op = BmmFwdOp()
+    a = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    b_ok = torch.randn(4, 16, 16, device="cuda", dtype=torch.float16)
+    op(a, b_ok)  # populate the fast path
+    b_bad = torch.randn(4, 16, 16, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError):
+        op(a, b_bad)
+
+
+@pytest.mark.smoke
+def test_bmm_k_not_multiple_of_16_raises() -> None:
+    """K must be a multiple of 16 (manifest shape_rules + op precondition)."""
+    op = BmmFwdOp()
+    a = torch.randn(4, 16, 24, device="cuda", dtype=torch.float16)
+    b = torch.randn(4, 24, 16, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="multiple of 16"):
+        op(a, b)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -34,6 +34,7 @@ from .attention import (
     NSATopkVarlenKernel,
     SparseMlaKernel,
 )
+from .bmm import BmmKernel
 from .convolution import (
     Conv1dKernel,
     Conv1dPointwiseKernel,
@@ -96,6 +97,7 @@ __all__ = [
     "BatchNormFwdInferKernel",
     "BatchNormFwdTrainKernel",
     "BinaryKernel",
+    "BmmKernel",
     "Conv1dKernel",
     "Conv1dPointwiseKernel",
     "Conv2d1x1Kernel",

--- a/tileops/kernels/bmm.py
+++ b/tileops/kernels/bmm.py
@@ -138,8 +138,8 @@ def _bmm_wrapped_kernel(
 @_bmm_wrapped_kernel.register_fake
 def _(batch: int, m: int, n: int, k: int, dtype: str, block_m: int, block_n: int,
       block_k: int, num_stages: int, threads: int,
-      *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
-    return torch.empty((batch, m, n), dtype=inputs[0].dtype, device=inputs[0].device)
+      a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return torch.empty((batch, m, n), dtype=a.dtype, device=a.device)
 
 
 class BmmKernel(Kernel):
@@ -162,6 +162,9 @@ class BmmKernel(Kernel):
                  config: Optional[dict] = None,
                  tune: bool = False) -> None:
         super().__init__()
+        if k % 16 != 0:
+            raise ValueError(
+                f"BmmKernel requires contraction dim k to be a multiple of 16, got k={k}")
         self.batch = batch
         self.m = m
         self.n = n
@@ -173,26 +176,33 @@ class BmmKernel(Kernel):
     @property
     def default_config(self) -> dict:
         # 64x64x64, stages=2, 1 warpgroup. Modal winner on H20-3e manifest
+        block_k = 64 if self.k % 64 == 0 else (32 if self.k % 32 == 0 else 16)
         return {
             "block_m": 64,
             "block_n": 64,
-            "block_k": 64,
+            "block_k": block_k,
             "num_stages": 2,
             "threads": 128,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return [
+        block_k_options = [32, 64]
+        if self.k % 32 != 0 and self.k % 16 == 0:
+            block_k_options = [16]
+        configs = [
             {"block_m": bm, "block_n": bn, "block_k": bk,
              "num_stages": ns, "threads": 128}
             for bm in [64, 128]
             for bn in [64, 128]
-            for bk in [32, 64]
+            for bk in block_k_options
             for ns in [2, 3, 4]
         ]
+        return [c for c in configs if self.k % c["block_k"] == 0]
 
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         # Call the compiled JIT directly (cf. GemmKernel); the torch custom-op
         # is retained only for torch.compile compatibility.
-        return self.kernel(**self.config)(a, b)
+        if not hasattr(self, "_compiled_kernel"):
+            self._compiled_kernel = self.kernel(**self.config)
+        return self._compiled_kernel(a, b)

--- a/tileops/kernels/bmm.py
+++ b/tileops/kernels/bmm.py
@@ -1,0 +1,198 @@
+"""Batched GEMM kernel for BmmFwdOp.
+
+Shapes are strict 3D-3D — ``a: [B, M, K]``, ``b: [B, K,N]``, ``c: [B, M, N]``.
+"""
+
+import functools
+from typing import Callable, Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+
+__all__ = ["BmmKernel"] # from tileops.kernels.bmm import *
+
+
+@functools.lru_cache(maxsize=64)
+def _bmm_kernel(batch: int,
+                m: int,
+                n: int,
+                k: int,
+                dtype: str = "float16") -> Callable:
+    """Pipelined batched GEMM for Hopper (SM90).
+
+    Launches a 3D grid ``(ceildiv(n, block_n), ceildiv(m, block_m), batch)``.
+    Each block loads its per-batch A/B tiles into SMEM through a ``T.Pipelined``
+    K-loop and issues WGMMA into a fp32 accumulator; the epilogue guards the
+    M/N tails so ``m``/``n`` need not be multiples of the block sizes.
+
+    Args:
+        batch: Number of independent GEMM problems (grid.z).
+        m: Rows of each ``A[b]`` / ``C[b]``.
+        n: Columns of each ``B[b]`` / ``C[b]``.
+        k: Contraction dim shared across all batches.
+        dtype: Activation / weight dtype string (``"float16"`` or
+            ``"bfloat16"``).
+
+    Returns:
+        A ``@tilelang.jit`` factory; calling it with ``(block_m, block_n,
+        block_k, num_stages, threads)`` returns the compiled ``prim_func``.
+
+    Note:
+        WS pass is hard-disabled (``tl.disable_warp_specialized=True``);
+        a full manifest scan on H20-3e showed it never won a shape.
+    """
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _bmm_func(block_m: int = 128,
+                  block_n: int = 128,
+                  block_k: int = 64,
+                  num_stages: int = 3,
+                  threads: int = 128) -> Callable:
+
+        @T.prim_func
+        def _bmm_main(
+                a: T.Tensor((batch, m, k), dtype),
+                b: T.Tensor((batch, k, n), dtype),
+                c: T.Tensor((batch, m, n), dtype),
+        ) -> None:
+            with T.Kernel(
+                    T.ceildiv(n, block_n),
+                    T.ceildiv(m, block_m),
+                    batch,
+                    threads=threads) as (bx, by, bz):
+                a_smem = T.alloc_shared((block_m, block_k), dtype)
+                b_smem = T.alloc_shared((block_k, block_n), dtype)
+                c_smem = T.alloc_shared((block_m, block_n), dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout({
+                    a_smem: tilelang.layout.make_swizzled_layout(a_smem),
+                    b_smem: tilelang.layout.make_swizzled_layout(b_smem),
+                    c_smem: tilelang.layout.make_swizzled_layout(c_smem),
+                })
+
+                # L2 rasterization: reshape the (bx, by) traversal order into
+                # panels of ``panel_size`` blocks along N so neighbouring waves
+                # reuse the same A/B rows in L2.
+                T.use_swizzle(10, enable=True)
+
+                T.clear(c_local)
+                m_start = by * block_m
+                n_start = bx * block_n
+
+                for ki in T.Pipelined(T.ceildiv(k, block_k), num_stages=num_stages):
+                    k_start = ki * block_k
+                    T.copy(
+                        a[bz, m_start:m_start + block_m, k_start:k_start + block_k],
+                        a_smem,
+                    )
+                    T.copy(
+                        b[bz, k_start:k_start + block_k, n_start:n_start + block_n],
+                        b_smem,
+                    )
+                    T.gemm(a_smem, b_smem, c_local,
+                           policy=T.GemmWarpPolicy.FullRow)
+
+                # Epilogue: stage fp32 accum through SMEM before GMEM store.
+                # 1-19% faster than direct fragment->GMEM — the M/N
+                # tail guard breaks coalescing off the wgmma fragment layout,
+                # but SMEM->GMEM stores stay coalesced under predication.
+                T.copy(c_local, c_smem)
+                for i, j in T.Parallel(block_m, block_n):
+                    if m_start + i < m and n_start + j < n:
+                        c[bz, m_start + i, n_start + j] = c_smem[i, j]
+
+        return _bmm_main
+
+    return _bmm_func
+
+
+@torch.library.custom_op("top::bmm_wrapped_kernel", mutates_args=())
+def _bmm_wrapped_kernel(
+    batch: int,
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_stages: int,
+    threads: int,
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
+    """Torch custom-op wrapper for ``torch.compile`` compatibility."""
+    return _bmm_kernel(batch, m, n, k, dtype)(
+        block_m, block_n, block_k, num_stages, threads)(a, b)
+
+
+@_bmm_wrapped_kernel.register_fake
+def _(batch: int, m: int, n: int, k: int, dtype: str, block_m: int, block_n: int,
+      block_k: int, num_stages: int, threads: int,
+      *inputs: tuple[torch.Tensor, ...]) -> torch.Tensor:
+    return torch.empty((batch, m, n), dtype=inputs[0].dtype, device=inputs[0].device)
+
+
+class BmmKernel(Kernel):
+    """Batched dense GEMM kernel (SM90).
+
+    Computes ``C[b] = A[b] @ B[b]`` for ``b in [0, batch)`` where
+    ``A: [batch, m, k]``, ``B: [batch, k, n]``, ``C: [batch, m, n]``.
+    fp16 / bf16 inputs, fp32 accumulation. Grid maps the batch axis to
+    ``blockIdx.z`` so all batches run in a single kernel launch.
+    """
+
+    supported_archs: list[int] = [90]
+
+    def __init__(self,
+                 batch: int,
+                 m: int,
+                 n: int,
+                 k: int,
+                 dtype: torch.dtype,
+                 config: Optional[dict] = None,
+                 tune: bool = False) -> None:
+        super().__init__()
+        self.batch = batch
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.kernel = _bmm_kernel(batch, m, n, k, self.dtype_str)
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        # 64x64x64, stages=2, 1 warpgroup. Modal winner on H20-3e manifest
+        return {
+            "block_m": 64,
+            "block_n": 64,
+            "block_k": 64,
+            "num_stages": 2,
+            "threads": 128,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": bm, "block_n": bn, "block_k": bk,
+             "num_stages": ns, "threads": 128}
+            for bm in [64, 128]
+            for bn in [64, 128]
+            for bk in [32, 64]
+            for ns in [2, 3, 4]
+        ]
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        # Call the compiled JIT directly (cf. GemmKernel); the torch custom-op
+        # is retained only for torch.compile compatibility.
+        return self.kernel(**self.config)(a, b)

--- a/tileops/manifest/bmm.yaml
+++ b/tileops/manifest/bmm.yaml
@@ -1,0 +1,45 @@
+# Batched GEMM family.
+#
+# BmmFwdOp: strict 3D-3D batched matrix multiplication
+BmmFwdOp:
+  ref_api: "torch.bmm"
+  family: bmm
+  status: implemented
+
+  signature:
+    inputs:
+      a: {dtype: "float16 | bfloat16"}
+      b: {dtype: "same_as(a)"}
+    outputs:
+      d: {dtype: "same_as(a)"}
+    shape_rules:
+    # a: [B, M, K], b: [B, K, N] -> d: [B, M, N]. Batch dim and contraction
+    # dim must match; no broadcasting is performed (this is torch.bmm, not
+    # torch.matmul).
+    - "a.shape[0] == b.shape[0]"
+    - "a.shape[2] == b.shape[1]"
+    - "d.shape == (a.shape[0], a.shape[1], b.shape[2])"
+
+  workloads:
+  # A representative sweep across small/large batch counts and decode/prefill
+  - {b: 8, m: 128, n: 128, k: 128, dtypes: [float16, bfloat16], label: "small-b8-128"}
+  - {b: 8, m: 1024, n: 1024, k: 1024, dtypes: [float16, bfloat16], label: "square-b8-1k"}
+  - {b: 16, m: 512, n: 512, k: 512, dtypes: [float16, bfloat16], label: "square-b16-512"}
+  - {b: 32, m: 256, n: 256, k: 256, dtypes: [float16, bfloat16], label: "square-b32-256"}
+  - {b: 4, m: 4096, n: 4096, k: 4096, dtypes: [bfloat16], label: "square-b4-4k"}
+  - {b: 8, m: 2048, n: 2048, k: 2048, dtypes: [float16, bfloat16], label: "square-b8-2k"}
+  - {b: 64, m: 128, n: 2048, k: 128, dtypes: [float16, bfloat16], label: "mha-decode-b64-qk"}
+  - {b: 64, m: 128, n: 128, k: 2048, dtypes: [float16, bfloat16], label: "mha-decode-b64-pv"}
+  - {b: 128, m: 512, n: 512, k: 2048, dtypes: [bfloat16], label: "moe-prefill-b128"}
+
+  roofline:
+    func: "tileops.perf.formulas.bmm_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/bmm.py
+    op: tileops/ops/bmm.py
+    test: tests/ops/test_bmm.py
+    bench: benchmarks/ops/bench_bmm.py
+    bench_manifest_driven: true
+    kernel_map:
+      bmm_kernel: BmmKernel

--- a/tileops/manifest/bmm.yaml
+++ b/tileops/manifest/bmm.yaml
@@ -18,6 +18,7 @@ BmmFwdOp:
     # torch.matmul).
     - "a.shape[0] == b.shape[0]"
     - "a.shape[2] == b.shape[1]"
+    - "a.shape[2] % 16 == 0"
     - "d.shape == (a.shape[0], a.shape[1], b.shape[2])"
 
   workloads:

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -19,6 +19,7 @@ from .attention import (
     NSAFwdVarlenOp,
     NSATopkVarlenOp,
 )
+from .bmm import BmmFwdOp
 from .convolution import (
     Conv1dBiasFwdOp,
     Conv1dFwdOp,
@@ -113,6 +114,7 @@ __all__ = [
     "AdaLayerNormZeroFwdOp",
     "BatchNormBwdOp",
     "BatchNormFwdOp",
+    "BmmFwdOp",
     "Conv1dBiasFwdOp",
     "Conv1dFwdOp",
     "Conv2dBiasFwdOp",

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -1,0 +1,134 @@
+"""Batched GEMM op (BmmFwdOp).
+
+Strict 3D-3D batched matrix multiplication matching ``torch.bmm``: every
+batch item is an independent GEMM, no broadcasting.
+"""
+
+from typing import Dict, Hashable, Optional, Tuple
+
+import torch
+
+from tileops.kernels.bmm import BmmKernel
+from tileops.kernels.kernel_base import Kernel
+
+from .op_base import Op
+
+__all__ = ["BmmFwdOp"]
+
+
+class BmmFwdOp(Op):
+    """Batched dense GEMM: ``d[i] = a[i] @ b[i]``.
+
+    Input shapes are strict 3D — ``a: [B, M, K]``, ``b: [B, K, N]``,
+    ``d: [B, M, N]``. Batch and contraction dims are checked at
+    ``forward()`` time;  The kernel is compiled on first use for each ``(batch, m, n, k, dtype)`` combo
+    and cached.
+
+    Args:
+        kernel_map: Optional kernel override dict.
+        tune: Whether to autotune (applied when a kernel is first built).
+
+    Example:
+        >>> op = BmmFwdOp()
+        >>> d = op(a, b)                          # a=[B,M,K], b=[B,K,N] -> d=[B,M,N]
+        >>> flops, nbytes = op.eval_roofline()    # valid after the forward
+    """
+
+    def __init__(
+        self,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        self._tune = tune
+        self.dispatch_kernel(kernel_map)
+        # (batch, m, n, k, dtype) -> Kernel instance; built lazily on first use.
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
+        # Fast path: skip re-inference when the input signature is unchanged.
+        self._active_sig: Optional[tuple] = None
+        self._active_kernel: Optional[Kernel] = None
+        # Roofline / dtype bindings, populated on the first forward().
+        self.batch: Optional[int] = None
+        self.m: Optional[int] = None
+        self.n: Optional[int] = None
+        self.k: Optional[int] = None
+        self.dtype: Optional[torch.dtype] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"bmm_kernel": BmmKernel}
+
+    def _infer_bmnk(
+        self, a: torch.Tensor, b: torch.Tensor,
+    ) -> Tuple[int, int, int, int]:
+        """Derive logical ``(batch, m, n, k)`` from ``[B,M,K]`` and ``[B,K,N]``.
+
+        Raises:
+            ValueError: If ranks are wrong, batch dims mismatch, or the
+                k dim disagrees between ``a`` and ``b``.
+        """
+        if a.dim() != 3 or b.dim() != 3:
+            raise ValueError(
+                f"BmmFwdOp expects strict 3D inputs a=[B,M,K] and b=[B,K,N] "
+                f"(got a.shape={tuple(a.shape)}, b.shape={tuple(b.shape)}); "
+            )
+        batch_a, m, k_a = a.shape
+        batch_b, k_b, n = b.shape
+        if batch_a != batch_b:
+            raise ValueError(
+                f"BmmFwdOp batch dim mismatch: a.shape[0]={batch_a} vs "
+                f"b.shape[0]={batch_b}"
+            )
+        if k_a != k_b:
+            raise ValueError(
+                f"BmmFwdOp contraction dim mismatch: a contributes K={k_a}, "
+                f"b contributes K={k_b} (a.shape={tuple(a.shape)}, "
+                f"b.shape={tuple(b.shape)})."
+            )
+        return batch_a, m, n, k_a
+
+    def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
+        """Project onto the dims the kernel actually specializes on."""
+        return (self.batch, self.m, self.n, self.k,
+                None if self.dtype is None else str(self.dtype))
+
+    def _get_kernel(
+        self, batch: int, m: int, n: int, k: int, dtype: torch.dtype,
+    ) -> Kernel:
+        """Return the cached BmmKernel for the given dims, building lazily."""
+        key = (batch, m, n, k, dtype)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["bmm_kernel"](
+                batch, m, n, k, dtype, tune=self._tune)
+            self._kernel_cache[key] = kernel
+        return kernel
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        # Fast path: same input signature as the last call → reuse the already
+        # built/JIT'd kernel directly.
+        sig = (a.shape, b.shape, a.dtype)
+        if sig != self._active_sig:
+            self._validate_dtypes(a, b)
+            batch, m, n, k = self._infer_bmnk(a, b)
+            # Bind dims/dtype for the manifest func-mode roofline.
+            self.batch, self.m, self.n, self.k = batch, m, n, k
+            self.dtype = a.dtype
+            self.a_shape = tuple(a.shape)
+            self.b_shape = tuple(b.shape)
+            kernel = self._get_kernel(batch, m, n, k, a.dtype)
+            # Expose the active kernel so autotune()/introspection can find it.
+            self.kernel = kernel
+            self._active_kernel = kernel
+            self._active_sig = sig
+
+        return self._active_kernel(a, b)
+
+    def autotune(self) -> None:
+        """Autotune every kernel built so far.
+
+        ``BmmFwdOp`` caches kernels lazily in ``self._kernel_cache`` rather
+        than as direct attributes, so the base ``Op.autotune`` (which scans
+        ``dir(self)``) would miss them. Tune each cached kernel instead.
+        """
+        for kernel in self._kernel_cache.values():
+            kernel.autotune()

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -88,6 +88,12 @@ class BmmFwdOp(Op):
 
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
         """Project onto the dims the kernel actually specializes on."""
+        if len(input_shapes) == 2:
+            a_shape, b_shape = input_shapes
+            if len(a_shape) == 3 and len(b_shape) == 3:
+                batch, m, k = a_shape
+                _, _, n = b_shape
+                return (batch, m, n, k, None if self.dtype is None else str(self.dtype))
         return (self.batch, self.m, self.n, self.k,
                 None if self.dtype is None else str(self.dtype))
 

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -84,6 +84,10 @@ class BmmFwdOp(Op):
                 f"b contributes K={k_b} (a.shape={tuple(a.shape)}, "
                 f"b.shape={tuple(b.shape)})."
             )
+        if k_a % 16 != 0:
+            raise ValueError(
+                f"BmmFwdOp requires contraction dim K to be a multiple of 16 "
+                f"(WGMMA alignment; see manifest shape_rules), got K={k_a}")
         return batch_a, m, n, k_a
 
     def _cache_key(self, *input_shapes: Tuple[int, ...]) -> Hashable:
@@ -112,7 +116,7 @@ class BmmFwdOp(Op):
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         # Fast path: same input signature as the last call → reuse the already
         # built/JIT'd kernel directly.
-        sig = (a.shape, b.shape, a.dtype)
+        sig = (a.shape, b.shape, a.dtype, b.dtype)
         if sig != self._active_sig:
             self._validate_dtypes(a, b)
             batch, m, n, k = self._infer_bmnk(a, b)

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -1300,3 +1300,27 @@ def mhc_post_roofline(op: "Op") -> tuple[int, int]:
     x_out_bytes = batch * n_expand * c_x * x_elem
     nbytes = x_layer_out_bytes + h_post_bytes + x_res_bytes + x_out_bytes
     return int(flops), int(nbytes)
+
+def bmm_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for batched GEMM ``BmmFwdOp`` (``d[i] = a[i] @ b[i]``).
+
+    Models ``torch.bmm`` exactly: strict 3D-3D with no broadcasting. Each of
+    the ``B`` batch items is an independent ``(M, K) @ (K, N)`` GEMM whose
+    flops/bytes are ``B``-scaled totals. ``BmmFwdOp`` is input-inferred, so
+    the logical dims ``batch/m/n/k`` and the dtype are bound on the op during
+    ``forward()``; this reads them directly, matching ``gemm_fwd_roofline``'s
+    contract. Valid only after the first ``forward()``.
+
+    Raises:
+        RuntimeError: If called before ``forward()`` has bound the dims.
+    """
+    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(
+            "BmmFwdOp.eval_roofline() is valid only after the first forward(); "
+            "batch/m/n/k and dtype are inferred from the inputs."
+        )
+    batch, m, n, k = op.batch, op.m, op.n, op.k
+    elem_bytes = op.dtype.itemsize
+    flops = 2 * batch * m * n * k
+    nbytes = batch * (m * k + n * k + m * n) * elem_bytes
+    return int(flops), int(nbytes)

--- a/workloads/bmm.py
+++ b/workloads/bmm.py
@@ -1,0 +1,19 @@
+import torch
+
+from workloads.workload_base import WorkloadBase
+
+
+class BmmTest(WorkloadBase):
+    """Workload for batched matmul: a=[B,M,K], b=[B,K,N] -> d=[B,M,N]."""
+
+    def __init__(self, batch: int, m: int, n: int, k: int, dtype: torch.dtype):
+        self.batch = batch
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor, torch.Tensor]:
+        a = torch.randn(self.batch, self.m, self.k, device="cuda", dtype=self.dtype)
+        b = torch.randn(self.batch, self.k, self.n, device="cuda", dtype=self.dtype)
+        return a, b

--- a/workloads/bmm.py
+++ b/workloads/bmm.py
@@ -3,7 +3,7 @@ import torch
 from workloads.workload_base import WorkloadBase
 
 
-class BmmTest(WorkloadBase):
+class BmmWorkload(WorkloadBase):
     """Workload for batched matmul: a=[B,M,K], b=[B,K,N] -> d=[B,M,N]."""
 
     def __init__(self, batch: int, m: int, n: int, k: int, dtype: torch.dtype):


### PR DESCRIPTION
## Summary

- Add `BmmFwdOp` for strict 3D-3D batched matmul (`torch.bmm` semantics, no broadcasting) covering `float16` / `bfloat16`.
- Add a simple TileLang BMM kernel: CTA grid `(ceildiv(N, block_n), ceildiv(M, block_m), B)`, every CTA loops over full K with a multi-stage `T.Pipelined` K loop and FP32 accumulate.
- Add manifest workloads, roofline accounting, correctness tests, and manifest-driven BMM benchmarks against `torch.bmm` (cuBLAS).

#1663 

## Performance (NVIDIA H20-3e)

`pytest benchmarks/ops/bench_bmm.py` — all 16 workloads beat `torch.bmm`, speedup 1.02×–1.20×.
Shape is `[B, M, N, K]`.

| shape                  | dtype       | tileops TFLOPS  | cuBLAS TFLOPS   | speedup       |
| ---------------------- | ----------- | --------------: | --------------: | ------------: |
| [8, 128, 128, 128]     | fp16 / bf16 | 12.60 / 12.69   | 11.93 / 11.89   | 1.06× / 1.07× |
| [8, 1024, 1024, 1024]  | fp16 / bf16 | 134.04 / 134.31 | 129.34 / 129.49 | 1.04× / 1.04× |
| [16, 512, 512, 512]    | fp16 / bf16 | 118.66 / 119.12 | 101.77 / 102.22 | 1.17× / 1.17× |
| [32, 256, 256, 256]    | fp16 / bf16 | 96.50 / 96.64   | 80.39 / 80.38   | 1.20× / 1.20× |
| [4, 4096, 4096, 4096]  | bf16        | 142.14          | 139.56          | 1.02×         |
| [8, 2048, 2048, 2048]  | fp16 / bf16 | 140.69 / 140.83 | 133.84 / 134.13 | 1.05× / 1.05× |
| [64, 128, 2048, 128]   | fp16 / bf16 | 117.56 / 117.65 | 110.62 / 110.27 | 1.06× / 1.07× |
| [64, 128, 128, 2048]   | fp16 / bf16 | 105.67 / 105.84 | 103.52 / 103.88 | 1.02× / 1.02× |
| [128, 512, 512, 2048]  | bf16        | 140.84          | 133.84          | 1.05×         |