### PR TITLE
 [Perf][DELTANET] tile bf16 decode Pass-1 state read through shared memory

### DIFF
--- a/tileops/kernels/deltanet_recurrence.py
+++ b/tileops/kernels/deltanet_recurrence.py
@@ -61,6 +61,7 @@ def _deltanet_decode_tl(
         ):
             with T.Kernel(batch, head, threads=threads) as (bid, hid):
                 h_tile = T.alloc_shared([k_tile, dim_v], dtype)
+                h_tile_o = T.alloc_shared([k_tile, dim_v], dtype)
                 sk_frag = T.alloc_fragment([dim_v], accum_dtype)
                 sq_frag = T.alloc_fragment([dim_v], accum_dtype)
                 v_new = T.alloc_shared([dim_v], accum_dtype)
@@ -74,13 +75,15 @@ def _deltanet_decode_tl(
                 # lower reliably without sacrificing recurrent decode numerics.
                 T.fill(sk_frag, 0.0)
                 T.fill(sq_frag, 0.0)
-                for kk in T.Serial(dim_k):
-                    k_val = T.cast(k[bid, hid, kk], accum_dtype)
-                    q_val = T.cast(q[bid, hid, kk], accum_dtype)
-                    for j in T.Parallel(dim_v):
-                        h_val = T.cast(state[bid, hid, kk, j], accum_dtype)
-                        sk_frag[j] = sk_frag[j] + k_val * h_val
-                        sq_frag[j] = sq_frag[j] + q_val * h_val
+                for kt in T.Pipelined(dim_k // k_tile, num_stages=num_stages):
+                    T.copy(state[bid, hid, kt * k_tile, 0], h_tile_o)
+                    for kk in T.Serial(k_tile):
+                        k_val = T.cast(k[bid, hid, kt * k_tile + kk], accum_dtype)
+                        q_val = T.cast(q[bid, hid, kt * k_tile + kk], accum_dtype)
+                        for j in T.Parallel(dim_v):
+                            h_val = T.cast(h_tile_o[kk, j], accum_dtype)
+                            sk_frag[j] = sk_frag[j] + k_val * h_val
+                            sq_frag[j] = sq_frag[j] + q_val * h_val
 
                 # q . k is a scalar reduction, so keep it separate from the
                 # matvec loop whose inner work is parallelized over dim_v.


### PR DESCRIPTION
## Summary

- Optimize `DeltaNetDecodeKernel` (bf16/fp16) Pass-1 state read: replace scalar per-element global loads of `state` with a tiled `T.copy` into shared memory + `T.Pipelined` async prefetch, mirroring the existing Pass-2 state-update path.
- Uses a separate shared buffer (`h_tile_o`) for Pass 1 — its read layout differs from Pass 2's write layout, so sharing one buffer fails layout inference.
- fp32 kernel (`DeltaNetDecodeFP32Kernel`) untouched; no manifest / test / benchmark changes.

## Test plan

- [x] pre-commit passed (ruff, codespell, gitleaks, mdformat)
- [x] `pytest tests/ops/test_deltanet_recurrence.py` — 14 passed
- [x] `pytest benchmarks/tests` (contract) — 8 passed
- [x] `python scripts/validate_manifest.py` — all checks passed

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.0, PyTorch 2.10.0, TileLang 0.1.11+cuda.git5aaef0fd

### DeltaNetDecodeOp (bf16)

| Shape (b, h, dk, dv) | This PR (ms) | main (ms) | Speedup | BW (TB/s) |
| -------------------- | ------------ | --------- | ------- | --------- |
| (1, 32, 128, 128)    | 0.0094       | 0.0147    | 1.56×   | 0.23      |
| (8, 32, 128, 128)    | 0.0192       | 0.0303    | 1.58×   | 0.89      |
| (16, 32, 128, 128)   | 0.0369       | 0.0592    | 1.60×   | 0.92      |
| (32, 32, 128, 128)   | 0.0719       | 0.1169    | 1.63×   | 0.96      |
| (64, 32, 128, 128)   | 0.1418       | 0.2304    | 1.62×   | 0.96      |

**Command:** `python -m pytest benchmarks/ops/bench_deltanet_recurrence.py -v`