### PR TITLE
[Fix][Manifest] Keep UnaryOp dispatch visible to validator

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3208,7 +3208,7 @@ _MISSING = object()
 def _init_calls_dispatch_kernel(cls: type) -> "bool | None":
     """Return True if ``cls.__init__`` body either calls
     ``self.dispatch_kernel(...)`` directly or delegates via
-    ``super().__init__(...)``.
+    ``super().__init__(...)`` / a ``self.<helper>(...)`` method.
 
     ``None`` means we could not parse the source (built-in / dynamically
     generated ``__init__``); the caller treats that as inconclusive.
@@ -3219,34 +3219,58 @@ def _init_calls_dispatch_kernel(cls: type) -> "bool | None":
     ``super().__init__(...)`` satisfies S13 transitively — the parent's
     body owns the dispatch call. No runtime construction; no GPU.
     """
-    try:
-        src = inspect.getsource(cls.__init__)
-    except (OSError, TypeError):
-        return None
-    try:
-        tree = ast.parse(textwrap.dedent(src))
-    except SyntaxError:
-        return None
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
-            continue
-        # self.dispatch_kernel(...)
-        if (
-            node.func.attr == "dispatch_kernel"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "self"
-        ):
-            return True
-        # super().__init__(...): delegates to the parent's body which is
-        # expected to honor S13 itself.
-        if (
-            node.func.attr == "__init__"
-            and isinstance(node.func.value, ast.Call)
-            and isinstance(node.func.value.func, ast.Name)
-            and node.func.value.func.id == "super"
-        ):
-            return True
-    return False
+    def _body_calls_dispatch(fn, seen: set[int]) -> "bool | None":
+        key = id(fn)
+        if key in seen:
+            return False
+        seen.add(key)
+        try:
+            src = inspect.getsource(fn)
+        except (OSError, TypeError):
+            return None
+        try:
+            tree = ast.parse(textwrap.dedent(src))
+        except SyntaxError:
+            return None
+
+        inconclusive = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            # self.dispatch_kernel(...)
+            if (
+                node.func.attr == "dispatch_kernel"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                return True
+            # super().__init__(...): delegates to the parent's body which is
+            # expected to honor S13 itself.
+            if (
+                node.func.attr == "__init__"
+                and isinstance(node.func.value, ast.Call)
+                and isinstance(node.func.value.func, ast.Name)
+                and node.func.value.func.id == "super"
+            ):
+                return True
+            # self.<helper>(...): follow class-local helper methods such as
+            # UnaryOp._prepare_unary_instance without constructing the Op.
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr != "__init__"
+            ):
+                helper = getattr(cls, node.func.attr, None)
+                if helper is None:
+                    continue
+                helper_result = _body_calls_dispatch(inspect.unwrap(helper), seen)
+                if helper_result is True:
+                    return True
+                if helper_result is None:
+                    inconclusive = True
+        return None if inconclusive else False
+
+    return _body_calls_dispatch(inspect.unwrap(cls.__init__), set())
 
 
 def check_c3_ctor_signature_parity(

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3208,7 +3208,7 @@ _MISSING = object()
 def _init_calls_dispatch_kernel(cls: type) -> "bool | None":
     """Return True if ``cls.__init__`` body either calls
     ``self.dispatch_kernel(...)`` directly or delegates via
-    ``super().__init__(...)`` / a ``self.<helper>(...)`` method.
+    ``super().__init__(...)``.
 
     ``None`` means we could not parse the source (built-in / dynamically
     generated ``__init__``); the caller treats that as inconclusive.
@@ -3219,58 +3219,46 @@ def _init_calls_dispatch_kernel(cls: type) -> "bool | None":
     ``super().__init__(...)`` satisfies S13 transitively — the parent's
     body owns the dispatch call. No runtime construction; no GPU.
     """
-    def _body_calls_dispatch(fn, seen: set[int]) -> "bool | None":
-        key = id(fn)
-        if key in seen:
-            return False
-        seen.add(key)
-        try:
-            src = inspect.getsource(fn)
-        except (OSError, TypeError):
-            return None
-        try:
-            tree = ast.parse(textwrap.dedent(src))
-        except SyntaxError:
-            return None
+    try:
+        lines, start_lineno = inspect.getsourcelines(cls.__init__)
+    except (OSError, TypeError):
+        return None
+    try:
+        tree = ast.parse(textwrap.dedent("".join(lines)))
+    except SyntaxError:
+        return None
+    code = getattr(cls.__init__, "__code__", None)
+    target_lineno = getattr(code, "co_firstlineno", None)
+    init_node = None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "__init__":
+            continue
+        if target_lineno is None or start_lineno + node.lineno - 1 == target_lineno:
+            init_node = node
+            break
+    if init_node is None:
+        return None
 
-        inconclusive = False
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
-                continue
-            # self.dispatch_kernel(...)
-            if (
-                node.func.attr == "dispatch_kernel"
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "self"
-            ):
-                return True
-            # super().__init__(...): delegates to the parent's body which is
-            # expected to honor S13 itself.
-            if (
-                node.func.attr == "__init__"
-                and isinstance(node.func.value, ast.Call)
-                and isinstance(node.func.value.func, ast.Name)
-                and node.func.value.func.id == "super"
-            ):
-                return True
-            # self.<helper>(...): follow class-local helper methods such as
-            # UnaryOp._prepare_unary_instance without constructing the Op.
-            if (
-                isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "self"
-                and node.func.attr != "__init__"
-            ):
-                helper = getattr(cls, node.func.attr, None)
-                if helper is None:
-                    continue
-                helper_result = _body_calls_dispatch(inspect.unwrap(helper), seen)
-                if helper_result is True:
-                    return True
-                if helper_result is None:
-                    inconclusive = True
-        return None if inconclusive else False
-
-    return _body_calls_dispatch(inspect.unwrap(cls.__init__), set())
+    for node in ast.walk(init_node):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        # self.dispatch_kernel(...)
+        if (
+            node.func.attr == "dispatch_kernel"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+        ):
+            return True
+        # super().__init__(...): delegates to the parent's body which is
+        # expected to honor S13 itself.
+        if (
+            node.func.attr == "__init__"
+            and isinstance(node.func.value, ast.Call)
+            and isinstance(node.func.value.func, ast.Name)
+            and node.func.value.func.id == "super"
+        ):
+            return True
+    return False
 
 
 def check_c3_ctor_signature_parity(

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -81,12 +81,14 @@ LOGICAL_BINARY_KERNELS = [LogicalAndFwdKernel, LogicalOrFwdKernel]
 @pytest.mark.full
 @pytest.mark.parametrize("kernel_cls", COMPARISON_KERNELS + LOGICAL_BINARY_KERNELS)
 def test_bool_like_elementwise_kernels_expose_torch_dtype_output(kernel_cls):
-    """Comparison and logical kernels should declare `OUTPUT_DTYPE` as `torch.int8`."""
+    """Comparison and logical kernels should declare public bool output."""
     assert isinstance(kernel_cls.OUTPUT_DTYPE, torch.dtype), (
         f"{kernel_cls.__name__}.OUTPUT_DTYPE is {type(kernel_cls.OUTPUT_DTYPE).__name__} "
         f"({kernel_cls.OUTPUT_DTYPE!r}), expected torch.dtype"
     )
-    assert torch.int8 == kernel_cls.OUTPUT_DTYPE
+    # Bool-storage specializations may use uint8 internally, but the public
+    # kernel contract is a torch.bool output dtype.
+    assert torch.bool == kernel_cls.OUTPUT_DTYPE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -4678,8 +4678,8 @@ class TestStrictParityC5Dispatch:
             "BranchOp", {}, BranchOp,
         ) == []
 
-    def test_dispatch_kernel_call_in_helper_detected(self, validator):
-        """S13 walker follows class-local helpers called from __init__."""
+    def test_dispatch_kernel_call_in_helper_rejected(self, validator):
+        """S13 requires dispatch_kernel in __init__ or super().__init__."""
         from tileops.ops.op_base import Op
 
         class HelperOp(Op):
@@ -4691,27 +4691,10 @@ class TestStrictParityC5Dispatch:
             @property
             def default_kernel_map(self): return {}
 
-        assert validator.check_c5_dispatch_kernel_invariant(
+        errs = validator.check_c5_dispatch_kernel_invariant(
             "HelperOp", {}, HelperOp,
-        ) == []
-
-    def test_unhashable_helper_attribute_is_advisory(self, validator):
-        """S13 walker does not crash on unhashable self.<attr>() targets."""
-        from tileops.ops.op_base import Op
-
-        class UnhashableHelperAttrOp(Op):
-            _prepare = []
-            def __init__(self, kernel_map=None):
-                self._prepare(kernel_map)
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
-        warnings = []
-        assert validator.check_c5_dispatch_kernel_invariant(
-            "UnhashableHelperAttrOp", {}, UnhashableHelperAttrOp, warnings=warnings,
-        ) == []
-        assert any("S13 advisory" in warning for warning in warnings), warnings
+        )
+        assert any("does not call self.dispatch_kernel" in e for e in errs), errs
 
 
 class TestStrictParityC6C7Stub:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -4678,6 +4678,41 @@ class TestStrictParityC5Dispatch:
             "BranchOp", {}, BranchOp,
         ) == []
 
