### PR TITLE
Fix eager trace pass imports

### DIFF
--- a/tests/trace/test_imports.py
+++ b/tests/trace/test_imports.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_ops_import_does_not_eagerly_load_trace_passes() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not env.get("PYTHONPATH")
+        else f"{repo_root}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    code = r"""
+import builtins
+
+original_import = builtins.__import__
+
+
+def guarded_import(name, *args, **kwargs):
+    if name == "tileops.trace.passes":
+        raise RuntimeError("unexpected eager import of tileops.trace.passes")
+    return original_import(name, *args, **kwargs)
+
+
+builtins.__import__ = guarded_import
+import tileops.ops  # noqa: F401
+
+import sys
+
+assert "tileops.trace.passes" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, cwd=repo_root, env=env)

--- a/tileops/trace/api.py
+++ b/tileops/trace/api.py
@@ -38,7 +38,6 @@ End-to-end::
 
 import os
 
-from . import passes
 from .decode import decode as _decode
 from .markers import (
     DEFAULT_LANE,
@@ -54,6 +53,12 @@ from .record import MAX_EVENTS_DEFAULT
 from .ui import export_timeline_html as _export_timeline_html
 
 __all__ = ["trace"]
+
+
+def _passes():
+    from . import passes
+
+    return passes
 
 
 class _Trace:
@@ -297,7 +302,7 @@ class _Trace:
         Example:
             >>> return trace.lower(main, max_events=1024)
         """
-        return passes.lower(primfunc, max_events=max_events)
+        return _passes().lower(primfunc, max_events=max_events)
 
     def strip(self, primfunc):
         """Primitive: no-op every marker so the kernel compiles without tracing.
@@ -314,7 +319,7 @@ class _Trace:
         Example:
             >>> return trace.strip(main)
         """
-        return passes.strip(primfunc)
+        return _passes().strip(primfunc)
 
     # == Run & export =======================================================
 
@@ -367,7 +372,7 @@ class _Trace:
             >>> *_, slots = compiled(a, b)
             >>> events = trace.decode(compiled, slots)
         """
-        maps = passes.lookup_meta(compiled)
+        maps = _passes().lookup_meta(compiled)
         return _decode(slots, id_to_name=maps["id_to_name"],
                        group_id_to_name=maps["group_id_to_name"],
                        lane_id_to_name=maps["lane_id_to_name"],
@@ -416,7 +421,7 @@ class _Trace:
         Example:
             >>> trace.export_html(events, "timeline.html", compiled=compiled)
         """
-        maps = passes.lookup_meta(compiled)
+        maps = _passes().lookup_meta(compiled)
         _export_timeline_html(events, path, group_id_to_name=maps["group_id_to_name"],
                               lane_id_to_name=maps["lane_id_to_name"],
                               flows=maps["flows"], title=title,


### PR DESCRIPTION
## Summary
- lazily import trace lowering passes from the public trace API
- keep ordinary tileops.ops imports from eager-loading tileops.trace.passes
- add a smoke regression test for the import boundary

Fixes #1669

## Tests
- python -m ruff check tileops/trace/api.py tileops/trace/passes.py tests/trace/test_imports.py
- python -m pytest -q tests/trace/test_imports.py
- docker run --rm --gpus all --ipc host -v /home/ga/TileOPs-issue-1669/TileOPs:/workspace/TileOPs --entrypoint bash ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10 -lc 'cd /workspace/TileOPs && python -m pytest -q tests/trace/test_imports.py tests/trace/test_payload.py'
