### PR TITLE
[CI][SMOKE] Route MHA forward through GQA dispatch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,10 +77,7 @@ TILELANG_019_KNOWN_FAILING_NODEIDS = {
     "tests/ops/test_norm_ops.py::TestBatchNormCustomOp::test_bwd_torch_compile_smoke",
 }
 
-TILELANG_019_KNOWN_FAILING_PREFIXES = (
-    "tests/test_autotune.py::test_mha_kernel_autotune",
-    "tests/test_compile.py::test_mha_kernel_compile",
-)
+TILELANG_019_KNOWN_FAILING_PREFIXES = ()
 
 def _get_callspec_params(item: pytest.Item) -> dict | None:
     callspec = getattr(item, "callspec", None)

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -6,10 +6,22 @@ import torch
 import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
+import tileops.ops.attention.gqa as gqa_module
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
 from workloads.attention.mha import MhaBwdTest as _MhaBwdTestWorkload
 from workloads.attention.mha import MhaFwdTest as _MhaFwdTestWorkload
+
+
+class _FakeDenseKernel(Kernel):
+    def forward(self, *args: object, **kwargs: object) -> object:
+        return None
+
+
+class _FakeSquareDenseKernel(Kernel):
+    def forward(self, *args: object, **kwargs: object) -> object:
+        return None
 
 
 class MhaBwdTest(_MhaBwdTestWorkload, TestBase):
@@ -101,6 +113,33 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
     test = MhaFwdTest(batch, heads, seq_len, dim, causal, dtype)
     op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_mha_fwd_dispatches_to_gqa_kernel() -> None:
+    op = MultiHeadAttentionFwdOp(1, 8, 128, 64, False, torch.float16)
+    assert op.kernel.__class__.__name__.startswith("GQA")
+
+
+@pytest.mark.smoke
+def test_mha_fwd_preserves_gqa_square_dense_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gqa_module, "is_h200", lambda: True)
+    op = MultiHeadAttentionFwdOp(
+        batch=4,
+        heads=64,
+        seq_len=512,
+        dim=128,
+        is_causal=True,
+        dtype=torch.float16,
+        kernel_map={
+            "gqa_prefill_fwd_kernel": _FakeDenseKernel,
+            "gqa_prefill_square_fwd_kernel": _FakeSquareDenseKernel,
+        },
+    )
+
+    assert isinstance(op.kernel, _FakeSquareDenseKernel)
 
 
 @MhaBwdFixture

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -38,7 +38,8 @@ MultiHeadAttentionFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      mha_fwd_kernel: MHAFwdKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
     bench: benchmarks/ops/attention/bench_mha.py
@@ -131,7 +132,8 @@ GroupedQueryAttentionFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
     bench: benchmarks/ops/attention/bench_gqa.py

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -303,7 +303,10 @@ class GroupedQueryAttentionFwdOp(Op):
             sm_scale=self.sm_scale,
             softcap=self.softcap,
         )
-        return {"gqa_prefill_fwd_kernel": dense_kernel_cls}
+        return {
+            "gqa_prefill_fwd_kernel": dense_kernel_cls,
+            "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
+        }
 
     @property
     def kernel(self) -> Kernel:

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -6,17 +6,17 @@ import torch.nn.functional as F
 from tileops.kernels.attention import (
     FlashAttnBwdPostprocessKernel,
     FlashAttnBwdPreprocessKernel,
+    GQAFwdWsPersistentCausalKernel,
     MHABwdKernel,
     MHABwdWgmmaPipelinedKernel,
     MHADecodeKernel,
     MHADecodePagedKernel,
-    MHAFwdKernel,
-    MHAFwdWgmmaPipelinedKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import is_hopper
 
 from ..op_base import Op
+from .gqa import GroupedQueryAttentionFwdOp, _select_gqa_prefill_fwd_kernel_cls
 
 __all__ = [
     "MultiHeadAttentionBwdOp",
@@ -27,7 +27,12 @@ __all__ = [
 
 
 class MultiHeadAttentionFwdOp(Op):
-    """Layout: BSHD"""
+    """Layout: BSHD.
+
+    MHA is the heads_kv == heads specialization of GQA, so route the
+    maintained forward path through the GQA prefill dispatcher while keeping
+    the historical MHA return contract `(output, lse)`.
+    """
 
     def __init__(self,
                  batch: int,
@@ -43,18 +48,53 @@ class MultiHeadAttentionFwdOp(Op):
         self.seq_len = seq_len  # TODO: support s_q != s_kv
         self.dim = dim
         self.is_causal = is_causal
-
         self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["mha_fwd_kernel"](
-            batch, heads, seq_len, dim, is_causal, self.dtype, tune=tune)
+        self._gqa_op = GroupedQueryAttentionFwdOp(
+            batch=batch,
+            heads=heads,
+            heads_kv=heads,
+            seq_len=seq_len,
+            dim=dim,
+            is_causal=is_causal,
+            dtype=dtype,
+            kernel_map=self.kernel_map,
+            tune=tune,
+        )
+        # GroupedQueryAttentionFwdOp instantiates its kernel lazily. MHA's
+        # torch.compile smoke expects forward to call an already-built custom op,
+        # so instantiate the same dense-path choice at construction time.
+        self._kernel = (
+            self._gqa_op._prefill_op._get_square_dense_kernel()
+            if self._gqa_op._prefill_op._uses_square_dense_fast_path()
+            else self._gqa_op.kernel
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"mha_fwd_kernel": MHAFwdWgmmaPipelinedKernel if is_hopper() else MHAFwdKernel}
+        return {
+            "gqa_prefill_fwd_kernel": _select_gqa_prefill_fwd_kernel_cls(
+                self.dim,
+                self.is_causal,
+                self.dtype,
+                sm_scale=None,
+                softcap=0.0,
+                hopper=is_hopper(),
+            ),
+            "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
+        }
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    @property
+    def kernel(self) -> Kernel:
+        return self._kernel
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         return self.kernel(q, k, v)
 
 


### PR DESCRIPTION
Closes #1694

## Summary
- route `MultiHeadAttentionFwdOp` through the maintained GQA prefill dispatcher, using MHA as the `heads_kv == heads` specialization of GQA
- instantiate the selected GQA kernel during MHA op construction so `torch.compile(fullgraph=True)` does not trace TileLang JIT or device-name dispatch logic
- preserve the MHA forward return contract by returning the underlying GQA kernel result `(output, lse)`
- remove the MHA TileLang smoke skip prefixes while leaving the non-MHA skips for #1695 / #1697
- add a smoke assertion that MHA forward dispatches to a GQA kernel

## Validation
Official CI docker image: `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`

```bash
python -m pytest -q \
  tests/ops/attention/test_mha.py::test_mha_fwd \
  tests/ops/attention/test_mha.py::test_mha_fwd_dispatches_to_gqa_kernel \
  tests/test_compile.py::test_mha_kernel_compile \
  tests/test_autotune.py::test_mha_kernel_autotune \
  -rs --tb=short -p no:cacheprovider
```

Result: `9 passed, 14 warnings in 8.46s`

```bash
python -m pytest -q \
  tests/test_validate_manifest.py::TestIntegration::test_schema_validation_no_errors_on_real_manifest \
  tests/test_validate_manifest.py::TestIntegration::test_validator_passes_on_current_codebase \
  --tb=short -p no:cacheprovider
```

Result: `2 passed, 14 warnings in 11.94s`
