### PR TITLE
[Perf][Pool] Optimize avg pool1d and 3d mapping

### DIFF
--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -7,8 +7,10 @@ import torch.nn.functional as F
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
+    AvgPool1dKernel,
     AvgPool1dSpatialKernel,
     AvgPool2dSpatialKernel,
+    AvgPool3dKernel,
     AvgPool3dSpatialKernel,
 )
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
@@ -16,19 +18,6 @@ from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 class _DummyKernel(Kernel):
     supported_archs = [80]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x
-
-
-class _InjectedKernel(Kernel):
-    """Kernel stub used to verify explicit kernel-map dispatch."""
-
-    supported_archs = [80, 86, 89, 90]
-
-    def __init__(self, **kwargs: object) -> None:
-        super().__init__()
-        self.kwargs = kwargs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x
@@ -123,6 +112,12 @@ def test_avg_pool1d(
     )
     atol, rtol = ((1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2))
     test.check(op, *test.gen_inputs(n, c_in, l_in), atol=atol, rtol=rtol)
+    expected_kernel = (
+        AvgPool1dSpatialKernel
+        if not ceil_mode and count_include_pad
+        else AvgPool1dKernel
+    )
+    assert isinstance(op.kernel, expected_kernel)
 
 
 @pytest.mark.smoke
@@ -165,27 +160,6 @@ def test_avg_pool1d_rejects_non_3d_input(monkeypatch: pytest.MonkeyPatch) -> Non
     x = torch.randn(2, 8, 16, 4)
     with pytest.raises(ValueError, match="expects input to be a 3D NCL tensor"):
         op(x)
-
-
-@pytest.mark.smoke
-def test_avg_pool1d_dispatches_spatial_kernel() -> None:
-    op = AvgPool1dFwdOp(kernel_size=3, stride=2, padding=1)
-    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16).contiguous()
-    op(x)
-    assert isinstance(op.kernel, AvgPool1dSpatialKernel)
-
-
-@pytest.mark.smoke
-def test_avg_pool1d_custom_generic_kernel_takes_priority() -> None:
-    op = AvgPool1dFwdOp(
-        kernel_size=3,
-        stride=2,
-        padding=1,
-        kernel_map={"avg_pool1d_kernel": _InjectedKernel},
-    )
-    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16).contiguous()
-    op(x)
-    assert isinstance(op.kernel, _InjectedKernel)
 
 
 class AvgPool2dFixture(FixtureBase):
@@ -492,6 +466,7 @@ class AvgPool3dTest(TestBase):
             h_in,
             w_in,
             device="cuda",
+            dtype=self.dtype,
         ).contiguous()
         return (x,)
 
@@ -543,31 +518,12 @@ def test_avg_pool3d(
     )
     atol, rtol = ((1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2))
     test.check(op, *test.gen_inputs(n, c_in, d_in, h_in, w_in), atol=atol, rtol=rtol)
-
-
-@pytest.mark.smoke
-def test_avg_pool3d_dispatches_kernel() -> None:
-    op = AvgPool3dFwdOp(
-        kernel_size=(2, 2, 2),
-        stride=(2, 2, 2),
-        padding=(0, 0, 0),
+    expected_kernel = (
+        AvgPool3dSpatialKernel
+        if not ceil_mode and count_include_pad and divisor_override is None
+        else AvgPool3dKernel
     )
-    x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    op(x)
-    assert isinstance(op.kernel, AvgPool3dSpatialKernel)
-
-
-@pytest.mark.smoke
-def test_avg_pool3d_custom_generic_kernel_takes_priority() -> None:
-    op = AvgPool3dFwdOp(
-        kernel_size=(2, 2, 2),
-        stride=(2, 2, 2),
-        padding=(0, 0, 0),
-        kernel_map={"avg_pool3d_kernel": _InjectedKernel},
-    )
-    x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
-    op(x)
-    assert isinstance(op.kernel, _InjectedKernel)
+    assert isinstance(op.kernel, expected_kernel)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -6,12 +6,29 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.pool import AvgPool2dSpatialKernel, AvgPool3dKernel
+from tileops.kernels.pool import (
+    AvgPool1dSpatialKernel,
+    AvgPool2dSpatialKernel,
+    AvgPool3dSpatialKernel,
+)
 from tileops.ops import AvgPool1dFwdOp, AvgPool2dFwdOp, AvgPool3dFwdOp
 
 
 class _DummyKernel(Kernel):
     supported_archs = [80]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class _InjectedKernel(Kernel):
+    """Kernel stub used to verify explicit kernel-map dispatch."""
+
+    supported_archs = [80, 86, 89, 90]
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__()
+        self.kwargs = kwargs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x
@@ -148,6 +165,27 @@ def test_avg_pool1d_rejects_non_3d_input(monkeypatch: pytest.MonkeyPatch) -> Non
     x = torch.randn(2, 8, 16, 4)
     with pytest.raises(ValueError, match="expects input to be a 3D NCL tensor"):
         op(x)
+
+
+@pytest.mark.smoke
+def test_avg_pool1d_dispatches_spatial_kernel() -> None:
+    op = AvgPool1dFwdOp(kernel_size=3, stride=2, padding=1)
+    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16).contiguous()
+    op(x)
+    assert isinstance(op.kernel, AvgPool1dSpatialKernel)
+
+
+@pytest.mark.smoke
+def test_avg_pool1d_custom_generic_kernel_takes_priority() -> None:
+    op = AvgPool1dFwdOp(
+        kernel_size=3,
+        stride=2,
+        padding=1,
+        kernel_map={"avg_pool1d_kernel": _InjectedKernel},
+    )
+    x = torch.randn(1, 32, 128, device="cuda", dtype=torch.float16).contiguous()
+    op(x)
+    assert isinstance(op.kernel, _InjectedKernel)
 
 
 class AvgPool2dFixture(FixtureBase):
