### PR TITLE
[Perf][Elementwise] exp2 SiLU + 128x8 occupancy config for fused gated activation

### DIFF
--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -167,13 +167,23 @@ def test_binary_default_config_preserves_strategy_npt_split():
 
 
 @pytest.mark.full
-def test_fused_gated_default_config_preserves_strategy_npt_split():
-    """Fused-gated kernels should keep the direct/explicit_parallel npt split."""
+def test_fused_gated_explicit_uses_occupancy_config():
+    """Fused-gated explicit_parallel uses the 128x8 occupancy config for fp16/bf16.
+
+    threads=128, npt=8 keeps block_N = 1024 (same tiling as the old 256x4) while
+    raising occupancy/ILP at large M. fp32 falls back to 256/4: npt=4 already
+    saturates the 128-bit load width, so 128/8 would only add register pressure.
+    The direct strategy keeps the dtype-driven npt.
+    """
     with (
         patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
         patch.object(SiluAndMulFwdKernel, "init_config"),
     ):
         direct = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="direct")
-        explicit = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="explicit_parallel")
+        explicit_fp16 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="explicit_parallel")
+        explicit_bf16 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.bfloat16, strategy="explicit_parallel")
+        explicit_fp32 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float32, strategy="explicit_parallel")
     assert direct.default_config["num_per_thread"] == 8
-    assert explicit.default_config["num_per_thread"] == 4
+    assert explicit_fp16.default_config == {"threads": 128, "num_per_thread": 8}
+    assert explicit_bf16.default_config == {"threads": 128, "num_per_thread": 8}
+    assert explicit_fp32.default_config == {"threads": 256, "num_per_thread": 4}

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -1108,6 +1108,10 @@ class FusedGatedKernel(Kernel):
     def default_config(self) -> dict:
         if _is_fp8(self.dtype):
             return {"threads": 256, "num_per_thread": 16}
+        if self.strategy == "explicit_parallel" and self.dtype in (torch.float16, torch.bfloat16):
+            # 128x8 keeps block_N=1024 but widens loads to 128-bit and lifts occupancy.
+            # Only fp16/bf16 gain the width: fp32 npt=4 already saturates LDG.128.
+            return {"threads": 128, "num_per_thread": 8}
         npt = _strategy_npt(self.strategy, self.dtype)
         return {"threads": 256, "num_per_thread": npt}
 

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -1733,7 +1733,11 @@ class SiluAndMulFwdKernel(FusedGatedKernel):
 
     @staticmethod
     def activation_func(x):
-        return x * T.sigmoid(x)
+        # exp2 form (fp32): exp2 lowers to one MUFU.EX2 vs expf's multi-op sequence.
+        g = T.Cast("float32", x)
+        one = T.cast(1.0, "float32")
+        log2e = T.cast(1.4426950408889634, "float32")
+        return g / (one + T.exp2(-g * log2e))
 
 
 class GeluAndMulFwdKernel(FusedGatedKernel):


### PR DESCRIPTION
Closes #1692.

## Summary

- Optimize fused gated activation kernels with two tuning changes: exp2-based SiLU math and a 128x8 explicit_parallel config for fp16/bf16.
- Keep `block_N = threads * num_per_thread = 1024`, so column tiling and OOB behavior stay unchanged from the old 256x4 config.
- Scope the 128x8 config to fp16/bf16 only; fp32 keeps 256x4 because `num_per_thread=4` already reaches 128-bit load width.
- Update the config unit test to cover fp16, bf16, fp32, and direct-strategy behavior.

## Performance tuning conclusions

- SiLU decode is issue/SFU-bound, so rewriting sigmoid through `exp2(-x * log2e)` reduces transcendental instruction pressure and improves the small-M case.
- Prefill is bandwidth/occupancy-sensitive; for fp16/bf16, 128x8 widens per-thread access to 16 bytes and improves occupancy while preserving the same tile width.
- GELU and GELU-tanh keep their math unchanged; they only benefit from the shared config change.
- The 128x8 config is not generally better for fp32 because it does not widen memory access beyond LDG.128 and can add unnecessary per-thread work.

## Benchmark

H200, bf16, N=1024, ncu locked-clock profiling:

| kernel | shape | before | after | delta |
|--------|-------|--------|-------|-------|
| silu | M=4096 | 9.82us | 8.96us | -8.8% |
| silu | M=32768 | 55.30us | 47.42us | -14.2% |
| gelu | M=4096 | 11.58us | 11.26us | -2.8% |
| gelu | M=32768 | 69.02us | 65.73us | -4.8% |
| gelu_tanh | M=4096 | 10.59us | 10.62us | tie |
| gelu_tanh | M=32768 | 59.33us | 56.96us | -4.0% |

## Test plan

- [x] `tests/ops/test_fused_gated.py`: 30 passed
- [x] `tests/ops/test_elementwise_config_dtype.py::test_fused_gated_explicit_uses_occupancy_config`
- [x] Full elementwise sweep reported in PR: 174 passed
- [x] CI pre-commit and GPU smoke passed