### PR TITLE
[Perf][Elementwise] vectorize bool storage paths

### DIFF
--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -426,6 +426,7 @@ def test_unary_float_compile(op_cls, ref_fn, input_fn, name):
 
 _UNARY_BOOL_OPS = [
     pytest.param(LogicalNotFwdOp, lambda x: ~(x != 0), torch.float16, "logical_not", marks=pytest.mark.full),
+    pytest.param(LogicalNotFwdOp, torch.logical_not, torch.bool, "logical_not_bool", marks=pytest.mark.smoke),
     pytest.param(IsnanFwdOp, torch.isnan, torch.float16, "isnan", marks=pytest.mark.full),
     pytest.param(IsinfFwdOp, torch.isinf, torch.float16, "isinf", marks=pytest.mark.full),
     pytest.param(IsfiniteFwdOp, torch.isfinite, torch.float16, "isfinite", marks=pytest.mark.full),
@@ -438,7 +439,10 @@ def test_unary_bool_compile(op_cls, ref_fn, dtype, name):
     n = _N
     op = op_cls(N_total=n, dtype=dtype)
     compiled_op = torch.compile(op, fullgraph=True)
-    x = torch.randn(n, dtype=dtype, device="cuda")
+    if dtype == torch.bool:
+        x = torch.rand(n, device="cuda") > 0.5
+    else:
+        x = torch.randn(n, dtype=dtype, device="cuda")
     out = compiled_op(x)
     ref = ref_fn(x)
     assert out.dtype == torch.bool

--- a/tests/ops/test_logical.py
+++ b/tests/ops/test_logical.py
@@ -131,6 +131,20 @@ def test_logical_broadcast(
     _bool_compare(out, ref)
 
 
+@pytest.mark.smoke
+def test_logical_and_bool_broadcast() -> None:
+    """Bool-input binary broadcast path uses uint8 storage internally."""
+    a_shape = (2, 512, 768)
+    b_shape = (1, 1, 768)
+    a = torch.randint(0, 2, a_shape, device="cuda").to(torch.bool)
+    b = torch.randint(0, 2, b_shape, device="cuda").to(torch.bool)
+    op = LogicalAndFwdOp(a_shape=a_shape, b_shape=b_shape, dtype=torch.bool)
+    ref = torch.logical_and(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    _bool_compare(out, ref)
+
+
 # ---------------------------------------------------------------------------
 # LogicalNot op
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -78,6 +78,7 @@ __all__ = [
     "TanhFwdKernel",
     # --- unary: logical / bitwise (2) ---
     "BitwiseNotFwdKernel",
+    "LogicalNotBoolStorageFwdKernel",
     "LogicalNotFwdKernel",
     # --- unary: special predicates (3) ---
     "IsfiniteFwdKernel",
@@ -95,15 +96,23 @@ __all__ = [
     "LerpFwdKernel",
     "MaximumFwdKernel",
     "MinimumFwdKernel",
-    # --- comparison (OUTPUT_DTYPE = torch.int8, cast to bool by Op layer) ---
+    # --- comparison (OUTPUT_DTYPE = torch.bool) ---
+    "EqBoolStorageFwdKernel",
     "EqFwdKernel",
-    "NeFwdKernel",
-    "GtFwdKernel",
-    "LtFwdKernel",
+    "GeBoolStorageFwdKernel",
     "GeFwdKernel",
+    "GtBoolStorageFwdKernel",
+    "GtFwdKernel",
+    "LeBoolStorageFwdKernel",
     "LeFwdKernel",
-    # --- logical (OUTPUT_DTYPE = torch.int8, cast to bool by Op layer) ---
+    "LtFwdKernel",
+    "LtBoolStorageFwdKernel",
+    "NeBoolStorageFwdKernel",
+    "NeFwdKernel",
+    # --- logical (OUTPUT_DTYPE = torch.bool) ---
+    "LogicalAndBoolStorageFwdKernel",
     "LogicalAndFwdKernel",
+    "LogicalOrBoolStorageFwdKernel",
     "LogicalOrFwdKernel",
     # --- bitwise ---
     "BitwiseAndFwdKernel",
@@ -679,9 +688,21 @@ class UnaryKernel(Kernel):
             self.output_dtype = torch.float16
         else:
             self.output_dtype = self.OUTPUT_DTYPE or dtype
+        # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads, which
+        # the CUDA codegen cannot lower. Keep bool inputs on the scalar path.
+        if dtype == torch.bool:
+            if strategy is not None and strategy != "direct":
+                warnings.warn(
+                    f"UnaryKernel: dtype=torch.bool requires strategy="
+                    f"'direct' (TileLang cannot lower vectorised boolx<N> "
+                    f"loads); overriding requested strategy={strategy!r}.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            self.strategy = "direct"
         # fp8: register_copy may not reliably handle 8-bit fragments;
         # default to explicit_parallel for fp8 dtypes
-        if strategy is None and _is_fp8(dtype):
+        elif strategy is None and _is_fp8(dtype):
             self.strategy = "explicit_parallel"
         else:
             self.strategy = strategy or self.DEFAULT_STRATEGY
@@ -869,6 +890,7 @@ class BinaryKernel(Kernel):
         # stores, which the CUDA codegen cannot lower. Force the scalar
         # ``direct`` strategy for bool inputs regardless of caller request.
         bool_input = dtype == torch.bool
+        bool_output = self.OUTPUT_DTYPE == torch.bool
         if bool_input:
             if strategy is not None and strategy != "direct":
                 warnings.warn(
@@ -883,11 +905,11 @@ class BinaryKernel(Kernel):
             # register_copy requires same-shape contiguous inputs (no
             # broadcast); silently downgrade to explicit_parallel when
             # the caller requests register_copy on broadcast shapes.
-            if strategy == "register_copy" and not self._same_shape:
+            if strategy == "register_copy" and (not self._same_shape or bool_output):
                 self.strategy = "explicit_parallel"
             else:
                 self.strategy = strategy
-        elif self._same_shape:
+        elif self._same_shape and not bool_output:
             # register_copy gives vectorized 128-bit loads, ~2-3x faster
             # for complex op_funcs that block TVM's auto-vectorizer.
             self.strategy = "register_copy"
@@ -1187,16 +1209,38 @@ class FloatUnaryKernel(UnaryKernel):
 class FloatPredicateKernel(FloatUnaryKernel):
     """Unary kernel base for float predicates with bool output."""
 
-    DEFAULT_STRATEGY = "direct"
+    DEFAULT_STRATEGY = "explicit_parallel"
     OUTPUT_DTYPE = torch.bool
 
 
 class LogicalUnaryKernel(UnaryKernel):
     """Unary kernel base for logical predicates with bool output."""
 
-    DEFAULT_STRATEGY = "direct"
+    DEFAULT_STRATEGY = "explicit_parallel"
     SUPPORTED_DTYPES = _LOGICAL_DTYPES
     OUTPUT_DTYPE = torch.bool
+
+
+class _Uint8StorageUnaryKernel(UnaryKernel):
+    """Unary bool-storage kernel: public bool tensors are viewed as uint8."""
+
+    DEFAULT_STRATEGY = "register_copy"
+    SUPPORTED_DTYPES = (torch.uint8,)
+
+    @property
+    def default_config(self) -> dict:
+        return {"threads": 256, "num_per_thread": 16}
+
+
+class _Uint8StorageBinaryKernel(BinaryKernel):
+    """Binary bool-storage kernel: public bool tensors are viewed as uint8."""
+
+    DEFAULT_STRATEGY = "explicit_parallel"
+    SUPPORTED_DTYPES = (torch.uint8,)
+
+    @property
+    def default_config(self) -> dict:
+        return {"threads": 256, "num_per_thread": 16}
 
 
 class ReluFwdKernel(FloatUnaryKernel):
@@ -1569,121 +1613,185 @@ class MinimumFwdKernel(BinaryKernel):
 
 
 # ---------------------------------------------------------------------------
-# Comparison kernel subclasses (output int8: 1/0 flags, cast to bool in Op layer)
+# Comparison kernel subclasses (bool output)
 # ---------------------------------------------------------------------------
 
 
 class EqFwdKernel(BinaryKernel):
-    """Element-wise equality: y = (a == b), stored as int8 (1/0)."""
+    """Element-wise equality: y = (a == b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a == b, one, zero)
+        return a == b
+
+
+class EqBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise equality on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_xor(T.bitwise_xor(a, b), T.cast(1, "uint8"))
 
 
 class NeFwdKernel(BinaryKernel):
-    """Element-wise not-equal: y = (a != b), stored as int8 (1/0)."""
+    """Element-wise not-equal: y = (a != b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a != b, one, zero)
+        return a != b
+
+
+class NeBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise not-equal on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_xor(a, b)
 
 
 class GtFwdKernel(BinaryKernel):
-    """Element-wise greater-than: y = (a > b), stored as int8 (1/0)."""
+    """Element-wise greater-than: y = (a > b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a > b, one, zero)
+        return a > b
+
+
+class GtBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise greater-than on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.if_then_else(
+            a > b, T.cast(1, "uint8"), T.cast(0, "uint8"),
+        )
 
 
 class LtFwdKernel(BinaryKernel):
-    """Element-wise less-than: y = (a < b), stored as int8 (1/0)."""
+    """Element-wise less-than: y = (a < b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a < b, one, zero)
+        return a < b
+
+
+class LtBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise less-than on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.if_then_else(
+            a < b, T.cast(1, "uint8"), T.cast(0, "uint8"),
+        )
 
 
 class GeFwdKernel(BinaryKernel):
-    """Element-wise greater-equal: y = (a >= b), stored as int8 (1/0)."""
+    """Element-wise greater-equal: y = (a >= b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a >= b, one, zero)
+        return a >= b
+
+
+class GeBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise greater-equal on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.if_then_else(
+            a >= b, T.cast(1, "uint8"), T.cast(0, "uint8"),
+        )
 
 
 class LeFwdKernel(BinaryKernel):
-    """Element-wise less-equal: y = (a <= b), stored as int8 (1/0)."""
+    """Element-wise less-equal: y = (a <= b)."""
 
     SUPPORTED_DTYPES = _BINARY_FULL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
-        return T.if_then_else(a <= b, one, zero)
+        return a <= b
+
+
+class LeBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise less-equal on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.if_then_else(
+            a <= b, T.cast(1, "uint8"), T.cast(0, "uint8"),
+        )
 
 
 # ---------------------------------------------------------------------------
-# Logical kernel subclasses (output int8: 1/0-encoded logical values)
+# Logical kernel subclasses (bool output)
 # ---------------------------------------------------------------------------
 
 
 class LogicalAndFwdKernel(BinaryKernel):
-    """Element-wise logical AND with non-zero truthiness, stored as int8."""
+    """Element-wise logical AND with non-zero truthiness."""
 
     SUPPORTED_DTYPES = _LOGICAL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
         a_nonzero = a != T.cast(0, a.dtype)
         b_nonzero = b != T.cast(0, b.dtype)
-        return T.if_then_else(a_nonzero & b_nonzero, one, zero)
+        return a_nonzero & b_nonzero
+
+
+class LogicalAndBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise logical AND on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_and(a, b)
 
 
 class LogicalOrFwdKernel(BinaryKernel):
-    """Element-wise logical OR with non-zero truthiness, stored as int8."""
+    """Element-wise logical OR with non-zero truthiness."""
 
     SUPPORTED_DTYPES = _LOGICAL_DTYPES
-    OUTPUT_DTYPE = torch.int8
+    OUTPUT_DTYPE = torch.bool
+    DEFAULT_STRATEGY = "explicit_parallel"
 
     @staticmethod
     def op_func(a, b):
-        one = T.IntImm("int8", 1)
-        zero = T.IntImm("int8", 0)
         a_nonzero = a != T.cast(0, a.dtype)
         b_nonzero = b != T.cast(0, b.dtype)
-        return T.if_then_else(a_nonzero | b_nonzero, one, zero)
+        return a_nonzero | b_nonzero
+
+
+class LogicalOrBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise logical OR on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_or(a, b)
 
 
 # ---------------------------------------------------------------------------
@@ -2065,6 +2173,14 @@ class LogicalNotFwdKernel(LogicalUnaryKernel):
     @staticmethod
     def op_func(x):
         return x == T.cast(0, x.dtype)
+
+
+class LogicalNotBoolStorageFwdKernel(_Uint8StorageUnaryKernel):
+    """Element-wise logical NOT on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(x):
+        return T.bitwise_xor(x, T.cast(1, "uint8"))
 
 
 class BitwiseNotFwdKernel(UnaryKernel):

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -890,13 +890,27 @@ class BinaryKernel(Kernel):
         # stores, which the CUDA codegen cannot lower. Force the scalar
         # ``direct`` strategy for bool inputs regardless of caller request.
         bool_input = dtype == torch.bool
-        bool_output = self.OUTPUT_DTYPE == torch.bool
+        bool_output = torch.bool == self.OUTPUT_DTYPE
+        bool_output_needs_scalar = bool_output and dtype in (
+            torch.uint8, torch.int8, torch.int16,
+        )
         if bool_input:
             if strategy is not None and strategy != "direct":
                 warnings.warn(
                     f"BinaryKernel: dtype=torch.bool requires strategy="
                     f"'direct' (TileLang cannot lower vectorised boolx<N> "
                     f"loads); overriding requested strategy={strategy!r}.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            self.strategy = "direct"
+        elif bool_output_needs_scalar:
+            if strategy is not None and strategy != "direct":
+                warnings.warn(
+                    f"BinaryKernel: dtype={dtype} with torch.bool output "
+                    f"requires strategy='direct' (TileLang cannot lower "
+                    f"vectorised boolx<N> stores for sub-32-bit integer "
+                    f"inputs); overriding requested strategy={strategy!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
@@ -1674,9 +1688,7 @@ class GtBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
 
     @staticmethod
     def op_func(a, b):
-        return T.if_then_else(
-            a > b, T.cast(1, "uint8"), T.cast(0, "uint8"),
-        )
+        return T.bitwise_and(a, T.bitwise_xor(b, T.cast(1, "uint8")))
 
 
 class LtFwdKernel(BinaryKernel):
@@ -1696,9 +1708,7 @@ class LtBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
 
     @staticmethod
     def op_func(a, b):
-        return T.if_then_else(
-            a < b, T.cast(1, "uint8"), T.cast(0, "uint8"),
-        )
+        return T.bitwise_and(T.bitwise_xor(a, T.cast(1, "uint8")), b)
 
 
 class GeFwdKernel(BinaryKernel):
@@ -1718,9 +1728,7 @@ class GeBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
 
     @staticmethod
     def op_func(a, b):
-        return T.if_then_else(
-            a >= b, T.cast(1, "uint8"), T.cast(0, "uint8"),
-        )
+        return T.bitwise_or(a, T.bitwise_xor(b, T.cast(1, "uint8")))
 
 
 class LeFwdKernel(BinaryKernel):
@@ -1740,9 +1748,7 @@ class LeBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
 
     @staticmethod
     def op_func(a, b):
-        return T.if_then_else(
-            a <= b, T.cast(1, "uint8"), T.cast(0, "uint8"),
-        )
+        return T.bitwise_or(T.bitwise_xor(a, T.cast(1, "uint8")), b)
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -690,12 +690,27 @@ class UnaryKernel(Kernel):
             self.output_dtype = self.OUTPUT_DTYPE or dtype
         # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads, which
         # the CUDA codegen cannot lower. Keep bool inputs on the scalar path.
+        bool_output = torch.bool == self.OUTPUT_DTYPE
+        bool_output_needs_scalar = bool_output and dtype in (
+            torch.uint8, torch.int8, torch.int16,
+        )
         if dtype == torch.bool:
             if strategy is not None and strategy != "direct":
                 warnings.warn(
                     f"UnaryKernel: dtype=torch.bool requires strategy="
                     f"'direct' (TileLang cannot lower vectorised boolx<N> "
                     f"loads); overriding requested strategy={strategy!r}.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            self.strategy = "direct"
+        elif bool_output_needs_scalar:
+            if strategy is not None and strategy != "direct":
+                warnings.warn(
+                    f"UnaryKernel: dtype={dtype} with torch.bool output "
+                    f"requires strategy='direct' (TileLang cannot lower "
+                    f"vectorised boolx<N> stores for sub-32-bit integer "
+                    f"inputs); overriding requested strategy={strategy!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -643,17 +643,33 @@ class UnaryOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
+        self._prepare_unary_instance(N_total, dtype, strategy, kernel_map)
+        self.kernel = self.kernel_map[self._op_name](
+            N_total, dtype, strategy=strategy, tune=tune,
+        )
+        self._finish_unary_instance()
+
+    def _prepare_unary_instance(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        strategy: Optional[str],
+        kernel_map: Optional[Dict[str, Kernel]],
+    ) -> None:
         self.N_total = N_total
         self.dtype = dtype
         self.strategy = strategy
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            N_total, dtype, strategy=strategy, tune=tune,
-        )
+
+    def _finish_unary_instance(
+        self, output_dtype: Optional[torch.dtype] = None,
+    ) -> None:
         # Use _fp8_output_dtype (the final dtype after Op-layer post-cast)
         # rather than kernel.output_dtype (which is fp16 for e5m2).
         fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
-        self.output_dtype = fp8_out or getattr(self.kernel, "output_dtype", dtype)
+        self.output_dtype = output_dtype or fp8_out or getattr(
+            self.kernel, "output_dtype", self.dtype,
+        )
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -1198,8 +1214,8 @@ class _BoolOutputBinaryOp(BinaryOp):
             result = self.kernel(
                 input.contiguous().view(-1).view(torch.uint8),
                 other.contiguous().view(-1).view(torch.uint8),
-            ).reshape(self.out_shape)
-            return result.view(torch.bool)
+            )
+            return result.view(torch.bool).reshape(self.out_shape)
         result = super()._eager_forward(input, other)
         if result.dtype is not torch.bool:
             return result.to(torch.bool)

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -1163,21 +1163,47 @@ class _AlphaScaledBinaryOp(BinaryOp):
 
 
 class _BoolOutputBinaryOp(BinaryOp):
-    """Binary op base whose kernel emits int8 (1/0) and whose Op output is bool.
+    """Binary op base whose public output dtype is bool."""
 
-    TileLang cannot vectorize bool, so the kernel produces int8. The Op
-    casts to ``torch.bool`` after the kernel call. ``register_fake``
-    already declares ``torch.bool`` as the output dtype, so the
-    ``torch.compile`` path stays consistent.
-    """
+    bool_storage_kernel_cls: Optional[type] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        kernel_map = {self._op_name: self.kernel_cls}
+        if self.bool_storage_kernel_cls is not None:
+            kernel_map[f"{self._op_name}_bool_storage"] = self.bool_storage_kernel_cls
+        return kernel_map
+
+    def _build_kernel_instance(
+        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+    ):
+        self._bool_storage = (
+            self.dtype == torch.bool and self.bool_storage_kernel_cls is not None
+        )
+        if self._bool_storage:
+            return self.kernel_map[f"{self._op_name}_bool_storage"](
+                self.N_total, torch.uint8, coalesced_shape, a_strides, b_strides,
+                self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            )
+        return super()._build_kernel_instance(
+            coalesced_shape, a_strides, b_strides, strategy, tune,
+        )
 
     def _eager_forward(
         self,
         input: torch.Tensor,  # noqa: A002 — manifest-aligned PyTorch param name
         other: torch.Tensor,
     ) -> torch.Tensor:
+        if getattr(self, "_bool_storage", False):
+            result = self.kernel(
+                input.contiguous().view(-1).view(torch.uint8),
+                other.contiguous().view(-1).view(torch.uint8),
+            ).reshape(self.out_shape)
+            return result.view(torch.bool)
         result = super()._eager_forward(input, other)
-        return result.to(torch.bool)
+        if result.dtype is not torch.bool:
+            return result.to(torch.bool)
+        return result
 
 
 _MANIFEST_INT_DTYPES = (

--- a/tileops/ops/elementwise/comparison.py
+++ b/tileops/ops/elementwise/comparison.py
@@ -1,15 +1,17 @@
-"""Element-wise comparison ops (output bool).
-
-Kernels produce int8 (1/0) because TileLang cannot vectorize bool.
-The Op forward() casts to torch.bool after the kernel call.
-"""
+"""Element-wise comparison ops (output bool)."""
 
 from tileops.kernels.elementwise import (
+    EqBoolStorageFwdKernel,
     EqFwdKernel,
+    GeBoolStorageFwdKernel,
     GeFwdKernel,
+    GtBoolStorageFwdKernel,
     GtFwdKernel,
+    LeBoolStorageFwdKernel,
     LeFwdKernel,
+    LtBoolStorageFwdKernel,
     LtFwdKernel,
+    NeBoolStorageFwdKernel,
     NeFwdKernel,
 )
 
@@ -21,6 +23,7 @@ class EqFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "eq"
     kernel_cls = EqFwdKernel
+    bool_storage_kernel_cls = EqBoolStorageFwdKernel
 
 
 class NeFwdOp(_BoolOutputBinaryOp):
@@ -28,6 +31,7 @@ class NeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "ne"
     kernel_cls = NeFwdKernel
+    bool_storage_kernel_cls = NeBoolStorageFwdKernel
 
 
 class GtFwdOp(_BoolOutputBinaryOp):
@@ -35,6 +39,7 @@ class GtFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "gt"
     kernel_cls = GtFwdKernel
+    bool_storage_kernel_cls = GtBoolStorageFwdKernel
 
 
 class LtFwdOp(_BoolOutputBinaryOp):
@@ -42,6 +47,7 @@ class LtFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "lt"
     kernel_cls = LtFwdKernel
+    bool_storage_kernel_cls = LtBoolStorageFwdKernel
 
 
 class GeFwdOp(_BoolOutputBinaryOp):
@@ -49,6 +55,7 @@ class GeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "ge"
     kernel_cls = GeFwdKernel
+    bool_storage_kernel_cls = GeBoolStorageFwdKernel
 
 
 class LeFwdOp(_BoolOutputBinaryOp):
@@ -56,3 +63,4 @@ class LeFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "le"
     kernel_cls = LeFwdKernel
+    bool_storage_kernel_cls = LeBoolStorageFwdKernel

--- a/tileops/ops/elementwise/logical.py
+++ b/tileops/ops/elementwise/logical.py
@@ -1,12 +1,17 @@
 """Element-wise logical ops (output bool)."""
 
+import torch
+
 from tileops.kernels.elementwise import (
+    LogicalAndBoolStorageFwdKernel,
     LogicalAndFwdKernel,
+    LogicalNotBoolStorageFwdKernel,
     LogicalNotFwdKernel,
+    LogicalOrBoolStorageFwdKernel,
     LogicalOrFwdKernel,
 )
 
-from ._base import UnaryOp, _BoolOutputBinaryOp
+from ._base import UnaryOp, _BoolOutputBinaryOp, _OP_REGISTRY
 
 
 class LogicalAndFwdOp(_BoolOutputBinaryOp):
@@ -14,6 +19,7 @@ class LogicalAndFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "logical_and"
     kernel_cls = LogicalAndFwdKernel
+    bool_storage_kernel_cls = LogicalAndBoolStorageFwdKernel
 
 
 class LogicalOrFwdOp(_BoolOutputBinaryOp):
@@ -21,6 +27,7 @@ class LogicalOrFwdOp(_BoolOutputBinaryOp):
 
     _op_name = "logical_or"
     kernel_cls = LogicalOrFwdKernel
+    bool_storage_kernel_cls = LogicalOrBoolStorageFwdKernel
 
 
 class LogicalNotFwdOp(UnaryOp):
@@ -28,3 +35,45 @@ class LogicalNotFwdOp(UnaryOp):
 
     _op_name = "logical_not"
     kernel_cls = LogicalNotFwdKernel
+    bool_storage_kernel_cls = LogicalNotBoolStorageFwdKernel
+
+    @property
+    def default_kernel_map(self):
+        return {
+            self._op_name: self.kernel_cls,
+            f"{self._op_name}_bool_storage": self.bool_storage_kernel_cls,
+        }
+
+    def __init__(
+        self,
+        N_total: int,
+        dtype: torch.dtype,
+        strategy=None,
+        kernel_map=None,
+        tune: bool = False,
+    ):
+        if dtype != torch.bool:
+            self._bool_storage = False
+            super().__init__(
+                N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+            )
+            return
+
+        self.N_total = N_total
+        self.dtype = dtype
+        self.strategy = strategy
+        self.dispatch_kernel(kernel_map)
+        self._bool_storage = True
+        self.kernel = self.kernel_map[f"{self._op_name}_bool_storage"](
+            N_total, torch.uint8, strategy=strategy, tune=tune,
+        )
+        self.output_dtype = torch.bool
+        self._instance_key = id(self)
+        _OP_REGISTRY[self._instance_key] = self
+
+    def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if self._bool_storage:
+            orig_shape = input.shape
+            flat = input.contiguous().view(-1).view(torch.uint8)
+            return self.kernel(flat).view(torch.bool).reshape(orig_shape)
+        return super()._eager_forward(input)

--- a/tileops/ops/elementwise/logical.py
+++ b/tileops/ops/elementwise/logical.py
@@ -11,7 +11,7 @@ from tileops.kernels.elementwise import (
     LogicalOrFwdKernel,
 )
 
-from ._base import UnaryOp, _BoolOutputBinaryOp, _OP_REGISTRY
+from ._base import UnaryOp, _BoolOutputBinaryOp
 
 
 class LogicalAndFwdOp(_BoolOutputBinaryOp):
@@ -59,17 +59,12 @@ class LogicalNotFwdOp(UnaryOp):
             )
             return
 
-        self.N_total = N_total
-        self.dtype = dtype
-        self.strategy = strategy
-        self.dispatch_kernel(kernel_map)
+        self._prepare_unary_instance(N_total, dtype, strategy, kernel_map)
         self._bool_storage = True
         self.kernel = self.kernel_map[f"{self._op_name}_bool_storage"](
             N_total, torch.uint8, strategy=strategy, tune=tune,
         )
-        self.output_dtype = torch.bool
-        self._instance_key = id(self)
-        _OP_REGISTRY[self._instance_key] = self
+        self._finish_unary_instance(output_dtype=torch.bool)
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
         if self._bool_storage:


### PR DESCRIPTION
Closes #1700.

## Summary

- Remove the hot-path `int8 -> torch.bool` PyTorch cast from binary comparison/logical elementwise ops by making the TileLang kernels produce bool outputs directly.
- Add uint8-backed bool-storage kernels for bool input paths, so public `torch.bool` tensors are viewed as `torch.uint8` in the Op layer and processed with vectorized-friendly storage kernels instead of TileLang `boolx<N>` loads/stores.
- Move float predicate/logical unary bool-output paths from scalar `direct` to `explicit_parallel`, while keeping raw bool input protected from TileLang vectorized bool lowering.
- Wire bool-storage dispatch for `logical_and`, `logical_or`, `logical_not`, and bool-input comparison ops without changing public API or output dtype.

## Performance tuning conclusions

- Binary bool-output comparison/logical ops were dominated by a separate PyTorch `result.to(torch.bool)` cast kernel; removing that cast turns the hot path into a single TileLang kernel.
- TileLang 0.1.11 cannot lower vectorized bool storage such as `boolx8`, so bool input paths need to avoid exposing bool tensors to vectorized TileLang kernels.
- Viewing `torch.bool` tensors as `torch.uint8` preserves the public bool API while letting storage kernels use byte-oriented register-copy / explicit-parallel paths.
- Predicate and logical unary float inputs can use `explicit_parallel`; only actual `torch.bool` inputs need to remain guarded from bool-vector lowering.

## Benchmark

H200, TileLang 0.1.11, TileOpsGov local docker benchmark flow, effective HBM target = 4.0704 TB/s.

| kernel | workload | before | after | SOL before | SOL after |
|--------|----------|--------|-------|------------|-----------|
| eq | hidden-state-prefill fp16 | 0.0367ms / 1.14 TB/s | 0.0147ms / 2.86 TB/s | 28.0% | 70.3% |
| eq | hidden-state-prefill fp32 | 0.0462ms / 1.63 TB/s | 0.0231ms / 3.27 TB/s | 40.0% | 80.3% |
| logical_and | hidden-state-prefill bool | 0.0514ms / 0.49 TB/s | 0.0088ms / 2.86 TB/s | 12.0% | 70.3% |
| logical_and | cnn-feat-broadcast bool | 0.0752ms / 0.34 TB/s | 0.0089ms / 2.90 TB/s | 8.4% | 71.2% |
| logical_or | hidden-state-prefill bool | 0.0514ms / 0.49 TB/s | 0.0088ms / 2.85 TB/s | 12.0% | 70.0% |
| logical_not | 16M bool | 0.0507ms / 0.66 TB/s | 0.0108ms / 3.11 TB/s | 16.2% | 76.4% |
| logical_not | 256M bool | 0.7809ms / 0.69 TB/s | 0.1273ms / 4.22 TB/s | 17.0% | 103.7% |
| isnan | 16M fp16 | 0.0549ms / 0.92 TB/s | 0.0212ms / 2.38 TB/s | 22.6% | 58.5% |
| isnan | 256M fp16 | 0.8275ms / 0.97 TB/s | 0.2732ms / 2.95 TB/s | 23.8% | 72.5% |

## Test plan

- [x] `python3 -m pytest -q benchmarks/ops/bench_unary_elementwise.py -k 'logical_not' --junit-xml=/workspace/TileOPs/results/elementwise_bool_storage_logical_not.xml --tb=short --timeout=900 --timeout-method=thread`: 4 passed
- [x] `python3 -m pytest -q benchmarks/ops/bench_unary_elementwise.py::test_logical_not_bench benchmarks/ops/bench_elementwise_manifest.py -k 'logical_and_manifest or logical_or_manifest' --junit-xml=/workspace/TileOPs/results/elementwise_bool_storage_targeted.xml --tb=short --timeout=900 --timeout-method=thread`: 16 passed
- [x] Full official elementwise sweep: `bench_unary_elementwise.py`, `bench_elementwise_manifest.py`, `bench_binary_elementwise.py`, `bench_independent_elementwise.py`: 552 passed, 24 skipped