+    def test_dispatch_kernel_call_in_helper_detected(self, validator):
+        """S13 walker follows class-local helpers called from __init__."""
+        from tileops.ops.op_base import Op
+
+        class HelperOp(Op):
+            def __init__(self, kernel_map=None):
+                self._prepare(kernel_map)
+            def _prepare(self, kernel_map=None):
+                self.dispatch_kernel(kernel_map)
+            def forward(self, x): return None
+            @property
+            def default_kernel_map(self): return {}
+
+        assert validator.check_c5_dispatch_kernel_invariant(
+            "HelperOp", {}, HelperOp,
+        ) == []
+
+    def test_unhashable_helper_attribute_is_advisory(self, validator):
+        """S13 walker does not crash on unhashable self.<attr>() targets."""
+        from tileops.ops.op_base import Op
+
+        class UnhashableHelperAttrOp(Op):
+            _prepare = []
+            def __init__(self, kernel_map=None):
+                self._prepare(kernel_map)
+            def forward(self, x): return None
+            @property
+            def default_kernel_map(self): return {}
+
+        warnings = []
+        assert validator.check_c5_dispatch_kernel_invariant(
+            "UnhashableHelperAttrOp", {}, UnhashableHelperAttrOp, warnings=warnings,
+        ) == []
+        assert any("S13 advisory" in warning for warning in warnings), warnings
+
 
 class TestStrictParityC6C7Stub:
     """C6 / C7: _validate_dtypes / eval_roofline must not be base stubs."""

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -643,36 +643,38 @@ class UnaryOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self._prepare_unary_instance(N_total, dtype, strategy, kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            N_total, dtype, strategy=strategy, tune=tune,
-        )
-        self._finish_unary_instance()
-
-    def _prepare_unary_instance(
-        self,
-        N_total: int,
-        dtype: torch.dtype,
-        strategy: Optional[str],
-        kernel_map: Optional[Dict[str, Kernel]],
-    ) -> None:
         self.N_total = N_total
         self.dtype = dtype
         self.strategy = strategy
         self.dispatch_kernel(kernel_map)
