### PR TITLE
[Perf][GLA] tile decode Pass-1 state read through shared memory

### DIFF
--- a/tileops/kernels/gla_recurrence.py
+++ b/tileops/kernels/gla_recurrence.py
@@ -70,6 +70,7 @@ def _gla_decode_tl(
         ):
             with T.Kernel(batch, head, threads=threads) as (bid, hid):
                 h_tile = T.alloc_shared([k_tile, dim_v], dtype)
+                h_tile_o = T.alloc_shared([k_tile, dim_v], dtype)
                 v_shared = T.alloc_shared([dim_v], accum_dtype)
                 sq_frag = T.alloc_fragment([dim_v], accum_dtype)
                 qk_dot = T.alloc_local([1], accum_dtype)
@@ -95,15 +96,17 @@ def _gla_decode_tl(
                 # TODO: restore a tensor-core fast path once fragment copies
                 # lower reliably without sacrificing recurrent decode numerics.
                 T.fill(sq_frag, 0.0)
-                for kk in T.Serial(dim_k):
-                    gk_val = gk_shared[kk]
-                    alpha_i = T.exp2(gk_val * _LOG2E)
-                    q_gated = q_shared[kk] * alpha_i
-                    for j in T.Parallel(dim_v):
-                        sq_frag[j] = (
-                            sq_frag[j]
-                            + q_gated * T.cast(state[bid, hid, kk, j], accum_dtype)
-                        )
+                for kt in T.Pipelined(dim_k // k_tile, num_stages=num_stages):
+                    T.copy(state[bid, hid, kt * k_tile, 0], h_tile_o)
+                    for kk in T.Serial(k_tile):
+                        gk_val = gk_shared[kt * k_tile + kk]
+                        alpha_i = T.exp2(gk_val * _LOG2E)
+                        q_gated = q_shared[kt * k_tile + kk] * alpha_i
+                        for j in T.Parallel(dim_v):
+                            sq_frag[j] = (
+                                sq_frag[j]
+                                + q_gated * T.cast(h_tile_o[kk, j], accum_dtype)
+                            )
 
                 # Keep this scalar reduction separate from the matvec's
                 # dim_v-parallel inner loop.


### PR DESCRIPTION
## Summary

- Optimize `GLADecodeKernel` (bf16/fp16) Pass-1 state read: replace scalar per-element global
  loads of `state` with a tiled `T.copy` into shared memory + `T.Pipelined` async prefetch,
  mirroring the existing Pass-2 state-update path. 
- Similar to #1683
- Uses a separate shared buffer (`h_tile_o`) for Pass 1 — its read layout differs from Pass 2's
  write layout, so sharing one buffer fails layout inference.
- fp32 kernel (`GLADecodeFP32Kernel`) untouched; no manifest / test / benchmark changes.

## Test plan

- [x] pre-commit passed (ruff, codespell, gitleaks, mdformat)
- [x] `pytest tests/ops/test_gla_recurrence.py` — 14 passed
- [x] `pytest benchmarks/tests` (contract) — 8 passed
- [x] `python scripts/validate_manifest.py` — all checks passed

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.0, PyTorch 2.10.0, TileLang 0.1.11+cuda.git5aaef0fd

### GLADecodeOp (bf16)

| Shape (b, h, dk, dv) | This PR (ms) | main (ms) | Speedup | BW (TB/s) |
| -------------------- | ------------ | --------- | ------- | --------- |
| (1, 32, 128, 128)    | 0.0068       | 0.0117    | 1.72×   | 0.31      |
| (8, 32, 128, 128)    | 0.0140       | 0.0244    | 1.74×   | 1.22      |
| (16, 32, 128, 128)   | 0.0268       | 0.0479    | 1.79×   | 1.28      |
| (32, 32, 128, 128)   | 0.0522       | 0.0947    | 1.81×   | 1.31      |
| (64, 32, 128, 128)   | 0.1022       | 0.1870    | 1.83×   | 1.34      |

**Takeaways:**

* bf16/fp16 decode 1.72–1.83× across batch 1–64 (fp16 tracks bf16 within noise).
* The win is latency-hiding, not coalescing — ncu (bf16 b64) shows the state loads were already sector-coalesced (bytes/sector 100 % before and after);
* `T.Pipelined` prefetch overlaps the state-load latency with compute. DRAM utilization 12.25 % → 21.48 %, duration 200.74 → 113.95 µs, occupancy flat (12.32 % → 9.74 %, so the gain is not from added concurrency), long-scoreboard stall 54.76 % → 50.35 %. fp32 path is a control (unchanged: 0.2037 → 0.2035 ms at b=64).

**Command:** `python -m pytest benchmarks/ops/bench_gla_recurrence.py -v`
