### PR TITLE
[Perf][FP8_LIGHTING_INDEXER] drop logits clone and bound clean_logits scan

### DIFF
--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -151,11 +151,9 @@ def clean_logits_(threads: int = 512,):
     ):
         with T.Kernel(seq_len, batch, threads=threads) as (bx, by):
             tx = T.get_thread_binding()
-            cu_k_s = T.min(CuSeqLenKS[bx], seq_len_kv)
-            cu_k_e = T.min(CuSeqLenKE[bx], seq_len_kv)
+            cu_k_s = T.max(T.min(CuSeqLenKS[bx], seq_len_kv), 0)
+            cu_k_e = T.max(T.min(CuSeqLenKE[bx], seq_len_kv), cu_k_s)
 
-            # Only positions outside [cu_k_s, cu_k_e) need -inf; iterate the two
-            # out-of-window spans instead of scanning all seq_len_kv positions.
             for n_i in T.serial(T.ceildiv(cu_k_s, threads)):
                 idx = n_i * threads + tx
                 if idx < cu_k_s:

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -134,7 +134,7 @@ def _fp8_lighting_indexer_kernel(batch,
 
 
 @tilelang.jit
-def clean_logits_(block_K: int = 4096,):
+def clean_logits_(threads: int = 512,):
     batch = T.dynamic("batch")
     seq_len = T.dynamic("seq_len")
     seq_len_kv = T.dynamic("seq_len_kv")
@@ -149,29 +149,35 @@ def clean_logits_(block_K: int = 4096,):
             CuSeqLenKS: T.Tensor([seq_len], indices_dtype),  # type: ignore
             CuSeqLenKE: T.Tensor([seq_len], indices_dtype),  # type: ignore
     ):
-        with T.Kernel(seq_len, batch, threads=512) as (bx, by):
+        with T.Kernel(seq_len, batch, threads=threads) as (bx, by):
             tx = T.get_thread_binding()
-            cu_k_s = CuSeqLenKS[bx]
-            cu_k_e = CuSeqLenKE[bx]
+            cu_k_s = T.min(CuSeqLenKS[bx], seq_len_kv)
+            cu_k_e = T.min(CuSeqLenKE[bx], seq_len_kv)
 
-            for n_i in T.Pipelined(T.ceildiv(seq_len_kv, block_K)):
-                for k_i in T.serial(block_K // 512):
-                    idx = n_i * block_K + k_i * 512 + tx
-                    if idx < cu_k_s or idx >= cu_k_e:
-                        for g in T.serial(kv_group):
-                            Logits[by, bx, idx, g] = -T.infinity(dtype)
+            # Only positions outside [cu_k_s, cu_k_e) need -inf; iterate the two
+            # out-of-window spans instead of scanning all seq_len_kv positions.
+            for n_i in T.serial(T.ceildiv(cu_k_s, threads)):
+                idx = n_i * threads + tx
+                if idx < cu_k_s:
+                    for g in T.serial(kv_group):
+                        Logits[by, bx, idx, g] = -T.infinity(dtype)
+            for n_i in T.serial(T.ceildiv(seq_len_kv - cu_k_e, threads)):
+                idx = cu_k_e + n_i * threads + tx
+                if idx < seq_len_kv:
+                    for g in T.serial(kv_group):
+                        Logits[by, bx, idx, g] = -T.infinity(dtype)
 
     return clean_logits_kernel
 
 
-@torch.library.custom_op("top::fp8_lighting_indexer_wrapped_kernel", mutates_args=())
+@torch.library.custom_op("top::fp8_lighting_indexer_wrapped_kernel", mutates_args=("Logits",))
 def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, index_dim: int,
                                         seq_len_kv: int, kv_group: int, clean_logits: bool,
                                         block_N: int, num_stages: int, threads: int, block_Q: int,
                                         IndexQ: torch.Tensor, IndexK: torch.Tensor,
                                         IndexKScale: torch.Tensor, Logits: torch.Tensor,
                                         Weights: torch.Tensor, CuSeqLenKS: torch.Tensor,
-                                        CuSeqLenKE: torch.Tensor) -> torch.Tensor:
+                                        CuSeqLenKE: torch.Tensor) -> None:
 
     _fp8_lighting_indexer_kernel(batch, seq_len, heads, index_dim, seq_len_kv,
                                  kv_group)(block_N, num_stages, threads,
@@ -180,7 +186,6 @@ def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, in
                                                     Logits, Weights, CuSeqLenKS, CuSeqLenKE)
     if clean_logits:
         clean_logits_()(Logits, CuSeqLenKS, CuSeqLenKE)
