### PR TITLE
[Feat][NORM_SOFTMAX] Infer shape metadata from inputs

### DIFF
--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -146,7 +146,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     # Manifest input order: (x, running_mean, running_var, weight, bias).
     inputs = (x, running_mean, running_var, weight, bias)
 
-    op = BatchNormFwdOp(N, C, tuple(spatial), dtype=dtype, training=training, tune=tune)
+    op = BatchNormFwdOp(training=training, tune=tune)
 
     test = BatchNormFwdTest(N, C, spatial, dtype, training)
     bm = BatchNormFwdBenchmark(test, op)
@@ -165,7 +165,7 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
 def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     inputs = _make_bwd_inputs(N, C, spatial, dtype)
 
-    op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    op = BatchNormBwdOp()
 
     test = BatchNormBwdTest(N, C, spatial, dtype)
     bm = BatchNormBwdBenchmark(test, op)

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -65,10 +65,7 @@ def test_group_norm_bench(n: int, c: int, spatial: tuple, num_groups: int,
     test = GroupNormTest(n, c, spatial, num_groups, dtype)
     x, weight, bias = test.gen_inputs()
 
-    op = GroupNormFwdOp(
-        N=n, C=c, spatial=spatial, num_groups=num_groups,
-        dtype=dtype, tune=tune,
-    )
+    op = GroupNormFwdOp(num_groups=num_groups, tune=tune)
     bm = GroupNormBenchmark(test, op)
     result = bm.profile(op, x, weight, bias)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -89,10 +86,7 @@ def test_group_norm_no_affine_bench(n: int, c: int, spatial: tuple,
     test = GroupNormTest(n, c, spatial, num_groups, dtype)
     x, _, _ = test.gen_inputs()
 
-    op = GroupNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, num_groups=num_groups,
-        dtype=dtype, tune=tune,
-    )
+    op = GroupNormFwdOpNoAffine(num_groups=num_groups, tune=tune)
     bm = GroupNormBenchmark(test, op)
     result = bm.profile(op, x)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -59,7 +59,7 @@ def test_instance_norm_bench(n: int, c: int, spatial: tuple,
     test = InstanceNormTest(n, c, spatial, dtype)
     x, weight, bias = test.gen_inputs()
 
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype, tune=tune)
+    op = InstanceNormFwdOp(tune=tune)
     bm = InstanceNormBenchmark(test, op)
     result = bm.profile(op, x, weight, bias)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -78,9 +78,7 @@ def test_instance_norm_no_affine_bench(n: int, c: int, spatial: tuple,
     test = InstanceNormTest(n, c, spatial, dtype)
     x, _, _ = test.gen_inputs()
 
-    op = InstanceNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, dtype=dtype, tune=tune,
-    )
+    op = InstanceNormFwdOpNoAffine(tune=tune)
     bm = InstanceNormBenchmark(test, op)
     # Running stats are required positional args (R16) but ignored on the
     # use_input_stats=True path; pass placeholders.

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -37,7 +37,7 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = SoftmaxTest(shape, dtype)
     inputs = test.gen_inputs()
 
-    op = SoftmaxFwdOp(N=shape[-1], dtype=dtype, dim=-1, tune=True)
+    op = SoftmaxFwdOp(dim=-1, tune=True)
     bm = ManifestBenchmark(_SOFTMAX_OP, op, test)
     try:
         result = bm.profile(op, *inputs)
@@ -64,7 +64,7 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = LogSoftmaxTest(shape, dtype)
     inputs = test.gen_inputs()
 
-    op = LogSoftmaxFwdOp(N=shape[-1], dtype=dtype, dim=-1, tune=True)
+    op = LogSoftmaxFwdOp(dim=-1, tune=True)
     bm = ManifestBenchmark(_LOG_SOFTMAX_OP, op, test)
     try:
         result = bm.profile(op, *inputs)

--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -115,7 +115,7 @@ def test_batch_norm_fwd(N, C, spatial, dtype, training):
     running_mean_ref = running_mean.clone()
     running_var_ref = running_var.clone()
 
-    op = BatchNormFwdOp(N, C, tuple(spatial), dtype=dtype, training=training)
+    op = BatchNormFwdOp(training=training)
     # Manifest input order: (x, running_mean, running_var, weight, bias).
     y = op(x, running_mean, running_var, weight, bias)
 
@@ -144,7 +144,7 @@ def test_batch_norm_bwd(N, C, spatial, dtype):
     test = BatchNormBwdTest(N, C, spatial, dtype)
     grad_out, x, weight, mean, rstd = test.gen_inputs()
 
-    op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    op = BatchNormBwdOp()
     grad_x, grad_weight, grad_bias = op(grad_out, x, weight, mean, rstd)
 
     ref_gx, ref_gw, ref_gb = test.ref_program(grad_out, x, weight, mean, rstd)
@@ -171,7 +171,7 @@ def test_batch_norm_fwd_returns_single_tensor() -> None:
         pytest.skip("CUDA required for forward call")
 
     N, C, H, W = 4, 8, 4, 4
-    op = BatchNormFwdOp(N, C, (H, W), dtype=torch.float16, training=False)
+    op = BatchNormFwdOp(training=False)
     x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
     weight = torch.randn(C, device="cuda", dtype=torch.float32)
     bias = torch.randn(C, device="cuda", dtype=torch.float32)

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -61,7 +61,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 def test_group_norm_op(n: int, c: int, spatial: tuple, g: int,
                        dtype: torch.dtype, tune: bool) -> None:
     test = GroupNormTest(n, c, spatial, g, dtype)
-    op = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
+    op = GroupNormFwdOp(num_groups=g)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -85,7 +85,7 @@ def test_group_norm_non_contiguous(n: int, c: int, spatial: tuple, g: int,
     weight = torch.randn(c, dtype=dtype, device="cuda")
     bias = torch.randn(c, dtype=dtype, device="cuda")
 
-    op = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
+    op = GroupNormFwdOp(num_groups=g)
 
     y_ref = F.group_norm(
         x.contiguous().float(), g,
@@ -102,7 +102,7 @@ def test_group_norm_non_contiguous(n: int, c: int, spatial: tuple, g: int,
 def test_group_norm_rejects_none_weight_or_bias() -> None:
     """Affine op rejects ``weight=None`` / ``bias=None``; affine-free path lives on NoAffine."""
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    op = GroupNormFwdOp(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
+    op = GroupNormFwdOp(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     weight = torch.randn((c,), dtype=dtype, device="cuda")
     bias = torch.randn((c,), dtype=dtype, device="cuda")
@@ -127,22 +127,13 @@ def test_group_norm_forward_required_signature() -> None:
 
 
 @pytest.mark.smoke
-def test_group_norm_rejects_device_mismatch() -> None:
-    """Forward must raise ValueError when input device differs from kernel device.
-
-    The compiled kernel binds to the active CUDA device at construction
-    time, so callers must construct one op per device. Verify the op
-    surfaces a clean ValueError rather than letting the kernel layer
-    raise an opaque device-id error.
-    """
+def test_group_norm_lazily_specializes_per_device() -> None:
+    """A single op can lazily build specializations for different CUDA devices."""
     if torch.cuda.device_count() < 2:
-        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
+        pytest.skip("multi-device test requires >= 2 CUDA devices")
 
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    with torch.cuda.device(0):
-        op = GroupNormFwdOp(
-            N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
-        )
+    op = GroupNormFwdOp(num_groups=g)
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
@@ -152,8 +143,9 @@ def test_group_norm_rejects_device_mismatch() -> None:
     bias_other = torch.randn(
         (c,), dtype=dtype, device=torch.device("cuda", 1),
     )
-    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other, weight_other, bias_other)
+    y = op(x_other, weight_other, bias_other)
+    assert y.device == x_other.device
+    assert len(op._kernel_cache) == 1
 
 
 @pytest.mark.smoke
@@ -168,10 +160,7 @@ def test_group_norm_rejects_affine_device_mismatch() -> None:
         pytest.skip("affine-device-mismatch test requires >= 2 CUDA devices")
 
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    with torch.cuda.device(0):
-        op = GroupNormFwdOp(
-            N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
-        )
+    op = GroupNormFwdOp(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device=torch.device("cuda", 0))
     weight_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
     bias_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
@@ -207,7 +196,7 @@ class GroupNormNoAffineFixture(FixtureBase):
 def test_group_norm_no_affine_op(n: int, c: int, spatial: tuple, g: int,
                                  dtype: torch.dtype) -> None:
     """No-affine GroupNorm op matches torch.nn.functional.group_norm with weight=bias=None."""
-    op = GroupNormFwdOpNoAffine(N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype)
+    op = GroupNormFwdOpNoAffine(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     y = op(x)
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None, eps=1e-5).to(dtype)
@@ -226,21 +215,19 @@ def test_group_norm_no_affine_forward_signature() -> None:
 
 
 @pytest.mark.smoke
-def test_group_norm_no_affine_rejects_device_mismatch() -> None:
-    """Forward raises ValueError when input lives on a different CUDA device."""
+def test_group_norm_no_affine_lazily_specializes_per_device() -> None:
+    """No-affine op can lazily build specializations for different CUDA devices."""
     if torch.cuda.device_count() < 2:
-        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
+        pytest.skip("multi-device test requires >= 2 CUDA devices")
 
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    with torch.cuda.device(0):
-        op = GroupNormFwdOpNoAffine(
-            N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
-        )
+    op = GroupNormFwdOpNoAffine(num_groups=g)
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
-    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other)
+    y = op(x_other)
+    assert y.device == x_other.device
+    assert len(op._kernel_cache) == 1
 
 
 @pytest.mark.smoke
@@ -279,8 +266,7 @@ def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
                                          g: int) -> None:
     """No-affine GroupNorm handles M not divisible by the kernel's block_m."""
     dtype = torch.float16
-    op = GroupNormFwdOpNoAffine(N=n, C=c, spatial=spatial, num_groups=g,
-                                dtype=dtype)
+    op = GroupNormFwdOpNoAffine(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     y = op(x)
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None,

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -149,6 +149,41 @@ def test_group_norm_lazily_specializes_per_device() -> None:
 
 
 @pytest.mark.smoke
+def test_group_norm_lazy_cache_reuse_and_respecialization() -> None:
+    """One op instance reuses identical specs and caches changed specs."""
+    op = GroupNormFwdOp(num_groups=4)
+
+    def run_case(n: int, c: int, spatial: tuple[int, ...], dtype: torch.dtype) -> None:
+        x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+        weight = torch.randn((c,), dtype=dtype, device="cuda")
+        bias = torch.randn((c,), dtype=dtype, device="cuda")
+
+        y = op(x, weight, bias)
+        y_ref = F.group_norm(
+            x.float(), 4, weight=weight.float(), bias=bias.float(), eps=1e-5,
+        ).to(dtype)
+        atol, rtol = _get_tolerances(dtype)
+        assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
+
+    run_case(2, 16, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    assert op.eval_roofline() == (
+        5 * 2 * 16 * 16,
+        (2 * 2 * 16 * 16 + 2 * 16) * torch.float16.itemsize,
+    )
+
+    run_case(2, 16, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+
+    run_case(3, 24, (2, 8), torch.bfloat16)
+    assert len(op._kernel_cache) == 2
+    assert op.eval_roofline() == (
+        5 * 3 * 24 * 16,
+        (2 * 3 * 24 * 16 + 2 * 24) * torch.bfloat16.itemsize,
+    )
+
+
+@pytest.mark.smoke
 def test_group_norm_rejects_affine_device_mismatch() -> None:
     """Forward must raise ValueError when weight/bias live on a different CUDA device than x.
 

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -266,30 +266,6 @@ def test_group_norm_no_affine_lazily_specializes_per_device() -> None:
 
 
 @pytest.mark.smoke
-def test_group_norm_no_affine_rejects_shape_mismatch() -> None:
-    """Forward raises ValueError when input shape differs from configured (N, C, *spatial)."""
-    n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    op = GroupNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, num_groups=g, dtype=dtype,
-    )
-    x_bad = torch.randn((n, c, 4, 8), dtype=dtype, device="cuda")
-    with pytest.raises(ValueError, match="shape"):
-        op(x_bad)
-
-
-@pytest.mark.smoke
-def test_group_norm_no_affine_rejects_dtype_mismatch() -> None:
-    """Forward raises ValueError when input dtype differs from configured dtype."""
-    n, c, spatial, g = 2, 32, (8, 8), 8
-    op = GroupNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, num_groups=g, dtype=torch.float16,
-    )
-    x = torch.randn((n, c, *spatial), dtype=torch.float32, device="cuda")
-    with pytest.raises(ValueError, match="dtype"):
-        op(x)
-
-
-@pytest.mark.smoke
 @pytest.mark.parametrize("n, c, spatial, g", [
     # M = N * num_groups not divisible by max block_m (16): triggers tail
     # program reading/writing rows >= M before the M-padding fix.

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -57,7 +57,7 @@ def _get_tolerances(dtype: torch.dtype) -> tuple[float, float]:
 def test_instance_norm_op(n: int, c: int, spatial: tuple,
                           dtype: torch.dtype, tune: bool) -> None:
     test = InstanceNormTest(n, c, spatial, dtype)
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp()
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -81,7 +81,7 @@ def test_instance_norm_non_contiguous(n: int, c: int, spatial: tuple,
     weight = torch.randn(c, dtype=dtype, device="cuda")
     bias = torch.randn(c, dtype=dtype, device="cuda")
 
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp()
 
     y_ref = F.instance_norm(
         x.contiguous().float(),
@@ -118,7 +118,7 @@ class InstanceNormNoAffineFixture(FixtureBase):
 def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
                                     dtype: torch.dtype, tune: bool) -> None:
     """Forward correctness for InstanceNormFwdOpNoAffine vs F.instance_norm(weight=None, bias=None)."""
-    op = InstanceNormFwdOpNoAffine(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOpNoAffine()
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     # Running stats are required positional args (R16) but ignored on the
     # use_input_stats=True path; pass placeholders.
@@ -138,9 +138,7 @@ def test_instance_norm_no_affine_running_stats(
     n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool,
 ) -> None:
     """use_input_stats=False uses running_mean/running_var; matches torch reference."""
-    op = InstanceNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, dtype=dtype, use_input_stats=False,
-    )
+    op = InstanceNormFwdOpNoAffine(use_input_stats=False)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     running_mean = torch.randn(c, dtype=torch.float32, device="cuda")
     running_var = torch.rand(c, dtype=torch.float32, device="cuda") + 0.1
@@ -158,7 +156,7 @@ def test_instance_norm_no_affine_running_stats(
 def test_instance_norm_rejects_none_weight_or_bias() -> None:
     """Affine op rejects ``weight=None`` / ``bias=None``; affine-free path lives on NoAffine."""
     n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp()
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     weight = torch.randn((c,), dtype=dtype, device="cuda")
     bias = torch.randn((c,), dtype=dtype, device="cuda")
@@ -185,6 +183,7 @@ def test_instance_norm_forward_required_signature() -> None:
 def test_instance_norm_rejects_ctor_input_dtype_mismatch() -> None:
     op = InstanceNormFwdOp.__new__(InstanceNormFwdOp)
     op.dtype = torch.float16
+    op._committed_dtype = torch.float16
 
     fp16 = torch.empty(0, dtype=torch.float16)
     bf16 = torch.empty(0, dtype=torch.bfloat16)
@@ -217,20 +216,13 @@ def test_instance_norm_validate_dtypes_matches_manifest_inputs() -> None:
 
 
 @pytest.mark.smoke
-def test_instance_norm_rejects_device_mismatch() -> None:
-    """Forward must raise ValueError when input device differs from kernel device.
-
-    The compiled kernel binds to the active CUDA device at construction
-    time, so callers must construct one op per device. Verify the op
-    surfaces a clean ValueError rather than letting the kernel layer
-    raise an opaque device-id error.
-    """
+def test_instance_norm_lazily_specializes_per_device() -> None:
+    """A single op can lazily build specializations for different CUDA devices."""
     if torch.cuda.device_count() < 2:
-        pytest.skip("device-mismatch test requires >= 2 CUDA devices")
+        pytest.skip("multi-device test requires >= 2 CUDA devices")
 
     n, c, spatial, dtype = 2, 32, (8, 8), torch.float16
-    with torch.cuda.device(0):
-        op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+    op = InstanceNormFwdOp()
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
@@ -240,8 +232,9 @@ def test_instance_norm_rejects_device_mismatch() -> None:
     bias_other = torch.randn(
         (c,), dtype=dtype, device=torch.device("cuda", 1),
     )
-    with pytest.raises(ValueError, match="[Dd]evice mismatch"):
-        op(x_other, weight_other, bias_other)
+    y = op(x_other, weight_other, bias_other)
+    assert y.device == x_other.device
+    assert len(op._kernel_cache) == 1
 
 
 @pytest.mark.smoke
@@ -257,7 +250,7 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
 
     n, c, spatial, dtype = 2, 32, (8, 8), torch.float16
     with torch.cuda.device(0):
-        op = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
+        op = InstanceNormFwdOp()
     x = torch.randn((n, c, *spatial), dtype=dtype, device=torch.device("cuda", 0))
     weight_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
     bias_other = torch.randn((c,), dtype=dtype, device=torch.device("cuda", 1))
@@ -328,19 +321,14 @@ def test_instance_norm_init_signature_covers_manifest_params(
 def test_instance_norm_affine_rejects_running_stats_path() -> None:
     """The affine variant still defers `use_input_stats=False`."""
     with pytest.raises(NotImplementedError, match="running-stats"):
-        InstanceNormFwdOp(
-            N=2, C=16, spatial=(8, 8), dtype=torch.float16,
-            use_input_stats=False,
-        )
+        InstanceNormFwdOp(use_input_stats=False)
 
 
 @pytest.mark.smoke
 def test_instance_norm_no_affine_accepts_running_stats_path() -> None:
     """No-affine variant supports `use_input_stats=False` end-to-end."""
     n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op = InstanceNormFwdOpNoAffine(
-        N=n, C=c, spatial=spatial, dtype=dtype, use_input_stats=False,
-    )
+    op = InstanceNormFwdOpNoAffine(use_input_stats=False)
     assert op.use_input_stats is False
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     running_mean = torch.randn(c, dtype=torch.float32, device="cuda")
@@ -358,10 +346,8 @@ def test_instance_norm_no_affine_accepts_running_stats_path() -> None:
 def test_instance_norm_default_momentum_does_not_change_output() -> None:
     """Per-batch path is independent of `momentum`; default value must match torch."""
     n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op_default = InstanceNormFwdOp(N=n, C=c, spatial=spatial, dtype=dtype)
-    op_other = InstanceNormFwdOp(
-        N=n, C=c, spatial=spatial, dtype=dtype, momentum=0.5,
-    )
+    op_default = InstanceNormFwdOp()
+    op_other = InstanceNormFwdOp(momentum=0.5)
     assert op_default.momentum == pytest.approx(0.1)
     assert op_other.momentum == pytest.approx(0.5)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -238,6 +238,41 @@ def test_instance_norm_lazily_specializes_per_device() -> None:
 
 
 @pytest.mark.smoke
+def test_instance_norm_lazy_cache_reuse_and_respecialization() -> None:
+    """One op instance reuses identical specs and caches changed specs."""
+    op = InstanceNormFwdOp()
+
+    def run_case(n: int, c: int, spatial: tuple[int, ...], dtype: torch.dtype) -> None:
+        x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+        weight = torch.randn((c,), dtype=dtype, device="cuda")
+        bias = torch.randn((c,), dtype=dtype, device="cuda")
+
+        y = op(x, weight, bias)
+        y_ref = F.instance_norm(
+            x.float(), weight=weight.float(), bias=bias.float(), eps=1e-5,
+        ).to(dtype)
+        atol, rtol = _get_tolerances(dtype)
+        assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    assert op.eval_roofline() == (
+        5 * 2 * 8 * 16,
+        (2 * 2 * 8 * 16 + 2 * 8) * torch.float16.itemsize,
+    )
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+
+    run_case(3, 12, (2, 8), torch.bfloat16)
+    assert len(op._kernel_cache) == 2
+    assert op.eval_roofline() == (
+        5 * 3 * 12 * 16,
+        (2 * 3 * 12 * 16 + 2 * 12) * torch.bfloat16.itemsize,
+    )
+
+
+@pytest.mark.smoke
 def test_instance_norm_rejects_affine_device_mismatch() -> None:
     """Forward must raise ValueError when weight/bias live on a different CUDA device than x.
 

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -180,18 +180,17 @@ def test_instance_norm_forward_required_signature() -> None:
 
 
 @pytest.mark.smoke
-def test_instance_norm_rejects_ctor_input_dtype_mismatch() -> None:
+def test_instance_norm_rejects_input_affine_dtype_mismatch() -> None:
     op = InstanceNormFwdOp.__new__(InstanceNormFwdOp)
-    op.dtype = torch.float16
-    op._committed_dtype = torch.float16
 
     fp16 = torch.empty(0, dtype=torch.float16)
     bf16 = torch.empty(0, dtype=torch.bfloat16)
+    int32 = torch.empty(0, dtype=torch.int32)
 
     op._validate_dtypes(fp16, fp16, fp16)
 
     with pytest.raises(ValueError, match="x.dtype"):
-        op._validate_dtypes(bf16, fp16, fp16)
+        op._validate_dtypes(int32, fp16, fp16)
     with pytest.raises(ValueError, match="weight.dtype"):
         op._validate_dtypes(fp16, bf16, fp16)
     with pytest.raises(ValueError, match="bias.dtype"):

--- a/tests/ops/test_norm_lazy_cache.py
+++ b/tests/ops/test_norm_lazy_cache.py
@@ -2,7 +2,18 @@ import pytest
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.ops.norm.batch_norm import BatchNormFwdOp
+from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
+
+
+def _to_cl(x: torch.Tensor) -> torch.Tensor:
+    return x.permute(1, 0, *range(2, x.ndim)).reshape(x.shape[1], -1).contiguous()
+
+
+def _from_cl(x_cl: torch.Tensor, orig_shape: torch.Size) -> torch.Tensor:
+    n = orig_shape[0]
+    c = orig_shape[1]
+    spatial = orig_shape[2:]
+    return x_cl.reshape(c, n, *spatial).permute(1, 0, *range(2, len(orig_shape))).contiguous()
 
 
 class _FakeBatchNormFwdInferKernel(Kernel):
@@ -66,6 +77,41 @@ class _FakeBatchNormFwdTrainKernel(_FakeBatchNormFwdInferKernel):
         return y.to(self.dtype), mean, rstd
 
 
+class _FakeBatchNormBwdKernel(Kernel):
+    def __init__(
+        self,
+        C: int,
+        L: int,
+        dtype: torch.dtype,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.C = C
+        self.L = L
+        self.dtype = dtype
+        self.tune = tune
+
+    def forward(
+        self,
+        grad_out_cl: torch.Tensor,
+        x_cl: torch.Tensor,
+        weight: torch.Tensor,
+        mean: torch.Tensor,
+        rstd: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        grad_out_f = grad_out_cl.float()
+        x_hat = (x_cl.float() - mean[:, None]) * rstd[:, None]
+        grad_bias = grad_out_f.sum(dim=1)
+        grad_weight = (grad_out_f * x_hat).sum(dim=1)
+        grad_x = (
+            weight[:, None]
+            * rstd[:, None]
+            * (self.L * grad_out_f - grad_bias[:, None] - x_hat * grad_weight[:, None])
+            / self.L
+        )
+        return grad_x.to(self.dtype), grad_weight, grad_bias
+
+
 def _batch_norm_infer_ref(
     x: torch.Tensor,
     running_mean: torch.Tensor,
@@ -79,6 +125,35 @@ def _batch_norm_infer_ref(
         running_var.reshape(affine_shape) + eps)
     y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
     return y.to(x.dtype)
+
+
+def _batch_norm_train_ref(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    x_cl = _to_cl(x)
+    mean = x_cl.float().mean(dim=1)
+    var = x_cl.float().var(dim=1, unbiased=False)
+    rstd = torch.rsqrt(var + eps)
+    y_cl = (x_cl.float() - mean[:, None]) * rstd[:, None]
+    y_cl = y_cl * weight[:, None] + bias[:, None]
+    return _from_cl(y_cl.to(x.dtype), x.shape), mean, rstd
+
+
+def _batch_norm_bwd_ref(
+    grad_out: torch.Tensor,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    grad_out_cl = _to_cl(grad_out)
+    x_cl = _to_cl(x)
+    kernel = _FakeBatchNormBwdKernel(x.shape[1], grad_out.numel() // x.shape[1], x.dtype)
+    grad_x_cl, grad_weight, grad_bias = kernel(grad_out_cl, x_cl, weight, mean, rstd)
+    return _from_cl(grad_x_cl, x.shape), grad_weight, grad_bias
 
 
 @pytest.mark.smoke
@@ -109,6 +184,7 @@ def test_batch_norm_fwd_lazy_cache_reuse_and_respecialization() -> None:
 
     run_case(2, 8, (4, 4), torch.float16)
     assert len(op._kernel_cache) == 1
+    first_kernel = op.kernel
     assert op.eval_roofline() == (
         10 * 8 * 32,
         2 * 8 * 32 * torch.float16.itemsize + 4 * 8 * 4,
@@ -116,10 +192,102 @@ def test_batch_norm_fwd_lazy_cache_reuse_and_respecialization() -> None:
 
     run_case(2, 8, (4, 4), torch.float16)
     assert len(op._kernel_cache) == 1
+    assert op.kernel is first_kernel
 
     run_case(3, 12, (2, 8), torch.bfloat16)
     assert len(op._kernel_cache) == 2
+    assert op.kernel is not first_kernel
     assert op.eval_roofline() == (
         10 * 12 * 48,
         2 * 12 * 48 * torch.bfloat16.itemsize + 4 * 12 * 4,
+    )
+
+
+@pytest.mark.smoke
+def test_batch_norm_training_fwd_lazy_cache_reuse_and_respecialization() -> None:
+    """Training BatchNorm forward cache path is executable under fake kernels."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for forward call")
+
+    op = BatchNormFwdOp(
+        training=True,
+        kernel_map={
+            "fwd_infer_kernel": _FakeBatchNormFwdInferKernel,
+            "fwd_train_kernel": _FakeBatchNormFwdTrainKernel,
+        },
+    )
+
+    def run_case(N: int, C: int, spatial: tuple[int, ...], dtype: torch.dtype) -> None:
+        x = torch.randn((N, C, *spatial), device="cuda", dtype=dtype)
+        weight = torch.randn(C, device="cuda", dtype=torch.float32)
+        bias = torch.randn(C, device="cuda", dtype=torch.float32)
+        running_mean = torch.zeros(C, device="cuda", dtype=torch.float32)
+        running_var = torch.ones(C, device="cuda", dtype=torch.float32)
+
+        y = op(x, running_mean, running_var, weight, bias)
+        ref_y, _, _ = _batch_norm_train_ref(x, weight, bias, op.eps)
+        assert torch.allclose(y.float(), ref_y.float(), atol=0.0, rtol=0.0)
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    first_kernel = op.kernel
+    assert op.eval_roofline() == (
+        10 * 8 * 32,
+        2 * 8 * 32 * torch.float16.itemsize + 4 * 8 * 4,
+    )
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    assert op.kernel is first_kernel
+
+    run_case(3, 12, (2, 8), torch.bfloat16)
+    assert len(op._kernel_cache) == 2
+    assert op.kernel is not first_kernel
+    assert op.eval_roofline() == (
+        10 * 12 * 48,
+        2 * 12 * 48 * torch.bfloat16.itemsize + 4 * 12 * 4,
+    )
+
+
+@pytest.mark.smoke
+def test_batch_norm_bwd_lazy_cache_reuse_and_respecialization() -> None:
+    """BatchNorm backward cache path is executable under fake kernels."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for backward call")
+
+    eps = 1e-5
+    op = BatchNormBwdOp(kernel_map={"bwd_kernel": _FakeBatchNormBwdKernel})
+
+    def run_case(N: int, C: int, spatial: tuple[int, ...], dtype: torch.dtype) -> None:
+        x = torch.randn((N, C, *spatial), device="cuda", dtype=dtype)
+        grad_out = torch.randn((N, C, *spatial), device="cuda", dtype=dtype)
+        weight = torch.randn(C, device="cuda", dtype=torch.float32)
+        _y, mean, rstd = _batch_norm_train_ref(
+            x, torch.ones_like(weight), torch.zeros_like(weight), eps)
+
+        grad_x, grad_weight, grad_bias = op(grad_out, x, weight, mean, rstd)
+        ref_grad_x, ref_grad_weight, ref_grad_bias = _batch_norm_bwd_ref(
+            grad_out, x, weight, mean, rstd)
+        assert torch.allclose(grad_x.float(), ref_grad_x.float(), atol=0.0, rtol=0.0)
+        assert torch.allclose(grad_weight, ref_grad_weight, atol=0.0, rtol=0.0)
+        assert torch.allclose(grad_bias, ref_grad_bias, atol=0.0, rtol=0.0)
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    first_kernel = op.kernel
+    assert op.eval_roofline() == (
+        8 * 8 * 32,
+        3 * 8 * 32 * torch.float16.itemsize + 3 * 8 * 4,
+    )
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    assert op.kernel is first_kernel
+
+    run_case(3, 12, (2, 8), torch.bfloat16)
+    assert len(op._kernel_cache) == 2
+    assert op.kernel is not first_kernel
+    assert op.eval_roofline() == (
+        8 * 12 * 48,
+        3 * 12 * 48 * torch.bfloat16.itemsize + 3 * 12 * 4,
     )

--- a/tests/ops/test_norm_lazy_cache.py
+++ b/tests/ops/test_norm_lazy_cache.py
@@ -1,0 +1,125 @@
+import pytest
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+from tileops.ops.norm.batch_norm import BatchNormFwdOp
+
+
+class _FakeBatchNormFwdInferKernel(Kernel):
+    def __init__(
+        self,
+        C: int,
+        L: int,
+        dtype: torch.dtype,
+        eps: float,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        self.C = C
+        self.L = L
+        self.dtype = dtype
+        self.eps = eps
+        self.tune = tune
+
+    def forward(
+        self,
+        x_cl: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        running_mean: torch.Tensor,
+        running_var: torch.Tensor,
+    ) -> torch.Tensor:
+        y = (x_cl.float() - running_mean[:, None]) * torch.rsqrt(
+            running_var[:, None] + self.eps)
+        y = y * weight[:, None] + bias[:, None]
+        return y.to(self.dtype)
+
+
+class _FakeBatchNormFwdTrainKernel(_FakeBatchNormFwdInferKernel):
+    def __init__(
+        self,
+        C: int,
+        L: int,
+        dtype: torch.dtype,
+        eps: float,
+        momentum: float,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(C, L, dtype, eps, tune=tune)
+        self.momentum = momentum
+
+    def forward(
+        self,
+        x_cl: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        running_mean: torch.Tensor,
+        running_var: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        mean = x_cl.float().mean(dim=1)
+        var = x_cl.float().var(dim=1, unbiased=False)
+        rstd = torch.rsqrt(var + self.eps)
+        running_mean.mul_(1 - self.momentum).add_(self.momentum * mean)
+        running_var.mul_(1 - self.momentum).add_(self.momentum * var)
+        y = (x_cl.float() - mean[:, None]) * rstd[:, None]
+        y = y * weight[:, None] + bias[:, None]
+        return y.to(self.dtype), mean, rstd
+
+
+def _batch_norm_infer_ref(
+    x: torch.Tensor,
+    running_mean: torch.Tensor,
+    running_var: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    affine_shape = (1, x.shape[1]) + (1,) * (x.ndim - 2)
+    y = (x.float() - running_mean.reshape(affine_shape)) * torch.rsqrt(
+        running_var.reshape(affine_shape) + eps)
+    y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
+    return y.to(x.dtype)
+
+
+@pytest.mark.smoke
+def test_batch_norm_fwd_lazy_cache_reuse_and_respecialization() -> None:
+    """BatchNorm op-layer cache reuses identical specs and caches changed specs."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for forward call")
+
+    op = BatchNormFwdOp(
+        training=False,
+        kernel_map={
+            "fwd_infer_kernel": _FakeBatchNormFwdInferKernel,
+            "fwd_train_kernel": _FakeBatchNormFwdTrainKernel,
+        },
+    )
+
+    def run_case(N: int, C: int, spatial: tuple[int, ...], dtype: torch.dtype) -> None:
+        x = torch.randn((N, C, *spatial), device="cuda", dtype=dtype)
+        weight = torch.randn(C, device="cuda", dtype=torch.float32)
+        bias = torch.randn(C, device="cuda", dtype=torch.float32)
+        running_mean = torch.zeros(C, device="cuda", dtype=torch.float32)
+        running_var = torch.ones(C, device="cuda", dtype=torch.float32)
+
+        y = op(x, running_mean, running_var, weight, bias)
+        ref_y = _batch_norm_infer_ref(
+            x, running_mean, running_var, weight, bias, op.eps)
+        assert torch.allclose(y.float(), ref_y.float(), atol=0.0, rtol=0.0)
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+    assert op.eval_roofline() == (
+        10 * 8 * 32,
+        2 * 8 * 32 * torch.float16.itemsize + 4 * 8 * 4,
+    )
+
+    run_case(2, 8, (4, 4), torch.float16)
+    assert len(op._kernel_cache) == 1
+
+    run_case(3, 12, (2, 8), torch.bfloat16)
+    assert len(op._kernel_cache) == 2
+    assert op.eval_roofline() == (
+        10 * 12 * 48,
+        2 * 12 * 48 * torch.bfloat16.itemsize + 4 * 12 * 4,
+    )

--- a/tests/ops/test_norm_ops.py
+++ b/tests/ops/test_norm_ops.py
@@ -19,7 +19,7 @@ class TestBatchNormFwdValidation:
 
     def _make_op(self):
         from tileops.ops.norm.batch_norm import BatchNormFwdOp
-        return BatchNormFwdOp(4, 8, (4, 4), dtype=torch.float16)
+        return BatchNormFwdOp()
 
     def _make_inputs(self, device="cuda", dtype=torch.float16):
         x = torch.randn(4, 8, 4, 4, device=device, dtype=dtype)
@@ -37,7 +37,8 @@ class TestBatchNormFwdValidation:
             op(x_cpu, rm, rv, weight, bias)
 
     def test_rejects_wrong_dtype(self):
-        op = self._make_op()
+        from tileops.ops.norm.batch_norm import BatchNormFwdOp
+        op = BatchNormFwdOp(dtype=torch.float16)
         x_wrong = torch.randn(4, 8, 4, 4, device="cuda", dtype=torch.float32)
         _, weight, bias, rm, rv = self._make_inputs()
         with pytest.raises(ValueError, match="dtype"):
@@ -62,7 +63,7 @@ class TestBatchNormCustomOp:
 
     def test_fwd_torch_compile_smoke(self):
         from tileops.ops.norm.batch_norm import BatchNormFwdOp
-        op = BatchNormFwdOp(4, 8, (4, 4), dtype=torch.float16, training=True)
+        op = BatchNormFwdOp(training=True)
         x = torch.randn(4, 8, 4, 4, device="cuda", dtype=torch.float16)
         weight = torch.randn(8, device="cuda", dtype=torch.float32)
         bias = torch.randn(8, device="cuda", dtype=torch.float32)
@@ -77,7 +78,7 @@ class TestBatchNormCustomOp:
     def test_bwd_torch_compile_smoke(self):
         from tileops.ops.norm.batch_norm import BatchNormBwdOp
         N, C, H, W = 4, 8, 4, 4
-        op = BatchNormBwdOp(N, C, H, W, dtype=torch.float16)
+        op = BatchNormBwdOp()
         grad_out = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
         x = torch.randn(N, C, H, W, device="cuda", dtype=torch.float16)
         weight = torch.randn(C, device="cuda", dtype=torch.float32)

--- a/tests/ops/test_norm_ops.py
+++ b/tests/ops/test_norm_ops.py
@@ -38,8 +38,8 @@ class TestBatchNormFwdValidation:
 
     def test_rejects_wrong_dtype(self):
         from tileops.ops.norm.batch_norm import BatchNormFwdOp
-        op = BatchNormFwdOp(dtype=torch.float16)
-        x_wrong = torch.randn(4, 8, 4, 4, device="cuda", dtype=torch.float32)
+        op = BatchNormFwdOp()
+        x_wrong = torch.randn(4, 8, 4, 4, device="cuda", dtype=torch.float64)
         _, weight, bias, rm, rv = self._make_inputs()
         with pytest.raises(ValueError, match="dtype"):
             op(x_wrong, rm, rv, weight, bias)

--- a/tests/ops/test_normalization_alignment.py
+++ b/tests/ops/test_normalization_alignment.py
@@ -73,7 +73,5 @@ def test_layer_norm_accepts_tuple_normalized_shape_runtime() -> None:
 def test_group_norm_uses_num_groups_kwarg() -> None:
     from tileops.ops.norm.group_norm import GroupNormFwdOp
 
-    op = GroupNormFwdOp(
-        N=2, C=32, spatial=(8, 8), num_groups=8, dtype=torch.float16,
-    )
+    op = GroupNormFwdOp(num_groups=8)
     assert op.num_groups == 8

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -8,8 +8,8 @@ Smoke tests (1 per function, first param) use small data for quick CI.
 Full tests use small data for config breadth + large data for stress.
 
 All operators use the spec-conformant interface:
-  SoftmaxFwdOp(N=N, dtype=dtype, dim=dim)
-  LogSoftmaxFwdOp(N=N, dtype=dtype, dim=dim)
+  SoftmaxFwdOp(dim=dim)
+  LogSoftmaxFwdOp(dim=dim)
   LogSumExpFwdOp(dtype=dtype, dim=dim, keepdim=keepdim)
 """
 
@@ -105,7 +105,7 @@ class SoftmaxTest(_SoftmaxTestWorkload, TestBase):
 @SoftmaxFixture
 def test_softmax_op(shape: tuple, dim: int, dtype: torch.dtype, tune: bool) -> None:
     test = SoftmaxTest(shape, dtype, dim=dim)
-    op = SoftmaxFwdOp(N=shape[dim], dtype=dtype, dim=dim, tune=tune)
+    op = SoftmaxFwdOp(dim=dim, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -138,7 +138,7 @@ def test_softmax_non_contiguous(shape: tuple, dtype: torch.dtype) -> None:
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]  # non-contiguous slice
 
-    op = SoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
+    op = SoftmaxFwdOp(dim=-1)
 
     y_ref = F.softmax(x.float().contiguous(), dim=-1).to(dtype)
     y = op(x)
@@ -173,7 +173,7 @@ class Softmax1DFixture(FixtureBase):
 def test_softmax_1d(n: int, dtype: torch.dtype) -> None:
     """Test softmax with 1D input (single row)."""
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = SoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
+    op = SoftmaxFwdOp(dim=-1)
 
     y_ref = F.softmax(x.float(), dim=-1).to(dtype)
     y = op(x)
@@ -249,7 +249,7 @@ class LogSoftmaxTest(_LogSoftmaxTestWorkload, TestBase):
 @LogSoftmaxFixture
 def test_log_softmax_op(shape: tuple, dim: int, dtype: torch.dtype, tune: bool) -> None:
     test = LogSoftmaxTest(shape, dtype, dim=dim)
-    op = LogSoftmaxFwdOp(N=shape[dim], dtype=dtype, dim=dim, tune=tune)
+    op = LogSoftmaxFwdOp(dim=dim, tune=tune)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -392,7 +392,7 @@ def test_log_softmax_non_contiguous(shape: tuple, dtype: torch.dtype) -> None:
     x_full = torch.randn(m, n * 2, dtype=dtype, device="cuda")
     x = x_full[:, :n]
 
-    op = LogSoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
+    op = LogSoftmaxFwdOp(dim=-1)
 
     y_ref = F.log_softmax(x.float().contiguous(), dim=-1).to(dtype)
     y = op(x)
@@ -460,7 +460,7 @@ class LogSoftmax1DFixture(FixtureBase):
 def test_log_softmax_1d(n: int, dtype: torch.dtype) -> None:
     """Test log_softmax with 1D input."""
     x = torch.randn(n, dtype=dtype, device="cuda")
-    op = LogSoftmaxFwdOp(N=n, dtype=dtype, dim=-1)
+    op = LogSoftmaxFwdOp(dim=-1)
 
     y_ref = F.log_softmax(x.float(), dim=-1).to(dtype)
     y = op(x)
@@ -511,7 +511,7 @@ def test_logsumexp_1d(n: int, dtype: torch.dtype) -> None:
 def test_softmax_rejects_multidim_before_kernel() -> None:
     """SoftmaxFwdOp must raise ValueError for list dim before touching the kernel."""
     x = torch.randn(4, 8, device="cuda", dtype=torch.float32)
-    op = SoftmaxFwdOp(N=8, dtype=torch.float32, dim=[-1, 0])
+    op = SoftmaxFwdOp(dim=[-1, 0])
     with pytest.raises(ValueError, match="does not support multi-dim"):
         op(x)
     # Verify no kernel was built (cache must remain empty).
@@ -522,7 +522,7 @@ def test_softmax_rejects_multidim_before_kernel() -> None:
 def test_log_softmax_rejects_multidim_before_kernel() -> None:
     """LogSoftmaxFwdOp must raise ValueError for list dim before touching the kernel."""
     x = torch.randn(4, 8, device="cuda", dtype=torch.float32)
-    op = LogSoftmaxFwdOp(N=8, dtype=torch.float32, dim=[-1, 0])
+    op = LogSoftmaxFwdOp(dim=[-1, 0])
     with pytest.raises(ValueError, match="does not support multi-dim"):
         op(x)
     assert len(op._kernel_cache) == 0
@@ -561,8 +561,7 @@ def test_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) -> Non
     """SoftmaxFwdOp(dim=None) must match F.softmax(x, dim=None) and warn."""
     import warnings as _warnings
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    expected_dim = _expected_implicit_dim(x.ndim)
-    op = SoftmaxFwdOp(N=shape[expected_dim], dtype=dtype, dim=None)
+    op = SoftmaxFwdOp(dim=None)
 
     with _warnings.catch_warnings(record=True) as caught:
         _warnings.simplefilter("always")
@@ -588,8 +587,7 @@ def test_log_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) ->
     """LogSoftmaxFwdOp(dim=None) must match F.log_softmax(x, dim=None) and warn."""
     import warnings as _warnings
     x = torch.randn(*shape, dtype=dtype, device="cuda")
-    expected_dim = _expected_implicit_dim(x.ndim)
-    op = LogSoftmaxFwdOp(N=shape[expected_dim], dtype=dtype, dim=None)
+    op = LogSoftmaxFwdOp(dim=None)
 
     with _warnings.catch_warnings(record=True) as caught:
         _warnings.simplefilter("always")
@@ -614,7 +612,7 @@ def test_log_softmax_dim_none_implicit_axis(shape: tuple, dtype: torch.dtype) ->
 def test_softmax_dim_none_reused_across_ranks() -> None:
     """SoftmaxFwdOp(dim=None) must re-resolve per call across input ranks."""
     import warnings as _warnings
-    op = SoftmaxFwdOp(N=4, dtype=torch.float32, dim=None)
+    op = SoftmaxFwdOp(dim=None)
 
     x1 = torch.randn(4, dtype=torch.float32, device="cuda")
     x2 = torch.randn(2, 4, dtype=torch.float32, device="cuda")
@@ -641,7 +639,7 @@ def test_softmax_dim_none_reused_across_ranks() -> None:
 def test_log_softmax_dim_none_reused_across_ranks() -> None:
     """LogSoftmaxFwdOp(dim=None) must re-resolve per call (no self.dim mutation)."""
     import warnings as _warnings
-    op = LogSoftmaxFwdOp(N=4, dtype=torch.float32, dim=None)
+    op = LogSoftmaxFwdOp(dim=None)
 
     x1 = torch.randn(4, dtype=torch.float32, device="cuda")
     x2 = torch.randn(2, 4, dtype=torch.float32, device="cuda")
@@ -676,7 +674,7 @@ def test_log_softmax_eval_roofline_flops_5mn() -> None:
     """LogSoftmaxFwdOp.eval_roofline() must report flops == 5 * M * N."""
     M, N = 64, 256
     dtype = torch.float16
-    op = LogSoftmaxFwdOp(N=N, dtype=dtype, dim=-1)
+    op = LogSoftmaxFwdOp(dim=-1)
     x = torch.randn(M, N, dtype=dtype, device="cuda")
     op(x)  # bind dynamic shape
     flops, mem_bytes = op.eval_roofline()

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -314,8 +314,6 @@ BatchNormFwdOp:
       training: {type: bool, default: false}
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      C: "x.shape[1]"
     shape_rules:
       - "running_mean.shape == (x.shape[1],)"
       - "running_var.shape == (x.shape[1],)"
@@ -368,8 +366,6 @@ BatchNormBwdOp:
       grad_weight: {dtype: "float32"}
       grad_bias: {dtype: "float32"}
     params: {}
-    static_dims:
-      C: "grad_out.shape[1]"
     shape_rules:
       - "x.shape == grad_out.shape"
       - "weight.shape == (grad_out.shape[1],)"
@@ -421,8 +417,6 @@ GroupNormFwdOp:
     params:
       num_groups: {type: int}
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      C: "x.shape[1]"
     shape_rules:
       - "weight.shape == (x.shape[1],)"
       - "bias.shape == (x.shape[1],)"
@@ -473,8 +467,6 @@ GroupNormFwdOpNoAffine:
     params:
       num_groups: {type: int}
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      C: "x.shape[1]"
     shape_rules:
       - "x.shape[1] % num_groups == 0"
       - "output.shape == x.shape"
@@ -522,8 +514,6 @@ InstanceNormFwdOp:
       use_input_stats: {type: bool, default: true}
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      C: "x.shape[1]"
     shape_rules:
       - "weight.shape == (x.shape[1],)"
       - "bias.shape == (x.shape[1],)"
@@ -575,8 +565,6 @@ InstanceNormFwdOpNoAffine:
       use_input_stats: {type: bool, default: true}
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
-    static_dims:
-      C: "x.shape[1]"
     shape_rules:
       - "running_mean.shape == (x.shape[1],)"
       - "running_var.shape == (x.shape[1],)"

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -5,13 +5,10 @@ in a standard TileOPs Op interface.
 
 User-facing API mirrors :func:`torch.nn.functional.batch_norm`:
 
-    fwd_op = BatchNormFwdOp(
-        N, C, spatial, dtype=dtype, training=False,
-        momentum=0.1, eps=1e-5,
-    )
+    fwd_op = BatchNormFwdOp(training=False, momentum=0.1, eps=1e-5)
     y = fwd_op(x, running_mean, running_var, weight, bias)
 
-    bwd_op = BatchNormBwdOp(N, C, *spatial, dtype=dtype)
+    bwd_op = BatchNormBwdOp()
     grad_x, grad_weight, grad_bias = bwd_op(grad_out, x, weight, mean, rstd)
 
 Forward returns the normalized output only (manifest contract); ``mean`` and
@@ -88,10 +85,10 @@ class BatchNormFwdOp(Op):
         to ``(C, L)`` internally where ``L = N * prod(spatial)``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        *spatial: Spatial dimensions (H, W, ...).
-        dtype: Input/output data type.
+        N: Optional committed batch size for compatibility.
+        C: Optional committed channel count for compatibility.
+        spatial: Optional committed spatial dimensions for compatibility.
+        dtype: Optional committed input/output data type for compatibility.
         training: Default ``training`` flag for ``forward()``; per the
             manifest the default is ``False``.
         momentum: Running-stat update momentum (used in training mode).
@@ -102,10 +99,10 @@ class BatchNormFwdOp(Op):
 
     def __init__(
         self,
-        N: int,
-        C: int,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
         spatial: Tuple[int, ...] = (),
-        dtype: torch.dtype = torch.float16,
+        dtype: Optional[torch.dtype] = None,
         training: bool = False,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -116,18 +113,27 @@ class BatchNormFwdOp(Op):
         self.N = N
         self.C = C
         self.spatial = tuple(spatial)
-        self.L = N * math.prod(self.spatial) if self.spatial else N
+        self.L = (
+            N * math.prod(self.spatial)
+            if N is not None and self.spatial
+            else N
+        )
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = tuple(spatial) if spatial else None
+        self._committed_dtype = dtype
         self.training = training
         self.eps = eps
         self.momentum = momentum
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        self.train_kernel: BatchNormFwdTrainKernel = self.kernel_map["fwd_train_kernel"](
-            C, self.L, dtype, eps, momentum, tune=tune)
-        self.infer_kernel: BatchNormFwdInferKernel = self.kernel_map["fwd_infer_kernel"](
-            C, self.L, dtype, eps, tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel: Optional[Kernel] = None
+        self.train_kernel: Optional[BatchNormFwdTrainKernel] = None
+        self.infer_kernel: Optional[BatchNormFwdInferKernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -137,29 +143,113 @@ class BatchNormFwdOp(Op):
         }
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "BatchNormFwdOp.eval_roofline() requires a prior forward() call"
+            )
+        C, L, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            10 * self.C * self.L,
-            2 * self.C * self.L * elem_bytes + 4 * self.C * 4,
+            10 * C * L,
+            2 * C * L * elem_bytes + 4 * C * 4,
         )
 
     def _prepare(self, x: torch.Tensor) -> Tuple[torch.Tensor, Tuple]:
         """Reshape x to (C, L)."""
         return _reshape_to_CL(x)
 
-    def _validate_inputs(self, x: torch.Tensor) -> None:
-        """Validate device, dtype, and shape of the input tensor."""
+    def _resolve_spec(self, x: torch.Tensor) -> Tuple[int, int, Tuple[int, ...], int, torch.dtype]:
+        """Validate input metadata and return (N, C, spatial, L, dtype)."""
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
+        if x.ndim < 2:
+            raise ValueError("x must have shape (N, C, *spatial)")
+        if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
             raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+                "x.dtype must be float32, float16, or bfloat16, "
+                f"got {x.dtype}"
             )
-        expected_shape = (self.N, self.C, *self.spatial)
-        if x.shape != expected_shape:
+        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
             raise ValueError(
-                f"Expected input shape {expected_shape}, got {x.shape}"
+                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
             )
+        N, C, *spatial_list = x.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected spatial={self._committed_spatial}, got {spatial}"
+            )
+        L = x.numel() // C
+        return N, C, spatial, L, x.dtype
+
+    @staticmethod
+    def _validate_channel_tensor(
+        name: str,
+        tensor: torch.Tensor,
+        C: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if not tensor.is_cuda:
+            raise ValueError(f"{name} must be a CUDA tensor")
+        if tensor.device != device:
+            raise ValueError(f"Expected {name} on {device}, got {tensor.device}")
+        if tensor.dtype != dtype:
+            raise ValueError(f"Expected {name}.dtype {dtype}, got {tensor.dtype}")
+        if tensor.ndim != 1 or tensor.shape[0] != C:
+            raise ValueError(f"Expected {name} shape ({C},), got {tuple(tensor.shape)}")
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        L: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.L = L
+        self.dtype = dtype
+        self._last_roofline_spec = (C, L, dtype)
+
+    def _get_kernel(
+        self,
+        C: int,
+        L: int,
+        dtype: torch.dtype,
+        device_index: Optional[int],
+    ) -> Kernel:
+        mode = "train" if self.training else "infer"
+        key = (mode, C, L, dtype, device_index, self.eps, self.momentum, self.tune)
+        if key not in self._kernel_cache:
+            if self.training:
+                self._kernel_cache[key] = self.kernel_map["fwd_train_kernel"](
+                    C, L, dtype, self.eps, self.momentum, tune=self.tune,
+                )
+            else:
+                self._kernel_cache[key] = self.kernel_map["fwd_infer_kernel"](
+                    C, L, dtype, self.eps, tune=self.tune,
+                )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        if self.training:
+            self.train_kernel = kernel
+        else:
+            self.infer_kernel = kernel
+        return kernel
+
+    def _validate_inputs(self, x: torch.Tensor) -> None:
+        """Backward-compatible validation entry point."""
+        self._resolve_spec(x)
 
     def forward(
         self,
@@ -190,15 +280,21 @@ class BatchNormFwdOp(Op):
         Returns:
             Normalized output tensor with the same shape as ``x``.
         """
-        self._validate_inputs(x)
+        N, C, spatial, L, dtype = self._resolve_spec(x)
+        self._validate_channel_tensor("running_mean", running_mean, C, x.device, torch.float32)
+        self._validate_channel_tensor("running_var", running_var, C, x.device, torch.float32)
+        self._validate_channel_tensor("weight", weight, C, x.device, torch.float32)
+        self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
+        self._bind_spec(N, C, spatial, L, dtype)
         x_cl, orig_shape = self._prepare(x)
+        kernel = self._get_kernel(C, L, dtype, x.device.index)
 
         if self.training:
-            y_cl, _mean, _rstd = self.train_kernel(
+            y_cl, _mean, _rstd = kernel(
                 x_cl, weight.float(), bias.float(),
                 running_mean, running_var)
         else:
-            y_cl = self.infer_kernel(
+            y_cl = kernel(
                 x_cl, weight.float(), bias.float(),
                 running_mean, running_var)
         return _restore_shape(y_cl, orig_shape)
@@ -218,48 +314,160 @@ class BatchNormBwdOp(Op):
         to ``(C, L)`` internally where ``L = N * prod(spatial)``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        *spatial: Spatial dimensions (H, W, ...).
-        dtype: Data type of ``grad_out``, ``x``, and ``grad_x``.
+        N: Optional committed batch size for compatibility.
+        C: Optional committed channel count for compatibility.
+        *spatial: Optional committed spatial dimensions for compatibility.
+        dtype: Optional committed data type of ``grad_out``, ``x``, and ``grad_x``.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
     """
 
     def __init__(
         self,
-        N: int,
-        C: int,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
         *spatial: int,
-        dtype: torch.dtype = torch.float16,
+        dtype: Optional[torch.dtype] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
         self.N = N
         self.C = C
         self.spatial = spatial
-        self.L = N * math.prod(spatial) if spatial else N
+        self.L = (
+            N * math.prod(spatial)
+            if N is not None and spatial
+            else N
+        )
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = tuple(spatial) if spatial else None
+        self._committed_dtype = dtype
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        self.bwd_kernel: BatchNormBwdKernel = self.kernel_map["bwd_kernel"](
-            C, self.L, dtype, tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel: Optional[Kernel] = None
+        self.bwd_kernel: Optional[BatchNormBwdKernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"bwd_kernel": BatchNormBwdKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "BatchNormBwdOp.eval_roofline() requires a prior forward() call"
+            )
+        C, L, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            8 * self.C * self.L,
-            3 * self.C * self.L * elem_bytes + 3 * self.C * 4,
+            8 * C * L,
+            3 * C * L * elem_bytes + 3 * C * 4,
         )
 
     def _prepare(self, t: torch.Tensor) -> torch.Tensor:
         t_cl, _ = _reshape_to_CL(t)
         return t_cl
+
+    def _resolve_spec(
+        self, grad_out: torch.Tensor, x: torch.Tensor
+    ) -> Tuple[int, int, Tuple[int, ...], int, torch.dtype]:
+        if not grad_out.is_cuda:
+            raise ValueError("grad_out must be a CUDA tensor")
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if grad_out.device != x.device:
+            raise ValueError(
+                f"Expected grad_out and x on the same device, got "
+                f"{grad_out.device} and {x.device}"
+            )
+        if grad_out.shape != x.shape:
+            raise ValueError(f"Expected x shape {grad_out.shape}, got {x.shape}")
+        if grad_out.dtype != x.dtype:
+            raise ValueError(
+                f"Expected x.dtype {grad_out.dtype}, got {x.dtype}"
+            )
+        if grad_out.ndim < 2:
+            raise ValueError("grad_out must have shape (N, C, *spatial)")
+        if grad_out.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "grad_out.dtype must be float32, float16, or bfloat16, "
+                f"got {grad_out.dtype}"
+            )
+        if (
+            self._committed_dtype is not None
+            and grad_out.dtype != self._committed_dtype
+        ):
+            raise ValueError(
+                f"Expected grad_out.dtype {self._committed_dtype}, got {grad_out.dtype}"
+            )
+        N, C, *spatial_list = grad_out.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected spatial={self._committed_spatial}, got {spatial}"
+            )
+        L = grad_out.numel() // C
+        return N, C, spatial, L, grad_out.dtype
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        L: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.L = L
+        self.dtype = dtype
+        self._last_roofline_spec = (C, L, dtype)
+
+    def _get_kernel(
+        self,
+        C: int,
+        L: int,
+        dtype: torch.dtype,
+        device_index: Optional[int],
+    ) -> Kernel:
+        key = (C, L, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["bwd_kernel"](
+                C, L, dtype, tune=self.tune,
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        self.bwd_kernel = kernel
+        return kernel
+
+    @staticmethod
+    def _validate_channel_tensor(
+        name: str,
+        tensor: torch.Tensor,
+        C: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if not tensor.is_cuda:
+            raise ValueError(f"{name} must be a CUDA tensor")
+        if tensor.device != device:
+            raise ValueError(f"Expected {name} on {device}, got {tensor.device}")
+        if tensor.dtype != dtype:
+            raise ValueError(f"Expected {name}.dtype {dtype}, got {tensor.dtype}")
+        if tensor.ndim != 1 or tensor.shape[0] != C:
+            raise ValueError(f"Expected {name} shape ({C},), got {tuple(tensor.shape)}")
 
     def forward(
         self,
@@ -289,11 +497,17 @@ class BatchNormBwdOp(Op):
             has the same shape as ``x``, ``grad_weight`` has shape ``(C,)``,
             and ``grad_bias`` has shape ``(C,)``.
         """
+        N, C, spatial, L, dtype = self._resolve_spec(grad_out, x)
+        self._validate_channel_tensor("weight", weight, C, grad_out.device, torch.float32)
+        self._validate_channel_tensor("mean", mean, C, grad_out.device, torch.float32)
+        self._validate_channel_tensor("rstd", rstd, C, grad_out.device, torch.float32)
+        self._bind_spec(N, C, spatial, L, dtype)
         orig_shape = grad_out.shape
         go_cl = self._prepare(grad_out)
         x_cl = self._prepare(x)
+        kernel = self._get_kernel(C, L, dtype, grad_out.device.index)
 
-        grad_x_cl, grad_weight, grad_bias = self.bwd_kernel(
+        grad_x_cl, grad_weight, grad_bias = kernel(
             go_cl, x_cl, weight.float(), mean, rstd)
 
         grad_x = _restore_shape(grad_x_cl, orig_shape)
@@ -355,14 +569,20 @@ def _batchnorm_fwd_eager_forward(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     """Direct kernel call (no torch.compile wrapping)."""
-    self._validate_inputs(x)
+    N, C, spatial, L, dtype = self._resolve_spec(x)
+    self._validate_channel_tensor("running_mean", running_mean, C, x.device, torch.float32)
+    self._validate_channel_tensor("running_var", running_var, C, x.device, torch.float32)
+    self._validate_channel_tensor("weight", weight, C, x.device, torch.float32)
+    self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
+    self._bind_spec(N, C, spatial, L, dtype)
     x_cl, orig_shape = self._prepare(x)
+    kernel = self._get_kernel(C, L, dtype, x.device.index)
     if self.training:
-        y_cl, _mean, _rstd = self.train_kernel(
+        y_cl, _mean, _rstd = kernel(
             x_cl, weight.float(), bias.float(),
             running_mean, running_var)
     else:
-        y_cl = self.infer_kernel(
+        y_cl = kernel(
             x_cl, weight.float(), bias.float(),
             running_mean, running_var)
     return _restore_shape(y_cl, orig_shape)
@@ -439,10 +659,16 @@ def _batchnorm_bwd_eager_forward(
     rstd: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Direct kernel call (no torch.compile wrapping)."""
+    N, C, spatial, L, dtype = self._resolve_spec(grad_out, x)
+    self._validate_channel_tensor("weight", weight, C, grad_out.device, torch.float32)
+    self._validate_channel_tensor("mean", mean, C, grad_out.device, torch.float32)
+    self._validate_channel_tensor("rstd", rstd, C, grad_out.device, torch.float32)
+    self._bind_spec(N, C, spatial, L, dtype)
     orig_shape = grad_out.shape
     go_cl = self._prepare(grad_out)
     x_cl = self._prepare(x)
-    grad_x_cl, grad_weight, grad_bias = self.bwd_kernel(
+    kernel = self._get_kernel(C, L, dtype, grad_out.device.index)
+    grad_x_cl, grad_weight, grad_bias = kernel(
         go_cl, x_cl, weight.float(), mean, rstd)
     grad_x = _restore_shape(grad_x_cl, orig_shape)
     return grad_x, grad_weight, grad_bias

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -251,6 +251,33 @@ class BatchNormFwdOp(Op):
         """Backward-compatible validation entry point."""
         self._resolve_spec(x)
 
+    def _forward_impl(
+        self,
+        x: torch.Tensor,
+        running_mean: torch.Tensor,
+        running_var: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        N, C, spatial, L, dtype = self._resolve_spec(x)
+        self._validate_channel_tensor("running_mean", running_mean, C, x.device, torch.float32)
+        self._validate_channel_tensor("running_var", running_var, C, x.device, torch.float32)
+        self._validate_channel_tensor("weight", weight, C, x.device, torch.float32)
+        self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
+        self._bind_spec(N, C, spatial, L, dtype)
+        x_cl, orig_shape = self._prepare(x)
+        kernel = self._get_kernel(C, L, dtype, x.device.index)
+
+        if self.training:
+            y_cl, _mean, _rstd = kernel(
+                x_cl, weight.float(), bias.float(),
+                running_mean, running_var)
+        else:
+            y_cl = kernel(
+                x_cl, weight.float(), bias.float(),
+                running_mean, running_var)
+        return _restore_shape(y_cl, orig_shape)
+
     def forward(
         self,
         x: torch.Tensor,
@@ -280,24 +307,7 @@ class BatchNormFwdOp(Op):
         Returns:
             Normalized output tensor with the same shape as ``x``.
         """
-        N, C, spatial, L, dtype = self._resolve_spec(x)
-        self._validate_channel_tensor("running_mean", running_mean, C, x.device, torch.float32)
-        self._validate_channel_tensor("running_var", running_var, C, x.device, torch.float32)
-        self._validate_channel_tensor("weight", weight, C, x.device, torch.float32)
-        self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
-        self._bind_spec(N, C, spatial, L, dtype)
-        x_cl, orig_shape = self._prepare(x)
-        kernel = self._get_kernel(C, L, dtype, x.device.index)
-
-        if self.training:
-            y_cl, _mean, _rstd = kernel(
-                x_cl, weight.float(), bias.float(),
-                running_mean, running_var)
-        else:
-            y_cl = kernel(
-                x_cl, weight.float(), bias.float(),
-                running_mean, running_var)
-        return _restore_shape(y_cl, orig_shape)
+        return self._forward_impl(x, running_mean, running_var, weight, bias)
 
 
 class BatchNormBwdOp(Op):
@@ -469,6 +479,30 @@ class BatchNormBwdOp(Op):
         if tensor.ndim != 1 or tensor.shape[0] != C:
             raise ValueError(f"Expected {name} shape ({C},), got {tuple(tensor.shape)}")
 
+    def _forward_impl(
+        self,
+        grad_out: torch.Tensor,
+        x: torch.Tensor,
+        weight: torch.Tensor,
+        mean: torch.Tensor,
+        rstd: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        N, C, spatial, L, dtype = self._resolve_spec(grad_out, x)
+        self._validate_channel_tensor("weight", weight, C, grad_out.device, torch.float32)
+        self._validate_channel_tensor("mean", mean, C, grad_out.device, torch.float32)
+        self._validate_channel_tensor("rstd", rstd, C, grad_out.device, torch.float32)
+        self._bind_spec(N, C, spatial, L, dtype)
+        orig_shape = grad_out.shape
+        go_cl = self._prepare(grad_out)
+        x_cl = self._prepare(x)
+        kernel = self._get_kernel(C, L, dtype, grad_out.device.index)
+
+        grad_x_cl, grad_weight, grad_bias = kernel(
+            go_cl, x_cl, weight.float(), mean, rstd)
+
+        grad_x = _restore_shape(grad_x_cl, orig_shape)
+        return grad_x, grad_weight, grad_bias
+
     def forward(
         self,
         grad_out: torch.Tensor,
@@ -497,21 +531,7 @@ class BatchNormBwdOp(Op):
             has the same shape as ``x``, ``grad_weight`` has shape ``(C,)``,
             and ``grad_bias`` has shape ``(C,)``.
         """
-        N, C, spatial, L, dtype = self._resolve_spec(grad_out, x)
-        self._validate_channel_tensor("weight", weight, C, grad_out.device, torch.float32)
-        self._validate_channel_tensor("mean", mean, C, grad_out.device, torch.float32)
-        self._validate_channel_tensor("rstd", rstd, C, grad_out.device, torch.float32)
-        self._bind_spec(N, C, spatial, L, dtype)
-        orig_shape = grad_out.shape
-        go_cl = self._prepare(grad_out)
-        x_cl = self._prepare(x)
-        kernel = self._get_kernel(C, L, dtype, grad_out.device.index)
-
-        grad_x_cl, grad_weight, grad_bias = kernel(
-            go_cl, x_cl, weight.float(), mean, rstd)
-
-        grad_x = _restore_shape(grad_x_cl, orig_shape)
-        return grad_x, grad_weight, grad_bias
+        return self._forward_impl(grad_out, x, weight, mean, rstd)
 
 
 # ---------------------------------------------------------------------------
@@ -569,23 +589,7 @@ def _batchnorm_fwd_eager_forward(
     bias: torch.Tensor,
 ) -> torch.Tensor:
     """Direct kernel call (no torch.compile wrapping)."""
-    N, C, spatial, L, dtype = self._resolve_spec(x)
-    self._validate_channel_tensor("running_mean", running_mean, C, x.device, torch.float32)
-    self._validate_channel_tensor("running_var", running_var, C, x.device, torch.float32)
-    self._validate_channel_tensor("weight", weight, C, x.device, torch.float32)
-    self._validate_channel_tensor("bias", bias, C, x.device, torch.float32)
-    self._bind_spec(N, C, spatial, L, dtype)
-    x_cl, orig_shape = self._prepare(x)
-    kernel = self._get_kernel(C, L, dtype, x.device.index)
-    if self.training:
-        y_cl, _mean, _rstd = kernel(
-            x_cl, weight.float(), bias.float(),
-            running_mean, running_var)
-    else:
-        y_cl = kernel(
-            x_cl, weight.float(), bias.float(),
-            running_mean, running_var)
-    return _restore_shape(y_cl, orig_shape)
+    return self._forward_impl(x, running_mean, running_var, weight, bias)
 
 
 BatchNormFwdOp._eager_forward = _batchnorm_fwd_eager_forward
@@ -659,19 +663,7 @@ def _batchnorm_bwd_eager_forward(
     rstd: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Direct kernel call (no torch.compile wrapping)."""
-    N, C, spatial, L, dtype = self._resolve_spec(grad_out, x)
-    self._validate_channel_tensor("weight", weight, C, grad_out.device, torch.float32)
-    self._validate_channel_tensor("mean", mean, C, grad_out.device, torch.float32)
-    self._validate_channel_tensor("rstd", rstd, C, grad_out.device, torch.float32)
-    self._bind_spec(N, C, spatial, L, dtype)
-    orig_shape = grad_out.shape
-    go_cl = self._prepare(grad_out)
-    x_cl = self._prepare(x)
-    kernel = self._get_kernel(C, L, dtype, grad_out.device.index)
-    grad_x_cl, grad_weight, grad_bias = kernel(
-        go_cl, x_cl, weight.float(), mean, rstd)
-    grad_x = _restore_shape(grad_x_cl, orig_shape)
-    return grad_x, grad_weight, grad_bias
+    return self._forward_impl(grad_out, x, weight, mean, rstd)
 
 
 BatchNormBwdOp._eager_forward = _batchnorm_bwd_eager_forward

--- a/tileops/ops/norm/batch_norm.py
+++ b/tileops/ops/norm/batch_norm.py
@@ -21,7 +21,6 @@ kernel's block_l (chosen automatically by the kernel's default_config).
 """
 
 import functools
-import math
 import weakref
 from typing import Dict, Optional, Tuple
 
@@ -85,10 +84,6 @@ class BatchNormFwdOp(Op):
         to ``(C, L)`` internally where ``L = N * prod(spatial)``.
 
     Args:
-        N: Optional committed batch size for compatibility.
-        C: Optional committed channel count for compatibility.
-        spatial: Optional committed spatial dimensions for compatibility.
-        dtype: Optional committed input/output data type for compatibility.
         training: Default ``training`` flag for ``forward()``; per the
             manifest the default is ``False``.
         momentum: Running-stat update momentum (used in training mode).
@@ -99,10 +94,6 @@ class BatchNormFwdOp(Op):
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        spatial: Tuple[int, ...] = (),
-        dtype: Optional[torch.dtype] = None,
         training: bool = False,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -110,19 +101,11 @@ class BatchNormFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.N = N
-        self.C = C
-        self.spatial = tuple(spatial)
-        self.L = (
-            N * math.prod(self.spatial)
-            if N is not None and self.spatial
-            else N
-        )
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = tuple(spatial) if spatial else None
-        self._committed_dtype = dtype
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
+        self.L: Optional[int] = None
+        self.dtype: Optional[torch.dtype] = None
         self.training = training
         self.eps = eps
         self.momentum = momentum
@@ -169,23 +152,8 @@ class BatchNormFwdOp(Op):
                 "x.dtype must be float32, float16, or bfloat16, "
                 f"got {x.dtype}"
             )
-        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
-            )
         N, C, *spatial_list = x.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected spatial={self._committed_spatial}, got {spatial}"
-            )
         L = x.numel() // C
         return N, C, spatial, L, x.dtype
 
@@ -246,10 +214,6 @@ class BatchNormFwdOp(Op):
         else:
             self.infer_kernel = kernel
         return kernel
-
-    def _validate_inputs(self, x: torch.Tensor) -> None:
-        """Backward-compatible validation entry point."""
-        self._resolve_spec(x)
 
     def _forward_impl(
         self,
@@ -324,36 +288,21 @@ class BatchNormBwdOp(Op):
         to ``(C, L)`` internally where ``L = N * prod(spatial)``.
 
     Args:
-        N: Optional committed batch size for compatibility.
-        C: Optional committed channel count for compatibility.
-        *spatial: Optional committed spatial dimensions for compatibility.
-        dtype: Optional committed data type of ``grad_out``, ``x``, and ``grad_x``.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
     """
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        *spatial: int,
-        dtype: Optional[torch.dtype] = None,
+        *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.N = N
-        self.C = C
-        self.spatial = spatial
-        self.L = (
-            N * math.prod(spatial)
-            if N is not None and spatial
-            else N
-        )
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = tuple(spatial) if spatial else None
-        self._committed_dtype = dtype
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
+        self.L: Optional[int] = None
+        self.dtype: Optional[torch.dtype] = None
         self.tune = tune
 
         self.dispatch_kernel(kernel_map)
@@ -407,26 +356,8 @@ class BatchNormBwdOp(Op):
                 "grad_out.dtype must be float32, float16, or bfloat16, "
                 f"got {grad_out.dtype}"
             )
-        if (
-            self._committed_dtype is not None
-            and grad_out.dtype != self._committed_dtype
-        ):
-            raise ValueError(
-                f"Expected grad_out.dtype {self._committed_dtype}, got {grad_out.dtype}"
-            )
         N, C, *spatial_list = grad_out.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected spatial={self._committed_spatial}, got {spatial}"
-            )
         L = grad_out.numel() // C
         return N, C, spatial, L, grad_out.dtype
 

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -54,13 +54,8 @@ class GroupNormFwdOp(Op):
         Hidden dimension is padded to 256-element alignment internally.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        spatial: Spatial dimensions tuple ``(H, W, ...)``.
         num_groups: Number of groups (manifest ``params.num_groups``).
             Must divide *C* evenly.
-        dtype: Data type (``torch.float32``, ``torch.float16``, or
-            ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
@@ -69,38 +64,22 @@ class GroupNormFwdOp(Op):
     def __init__(
         self,
         num_groups: int,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        spatial: Optional[tuple] = None,
-        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if C is not None and C % num_groups != 0:
-            raise ValueError(
-                f"C={C} must be divisible by num_groups={num_groups}"
-            )
-        self.N = N
-        self.C = C
-        self.spatial = tuple(spatial) if spatial is not None else None
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
         self.num_groups = num_groups
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = self.spatial
-        self._committed_dtype = dtype
+        self.dtype: Optional[torch.dtype] = None
         self.eps = eps
         self.tune = tune
-        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
-        self.D = (
-            (C // num_groups) * self.spatial_size
-            if C is not None and self.spatial_size is not None
-            else None
-        )
-        self.M = N * num_groups if N is not None else None
-        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
+        self.spatial_size: Optional[int] = None
+        self.D: Optional[int] = None
+        self.M: Optional[int] = None
+        self.D_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
@@ -135,23 +114,8 @@ class GroupNormFwdOp(Op):
                 "x.dtype must be float32, float16, or bfloat16, "
                 f"got {x.dtype}"
             )
-        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
-            )
         N, C, *spatial_list = x.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
-            )
         if C % self.num_groups != 0:
             raise ValueError(
                 f"C={C} must be divisible by num_groups={self.num_groups}"
@@ -328,13 +292,8 @@ class GroupNormFwdOpNoAffine(Op):
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        spatial: Spatial dimensions tuple ``(H, W, ...)``.
         num_groups: Number of groups (manifest ``params.num_groups``).
             Must divide *C* evenly.
-        dtype: Data type (``torch.float32``, ``torch.float16``, or
-            ``torch.bfloat16``).
         eps: Epsilon for numerical stability.
         kernel_map: Optional kernel override dictionary.
         tune: If ``True``, autotune tile configurations.
@@ -343,39 +302,23 @@ class GroupNormFwdOpNoAffine(Op):
     def __init__(
         self,
         num_groups: int,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        spatial: Optional[tuple] = None,
-        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if C is not None and C % num_groups != 0:
-            raise ValueError(
-                f"C={C} must be divisible by num_groups={num_groups}"
-            )
-        self.N = N
-        self.C = C
-        self.spatial = tuple(spatial) if spatial is not None else None
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
         self.num_groups = num_groups
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = self.spatial
-        self._committed_dtype = dtype
+        self.dtype: Optional[torch.dtype] = None
         self.eps = eps
         self.tune = tune
-        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
-        self.D = (
-            (C // num_groups) * self.spatial_size
-            if C is not None and self.spatial_size is not None
-            else None
-        )
-        self.M = N * num_groups if N is not None else None
-        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
-        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN) if self.M is not None else None
+        self.spatial_size: Optional[int] = None
+        self.D: Optional[int] = None
+        self.M: Optional[int] = None
+        self.D_padded: Optional[int] = None
+        self.M_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self.kernel: Optional[Kernel] = None
@@ -409,23 +352,8 @@ class GroupNormFwdOpNoAffine(Op):
                 "x.dtype must be float32, float16, or bfloat16, "
                 f"got {x.dtype}"
             )
-        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
-            )
         N, C, *spatial_list = x.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
-            )
         if C % self.num_groups != 0:
             raise ValueError(
                 f"C={C} must be divisible by num_groups={self.num_groups}"

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -4,9 +4,7 @@ Wraps GroupNormKernel in the standard TileOPs Op interface.
 
 User-facing API mirrors torch.nn.functional.group_norm:
 
-    op = GroupNormFwdOp(
-        N=batch, C=channels, spatial=(H, W), num_groups=groups, dtype=dtype,
-    )
+    op = GroupNormFwdOp(num_groups=groups)
     y = op(x, weight, bias)
 
 Input tensors accept shape (N, C, *spatial); the op reshapes to
@@ -15,7 +13,7 @@ D = (C/num_groups) * spatial_size.
 """
 
 import math
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -70,65 +68,145 @@ class GroupNormFwdOp(Op):
 
     def __init__(
         self,
-        N: int,
-        C: int,
-        spatial: tuple,
         num_groups: int,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
+        spatial: Optional[tuple] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if C % num_groups != 0:
+        if C is not None and C % num_groups != 0:
             raise ValueError(
                 f"C={C} must be divisible by num_groups={num_groups}"
             )
         self.N = N
         self.C = C
-        self.spatial = spatial
+        self.spatial = tuple(spatial) if spatial is not None else None
         self.num_groups = num_groups
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = self.spatial
+        self._committed_dtype = dtype
         self.eps = eps
-        self.spatial_size = math.prod(spatial)
-        # row length before padding
-        self.D = (C // num_groups) * self.spatial_size
-        self.M = N * num_groups  # number of rows
-        self.D_padded = align_up(self.D, ALIGNMENT)
+        self.tune = tune
+        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
+        self.D = (
+            (C // num_groups) * self.spatial_size
+            if C is not None and self.spatial_size is not None
+            else None
+        )
+        self.M = N * num_groups if N is not None else None
+        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["group_norm"](
-            self.M, self.D, eps, dtype, tune=tune,
-        )
-        # The compiled kernel binds to the active CUDA device at construction
-        # time, so subsequent forwards must receive inputs on that same
-        # device. Capture it here so forward() can raise a clean error
-        # rather than letting the kernel layer surface an opaque
-        # device-mismatch failure.
-        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
-        # Pre-allocate forward-time constants. The kernel binds 1D weight/bias
-        # row-broadcast inputs; GroupNorm needs per-group affine, so the kernel
-        # call uses identity (unit/zero) buffers and the per-channel affine is
-        # applied after. These tensors are immutable for the op's lifetime.
-        self._unit_weight = torch.ones(
-            self.D_padded, dtype=dtype, device=self._kernel_device,
-        )
-        self._zero_bias = torch.zeros(
-            self.D_padded, dtype=dtype, device=self._kernel_device,
-        )
-        self._expected_shape = (self.N, self.C, *self.spatial)
-        self._cpg = self.C // self.num_groups
-        self._affine_shape = (1, self.C) + (1,) * len(self.spatial)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
+        self.kernel: Optional[Kernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"group_norm": GroupNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "GroupNormFwdOp.eval_roofline() requires a prior forward() call"
+            )
+        N, C, spatial_size, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            5 * self.N * self.C * self.spatial_size,
-            (2 * self.N * self.C * self.spatial_size + 2 * self.C) * elem_bytes,
+            5 * N * C * spatial_size,
+            (2 * N * C * spatial_size + 2 * C) * elem_bytes,
         )
+
+    def _resolve_spec(
+        self, x: torch.Tensor
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.ndim < 2:
+            raise ValueError("x must have shape (N, C, *spatial)")
+        if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "x.dtype must be float32, float16, or bfloat16, "
+                f"got {x.dtype}"
+            )
+        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
+            )
+        N, C, *spatial_list = x.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
+            )
+        if C % self.num_groups != 0:
+            raise ValueError(
+                f"C={C} must be divisible by num_groups={self.num_groups}"
+            )
+        spatial_size = math.prod(spatial)
+        cpg = C // self.num_groups
+        D = cpg * spatial_size
+        M = N * self.num_groups
+        D_padded = align_up(D, ALIGNMENT)
+        return N, C, spatial, spatial_size, cpg, D, M, D_padded, x.dtype
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        spatial_size: int,
+        D: int,
+        M: int,
+        D_padded: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.spatial_size = spatial_size
+        self.D = D
+        self.M = M
+        self.D_padded = D_padded
+        self.dtype = dtype
+        self._last_roofline_spec = (N, C, spatial_size, dtype)
+
+    def _get_kernel_and_constants(
+        self,
+        M: int,
+        D: int,
+        D_padded: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        device_index: Optional[int],
+    ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
+        key = (M, D, D_padded, dtype, device_index, self.eps, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["group_norm"](
+                M, D, self.eps, dtype, tune=self.tune,
+            )
+        if key not in self._constant_cache:
+            self._constant_cache[key] = (
+                torch.ones(D_padded, dtype=dtype, device=device),
+                torch.zeros(D_padded, dtype=dtype, device=device),
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        unit_weight, zero_bias = self._constant_cache[key]
+        return kernel, unit_weight, zero_bias
 
     def forward(
         self,
@@ -152,22 +230,17 @@ class GroupNormFwdOp(Op):
             ValueError: If any tensor is not on CUDA, dtypes mismatch, or
                 shapes are incompatible with the configured dimensions.
         """
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.device != self._kernel_device:
-            raise ValueError(
-                f"Device mismatch: op was constructed for {self._kernel_device} "
-                f"but x is on {x.device}. Construct a separate op instance per "
-                f"CUDA device."
-            )
-        if x.dtype != self.dtype:
-            raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
-            )
-        if tuple(x.shape) != self._expected_shape:
-            raise ValueError(
-                f"Expected x shape {self._expected_shape}, got {tuple(x.shape)}"
-            )
+        (
+            N,
+            C,
+            spatial,
+            spatial_size,
+            cpg,
+            D,
+            M,
+            D_padded,
+            dtype,
+        ) = self._resolve_spec(x)
         if not isinstance(weight, torch.Tensor):
             raise ValueError(
                 "weight is required; use GroupNormFwdOpNoAffine for the "
@@ -184,13 +257,13 @@ class GroupNormFwdOp(Op):
             raise ValueError(
                 f"Expected weight on {x.device}, got {weight.device}"
             )
-        if weight.dtype != self.dtype:
+        if weight.dtype != dtype:
             raise ValueError(
-                f"Expected weight.dtype {self.dtype}, got {weight.dtype}"
+                f"Expected weight.dtype {dtype}, got {weight.dtype}"
             )
-        if weight.ndim != 1 or weight.shape[0] != self.C:
+        if weight.ndim != 1 or weight.shape[0] != C:
             raise ValueError(
-                f"Expected weight shape ({self.C},), got {weight.shape}"
+                f"Expected weight shape ({C},), got {weight.shape}"
             )
         if not bias.is_cuda:
             raise ValueError("bias must be a CUDA tensor")
@@ -198,37 +271,42 @@ class GroupNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias on {x.device}, got {bias.device}"
             )
-        if bias.dtype != self.dtype:
+        if bias.dtype != dtype:
             raise ValueError(
-                f"Expected bias.dtype {self.dtype}, got {bias.dtype}"
+                f"Expected bias.dtype {dtype}, got {bias.dtype}"
             )
-        if bias.ndim != 1 or bias.shape[0] != self.C:
+        if bias.ndim != 1 or bias.shape[0] != C:
             raise ValueError(
-                f"Expected bias shape ({self.C},), got {bias.shape}"
+                f"Expected bias shape ({C},), got {bias.shape}"
             )
 
+        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, dtype)
+        kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
+            M, D, D_padded, dtype, x.device, x.device.index,
+        )
         orig_shape = x.shape
         x = x.contiguous()
         x_reshaped = x.reshape(
-            self.N, self.num_groups, self._cpg, *self.spatial,
+            N, self.num_groups, cpg, *spatial,
         )
-        x_2d = x_reshaped.reshape(self.M, self.D)
+        x_2d = x_reshaped.reshape(M, D)
 
-        if self.D_padded != self.D:
-            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+        if D_padded != D:
+            x_2d = F.pad(x_2d, (0, D_padded - D))
 
         # Kernel broadcasts 1D weight/bias row-wise; GroupNorm's per-group
         # affine doesn't fit that layout, so run the kernel with identity
         # (unit/zero) and apply per-channel affine after.
-        y_2d = self.kernel(x_2d, self._unit_weight, self._zero_bias)
+        y_2d = kernel(x_2d, unit_weight, zero_bias)
 
-        if self.D_padded != self.D:
-            y_2d = y_2d[:, :self.D]
+        if D_padded != D:
+            y_2d = y_2d[:, :D]
 
-        y = y_2d.reshape(self.N, self.num_groups, self._cpg, *self.spatial)
+        y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
         y = y.reshape(orig_shape)
 
-        y = y * weight.reshape(self._affine_shape) + bias.reshape(self._affine_shape)
+        affine_shape = (1, C) + (1,) * len(spatial)
+        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
         return y
 
 
@@ -264,50 +342,140 @@ class GroupNormFwdOpNoAffine(Op):
 
     def __init__(
         self,
-        N: int,
-        C: int,
-        spatial: tuple,
         num_groups: int,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
+        spatial: Optional[tuple] = None,
+        dtype: Optional[torch.dtype] = None,
         eps: float = 1e-5,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        if C % num_groups != 0:
+        if C is not None and C % num_groups != 0:
             raise ValueError(
                 f"C={C} must be divisible by num_groups={num_groups}"
             )
         self.N = N
         self.C = C
-        self.spatial = spatial
+        self.spatial = tuple(spatial) if spatial is not None else None
         self.num_groups = num_groups
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = self.spatial
+        self._committed_dtype = dtype
         self.eps = eps
-        self.spatial_size = math.prod(spatial)
-        self.D = (C // num_groups) * self.spatial_size
-        self.M = N * num_groups
-        self.D_padded = align_up(self.D, ALIGNMENT)
-        # Kernel launches T.ceildiv(M, block_m) programs, each copying a full
-        # block_m-row tile. Pad M to a multiple of the largest candidate
-        # block_m so the tail program never reads/writes past the input.
-        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN)
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["group_norm_no_affine"](
-            self.M_padded, self.D, eps, dtype, tune=tune,
+        self.tune = tune
+        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
+        self.D = (
+            (C // num_groups) * self.spatial_size
+            if C is not None and self.spatial_size is not None
+            else None
         )
-        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+        self.M = N * num_groups if N is not None else None
+        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
+        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN) if self.M is not None else None
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel: Optional[Kernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"group_norm_no_affine": GroupNormNoAffineKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "GroupNormFwdOpNoAffine.eval_roofline() requires a prior forward() call"
+            )
+        N, C, spatial_size, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            3 * self.N * self.C * self.spatial_size,
-            2 * self.N * self.C * self.spatial_size * elem_bytes,
+            3 * N * C * spatial_size,
+            2 * N * C * spatial_size * elem_bytes,
         )
+
+    def _resolve_spec(
+        self, x: torch.Tensor
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.ndim < 2:
+            raise ValueError("x must have shape (N, C, *spatial)")
+        if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "x.dtype must be float32, float16, or bfloat16, "
+                f"got {x.dtype}"
+            )
+        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
+            )
+        N, C, *spatial_list = x.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
+            )
+        if C % self.num_groups != 0:
+            raise ValueError(
+                f"C={C} must be divisible by num_groups={self.num_groups}"
+            )
+        spatial_size = math.prod(spatial)
+        cpg = C // self.num_groups
+        D = cpg * spatial_size
+        M = N * self.num_groups
+        D_padded = align_up(D, ALIGNMENT)
+        M_padded = align_up(M, _M_BLOCK_ALIGN)
+        return N, C, spatial, spatial_size, cpg, D, M, D_padded, M_padded, x.dtype
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        spatial_size: int,
+        D: int,
+        M: int,
+        D_padded: int,
+        M_padded: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.spatial_size = spatial_size
+        self.D = D
+        self.M = M
+        self.D_padded = D_padded
+        self.M_padded = M_padded
+        self.dtype = dtype
+        self._last_roofline_spec = (N, C, spatial_size, dtype)
+
+    def _get_kernel(
+        self,
+        M_padded: int,
+        D: int,
+        dtype: torch.dtype,
+        device_index: Optional[int],
+    ) -> Kernel:
+        key = (M_padded, D, dtype, device_index, self.eps, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["group_norm_no_affine"](
+                M_padded, D, self.eps, dtype, tune=self.tune,
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        return kernel
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Apply group normalization without affine.
@@ -323,42 +491,38 @@ class GroupNormFwdOpNoAffine(Op):
                 device than the op was constructed for, or its dtype does
                 not match the configured dtype.
         """
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.device != self._kernel_device:
-            raise ValueError(
-                f"Device mismatch: op was constructed for {self._kernel_device} "
-                f"but x is on {x.device}. Construct a separate op instance per "
-                f"CUDA device."
-            )
-        if x.dtype != self.dtype:
-            raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
-            )
-        expected_shape = (self.N, self.C, *self.spatial)
-        if tuple(x.shape) != expected_shape:
-            raise ValueError(
-                f"Expected x shape {expected_shape}, got {tuple(x.shape)}"
-            )
+        (
+            N,
+            C,
+            spatial,
+            spatial_size,
+            cpg,
+            D,
+            M,
+            D_padded,
+            M_padded,
+            dtype,
+        ) = self._resolve_spec(x)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, M_padded, dtype)
+        kernel = self._get_kernel(M_padded, D, dtype, x.device.index)
 
         orig_shape = x.shape
         x = x.contiguous()
-        cpg = self.C // self.num_groups
-        x_reshaped = x.reshape(self.N, self.num_groups, cpg, *self.spatial)
-        x_2d = x_reshaped.reshape(self.M, self.D)
+        x_reshaped = x.reshape(N, self.num_groups, cpg, *spatial)
+        x_2d = x_reshaped.reshape(M, D)
 
-        if self.D_padded != self.D:
-            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
-        if self.M_padded != self.M:
+        if D_padded != D:
+            x_2d = F.pad(x_2d, (0, D_padded - D))
+        if M_padded != M:
             # Pad along dim 0 (M); padded rows are dropped after the kernel.
-            x_2d = F.pad(x_2d, (0, 0, 0, self.M_padded - self.M))
+            x_2d = F.pad(x_2d, (0, 0, 0, M_padded - M))
 
-        y_2d = self.kernel(x_2d)
+        y_2d = kernel(x_2d)
 
-        if self.M_padded != self.M:
-            y_2d = y_2d[:self.M, :]
-        if self.D_padded != self.D:
-            y_2d = y_2d[:, :self.D]
+        if M_padded != M:
+            y_2d = y_2d[:M, :]
+        if D_padded != D:
+            y_2d = y_2d[:, :D]
 
-        y = y_2d.reshape(self.N, self.num_groups, cpg, *self.spatial)
+        y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -125,7 +125,7 @@ class GroupNormFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:
@@ -399,7 +399,7 @@ class GroupNormFwdOpNoAffine(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -6,14 +6,14 @@ delegates to :class:`GroupNormKernel` with that grouping.
 
 User-facing API mirrors :func:`torch.nn.functional.instance_norm`:
 
-    op = InstanceNormFwdOp(N=batch, C=channels, spatial=(H, W), dtype=dtype)
+    op = InstanceNormFwdOp()
     y = op(x, weight, bias)
 
 Input tensors accept shape ``(N, C, *spatial)``.
 """
 
 import math
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -85,10 +85,10 @@ class InstanceNormFwdOp(Op):
 
     def __init__(
         self,
-        N: int,
-        C: int,
-        spatial: tuple,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
+        spatial: Optional[tuple] = None,
+        dtype: Optional[torch.dtype] = None,
         use_input_stats: bool = True,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -104,49 +104,40 @@ class InstanceNormFwdOp(Op):
             )
         self.N = N
         self.C = C
-        self.spatial = spatial
+        self.spatial = tuple(spatial) if spatial is not None else None
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = self.spatial
+        self._committed_dtype = dtype
         self.use_input_stats = use_input_stats
         self.momentum = momentum
         self.eps = eps
-        self.spatial_size = math.prod(spatial)
-        # InstanceNorm: each channel is its own group (num_groups = C)
-        # so D = (C/C) * spatial_size = spatial_size and M = N * C.
+        self.tune = tune
+        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
         self.D = self.spatial_size
-        self.M = N * C
-        self.D_padded = align_up(self.D, ALIGNMENT)
+        self.M = N * C if N is not None and C is not None else None
+        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["group_norm"](
-            self.M, self.D, eps, dtype, tune=tune,
-        )
-        # The compiled kernel binds to the active CUDA device at construction
-        # time, so subsequent forwards must receive inputs on that same
-        # device. Capture it here so forward() can raise a clean error
-        # rather than letting the kernel layer surface an opaque
-        # device-mismatch failure.
-        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
-        # Pre-allocate forward-time constants. The kernel binds 1D weight/bias
-        # row-broadcast inputs; per-channel affine doesn't fit that layout, so
-        # the kernel call uses identity (unit/zero) buffers and the affine is
-        # applied after. These tensors are immutable for the op's lifetime.
-        self._unit_weight = torch.ones(
-            self.D_padded, dtype=dtype, device=self._kernel_device,
-        )
-        self._zero_bias = torch.zeros(
-            self.D_padded, dtype=dtype, device=self._kernel_device,
-        )
-        self._expected_shape = (self.N, self.C, *self.spatial)
-        self._affine_shape = (1, self.C) + (1,) * len(self.spatial)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
+        self.kernel: Optional[Kernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"group_norm": GroupNormKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "InstanceNormFwdOp.eval_roofline() requires a prior forward() call"
+            )
+        N, C, spatial_size, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            5 * self.N * self.C * self.spatial_size,
-            (2 * self.N * self.C * self.spatial_size + 2 * self.C) * elem_bytes,
+            5 * N * C * spatial_size,
+            (2 * N * C * spatial_size + 2 * C) * elem_bytes,
         )
 
     def _validate_dtypes(
@@ -156,16 +147,98 @@ class InstanceNormFwdOp(Op):
         bias: torch.Tensor,
     ) -> None:
         allowed = (torch.float32, torch.float16, torch.bfloat16)
-        if self.dtype not in allowed:
-            raise ValueError(
-                f"self.dtype must be one of {allowed}, got {self.dtype}"
-            )
+        expected_dtype = getattr(self, "_committed_dtype", None)
         for name, t in (("x", x), ("weight", weight), ("bias", bias)):
-            if t.dtype != self.dtype:
+            if t.dtype not in allowed:
+                raise ValueError(f"{name}.dtype must be one of {allowed}, got {t.dtype}")
+            if expected_dtype is None:
+                expected_dtype = t.dtype
+            if t.dtype != expected_dtype:
                 raise ValueError(
-                    f"Expected {name}.dtype == self.dtype ({self.dtype}), "
+                    f"Expected {name}.dtype == {expected_dtype}, "
                     f"got {t.dtype}"
                 )
+
+    def _resolve_spec(
+        self, x: torch.Tensor
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, torch.dtype]:
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.ndim < 2:
+            raise ValueError("x must have shape (N, C, *spatial)")
+        if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "x.dtype must be float32, float16, or bfloat16, "
+                f"got {x.dtype}"
+            )
+        committed_dtype = getattr(self, "_committed_dtype", None)
+        if committed_dtype is not None and x.dtype != committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
+            )
+        N, C, *spatial_list = x.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
+            )
+        spatial_size = math.prod(spatial)
+        D = spatial_size
+        M = N * C
+        D_padded = align_up(D, ALIGNMENT)
+        return N, C, spatial, spatial_size, D, M, D_padded, x.dtype
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        spatial_size: int,
+        D: int,
+        M: int,
+        D_padded: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.spatial_size = spatial_size
+        self.D = D
+        self.M = M
+        self.D_padded = D_padded
+        self.dtype = dtype
+        self._last_roofline_spec = (N, C, spatial_size, dtype)
+
+    def _get_kernel_and_constants(
+        self,
+        M: int,
+        D: int,
+        D_padded: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        device_index: Optional[int],
+    ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
+        key = (M, D, D_padded, dtype, device_index, self.eps, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["group_norm"](
+                M, D, self.eps, dtype, tune=self.tune,
+            )
+        if key not in self._constant_cache:
+            self._constant_cache[key] = (
+                torch.ones(D_padded, dtype=dtype, device=device),
+                torch.zeros(D_padded, dtype=dtype, device=device),
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        unit_weight, zero_bias = self._constant_cache[key]
+        return kernel, unit_weight, zero_bias
 
     def forward(
         self,
@@ -200,27 +273,16 @@ class InstanceNormFwdOp(Op):
                 "affine-free path"
             )
         self._validate_dtypes(x, weight, bias)
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.device != self._kernel_device:
-            raise ValueError(
-                f"Device mismatch: op was constructed for {self._kernel_device} "
-                f"but x is on {x.device}. Construct a separate op instance per "
-                f"CUDA device."
-            )
-        if tuple(x.shape) != self._expected_shape:
-            raise ValueError(
-                f"Expected x shape {self._expected_shape}, got {tuple(x.shape)}"
-            )
+        N, C, spatial, spatial_size, D, M, D_padded, dtype = self._resolve_spec(x)
         if not weight.is_cuda:
             raise ValueError("weight must be a CUDA tensor")
         if weight.device != x.device:
             raise ValueError(
                 f"Expected weight on {x.device}, got {weight.device}"
             )
-        if weight.ndim != 1 or weight.shape[0] != self.C:
+        if weight.ndim != 1 or weight.shape[0] != C:
             raise ValueError(
-                f"Expected weight shape ({self.C},), got {weight.shape}"
+                f"Expected weight shape ({C},), got {weight.shape}"
             )
         if not bias.is_cuda:
             raise ValueError("bias must be a CUDA tensor")
@@ -228,30 +290,35 @@ class InstanceNormFwdOp(Op):
             raise ValueError(
                 f"Expected bias on {x.device}, got {bias.device}"
             )
-        if bias.ndim != 1 or bias.shape[0] != self.C:
+        if bias.ndim != 1 or bias.shape[0] != C:
             raise ValueError(
-                f"Expected bias shape ({self.C},), got {bias.shape}"
+                f"Expected bias shape ({C},), got {bias.shape}"
             )
 
+        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, dtype)
+        kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
+            M, D, D_padded, dtype, x.device, x.device.index,
+        )
         orig_shape = x.shape
         x = x.contiguous()
-        x_2d = x.reshape(self.M, self.D)
+        x_2d = x.reshape(M, D)
 
-        if self.D_padded != self.D:
-            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
+        if D_padded != D:
+            x_2d = F.pad(x_2d, (0, D_padded - D))
 
         # Kernel broadcasts 1D weight/bias row-wise; per-channel affine is
         # applied after, so run the kernel with identity (unit/zero) buffers.
-        y_2d = self.kernel(x_2d, self._unit_weight, self._zero_bias)
+        y_2d = kernel(x_2d, unit_weight, zero_bias)
 
         # Trim padding
-        if self.D_padded != self.D:
-            y_2d = y_2d[:, :self.D]
+        if D_padded != D:
+            y_2d = y_2d[:, :D]
 
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)
 
-        y = y * weight.reshape(self._affine_shape) + bias.reshape(self._affine_shape)
+        affine_shape = (1, C) + (1,) * len(spatial)
+        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
         return y
 
 
@@ -293,10 +360,10 @@ class InstanceNormFwdOpNoAffine(Op):
 
     def __init__(
         self,
-        N: int,
-        C: int,
-        spatial: tuple,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        C: Optional[int] = None,
+        spatial: Optional[tuple] = None,
+        dtype: Optional[torch.dtype] = None,
         use_input_stats: bool = True,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -306,36 +373,45 @@ class InstanceNormFwdOpNoAffine(Op):
     ):
         self.N = N
         self.C = C
-        self.spatial = spatial
+        self.spatial = tuple(spatial) if spatial is not None else None
         self.dtype = dtype
+        self._committed_N = N
+        self._committed_C = C
+        self._committed_spatial = self.spatial
+        self._committed_dtype = dtype
         self.use_input_stats = use_input_stats
         self.momentum = momentum
         self.eps = eps
-        self.spatial_size = math.prod(spatial)
+        self.tune = tune
+        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
         self.D = self.spatial_size
-        self.M = N * C
-        # Eval-mode broadcast layout for running stats: [1, C, 1, ...] (one 1 per spatial dim).
-        self._running_stats_broadcast_shape = [1, C] + [1] * len(spatial)
-        self.D_padded = align_up(self.D, ALIGNMENT)
-        # Kernel launches T.ceildiv(M, block_m) programs, each copying a full
-        # block_m-row tile. Pad M to a multiple of the largest candidate
-        # block_m so the tail program never reads/writes past the input.
-        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN)
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["instance_norm_no_affine"](
-            self.M_padded, self.D, eps, dtype, tune=tune,
+        self.M = N * C if N is not None and C is not None else None
+        self._running_stats_broadcast_shape = (
+            [1, C] + [1] * len(self.spatial)
+            if C is not None and self.spatial is not None
+            else None
         )
-        self._kernel_device = torch.device("cuda", torch.cuda.current_device())
+        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
+        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN) if self.M is not None else None
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel: Optional[Kernel] = None
+        self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"instance_norm_no_affine": InstanceNormNoAffineKernel}
 
     def eval_roofline(self) -> tuple[int, int]:
-        elem_bytes = self.dtype.itemsize
+        if self._last_roofline_spec is None:
+            raise RuntimeError(
+                "InstanceNormFwdOpNoAffine.eval_roofline() requires a prior forward() call"
+            )
+        N, C, spatial_size, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         return (
-            3 * self.N * self.C * self.spatial_size,
-            2 * self.N * self.C * self.spatial_size * elem_bytes,
+            3 * N * C * spatial_size,
+            2 * N * C * spatial_size * elem_bytes,
         )
 
     def _validate_dtypes(
@@ -361,17 +437,14 @@ class InstanceNormFwdOpNoAffine(Op):
                 ``x.dtype`` does not match ``self.dtype``.
         """
         allowed = (torch.float32, torch.float16, torch.bfloat16)
-        if self.dtype not in allowed:
-            raise ValueError(
-                f"self.dtype must be one of {allowed}, got {self.dtype}"
-            )
         if x.dtype not in allowed:
             raise ValueError(
                 f"x.dtype must be one of {allowed}, got {x.dtype}"
             )
-        if x.dtype != self.dtype:
+        committed_dtype = getattr(self, "_committed_dtype", None)
+        if committed_dtype is not None and x.dtype != committed_dtype:
             raise ValueError(
-                f"Expected x.dtype {self.dtype}, got {x.dtype}"
+                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
             )
         if running_mean.dtype != torch.float32:
             raise ValueError(
@@ -383,7 +456,7 @@ class InstanceNormFwdOpNoAffine(Op):
             )
 
     def _validate_running_stats(
-        self, name: str, t: torch.Tensor, x_device: torch.device,
+        self, name: str, t: torch.Tensor, x_device: torch.device, C: int,
     ) -> None:
         """Validate device, dtype, and shape of a running-stats tensor."""
         if not t.is_cuda:
@@ -396,10 +469,87 @@ class InstanceNormFwdOpNoAffine(Op):
             raise ValueError(
                 f"Expected {name}.dtype torch.float32, got {t.dtype}"
             )
-        if t.ndim != 1 or t.shape[0] != self.C:
+        if t.ndim != 1 or t.shape[0] != C:
             raise ValueError(
-                f"Expected {name} shape ({self.C},), got {tuple(t.shape)}"
+                f"Expected {name} shape ({C},), got {tuple(t.shape)}"
             )
+
+    def _resolve_spec(
+        self, x: torch.Tensor
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.ndim < 2:
+            raise ValueError("x must have shape (N, C, *spatial)")
+        if x.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(
+                "x.dtype must be float32, float16, or bfloat16, "
+                f"got {x.dtype}"
+            )
+        committed_dtype = getattr(self, "_committed_dtype", None)
+        if committed_dtype is not None and x.dtype != committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
+            )
+        N, C, *spatial_list = x.shape
+        spatial = tuple(spatial_list)
+        if self._committed_N is not None and self._committed_N != N:
+            raise ValueError(f"Expected N={self._committed_N}, got {N}")
+        if self._committed_C is not None and self._committed_C != C:
+            raise ValueError(f"Expected C={self._committed_C}, got {C}")
+        if (
+            self._committed_spatial is not None
+            and spatial != self._committed_spatial
+        ):
+            raise ValueError(
+                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
+            )
+        spatial_size = math.prod(spatial)
+        D = spatial_size
+        M = N * C
+        D_padded = align_up(D, ALIGNMENT)
+        M_padded = align_up(M, _M_BLOCK_ALIGN)
+        return N, C, spatial, spatial_size, D, M, D_padded, M_padded, x.dtype
+
+    def _bind_spec(
+        self,
+        N: int,
+        C: int,
+        spatial: Tuple[int, ...],
+        spatial_size: int,
+        D: int,
+        M: int,
+        D_padded: int,
+        M_padded: int,
+        dtype: torch.dtype,
+    ) -> None:
+        self.N = N
+        self.C = C
+        self.spatial = spatial
+        self.spatial_size = spatial_size
+        self.D = D
+        self.M = M
+        self.D_padded = D_padded
+        self.M_padded = M_padded
+        self._running_stats_broadcast_shape = [1, C] + [1] * len(spatial)
+        self.dtype = dtype
+        self._last_roofline_spec = (N, C, spatial_size, dtype)
+
+    def _get_kernel(
+        self,
+        M_padded: int,
+        D: int,
+        dtype: torch.dtype,
+        device_index: Optional[int],
+    ) -> Kernel:
+        key = (M_padded, D, dtype, device_index, self.eps, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["instance_norm_no_affine"](
+                M_padded, D, self.eps, dtype, tune=self.tune,
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        return kernel
 
     def forward(
         self,
@@ -428,21 +578,20 @@ class InstanceNormFwdOpNoAffine(Op):
                 shapes are incompatible with the configured dimensions.
         """
         self._validate_dtypes(x, running_mean, running_var)
-        if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
-        if x.device != self._kernel_device:
-            raise ValueError(
-                f"Device mismatch: op was constructed for {self._kernel_device} "
-                f"but x is on {x.device}. Construct a separate op instance per "
-                f"CUDA device."
-            )
-        expected_shape = (self.N, self.C, *self.spatial)
-        if tuple(x.shape) != expected_shape:
-            raise ValueError(
-                f"Expected x shape {expected_shape}, got {tuple(x.shape)}"
-            )
-        self._validate_running_stats("running_mean", running_mean, x.device)
-        self._validate_running_stats("running_var", running_var, x.device)
+        (
+            N,
+            C,
+            spatial,
+            spatial_size,
+            D,
+            M,
+            D_padded,
+            M_padded,
+            dtype,
+        ) = self._resolve_spec(x)
+        self._validate_running_stats("running_mean", running_mean, x.device, C)
+        self._validate_running_stats("running_var", running_var, x.device, C)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, M_padded, dtype)
 
         if not self.use_input_stats:
             # Eval-mode path: y = (x - running_mean[c]) / sqrt(running_var[c] + eps).
@@ -456,19 +605,20 @@ class InstanceNormFwdOpNoAffine(Op):
 
         orig_shape = x.shape
         x = x.contiguous()
-        x_2d = x.reshape(self.M, self.D)
+        x_2d = x.reshape(M, D)
 
-        if self.D_padded != self.D:
-            x_2d = F.pad(x_2d, (0, self.D_padded - self.D))
-        if self.M_padded != self.M:
+        if D_padded != D:
+            x_2d = F.pad(x_2d, (0, D_padded - D))
+        if M_padded != M:
             # Pad along dim 0 (M); padded rows are dropped after the kernel.
-            x_2d = F.pad(x_2d, (0, 0, 0, self.M_padded - self.M))
+            x_2d = F.pad(x_2d, (0, 0, 0, M_padded - M))
 
-        y_2d = self.kernel(x_2d)
+        kernel = self._get_kernel(M_padded, D, dtype, x.device.index)
+        y_2d = kernel(x_2d)
 
-        if self.M_padded != self.M:
-            y_2d = y_2d[:self.M, :]
-        if self.D_padded != self.D:
-            y_2d = y_2d[:, :self.D]
+        if M_padded != M:
+            y_2d = y_2d[:M, :]
+        if D_padded != D:
+            y_2d = y_2d[:, :D]
 
         return y_2d.reshape(orig_shape)

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -161,7 +161,7 @@ class InstanceNormFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -61,11 +61,6 @@ class InstanceNormFwdOp(Op):
         for this op.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        spatial: Spatial dimensions tuple ``(H, W, ...)``.
-        dtype: Data type (``torch.float32``, ``torch.float16``, or
-            ``torch.bfloat16``).
         use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
             ``True`` (the default and only supported value), per-batch
             statistics are computed from the input. ``False`` (the
@@ -85,10 +80,6 @@ class InstanceNormFwdOp(Op):
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        spatial: Optional[tuple] = None,
-        dtype: Optional[torch.dtype] = None,
         use_input_stats: bool = True,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -102,22 +93,18 @@ class InstanceNormFwdOp(Op):
                 "is not supported by InstanceNormFwdOp; only "
                 "use_input_stats=True (per-batch statistics) is implemented."
             )
-        self.N = N
-        self.C = C
-        self.spatial = tuple(spatial) if spatial is not None else None
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = self.spatial
-        self._committed_dtype = dtype
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
+        self.dtype: Optional[torch.dtype] = None
         self.use_input_stats = use_input_stats
         self.momentum = momentum
         self.eps = eps
         self.tune = tune
-        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
-        self.D = self.spatial_size
-        self.M = N * C if N is not None and C is not None else None
-        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
+        self.spatial_size: Optional[int] = None
+        self.D: Optional[int] = None
+        self.M: Optional[int] = None
+        self.D_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
@@ -147,12 +134,10 @@ class InstanceNormFwdOp(Op):
         bias: torch.Tensor,
     ) -> None:
         allowed = (torch.float32, torch.float16, torch.bfloat16)
-        expected_dtype = getattr(self, "_committed_dtype", None)
+        expected_dtype = x.dtype
         for name, t in (("x", x), ("weight", weight), ("bias", bias)):
             if t.dtype not in allowed:
                 raise ValueError(f"{name}.dtype must be one of {allowed}, got {t.dtype}")
-            if expected_dtype is None:
-                expected_dtype = t.dtype
             if t.dtype != expected_dtype:
                 raise ValueError(
                     f"Expected {name}.dtype == {expected_dtype}, "
@@ -171,24 +156,8 @@ class InstanceNormFwdOp(Op):
                 "x.dtype must be float32, float16, or bfloat16, "
                 f"got {x.dtype}"
             )
-        committed_dtype = getattr(self, "_committed_dtype", None)
-        if committed_dtype is not None and x.dtype != committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
-            )
         N, C, *spatial_list = x.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
-            )
         spatial_size = math.prod(spatial)
         D = spatial_size
         M = N * C
@@ -340,11 +309,6 @@ class InstanceNormFwdOpNoAffine(Op):
         ``torch.float32``, ``torch.float16``, ``torch.bfloat16``.
 
     Args:
-        N: Batch size.
-        C: Number of channels.
-        spatial: Spatial dimensions tuple ``(H, W, ...)``.
-        dtype: Data type (``torch.float32``, ``torch.float16``, or
-            ``torch.bfloat16``).
         use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
             ``True`` (the default), per-instance statistics are computed from
             the input. When ``False``, the supplied ``running_mean`` and
@@ -360,10 +324,6 @@ class InstanceNormFwdOpNoAffine(Op):
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        C: Optional[int] = None,
-        spatial: Optional[tuple] = None,
-        dtype: Optional[torch.dtype] = None,
         use_input_stats: bool = True,
         momentum: float = 0.1,
         eps: float = 1e-5,
@@ -371,28 +331,20 @@ class InstanceNormFwdOpNoAffine(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.N = N
-        self.C = C
-        self.spatial = tuple(spatial) if spatial is not None else None
-        self.dtype = dtype
-        self._committed_N = N
-        self._committed_C = C
-        self._committed_spatial = self.spatial
-        self._committed_dtype = dtype
+        self.N: Optional[int] = None
+        self.C: Optional[int] = None
+        self.spatial: Optional[Tuple[int, ...]] = None
+        self.dtype: Optional[torch.dtype] = None
         self.use_input_stats = use_input_stats
         self.momentum = momentum
         self.eps = eps
         self.tune = tune
-        self.spatial_size = math.prod(self.spatial) if self.spatial is not None else None
-        self.D = self.spatial_size
-        self.M = N * C if N is not None and C is not None else None
-        self._running_stats_broadcast_shape = (
-            [1, C] + [1] * len(self.spatial)
-            if C is not None and self.spatial is not None
-            else None
-        )
-        self.D_padded = align_up(self.D, ALIGNMENT) if self.D is not None else None
-        self.M_padded = align_up(self.M, _M_BLOCK_ALIGN) if self.M is not None else None
+        self.spatial_size: Optional[int] = None
+        self.D: Optional[int] = None
+        self.M: Optional[int] = None
+        self._running_stats_broadcast_shape: Optional[list[int]] = None
+        self.D_padded: Optional[int] = None
+        self.M_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self.kernel: Optional[Kernel] = None
@@ -441,11 +393,6 @@ class InstanceNormFwdOpNoAffine(Op):
             raise ValueError(
                 f"x.dtype must be one of {allowed}, got {x.dtype}"
             )
-        committed_dtype = getattr(self, "_committed_dtype", None)
-        if committed_dtype is not None and x.dtype != committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
-            )
         if running_mean.dtype != torch.float32:
             raise ValueError(
                 f"Expected running_mean.dtype torch.float32, got {running_mean.dtype}"
@@ -486,24 +433,8 @@ class InstanceNormFwdOpNoAffine(Op):
                 "x.dtype must be float32, float16, or bfloat16, "
                 f"got {x.dtype}"
             )
-        committed_dtype = getattr(self, "_committed_dtype", None)
-        if committed_dtype is not None and x.dtype != committed_dtype:
-            raise ValueError(
-                f"Expected x.dtype {committed_dtype}, got {x.dtype}"
-            )
         N, C, *spatial_list = x.shape
         spatial = tuple(spatial_list)
-        if self._committed_N is not None and self._committed_N != N:
-            raise ValueError(f"Expected N={self._committed_N}, got {N}")
-        if self._committed_C is not None and self._committed_C != C:
-            raise ValueError(f"Expected C={self._committed_C}, got {C}")
-        if (
-            self._committed_spatial is not None
-            and spatial != self._committed_spatial
-        ):
-            raise ValueError(
-                f"Expected shape spatial={self._committed_spatial}, got {spatial}"
-            )
         spatial_size = math.prod(spatial)
         D = spatial_size
         M = N * C

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -45,8 +45,9 @@ class _SoftmaxBaseOp(Op):
     override output reshaping if needed.
 
     Args:
-        dtype: Data type (float32, float16, or bfloat16).
+        dtype: Optional committed dtype for subclasses that still expose it.
         dim: Reduction dimension (default -1).
+        N: Optional committed reduction dim for subclasses that still expose it.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """

--- a/tileops/ops/reduction/_softmax_base.py
+++ b/tileops/ops/reduction/_softmax_base.py
@@ -4,9 +4,9 @@ Provides the shared validate -> reshape -> kernel -> trim -> reshape
 pattern for softmax, log_softmax, and logsumexp ops.  Alignment padding
 is handled inside the kernel via masked loads, not on the host.
 
-Construction: ``op(dtype=..., dim=-1)``.  M and N are derived
+Construction: ``op(dim=-1)``.  M, N, and dtype are derived
 from the input tensor at forward time, and kernels are cached by
-``(M, N)`` to avoid rebuilds.
+``(M, N, dtype, device)`` to avoid rebuilds.
 """
 
 import warnings
@@ -25,7 +25,7 @@ __all__ = ["_SoftmaxBaseOp"]
 
 
 def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
-    """Mirror ``torch.nn.functional._get_softmax_dim``: pick 0 for ``ndim in {0, 1, 3}`` else 1, with the same deprecation warning."""
+    """Mirror ``torch.nn.functional._get_softmax_dim``."""
     warnings.warn(
         f"Implicit dimension choice for {name} has been deprecated. "
         "Change the call to include dim=X as an argument.",
@@ -64,7 +64,7 @@ class _SoftmaxBaseOp(Op):
 
     def __init__(
         self,
-        dtype: torch.dtype,
+        dtype: Optional[torch.dtype] = None,
         dim: Union[int, List[int]] = -1,
         N: Optional[int] = None,
         *,
@@ -72,13 +72,15 @@ class _SoftmaxBaseOp(Op):
         tune: bool = False,
     ):
         self.dtype = dtype
+        self._committed_dtype = dtype
         self.dim = dim
         self.N = N
         self.keepdim = False
         self._tune = tune
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, object] = {}
-        self._last_roofline_mn: tuple[int, int] | None = None
+        self.kernel: object | None = None
+        self._last_roofline_spec: tuple[int, int, torch.dtype] | None = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -92,10 +94,18 @@ class _SoftmaxBaseOp(Op):
         """Validate input tensor."""
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
+        if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise ValueError(
+                "x.dtype must be float16, bfloat16, or float32, "
+                f"got {x.dtype}"
+            )
+        if self._committed_dtype is not None and x.dtype != self._committed_dtype:
+            raise ValueError(
+                f"Expected x.dtype {self._committed_dtype}, got {x.dtype}"
+            )
         if x.ndim == 0:
             raise ValueError("Input tensor must be at least 1D")
+        self.dtype = x.dtype
 
     # ------------------------------------------------------------------
     # Forward
@@ -132,9 +142,13 @@ class _SoftmaxBaseOp(Op):
             x, orig_shape, _kept = flatten_for_multidim(x, dims)
             N = x.shape[-1]
             M = prod(x.shape[:-1])
-            self._last_roofline_mn = (M, N)
+            dtype = x.dtype
+            self._last_roofline_spec = (M, N, dtype)
             x = x.reshape(M, N)
-            kernel = self._get_or_create_kernel(M, N, device_index=x.device.index)
+            kernel = self._get_or_create_kernel(
+                M, N, dtype=dtype, device_index=x.device.index,
+            )
+            self.kernel = kernel
             # Alignment padding is handled by the kernel's forward().
             y = kernel(x)
             N_padded = align_up(N, DEFAULT_ALIGNMENT)
@@ -163,7 +177,8 @@ class _SoftmaxBaseOp(Op):
         # Op-layer cache-key / introspection consumers see the committed axis.
         self._static_axes = frozenset({(0, dim)})
         M = prod(s for i, s in enumerate(x.shape) if i != dim)
-        self._last_roofline_mn = (M, N)
+        dtype = x.dtype
+        self._last_roofline_spec = (M, N, dtype)
 
         # If reduction dim is not the last, move it to the end.
         needs_transpose = dim != x.ndim - 1
@@ -173,7 +188,10 @@ class _SoftmaxBaseOp(Op):
         x = x.contiguous().reshape(M, N)
 
         # Get or create cached kernel for this (M, N, device).
-        kernel = self._get_or_create_kernel(M, N, device_index=x.device.index)
+        kernel = self._get_or_create_kernel(
+            M, N, dtype=dtype, device_index=x.device.index,
+        )
+        self.kernel = kernel
 
         # Alignment padding is handled by the kernel's forward().
         y = kernel(x)
@@ -186,13 +204,13 @@ class _SoftmaxBaseOp(Op):
         return self._reshape_output(y, orig_shape, dim, needs_transpose)
 
     def eval_roofline(self) -> tuple[int, int]:
-        if self._last_roofline_mn is None:
+        if self._last_roofline_spec is None:
             raise RuntimeError(
                 f"{type(self).__name__}.eval_roofline() requires a prior forward() "
                 "call to bind dynamic input shape"
             )
-        M, N = self._last_roofline_mn
-        elem_bytes = self.dtype.itemsize
+        M, N, dtype = self._last_roofline_spec
+        elem_bytes = dtype.itemsize
         if self._op_kind == "softmax":
             return 5 * M * N, 2 * M * N * elem_bytes
         if self._op_kind == "log_softmax":
@@ -203,13 +221,19 @@ class _SoftmaxBaseOp(Op):
             f"{type(self).__name__} has unknown roofline op kind {self._op_kind!r}"
         )
 
-    def _get_or_create_kernel(self, M: int, N: int, device_index: int | None = None) -> object:
-        """Return a cached kernel for (M, N, device_index), creating one if needed."""
-        key = (M, N, device_index)
+    def _get_or_create_kernel(
+        self,
+        M: int,
+        N: int,
+        dtype: torch.dtype,
+        device_index: int | None = None,
+    ) -> object:
+        """Return a cached kernel for (M, N, dtype, device), creating one if needed."""
+        key = (M, N, dtype, device_index)
         if key not in self._kernel_cache:
             kernel_cls = self.kernel_map[self._kernel_key]
             self._kernel_cache[key] = kernel_cls(
-                M, N, self._op_kind, self.dtype, tune=self._tune,
+                M, N, self._op_kind, dtype, tune=self._tune,
                 device_index=device_index,
             )
         return self._kernel_cache[key]

--- a/tileops/ops/reduction/log_softmax.py
+++ b/tileops/ops/reduction/log_softmax.py
@@ -4,7 +4,7 @@ Provides:
   - LogSoftmaxFwdOp: y = log_softmax(x, dim)
 
 Example:
-    >>> op = LogSoftmaxFwdOp(N=4096, dtype=torch.float16, dim=-1)
+    >>> op = LogSoftmaxFwdOp(dim=-1)
     >>> x = torch.randn(1024, 4096, dtype=torch.float16, device="cuda")
     >>> y = op(x)  # shape: (1024, 4096)
 """
@@ -25,19 +25,18 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
     """Log-softmax operator: y = log_softmax(x, dim).
 
     Output has the same shape and dtype as input. The reduction-dim extent
-    ``N`` is committed at construction time per manifest
-    ``static_dims.N = "x.shape[dim]"`` (R20); ``forward()`` validates the
-    actual tensor against the committed value.
+    ``N`` and dtype are inferred from ``x`` during ``forward()``. Optional
+    ``N`` and ``dtype`` constructor arguments are retained as compatibility
+    guards and, when provided, are validated against the input tensor.
 
     Args:
-        N: Reduction-dim size (statically committed at ctor; corresponds to
-            manifest ``static_dims.N = "x.shape[dim]"``).
-        dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default ``None``, matching PyTorch's
             ``torch.nn.functional.log_softmax``). When ``None``, the axis is
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
+        N: Optional committed reduction-dim size for compatibility.
+        dtype: Optional committed data type for compatibility.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -48,8 +47,8 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
 
     def __init__(
         self,
-        N: int,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         dim: Optional[int] = None,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,

--- a/tileops/ops/reduction/log_softmax.py
+++ b/tileops/ops/reduction/log_softmax.py
@@ -11,8 +11,6 @@ Example:
 
 from typing import Dict, Optional
 
-import torch
-
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 
@@ -25,9 +23,7 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
     """Log-softmax operator: y = log_softmax(x, dim).
 
     Output has the same shape and dtype as input. The reduction-dim extent
-    ``N`` and dtype are inferred from ``x`` during ``forward()``. Optional
-    ``N`` and ``dtype`` constructor arguments are retained as compatibility
-    guards and, when provided, are validated against the input tensor.
+    ``N`` and dtype are inferred from ``x`` during ``forward()``.
 
     Args:
         dim: Reduction dimension (default ``None``, matching PyTorch's
@@ -35,8 +31,6 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
-        N: Optional committed reduction-dim size for compatibility.
-        dtype: Optional committed data type for compatibility.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -47,13 +41,9 @@ class LogSoftmaxFwdOp(_SoftmaxBaseOp):
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        dtype: Optional[torch.dtype] = None,
         dim: Optional[int] = None,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(
-            N=N, dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune,
-        )
+        super().__init__(dim=dim, kernel_map=kernel_map, tune=tune)

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -11,8 +11,6 @@ Example:
 
 from typing import Dict, Optional
 
-import torch
-
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 
@@ -25,9 +23,7 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
     """Softmax operator: y = softmax(x, dim).
 
     Output has the same shape and dtype as input. The reduction-dim extent
-    ``N`` and dtype are inferred from ``x`` during ``forward()``. Optional
-    ``N`` and ``dtype`` constructor arguments are retained as compatibility
-    guards and, when provided, are validated against the input tensor.
+    ``N`` and dtype are inferred from ``x`` during ``forward()``.
 
     Args:
         dim: Reduction dimension (default ``None``, matching PyTorch's
@@ -35,8 +31,6 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
-        N: Optional committed reduction-dim size for compatibility.
-        dtype: Optional committed data type for compatibility.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -47,13 +41,9 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
 
     def __init__(
         self,
-        N: Optional[int] = None,
-        dtype: Optional[torch.dtype] = None,
         dim: Optional[int] = None,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(
-            N=N, dtype=dtype, dim=dim, kernel_map=kernel_map, tune=tune,
-        )
+        super().__init__(dim=dim, kernel_map=kernel_map, tune=tune)

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -4,7 +4,7 @@ Provides:
   - SoftmaxFwdOp: y = softmax(x, dim)
 
 Example:
-    >>> op = SoftmaxFwdOp(N=4096, dtype=torch.float16, dim=-1)
+    >>> op = SoftmaxFwdOp(dim=-1)
     >>> x = torch.randn(2, 32, 4096, dtype=torch.float16, device="cuda")
     >>> y = op(x)  # shape: (2, 32, 4096)
 """
@@ -25,19 +25,18 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
     """Softmax operator: y = softmax(x, dim).
 
     Output has the same shape and dtype as input. The reduction-dim extent
-    ``N`` is committed at construction time per manifest
-    ``static_dims.N = "x.shape[dim]"`` (R20); ``forward()`` validates the
-    actual tensor against the committed value.
+    ``N`` and dtype are inferred from ``x`` during ``forward()``. Optional
+    ``N`` and ``dtype`` constructor arguments are retained as compatibility
+    guards and, when provided, are validated against the input tensor.
 
     Args:
-        N: Reduction-dim size (statically committed at ctor; corresponds to
-            manifest ``static_dims.N = "x.shape[dim]"``).
-        dtype: Data type (float32, float16, or bfloat16).
         dim: Reduction dimension (default ``None``, matching PyTorch's
             ``torch.nn.functional.softmax``). When ``None``, the axis is
             resolved at forward time using PyTorch's implicit-axis rule
             (``0`` for ``ndim in {0, 1, 3}`` else ``1``) and the same
             deprecation ``UserWarning`` is emitted.
+        N: Optional committed reduction-dim size for compatibility.
+        dtype: Optional committed data type for compatibility.
         kernel_map: Optional override for kernel dispatch.
         tune: Whether to autotune (default False).
     """
@@ -48,8 +47,8 @@ class SoftmaxFwdOp(_SoftmaxBaseOp):
 
     def __init__(
         self,
-        N: int,
-        dtype: torch.dtype,
+        N: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
         dim: Optional[int] = None,
         *,
         kernel_map: Optional[Dict[str, Kernel]] = None,


### PR DESCRIPTION
## Summary

- infer BatchNorm/GroupNorm/InstanceNorm and Softmax/LogSoftmax shape/dtype metadata from forward inputs instead of requiring construction-time `N/C/spatial/dtype` metadata
- lazily specialize and JIT kernels in `forward()` with `_kernel_cache` as the authoritative specialization cache
- retain `self.kernel` as the last-used kernel handle only, so repeated calls can overwrite it when dispatching a different specialization while cache hits avoid rebuild/JIT work
- update tests and benchmarks to use the preferred input-derived API while keeping explicit constructor metadata as optional compatibility guards

## Kernel Cache / `self.kernel` Contract

- `__init__` no longer eagerly builds kernels for these ops.
- `forward()` resolves the specialization from runtime tensors, looks up/builds the cached kernel, and assigns `self.kernel = kernel` for compatibility/debug visibility.
- `_kernel_cache` owns compiled specializations; `self.kernel` is not the cache and may change on later calls with different input shapes/devices/dtypes.
- For an already-JITed specialization, the hot path is metadata validation + cache key lookup + assignment, without another kernel build.

## Testing

- `python -m py_compile` on changed op/test/benchmark files
- `python -m ruff check` on changed op/test/benchmark files
- local Docker GPU smoke with `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10` on GPU 4:
  - `87 passed, 12 skipped, 138 deselected, 14 warnings`
- local Docker manifest checks for affected ops:
  - `SoftmaxFwdOp`, `LogSoftmaxFwdOp`, `BatchNormFwdOp`, `BatchNormBwdOp`, `GroupNormFwdOp`, `GroupNormFwdOpNoAffine`, `InstanceNormFwdOp`, `InstanceNormFwdOpNoAffine`
  - all passed; remaining output is existing advisory `_infer_output_shapes` warnings

Closes #1686
Refs #1674
