### PR TITLE
[Perf][Linear-Attn] Add DeltaNet decode raw fast path

### DIFF
--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -3,7 +3,10 @@
 import pytest
 import torch
 
+import tileops.ops.deltanet_recurrence as deltanet_ops
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.deltanet_recurrence import DeltaNetDecodeRawCudaFlaStyleKernel
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops import DeltaNetDecodeOp
 from workloads.deltanet import DeltaNetDecodeTest as _DeltaNetDecodeTestWorkload
 
@@ -152,6 +155,228 @@ def test_deltanet_decode_rejects_manifest_shape_mismatch() -> None:
 
     with pytest.raises(ValueError, match="q must have shape"):
         op.forward(q, k, v, beta, state)
+
+
+def _skip_unless_raw_cuda_decode_supported() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for raw DeltaNet decode smoke coverage")
+    try:
+        sm_version = deltanet_ops.get_sm_version()
+    except Exception as exc:
+        pytest.skip(f"could not query CUDA architecture: {exc}")
+    if sm_version not in DeltaNetDecodeRawCudaFlaStyleKernel.supported_archs:
+        pytest.skip(
+            f"raw DeltaNet decode requires SM90, got SM{sm_version}"
+        )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_deltanet_decode_raw_cuda_real_128x128_smoke(dtype: torch.dtype) -> None:
+    """PR smoke must compile and execute the real raw CUDA 128x128 fast path."""
+    _skip_unless_raw_cuda_decode_supported()
+
+    torch.manual_seed(42)
+    test = DeltaNetDecodeTest(2, 4, 128, 128, dtype)
+    op = DeltaNetDecodeOp(2, 4, 128, 128, dtype, tune=False)
+
+    assert isinstance(op.kernel, DeltaNetDecodeRawCudaFlaStyleKernel)
+    test.check(op, *test.gen_inputs(), **_get_tolerances(dtype))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_deltanet_decode_raw_cuda_real_128x128_multi_step_smoke(
+    dtype: torch.dtype,
+) -> None:
+    """PR smoke must exercise raw CUDA state propagation across decode steps."""
+    _skip_unless_raw_cuda_decode_supported()
+
+    torch.manual_seed(42)
+    num_steps = 8
+    B, H, DK, DV = 2, 4, 128, 128
+    op = DeltaNetDecodeOp(B, H, DK, DV, dtype, tune=False)
+    tols = _get_tolerances(dtype)
+
+    assert isinstance(op.kernel, DeltaNetDecodeRawCudaFlaStyleKernel)
+
+    state_op = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
+    state_ref = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
+
+    for _ in range(num_steps):
+        q = torch.randn(B, H, DK, device="cuda", dtype=dtype) * 0.1
+        k = torch.randn(B, H, DK, device="cuda", dtype=dtype) * 0.1
+        v = torch.randn(B, H, DV, device="cuda", dtype=dtype) * 0.1
+        beta = torch.rand(B, H, device="cuda", dtype=dtype) * 0.5
+
+        o_ref, state_ref = deltanet_decode_torch(q, k, v, beta, state_ref)
+        o_ref = o_ref.to(dtype)
+        state_ref = state_ref.to(dtype)
+
+        with torch.no_grad():
+            o_op, state_op = op(q, k, v, beta, state_op)
+
+        torch.testing.assert_close(o_op, o_ref, **tols)
+        torch.testing.assert_close(state_op, state_ref, **tols)
+
+
+class _DispatchMarkerKernel(Kernel):
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+        self.args = args
+        self.kwargs = kwargs
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class _DefaultDispatchKernel(_DispatchMarkerKernel):
+    pass
+
+
+class _FP32DispatchKernel(_DispatchMarkerKernel):
+    pass
+
+
+class _RawDispatchKernel(_DispatchMarkerKernel):
+    pass
+
+
+def _dispatch_kernel_map() -> dict:
+    return {
+        "DeltaNetDecodeKernel": _DefaultDispatchKernel,
+        "DeltaNetDecodeFP32Kernel": _FP32DispatchKernel,
+        "DeltaNetDecodeRawCudaFlaStyleKernel": _RawDispatchKernel,
+    }
+
+
+def _mock_dispatch_arch(monkeypatch, sm_version: int) -> None:
+    monkeypatch.setattr(deltanet_ops, "get_sm_version", lambda: sm_version)
+
+
+@pytest.mark.parametrize(("dtype", "tune"), [
+    pytest.param(torch.float16, False, marks=pytest.mark.smoke, id="smoke-fp16"),
+    pytest.param(torch.bfloat16, False, marks=pytest.mark.smoke, id="smoke-bf16"),
+    pytest.param(torch.bfloat16, True, marks=pytest.mark.full, id="full-bf16-tuned"),
+])
+def test_deltanet_decode_raw_cuda_dispatch_selects_raw_on_supported_sm90(
+    monkeypatch,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    _mock_dispatch_arch(monkeypatch, 90)
+
+    op = DeltaNetDecodeOp(
+        1,
+        32,
+        128,
+        128,
+        dtype=dtype,
+        kernel_map=_dispatch_kernel_map(),
+        tune=tune,
+    )
+
+    assert isinstance(op.kernel, _RawDispatchKernel)
+    assert op.kernel.kwargs["tune"] is tune
+
+
+@pytest.mark.smoke
+def test_deltanet_decode_raw_cuda_dispatch_falls_back_on_unsupported_sm(
+    monkeypatch,
+) -> None:
+    _mock_dispatch_arch(monkeypatch, 80)
+
+    op = DeltaNetDecodeOp(
+        1,
+        32,
+        128,
+        128,
+        dtype=torch.bfloat16,
+        kernel_map=_dispatch_kernel_map(),
+        tune=False,
+    )
+
+    assert isinstance(op.kernel, _DefaultDispatchKernel)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(("dim_k", "dim_v"), [(64, 128), (128, 64)])
+def test_deltanet_decode_raw_cuda_dispatch_falls_back_on_non_128_shapes(
+    monkeypatch,
+    dim_k: int,
+    dim_v: int,
+) -> None:
+    _mock_dispatch_arch(monkeypatch, 90)
+
+    op = DeltaNetDecodeOp(
+        1,
+        32,
+        dim_k,
+        dim_v,
+        dtype=torch.bfloat16,
+        kernel_map=_dispatch_kernel_map(),
+        tune=False,
+    )
+
+    assert isinstance(op.kernel, _DefaultDispatchKernel)
+    assert op.kernel.kwargs["tune"] is False
+
+
+@pytest.mark.smoke
+def test_deltanet_decode_raw_cuda_dispatch_uses_fp32_kernel_for_fp32(
+    monkeypatch,
+) -> None:
+    _mock_dispatch_arch(monkeypatch, 90)
+
+    op = DeltaNetDecodeOp(
+        1,
+        32,
+        128,
+        128,
+        dtype=torch.float32,
+        kernel_map=_dispatch_kernel_map(),
+        tune=False,
+    )
+
+    assert isinstance(op.kernel, _FP32DispatchKernel)
+    assert op.kernel.kwargs["tune"] is False
+
+
+@pytest.mark.smoke
+def test_deltanet_decode_raw_cuda_config_requires_full_warp_mapping() -> None:
+    with pytest.raises(ValueError, match="threads .* must equal raw_group_size \\* v_tile"):
+        DeltaNetDecodeRawCudaFlaStyleKernel(
+            1,
+            32,
+            128,
+            128,
+            dtype="bfloat16",
+            config={
+                "threads": 16,
+                "v_tile": 16,
+                "raw_group_size": 2,
+                "raw_maxrregcount": 146,
+            },
+        )
+
+
+@pytest.mark.smoke
+def test_deltanet_decode_raw_cuda_config_requires_two_lane_group() -> None:
+    with pytest.raises(ValueError, match="raw_group_size must equal 2"):
+        DeltaNetDecodeRawCudaFlaStyleKernel(
+            1,
+            32,
+            128,
+            128,
+            dtype="bfloat16",
+            config={
+                "threads": 32,
+                "v_tile": 8,
+                "raw_group_size": 4,
+                "raw_maxrregcount": 146,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -74,6 +74,8 @@ class DeltaNetDecodeFixture(FixtureBase):
             pytest.param(1, 4, 64, 64, torch.bfloat16, False, marks=pytest.mark.smoke),
             pytest.param(2, 8, 64, 64, torch.float32, False, marks=pytest.mark.full),
             pytest.param(2, 4, 128, 128, torch.float32, False, marks=pytest.mark.full),
+            pytest.param(2, 4, 128, 128, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(2, 4, 128, 128, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(2, 8, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 8, 64, 64, torch.bfloat16, False, marks=pytest.mark.full),
         ]),

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -46,7 +46,11 @@ from .convolution import (
     GroupConv3dKernel,
 )
 from .deltanet import DeltaNetBwdKernel, DeltaNetFwdKernel
-from .deltanet_recurrence import DeltaNetDecodeFP32Kernel, DeltaNetDecodeKernel
+from .deltanet_recurrence import (
+    DeltaNetDecodeFP32Kernel,
+    DeltaNetDecodeKernel,
+    DeltaNetDecodeRawCudaFlaStyleKernel,
+)
 from .dropout import DropoutKernel
 from .elementwise import BinaryKernel, FusedGatedKernel, UnaryKernel
 from .engram import EngramDecodeKernel, EngramGateConvBwdKernel, EngramGateConvFwdKernel
@@ -116,6 +120,7 @@ __all__ = [
     "DeltaNetBwdKernel",
     "DeltaNetDecodeFP32Kernel",
     "DeltaNetDecodeKernel",
+    "DeltaNetDecodeRawCudaFlaStyleKernel",
     "DeltaNetFwdKernel",
     "DropoutKernel",
     "EngramDecodeKernel",

--- a/tileops/kernels/deltanet_recurrence.py
+++ b/tileops/kernels/deltanet_recurrence.py
@@ -450,7 +450,8 @@ class DeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
         from tilelang.profiler import do_bench
 
         best_time = float("inf")
-        best_config = self.default_config
+        best_config: Optional[dict] = None
+        failures: list[str] = []
 
         B, H, DK, DV = self.batch, self.head, self.dim_k, self.dim_v
         torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[self.dtype_str]
@@ -481,8 +482,23 @@ class DeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
                 if t < best_time:
                     best_time = t
                     best_config = config
-            except Exception:
+            except Exception as exc:
+                failures.append(
+                    f"{config}: {type(exc).__name__}: {exc}"
+                )
                 continue
+
+        if failures:
+            print(
+                f"{self.__class__.__name__} skipped {len(failures)} raw autotune "
+                f"candidate(s): {failures}"
+            )
+        if best_config is None:
+            print(
+                f"{self.__class__.__name__} found no successful raw autotune "
+                "candidate; falling back to default config."
+            )
+            best_config = self.default_config
 
         self.config = best_config
         print(f"{self.__class__.__name__} initialized with config: {self.config}")

--- a/tileops/kernels/deltanet_recurrence.py
+++ b/tileops/kernels/deltanet_recurrence.py
@@ -23,9 +23,112 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-__all__ = ["DeltaNetDecodeFP32Kernel", "DeltaNetDecodeKernel"]
+__all__ = [
+    "DeltaNetDecodeFP32Kernel",
+    "DeltaNetDecodeKernel",
+    "DeltaNetDecodeRawCudaFlaStyleKernel",
+]
 
 _DEFAULT_K_TILE = 16
+
+
+@functools.lru_cache(maxsize=32)
+def _deltanet_decode_raw_cuda_flastyle_tl(
+    batch: int,
+    head: int,
+    dim_k: int,
+    dim_v: int,
+    v_tile: int = 16,
+    raw_group_size: int = 2,
+    raw_maxrregcount: int = 146,
+    dtype: str = "bfloat16",
+):
+    if dtype not in ("float16", "bfloat16"):
+        raise ValueError("Raw CUDA DeltaNet decode currently supports float16/bfloat16 only.")
+    if dim_k != 128 or dim_v != 128:
+        raise ValueError("Raw CUDA DeltaNet decode currently requires DK=DV=128.")
+    if dim_v % v_tile != 0:
+        raise ValueError(f"dim_v={dim_v} must be divisible by v_tile={v_tile}")
+    if raw_group_size != 2:
+        raise ValueError("raw_group_size must equal 2 for the fixed two-lane reductions.")
+    if raw_group_size * v_tile != 32:
+        raise ValueError("raw_group_size * v_tile must equal one warp")
+    if dim_k % raw_group_size != 0:
+        raise ValueError(f"dim_k={dim_k} must be divisible by raw_group_size={raw_group_size}")
+
+    total_blocks = batch * head * (dim_v // v_tile)
+    k_chunk = dim_k // raw_group_size
+
+    raw_compile_flags = ["-O3", "-DENABLE_BF16", "--use_fast_math"]
+    if raw_maxrregcount > 0:
+        raw_compile_flags.append(f"--maxrregcount={raw_maxrregcount}")
+
+    @tilelang.jit(
+        out_idx=[-2, -1],
+        compile_flags=raw_compile_flags,
+    )
+    def _decode_func(threads=32):
+        @T.prim_func
+        def deltanet_decode_raw_cuda_flastyle(
+            q: T.Tensor([batch, head, dim_k], dtype),
+            k: T.Tensor([batch, head, dim_k], dtype),
+            v: T.Tensor([batch, head, dim_v], dtype),
+            beta: T.Tensor([batch, head], dtype),
+            state: T.Tensor([batch, head, dim_k, dim_v], dtype),
+            o: T.Tensor([batch, head, dim_v], dtype),
+            new_state: T.Tensor([batch, head, dim_k, dim_v], dtype),
+        ):
+            with T.Kernel(total_blocks, threads=threads) as (block,):
+                tx = T.get_thread_binding()
+                vid = block % (dim_v // v_tile)
+                nh = block // (dim_v // v_tile)
+                bid = nh // head
+                hid = nh - bid * head
+                v_lane = tx // raw_group_size
+                k_rank = tx - v_lane * raw_group_size
+                v_idx = vid * v_tile + v_lane
+                k_begin = k_rank * k_chunk
+
+                k_shared = T.alloc_shared([dim_k], "float32")
+                q_shared = T.alloc_shared([dim_k], "float32")
+                h = T.alloc_local([k_chunk], "float32")
+                old_partial = T.alloc_var("float32", init=0.0)
+                out_partial = T.alloc_var("float32", init=0.0)
+                v_new = T.alloc_var("float32", init=0.0)
+
+                for i in T.serial(T.ceildiv(dim_k, 32)):
+                    kk = tx + i * 32
+                    if kk < dim_k:
+                        k_shared[kk] = T.cast(k[bid, hid, kk], "float32")
+                        q_shared[kk] = T.cast(q[bid, hid, kk], "float32")
+                T.sync_threads()
+
+                beta_val = T.cast(beta[bid, hid], "float32")
+
+                for ii in T.serial(k_chunk):
+                    kk = k_begin + ii
+                    h_val = T.cast(state[bid, hid, kk, v_idx], "float32")
+                    h[ii] = h_val
+                    old_partial += h_val * k_shared[kk]
+
+                old_val = old_partial + T.shfl_down(old_partial, 1, width=raw_group_size)
+                if k_rank == 0:
+                    v_new = beta_val * (T.cast(v[bid, hid, v_idx], "float32") - old_val)
+                v_new = T.shfl_sync(v_new, v_lane * raw_group_size, width=raw_group_size)
+
+                for ii in T.serial(k_chunk):
+                    kk = k_begin + ii
+                    h_new = h[ii] + k_shared[kk] * v_new
+                    new_state[bid, hid, kk, v_idx] = T.cast(h_new, dtype)
+                    out_partial += h_new * q_shared[kk]
+
+                out_val = out_partial + T.shfl_down(out_partial, 1, width=raw_group_size)
+                if k_rank == 0:
+                    o[bid, hid, v_idx] = T.cast(out_val, dtype)
+
+        return deltanet_decode_raw_cuda_flastyle
+
+    return _decode_func
 
 
 @functools.lru_cache(maxsize=32)
@@ -260,6 +363,78 @@ class DeltaNetDecodeKernel(Kernel):
             "num_stages": 2,
             "threads": 128,
             "k_tile": _DEFAULT_K_TILE,
+        }
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self._kernel_fn(q, k, v, beta, state)
+
+
+class DeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
+    """Hopper low-precision decode kernel for the DK=DV=128 DeltaNet case.
+
+    This is the ungated counterpart of the Gated DeltaNet raw fast path. One
+    warp handles one `(batch, head, V tile)`, two lanes cooperate on each
+    output value, and each lane keeps its half of the K dimension live in fp32
+    local storage.
+    """
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        batch: int,
+        head: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: str = "bfloat16",
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ):
+        super().__init__()
+        if tune:
+            raise NotImplementedError("Raw CUDA DeltaNet decode does not autotune.")
+        self.batch = batch
+        self.head = head
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.init_config(config, tune=False)
+        if self.config["raw_group_size"] != 2:
+            raise ValueError(
+                "raw_group_size must equal 2 because this kernel uses fixed "
+                "two-lane shuffle reductions."
+            )
+        required_threads = self.config["raw_group_size"] * self.config["v_tile"]
+        if self.config["threads"] != required_threads:
+            raise ValueError(
+                f"threads ({self.config['threads']}) must equal raw_group_size * v_tile "
+                f"({required_threads}) for the warp-lane mapping used by this kernel."
+            )
+        self._kernel_fn = _deltanet_decode_raw_cuda_flastyle_tl(
+            batch,
+            head,
+            dim_k,
+            dim_v,
+            self.config["v_tile"],
+            self.config["raw_group_size"],
+            self.config["raw_maxrregcount"],
+            self.dtype_str,
+        )(self.config["threads"])
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "threads": 32,
+            "v_tile": 16,
+            "raw_group_size": 2,
+            "raw_maxrregcount": 146,
         }
 
     def forward(

--- a/tileops/kernels/deltanet_recurrence.py
+++ b/tileops/kernels/deltanet_recurrence.py
@@ -398,14 +398,15 @@ class DeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
         tune: bool = False,
     ):
         super().__init__()
-        if tune:
-            raise NotImplementedError("Raw CUDA DeltaNet decode does not autotune.")
         self.batch = batch
         self.head = head
         self.dim_k = dim_k
         self.dim_v = dim_v
         self.dtype = dtype
-        self.init_config(config, tune=False)
+        if tune:
+            self._autotune_raw_cuda()
+        else:
+            self.init_config(config, tune=False)
         if self.config["raw_group_size"] != 2:
             raise ValueError(
                 "raw_group_size must equal 2 because this kernel uses fixed "
@@ -436,6 +437,55 @@ class DeltaNetDecodeRawCudaFlaStyleKernel(Kernel):
             "raw_group_size": 2,
             "raw_maxrregcount": 146,
         }
+
+    @property
+    def raw_autotune_configs(self) -> list[dict]:
+        base = self.default_config
+        return [
+            {**base, "raw_maxrregcount": raw_maxrregcount}
+            for raw_maxrregcount in (0, 128, 132, 146, 160)
+        ]
+
+    def _autotune_raw_cuda(self) -> None:
+        from tilelang.profiler import do_bench
+
+        best_time = float("inf")
+        best_config = self.default_config
+
+        B, H, DK, DV = self.batch, self.head, self.dim_k, self.dim_v
+        torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[self.dtype_str]
+        q = torch.randn(B, H, DK, device="cuda", dtype=torch_dtype)
+        k = torch.randn(B, H, DK, device="cuda", dtype=torch_dtype)
+        v = torch.randn(B, H, DV, device="cuda", dtype=torch_dtype)
+        beta = torch.rand(B, H, device="cuda", dtype=torch_dtype)
+        state = torch.randn(B, H, DK, DV, device="cuda", dtype=torch_dtype)
+
+        print(f"Start autotuning {self.__class__.__name__}...")
+        for config in self.raw_autotune_configs:
+            try:
+                fn = _deltanet_decode_raw_cuda_flastyle_tl(
+                    B,
+                    H,
+                    DK,
+                    DV,
+                    config["v_tile"],
+                    config["raw_group_size"],
+                    config["raw_maxrregcount"],
+                    self.dtype_str,
+                )(config["threads"])
+                t = do_bench(
+                    lambda _fn=fn: _fn(q, k, v, beta, state),
+                    warmup=10,
+                    rep=20,
+                )
+                if t < best_time:
+                    best_time = t
+                    best_config = config
+            except Exception:
+                continue
+
+        self.config = best_config
+        print(f"{self.__class__.__name__} initialized with config: {self.config}")
 
     def forward(
         self,

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -138,14 +138,8 @@ DeltaNetDecodeOp:
 
   workloads:
     - {q_shape: [1, 4, 64], k_shape: [1, 4, 64], v_shape: [1, 4, 64], beta_shape: [1, 4], state_shape: [1, 4, 64, 64], dtypes: [float16, bfloat16, float32], label: "delta-decode-smoke-d64"}
-    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b1-h32-d128"}
-    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b8-h32-d128"}
-    - {q_shape: [16, 32, 128], k_shape: [16, 32, 128], v_shape: [16, 32, 128], beta_shape: [16, 32], state_shape: [16, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b16-h32-d128"}
-    - {q_shape: [32, 32, 128], k_shape: [32, 32, 128], v_shape: [32, 32, 128], beta_shape: [32, 32], state_shape: [32, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b32-h32-d128"}
-    - {q_shape: [1, 32, 64], k_shape: [1, 32, 64], v_shape: [1, 32, 64], beta_shape: [1, 32], state_shape: [1, 32, 64, 64], dtypes: [float32], label: "delta-decode-b1-h32-d64"}
-    - {q_shape: [8, 32, 64], k_shape: [8, 32, 64], v_shape: [8, 32, 64], beta_shape: [8, 32], state_shape: [8, 32, 64, 64], dtypes: [float32], label: "delta-decode-b8-h32-d64"}
-    - {q_shape: [32, 32, 64], k_shape: [32, 32, 64], v_shape: [32, 32, 64], beta_shape: [32, 32], state_shape: [32, 32, 64, 64], dtypes: [float32], label: "delta-decode-b32-h32-d64"}
-    - {q_shape: [64, 32, 128], k_shape: [64, 32, 128], v_shape: [64, 32, 128], beta_shape: [64, 32], state_shape: [64, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b64-h32-d128"}
+    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b1-h32-d128"}
+    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b8-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.deltanet_decode_roofline"

--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -138,8 +138,14 @@ DeltaNetDecodeOp:
 
   workloads:
     - {q_shape: [1, 4, 64], k_shape: [1, 4, 64], v_shape: [1, 4, 64], beta_shape: [1, 4], state_shape: [1, 4, 64, 64], dtypes: [float16, bfloat16, float32], label: "delta-decode-smoke-d64"}
-    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b1-h32-d128"}
-    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [bfloat16, float32], label: "delta-decode-b8-h32-d128"}
+    - {q_shape: [1, 32, 128], k_shape: [1, 32, 128], v_shape: [1, 32, 128], beta_shape: [1, 32], state_shape: [1, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b1-h32-d128"}
+    - {q_shape: [8, 32, 128], k_shape: [8, 32, 128], v_shape: [8, 32, 128], beta_shape: [8, 32], state_shape: [8, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b8-h32-d128"}
+    - {q_shape: [16, 32, 128], k_shape: [16, 32, 128], v_shape: [16, 32, 128], beta_shape: [16, 32], state_shape: [16, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b16-h32-d128"}
+    - {q_shape: [32, 32, 128], k_shape: [32, 32, 128], v_shape: [32, 32, 128], beta_shape: [32, 32], state_shape: [32, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b32-h32-d128"}
+    - {q_shape: [1, 32, 64], k_shape: [1, 32, 64], v_shape: [1, 32, 64], beta_shape: [1, 32], state_shape: [1, 32, 64, 64], dtypes: [float32], label: "delta-decode-b1-h32-d64"}
+    - {q_shape: [8, 32, 64], k_shape: [8, 32, 64], v_shape: [8, 32, 64], beta_shape: [8, 32], state_shape: [8, 32, 64, 64], dtypes: [float32], label: "delta-decode-b8-h32-d64"}
+    - {q_shape: [32, 32, 64], k_shape: [32, 32, 64], v_shape: [32, 32, 64], beta_shape: [32, 32], state_shape: [32, 32, 64, 64], dtypes: [float32], label: "delta-decode-b32-h32-d64"}
+    - {q_shape: [64, 32, 128], k_shape: [64, 32, 128], v_shape: [64, 32, 128], beta_shape: [64, 32], state_shape: [64, 32, 128, 128], dtypes: [float16, bfloat16, float32], label: "delta-decode-b64-h32-d128"}
 
   roofline:
     func: "tileops.perf.formulas.deltanet_decode_roofline"
@@ -149,6 +155,7 @@ DeltaNetDecodeOp:
     kernel_map:
       DeltaNetDecodeKernel: DeltaNetDecodeKernel
       DeltaNetDecodeFP32Kernel: DeltaNetDecodeFP32Kernel
+      DeltaNetDecodeRawCudaFlaStyleKernel: DeltaNetDecodeRawCudaFlaStyleKernel
     op: tileops/ops/deltanet_recurrence.py
     test: tests/ops/test_deltanet_recurrence.py
     bench: benchmarks/ops/bench_deltanet_recurrence.py

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -5,8 +5,10 @@ import torch
 from tileops.kernels.deltanet_recurrence import (
     DeltaNetDecodeFP32Kernel,
     DeltaNetDecodeKernel,
+    DeltaNetDecodeRawCudaFlaStyleKernel,
 )
 from tileops.kernels.kernel_base import Kernel
+from tileops.utils import get_sm_version
 
 from .op_base import Op
 
@@ -28,6 +30,25 @@ class DeltaNetDecodeOp(Op):
     element-wise matvec instead of T.gemm to avoid TF32 mantissa truncation.
     """
 
+    @staticmethod
+    def _raw_cuda_decode_arch_supported() -> bool:
+        try:
+            sm_version = get_sm_version()
+        except Exception:
+            return False
+        return sm_version in DeltaNetDecodeRawCudaFlaStyleKernel.supported_archs
+
+    @staticmethod
+    def _should_use_raw_cuda_decode(
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        tune: bool,
+    ) -> bool:
+        if tune or dtype not in (torch.float16, torch.bfloat16) or dim_k != 128 or dim_v != 128:
+            return False
+        return DeltaNetDecodeOp._raw_cuda_decode_arch_supported()
+
     def __init__(
         self,
         batch: int,
@@ -46,9 +67,14 @@ class DeltaNetDecodeOp(Op):
 
         self.dispatch_kernel(kernel_map)
 
-        # Dispatch: fp32 -> FP32 kernel (no TF32), fp16/bf16 -> TC kernel
+        # Dispatch:
+        #   fp32 -> FP32 kernel (no TF32)
+        #   fp16/bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
+        #   other fp16/bf16 shapes -> default TileLang kernel
         if dtype == torch.float32:
             kernel_cls = self.kernel_map["DeltaNetDecodeFP32Kernel"]
+        elif self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune):
+            kernel_cls = self.kernel_map["DeltaNetDecodeRawCudaFlaStyleKernel"]
         else:
             kernel_cls = self.kernel_map["DeltaNetDecodeKernel"]
         kernel_dtype = Kernel.dtype_to_str(dtype)
@@ -60,10 +86,15 @@ class DeltaNetDecodeOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {
+        kernels = {
             "DeltaNetDecodeKernel": DeltaNetDecodeKernel,
             "DeltaNetDecodeFP32Kernel": DeltaNetDecodeFP32Kernel,
         }
+        if self._raw_cuda_decode_arch_supported():
+            kernels["DeltaNetDecodeRawCudaFlaStyleKernel"] = (
+                DeltaNetDecodeRawCudaFlaStyleKernel
+            )
+        return kernels
 
     def _infer_output_shapes(
         self,

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -45,7 +45,7 @@ class DeltaNetDecodeOp(Op):
         dtype: torch.dtype,
         tune: bool,
     ) -> bool:
-        if tune or dtype not in (torch.float16, torch.bfloat16) or dim_k != 128 or dim_v != 128:
+        if dtype not in (torch.float16, torch.bfloat16) or dim_k != 128 or dim_v != 128:
             return False
         return DeltaNetDecodeOp._raw_cuda_decode_arch_supported()
 
@@ -71,9 +71,10 @@ class DeltaNetDecodeOp(Op):
         #   fp32 -> FP32 kernel (no TF32)
         #   fp16/bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
         #   other fp16/bf16 shapes -> default TileLang kernel
+        use_raw_cuda_decode = self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune)
         if dtype == torch.float32:
             kernel_cls = self.kernel_map["DeltaNetDecodeFP32Kernel"]
-        elif self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune):
+        elif use_raw_cuda_decode:
             kernel_cls = self.kernel_map["DeltaNetDecodeRawCudaFlaStyleKernel"]
         else:
             kernel_cls = self.kernel_map["DeltaNetDecodeKernel"]

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -43,7 +43,6 @@ class DeltaNetDecodeOp(Op):
         dim_k: int,
         dim_v: int,
         dtype: torch.dtype,
-        tune: bool,
     ) -> bool:
         if dtype not in (torch.float16, torch.bfloat16) or dim_k != 128 or dim_v != 128:
             return False
@@ -71,7 +70,7 @@ class DeltaNetDecodeOp(Op):
         #   fp32 -> FP32 kernel (no TF32)
         #   fp16/bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
         #   other fp16/bf16 shapes -> default TileLang kernel
-        use_raw_cuda_decode = self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune)
+        use_raw_cuda_decode = self._should_use_raw_cuda_decode(dim_k, dim_v, dtype)
         if dtype == torch.float32:
             kernel_cls = self.kernel_map["DeltaNetDecodeFP32Kernel"]
         elif use_raw_cuda_decode:


### PR DESCRIPTION
## Summary

- Add a Hopper raw TileLang fast path for `DeltaNetDecodeOp` when `dtype in {fp16, bf16}` and `DK=DV=128`.
- Reuse the Gated DeltaNet decode warp-per-Vtile strategy for the ungated DeltaNet recurrence:
  - one warp handles one `(batch, head, V tile)`
  - `v_tile=16`, `raw_group_size=2`
  - K/Q staged once in shared memory
  - each lane keeps its K slice in fp32 local storage
  - two-lane shuffle reductions produce each output value
- Keep dispatch conservative: fp32 stays on the no-TF32 FP32 kernel; non-128 shapes and non-Hopper devices stay on the existing TileLang fallback.
- Add fp16/bf16 `128x128` raw decode smoke/full coverage without changing manifest-owned workload definitions.

## Benchmark

Environment: H200, `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`, CUDA 12.9 runner stack.

Compared raw fast path against the current generic fallback, which already includes the 2026-07-10 Pass-1 shared-memory state read optimization.

| dtype | shape `(B,H,DK,DV)` | raw (ms) | generic (ms) | speedup |
| --- | ---: | ---: | ---: | ---: |
| fp16 | `(1,32,128,128)` | `0.007456` | `0.015251` | `2.05x` |
| fp16 | `(8,32,128,128)` | `0.013632` | `0.017964` | `1.32x` |
| fp16 | `(32,32,128,128)` | `0.033224` | `0.039338` | `1.18x` |
| bf16 | `(1,32,128,128)` | `0.008390` | `0.015515` | `1.85x` |
| bf16 | `(8,32,128,128)` | `0.013002` | `0.019029` | `1.46x` |
| bf16 | `(32,32,128,128)` | `0.034677` | `0.053997` | `1.56x` |

## Test plan

- [x] pre-commit passed in CI.
- [x] GPU smoke passed: 19 tests.
- [x] Structural readiness passed: manifest validation and benchmark contract tests.
- [x] Test node delta: tests/ops/test_deltanet_recurrence.py 15 -> 32 (+17).

### Verification

All Docker validation used the prebuilt TileOpsGov runner image `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10` as-is, with no tilelang/torch/dependency install or upgrade. The image reports `torch 2.10.0+cu129` and `tilelang 0.1.11+cu129.git65dbc983`.

```bash
python scripts/validate_manifest.py   --levels schema,signature,shape,dtype,bench   --strict   --check-op DeltaNetDecodeOp
```

Result: passed.

```bash
python -m ruff check   tileops/kernels/deltanet_recurrence.py   tileops/ops/deltanet_recurrence.py   tests/ops/test_deltanet_recurrence.py   benchmarks/ops/bench_deltanet_recurrence.py
```

Result: passed.

```bash
git diff --check
```

Result: passed.

```bash
python -m pytest -q benchmarks/tests   tests/test_validate_manifest.py::TestIntegration::test_validator_passes_on_current_codebase   --tb=short -p no:cacheprovider
```

Result: `9 passed`.

```bash
LD_PRELOAD=/lib/x86_64-linux-gnu/libcuda.so.1 python -m pytest -q   tests/ops/test_deltanet_recurrence.py -m smoke --tb=short -s -p no:cacheprovider
```

Result: `19 passed, 13 deselected, 14 warnings`.

```bash
LD_PRELOAD=/lib/x86_64-linux-gnu/libcuda.so.1 python -m pytest -q   tests/ops/test_deltanet_recurrence.py --tb=short -s -p no:cacheprovider
```

Result: `32 passed, 14 warnings`.


