### PR TITLE
[Feat][BMM] Add FP8 BMM op

### DIFF
--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -4,16 +4,43 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tests.ops.test_bmm import BmmTest
+from tests.ops.test_bmm import BmmFp8Test, BmmTest
 from tileops.manifest import load_workloads
-from tileops.ops import BmmFwdOp
+from tileops.ops import BmmFp8Op, BmmFwdOp
 
 _OP_NAME = "BmmFwdOp"
+_FP8_OP_NAME = "BmmFp8Op"
 
 _DTYPE_MAP = {
     "bfloat16": torch.bfloat16,
     "float16": torch.float16,
+    "float8_e4m3fn": torch.float8_e4m3fn,
+    "float8_e5m2": torch.float8_e5m2,
 }
+
+
+def _flashinfer_bmm_fp8_per_tensor_ref(
+    test: BmmFp8Test, a: torch.Tensor, b_kmajor: torch.Tensor,
+    scale_a: torch.Tensor, scale_b: torch.Tensor,
+) -> torch.Tensor:
+
+    import flashinfer
+
+    if a.dtype != torch.float8_e4m3fn or b_kmajor.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            "FlashInfer bmm_fp8 baseline requires float8_e4m3fn.")
+    if test.out_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            "FlashInfer bmm_fp8 baseline requires bfloat16 / float16 output.")
+    if scale_a.dim() != 0 or scale_b.dim() != 0:
+        raise ValueError(
+            "FlashInfer bmm_fp8 baseline requires 0-D per-tensor scales, "
+            f"got {tuple(scale_a.shape)} / {tuple(scale_b.shape)}"
+        )
+    return flashinfer.bmm_fp8(
+        a, b_kmajor, scale_a, scale_b,
+        dtype=test.out_dtype, backend="cudnn",
+    )
 
 
 class BmmBenchmark(BenchmarkBase[BmmTest]):
@@ -43,10 +70,42 @@ class BmmBenchmark(BenchmarkBase[BmmTest]):
         return self._get_roofline()[1]
 
 
+class BmmFp8Benchmark(BenchmarkBase[BmmFp8Test]):
+    _roofline_cache: Optional[tuple[float, float]] = None
+
+    def __init__(self, test: BmmFp8Test, op: BmmFp8Op):
+        super().__init__(test)
+        self._op = op
+
+    def _get_roofline(self) -> tuple[float, float]:
+        if self._roofline_cache is None:
+            flops, mem_bytes = self._op.eval_roofline()
+            self._roofline_cache = (float(flops), float(mem_bytes))
+        return self._roofline_cache
+
+    def calculate_flops(self) -> Optional[float]:
+        return self._get_roofline()[0]
+
+    def calculate_memory(self) -> Optional[float]:
+        return self._get_roofline()[1]
+
+
 def _manifest_params() -> list:
     """Convert manifest workloads to pytest params (batch, m, n, k, dtype)."""
     params = []
     for w in load_workloads(_OP_NAME):
