### PR TITLE
[CI][Runner] unset RUNNER_TOKEN before the runner starts

### DIFF
--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -100,7 +100,9 @@ tilelang is missing (the image provides it).
 ## Run as a self-hosted runner
 
 `entrypoint.sh` registers an ephemeral runner (one job per container), then deregisters on
-exit. Provide a registration token and the target URL; bind-mount the host cache.
+exit. Provide a registration token and the target URL; bind-mount the host cache. The
+entrypoint removes `RUNNER_TOKEN` from the environment before the runner starts, so jobs
+cannot read the registration token.
 
 ```bash
 docker run -d --gpus all \

--- a/.github/runner/entrypoint.sh
+++ b/.github/runner/entrypoint.sh
@@ -16,6 +16,13 @@ fi
 : "${RUNNER_TOKEN:?Environment variable RUNNER_TOKEN is required}"
 : "${RUNNER_URL:?Environment variable RUNNER_URL is required}"
 
+# Jobs run as children of the listener and inherit its environment; a job that reads
+# RUNNER_TOKEN can register a rogue runner with trusted labels while the token is valid.
+# Hold the token in an unexported shell variable and drop it from the environment before
+# anything else runs.
+reg_token="${RUNNER_TOKEN}"
+unset RUNNER_TOKEN
+
 RUNNER_NAME="${RUNNER_NAME:-$(hostname)}"
 RUNNER_LABELS="${RUNNER_LABELS:-self-hosted,tile-ops,venv}"
 RUNNER_WORKDIR="${RUNNER_WORKDIR:-_work}"
@@ -23,7 +30,7 @@ RUNNER_WORKDIR="${RUNNER_WORKDIR:-_work}"
 # ── Cleanup function — deregister runner on exit ─────────────────────────────
 cleanup() {
     echo "Removing runner registration..."
-    ./config.sh remove --token "${RUNNER_TOKEN}" 2>/dev/null || true
+    ./config.sh remove --token "${reg_token}" 2>/dev/null || true
 }
 
 trap cleanup EXIT INT TERM
@@ -31,7 +38,7 @@ trap cleanup EXIT INT TERM
 # ── Configure the runner (ephemeral: one job per lifecycle) ──────────────────
 ./config.sh \
     --url "${RUNNER_URL}" \
-    --token "${RUNNER_TOKEN}" \
+    --token "${reg_token}" \
     --name "${RUNNER_NAME}" \
     --labels "${RUNNER_LABELS}" \
     --work "${RUNNER_WORKDIR}" \

--- a/.github/runner/entrypoint.sh
+++ b/.github/runner/entrypoint.sh
@@ -19,7 +19,9 @@ fi
 # Jobs run as children of the listener and inherit its environment; a job that reads
 # RUNNER_TOKEN can register a rogue runner with trusted labels while the token is valid.
 # Hold the token in an unexported shell variable and drop it from the environment before
-# anything else runs.
+# anything else runs. unset first: if reg_token arrived exported from the container
+# environment, plain assignment would keep the export attribute and leak the token anyway.
+unset reg_token
 reg_token="${RUNNER_TOKEN}"
 unset RUNNER_TOKEN
 


### PR DESCRIPTION
## Problem

`entrypoint.sh` keeps `RUNNER_TOKEN` exported for the whole runner lifecycle (it was retained for the `config.sh remove` cleanup trap). Jobs run as children of the runner listener and inherit its environment, so **any job can read the registration token** and use it to register a rogue runner with trusted labels (e.g. `self-hosted,tile-ops,nightly`) while the token is valid (~1 hour). A rogue trusted runner would then receive trusted jobs carrying a write-scoped `GITHUB_TOKEN`.

This is exploitable today by any code that runs on the runner, and becomes the critical gap once the on-demand fork runner pool starts running untrusted external fork PRs on this image.

## Fix

Copy the token into an unexported shell variable, `unset RUNNER_TOKEN` immediately after validation, and use the variable in `config.sh` and the cleanup trap. Shell variables are not part of the environment, so neither the listener nor its job children can see the token.

## Verification

- `bash -n` + `shellcheck` on `entrypoint.sh` pass.
- Env-inheritance check: after `reg_token="$RUNNER_TOKEN"; unset RUNNER_TOKEN`, a child process sees the variable as absent while the parent shell variable still holds the value.
- pre-commit hooks pass.

## Deployment note

The fix takes effect on the next runner image rebuild; the CI host launchers pass the token via `--env-file` unchanged.