-
-    def _finish_unary_instance(
-        self, output_dtype: Optional[torch.dtype] = None,
-    ) -> None:
-        # Use _fp8_output_dtype (the final dtype after Op-layer post-cast)
-        # rather than kernel.output_dtype (which is fp16 for e5m2).
-        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
-        self.output_dtype = output_dtype or fp8_out or getattr(
-            self.kernel, "output_dtype", self.dtype,
+        self.kernel = self._build_kernel_instance(
+            N_total=N_total, dtype=dtype, strategy=strategy, tune=tune,
         )
+        self.output_dtype = self._resolve_output_dtype()
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
+
+    def _build_kernel_instance(
+        self,
+        *,
+        N_total: int,
+        dtype: torch.dtype,
+        strategy: Optional[str],
+        tune: bool,
+    ):
+        """Construct the kernel. Subclasses override to specialize construction."""
+        return self.kernel_map[self._op_name](
+            N_total, dtype, strategy=strategy, tune=tune,
+        )
+
+    def _resolve_output_dtype(self) -> torch.dtype:
+        # Use _fp8_output_dtype (the final dtype after Op-layer post-cast)
+        # rather than kernel.output_dtype (which is fp16 for e5m2).
+        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
+        return fp8_out or getattr(
+            self.kernel, "output_dtype", self.dtype,
+        )
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:

--- a/tileops/ops/elementwise/logical.py
+++ b/tileops/ops/elementwise/logical.py
@@ -44,27 +44,27 @@ class LogicalNotFwdOp(UnaryOp):
             f"{self._op_name}_bool_storage": self.bool_storage_kernel_cls,
         }
 
