### PR TITLE
[Perf][FP8_LIGHTING_INDEXER] add kv_group==1 fast path with direct GEMM accumulation

### DIFF
--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -5,10 +5,10 @@ import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import FP8LightningIndexerOp
-from workloads.fp8_lightning_indexer import FP8LightningIndexerTest
+from workloads.fp8_lightning_indexer import FP8LightningIndexerWorkload
 
 
-class _FP8LightningIndexerTestBaseline(FP8LightningIndexerTest):
+class _FP8LightningIndexerBaseline(FP8LightningIndexerWorkload):
     """Adds baseline ref_program for benchmark profiling."""
 
     def ref_program(self, q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
@@ -39,7 +39,7 @@ class _FP8LightningIndexerTestBaseline(FP8LightningIndexerTest):
         return (logits,)
 
 
-class FP8LightningIndexerBenchmark(BenchmarkBase[FP8LightningIndexerTest]):
+class FP8LightningIndexerBenchmark(BenchmarkBase[FP8LightningIndexerWorkload]):
 
     def calculate_flops(self) -> Optional[float]:
         # Flops depend on the actual mask cost which varies per input
@@ -76,7 +76,7 @@ _FP8_LIGHTING_INDEXER_BENCH_PARAMS = [
 def test_fp8_lightning_indexer_bench(batch: int, seq_len: int, heads: int, index_dim: int,
                                     seq_len_kv: int, kv_group: int, clean_logits: bool,
                                     config: Optional[dict], tune: bool) -> None:
-    test = _FP8LightningIndexerTestBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+    test = _FP8LightningIndexerBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
     bm = FP8LightningIndexerBenchmark(test)
     inputs = test.gen_inputs()

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -4,11 +4,11 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tileops.ops import FP8LightingIndexerOp
-from workloads.fp8_lighting_indexer import FP8LightingIndexerTest
+from tileops.ops import FP8LightningIndexerOp
+from workloads.fp8_lightning_indexer import FP8LightningIndexerTest
 
 
-class _FP8LightingIndexerTestBaseline(FP8LightingIndexerTest):
+class _FP8LightningIndexerTestBaseline(FP8LightningIndexerTest):
     """Adds baseline ref_program for benchmark profiling."""
 
     def ref_program(self, q: torch.Tensor, kv: torch.Tensor, weights: torch.Tensor,
@@ -39,7 +39,7 @@ class _FP8LightingIndexerTestBaseline(FP8LightingIndexerTest):
         return (logits,)
 
 
-class FP8LightingIndexerBenchmark(BenchmarkBase[FP8LightingIndexerTest]):
+class FP8LightningIndexerBenchmark(BenchmarkBase[FP8LightningIndexerTest]):
 
     def calculate_flops(self) -> Optional[float]:
         # Flops depend on the actual mask cost which varies per input
@@ -73,15 +73,15 @@ _FP8_LIGHTING_INDEXER_BENCH_PARAMS = [
     "batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune",
     _FP8_LIGHTING_INDEXER_BENCH_PARAMS,
 )
-def test_fp8_lighting_indexer_bench(batch: int, seq_len: int, heads: int, index_dim: int,
+def test_fp8_lightning_indexer_bench(batch: int, seq_len: int, heads: int, index_dim: int,
                                     seq_len_kv: int, kv_group: int, clean_logits: bool,
                                     config: Optional[dict], tune: bool) -> None:
-    test = _FP8LightingIndexerTestBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+    test = _FP8LightningIndexerTestBaseline(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
-    bm = FP8LightingIndexerBenchmark(test)
+    bm = FP8LightningIndexerBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FP8LightingIndexerOp(batch=batch,
+    op = FP8LightningIndexerOp(batch=batch,
                               seq_len=seq_len,
                               heads=heads,
                               index_dim=index_dim,

--- a/tests/ops/test_fp8_lightning_indexer.py
+++ b/tests/ops/test_fp8_lightning_indexer.py
@@ -4,13 +4,13 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import FP8LightingIndexerOp
-from workloads.fp8_lighting_indexer import (
-    FP8LightingIndexerTest as _FP8LightingIndexerTestWorkload,
+from tileops.ops import FP8LightningIndexerOp
+from workloads.fp8_lightning_indexer import (
+    FP8LightningIndexerTest as _FP8LightningIndexerTestWorkload,
 )
 
 
-class FP8LightingIndexerTest(_FP8LightingIndexerTestWorkload, TestBase):
+class FP8LightningIndexerTest(_FP8LightningIndexerTestWorkload, TestBase):
 
     @staticmethod
     def _compute_correlation(a: torch.Tensor, b: torch.Tensor) -> float:
@@ -39,7 +39,7 @@ class FP8LightingIndexerTest(_FP8LightingIndexerTestWorkload, TestBase):
         ).all(), "Error: nonfinite value mismatch"
         output = output.masked_fill(~a_finite, 0)
         output_ref = output_ref.masked_fill(~b_finite, 0)
-        correlation = FP8LightingIndexerTest._compute_correlation(output, output_ref)
+        correlation = FP8LightningIndexerTest._compute_correlation(output, output_ref)
         difference = 1.0 - correlation
         assert 0 <= difference <= tolerance, \
             f"outputs is not close to outputs_ref, difference: {difference}"
@@ -72,7 +72,7 @@ class FP8LightingIndexerTest(_FP8LightingIndexerTestWorkload, TestBase):
         return (logits,)
 
 
-class FP8LightingIndexerFixture(FixtureBase):
+class FP8LightningIndexerFixture(FixtureBase):
     PARAMS = [
         ("batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune", [
              pytest.param(1, 4096, 32, 64, 8192, 1, True, None, False, marks=pytest.mark.smoke),
@@ -81,12 +81,12 @@ class FP8LightingIndexerFixture(FixtureBase):
     ]
 
 
-@FP8LightingIndexerFixture
+@FP8LightningIndexerFixture
 def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_kv: int,
                  kv_group: int, clean_logits: bool, config: Optional[dict], tune: bool) -> None:
-    test = FP8LightingIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
+    test = FP8LightningIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
-    op = FP8LightingIndexerOp(
+    op = FP8LightningIndexerOp(
         batch=batch,
         seq_len=seq_len,
         heads=heads,
@@ -96,7 +96,7 @@ def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_k
         clean_logits=clean_logits,
         config=config,
         tune=tune)
-    test.check(op, *test.gen_inputs(), compare=FP8LightingIndexerTest._validate_tensor_match)
+    test.check(op, *test.gen_inputs(), compare=FP8LightningIndexerTest._validate_tensor_match)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_fp8_lightning_indexer.py
+++ b/tests/ops/test_fp8_lightning_indexer.py
@@ -5,12 +5,10 @@ import torch
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import FP8LightningIndexerOp
-from workloads.fp8_lightning_indexer import (
-    FP8LightningIndexerTest as _FP8LightningIndexerTestWorkload,
-)
+from workloads.fp8_lightning_indexer import FP8LightningIndexerWorkload
 
 
-class FP8LightningIndexerTest(_FP8LightningIndexerTestWorkload, TestBase):
+class FP8LightningIndexerTest(FP8LightningIndexerWorkload, TestBase):
 
     @staticmethod
     def _compute_correlation(a: torch.Tensor, b: torch.Tensor) -> float:

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -51,7 +51,7 @@ from .dropout import DropoutKernel
 from .elementwise import BinaryKernel, FusedGatedKernel, UnaryKernel
 from .engram import EngramDecodeKernel, EngramGateConvBwdKernel, EngramGateConvFwdKernel
 from .fft import FFTC2CKernel
-from .fp8_lighting_indexer import FP8LightingIndexerKernel
+from .fp8_lightning_indexer import FP8LightningIndexerKernel
 from .fp8_quant import FP8QuantKernel
 from .gated_deltanet import (
     GatedDeltaNetBwdKernel,
@@ -112,7 +112,7 @@ __all__ = [
     "EngramGateConvBwdKernel",
     "EngramGateConvFwdKernel",
     "FFTC2CKernel",
-    "FP8LightingIndexerKernel",
+    "FP8LightningIndexerKernel",
     "FP8QuantKernel",
     "FlashAttnBwdPostprocessKernel",
     "FlashAttnBwdPreprocessKernel",

--- a/tileops/kernels/fp8_lighting_indexer.py
+++ b/tileops/kernels/fp8_lighting_indexer.py
@@ -64,15 +64,17 @@ def _fp8_lighting_indexer_kernel(batch,
             heads_per_group = heads // kv_group
             with T.Kernel(T.ceildiv(seq_len, block_Q), batch, threads=threads) as (bx, by):
                 index_q_shared = T.alloc_shared([block_Q * heads, index_dim], dtype)
-                index_q_group_shared = T.alloc_shared([block_Q * heads_per_group, index_dim], dtype)
-                index_k_shared = T.alloc_shared([block_N, kv_group, index_dim], dtype)
-                index_k_group_shared = T.alloc_shared([block_N, index_dim], dtype)
                 index_k_scale_fragment = T.alloc_fragment([block_N, kv_group], accum_dtype)
                 s = T.alloc_fragment([block_N, block_Q * heads], accum_dtype)  #
                 s_reshaped = T.reshape(s, (block_N, block_Q, heads_per_group, kv_group))
-                s_tmp = T.alloc_fragment([block_N, block_Q * heads_per_group], accum_dtype)
                 logits = T.alloc_fragment([block_N, block_Q, kv_group], accum_dtype)
                 weights = T.alloc_fragment([block_Q, heads], accum_dtype)
+                index_k_group_shared = T.alloc_shared([block_N, index_dim], dtype)
+                if kv_group > 1:
+                    index_k_shared = T.alloc_shared([block_N, kv_group, index_dim], dtype)
+                    index_q_group_shared = T.alloc_shared([block_Q * heads_per_group, index_dim],
+                                                          dtype)
+                    s_tmp = T.alloc_fragment([block_N, block_Q * heads_per_group], accum_dtype)
 
                 seq_len_i = bx * block_Q
                 b_i = by
@@ -93,27 +95,41 @@ def _fp8_lighting_indexer_kernel(batch,
 
                 for nbn_i in T.Pipelined(
                         T.ceildiv(cu_k_e_max - cu_k_s_min, block_N), num_stages=num_stages):
-                    T.copy(IndexK[b_i, cu_k_s_min + nbn_i * block_N, 0, 0], index_k_shared)
+                    if kv_group > 1:
+                        T.copy(IndexK[b_i, cu_k_s_min + nbn_i * block_N, 0, 0], index_k_shared)
                     T.copy(IndexKScale[b_i, cu_k_s_min + nbn_i * block_N, 0],
                            index_k_scale_fragment)
 
-                    for g in T.Serial(kv_group):
-                        for bn_i, d_i in T.Parallel(block_N, index_dim):
-                            index_k_group_shared[bn_i, d_i] = index_k_shared[bn_i, g, d_i]  #
-                        for i, d in T.Parallel(block_Q * heads_per_group, index_dim):
-                            index_q_group_shared[i, d] = index_q_shared[g * heads_per_group + i,
-                                                                        d]  #
+                    if kv_group == 1:
+                        T.copy(
+                            IndexK[b_i, cu_k_s_min + nbn_i * block_N:cu_k_s_min +
+                                   (nbn_i + 1) * block_N, 0, 0:index_dim], index_k_group_shared)
                         T.gemm(
                             index_k_group_shared,
-                            index_q_group_shared,
-                            s_tmp,
+                            index_q_shared,
+                            s,
                             transpose_B=True,
                             clear_accum=True,
                             policy=T.GemmWarpPolicy.FullCol,
                         )
-                        for bn_i, bq_i, h_i in T.Parallel(block_N, block_Q, heads_per_group):
-                            s_reshaped[bn_i, bq_i, h_i, g] = (
-                                s_tmp[bn_i, bq_i * heads_per_group + h_i])
+                    else:
+                        for g in T.Serial(kv_group):
+                            for bn_i, d_i in T.Parallel(block_N, index_dim):
+                                index_k_group_shared[bn_i, d_i] = index_k_shared[bn_i, g, d_i]  #
+                            for i, d in T.Parallel(block_Q * heads_per_group, index_dim):
+                                index_q_group_shared[i, d] = index_q_shared[g * heads_per_group +
+                                                                            i, d]  #
+                            T.gemm(
+                                index_k_group_shared,
+                                index_q_group_shared,
+                                s_tmp,
+                                transpose_B=True,
+                                clear_accum=True,
+                                policy=T.GemmWarpPolicy.FullCol,
+                            )
+                            for bn_i, bq_i, h_i in T.Parallel(block_N, block_Q, heads_per_group):
+                                s_reshaped[bn_i, bq_i, h_i, g] = (
+                                    s_tmp[bn_i, bq_i * heads_per_group + h_i])
 
                     for bn_i, bq_i, h_i, g in T.Parallel(block_N, block_Q, heads_per_group,
                                                          kv_group):

--- a/tileops/kernels/fp8_lightning_indexer.py
+++ b/tileops/kernels/fp8_lightning_indexer.py
@@ -116,9 +116,9 @@ def _fp8_lightning_indexer_kernel(batch,
                         for g in T.Serial(kv_group):
                             for bn_i, d_i in T.Parallel(block_N, index_dim):
                                 index_k_group_shared[bn_i, d_i] = index_k_shared[bn_i, g, d_i]  #
-                            for i, d in T.Parallel(block_Q * heads_per_group, index_dim):
-                                index_q_group_shared[i, d] = index_q_shared[g * heads_per_group +
-                                                                            i, d]  #
+                            for bq_i, h_i, d_i in T.Parallel(block_Q, heads_per_group, index_dim):
+                                index_q_group_shared[bq_i * heads_per_group + h_i, d_i] = (
+                                    index_q_shared[bq_i * heads + g * heads_per_group + h_i, d_i])
                             T.gemm(
                                 index_k_group_shared,
                                 index_q_group_shared,

--- a/tileops/kernels/fp8_lightning_indexer.py
+++ b/tileops/kernels/fp8_lightning_indexer.py
@@ -8,7 +8,7 @@ from tilelang import language as T
 
 from tileops.kernels.kernel_base import Kernel
 
-__all__ = ["FP8LightingIndexerKernel"]
+__all__ = ["FP8LightningIndexerKernel"]
 
 # block_Q == 1 deadlocks the software pipeline (some warps never reach the
 # pipeline barrier); such tiles must run unpipelined. block_Q >= 2 is safe.
@@ -16,7 +16,7 @@ _MIN_PIPELINED_BLOCK_Q = 2
 
 
 @functools.lru_cache(maxsize=32)
-def _fp8_lighting_indexer_kernel(batch,
+def _fp8_lightning_indexer_kernel(batch,
                                  seq_len,
                                  heads,
                                  index_dim,
@@ -28,7 +28,7 @@ def _fp8_lighting_indexer_kernel(batch,
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
         },)
-    def _fp8_lighting_indexer_func(
+    def _fp8_lightning_indexer_func(
         block_N=256,
         num_stages=3,
         threads=512,
@@ -52,7 +52,7 @@ def _fp8_lighting_indexer_kernel(batch,
         logits_shape = [batch, seq_len, seq_len_kv, kv_group]
 
         @T.prim_func
-        def _fp8_lighting_indexer_main(
+        def _fp8_lightning_indexer_main(
                 IndexQ: T.Tensor(index_q_shape, dtype),  # type: ignore
                 IndexK: T.Tensor(index_k_shape, dtype),  # type: ignore
                 IndexKScale: T.Tensor(index_k_scale_shape, accum_dtype),  # type: ignore
@@ -144,9 +144,9 @@ def _fp8_lighting_indexer_kernel(batch,
                                g] = logits[bn_i, bq_i, g]
 
         # Return the kernel function handle
-        return _fp8_lighting_indexer_main
+        return _fp8_lightning_indexer_main
 
-    return _fp8_lighting_indexer_func
+    return _fp8_lightning_indexer_func
 
 
 @tilelang.jit
@@ -184,8 +184,8 @@ def clean_logits_(threads: int = 512,):
     return clean_logits_kernel
 
 
-@torch.library.custom_op("top::fp8_lighting_indexer_wrapped_kernel", mutates_args=("Logits",))
-def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, index_dim: int,
+@torch.library.custom_op("top::fp8_lightning_indexer_wrapped_kernel", mutates_args=("Logits",))
+def fp8_lightning_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, index_dim: int,
                                         seq_len_kv: int, kv_group: int, clean_logits: bool,
                                         block_N: int, num_stages: int, threads: int, block_Q: int,
                                         IndexQ: torch.Tensor, IndexK: torch.Tensor,
@@ -193,7 +193,7 @@ def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, in
                                         Weights: torch.Tensor, CuSeqLenKS: torch.Tensor,
                                         CuSeqLenKE: torch.Tensor) -> None:
 
-    _fp8_lighting_indexer_kernel(batch, seq_len, heads, index_dim, seq_len_kv,
+    _fp8_lightning_indexer_kernel(batch, seq_len, heads, index_dim, seq_len_kv,
                                  kv_group)(block_N, num_stages, threads,
                                            block_Q)(IndexQ.view(batch, seq_len * heads,
                                                                 index_dim), IndexK, IndexKScale,
@@ -202,7 +202,7 @@ def fp8_lighting_indexer_wrapped_kernel(batch: int, seq_len: int, heads: int, in
         clean_logits_(threads=threads)(Logits, CuSeqLenKS, CuSeqLenKE)
 
 
-@fp8_lighting_indexer_wrapped_kernel.register_fake
+@fp8_lightning_indexer_wrapped_kernel.register_fake
 def _(
         batch: int,
         seq_len: int,
@@ -225,7 +225,7 @@ def _(
     return None
 
 
-class FP8LightingIndexerKernel(Kernel):
+class FP8LightningIndexerKernel(Kernel):
     supported_archs: list[int] = [90]
 
     def __init__(self,
@@ -248,7 +248,7 @@ class FP8LightingIndexerKernel(Kernel):
         self.clean_logits = clean_logits
         self.config = config
 
-        self.kernel = _fp8_lighting_indexer_kernel(self.batch, self.seq_len, self.heads,
+        self.kernel = _fp8_lightning_indexer_kernel(self.batch, self.seq_len, self.heads,
                                                    self.index_dim, self.seq_len_kv, self.kv_group,
                                                    self.clean_logits)
 
@@ -287,7 +287,7 @@ class FP8LightingIndexerKernel(Kernel):
         Logits = torch.empty([self.batch, self.seq_len, self.seq_len_kv, self.kv_group],
                              device=IndexQ.device,
                              dtype=torch.float32)
-        fp8_lighting_indexer_wrapped_kernel(
+        fp8_lightning_indexer_wrapped_kernel(
             self.batch, self.seq_len, self.heads, self.index_dim, self.seq_len_kv, self.kv_group,
             self.clean_logits, self.config["block_N"], self.config["num_stages"],
             self.config["threads"], self.config["block_Q"], IndexQ, IndexK, IndexKScale, Logits,

--- a/tileops/manifest/attention_indexing.yaml
+++ b/tileops/manifest/attention_indexing.yaml
@@ -1,6 +1,6 @@
 # Attention indexing and sparse selection operators.
 
-FP8LightingIndexerOp:
+FP8LightningIndexerOp:
   ref_api: "none"
   family: attention_indexing
   status: implemented
@@ -36,19 +36,19 @@ FP8LightingIndexerOp:
     - "index_k_scale.shape == (batch, seq_len_kv, kv_group)"
 
   workloads:
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lighting-indexer-bf16-s8k-h32-d64"}
-  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lighting-indexer-fp8-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-bf16-s8k-h32-d64"}
+  - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [float8_e4m3fn], label: "lightning-indexer-fp8-s8k-h32-d64"}
 
   roofline:
-    func: "tileops.perf.formulas.fp8_lighting_indexer_roofline"
+    func: "tileops.perf.formulas.fp8_lightning_indexer_roofline"
 
   source:
-    kernel: tileops/kernels/fp8_lighting_indexer.py
+    kernel: tileops/kernels/fp8_lightning_indexer.py
     kernel_map:
-      fp8_lighting_indexer_kernel: FP8LightingIndexerKernel
-    op: tileops/ops/fp8_lighting_indexer.py
-    test: tests/ops/test_fp8_lighting_indexer.py
-    bench: benchmarks/ops/bench_fp8_lighting_indexer.py
+      fp8_lightning_indexer_kernel: FP8LightningIndexerKernel
+    op: tileops/ops/fp8_lightning_indexer.py
+    test: tests/ops/test_fp8_lightning_indexer.py
+    bench: benchmarks/ops/bench_fp8_lightning_indexer.py
     bench_manifest_driven: false
 
 TopkSelectorOp:

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -34,7 +34,7 @@ from .deltanet_recurrence import DeltaNetDecodeOp
 from .dropout import DropoutOp
 from .elementwise import BinaryOp, FusedGatedOp, UnaryOp
 from .fft import FFTC2COp
-from .fp8_lighting_indexer import FP8LightingIndexerOp
+from .fp8_lightning_indexer import FP8LightningIndexerOp
 from .fp8_quant import FP8QuantOp
 from .gated_deltanet import (
     GatedDeltaNetBwdOp,
@@ -125,7 +125,7 @@ __all__ = [
     "DeepSeekSparseAttentionDecodeWithKVCacheFwdOp",
     "DropoutOp",
     "FFTC2COp",
-    "FP8LightingIndexerOp",
+    "FP8LightningIndexerOp",
     "FP8QuantOp",
     "FusedAddLayerNormFwdOp",
     "FusedAddRMSNormFwdOp",

--- a/tileops/ops/fp8_lightning_indexer.py
+++ b/tileops/ops/fp8_lightning_indexer.py
@@ -2,15 +2,15 @@ from typing import Dict, Optional, Tuple
 
 import torch
 
-from tileops.kernels.fp8_lighting_indexer import FP8LightingIndexerKernel
+from tileops.kernels.fp8_lightning_indexer import FP8LightningIndexerKernel
 from tileops.kernels.kernel_base import Kernel
 
 from .op_base import Op
 
-__all__ = ["FP8LightingIndexerOp"]
+__all__ = ["FP8LightningIndexerOp"]
 
 
-class FP8LightingIndexerOp(Op):
+class FP8LightningIndexerOp(Op):
 
     def __init__(self,
                  batch,
@@ -32,12 +32,12 @@ class FP8LightingIndexerOp(Op):
         self.clean_logits = clean_logits
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fp8_lighting_indexer_kernel"](
+        self.kernel = self.kernel_map["fp8_lightning_indexer_kernel"](
             batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune=tune)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"fp8_lighting_indexer_kernel": FP8LightingIndexerKernel}
+        return {"fp8_lightning_indexer_kernel": FP8LightningIndexerKernel}
 
     def torch_quant_forward(self, index_q: torch.Tensor, index_k: torch.Tensor,
                             weights: torch.Tensor, cu_seqlen_ks: torch.Tensor,

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -36,7 +36,7 @@ __all__ = [
     "eq_fwd_roofline",
     "fft_c2c_roofline",
     "floor_divide_fwd_roofline",
-    "fp8_lighting_indexer_roofline",
+    "fp8_lightning_indexer_roofline",
     "fp8_quant_roofline",
     "fused_moe_fwd_bytes",
     "gated_deltanet_prefill_fwd_roofline",
@@ -1171,7 +1171,7 @@ def fp8_quant_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
-def fp8_lighting_indexer_roofline(op: "Op") -> tuple[int, int]:
+def fp8_lightning_indexer_roofline(op: "Op") -> tuple[int, int]:
     batch = int(op.batch)
     seq_len = int(op.seq_len)
     heads = int(op.heads)

--- a/workloads/fp8_lightning_indexer.py
+++ b/workloads/fp8_lightning_indexer.py
@@ -5,7 +5,7 @@ import torch
 from workloads.workload_base import WorkloadBase
 
 
-class FP8LightingIndexerTest(WorkloadBase):
+class FP8LightningIndexerTest(WorkloadBase):
 
     def __init__(self,
                  batch: int,

--- a/workloads/fp8_lightning_indexer.py
+++ b/workloads/fp8_lightning_indexer.py
@@ -5,7 +5,7 @@ import torch
 from workloads.workload_base import WorkloadBase
 
 
-class FP8LightningIndexerTest(WorkloadBase):
+class FP8LightningIndexerWorkload(WorkloadBase):
 
     def __init__(self,
                  batch: int,


### PR DESCRIPTION
## Summary

- Add a `kv_group == 1` fast path to `_fp8_lightning_indexer_main` (the only case exercised by
  manifest workloads): load K tiles via a region-slice `T.copy` directly into a 2-D shared
  buffer, read `index_q_shared` in place, and let the GEMM accumulate directly into `s` — its
  output layout is bit-identical to `s_tmp`'s when there is a single group.
- This deletes, per KV tile on the fast path: two shared→shared shuffle loops (previously 6 %
  of warp-stall samples as `STS.128`), the `s_tmp` fragment, and the `s_tmp → s_reshaped`
  writeback.
- Fix the `kv_group > 1` q-shuffle indexing: `index_q_shared` rows are laid out as
  `query * heads + head`, so the old `index_q_shared[g * heads_per_group + i]` read the wrong
  rows when `block_Q > 1` — a latent bug, never triggered since all workloads use
  `kv_group == 1`. That path still has no test coverage; a `kv_group > 1` test is a follow-up.
- Rename `lighting` → `lightning` (typo, mechanical, all 9 files incl. manifest key and
  workload labels). Breaking: `FP8LightingIndexerOp` is removed without an alias.
- No Op signature or autotune-space change.

## Test plan

- [x] pre-commit passed (ruff, codespell, gitleaks)
- [x] `pytest tests/ops/test_fp8_lightning_indexer.py` — 2 passed (strict isfinite-mask compare
      on ragged varlen windows; covers tune=True; `kv_group == 1` only)
- [x] `pytest benchmarks/tests` (contract) — 8 passed
- [x] `python scripts/validate_manifest.py` — all checks passed

## Benchmark

**Environment**: NVIDIA H200, CUDA 13.0, PyTorch 2.10.0, TileLang 0.1.11+cuda.git5aaef0fd

### FP8LightningIndexerOp (end-to-end)

| Shape (b, s, h, d, s_kv, g) | This PR (ms) | main (ms) | Speedup |
| --------------------------- | ------------ | --------- | ------- |
| (1, 4096, 32, 64, 8192, 1)  | 0.0974       | 0.1034    | 1.06×   |
| (1, 2048, 16, 64, 4096, 1)  | 0.0636       | 0.0709    | 1.11×   |

### Main kernel (ncu `--set full`, seeded harness, paired same-day)

| Metric | main | This PR |
| --- | --- | --- |
| Elapsed cycles (locked clock) | 130,472 | 102,206 (**1.28×**) |
| Duration | 96.29 µs | 75.52 µs |
| Compute (SM) throughput | 38.99 % | 53.07 % |
| Warp cycles per issued instruction | 8.04 | 6.00 |
| Eligible warps per scheduler | 0.77 | 1.21 |
| Occupancy (achieved) | 22.48 % | 22.49 % |

**Takeaways:** the win is issue efficiency, not occupancy — registers stay at the 2-blocks/SM
launch-bound cap (127 → 128), occupancy is flat; removing the shuffle loops and their barriers
cuts warp-blocked cycles per instruction 8.04 → 6.00. The fp32 accumulation path is untouched;
correctness on the `kv_group == 1` path is validated by the strict isfinite-mask test on
random varlen windows.

**Command:** `python -m pytest benchmarks/ops/bench_fp8_lightning_indexer.py -v`