+        label = w.get("label", "unlabeled")
+        for dtype_str in w["dtypes"]:
+            params.append(pytest.param(
+                w["b"], w["m"], w["n"], w["k"], dtype_str,
+                id=f"{label}-{dtype_str}",
+            ))
+    return params
+
+
+def _manifest_fp8_params() -> list:
+    params = []
+    for w in load_workloads(_FP8_OP_NAME):
         label = w.get("label", "unlabeled")
         for dtype_str in w["dtypes"]:
             params.append(pytest.param(
@@ -72,6 +131,45 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
 
     result_bl = bm.profile(test.ref_program, a, b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
+
+
+@pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_fp8_params())
+def test_bmm_fp8_bench(
+    batch: int, m: int, n: int, k: int, dtype_str: str,
+) -> None:
+    dtype = _DTYPE_MAP[dtype_str]
+    out_dtype = torch.bfloat16
+    test = BmmFp8Test(batch, m, n, k, dtype, out_dtype=out_dtype)
+    a, b_kn, scale_a, scale_b = test.gen_inputs()
+    b_nk = b_kn.transpose(-2, -1).contiguous()      # [B, N, K], K-innermost
+    b_kmajor = b_nk.transpose(-2, -1)               # [B, K, N] view, zero-copy
+
+    op = BmmFp8Op(out_dtype=out_dtype, tune=True)
+    bm = BmmFp8Benchmark(test, op)
+    result = bm.profile(op, a, b_nk, scale_a, scale_b)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, a, b_kn, scale_a, scale_b)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-fp32-ref")
+
+    flashinfer = pytest.importorskip("flashinfer")
+    try:
+        result_flashinfer = bm.profile(
+            lambda a_, b_, sa_, sb_: _flashinfer_bmm_fp8_per_tensor_ref(
+                test, a_, b_, sa_, sb_),
+            a, b_kmajor, scale_a, scale_b,
+        )
+    except RuntimeError as exc:
+        # Only RuntimeError is expected here: it typically signals that the
+        # underlying cuBLASLt / CUDNN FP8 backend refuses this specific
+        # (shape, dtype, arch) combination.  ImportError is already handled
+        # by ``importorskip`` above; letting AttributeError / TypeError
+        # propagate keeps genuine bugs visible in bench reports instead of
+        # silently degrading the comparison surface.
+        pytest.skip(f"flashinfer bmm_fp8 unavailable for this shape: {exc}")
+    BenchmarkReport.record(
+        op, locals(), result_flashinfer, tag="flashinfer-bmm-fp8",
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -144,7 +144,8 @@ def test_bmm_fp8_bench(
     b_nk = b_kn.transpose(-2, -1).contiguous()      # [B, N, K], K-innermost
     b_kmajor = b_nk.transpose(-2, -1)               # [B, K, N] view, zero-copy
 
-    op = BmmFp8Op(out_dtype=out_dtype, tune=True)
+    # Fast path: feed [B, N, K] (K-innermost) via explicit b_layout='nk'.
+    op = BmmFp8Op(out_dtype=out_dtype, tune=True, b_layout="nk")
     bm = BmmFp8Benchmark(test, op)
     result = bm.profile(op, a, b_nk, scale_a, scale_b)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
@@ -160,12 +161,6 @@ def test_bmm_fp8_bench(
             a, b_kmajor, scale_a, scale_b,
         )
     except RuntimeError as exc:
-        # Only RuntimeError is expected here: it typically signals that the
-        # underlying cuBLASLt / CUDNN FP8 backend refuses this specific
-        # (shape, dtype, arch) combination.  ImportError is already handled
-        # by ``importorskip`` above; letting AttributeError / TypeError
-        # propagate keeps genuine bugs visible in bench reports instead of
-        # silently degrading the comparison surface.
         pytest.skip(f"flashinfer bmm_fp8 unavailable for this shape: {exc}")
     BenchmarkReport.record(
         op, locals(), result_flashinfer, tag="flashinfer-bmm-fp8",

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -2,13 +2,28 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops import BmmFwdOp
-from workloads.bmm import BmmWorkload
+from tileops.ops import BmmFp8Op, BmmFwdOp
+from workloads.bmm import BmmFp8Workload, BmmWorkload
 
 
 class BmmTest(BmmWorkload, TestBase):
     def ref_program(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         return torch.bmm(a, b)
+
+
+class BmmFp8Test(BmmFp8Workload, TestBase):
+    def ref_program(self, *inputs: torch.Tensor) -> torch.Tensor:
+        a, b, scale_a, scale_b = inputs
+        # per_tensor: 0-D fp32 scalars (matching flashinfer.bmm_fp8).
+        assert scale_a.dim() == 0 and scale_b.dim() == 0, (
+            f"BmmFp8Test only supports per-tensor scales, got "
+            f"{tuple(scale_a.shape)} / {tuple(scale_b.shape)}"
+        )
+        # b is [B, K, N] (torch.bmm layout, matching BmmFp8Op).
+        a_f = a.float() * scale_a
+        b_f = b.float() * scale_b
+        out = torch.bmm(a_f, b_f)
+        return out.to(self.out_dtype)
 
 
 class BmmFixture(FixtureBase):
@@ -139,6 +154,221 @@ def test_bmm_k_not_multiple_of_16_raises() -> None:
     b = torch.randn(4, 24, 16, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="multiple of 16"):
         op(a, b)
+
+
+class BmmFp8Fixture(FixtureBase):
+    # Only *supported* dtype combinations belong in the main fixture; a
+    # rejected dtype (e5m2) is exercised by its own dedicated negative
+    # test below so that each parametrised case has a single purpose.
+    PARAMS = [
+        ("batch, m, n, k, dtype, out_dtype", [
+            pytest.param(
+                4, 128, 128, 128, torch.float8_e4m3fn,
+                torch.bfloat16,
+                marks=pytest.mark.smoke,
+                id="smoke-fp8-b4-per-tensor",
+            ),
+            pytest.param(
+                8, 128, 256, 128, torch.float8_e4m3fn,
+                torch.float16,
+                marks=pytest.mark.full,
+                id="full-fp8-b8-per-tensor",
+            ),
+            pytest.param(
+                16, 128, 128, 2048, torch.float8_e4m3fn,
+                torch.bfloat16,
+                marks=pytest.mark.full,
+                id="full-fp8-b16-mha-pv-per-tensor",
+            ),
+        ]),
+    ]
+
+
+@BmmFp8Fixture
+def test_bmm_fp8(
+    batch: int,
+    m: int,
+    n: int,
+    k: int,
+    dtype: torch.dtype,
+    out_dtype: torch.dtype,
+) -> None:
+    test = BmmFp8Test(batch, m, n, k, dtype, out_dtype=out_dtype)
+    op = BmmFp8Op(out_dtype=out_dtype)
+    inputs = test.gen_inputs()
+    test.check(op, *inputs, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_rejects_e5m2() -> None:
+    """BmmFp8Op advertises fp8_e4m3fn only; e5m2 inputs must be rejected.
+
+    Kept separate from the main fixture so that ``test_bmm_fp8`` carries a
+    single purpose (correctness on supported dtypes) and this test carries
+    the other (dtype-guard on unsupported dtypes).
+    """
+    test = BmmFp8Test(4, 128, 128, 128, torch.float8_e5m2)
+    op = BmmFp8Op(out_dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="only supports torch.float8_e4m3fn"):
+        op(*test.gen_inputs())
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_rejects_unsupported_scale_grids() -> None:
+    """Per-tensor is 0-D; every other rank must be rejected."""
+    batch, m, n, k = 2, 128, 256, 256
+    test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
+    a, b, _, _ = test.gen_inputs()
+    op = BmmFp8Op()
+
+    scale_k = k // 128
+    # Legacy 2-D per-row block128 grid -- rejected now that per_tensor is
+    # the only supported scale layout (0-D scalars).
+    with pytest.raises(ValueError, match="supports scale shapes"):
+        op(
+            a,
+            b,
+            torch.ones((m, scale_k), device="cuda", dtype=torch.float32),
+            torch.ones((n, scale_k), device="cuda", dtype=torch.float32),
+        )
+
+    # 2-D 1x1 -- also rejected (per_tensor requires rank-0, not rank-2).
+    with pytest.raises(ValueError, match="supports scale shapes"):
+        op(
+            a,
+            b,
+            torch.ones((1, 1), device="cuda", dtype=torch.float32),
+            torch.ones((1, 1), device="cuda", dtype=torch.float32),
+        )
+
+    # Legacy per-batch ``(B, 1, 1)`` shape -- rejected now that per-tensor
+    # is 0-D (matches flashinfer.bmm_fp8's global A_scale/B_scale).
+    with pytest.raises(ValueError, match="supports scale shapes"):
+        op(
+            a,
+            b,
+            torch.ones((batch, 1, 1), device="cuda", dtype=torch.float32),
+            torch.ones((batch, 1, 1), device="cuda", dtype=torch.float32),
+        )
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_revalidates_cached_signature_dtypes() -> None:
+    test = BmmFp8Test(
+        2,
+        128,
+        128,
+        128,
+        torch.float8_e4m3fn,
+        out_dtype=torch.bfloat16,
+    )
+    a, b, scale_a, scale_b = test.gen_inputs()
+    op = BmmFp8Op(out_dtype=torch.bfloat16)
+    op(a, b, scale_a, scale_b)
+
+    with pytest.raises(ValueError, match="expects b dtype"):
+        op(a, b.to(torch.float8_e5m2), scale_a, scale_b)
+
+    with pytest.raises(ValueError, match="scale_a and scale_b"):
+        op(a, b, scale_a.to(torch.float16), scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_batch_mismatch_raises() -> None:
+    op = BmmFp8Op()
+    a = torch.randn(4, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randn(5, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="batch dim mismatch"):
+        op(a, b, scale_a, scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_contraction_mismatch_raises() -> None:
+    op = BmmFp8Op()
+    a = torch.randn(4, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randn(4, 64, 96, device="cuda").to(torch.float8_e4m3fn)
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="contraction dim mismatch"):
+        op(a, b, scale_a, scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_rank_mismatch_raises() -> None:
+    op = BmmFp8Op()
+    a = torch.randn(128, 128, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randn(4, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="strict 3D"):
+        op(a, b, scale_a, scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_k_not_multiple_of_32_raises() -> None:
+    op = BmmFp8Op()
+    a = torch.randn(4, 128, 48, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randn(4, 48, 128, device="cuda").to(torch.float8_e4m3fn)
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="multiple of 32"):
+        op(a, b, scale_a, scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_scale_dtype_change_after_valid_call_raises() -> None:
+    op = BmmFp8Op()
+    a = torch.randn(2, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randn(2, 128, 128, device="cuda").to(torch.float8_e4m3fn)
+    scale_a = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
+    op(a, b, scale_a, scale_b)  # populate the fast path
+    with pytest.raises(ValueError, match="scale_a and scale_b"):
+        op(a, b, scale_a.to(torch.float16), scale_b)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_accepts_nk_layout_when_k_ne_n() -> None:
+    batch, m, n, k = 4, 128, 256, 128
+    test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
+    a, b_kn, scale_a, scale_b = test.gen_inputs()  # b_kn is [B, K, N]
+    # NK-layout: [B, N, K], K-innermost, contiguous.  ``transpose+
+    # contiguous`` materialises the physical NK buffer so its shape[2]
+    # unambiguously carries K.
+    b_nk = b_kn.transpose(-2, -1).contiguous()
+    assert b_nk.shape == (batch, n, k)
+    op = BmmFp8Op(out_dtype=torch.bfloat16)
+    out_kn = op(a, b_kn, scale_a, scale_b).clone()
+    # New op instance to avoid the KN cached signature masking layout
+    # dispatch bugs.
+    op_nk = BmmFp8Op(out_dtype=torch.bfloat16)
+    out_nk = op_nk(a, b_nk, scale_a, scale_b)
+    # Numerically identical: same kernel, same buffer bits, just no
+    # internal DtoD copy on the NK path.
+    torch.testing.assert_close(out_kn, out_nk, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_nk_view_when_k_eq_n() -> None:
+    """When K == N, shape is ambiguous; a non-contiguous NK view forces
+    the fast path (``stride(-2) == 1`` tie-breaker).
+    """
+    batch, m, n, k = 4, 128, 128, 128  # K == N
+    test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
+    a, b_kn, scale_a, scale_b = test.gen_inputs()  # contiguous [B, K, N]
+    # ``transpose`` alone (no contiguous) yields the NK view; shape becomes
+    # [B, N, K] but stride is (K*N, 1, N) so stride(-2) == 1, marking the
+    # buffer as K-innermost so the op treats it as NK-input.
+    b_nk_view = b_kn.transpose(-2, -1)
+    assert b_nk_view.shape == (batch, n, k)
+    assert b_nk_view.stride(-2) == 1
+    op_kn = BmmFp8Op(out_dtype=torch.bfloat16)
+    op_nk = BmmFp8Op(out_dtype=torch.bfloat16)
+    out_kn = op_kn(a, b_kn, scale_a, scale_b).clone()
+    out_nk = op_nk(a, b_nk_view, scale_a, scale_b)
+    torch.testing.assert_close(out_kn, out_nk, atol=0.0, rtol=0.0)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -157,9 +157,6 @@ def test_bmm_k_not_multiple_of_16_raises() -> None:
 
 
 class BmmFp8Fixture(FixtureBase):
-    # Only *supported* dtype combinations belong in the main fixture; a
-    # rejected dtype (e5m2) is exercised by its own dedicated negative
-    # test below so that each parametrised case has a single purpose.
     PARAMS = [
         ("batch, m, n, k, dtype, out_dtype", [
             pytest.param(
@@ -339,11 +336,9 @@ def test_bmm_fp8_accepts_nk_layout_when_k_ne_n() -> None:
     # unambiguously carries K.
     b_nk = b_kn.transpose(-2, -1).contiguous()
     assert b_nk.shape == (batch, n, k)
-    op = BmmFp8Op(out_dtype=torch.bfloat16)
-    out_kn = op(a, b_kn, scale_a, scale_b).clone()
-    # New op instance to avoid the KN cached signature masking layout
-    # dispatch bugs.
-    op_nk = BmmFp8Op(out_dtype=torch.bfloat16)
+    op_kn = BmmFp8Op(out_dtype=torch.bfloat16)  # default b_layout='kn'
+    op_nk = BmmFp8Op(out_dtype=torch.bfloat16, b_layout="nk")
+    out_kn = op_kn(a, b_kn, scale_a, scale_b).clone()
     out_nk = op_nk(a, b_nk, scale_a, scale_b)
     # Numerically identical: same kernel, same buffer bits, just no
     # internal DtoD copy on the NK path.
@@ -352,23 +347,51 @@ def test_bmm_fp8_accepts_nk_layout_when_k_ne_n() -> None:
 
 @pytest.mark.smoke
 def test_bmm_fp8_nk_view_when_k_eq_n() -> None:
-    """When K == N, shape is ambiguous; a non-contiguous NK view forces
-    the fast path (``stride(-2) == 1`` tie-breaker).
-    """
     batch, m, n, k = 4, 128, 128, 128  # K == N
     test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
     a, b_kn, scale_a, scale_b = test.gen_inputs()  # contiguous [B, K, N]
-    # ``transpose`` alone (no contiguous) yields the NK view; shape becomes
-    # [B, N, K] but stride is (K*N, 1, N) so stride(-2) == 1, marking the
-    # buffer as K-innermost so the op treats it as NK-input.
     b_nk_view = b_kn.transpose(-2, -1)
     assert b_nk_view.shape == (batch, n, k)
     assert b_nk_view.stride(-2) == 1
-    op_kn = BmmFp8Op(out_dtype=torch.bfloat16)
-    op_nk = BmmFp8Op(out_dtype=torch.bfloat16)
+    op_kn = BmmFp8Op(out_dtype=torch.bfloat16)  # default 'kn'
+    op_nk = BmmFp8Op(out_dtype=torch.bfloat16, b_layout="nk")
     out_kn = op_kn(a, b_kn, scale_a, scale_b).clone()
     out_nk = op_nk(a, b_nk_view, scale_a, scale_b)
     torch.testing.assert_close(out_kn, out_nk, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_contiguous_nk_square_when_k_eq_n() -> None:
+    batch, m, n, k = 4, 128, 128, 128  # K == N
+    test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
+    a, b_kn, scale_a, scale_b = test.gen_inputs()  # contiguous [B, K, N]
+    # Physical contiguous [B, N, K]: stride is (N*K, K, 1) => stride(-2) == K.
+    b_nk = b_kn.transpose(-2, -1).contiguous()
+    assert b_nk.is_contiguous()
+    assert b_nk.shape == (batch, n, k)
+    assert b_nk.stride(-2) == k
+
+    # Same logical B matrix, explicit layouts.  Both must yield the same d.
+    op_nk = BmmFp8Op(out_dtype=torch.bfloat16, b_layout="nk")
+    out_nk = op_nk(a, b_nk, scale_a, scale_b).clone()
+    op_kn = BmmFp8Op(out_dtype=torch.bfloat16)  # default 'kn'
+    out_kn = op_kn(a, b_kn, scale_a, scale_b)
+    torch.testing.assert_close(out_nk, out_kn, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.smoke
+def test_bmm_fp8_persistent_default_tile_boundary() -> None:
+    batch, m, n, k = 8, 64, 64, 32
+    test = BmmFp8Test(batch, m, n, k, torch.float8_e4m3fn)
+    a, b_kn, scale_a, scale_b = test.gen_inputs()
+    op = BmmFp8Op(out_dtype=torch.bfloat16)
+    out = op(a, b_kn, scale_a, scale_b)
+
+    # Reference computed in float32 with the same per-tensor scales.
+    a_f = a.float() * scale_a
+    b_f = b_kn.float() * scale_b
+    ref = torch.bmm(a_f, b_f).to(torch.bfloat16)
+    torch.testing.assert_close(out, ref, atol=0.05, rtol=0.05)
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -34,7 +34,7 @@ from .attention import (
     NSATopkVarlenKernel,
     SparseMlaKernel,
 )
-from .bmm import BmmKernel
+from .bmm import BmmFp8Kernel, BmmKernel
 from .convolution import (
     Conv1dKernel,
     Conv1dPointwiseKernel,
@@ -107,6 +107,7 @@ __all__ = [
     "BatchNormFwdInferKernel",
     "BatchNormFwdTrainKernel",
     "BinaryKernel",
+    "BmmFp8Kernel",
     "BmmKernel",
     "Conv1dKernel",
     "Conv1dPointwiseKernel",

--- a/tileops/kernels/bmm.py
+++ b/tileops/kernels/bmm.py
@@ -12,7 +12,10 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
-__all__ = ["BmmKernel"] # from tileops.kernels.bmm import *
+__all__ = [
+    "BmmFp8Kernel",
+    "BmmKernel",
+]  # from tileops.kernels.bmm import *
 
 
 @functools.lru_cache(maxsize=64)
@@ -115,6 +118,479 @@ def _bmm_kernel(batch: int,
     return _bmm_func
 
 
+@functools.lru_cache(maxsize=32)
+def _bmm_fp8_kernel(
+    batch: int,
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+) -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+            "tl.disable_warp_specialized": False,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _bmm_fp8_func(
+        block_m: int = 128,
+        block_n: int = 128,
+        block_k: int = 64,
+        num_stages: int = 3,
+        threads: int = 256,
+    ) -> Callable:
+        scale_a_shape = (1,)
+        scale_b_shape = (1,)
+        k_exact = (k % block_k == 0)
+        n_exact = (n % block_n == 0)
+        m_exact = (m % block_m == 0)
+
+        @T.prim_func
+        def _bmm_fp8_main(
+            a: T.Tensor((batch, m, k), dtype),  # type: ignore
+            b: T.Tensor((batch, n, k), dtype),  # type: ignore  # N-major B
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            c: T.Tensor((batch, m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(
+                    T.ceildiv(n, block_n),
+                    T.ceildiv(m, block_m),
+                    batch,
+                    threads=threads) as (bx, by, bz):
+                a_shared = T.alloc_shared((block_m, block_k), dtype)
+                b_shared = T.alloc_shared((block_n, block_k), dtype)
+                c_shared = T.alloc_shared((block_m, block_n), out_dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout({
+                    a_shared: tilelang.layout.make_swizzled_layout(a_shared),
+                    b_shared: tilelang.layout.make_swizzled_layout(b_shared),
+                    c_shared: tilelang.layout.make_swizzled_layout(c_shared),
+                })
+
+                m_start = by * block_m
+                n_start = bx * block_n
+                T.clear(c_local)
+
+                for kk in T.Pipelined(
+                        T.ceildiv(k, block_k),
+                        num_stages=num_stages):
+                    k_start = kk * block_k
+                    if k_exact and m_exact:
+                        T.copy(
+                            a[bz,
+                              m_start:m_start + block_m,
+                              k_start:k_start + block_k],
+                            a_shared,
+                        )
+                    else:
+                        for i, j in T.Parallel(block_m, block_k):
+                            a_shared[i, j] = T.if_then_else(
+                                (m_start + i < m) & (k_start + j < k),
+                                a[bz, m_start + i, k_start + j],
+                                T.cast(0, dtype),
+                            )
+                    if k_exact and n_exact:
+                        T.copy(
+                            b[bz,
+                              n_start:n_start + block_n,
+                              k_start:k_start + block_k],
+                            b_shared,
+                        )
+                    else:
+                        for i, j in T.Parallel(block_n, block_k):
+                            b_shared[i, j] = T.if_then_else(
+                                (n_start + i < n) & (k_start + j < k),
+                                b[bz, n_start + i, k_start + j],
+                                T.cast(0, dtype),
+                            )
+                    T.gemm(a_shared, b_shared, c_local,
+                           transpose_B=True,
+                           policy=T.GemmWarpPolicy.FullRow)
+                for i, j in T.Parallel(block_m, block_n):
+                    c_local[i, j] = c_local[i, j] * scale_a[0] * scale_b[0]
+                T.copy(c_local, c_shared)
+                for i, j in T.Parallel(block_m, block_n):
+                    if m_start + i < m and n_start + j < n:
+                        c[bz, m_start + i, n_start + j] = c_shared[i, j]
+
+        return _bmm_fp8_main
+
+    return _bmm_fp8_func
+
+
+@functools.lru_cache(maxsize=32)
+def _bmm_fp8_persistent_kernel(
+    batch: int,
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    sm_count: int,
+) -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+            "tl.disable_warp_specialized": True,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _bmm_fp8_persistent_func(
+        block_m: int = 128,
+        block_n: int = 128,
+        block_k: int = 64,
+        num_stages: int = 3,
+        threads: int = 256,
+    ) -> Callable:
+        scale_a_shape = (1,)
+        scale_b_shape = (1,)
+        @T.prim_func
+        def _bmm_fp8_persistent_main(
+            a: T.Tensor((batch, m, k), dtype),  # type: ignore
+            b: T.Tensor((batch, n, k), dtype),  # type: ignore  # N-major B
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            c: T.Tensor((batch, m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(sm_count, 1, 1, threads=threads) as (bx, _by, _bz):
+                a_shared = T.alloc_shared((block_m, block_k), dtype)
+                b_shared = T.alloc_shared((block_n, block_k), dtype)
+                c_shared = T.alloc_shared((block_m, block_n), out_dtype)
+                c_local = T.alloc_fragment((block_m, block_n), accum_dtype)
+
+                T.annotate_layout({
+                    a_shared: tilelang.layout.make_swizzled_layout(a_shared),
+                    b_shared: tilelang.layout.make_swizzled_layout(b_shared),
+                    c_shared: tilelang.layout.make_swizzled_layout(c_shared),
+                })
+
+                for tile_b, tile_m, tile_n in T.Persistent(
+                        [batch, T.ceildiv(m, block_m), T.ceildiv(n, block_n)],
+                        wave_size=sm_count,
+                        index=bx,
+                        group_size=8):
+                    m_start = tile_m * block_m
+                    n_start = tile_n * block_n
+                    T.clear(c_local)
+
+                    for kk in T.Pipelined(
+                            T.ceildiv(k, block_k),
+                            num_stages=num_stages):
+                        k_start = kk * block_k
+                        T.copy(
+                            a[tile_b,
+                              m_start:m_start + block_m,
+                              k_start:k_start + block_k],
+                            a_shared,
+                        )
+                        T.copy(
+                            b[tile_b,
+                              n_start:n_start + block_n,
+                              k_start:k_start + block_k],
+                            b_shared,
+                        )
+                        T.gemm(a_shared, b_shared, c_local,
+                               transpose_B=True,
+                               policy=T.GemmWarpPolicy.FullRow)
+                    for i, j in T.Parallel(block_m, block_n):
+                        c_local[i, j] = (
+                            c_local[i, j] * scale_a[0] * scale_b[0])
+                    T.copy(c_local, c_shared)
+                    T.copy(c_shared, c[tile_b,
+                                       m_start:m_start + block_m,
+                                       n_start:n_start + block_n])
+
+        return _bmm_fp8_persistent_main
+
+    return _bmm_fp8_persistent_func
+
+
+@functools.lru_cache(maxsize=32)
+def _bmm_fp8_persistent_ws_kernel(
+    batch: int,
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    out_dtype: str,
+    sm_count: int,
+) -> Callable:
+    accum_dtype = "float"
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+            "tl.disable_warp_specialized": True,
+        },
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def _bmm_fp8_persistent_ws_func(
+        block_m: int = 128,
+        block_n: int = 128,
+        block_k: int = 128,
+        num_stages: int = 3,
+        threads: int = 384,
+        group_size_m: int = 8,
+    ) -> Callable:
+        assert threads == 384, (
+            f"3-WG persistent WS BMM requires threads=384 "
+            f"(1 producer + 2 consumer WGs); got threads={threads}"
+        )
+        assert block_m % 2 == 0 and block_m // 2 >= 64, (
+            f"cooperative template needs block_m>=128 and even; got {block_m}"
+        )
+        assert m % block_m == 0 and n % block_n == 0 and k % block_k == 0, (
+            f"WS variant requires aligned tile; got m={m}, n={n}, k={k}, "
+            f"block=({block_m},{block_n},{block_k})"
+        )
+        half_m = block_m // 2
+        num_pid_m = m // block_m
+        num_pid_n = n // block_n
+        k_iters = k // block_k
+        assert k_iters >= 2, (
+            f"WS variant needs k_iters>=2 for the 1-deep WGMMA pipeline; "
+            f"got k={k}, block_k={block_k}, k_iters={k_iters}"
+        )
+        total_tiles = batch * num_pid_m * num_pid_n
+        grid_cta = min(sm_count, total_tiles)
+        max_waves = (total_tiles + grid_cta - 1) // grid_cta + 1
+
+        scale_a_shape = (1,)
+        scale_b_shape = (1,)
+        @T.macro
+        def _swizzle_decode(mn_id, swz_m, swz_n):
+            _gin = T.int32(group_size_m * num_pid_n)
+            _fpm = (mn_id // _gin) * T.int32(group_size_m)
+            if T.int32(num_pid_m) - _fpm >= T.int32(group_size_m):
+                swz_m[0] = _fpm + (mn_id % _gin) % T.int32(group_size_m)
+                swz_n[0] = (mn_id % _gin) // T.int32(group_size_m)
+            else:
+                _gsm = T.int32(num_pid_m) - _fpm
+                swz_m[0] = _fpm + (mn_id % _gin) % _gsm
+                swz_n[0] = (mn_id % _gin) // _gsm
+
+        @T.prim_func
+        def _bmm_fp8_persistent_ws_main(
+            a: T.Tensor((batch, m, k), dtype),  # type: ignore
+            b: T.Tensor((batch, n, k), dtype),  # type: ignore  # N-major B
+            scale_a: T.Tensor(scale_a_shape, "float32"),  # type: ignore
+            scale_b: T.Tensor(scale_b_shape, "float32"),  # type: ignore
+            c: T.Tensor((batch, m, n), out_dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(grid_cta, threads=threads) as (pid,):
+                A_smem_top = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                A_smem_bot = T.alloc_shared((num_stages, half_m, block_k), dtype)
+                B_smem = T.alloc_shared((num_stages, block_n, block_k), dtype)
+
+                # Per-WG half-tile fp32 accumulator and dtype cast staging.
+                C_local_wg0 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                C_local_wg1 = T.alloc_fragment((half_m, block_n), accum_dtype)
+                C_local_cast_wg0 = T.alloc_fragment((half_m, block_n), out_dtype)
+                C_local_cast_wg1 = T.alloc_fragment((half_m, block_n), out_dtype)
+                C_shared_wg0 = T.alloc_shared((half_m, block_n), out_dtype)
+                C_shared_wg1 = T.alloc_shared((half_m, block_n), out_dtype)
+
+                bs = T.alloc_local((1,), "int32")   # batch id
+                ms = T.alloc_local((1,), "int32")   # M start (rows)
+                ns_ = T.alloc_local((1,), "int32")  # N start (cols)
+
+                ps0 = T.alloc_local((1,), "int32")
+                ps1 = T.alloc_local((1,), "int32")
+
+                swz_m = T.alloc_local((1,), "int32")
+                swz_n = T.alloc_local((1,), "int32")
+
+                T.annotate_layout({
+                    A_smem_top: tilelang.layout.make_swizzled_layout(A_smem_top),
+                    A_smem_bot: tilelang.layout.make_swizzled_layout(A_smem_bot),
+                    B_smem: tilelang.layout.make_swizzled_layout(B_smem),
+                    C_shared_wg0: tilelang.layout.make_swizzled_layout(C_shared_wg0),
+                    C_shared_wg1: tilelang.layout.make_swizzled_layout(C_shared_wg1),
+                })
+
+
+                ab_full = T.alloc_barrier([128] * num_stages)
+                ab_empty = T.alloc_barrier([256] * num_stages)
+
+                gi_prod = T.alloc_var("int32", init=0)
+                gi_cons_0 = T.alloc_var("int32", init=0)
+                gi_cons_1 = T.alloc_var("int32", init=0)
+
+                tx = T.get_thread_binding()
+
+                # ═════════════════════════════════════════════════════════
+                # Producer WG: tx < 128
+                # ═════════════════════════════════════════════════════════
+                if tx < 128:
+                    T.dec_max_nreg(24)
+
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid_cta) * w + pid
+
+                        if flat_id < T.int32(total_tiles):
+                            # BMM tile decode: flat_id = tile_b * (Mt*Nt) + mn_id
+                            bs[0] = flat_id // T.int32(num_pid_m * num_pid_n)
+                            mn_id = flat_id % T.int32(num_pid_m * num_pid_n)
+                            _swizzle_decode(mn_id, swz_m, swz_n)
+                            ms[0] = swz_m[0] * T.int32(block_m)
+                            ns_[0] = swz_n[0] * T.int32(block_n)
+
+                            for kk in T.Pipelined(k_iters, num_stages=0):
+                                k_start = kk * block_k
+                                slot = gi_prod % num_stages
+                                T.barrier_wait(
+                                    ab_empty[slot],
+                                    ((gi_prod // num_stages) & 1) ^ 1)
+                                # Top half of A (rows ms..ms+half_m).
+                                T.tma_copy(
+                                    a[bs[0],
+                                      ms[0]:ms[0] + half_m,
+                                      k_start:k_start + block_k],
+                                    A_smem_top[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                # Bottom half of A (rows ms+half_m..ms+block_m).
+                                T.tma_copy(
+                                    a[bs[0],
+                                      ms[0] + half_m:ms[0] + block_m,
+                                      k_start:k_start + block_k],
+                                    A_smem_bot[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                # Full B tile shared between the two math WGs.
+                                T.tma_copy(
+                                    b[bs[0],
+                                      ns_[0]:ns_[0] + block_n,
+                                      k_start:k_start + block_k],
+                                    B_smem[slot, :, :],
+                                    barrier=ab_full[slot],
+                                )
+                                T.barrier_arrive(ab_full[slot])
+                                gi_prod = gi_prod + 1
+
+                # ═════════════════════════════════════════════════════════
+                # Consumer WG0: 128 ≤ tx < 256 — top half (rows 0..half_m)
+                # ═════════════════════════════════════════════════════════
+                elif tx < 256:
+                    T.inc_max_nreg(240)
+
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid_cta) * w + pid
+
+                        if flat_id < T.int32(total_tiles):
+                            bs[0] = flat_id // T.int32(num_pid_m * num_pid_n)
+                            mn_id = flat_id % T.int32(num_pid_m * num_pid_n)
+                            _swizzle_decode(mn_id, swz_m, swz_n)
+                            ms[0] = swz_m[0] * T.int32(block_m)
+                            ns_[0] = swz_n[0] * T.int32(block_n)
+
+                            for kk in T.Pipelined(k_iters, num_stages=0):
+                                slot = gi_cons_0 % num_stages
+                                T.barrier_wait(ab_full[slot],
+                                               (gi_cons_0 // num_stages) & 1)
+                                T.wgmma_gemm(
+                                    A_smem_top[slot, :, :],
+                                    B_smem[slot, :, :],
+                                    C_local_wg0,
+                                    transpose_B=True,
+                                    policy=T.GemmWarpPolicy.FullRow,
+                                    clear_accum=(kk == 0),
+                                )
+
+                                if kk > 0:
+                                    T.wait_wgmma(1)
+                                    T.barrier_arrive(ab_empty[ps0[0]])
+                                ps0[0] = slot
+                                gi_cons_0 = gi_cons_0 + 1
+
+                            T.wait_wgmma(0)
+                            T.barrier_arrive(ab_empty[ps0[0]])
+                            T.warpgroup_fence_operand(C_local_wg0, num_regs=64)
+
+                            for i, j in T.Parallel(half_m, block_n):
+                                C_local_wg0[i, j] = (
+                                    C_local_wg0[i, j]
+                                    * scale_a[0] * scale_b[0])
+                            T.copy(C_local_wg0, C_local_cast_wg0)
+
+                            T.sync_threads(barrier_id=4, arrive_count=128)
+                            T.copy(C_local_cast_wg0, C_shared_wg0)
+
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=4, arrive_count=128)
+                            T.copy(C_shared_wg0,
+                                   c[bs[0], ms[0], ns_[0]])
+
+                # ═════════════════════════════════════════════════════════
+                # Consumer WG1: tx ≥ 256 — bottom half (rows half_m..block_m)
+                # ═════════════════════════════════════════════════════════
+                else:
+                    T.inc_max_nreg(240)
+
+                    for w in T.serial(max_waves):
+                        flat_id = T.int32(grid_cta) * w + pid
+
+                        if flat_id < T.int32(total_tiles):
+                            bs[0] = flat_id // T.int32(num_pid_m * num_pid_n)
+                            mn_id = flat_id % T.int32(num_pid_m * num_pid_n)
+                            _swizzle_decode(mn_id, swz_m, swz_n)
+                            ms[0] = swz_m[0] * T.int32(block_m)
+                            ns_[0] = swz_n[0] * T.int32(block_n)
+
+                            for kk in T.Pipelined(k_iters, num_stages=0):
+                                slot = gi_cons_1 % num_stages
+                                T.barrier_wait(ab_full[slot],
+                                               (gi_cons_1 // num_stages) & 1)
+                                T.wgmma_gemm(
+                                    A_smem_bot[slot, :, :],
+                                    B_smem[slot, :, :],
+                                    C_local_wg1,
+                                    transpose_B=True,
+                                    policy=T.GemmWarpPolicy.FullRow,
+                                    clear_accum=(kk == 0),
+                                )
+                                if kk > 0:
+                                    T.wait_wgmma(1)
+                                    T.barrier_arrive(ab_empty[ps1[0]])
+                                ps1[0] = slot
+                                gi_cons_1 = gi_cons_1 + 1
+
+                            T.wait_wgmma(0)
+                            T.barrier_arrive(ab_empty[ps1[0]])
+                            T.warpgroup_fence_operand(C_local_wg1, num_regs=64)
+
+                            # ── Epilogue: scale + cast + TMA-store ──
+                            for i, j in T.Parallel(half_m, block_n):
+                                C_local_wg1[i, j] = (
+                                    C_local_wg1[i, j]
+                                    * scale_a[0] * scale_b[0])
+                            T.copy(C_local_wg1, C_local_cast_wg1)
+                            # WG1's own named barrier (id=5) guards
+                            # C_shared_wg1 reuse across waves.
+                            T.sync_threads(barrier_id=5, arrive_count=128)
+                            T.copy(C_local_cast_wg1, C_shared_wg1)
+                            T.fence_proxy_async()
+                            T.sync_threads(barrier_id=5, arrive_count=128)
+                            T.copy(C_shared_wg1,
+                                   c[bs[0], ms[0] + half_m, ns_[0]])
+
+        return _bmm_fp8_persistent_ws_main
+
+    return _bmm_fp8_persistent_ws_func
+
+
 @torch.library.custom_op("top::bmm_wrapped_kernel", mutates_args=())
 def _bmm_wrapped_kernel(
     batch: int,
@@ -206,3 +682,208 @@ class BmmKernel(Kernel):
         if not hasattr(self, "_compiled_kernel"):
             self._compiled_kernel = self.kernel(**self.config)
         return self._compiled_kernel(a, b)
+
+
+class BmmFp8Kernel(Kernel):
+
+    supported_archs: list[int] = [90]
+
+    def __init__(
+        self,
+        batch: int,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        out_dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        # Every dispatched variant emits WGMMA + TMA (SM90+ only); fail fast
+        # with a clear message on pre-Hopper GPUs instead of a downstream
+        # nvcc / PTX error at JIT time.
+        cc = torch.cuda.get_device_capability(torch.cuda.current_device())
+        if cc[0] != 9:
+            raise NotImplementedError(
+                f"BmmFp8Kernel requires SM90 (Hopper); "
+                f"got sm{cc[0]}{cc[1]} on the current device")
+        if k % 32 != 0:
+            raise ValueError(
+                f"BmmFp8Kernel requires contraction dim k to be a "
+                f"multiple of 32 (FP8 WGMMA K-step), got k={k}")
+        self.batch = batch
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.out_dtype = out_dtype
+        # Dispatch policy (in order of preference):
+        #   1) 3-WG WS persistent (best throughput on aligned shapes);
+        #   2) plain persistent (removes wave quantisation);
+        #   3) classic 3D grid (handles arbitrary M/N tails).
+        self._sm_count = torch.cuda.get_device_properties(
+            torch.cuda.current_device()).multi_processor_count
+        self._use_ws = self._ws_eligible(batch, m, n, k, self._sm_count)
+        self._use_persistent = self._use_ws or self._persistent_eligible(m, n, k)
+        # Kernel expects N-major B (``[B, N, K]``, K innermost) -- see
+        # :func:`_bmm_fp8_kernel`.  Callers with a torch.bmm-style
+        # ``[B, K, N]`` buffer materialise the K-innermost view at the
+        # op layer (:class:`BmmFp8Op`).
+        if self._use_ws:
+            self.kernel = _bmm_fp8_persistent_ws_kernel(
+                batch, m, n, k, self.dtype_str, self.out_dtype_str,
+                self._sm_count)
+        elif self._use_persistent:
+            self.kernel = _bmm_fp8_persistent_kernel(
+                batch, m, n, k, self.dtype_str, self.out_dtype_str,
+                self._sm_count)
+        else:
+            self.kernel = _bmm_fp8_kernel(
+                batch, m, n, k, self.dtype_str, self.out_dtype_str)
+        self.init_config(config, tune)
+
+    # ---- Dispatch predicates ------------------------------------------
+    @staticmethod
+    def _ws_eligible(batch: int, m: int, n: int, k: int,
+                     sm_count: int) -> bool:
+        min_total_tiles = (sm_count * 3 + 1) // 2  # ceil(1.5 * sm_count)
+        for bm in (128, 256):
+            if m % bm != 0 or (bm // 2) < 64:
+                continue
+            for bn in (128, 256):
+                if n % bn != 0:
+                    continue
+                for bk in (64, 128):
+                    if bk > k or k % bk != 0:
+                        continue
+                    if k // bk < 2:
+                        continue
+                    total_tiles = batch * (m // bm) * (n // bn)
+                    if total_tiles < min_total_tiles:
+                        continue
+                    return True
+        return False
+
+    @staticmethod
+    def _persistent_eligible(m: int, n: int, k: int) -> bool:
+        """True iff some ``(bm, bn, bk)`` in the search space divides m/n/k.
+
+        Persistent variant emits unconditional TMA loads (no
+        ``T.if_then_else`` tail path), so it can only run when at least
+        one aligned tile shape exists.  In practice every "regular"
+        BMM shape (``m, n, k`` multiples of 64/64/32) qualifies; only
+        odd tail shapes fall through to :func:`_bmm_fp8_kernel`.
+        """
+        for bm in (64, 128, 256):
+            if m % bm != 0:
+                continue
+            for bn in (64, 128, 256):
+                if n % bn != 0:
+                    continue
+                for bk in (32, 64, 128):
+                    if bk > k or k % bk != 0:
+                        continue
+                    return True
+        return False
+
+    @property
+    def out_dtype_str(self) -> str:
+        return self.dtype_to_str(self.out_dtype)
+
+    @property
+    def default_config(self) -> dict:
+        if self._use_ws:
+            bn = 256 if (self.n % 256 == 0) else 128
+            bk = 128 if (self.k % 128 == 0 and self.k // 128 >= 2) else 64
+            return {
+                "block_m": 128,
+                "block_n": bn,
+                "block_k": bk,
+                "num_stages": 3,
+                "threads": 384,
+                "group_size_m": 8,
+            }
+        return {
+            "block_m": 128,
+            "block_n": 128,
+            "block_k": 128,
+            "num_stages": 3,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        if self._use_ws:
+            SMEM_BUDGET_BYTES = 228 * 1024  # H100/H20 shared-memory cap
+            configs = []
+            for bm in (128,):
+                half_m = bm // 2
+                for bn in (128, 256):
+                    if self.n % bn != 0:
+                        continue
+                    for bk in (64, 128):
+                        if bk > self.k or self.k % bk != 0:
+                            continue
+                        if self.k // bk < 2:
+                            continue
+                        for ns in (2, 3, 4):
+                            smem_main = (
+                                2 * ns * half_m * bk
+                                + ns * bn * bk)  # fp8 = 1B
+                            out_bytes = 2  # bf16/fp16 output
+                            smem_c = 2 * half_m * bn * out_bytes
+                            if smem_main + smem_c > SMEM_BUDGET_BYTES:
+                                continue
+                            for gsm in (1, 4, 8):
+                                configs.append({
+                                    "block_m": bm,
+                                    "block_n": bn,
+                                    "block_k": bk,
+                                    "num_stages": ns,
+                                    "threads": 384,
+                                    "group_size_m": gsm,
+                                })
+            return configs
+
+        SMEM_BUDGET_BYTES = 200 * 1024
+        raw_configs = []
+        for bm in (64, 128, 256):
+            if self._use_persistent and self.m % bm != 0:
+                continue
+            for bn in (64, 128, 256):
+                if self._use_persistent and self.n % bn != 0:
+                    continue
+                for bk in (32, 64, 128):
+                    if bk > self.k:
+                        continue
+                    if self._use_persistent and self.k % bk != 0:
+                        continue
+                    threads = 128 if bm == 64 else 256
+                    for ns in (2, 3, 4):
+                        smem = (bm * bk + bk * bn) * ns  # fp8 = 1B / elem
+                        if smem > SMEM_BUDGET_BYTES:
+                            continue
+                        raw_configs.append({
+                            "block_m": bm,
+                            "block_n": bn,
+                            "block_k": bk,
+                            "num_stages": ns,
+                            "threads": threads,
+                        })
+        return raw_configs
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.dtype != torch.float8_e4m3fn:
+            raise NotImplementedError(
+                f"BmmFp8Kernel only supports torch.float8_e4m3fn, "
+                f"got {self.dtype}")
+        if not hasattr(self, "_compiled_kernel"):
+            self._compiled_kernel = self.kernel(**self.config)
+        return self._compiled_kernel(a, b, scale_a, scale_b)

--- a/tileops/kernels/bmm.py
+++ b/tileops/kernels/bmm.py
@@ -728,11 +728,8 @@ class BmmFp8Kernel(Kernel):
         self._sm_count = torch.cuda.get_device_properties(
             device).multi_processor_count
         self._use_ws = self._ws_eligible(batch, m, n, k, self._sm_count)
-        self._use_persistent = self._use_ws or self._persistent_eligible(m, n, k)
-        # Kernel expects N-major B (``[B, N, K]``, K innermost) -- see
-        # :func:`_bmm_fp8_kernel`.  Callers with a torch.bmm-style
-        # ``[B, K, N]`` buffer materialise the K-innermost view at the
-        # op layer (:class:`BmmFp8Op`).
+        self._use_persistent = self._use_ws or self._persistent_eligible(
+            m, n, k, self._use_ws)
         if self._use_ws:
             self.kernel = _bmm_fp8_persistent_ws_kernel(
                 batch, m, n, k, self.dtype_str, self.out_dtype_str,
@@ -769,26 +766,13 @@ class BmmFp8Kernel(Kernel):
         return False
 
     @staticmethod
-    def _persistent_eligible(m: int, n: int, k: int) -> bool:
-        """True iff some ``(bm, bn, bk)`` in the search space divides m/n/k.
-
-        Persistent variant emits unconditional TMA loads (no
-        ``T.if_then_else`` tail path), so it can only run when at least
-        one aligned tile shape exists.  In practice every "regular"
-        BMM shape (``m, n, k`` multiples of 64/64/32) qualifies; only
-        odd tail shapes fall through to :func:`_bmm_fp8_kernel`.
-        """
-        for bm in (64, 128, 256):
-            if m % bm != 0:
-                continue
-            for bn in (64, 128, 256):
-                if n % bn != 0:
-                    continue
-                for bk in (32, 64, 128):
-                    if bk > k or k % bk != 0:
-                        continue
-                    return True
-        return False
+    def _persistent_eligible(m: int, n: int, k: int, use_ws: bool) -> bool:
+        if use_ws:
+            bn_ok = (n % 128 == 0) or (n % 256 == 0)
+            bk_ok = ((k % 64 == 0 and k // 64 >= 2)
+                     or (k % 128 == 0 and k // 128 >= 2))
+            return m % 128 == 0 and bn_ok and bk_ok
+        return m % 128 == 0 and n % 128 == 0 and k % 128 == 0
 
     @property
     def out_dtype_str(self) -> str:

--- a/tileops/kernels/bmm.py
+++ b/tileops/kernels/bmm.py
@@ -696,6 +696,7 @@ class BmmFp8Kernel(Kernel):
         k: int,
         dtype: torch.dtype,
         out_dtype: torch.dtype,
+        device: Optional[torch.device] = None,
         config: Optional[dict] = None,
         tune: bool = False,
     ) -> None:
@@ -703,7 +704,9 @@ class BmmFp8Kernel(Kernel):
         # Every dispatched variant emits WGMMA + TMA (SM90+ only); fail fast
         # with a clear message on pre-Hopper GPUs instead of a downstream
         # nvcc / PTX error at JIT time.
-        cc = torch.cuda.get_device_capability(torch.cuda.current_device())
+        if device is None:
+            device = torch.device(torch.cuda.current_device())
+        cc = torch.cuda.get_device_capability(device)
         if cc[0] != 9:
             raise NotImplementedError(
                 f"BmmFp8Kernel requires SM90 (Hopper); "
@@ -723,7 +726,7 @@ class BmmFp8Kernel(Kernel):
         #   2) plain persistent (removes wave quantisation);
         #   3) classic 3D grid (handles arbitrary M/N tails).
         self._sm_count = torch.cuda.get_device_properties(
-            torch.cuda.current_device()).multi_processor_count
+            device).multi_processor_count
         self._use_ws = self._ws_eligible(batch, m, n, k, self._sm_count)
         self._use_persistent = self._use_ws or self._persistent_eligible(m, n, k)
         # Kernel expects N-major B (``[B, N, K]``, K innermost) -- see
@@ -861,7 +864,8 @@ class BmmFp8Kernel(Kernel):
                         continue
                     threads = 128 if bm == 64 else 256
                     for ns in (2, 3, 4):
-                        smem = (bm * bk + bk * bn) * ns  # fp8 = 1B / elem
+                        # Include c_shared (bm * bn * 2 bytes) in the budget
+                        smem = (bm * bk + bk * bn) * ns + bm * bn * 2
                         if smem > SMEM_BUDGET_BYTES:
                             continue
                         raw_configs.append({

--- a/tileops/manifest/bmm.yaml
+++ b/tileops/manifest/bmm.yaml
@@ -63,6 +63,7 @@ BmmFp8Op:
       d: {dtype: "bfloat16 | float16", shape: "[B, M, N]"}
     params:
       out_dtype: {type: dtype, default: bfloat16}
+      b_layout: {type: str, default: "kn", choices: ["kn", "nk"]}
     # Only fp8_e4m3fn inputs are supported (fp8_e5m2 is rejected at
     # forward-time by :meth:`BmmFp8Op._validate_dtypes`); output picks
     # a single dtype per compile.  ``dtype_combos`` pins the Cartesian
@@ -72,11 +73,11 @@ BmmFp8Op:
       - {a: float8_e4m3fn, b: float8_e4m3fn, scale_a: float32, scale_b: float32, d: float16}
     shape_rules:
     - "a.shape[0] == b.shape[0]"
-    - "b.shape[1] == a.shape[2] or b.shape[2] == a.shape[2]"
+    - "(b.shape[1] == a.shape[2]) if b_layout == 'kn' else (b.shape[2] == a.shape[2])"
     - "a.shape[2] % 32 == 0"
     # per_tensor: single global fp32 scalar (0-D) shared across the whole batch
     - "scale_a.shape == () and scale_b.shape == ()"
-    - "d.shape == (a.shape[0], a.shape[1], (b.shape[2] if b.shape[1]==a.shape[2] else b.shape[1]))"
+    - "d.shape == (a.shape[0], a.shape[1], b.shape[2] if b_layout == 'kn' else b.shape[1])"
 
   workloads:
   - {b: 4, m: 1024, n: 1024, k: 1024, dtypes: [float8_e4m3fn], label: "square-b4-1k-per-tensor"}

--- a/tileops/manifest/bmm.yaml
+++ b/tileops/manifest/bmm.yaml
@@ -44,3 +44,55 @@ BmmFwdOp:
     bench_manifest_driven: true
     kernel_map:
       bmm_kernel: BmmKernel
+
+# BmmFp8Op: strict 3D-3D batched FP8 GEMM with per-tensor scaling.
+# A single fp32 scalar per operand is shared across the whole batch,
+# mirroring flashinfer.bmm_fp8's A_scale / B_scale signature 1:1.
+BmmFp8Op:
+  ref_api: "none"
+  family: bmm
+  status: implemented
+
+  signature:
+    inputs:
+      a: {dtype: "float8_e4m3fn", shape: "[B, M, K]"}
+      b: {dtype: "same_as(a)", shape: "[B, K, N] | [B, N, K]"}
+      scale_a: {dtype: "float32"}
+      scale_b: {dtype: "float32"}
+    outputs:
+      d: {dtype: "bfloat16 | float16", shape: "[B, M, N]"}
+    params:
+      out_dtype: {type: dtype, default: bfloat16}
+    # Only fp8_e4m3fn inputs are supported (fp8_e5m2 is rejected at
+    # forward-time by :meth:`BmmFp8Op._validate_dtypes`); output picks
+    # a single dtype per compile.  ``dtype_combos`` pins the Cartesian
+    # product so validators do not treat (e5m2, *) as legal.
+    dtype_combos:
+      - {a: float8_e4m3fn, b: float8_e4m3fn, scale_a: float32, scale_b: float32, d: bfloat16}
+      - {a: float8_e4m3fn, b: float8_e4m3fn, scale_a: float32, scale_b: float32, d: float16}
+    shape_rules:
+    - "a.shape[0] == b.shape[0]"
+    - "b.shape[1] == a.shape[2] or b.shape[2] == a.shape[2]"
+    - "a.shape[2] % 32 == 0"
+    # per_tensor: single global fp32 scalar (0-D) shared across the whole batch
+    - "scale_a.shape == () and scale_b.shape == ()"
+    - "d.shape == (a.shape[0], a.shape[1], (b.shape[2] if b.shape[1]==a.shape[2] else b.shape[1]))"
+
+  workloads:
+  - {b: 4, m: 1024, n: 1024, k: 1024, dtypes: [float8_e4m3fn], label: "square-b4-1k-per-tensor"}
+  - {b: 8, m: 2048, n: 2048, k: 2048, dtypes: [float8_e4m3fn], label: "square-b8-2k-per-tensor"}
+  - {b: 32, m: 128, n: 128, k: 2048, dtypes: [float8_e4m3fn], label: "mha-decode-b32-pv-per-tensor"}
+  - {b: 64, m: 128, n: 2048, k: 128, dtypes: [float8_e4m3fn], label: "mha-decode-b64-qk-per-tensor"}
+  - {b: 128, m: 512, n: 512, k: 2048, dtypes: [float8_e4m3fn], label: "moe-prefill-b128-per-tensor"}
+
+  roofline:
+    func: "tileops.perf.formulas.bmm_fp8_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/bmm.py
+    op: tileops/ops/bmm.py
+    test: tests/ops/test_bmm.py
+    bench: benchmarks/ops/bench_bmm.py
+    bench_manifest_driven: true
+    kernel_map:
+      bmm_fp8_kernel: BmmFp8Kernel

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -19,7 +19,7 @@ from .attention import (
     NSAFwdVarlenOp,
     NSATopkVarlenOp,
 )
-from .bmm import BmmFwdOp
+from .bmm import BmmFp8Op, BmmFwdOp
 from .convolution import (
     Conv1dBiasFwdOp,
     Conv1dFwdOp,
@@ -114,6 +114,7 @@ __all__ = [
     "AdaLayerNormZeroFwdOp",
     "BatchNormBwdOp",
     "BatchNormFwdOp",
+    "BmmFp8Op",
     "BmmFwdOp",
     "Conv1dBiasFwdOp",
     "Conv1dFwdOp",

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -163,10 +163,6 @@ class BmmFp8Op(Op):
 
     def __init__(
         self,
-        # ``out_dtype`` accepts either ``torch.dtype`` or a string alias
-        # (``"bfloat16"`` / ``"float16"``) so callers driven by the
-        # manifest loader -- which passes YAML string defaults -- can
-        # instantiate the op without an explicit conversion.
         out_dtype: torch.dtype | str = "bfloat16",
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
@@ -206,6 +202,17 @@ class BmmFp8Op(Op):
         scale_a: torch.Tensor,
         scale_b: torch.Tensor,
     ) -> None:
+        if not a.is_cuda:
+            raise ValueError(
+                f"BmmFp8Op expects all inputs to be on CUDA, got device {a.device}"
+            )
+        if (b.device != a.device or scale_a.device != a.device
+                or scale_b.device != a.device):
+            raise ValueError(
+                f"BmmFp8Op expects all inputs to be on the same CUDA device, got "
+                f"a: {a.device}, b: {b.device}, scale_a: {scale_a.device}, "
+                f"scale_b: {scale_b.device}"
+            )
         if a.dtype != torch.float8_e4m3fn:
             raise ValueError(
                 f"BmmFp8Op only supports torch.float8_e4m3fn, got {a.dtype}")
@@ -278,12 +285,14 @@ class BmmFp8Op(Op):
         n: int,
         k: int,
         dtype: torch.dtype,
+        device: torch.device,
     ) -> Kernel:
-        key = (batch, m, n, k, dtype, self.out_dtype)
+        key = (batch, m, n, k, dtype, self.out_dtype, device)
         kernel = self._kernel_cache.get(key)
         if kernel is None:
             kernel = self.kernel_map["bmm_fp8_kernel"](
-                batch, m, n, k, dtype, self.out_dtype, tune=self._tune)
+                batch, m, n, k, dtype, self.out_dtype, device=device,
+                tune=self._tune)
             self._kernel_cache[key] = kernel
         return kernel
 
@@ -294,10 +303,6 @@ class BmmFp8Op(Op):
         scale_a: torch.Tensor,
         scale_b: torch.Tensor,
     ) -> torch.Tensor:
-        # ``b.stride()`` is part of the signature because layout inference
-        # for the K == N case falls back to ``b.stride(-2) == 1`` (see
-        # :meth:`_infer_bmnk`); a stride change without a shape change can
-        # therefore flip the KN/NK dispatch and must invalidate the cache.
         sig = (
             a.shape,
             b.shape,
@@ -321,7 +326,7 @@ class BmmFp8Op(Op):
             self.scale_a_shape = tuple(scale_a.shape)
             self.scale_b_shape = tuple(scale_b.shape)
             self._b_is_nk = b_is_nk
-            kernel = self._get_kernel(batch, m, n, k, a.dtype)
+            kernel = self._get_kernel(batch, m, n, k, a.dtype, device=a.device)
             self._active = kernel
             self._active_sig = sig
         if self._b_is_nk:

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -166,6 +166,7 @@ class BmmFp8Op(Op):
         out_dtype: torch.dtype | str = "bfloat16",
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        b_layout: str = "kn",
     ) -> None:
         if isinstance(out_dtype, str):
             out_dtype = getattr(torch, out_dtype)
@@ -173,8 +174,12 @@ class BmmFp8Op(Op):
             raise ValueError(
                 f"BmmFp8Op outputs torch.float16 or torch.bfloat16, "
                 f"got {out_dtype}")
+        if b_layout not in ("kn", "nk"):
+            raise ValueError(
+                f"BmmFp8Op b_layout must be 'kn' or 'nk', got {b_layout!r}")
         self.out_dtype = out_dtype
         self._tune = tune
+        self.b_layout = b_layout
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[Hashable, Kernel] = {}
         self._active_sig: Optional[tuple] = None
@@ -202,17 +207,6 @@ class BmmFp8Op(Op):
         scale_a: torch.Tensor,
         scale_b: torch.Tensor,
     ) -> None:
-        if not a.is_cuda:
-            raise ValueError(
-                f"BmmFp8Op expects all inputs to be on CUDA, got device {a.device}"
-            )
-        if (b.device != a.device or scale_a.device != a.device
-                or scale_b.device != a.device):
-            raise ValueError(
-                f"BmmFp8Op expects all inputs to be on the same CUDA device, got "
-                f"a: {a.device}, b: {b.device}, scale_a: {scale_a.device}, "
-                f"scale_b: {scale_b.device}"
-            )
         if a.dtype != torch.float8_e4m3fn:
             raise ValueError(
                 f"BmmFp8Op only supports torch.float8_e4m3fn, got {a.dtype}")
@@ -225,11 +219,6 @@ class BmmFp8Op(Op):
         self, a: torch.Tensor, b: torch.Tensor,
     ) -> Tuple[int, int, int, int, bool]:
         """Derive logical ``(batch, m, n, k, b_is_nk)`` from ``a`` and ``b``.
-
-        ``a`` must be ``[B, M, K]``.  ``b`` may be either ``[B, K, N]``
-        (torch.bmm layout, N-innermost) or ``[B, N, K]`` (K-innermost,
-        the layout the WGMMA-fp8 TN kernel wants directly).  Returns
-        ``b_is_nk=True`` when the second form is detected.
         """
         if a.dim() != 3 or b.dim() != 3:
             raise ValueError(
@@ -244,17 +233,21 @@ class BmmFp8Op(Op):
                 f"BmmFp8Op batch dim mismatch: a.shape[0]={batch_a} vs "
                 f"b.shape[0]={batch_b}"
             )
-        # Layout inference: which axis of B carries the contraction K?
-        kn_ok = (b1 == k)  # b is [B, K, N]
-        nk_ok = (b2 == k)  # b is [B, N, K]
-        if not (kn_ok or nk_ok):
-            raise ValueError(
-                f"BmmFp8Op contraction dim mismatch: a contributes K={k}, "
-                f"but b.shape={tuple(b.shape)} matches neither [B,K,N] "
-                f"(needs b.shape[1]==K) nor [B,N,K] (needs b.shape[2]==K)."
-            )
-        b_is_nk = (b.stride(-2) == 1) if kn_ok and nk_ok else nk_ok
-        n = b1 if b_is_nk else b2
+        if self.b_layout == "nk":
+            if b2 != k:
+                raise ValueError(
+                    f"BmmFp8Op b_layout='nk' but b={tuple(b.shape)} is not a "
+                    f"valid [B,N,K] (needs b.shape[2]==K={k})"
+                )
+            n, b_is_nk = b1, True
+        else:  # 'kn'
+            if b1 != k:
+                raise ValueError(
+                    f"BmmFp8Op contraction dim mismatch: a contributes K={k}, "
+                    f"but b.shape={tuple(b.shape)} is not a valid [B,K,N] "
+                    f"(needs b.shape[1]==K={k})."
+                )
+            n, b_is_nk = b2, False
         if k % 32 != 0:
             raise ValueError(
                 f"BmmFp8Op requires contraction dim K to be a multiple of "
@@ -268,6 +261,17 @@ class BmmFp8Op(Op):
         scale_a: torch.Tensor,
         scale_b: torch.Tensor,
     ) -> Tuple[int, int, int, int, bool]:
+        if not a.is_cuda:
+            raise ValueError(
+                f"BmmFp8Op expects all inputs to be on CUDA, got device {a.device}"
+            )
+        if (b.device != a.device or scale_a.device != a.device
+                or scale_b.device != a.device):
+            raise ValueError(
+                f"BmmFp8Op expects all inputs to be on the same CUDA device, got "
+                f"a: {a.device}, b: {b.device}, scale_a: {scale_a.device}, "
+                f"scale_b: {scale_b.device}"
+            )
         batch, m, n, k, b_is_nk = self._infer_bmnk(a, b)
         if scale_a.dim() != 0 or scale_b.dim() != 0:
             raise ValueError(

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -4,16 +4,17 @@ Strict 3D-3D batched matrix multiplication matching ``torch.bmm``: every
 batch item is an independent GEMM, no broadcasting.
 """
 
-from typing import Dict, Hashable, Optional, Tuple
+import warnings
+from typing import Dict, Hashable, Optional, Set, Tuple
 
 import torch
 
-from tileops.kernels.bmm import BmmKernel
+from tileops.kernels.bmm import BmmFp8Kernel, BmmKernel
 from tileops.kernels.kernel_base import Kernel
 
 from .op_base import Op
 
-__all__ = ["BmmFwdOp"]
+__all__ = ["BmmFp8Op", "BmmFwdOp"]
 
 
 class BmmFwdOp(Op):
@@ -140,5 +141,212 @@ class BmmFwdOp(Op):
         than as direct attributes, so the base ``Op.autotune`` (which scans
         ``dir(self)``) would miss them. Tune each cached kernel instead.
         """
+        for kernel in self._kernel_cache.values():
+            kernel.autotune()
+
+
+class BmmFp8Op(Op):
+    """Batched FP8 GEMM: ``d[i] = (a[i] @ b[i]) * scale_a * scale_b``.
+    Args:
+        out_dtype: Output tensor dtype (``torch.float16`` or ``torch.bfloat16``).
+        kernel_map: Optional kernel override dict.
+        tune: Whether to autotune (applied when a kernel is first built).
+
+    Example:
+        >>> op = BmmFp8Op(out_dtype=torch.bfloat16)
+        >>> # Default path: b is [B,K,N] (torch.bmm layout).
+        >>> d = op(a, b_kn, scale_a, scale_b)
+        >>> # Fast path: b is [B,N,K] (K-innermost), zero-copy into kernel.
+        >>> d = op(a, b_nk, scale_a, scale_b)
+        >>> flops, nbytes = op.eval_roofline()    # valid after the forward
+    """
+
+    def __init__(
+        self,
+        # ``out_dtype`` accepts either ``torch.dtype`` or a string alias
+        # (``"bfloat16"`` / ``"float16"``) so callers driven by the
+        # manifest loader -- which passes YAML string defaults -- can
+        # instantiate the op without an explicit conversion.
+        out_dtype: torch.dtype | str = "bfloat16",
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        if isinstance(out_dtype, str):
+            out_dtype = getattr(torch, out_dtype)
+        if out_dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                f"BmmFp8Op outputs torch.float16 or torch.bfloat16, "
+                f"got {out_dtype}")
+        self.out_dtype = out_dtype
+        self._tune = tune
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[Hashable, Kernel] = {}
+        self._active_sig: Optional[tuple] = None
+        self._active: Optional[Kernel] = None
+        # Shape-signatures for which we've already emitted the "slow path"
+        # warning; keeps a single BmmFp8Op from spamming the log on every
+        # forward when a caller consistently passes b in [B,K,N] layout.
+        self._kn_warned: Set[Tuple[int, int, int, int]] = set()
+        self.batch: Optional[int] = None
+        self.m: Optional[int] = None
+        self.n: Optional[int] = None
+        self.k: Optional[int] = None
+        self.dtype: Optional[torch.dtype] = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "bmm_fp8_kernel": BmmFp8Kernel,
+        }
+
+    def _validate_dtypes(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> None:
+        if a.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"BmmFp8Op only supports torch.float8_e4m3fn, got {a.dtype}")
+        if b.dtype != a.dtype:
+            raise ValueError(f"BmmFp8Op expects b dtype {a.dtype}, got {b.dtype}")
+        if scale_a.dtype != torch.float32 or scale_b.dtype != torch.float32:
+            raise ValueError("BmmFp8Op expects scale_a and scale_b to be torch.float32")
+
+    def _infer_bmnk(
+        self, a: torch.Tensor, b: torch.Tensor,
+    ) -> Tuple[int, int, int, int, bool]:
+        """Derive logical ``(batch, m, n, k, b_is_nk)`` from ``a`` and ``b``.
+
+        ``a`` must be ``[B, M, K]``.  ``b`` may be either ``[B, K, N]``
+        (torch.bmm layout, N-innermost) or ``[B, N, K]`` (K-innermost,
+        the layout the WGMMA-fp8 TN kernel wants directly).  Returns
+        ``b_is_nk=True`` when the second form is detected.
+        """
+        if a.dim() != 3 or b.dim() != 3:
+            raise ValueError(
+                f"BmmFp8Op expects strict 3D inputs a=[B,M,K] and "
+                f"b=[B,K,N] or [B,N,K] (got a.shape={tuple(a.shape)}, "
+                f"b.shape={tuple(b.shape)})"
+            )
+        batch_a, m, k = a.shape
+        batch_b, b1, b2 = b.shape
+        if batch_a != batch_b:
+            raise ValueError(
+                f"BmmFp8Op batch dim mismatch: a.shape[0]={batch_a} vs "
+                f"b.shape[0]={batch_b}"
+            )
+        # Layout inference: which axis of B carries the contraction K?
+        kn_ok = (b1 == k)  # b is [B, K, N]
+        nk_ok = (b2 == k)  # b is [B, N, K]
+        if not (kn_ok or nk_ok):
+            raise ValueError(
+                f"BmmFp8Op contraction dim mismatch: a contributes K={k}, "
+                f"but b.shape={tuple(b.shape)} matches neither [B,K,N] "
+                f"(needs b.shape[1]==K) nor [B,N,K] (needs b.shape[2]==K)."
+            )
+        b_is_nk = (b.stride(-2) == 1) if kn_ok and nk_ok else nk_ok
+        n = b1 if b_is_nk else b2
+        if k % 32 != 0:
+            raise ValueError(
+                f"BmmFp8Op requires contraction dim K to be a multiple of "
+                f"32 (FP8 WGMMA K-step), got K={k}")
+        return batch_a, m, n, k, b_is_nk
+
+    def _validate_shapes(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> Tuple[int, int, int, int, bool]:
+        batch, m, n, k, b_is_nk = self._infer_bmnk(a, b)
+        if scale_a.dim() != 0 or scale_b.dim() != 0:
+            raise ValueError(
+                "BmmFp8Op supports scale shapes ()/() only (per-tensor, "
+                "global fp32 scalar shared across the batch, matching "
+                "flashinfer.bmm_fp8's A_scale/B_scale), got "
+                f"{tuple(scale_a.shape)}/{tuple(scale_b.shape)}"
+            )
+        return batch, m, n, k, b_is_nk
+
+    def _get_kernel(
+        self,
+        batch: int,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+    ) -> Kernel:
+        key = (batch, m, n, k, dtype, self.out_dtype)
+        kernel = self._kernel_cache.get(key)
+        if kernel is None:
+            kernel = self.kernel_map["bmm_fp8_kernel"](
+                batch, m, n, k, dtype, self.out_dtype, tune=self._tune)
+            self._kernel_cache[key] = kernel
+        return kernel
+
+    def forward(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+    ) -> torch.Tensor:
+        # ``b.stride()`` is part of the signature because layout inference
+        # for the K == N case falls back to ``b.stride(-2) == 1`` (see
+        # :meth:`_infer_bmnk`); a stride change without a shape change can
+        # therefore flip the KN/NK dispatch and must invalidate the cache.
+        sig = (
+            a.shape,
+            b.shape,
+            b.stride(),
+            scale_a.shape,
+            scale_b.shape,
+            a.dtype,
+            b.dtype,
+            scale_a.dtype,
+            scale_b.dtype,
+            self.out_dtype,
+        )
+        if sig != self._active_sig:
+            self._validate_dtypes(a, b, scale_a, scale_b)
+            batch, m, n, k, b_is_nk = self._validate_shapes(
+                a, b, scale_a, scale_b)
+            self.batch, self.m, self.n, self.k = batch, m, n, k
+            self.dtype = a.dtype
+            self.a_shape = tuple(a.shape)
+            self.b_shape = tuple(b.shape)
+            self.scale_a_shape = tuple(scale_a.shape)
+            self.scale_b_shape = tuple(scale_b.shape)
+            self._b_is_nk = b_is_nk
+            kernel = self._get_kernel(batch, m, n, k, a.dtype)
+            self._active = kernel
+            self._active_sig = sig
+        if self._b_is_nk:
+            b = b.contiguous()
+        else:
+            # Slow path: [B,K,N] layout requires an extra DtoD transpose
+            # before the fp8-TN WGMMA kernel can consume it. Emit a one-shot
+            # warning per (B,M,N,K) shape so users know how to opt into the
+            # zero-copy fast path (pass b as [B,N,K]).
+            shape_key = (self.batch, self.m, self.n, self.k)
+            if shape_key not in self._kn_warned:
+                self._kn_warned.add(shape_key)
+                warnings.warn(
+                    f"BmmFp8Op: b has layout [B,K,N] (shape={self.b_shape}); "
+                    f"triggering an extra transpose(-2,-1).contiguous() DtoD "
+                    f"copy before the fp8-TN WGMMA kernel. For best "
+                    f"performance pass b as [B,N,K] (K-innermost) for the "
+                    f"zero-copy fast path.",
+                    stacklevel=2,
+                )
+            b = b.transpose(-2, -1).contiguous()
+        scale_a = scale_a.reshape(1)
+        scale_b = scale_b.reshape(1)
+        return self._active(a, b, scale_a, scale_b)
+
+    def autotune(self) -> None:
         for kernel in self._kernel_cache.values():
             kernel.autotune()

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -1371,3 +1371,35 @@ def bmm_fwd_roofline(op: "Op") -> tuple[int, int]:
     flops = 2 * batch * m * n * k
     nbytes = batch * (m * k + n * k + m * n) * elem_bytes
     return int(flops), int(nbytes)
+
+
+def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for batched FP8 GEMM ``BmmFp8Op``.
+
+    Broadcast-free 3D-3D semantics scaled by the batch factor; matches
+    the fp16 ``bmm_fwd_roofline`` layout of ``a: [B, M, K]`` and
+    ``b: [B, K, N]``. The op is per-tensor-only and doesn't fuse a
+    bias, so the ``nbytes`` accounting has exactly three terms:
+
+      * ``B * M * K``  fp8 input bytes (A)
+      * ``B * K * N``  fp8 input bytes (B)
+      * ``B * M * N``  ``out_dtype`` bytes (C)
+      * ``+ 8``        two fp32 per-tensor scalars (A_scale, B_scale),
+                       batch-independent -- a single global scale per
+                       operand shared across the whole batch, matching
+                       ``flashinfer.bmm_fp8``'s ``A_scale`` / ``B_scale``.
+
+    Valid only after the first ``forward()`` (dims/dtype are inferred
+    from the inputs then).
+    """
+    if getattr(op, "m", None) is None or getattr(op, "dtype", None) is None:
+        raise RuntimeError(
+            "BmmFp8Op.eval_roofline() is valid only after the first forward(); "
+            "batch/m/n/k and dtype are inferred from the inputs."
+        )
+    batch, m, n, k = op.batch, op.m, op.n, op.k
+    input_bytes = op.dtype.itemsize
+    out_bytes = op.out_dtype.itemsize
+    flops = 2 * batch * m * n * k
+    nbytes = batch * ((m * k + n * k) * input_bytes + m * n * out_bytes) + 8
+    return int(flops), int(nbytes)

--- a/workloads/bmm.py
+++ b/workloads/bmm.py
@@ -17,3 +17,60 @@ class BmmWorkload(WorkloadBase):
         a = torch.randn(self.batch, self.m, self.k, device="cuda", dtype=self.dtype)
         b = torch.randn(self.batch, self.k, self.n, device="cuda", dtype=self.dtype)
         return a, b
+
+
+# randn * _FP8_INIT_SCALE keeps generated values roughly within ~4 sigma of the
+# fp8_e4m3fn dynamic range (+/-448) so K-loop accumulation up to K ~= 8192 does
+# not saturate.  Kept at module scope so downstream tests can import and reason
+# about the magnitude without re-guessing the magic number.
+_FP8_INIT_SCALE: float = 0.25
+
+
+class BmmFp8Workload(WorkloadBase):
+    """Workload for batched FP8 GEMM.
+
+    Layout contract
+    ---------------
+    * ``a`` is produced in ``[B, M, K]`` (K-contiguous, matches manifest input
+      ``a`` signature).
+    * ``b`` is produced in ``[B, K, N]`` (N-contiguous).  This is the *KN*
+      layout advertised by the manifest as the primary path.  The alternate
+      ``[B, N, K]`` layout accepted by ``BmmFp8Op`` is exercised directly in
+      ``tests/ops/test_bmm.py`` (see ``test_bmm_fp8_accepts_nk_layout_when_k_ne_n``),
+      not through this workload.
+    * ``scale_a`` / ``scale_b`` are per-tensor rank-0 fp32 scalars in
+      ``[0.5, 1.5)``.
+    """
+
+    def __init__(
+        self,
+        batch: int,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        out_dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        self.batch = batch
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.out_dtype = out_dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor, ...]:
+        a = (
+            torch.randn(self.batch, self.m, self.k, device="cuda") * _FP8_INIT_SCALE
+        ).to(self.dtype).contiguous()
+        b = (
+            torch.randn(self.batch, self.k, self.n, device="cuda") * _FP8_INIT_SCALE
+        ).to(self.dtype).contiguous()
+        # per_tensor uses 0-D scalars (empty shape); torch.rand accepts an
+        # empty size tuple and produces a rank-0 tensor.
+        scale_a = (
+            0.5 + torch.rand((), device="cuda", dtype=torch.float32)
+        ).contiguous()
+        scale_b = (
+            0.5 + torch.rand((), device="cuda", dtype=torch.float32)
+        ).contiguous()
+        return a, b, scale_a, scale_b

--- a/workloads/bmm.py
+++ b/workloads/bmm.py
@@ -18,11 +18,6 @@ class BmmWorkload(WorkloadBase):
         b = torch.randn(self.batch, self.k, self.n, device="cuda", dtype=self.dtype)
         return a, b
 
-
-# randn * _FP8_INIT_SCALE keeps generated values roughly within ~4 sigma of the
-# fp8_e4m3fn dynamic range (+/-448) so K-loop accumulation up to K ~= 8192 does
-# not saturate.  Kept at module scope so downstream tests can import and reason
-# about the magnitude without re-guessing the magic number.
 _FP8_INIT_SCALE: float = 0.25
 
 


### PR DESCRIPTION
## Summary

- Add `BmmFp8Op` + `BmmFp8Kernel` with a 3-warpgroup cooperative warp-specialized (WS) persistent Hopper kernel, a plain persistent variant, and a predicated 3D-grid fallback, wired through a three-tier `sm_count`-driven dispatch.

Closes #1663 

- [x] `pre-commit` passed (`ruff check` on all touched Python files: 0 findings)
- [x] `python -m pytest tests/ops/test_bmm.py -k fp8 -x -q` → **13 passed
- [x] `python -m pytest benchmarks/ops/bench_bmm.py::test_bmm_fp8_bench -vvs` 
- [x] Kernel dispatch predicates unit-covered: WS tier, plain-persistent tier, 3D-grid fallback each hit by at least one manifest shape

| Shape (B, M, N, K) | dtype (a, b, out) | Dispatch tier | TileOPs (ms) | flashinfer (ms) | Speedup | TFLOPS |
| ------------------ | ----------------- | ------------- | -----------: | --------------: | ------: | -----: |
| (4, 1024, 1024, 1024)   | e4m3fn, e4m3fn, bf16 | WS persistent    | 0.0728 | 0.0401 | 0.55× | 118.0 |
| (8, 2048, 2048, 2048)   | e4m3fn, e4m3fn, bf16 | WS persistent    | 0.7436 | 0.5069 | 0.68× | 184.9 |
| (32, 128, 128, 2048)    | e4m3fn, e4m3fn, bf16 | plain persistent | 0.0136 | 0.0137 | 1.01× |  98.7 |
| (64, 128, 2048, 128)    | e4m3fn, e4m3fn, bf16 | WS persistent    | 0.0222 | 0.0270 | 1.22× | 193.6 |
| (128, 512, 512, 2048)   | e4m3fn, e4m3fn, bf16 | WS persistent    | 0.5032 | 0.5004 | 0.99× | 273.1 |