@@ -516,7 +554,20 @@ def test_avg_pool3d_dispatches_kernel() -> None:
     )
     x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
     op(x)
-    assert isinstance(op.kernel, AvgPool3dKernel)
+    assert isinstance(op.kernel, AvgPool3dSpatialKernel)
+
+
+@pytest.mark.smoke
+def test_avg_pool3d_custom_generic_kernel_takes_priority() -> None:
+    op = AvgPool3dFwdOp(
+        kernel_size=(2, 2, 2),
+        stride=(2, 2, 2),
+        padding=(0, 0, 0),
+        kernel_map={"avg_pool3d_kernel": _InjectedKernel},
+    )
+    x = torch.randn(1, 16, 8, 16, 16, device="cuda", dtype=torch.float16).contiguous()
+    op(x)
+    assert isinstance(op.kernel, _InjectedKernel)
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -78,7 +78,14 @@ from .norm import (
     LayerNormKernel,
     RMSNormKernel,
 )
-from .pool import AvgPool1dKernel, AvgPool2dKernel, AvgPool3dKernel
+from .pool import (
+    AvgPool1dKernel,
+    AvgPool1dSpatialKernel,
+    AvgPool2dKernel,
+    AvgPool2dSpatialKernel,
+    AvgPool3dKernel,
+    AvgPool3dSpatialKernel,
+)
 from .rope import (
     RopeLlama31Kernel,
     RopeLongRopeKernel,
@@ -91,8 +98,11 @@ from .topk_selector import TopkSelectorKernel
 
 __all__ = [
     "AvgPool1dKernel",
+    "AvgPool1dSpatialKernel",
     "AvgPool2dKernel",
+    "AvgPool2dSpatialKernel",
     "AvgPool3dKernel",
+    "AvgPool3dSpatialKernel",
     "BatchNormBwdKernel",
     "BatchNormFwdInferKernel",
     "BatchNormFwdTrainKernel",

--- a/tileops/kernels/pool/__init__.py
+++ b/tileops/kernels/pool/__init__.py
@@ -1,10 +1,12 @@
-from .avg_pool1d import AvgPool1dKernel
+from .avg_pool1d import AvgPool1dKernel, AvgPool1dSpatialKernel
 from .avg_pool2d import AvgPool2dKernel, AvgPool2dSpatialKernel
-from .avg_pool3d import AvgPool3dKernel
+from .avg_pool3d import AvgPool3dKernel, AvgPool3dSpatialKernel
 
 __all__ = [
     "AvgPool1dKernel",
+    "AvgPool1dSpatialKernel",
     "AvgPool2dKernel",
     "AvgPool2dSpatialKernel",
     "AvgPool3dKernel",
+    "AvgPool3dSpatialKernel",
 ]

--- a/tileops/kernels/pool/avg_pool1d.py
+++ b/tileops/kernels/pool/avg_pool1d.py
@@ -9,7 +9,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool.common import pool_output_dim
 
-__all__ = ["AvgPool1dKernel"]
+__all__ = ["AvgPool1dKernel", "AvgPool1dSpatialKernel"]
 
 
 @functools.lru_cache(maxsize=64)
@@ -26,35 +26,37 @@ def _avg_pool1d_kernel(
 ):
     accum_dtype = "float"
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
+    total_output = n * c_in * out_l
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool1d_func(block_m: int, block_c: int, threads: int):
+    def _avg_pool1d_func(block_m: int, threads: int):
         @T.prim_func
         def _avg_pool1d_main(
             x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
             out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
         ):
-            with T.Kernel(
-                T.ceildiv(out_l, block_m),
-                T.ceildiv(c_in, block_c),
-                n,
-                threads=threads,
-            ) as (bx, by, bz):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
                 T.use_swizzle(10)
-                tile_ol_start = bx * block_m
-                tile_ol_end = tile_ol_start + block_m - 1
+                tile_out_start = bx * block_m
+                tile_out_end = tile_out_start + block_m - 1
+                tile_ol_start = tile_out_start % out_l
+                tile_ol_end = tile_out_end % out_l
+                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
                 tile_input_start = tile_ol_start * stride_l - pad_l
                 tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
                 tile_spatial_full = (
-                    (tile_ol_end < out_l)
+                    tile_same_row
                     & (tile_input_start >= 0)
                     & (tile_input_end < l_in)
                 )
-                for i, j in T.Parallel(block_m, block_c):
-                    ol = bx * block_m + i
-                    c_idx = by * block_c + j
-                    batch = bz
-                    if ol < out_l and c_idx < c_in:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ol = out_idx % out_l
+                        nc_idx = out_idx // out_l
+                        c_idx = nc_idx % c_in
+                        batch = nc_idx // c_in
+
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
 
@@ -94,6 +96,114 @@ def _avg_pool1d_kernel(
     return _avg_pool1d_func
 
 
+@functools.lru_cache(maxsize=64)
+def _avg_pool1d_spatial_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
+    total_output = n * c_in * out_l
+
+    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _avg_pool1d_spatial_func(block_m: int, threads: int):
+        @T.prim_func
+        def _avg_pool1d_spatial_main(
+            x: T.Tensor((n, c_in, l_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_l), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                T.use_swizzle(10)
+                tile_out_start = bx * block_m
+                tile_out_end = tile_out_start + block_m - 1
+                tile_ol_start = tile_out_start % out_l
+                tile_ol_end = tile_out_end % out_l
+                tile_same_row = tile_out_start // out_l == tile_out_end // out_l
+                tile_input_start = tile_ol_start * stride_l - pad_l
+                tile_input_end = tile_ol_end * stride_l + kernel_l - 1 - pad_l
+                tile_spatial_full = (
+                    tile_same_row
+                    & (tile_input_start >= 0)
+                    & (tile_input_end < l_in)
+                )
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ol = out_idx % out_l
+                        nc_idx = out_idx // out_l
+                        c_idx = nc_idx % c_in
+                        batch = nc_idx // c_in
+
+                        sum_val = T.alloc_var(T.float32)
+                        sum_val = T.cast(0.0, accum_dtype)
+
+                        if tile_spatial_full:
+                            for kw in T.serial(kernel_l):
+                                il = ol * stride_l + kw - pad_l
+                                sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
+                        else:
+                            for kw in T.serial(kernel_l):
+                                il = ol * stride_l + kw - pad_l
+                                if il >= 0 and il < l_in:
+                                    sum_val += T.cast(x[batch, c_idx, il], accum_dtype)
+
+                        out[batch, c_idx, ol] = T.cast(
+                            sum_val / T.cast(kernel_l, accum_dtype),
+                            dtype,
+                        )
+
+        return _avg_pool1d_spatial_main
+
+    return _avg_pool1d_spatial_func
+
+
+@torch.library.custom_op("top::avg_pool1d_spatial_wrapped_kernel", mutates_args=())
+def _avg_pool1d_spatial_wrapped_kernel(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _avg_pool1d_spatial_kernel(
+        n,
+        c_in,
+        l_in,
+        kernel_l,
+        stride_l,
+        pad_l,
+        dtype,
+    )(block_m, threads)(x)
+
+
+@_avg_pool1d_spatial_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    l_in: int,
+    kernel_l: int,
+    stride_l: int,
+    pad_l: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    _ = (dtype, block_m, threads)
+    out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
+    return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
+
+
 @torch.library.custom_op("top::avg_pool1d_wrapped_kernel", mutates_args=())
 def _avg_pool1d_wrapped_kernel(
     n: int,
@@ -106,7 +216,6 @@ def _avg_pool1d_wrapped_kernel(
     count_include_pad: bool,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -120,7 +229,7 @@ def _avg_pool1d_wrapped_kernel(
         ceil_mode,
         count_include_pad,
         dtype,
-    )(block_m, block_c, threads)(x)
+    )(block_m, threads)(x)
 
 
 @_avg_pool1d_wrapped_kernel.register_fake
@@ -135,13 +244,79 @@ def _(
     count_include_pad: bool,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    _ = (count_include_pad, dtype, block_m, block_c, threads)
+    _ = (count_include_pad, dtype, block_m, threads)
     out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, ceil_mode)
     return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
+
+
+class AvgPool1dSpatialKernel(Kernel):
+    """Fast path for common NCL avg_pool1d workloads."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        l_in: int,
+        kernel_l: int,
+        stride_l: int,
+        pad_l: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.l_in = l_in
+        self.kernel_l = kernel_l
+        self.stride_l = stride_l
+        self.pad_l = pad_l
+        self.dtype = dtype
+        self.out_l = pool_output_dim(l_in, kernel_l, stride_l, pad_l, False)
+
+        self.kernel = _avg_pool1d_spatial_kernel(
+            n,
+            c_in,
+            l_in,
+            kernel_l,
+            stride_l,
+            pad_l,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 256,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _avg_pool1d_spatial_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.l_in,
+            self.kernel_l,
+            self.stride_l,
+            self.pad_l,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )
 
 
 class AvgPool1dKernel(Kernel):
@@ -189,21 +364,15 @@ class AvgPool1dKernel(Kernel):
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 128,
-            "block_c": 64,
-            "threads": 128,
+            "block_m": 256,
+            "threads": 256,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        configs = itertools.product([64, 128, 256], [32, 64, 128], [128, 256])
         return [
-            {
-                "block_m": block_m,
-                "block_c": block_c,
-                "threads": threads,
-            }
-            for block_m, block_c, threads in configs
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -218,7 +387,6 @@ class AvgPool1dKernel(Kernel):
             self.count_include_pad,
             self.dtype_str,
             self.config["block_m"],
-            self.config["block_c"],
             self.config["threads"],
             x,
         )

--- a/tileops/kernels/pool/avg_pool3d.py
+++ b/tileops/kernels/pool/avg_pool3d.py
@@ -9,7 +9,7 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool.common import pool_output_dim
 
-__all__ = ["AvgPool3dKernel"]
+__all__ = ["AvgPool3dKernel", "AvgPool3dSpatialKernel"]
 
 
 @functools.lru_cache(maxsize=64)
@@ -38,153 +38,236 @@ def _avg_pool3d_kernel(
     out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode)
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
+    total_output = n * c_in * out_d * out_h * out_w
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _avg_pool3d_func(block_m: int, block_c: int, threads: int):
+    def _avg_pool3d_func(block_m: int, threads: int):
         @T.prim_func
         def _avg_pool3d_main(
             x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
             out: T.Tensor((n, c_in, out_d, out_h, out_w), dtype),  # type: ignore
         ):
-            with T.Kernel(
-                T.ceildiv(out_d * out_h * out_w, block_m),
-                T.ceildiv(c_in, block_c),
-                n,
-                threads=threads,
-            ) as (bx, by, bz):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
                 T.use_swizzle(10)
-                tile_spatial_start = bx * block_m
-                tile_spatial_end = tile_spatial_start + block_m - 1
-                tile_od_start = tile_spatial_start // (out_h * out_w)
-                tile_od_end = tile_spatial_end // (out_h * out_w)
-                tile_spatial_same_plane = tile_od_start == tile_od_end
-                tile_input_d_start = tile_od_start * stride_d - pad_d
-                tile_input_d_end = tile_od_end * stride_d + kernel_d - 1 - pad_d
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        od_spatial_idx = spatial_idx // out_h
+                        od = od_spatial_idx % out_d
+                        nc_idx = od_spatial_idx // out_d
+                        c_idx = nc_idx % c_in
+                        batch = nc_idx // c_in
 
-                rem_start = tile_spatial_start % (out_h * out_w)
-                rem_end = tile_spatial_end % (out_h * out_w)
-                tile_oh_start = rem_start // out_w
-                tile_oh_end = rem_end // out_w
-                tile_spatial_same_row = tile_oh_start == tile_oh_end
-                tile_ow_start = rem_start % out_w
-                tile_ow_end = rem_end % out_w
-
-                tile_input_h_start = tile_oh_start * stride_h - pad_h
-                tile_input_h_end = tile_oh_end * stride_h + kernel_h - 1 - pad_h
-                tile_input_w_start = tile_ow_start * stride_w - pad_w
-                tile_input_w_end = tile_ow_end * stride_w + kernel_w - 1 - pad_w
-
-                tile_spatial_full = (
-                    tile_spatial_same_plane
-                    & tile_spatial_same_row
-                    & (tile_input_d_start >= 0)
-                    & (tile_input_d_end < d_in)
-                    & (tile_input_h_start >= 0)
-                    & (tile_input_h_end < h_in)
-                    & (tile_input_w_start >= 0)
-                    & (tile_input_w_end < w_in)
-                )
-                use_fixed_kernel_divisor = count_include_pad and not use_divisor_override
-
-                for i, j in T.Parallel(block_m, block_c):
-                    out_spatial = bx * block_m + i
-                    od = out_spatial // (out_h * out_w)
-                    oh = (out_spatial // out_w) % out_h
-                    ow = out_spatial % out_w
-                    c_idx = by * block_c + j
-                    batch = bz
-                    if out_spatial < out_d * out_h * out_w and c_idx < c_in:
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)
-
-                        if tile_spatial_full and use_fixed_kernel_divisor:
-                            for kd in T.serial(kernel_d):
-                                for kh in T.serial(kernel_h):
-                                    for kw in T.serial(kernel_w):
-                                        id_ = od * stride_d + kd - pad_d
-                                        ih = oh * stride_h + kh - pad_h
-                                        iw = ow * stride_w + kw - pad_w
+                        for kd in T.serial(kernel_d):
+                            for kh in T.serial(kernel_h):
+                                for kw in T.serial(kernel_w):
+                                    id_ = od * stride_d + kd - pad_d
+                                    ih = oh * stride_h + kh - pad_h
+                                    iw = ow * stride_w + kw - pad_w
+                                    if (
+                                        id_ >= 0
+                                        and id_ < d_in
+                                        and ih >= 0
+                                        and ih < h_in
+                                        and iw >= 0
+                                        and iw < w_in
+                                    ):
                                         sum_val += T.cast(
-                                            x[batch, c_idx, id_, ih, iw], accum_dtype
+                                            x[batch, c_idx, id_, ih, iw],
+                                            accum_dtype,
                                         )
-                            out[batch, c_idx, od, oh, ow] = T.cast(
-                                sum_val
-                                / T.cast(
-                                    kernel_d * kernel_h * kernel_w, accum_dtype
-                                ),
-                                dtype,
-                            )
-                        else:
-                            for kd in T.serial(kernel_d):
-                                for kh in T.serial(kernel_h):
-                                    for kw in T.serial(kernel_w):
-                                        id_ = od * stride_d + kd - pad_d
-                                        ih = oh * stride_h + kh - pad_h
-                                        iw = ow * stride_w + kw - pad_w
-                                        if (
-                                            id_ >= 0
-                                            and id_ < d_in
-                                            and ih >= 0
-                                            and ih < h_in
-                                            and iw >= 0
-                                            and iw < w_in
-                                        ):
-                                            sum_val += T.cast(
-                                                x[batch, c_idx, id_, ih, iw],
-                                                accum_dtype,
-                                            )
 
-                            start_d = od * stride_d - pad_d
-                            start_h = oh * stride_h - pad_h
-                            start_w = ow * stride_w - pad_w
-                            end_d = start_d + kernel_d
-                            end_h = start_h + kernel_h
-                            end_w = start_w + kernel_w
-                            valid_d = T.max(
-                                T.min(end_d, d_in) - T.max(start_d, 0), 0
-                            )
-                            valid_h = T.max(
-                                T.min(end_h, h_in) - T.max(start_h, 0), 0
-                            )
-                            valid_w = T.max(
-                                T.min(end_w, w_in) - T.max(start_w, 0), 0
-                            )
-                            valid_count = valid_d * valid_h * valid_w
-                            padded_d = T.max(
-                                T.min(end_d, d_in + pad_d)
-                                - T.max(start_d, -pad_d),
-                                0,
-                            )
-                            padded_h = T.max(
-                                T.min(end_h, h_in + pad_h)
-                                - T.max(start_h, -pad_h),
-                                0,
-                            )
-                            padded_w = T.max(
-                                T.min(end_w, w_in + pad_w)
-                                - T.max(start_w, -pad_w),
-                                0,
-                            )
-                            padded_count = padded_d * padded_h * padded_w
-                            auto_divisor = T.max(
-                                T.if_then_else(
-                                    count_include_pad, padded_count, valid_count
-                                ),
-                                1,
-                            )
-                            divisor = T.if_then_else(
-                                use_divisor_override,
-                                divisor_override,
-                                auto_divisor,
-                            )
-                            out[batch, c_idx, od, oh, ow] = T.cast(
-                                sum_val / T.cast(divisor, accum_dtype),
-                                dtype,
-                            )
+                        start_d = od * stride_d - pad_d
+                        start_h = oh * stride_h - pad_h
+                        start_w = ow * stride_w - pad_w
+                        end_d = start_d + kernel_d
+                        end_h = start_h + kernel_h
+                        end_w = start_w + kernel_w
+                        valid_d = T.max(T.min(end_d, d_in) - T.max(start_d, 0), 0)
+                        valid_h = T.max(T.min(end_h, h_in) - T.max(start_h, 0), 0)
+                        valid_w = T.max(T.min(end_w, w_in) - T.max(start_w, 0), 0)
+                        valid_count = valid_d * valid_h * valid_w
+                        padded_d = T.max(
+                            T.min(end_d, d_in + pad_d) - T.max(start_d, -pad_d), 0
+                        )
+                        padded_h = T.max(
+                            T.min(end_h, h_in + pad_h) - T.max(start_h, -pad_h), 0
+                        )
+                        padded_w = T.max(
+                            T.min(end_w, w_in + pad_w) - T.max(start_w, -pad_w), 0
+                        )
+                        padded_count = padded_d * padded_h * padded_w
+                        auto_divisor = T.max(
+                            T.if_then_else(
+                                count_include_pad, padded_count, valid_count
+                            ),
+                            1,
+                        )
+                        divisor = T.if_then_else(
+                            use_divisor_override,
+                            divisor_override,
+                            auto_divisor,
+                        )
+                        out[batch, c_idx, od, oh, ow] = T.cast(
+                            sum_val / T.cast(divisor, accum_dtype),
+                            dtype,
+                        )
 
         return _avg_pool3d_main
 
     return _avg_pool3d_func
+
+
+@functools.lru_cache(maxsize=64)
+def _avg_pool3d_spatial_kernel(
+    n: int,
+    c_in: int,
+    d_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_d: int,
+    stride_h: int,
+    stride_w: int,
+    pad_d: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, False)
+    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+    total_output = n * c_in * out_d * out_h * out_w
+
+    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _avg_pool3d_spatial_func(block_m: int, threads: int):
+        @T.prim_func
+        def _avg_pool3d_spatial_main(
+            x: T.Tensor((n, c_in, d_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_d, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                T.use_swizzle(10)
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        od_spatial_idx = spatial_idx // out_h
+                        od = od_spatial_idx % out_d
+                        nc_idx = od_spatial_idx // out_d
+                        c_idx = nc_idx % c_in
+                        batch = nc_idx // c_in
+
+                        sum_val = T.alloc_var(T.float32)
+                        sum_val = T.cast(0.0, accum_dtype)
+                        for kd in T.serial(kernel_d):
+                            for kh in T.serial(kernel_h):
+                                for kw in T.serial(kernel_w):
+                                    id_ = od * stride_d + kd - pad_d
+                                    ih = oh * stride_h + kh - pad_h
+                                    iw = ow * stride_w + kw - pad_w
+                                    if (
+                                        id_ >= 0
+                                        and id_ < d_in
+                                        and ih >= 0
+                                        and ih < h_in
+                                        and iw >= 0
+                                        and iw < w_in
+                                    ):
+                                        sum_val += T.cast(
+                                            x[batch, c_idx, id_, ih, iw],
+                                            accum_dtype,
+                                        )
+
+                        out[batch, c_idx, od, oh, ow] = T.cast(
+                            sum_val
+                            / T.cast(
+                                kernel_d * kernel_h * kernel_w, accum_dtype
+                            ),
+                            dtype,
+                        )
+
+        return _avg_pool3d_spatial_main
+
+    return _avg_pool3d_spatial_func
+
+
+@torch.library.custom_op("top::avg_pool3d_spatial_wrapped_kernel", mutates_args=())
+def _avg_pool3d_spatial_wrapped_kernel(
+    n: int,
+    c_in: int,
+    d_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_d: int,
+    stride_h: int,
+    stride_w: int,
+    pad_d: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _avg_pool3d_spatial_kernel(
+        n,
+        c_in,
+        d_in,
+        h_in,
+        w_in,
+        kernel_d,
+        kernel_h,
+        kernel_w,
+        stride_d,
+        stride_h,
+        stride_w,
+        pad_d,
+        pad_h,
+        pad_w,
+        dtype,
+    )(block_m, threads)(x)
+
+
+@_avg_pool3d_spatial_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    d_in: int,
+    h_in: int,
+    w_in: int,
+    kernel_d: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_d: int,
+    stride_h: int,
+    stride_w: int,
+    pad_d: int,
+    pad_h: int,
+    pad_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    _ = (dtype, block_m, threads)
+    out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, False)
+    out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+    out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+    return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
 @torch.library.custom_op("top::avg_pool3d_wrapped_kernel", mutates_args=())
@@ -209,7 +292,6 @@ def _avg_pool3d_wrapped_kernel(
     divisor_override: int,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -233,7 +315,7 @@ def _avg_pool3d_wrapped_kernel(
         use_divisor_override,
         divisor_override,
         dtype,
-    )(block_m, block_c, threads)(x)
+    )(block_m, threads)(x)
 
 
 @_avg_pool3d_wrapped_kernel.register_fake
@@ -258,7 +340,6 @@ def _(
     divisor_override: int,
     dtype: str,
     block_m: int,
-    block_c: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
@@ -268,13 +349,113 @@ def _(
         divisor_override,
         dtype,
         block_m,
-        block_c,
         threads,
     )
     out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode)
     out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode)
     out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode)
     return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
+
+
+class AvgPool3dSpatialKernel(Kernel):
+    """Fast path for common NCDHW avg_pool3d workloads."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        d_in: int,
+        h_in: int,
+        w_in: int,
+        kernel_d: int,
+        kernel_h: int,
+        kernel_w: int,
+        stride_d: int,
+        stride_h: int,
+        stride_w: int,
+        pad_d: int,
+        pad_h: int,
+        pad_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.n = n
+        self.c_in = c_in
+        self.d_in = d_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.kernel_d = kernel_d
+        self.kernel_h = kernel_h
+        self.kernel_w = kernel_w
+        self.stride_d = stride_d
+        self.stride_h = stride_h
+        self.stride_w = stride_w
+        self.pad_d = pad_d
+        self.pad_h = pad_h
+        self.pad_w = pad_w
+        self.dtype = dtype
+        self.out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, False)
+        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, False)
+        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, False)
+
+        self.kernel = _avg_pool3d_spatial_kernel(
+            n,
+            c_in,
+            d_in,
+            h_in,
+            w_in,
+            kernel_d,
+            kernel_h,
+            kernel_w,
+            stride_d,
+            stride_h,
+            stride_w,
+            pad_d,
+            pad_h,
+            pad_w,
+            self.dtype_str,
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 128,
+            "threads": 128,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([64, 128, 256], [128, 256])
+        ]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _avg_pool3d_spatial_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.d_in,
+            self.h_in,
+            self.w_in,
+            self.kernel_d,
+            self.kernel_h,
+            self.kernel_w,
+            self.stride_d,
+            self.stride_h,
+            self.stride_w,
+            self.pad_d,
+            self.pad_h,
+            self.pad_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )
 
 
 class AvgPool3dKernel(Kernel):
@@ -353,21 +534,15 @@ class AvgPool3dKernel(Kernel):
     @property
     def default_config(self) -> dict:
         return {
-            "block_m": 64,
-            "block_c": 64,
+            "block_m": 128,
             "threads": 128,
         }
 
     @property
     def autotune_configs(self) -> list[dict]:
-        configs = itertools.product([32, 64, 128], [32, 64, 128], [128, 256])
         return [
-            {
-                "block_m": block_m,
-                "block_c": block_c,
-                "threads": threads,
-            }
-            for block_m, block_c, threads in configs
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([64, 128, 256], [128, 256])
         ]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -392,7 +567,6 @@ class AvgPool3dKernel(Kernel):
             self.divisor_override,
             self.dtype_str,
             self.config["block_m"],
-            self.config["block_c"],
             self.config["threads"],
             x,
         )

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -48,6 +48,7 @@ AvgPool1dFwdOp:
     kernel: tileops/kernels/pool/avg_pool1d.py
     kernel_map:
       avg_pool1d_kernel: AvgPool1dKernel
+      avg_pool1d_spatial_kernel: AvgPool1dSpatialKernel
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
@@ -179,6 +180,7 @@ AvgPool3dFwdOp:
     kernel: tileops/kernels/pool/avg_pool3d.py
     kernel_map:
       avg_pool3d_kernel: AvgPool3dKernel
+      avg_pool3d_spatial_kernel: AvgPool3dSpatialKernel
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -5,9 +5,11 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
     AvgPool1dKernel,
+    AvgPool1dSpatialKernel,
     AvgPool2dKernel,
     AvgPool2dSpatialKernel,
     AvgPool3dKernel,
+    AvgPool3dSpatialKernel,
 )
 from tileops.kernels.pool.common import (
     _normalize_pool_dims,
@@ -58,16 +60,29 @@ class AvgPool1dFwdOp(Op):
             padding=(self.padding,),
         )
         self.dispatch_kernel(kernel_map)
-        if "avg_pool1d_kernel" not in self.kernel_map:
+        if (
+            "avg_pool1d_kernel" not in self.kernel_map
+            and "avg_pool1d_spatial_kernel" not in self.kernel_map
+        ):
             raise NotImplementedError(
-                "AvgPool1dFwdOp requires 'avg_pool1d_kernel' in kernel_map"
+                "AvgPool1dFwdOp requires 'avg_pool1d_kernel' or "
+                "'avg_pool1d_spatial_kernel' in kernel_map"
             )
+        self._has_explicit_generic_kernel = (
+            kernel_map is not None and "avg_pool1d_kernel" in kernel_map
+        )
+        self._has_explicit_spatial_kernel = (
+            kernel_map is not None and "avg_pool1d_spatial_kernel" in kernel_map
+        )
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._last_roofline_spec: Optional[tuple] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"avg_pool1d_kernel": AvgPool1dKernel}
+        return {
+            "avg_pool1d_kernel": AvgPool1dKernel,
+            "avg_pool1d_spatial_kernel": AvgPool1dSpatialKernel,
+        }
 
     def _resolve_input_1d(
         self,
@@ -97,8 +112,22 @@ class AvgPool1dFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
+        use_spatial_fast_path = (
+            not self.ceil_mode
+            and self.count_include_pad
+            and "avg_pool1d_spatial_kernel" in self.kernel_map
+            and (
+                not self._has_explicit_generic_kernel
+                or self._has_explicit_spatial_kernel
+            )
+        )
+        kernel_name = (
+            "avg_pool1d_spatial_kernel"
+            if use_spatial_fast_path
+            else "avg_pool1d_kernel"
+        )
         key = (
-            "general",
+            kernel_name,
             n,
             c_in,
             l_in,
@@ -112,18 +141,26 @@ class AvgPool1dFwdOp(Op):
             self.tune,
         )
         if key not in self._kernel_cache:
-            self._kernel_cache[key] = self.kernel_map["avg_pool1d_kernel"](
+            kernel_kwargs = dict(
                 n=n,
                 c_in=c_in,
                 l_in=l_in,
                 kernel_l=self.kernel_size,
                 stride_l=self.stride,
                 pad_l=self.padding,
-                ceil_mode=self.ceil_mode,
-                count_include_pad=self.count_include_pad,
                 dtype=dtype,
                 tune=self.tune,
             )
+            if use_spatial_fast_path:
+                self._kernel_cache[key] = self.kernel_map[kernel_name](
+                    **kernel_kwargs
+                )
+            else:
+                self._kernel_cache[key] = self.kernel_map[kernel_name](
+                    **kernel_kwargs,
+                    ceil_mode=self.ceil_mode,
+                    count_include_pad=self.count_include_pad,
+                )
         return self._kernel_cache[key]
 
     def _infer_output_shapes(
@@ -415,16 +452,29 @@ class AvgPool3dFwdOp(Op):
             divisor_override=divisor_override,
         )
         self.dispatch_kernel(kernel_map)
-        if "avg_pool3d_kernel" not in self.kernel_map:
+        if (
+            "avg_pool3d_kernel" not in self.kernel_map
+            and "avg_pool3d_spatial_kernel" not in self.kernel_map
+        ):
             raise NotImplementedError(
-                "AvgPool3dFwdOp requires 'avg_pool3d_kernel' in kernel_map"
+                "AvgPool3dFwdOp requires 'avg_pool3d_kernel' or "
+                "'avg_pool3d_spatial_kernel' in kernel_map"
             )
+        self._has_explicit_generic_kernel = (
+            kernel_map is not None and "avg_pool3d_kernel" in kernel_map
+        )
+        self._has_explicit_spatial_kernel = (
+            kernel_map is not None and "avg_pool3d_spatial_kernel" in kernel_map
+        )
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._last_roofline_spec: Optional[tuple] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"avg_pool3d_kernel": AvgPool3dKernel}
+        return {
+            "avg_pool3d_kernel": AvgPool3dKernel,
+            "avg_pool3d_spatial_kernel": AvgPool3dSpatialKernel,
+        }
 
     def _resolve_input_3d(
         self,
@@ -462,8 +512,23 @@ class AvgPool3dFwdOp(Op):
         dtype: torch.dtype,
         device_index: int | None,
     ) -> Kernel:
+        use_spatial_fast_path = (
+            not self.ceil_mode
+            and self.count_include_pad
+            and self.divisor_override is None
+            and "avg_pool3d_spatial_kernel" in self.kernel_map
+            and (
+                not self._has_explicit_generic_kernel
+                or self._has_explicit_spatial_kernel
+            )
+        )
+        kernel_name = (
+            "avg_pool3d_spatial_kernel"
+            if use_spatial_fast_path
+            else "avg_pool3d_kernel"
+        )
         key = (
-            "general",
+            kernel_name,
             n,
             c_in,
             d_in,
@@ -480,7 +545,7 @@ class AvgPool3dFwdOp(Op):
             self.tune,
         )
         if key not in self._kernel_cache:
-            self._kernel_cache[key] = self.kernel_map["avg_pool3d_kernel"](
+            kernel_kwargs = dict(
                 n=n,
                 c_in=c_in,
                 d_in=d_in,
@@ -495,12 +560,20 @@ class AvgPool3dFwdOp(Op):
                 pad_d=self.padding[0],
                 pad_h=self.padding[1],
                 pad_w=self.padding[2],
-                ceil_mode=self.ceil_mode,
-                count_include_pad=self.count_include_pad,
-                divisor_override=self.divisor_override,
                 dtype=dtype,
                 tune=self.tune,
             )
+            if use_spatial_fast_path:
+                self._kernel_cache[key] = self.kernel_map[kernel_name](
+                    **kernel_kwargs
+                )
+            else:
+                self._kernel_cache[key] = self.kernel_map[kernel_name](
+                    **kernel_kwargs,
+                    ceil_mode=self.ceil_mode,
+                    count_include_pad=self.count_include_pad,
+                    divisor_override=self.divisor_override,
+                )
         return self._kernel_cache[key]
 
     def _infer_output_shapes(


### PR DESCRIPTION
## Summary

Optimizes avg_pool1d and avg_pool3d with flat-output generic kernels and fixed-divisor spatial fast paths. Common cases use the spatial path; ceil, exclude-pad, and divisor-override cases retain the generic path.

Closes #1682

## Benchmark

H200, CUDA 12.9, PyTorch 2.10.0+cu129. Ran `CUDA_VISIBLE_DEVICES=1 python -m pytest benchmarks/ops/bench_pool.py::test_avg_pool1d_bench benchmarks/ops/bench_pool.py::test_avg_pool3d_bench -vvs` twice; the second run is reported below. `speedup` is old TileOps latency / current TileOps latency; `vs torch` is torch-ref latency / current TileOps latency.

| Workload | Old TileOps (ms) | Current TileOps (ms) | torch-ref (ms) | speedup | vs torch |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1d audio-downsample fp16 | 0.0320 | 0.0065 | 0.0157 | 4.92x | 2.42x |
| 1d long-temporal fp16 | 0.1491 | 0.0218 | 0.0596 | 6.84x | 2.73x |
| 1d ceil bf16 | 0.0124 | 0.0038 | 0.0057 | 3.26x | 1.50x |
| 3d video-2x2x2 fp16 | 0.0173 | 0.0041 | 0.0104 | 4.22x | 2.54x |
| 3d ceil-video fp16 | 0.0218 | 0.0047 | 0.0118 | 4.64x | 2.51x |
| 3d divisor bf16 | 0.0069 | 0.0029 | 0.0055 | 2.38x | 1.90x |

Geomean: 1d `4.79x` vs old and `2.15x` vs torch-ref; 3d `3.60x` vs old and `2.30x` vs torch-ref; all workloads `4.15x` vs old and `2.22x` vs torch-ref.

Autotuned configurations: 1d spatial `block_m=512, threads=128`; 1d generic ceil `512, 256`; 3d spatial `256, 256`; 3d generic ceil `128, 128`; 3d generic divisor `128, 256`.

## Profiling

Fixed-config nsys medians: 1d long-temporal TileOps `20.384 us` vs torch-ref `58.720 us`; 3d video TileOps `3.520 us` vs torch-ref `8.800 us`.

ncu used `--launch-skip 51 --launch-count 3`. For 1d, TileOps executes `10.24M` dynamic instructions vs torch-ref `35.21M`, while both have `7.62 B/sector` loads and `32 B/sector` stores. For 3d, TileOps executes `1.00M` vs `3.19M` instructions, reaches `9.55` vs `7.14` active warps/scheduler and `1.79` vs `1.41` eligible warps/scheduler; its stores use `32 B/sector` vs torch-ref `22.4 B/sector`.

The speedup is therefore consistent with the implementation: fixed-divisor paths remove valid/padded-count and dynamic-divisor control work, while flat spatial mapping keeps lane work contiguous. The gains come chiefly from roughly 3x fewer instructions; 3d also improves actual scheduler readiness and store coalescing.

## Test plan

- `CUDA_VISIBLE_DEVICES=1 python -m pytest tests/ops/test_pool.py -v` (`57 passed`)
- GPU 1 benchmark command above, two consecutive runs; second run used for the table.