-    def __init__(
+    def _build_kernel_instance(
         self,
+        *,
         N_total: int,
         dtype: torch.dtype,
-        strategy=None,
-        kernel_map=None,
+        strategy,
         tune: bool = False,
     ):
-        if dtype != torch.bool:
-            self._bool_storage = False
-            super().__init__(
-                N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
+        self._bool_storage = dtype == torch.bool
+        if self._bool_storage:
+            return self.kernel_map[f"{self._op_name}_bool_storage"](
+                N_total, torch.uint8, strategy=strategy, tune=tune,
             )
-            return
-
-        self._prepare_unary_instance(N_total, dtype, strategy, kernel_map)
-        self._bool_storage = True
-        self.kernel = self.kernel_map[f"{self._op_name}_bool_storage"](
-            N_total, torch.uint8, strategy=strategy, tune=tune,
+        return super()._build_kernel_instance(
+            N_total=N_total, dtype=dtype, strategy=strategy, tune=tune,
         )
-        self._finish_unary_instance(output_dtype=torch.bool)
+
+    def _resolve_output_dtype(self):
+        if self._bool_storage:
+            return torch.bool
+        return super()._resolve_output_dtype()
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
         if self._bool_storage:


### PR DESCRIPTION
Fixes the unary-op manifest validation regression surfaced around #1707, using the reviewer-preferred approach from this PR discussion.

## Summary
- Keep `UnaryOp.__init__` calling `dispatch_kernel(...)` directly, so the S13 manifest rule remains simple and statically visible
- Replace the previous helper-call validator approach with explicit unary customization hooks: `_build_kernel_instance(...)` and `_resolve_output_dtype(...)`
- Let `LogicalNotFwdOp` override those hooks for the bool-storage path while still exposing public `OUTPUT_DTYPE = torch.bool`
- Tighten `validate_manifest.py` source lookup so it locates the exact class `__init__` AST node instead of relying on broader helper-call traversal
- Update bool-like elementwise dtype coverage to assert comparison/logical kernels expose `torch.bool` as their public output dtype

## Problem
#1705 refactored unary elementwise setup so `UnaryOp.__init__` reached `dispatch_kernel(...)` through `_prepare_unary_instance(...)`. That made the runtime behavior work, but it broke the S13 manifest invariant: the validator expects each op constructor to expose dispatch directly from `__init__`.

The first version of this PR taught the validator to chase `self.<helper>()` calls. After Ibuki's review, we changed direction because that made the validator more permissive than the contract we actually want. The better fix is to keep dispatch explicit in the op constructor and move only the customization points into helpers.

Separately, op tests exposed that bool-like comparison/logical kernels should advertise the public torch dtype (`torch.bool`) even when their internal storage path uses an integer/uint8 representation.

## Fix
`UnaryOp.__init__` now performs the dispatch in place again:

- `_build_kernel_instance(...)` prepares the kernel instance
- `_resolve_output_dtype(...)` resolves the public output dtype
- `dispatch_kernel(kernel_map)` remains directly visible in `__init__`

`LogicalNotFwdOp` customizes the two hooks it actually needs instead of routing the whole constructor through a dispatch helper. The manifest validator no longer needs to follow arbitrary helper calls for S13, and the regression test now rejects helper-only dispatch.

The bool-like elementwise dtype test now documents the public contract: comparison and logical kernels expose `torch.bool`; any uint8/int storage detail is internal to the implementation.

## Test plan
- [x] `pytest -q tests/ops/test_elementwise_config_dtype.py::test_bool_like_elementwise_kernels_expose_torch_dtype_output`
- [x] `pytest -q tests/test_validate_manifest.py::TestStrictParityC5Dispatch`
- [x] `python3 scripts/validate_manifest.py`
- [x] `python3 -m ruff check scripts/validate_manifest.py tests/test_validate_manifest.py tests/ops/test_elementwise_config_dtype.py`
- [x] `python3 -m py_compile scripts/validate_manifest.py`
- [x] `git diff --check`