### PR TITLE
[CI][SMOKE] Re-enable non-MHA TileLang 0.1.11 skipped ops

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,23 +59,9 @@ TILELANG_019_SKIP_REASON = (
     "when these tests pass against the current tilelang."
 )
 
-TILELANG_019_KNOWN_FAILING_PATH_SUFFIXES = (
-    "tests/ops/test_batch_norm.py",
-)
+TILELANG_019_KNOWN_FAILING_PATH_SUFFIXES = ()
 
-TILELANG_019_KNOWN_FAILING_NODEIDS = {
-    "tests/ops/test_engram.py::test_engram_gate_conv_bwd[1-32-256-dtype0-False]",
-    "tests/ops/test_engram.py::test_engram_gate_conv_bwd[1-32-256-dtype1-False]",
-    "tests/ops/test_engram.py::test_engram_gate_conv_bwd[2-64-512-dtype2-False]",
-    "tests/ops/test_engram.py::test_engram_gate_conv_bwd[2-16-256-dtype3-False]",
-    "tests/ops/test_engram.py::test_engram_decode[1-512-256-12-4-3-dtype0-False]",
-    "tests/ops/test_engram.py::test_engram_decode[1-512-256-12-4-3-dtype1-False]",
-    "tests/ops/test_engram.py::test_engram_decode[4-1024-512-20-4-5-dtype2-False]",
-    "tests/ops/test_engram.py::test_engram_decode[8-512-256-18-4-3-dtype3-False]",
-    "tests/ops/test_engram.py::test_engram_decode_multi_step",
-    "tests/ops/test_norm_ops.py::TestBatchNormCustomOp::test_fwd_torch_compile_smoke",
-    "tests/ops/test_norm_ops.py::TestBatchNormCustomOp::test_bwd_torch_compile_smoke",
-}
+TILELANG_019_KNOWN_FAILING_NODEIDS = set()
 
 TILELANG_019_KNOWN_FAILING_PREFIXES = (
     "tests/test_autotune.py::test_mha_kernel_autotune",

--- a/tileops/kernels/engram/engram_bwd.py
+++ b/tileops/kernels/engram/engram_bwd.py
@@ -7,8 +7,9 @@ computes:
     drms_w_h, drms_w_v  — gradients w.r.t. RMSNorm weights
     dconv_w             — gradient w.r.t. conv weights
 
-Three-pass design:
-    Pass 1:  SiLU+residual bwd -> dconv_w + store d_silu_out to buffer
+Staged design:
+    Pass 1:  SiLU+residual bwd -> store d_silu_out to buffer
+    Pass 1a: Reduce dconv_w from the buffered d_silu values
     Pass 1b: Conv transpose -> RMSNorm(v_hat) bwd -> d(v_hat)
     Pass 2:  Gate bwd -> RMSNorm(H) bwd, RMSNorm(k) bwd -> dH, dk, dv
 """
@@ -71,11 +72,8 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
                 for j in T.Parallel(d_padded):
                     drms_w_h[j] = 0.0
                     drms_w_v[j] = 0.0
-                for p in T.serial(KS):
-                    for j in T.Parallel(d_padded):
-                        dconv_w[p, j] = 0.0
 
-            # ======== Pass 1: SiLU bwd + dconv_w ========
+            # ======== Pass 1: SiLU bwd ========
             with T.Kernel(seq_len, M, threads=threads) as (bx, by):
                 dy_local = T.alloc_fragment((d_padded,), accum_dtype)
                 conv_out = T.alloc_fragment((d_padded,), accum_dtype)
@@ -112,26 +110,37 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
                     sig = 1.0 / (1.0 + T.exp(-conv_out[j]))
                     d_silu[j] = dy_local[j] * (sig + conv_out[j] * sig * (1.0 - sig))
 
-                # dconv_w[p,j] += d_silu[j] * v_hat_norm[src_t, j]
-                for p in T.serial(KS):
-                    src_t = tid - (KS - 1) + p
-                    for j in T.Parallel(d_padded):
-                        raw_val = T.if_then_else(
-                            src_t >= 0,
-                            T.cast(vhat[bid, src_t, j], accum_dtype),
-                            0.0,
-                        )
+                # Store d_silu for conv transpose in pass 1b
+                for j in T.Parallel(d_padded):
+                    dvhat_buf[bid, tid, j] = d_silu[j]
+
+            # ======== dconv_w reduction ========
+            # TileLang 0.1.11 lowers atomic_add(dconv_w[p, j], ...) in Pass 1
+            # into a launch-failing kernel. This separate reduction adds a
+            # small fixed launch cost but keeps the backward path correct.
+            with T.Kernel(KS, threads=threads) as (bx,):
+                dconv_local = T.alloc_fragment((d_padded,), accum_dtype)
+                p = bx
+                for j in T.Parallel(d_padded):
+                    dconv_local[j] = 0.0
+                for bid in T.serial(M):
+                    for tid in T.serial(seq_len):
+                        src_t = tid - (KS - 1) + p
                         src_rrms = T.if_then_else(
                             src_t >= 0,
                             rrms_v[bid, src_t],
                             0.0,
                         )
-                        normed = raw_val * src_rrms * T.cast(rms_w_v[j], accum_dtype)
-                        T.atomic_add(dconv_w[p, j], d_silu[j] * normed)
-
-                # Store d_silu for conv transpose in pass 1b
+                        for j in T.Parallel(d_padded):
+                            raw_val = T.if_then_else(
+                                src_t >= 0,
+                                T.cast(vhat[bid, src_t, j], accum_dtype),
+                                0.0,
+                            )
+                            normed = raw_val * src_rrms * T.cast(rms_w_v[j], accum_dtype)
+                            dconv_local[j] += dvhat_buf[bid, tid, j] * normed
                 for j in T.Parallel(d_padded):
-                    dvhat_buf[bid, tid, j] = d_silu[j]
+                    dconv_w[p, j] = dconv_local[j]
 
             # ======== Pass 1b: conv transpose + RMSNorm(vhat) bwd ========
             # d(v_hat_norm[t,j]) = sum_p conv_w[p,j] * d_silu[t+(KS-1)-p, j]
@@ -384,8 +393,9 @@ def _(M, seq_len, d, eps, dtype_str, threads,
 class EngramGateConvBwdKernel(Kernel):
     """Engram GateConv backward kernel.
 
-    Three-pass backward:
-      Pass 1:  SiLU bwd + dconv_w accumulation
+    Staged backward:
+      Pass 1:  SiLU bwd -> d_silu buffer
+      Pass 1a: dconv_w reduction
       Pass 1b: Conv transpose + RMSNorm(vhat) bwd -> d(vhat)
       Pass 2:  Gate bwd -> dH, dk, dv + drms_w_h accumulation
     """

--- a/tileops/kernels/norm/batch_norm.py
+++ b/tileops/kernels/norm/batch_norm.py
@@ -110,7 +110,7 @@ def _batch_norm_fwd_train_kernel(
     accum_dtype = "float32"
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _bn_fwd_train_func(block_l: int, num_stages: int, threads: int) -> Callable:
+    def _bn_fwd_train_func(block_l: int, threads: int) -> Callable:
 
         @T.prim_func
         def _bn_fwd_train(
@@ -135,13 +135,13 @@ def _batch_norm_fwd_train_kernel(
 
                 # Pass 1 – accumulate sum(x) and sum(x^2) over all tiles.
                 if block_l >= L:
-                    # Persistent path: T.copy into x_shared, single global read.
-                    for l_tile in T.Pipelined(L // block_l, num_stages=num_stages):
-                        T.copy(x[bc, l_tile * block_l:(l_tile + 1) * block_l], x_shared)
-                        for _i, j in T.Parallel(1, block_l):
-                            xval = T.cast(x_shared[j], accum_dtype)
-                            xsum_frag[_i, j] += xval
-                            xsq_frag[_i, j] += xval * xval
+                    # Persistent path has exactly one tile, so a pipelined loop
+                    # cannot overlap producer/consumer work.
+                    T.copy(x[bc, 0:block_l], x_shared)
+                    for _i, j in T.Parallel(1, block_l):
+                        xval = T.cast(x_shared[j], accum_dtype)
+                        xsum_frag[_i, j] += xval
+                        xsq_frag[_i, j] += xval * xval
                 else:
                     # Non-persistent path: direct global memory access avoids async-copy
                     # data race that occurs when T.copy is used inside T.Pipelined.
@@ -235,9 +235,10 @@ class BatchNormFwdTrainKernel(Kernel):
         if self.L <= _PERSISTENT_THRESHOLD:
             # Persistent path: block_l = L, single global read.
             t = _find_best_threads(self.L)
-            return {"block_l": self.L, "num_stages": 1, "threads": t}
+            return {"block_l": self.L, "threads": t}
         # Non-persistent path: find best block_l with non-power-of-2 thread counts.
-        return _find_best_block_l(self.L)
+        cfg = _find_best_block_l(self.L)
+        return {"block_l": cfg["block_l"], "threads": cfg["threads"]}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -245,7 +246,7 @@ class BatchNormFwdTrainKernel(Kernel):
         configs = []
 
         def _add(cfg: dict) -> None:
-            key = (cfg["block_l"], cfg["num_stages"], cfg["threads"])
+            key = (cfg["block_l"], cfg["threads"])
             if key not in seen:
                 seen.add(key)
                 configs.append(cfg)
@@ -254,7 +255,7 @@ class BatchNormFwdTrainKernel(Kernel):
         if self.L <= _PERSISTENT_THRESHOLD:
             for t in [256, 128, 64, 32]:
                 if self.L % t == 0:
-                    _add({"block_l": self.L, "num_stages": 1, "threads": t})
+                    _add({"block_l": self.L, "threads": t})
 
         # Non-persistent configs: power-of-2 threads, block_l can be non-power-of-2.
         # num_stages=0 disables T.Pipelined's async prefetch, which is required for
@@ -264,7 +265,7 @@ class BatchNormFwdTrainKernel(Kernel):
                 bl = threads * k
                 if bl >= self.L or self.L % bl != 0:
                     continue
-                _add({"block_l": bl, "num_stages": 0, "threads": threads})
+                _add({"block_l": bl, "threads": threads})
 
         return configs if configs else [self.default_config]
 
@@ -287,7 +288,6 @@ class BatchNormFwdTrainKernel(Kernel):
         rstd_out = torch.empty(self.C, device=x.device, dtype=torch.float32)
         y = self.kernel(
             self.config["block_l"],
-            self.config["num_stages"],
             self.config["threads"],
         )(x, weight, bias, running_mean, running_var, mean_out, rstd_out)
         return y, mean_out, rstd_out
@@ -443,7 +443,7 @@ def _batch_norm_bwd_kernel(
     accum_dtype = "float32"
 
     @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
-    def _bn_bwd_func(block_l: int, num_stages: int, threads: int) -> Callable:
+    def _bn_bwd_func(block_l: int, threads: int) -> Callable:
 
         @T.prim_func
         def _bn_bwd(
@@ -472,15 +472,15 @@ def _batch_norm_bwd_kernel(
 
                 # Pass 1 – accumulate grad_bias and grad_weight contributions.
                 if block_l >= L:
-                    # Persistent path: T.copy into shared memory, single global read.
-                    for l_tile in T.Pipelined(L // block_l, num_stages=num_stages):
-                        T.copy(grad_out[bc, l_tile * block_l:(l_tile + 1) * block_l], go_shared)
-                        T.copy(x[bc, l_tile * block_l:(l_tile + 1) * block_l], x_shared)
-                        for _i, j in T.Parallel(1, block_l):
-                            go_val = T.cast(go_shared[j], accum_dtype)
-                            x_hat = (T.cast(x_shared[j], accum_dtype) - mean_val) * rstd_val
-                            do_frag[_i, j] += go_val
-                            do_xhat_frag[_i, j] += go_val * x_hat
+                    # Persistent path has exactly one tile, so a pipelined loop
+                    # cannot overlap producer/consumer work.
+                    T.copy(grad_out[bc, 0:block_l], go_shared)
+                    T.copy(x[bc, 0:block_l], x_shared)
+                    for _i, j in T.Parallel(1, block_l):
+                        go_val = T.cast(go_shared[j], accum_dtype)
+                        x_hat = (T.cast(x_shared[j], accum_dtype) - mean_val) * rstd_val
+                        do_frag[_i, j] += go_val
+                        do_xhat_frag[_i, j] += go_val * x_hat
                 else:
                     # Non-persistent path: direct global memory access avoids async-copy
                     # data race that occurs when T.copy is used inside T.Pipelined.
@@ -569,8 +569,9 @@ class BatchNormBwdKernel(Kernel):
             # Persistent path: block_l = L, single global read.
             # go_shared and x_shared together use 2 * L * sizeof(dtype) SMEM.
             t = _find_best_threads(self.L)
-            return {"block_l": self.L, "num_stages": 1, "threads": t}
-        return _find_best_block_l(self.L)
+            return {"block_l": self.L, "threads": t}
+        cfg = _find_best_block_l(self.L)
+        return {"block_l": cfg["block_l"], "threads": cfg["threads"]}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -578,7 +579,7 @@ class BatchNormBwdKernel(Kernel):
         configs = []
 
         def _add(cfg: dict) -> None:
-            key = (cfg["block_l"], cfg["num_stages"], cfg["threads"])
+            key = (cfg["block_l"], cfg["threads"])
             if key not in seen:
                 seen.add(key)
                 configs.append(cfg)
@@ -587,7 +588,7 @@ class BatchNormBwdKernel(Kernel):
         if self.L <= _PERSISTENT_THRESHOLD:
             for t in [256, 128, 64, 32]:
                 if self.L % t == 0:
-                    _add({"block_l": self.L, "num_stages": 1, "threads": t})
+                    _add({"block_l": self.L, "threads": t})
 
         # Non-persistent configs: power-of-2 threads, block_l can be non-power-of-2.
         # num_stages=0 disables pipelining for correctness in multi-tile loops.
@@ -596,7 +597,7 @@ class BatchNormBwdKernel(Kernel):
                 bl = threads * k
                 if bl >= self.L or self.L % bl != 0:
                     continue
-                _add({"block_l": bl, "num_stages": 0, "threads": threads})
+                _add({"block_l": bl, "threads": threads})
 
         return configs if configs else [self.default_config]
 
@@ -619,7 +620,6 @@ class BatchNormBwdKernel(Kernel):
         grad_bias = torch.empty(self.C, device=grad_out.device, dtype=torch.float32)
         grad_x = self.kernel(
             self.config["block_l"],
-            self.config["num_stages"],
             self.config["threads"],
         )(grad_out, x, weight, mean, rstd, grad_weight, grad_bias)
         return grad_x, grad_weight, grad_bias


### PR DESCRIPTION
## Summary

Closes #1695.

This PR re-enables the non-MHA tests currently hidden by the TileLang 0.1.11 skip guard:

- BatchNorm forward/backward smoke coverage
- Engram GateConv backward smoke/full coverage
- Engram decode smoke/full and multi-step decode coverage
- BatchNorm `torch.compile` smoke coverage in `tests/ops/test_norm_ops.py`

## Changes

- Fix BatchNorm persistent forward/backward paths by removing the single-tile `T.Pipelined(..., num_stages=1)` loop around `T.copy`.
  - The persistent path has exactly one tile, so there is no producer/consumer overlap to pipeline.
  - Keeping `T.copy` inside that pipelined loop hangs under TileLang 0.1.11.
- Fix Engram GateConv backward by splitting `dconv_w` accumulation into a separate reduction kernel.
  - TileLang 0.1.11 lowers `T.atomic_add(dconv_w[p, j], ...)` in Pass 1 into a launch-failing kernel.
  - The separate reduction adds a small fixed launch cost, documented in the code.
- Remove stale non-MHA entries from `TILELANG_019_KNOWN_FAILING_PATH_SUFFIXES` and `TILELANG_019_KNOWN_FAILING_NODEIDS`.
  - MHA prefix skips are intentionally left untouched and tracked separately in #1694.

## Performance note

For the Engram `dconv_w` workaround, a quick CUDA-event comparison against a temporary no-`dconv_w` lower-bound variant showed roughly +4 to +12 us on the tested smoke/bench-like cases. The original atomic version cannot be timed meaningfully because it fails at launch.

## Validation

Ran in the official TileOps CI runner image:

```bash
docker run --rm --entrypoint bash --gpus 'device=2' --ipc host \
  -v /tmp/tileops-latest-ci-smoke:/workspace \
  -v /data3/shared/ci-cache:/ci-cache \
  -w /workspace ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10 -lc '
export PYTHONPATH=/workspace${PYTHONPATH:+:$PYTHONPATH}
export TILELANG_CACHE_DIR=/ci-cache/tilelang
python -m pytest -q tests/ops/test_batch_norm.py tests/ops/test_engram.py tests/ops/test_norm_ops.py -m smoke -rs --tb=short -p no:cacheprovider
'
```

Result:

```text
17 passed, 20 deselected, 14 warnings
```

Additional targeted checks run during debugging:

```text
tests/ops/test_batch_norm.py: 19 passed
tests/ops/test_engram.py: 13 passed
tests/ops/test_norm_ops.py::TestBatchNormCustomOp: 2 passed
tests/ops/test_engram.py::test_engram_gate_conv_bwd: 4 passed
```