-    return Logits.clone()
 
 
 @fp8_lighting_indexer_wrapped_kernel.register_fake
@@ -202,10 +207,8 @@ def _(
         Logits: torch.Tensor,
         Weights: torch.Tensor,
         CuSeqLenKS: torch.Tensor,
-        CuSeqLenKE: torch.Tensor) -> torch.Tensor:
-    fake_o = torch.empty([seq_len, seq_len_kv], dtype=IndexKScale.dtype, device=IndexKScale.device)
-
-    return fake_o
+        CuSeqLenKE: torch.Tensor) -> None:
+    return None
 
 
 class FP8LightingIndexerKernel(Kernel):
@@ -270,11 +273,12 @@ class FP8LightingIndexerKernel(Kernel):
         Logits = torch.empty([self.batch, self.seq_len, self.seq_len_kv, self.kv_group],
                              device=IndexQ.device,
                              dtype=torch.float32)
-        return fp8_lighting_indexer_wrapped_kernel(
+        fp8_lighting_indexer_wrapped_kernel(
             self.batch, self.seq_len, self.heads, self.index_dim, self.seq_len_kv, self.kv_group,
             self.clean_logits, self.config["block_N"], self.config["num_stages"],
             self.config["threads"], self.config["block_Q"], IndexQ, IndexK, IndexKScale, Logits,
             Weights, CuSeqLenKS, CuSeqLenKE)
+        return Logits
 
     def supply_prog(
         self, *args, **kwargs

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -183,7 +183,7 @@ def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, in
                                                                 index_dim), IndexK, IndexKScale,
                                                     Logits, Weights, CuSeqLenKS, CuSeqLenKE)
     if clean_logits:
-        clean_logits_()(Logits, CuSeqLenKS, CuSeqLenKE)
+        clean_logits_(threads=threads)(Logits, CuSeqLenKS, CuSeqLenKE)
 
 
 @fp8_lighting_indexer_wrapped_kernel.register_fake


### PR DESCRIPTION
## Summary

Ref: #1689 

- Declare `mutates_args=("Logits",)` on the indexer custom op and return the caller-owned
  `Logits` instead of `Logits.clone()` — removes a 134 MB fp32 device-to-device round-trip per
  call (the clone existed only to satisfy the previous `mutates_args=()` declaration). Also
  fixes `register_fake` to match the new None-return schema (its previous fake shape was wrong).
- Rewrite `clean_logits_kernel` to iterate only the two out-of-window spans `[0, ks)` /
  `[ke, seq_len_kv)` instead of predicate-scanning all `seq_len × seq_len_kv` positions; adds
  the same `seq_len_kv` clamp on ks/ke that the main kernel already applies.
- Code-only: no numerical change, no Op signature / manifest / autotune-space change.

## Test plan

- [x] pre-commit passed (ruff, codespell, gitleaks)
- [x] `pytest tests/ops/test_fp8_lighting_indexer.py` — 2 passed (strict isfinite-mask compare
      on ragged varlen windows; covers tune=True)
- [x] `pytest benchmarks/tests` (contract) — 8 passed
- [x] `python scripts/validate_manifest.py` — all checks passed

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.0, PyTorch 2.10.0, TileLang 0.1.11+cuda.git5aaef0fd

### FP8LightingIndexerOp

| Shape (b, s, h, d, s_kv, g) | This PR (ms) | main (ms) | Speedup | BW (TB/s) |
| --------------------------- | ------------ | --------- | ------- | --------- |
| (1, 4096, 32, 64, 8192, 1)  | 0.1048       | 0.1709    | 1.63×   | 1.37      |
| (1, 2048, 16, 64, 4096, 1)  | 0.0731       | 0.0882    | 1.21×   | 0.49      |

**Takeaways:** per-kernel breakdown (torch profiler, large shape) shows the win is removed
waste, not a changed kernel: the 64.8 µs clone Memcpy is eliminated entirely; `clean_logits`
drops 18.46 → 5.77 µs on full-range masks (on the ragged bench masks it is write-dominated —
119 MB of semantically required `-inf` fills — and stays ~41 µs); the main kernel is untouched
(96.6 → 93.8 µs, noise). Correctness is bit-preserved: same kernels, same write set, no
numerical path change.

**Command:** `python -m pytest benchmarks/ops/bench_fp8_lighting_indexer.py -v`