### PR TITLE
[CI][Runner] Fix benchmark baseline dependencies

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -159,12 +159,16 @@ ARG RUNNER_VERSION=2.334.0
 # hosts (it matches the majority of existing warm-cache entries; host normalization preserves them).
 # FlashInfer's flashinfer-cubin package keeps its packaged cubin tree under site-packages.
 # Some baselines materialize TRTLLM GEMM entries there at runtime, so the unprivileged runner
-# must own that tree instead of inheriting pip's root-owned directories.
+# must own the writable directories instead of inheriting pip's root-owned directories.
 RUN groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 -m -s /bin/bash ci-runner \
     && FLASHINFER_CUBIN_DIR="$(python -c 'import pathlib, flashinfer_cubin; print(pathlib.Path(flashinfer_cubin.get_cubin_dir()))' 2>/dev/null || true)" \
     && if [ -n "${FLASHINFER_CUBIN_DIR}" ]; then \
         mkdir -p "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm/gemm"; \
-        chown -R ci-runner:ci-runner "${FLASHINFER_CUBIN_DIR}"; \
+        chown ci-runner:ci-runner \
+            "${FLASHINFER_CUBIN_DIR}" \
+            "${FLASHINFER_CUBIN_DIR}/flashinfer" \
+            "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm" \
+            "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm/gemm"; \
     fi
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -96,9 +96,10 @@ RUN python -m pip freeze | grep -iE '^(torch|torchvision|torchaudio)==' > /tmp/t
     done
 # The Mamba benchmarks compare against the official mamba_ssm Triton kernels. Keep this
 # best-effort and dependency-free so it cannot re-resolve the CUDA-specific torch/triton stack
-# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image. Skip the
-# unrelated CUDA extension build; these benchmarks import mamba_ssm.ops.triton.*.
-RUN MAMBA_FORCE_BUILD=TRUE MAMBA_SKIP_CUDA_BUILD=TRUE \
+# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image. mamba_ssm's
+# package import loads selective_scan_cuda, so the CUDA extension must be built even when the
+# benchmark uses the Triton modules.
+RUN MAMBA_FORCE_BUILD=TRUE \
     python -m pip install --no-cache-dir --no-build-isolation --no-deps \
         -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
         "mamba-ssm==2.3.1" \
@@ -159,9 +160,11 @@ RUN if [ -n "${TILELANG_GIT_SHA}" ]; then \
         && git remote add origin https://github.com/tile-ai/tilelang.git \
         && git fetch --depth 1 origin "${TILELANG_GIT_SHA}" \
         && git checkout -q FETCH_HEAD \
-        && git submodule update --init --depth 1 --recursive 3rdparty/cutlass 3rdparty/tvm \
+        && git submodule update --init --depth 1 --recursive \
+            3rdparty/composable_kernel 3rdparty/cutlass 3rdparty/tvm \
         && mkdir -p /opt/tilelang-wheels \
-        && python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
+        && CMAKE_BUILD_PARALLEL_LEVEL="${MAX_JOBS}" \
+            python -m pip wheel . --no-deps --no-build-isolation -w /opt/tilelang-wheels \
         && python -m pip install --no-deps /opt/tilelang-wheels/tilelang-*.whl \
         && rm -rf /tmp/tilelang; \
     elif [ -n "${TILELANG_VERSION}" ]; then \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -157,7 +157,15 @@ ARG RUNNER_VERSION=2.334.0
 # useradd before WORKDIR: home stays ci-runner-owned, and WORKDIR precedes the relative-path RUN (hadolint).
 # Pin UID/GID 1000 so the account deterministically owns the shared /ci-cache bind-mount across
 # hosts (it matches the majority of existing warm-cache entries; host normalization preserves them).
-RUN groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 -m -s /bin/bash ci-runner
+# FlashInfer's flashinfer-cubin package keeps its packaged cubin tree under site-packages.
+# Some baselines materialize TRTLLM GEMM entries there at runtime, so the unprivileged runner
+# must own that tree instead of inheriting pip's root-owned directories.
+RUN groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 -m -s /bin/bash ci-runner \
+    && FLASHINFER_CUBIN_DIR="$(python -c 'import pathlib, flashinfer_cubin; print(pathlib.Path(flashinfer_cubin.get_cubin_dir()))' 2>/dev/null || true)" \
+    && if [ -n "${FLASHINFER_CUBIN_DIR}" ]; then \
+        mkdir -p "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm/gemm"; \
+        chown -R ci-runner:ci-runner "${FLASHINFER_CUBIN_DIR}"; \
+    fi
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \
     && curl -fsSL -o runner.tar.gz \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -112,7 +112,15 @@ RUN { mkdir -p /tmp/DeepGEMM \
         && git remote add origin https://github.com/deepseek-ai/DeepGEMM.git \
         && git fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" \
         && git checkout -q FETCH_HEAD \
-        && git submodule update --init --depth 1 third-party/cutlass third-party/fmt \
+        && for attempt in 1 2 3 4 5; do \
+            git -c http.version=HTTP/1.1 submodule update --init --depth 1 --jobs 1 \
+                third-party/cutlass third-party/fmt && break; \
+            status="$?"; \
+            echo "WARNING: DeepGEMM submodule fetch failed (attempt ${attempt}/5, status ${status})"; \
+            rm -rf third-party/cutlass third-party/fmt .git/modules/third-party/cutlass .git/modules/third-party/fmt; \
+            if [ "${attempt}" = 5 ]; then exit "${status}"; fi; \
+            sleep "$((attempt * 10))"; \
+        done \
         && DG_FORCE_BUILD=1 python -m pip install --no-cache-dir --no-build-isolation --no-deps \
             -c /tmp/constraints.txt -c /tmp/torch-cu129.txt .; } \
     || echo "WARNING: DeepGEMM v2.1.1.post3 install failed (non-fatal)"; \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -96,11 +96,22 @@ RUN python -m pip freeze | grep -iE '^(torch|torchvision|torchaudio)==' > /tmp/t
     done
 # The Mamba benchmarks compare against the official mamba_ssm Triton kernels. Keep this
 # best-effort and dependency-free so it cannot re-resolve the CUDA-specific torch/triton stack
-# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image.
-RUN python -m pip install --no-cache-dir --no-build-isolation --no-deps \
+# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image. Force source
+# build so setup.py skips its cached-wheel URL probe and lets BuildExtension honor MAX_JOBS.
+RUN MAMBA_FORCE_BUILD=TRUE python -m pip install --no-cache-dir --no-build-isolation --no-deps \
         -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
         "mamba-ssm==2.3.1" \
     || echo "WARNING: mamba-ssm 2.3.1 install failed (non-fatal)"
+# The grouped-GEMM benchmark can compare against DeepGEMM. Install from the official tag
+# instead of PyPI's stale 1.0.0 sdist, and fetch only the submodules needed for its headers.
+RUN { git clone --depth 1 --branch v2.1.1.post3 \
+            https://github.com/deepseek-ai/DeepGEMM.git /tmp/DeepGEMM \
+        && cd /tmp/DeepGEMM \
+        && git submodule update --init --depth 1 third-party/cutlass third-party/fmt \
+        && DG_FORCE_BUILD=1 python -m pip install --no-cache-dir --no-build-isolation --no-deps \
+            -c /tmp/constraints.txt -c /tmp/torch-cu129.txt .; } \
+    || echo "WARNING: DeepGEMM v2.1.1.post3 install failed (non-fatal)"; \
+    rm -rf /tmp/DeepGEMM
 # The attention benchmarks (benchmarks/ops/attention/) need a flashinfer newer than the 0.6.6
 # vllm pulls. Upgrade flashinfer-python/-cubin with --no-deps so torch and vllm's other deps are
 # untouched; add plain cuda-tile (flashinfer>=0.6.7 needs it — the [tileiras] extra would pull a
@@ -171,11 +182,7 @@ RUN groupadd -g 1000 ci-runner && useradd -u 1000 -g 1000 -m -s /bin/bash ci-run
     && FLASHINFER_CUBIN_DIR="$(python -c 'import pathlib, flashinfer_cubin; print(pathlib.Path(flashinfer_cubin.get_cubin_dir()))' 2>/dev/null || true)" \
     && if [ -n "${FLASHINFER_CUBIN_DIR}" ]; then \
         mkdir -p "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm/gemm"; \
-        chown ci-runner:ci-runner \
-            "${FLASHINFER_CUBIN_DIR}" \
-            "${FLASHINFER_CUBIN_DIR}/flashinfer" \
-            "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm" \
-            "${FLASHINFER_CUBIN_DIR}/flashinfer/trtllm/gemm"; \
+        find "${FLASHINFER_CUBIN_DIR}" -type d -exec chown ci-runner:ci-runner {} +; \
     fi
 WORKDIR /home/ci-runner/runner
 RUN mkdir -p /home/ci-runner/runner/_work/_tool \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -110,7 +110,13 @@ RUN { mkdir -p /tmp/DeepGEMM \
         && cd /tmp/DeepGEMM \
         && git init -q \
         && git remote add origin https://github.com/deepseek-ai/DeepGEMM.git \
-        && git fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" \
+        && for attempt in 1 2 3 4 5; do \
+            git -c http.version=HTTP/1.1 fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" && break; \
+            status="$?"; \
+            echo "WARNING: DeepGEMM fetch failed (attempt ${attempt}/5, status ${status})"; \
+            if [ "${attempt}" = 5 ]; then exit "${status}"; fi; \
+            sleep "$((attempt * 10))"; \
+        done \
         && git checkout -q FETCH_HEAD \
         && for attempt in 1 2 3 4 5; do \
             git -c http.version=HTTP/1.1 submodule update --init --depth 1 --jobs 1 \

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -94,6 +94,13 @@ RUN python -m pip freeze | grep -iE '^(torch|torchvision|torchaudio)==' > /tmp/t
             -c /tmp/constraints.txt -c /tmp/torch-cu129.txt "$pkg" \
             || echo "WARNING: bench baseline '$pkg' install failed (non-fatal)"; \
     done
+# The Mamba benchmarks compare against the official mamba_ssm Triton kernels. Keep this
+# best-effort and dependency-free so it cannot re-resolve the CUDA-specific torch/triton stack
+# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image.
+RUN python -m pip install --no-cache-dir --no-build-isolation --no-deps \
+        -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
+        "mamba-ssm==2.3.1" \
+    || echo "WARNING: mamba-ssm 2.3.1 install failed (non-fatal)"
 # The attention benchmarks (benchmarks/ops/attention/) need a flashinfer newer than the 0.6.6
 # vllm pulls. Upgrade flashinfer-python/-cubin with --no-deps so torch and vllm's other deps are
 # untouched; add plain cuda-tile (flashinfer>=0.6.7 needs it — the [tileiras] extra would pull a

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -96,9 +96,10 @@ RUN python -m pip freeze | grep -iE '^(torch|torchvision|torchaudio)==' > /tmp/t
     done
 # The Mamba benchmarks compare against the official mamba_ssm Triton kernels. Keep this
 # best-effort and dependency-free so it cannot re-resolve the CUDA-specific torch/triton stack
-# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image. Force source
-# build so setup.py skips its cached-wheel URL probe and lets BuildExtension honor MAX_JOBS.
-RUN MAMBA_FORCE_BUILD=TRUE python -m pip install --no-cache-dir --no-build-isolation --no-deps \
+# or pull the newer mamba_ssm tilelang/apache-tvm-ffi pins into the runner image. Skip the
+# unrelated CUDA extension build; these benchmarks import mamba_ssm.ops.triton.*.
+RUN MAMBA_FORCE_BUILD=TRUE MAMBA_SKIP_CUDA_BUILD=TRUE \
+    python -m pip install --no-cache-dir --no-build-isolation --no-deps \
         -c /tmp/constraints.txt -c /tmp/torch-cu129.txt \
         "mamba-ssm==2.3.1" \
     || echo "WARNING: mamba-ssm 2.3.1 install failed (non-fatal)"

--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -104,9 +104,13 @@ RUN MAMBA_FORCE_BUILD=TRUE python -m pip install --no-cache-dir --no-build-isola
     || echo "WARNING: mamba-ssm 2.3.1 install failed (non-fatal)"
 # The grouped-GEMM benchmark can compare against DeepGEMM. Install from the official tag
 # instead of PyPI's stale 1.0.0 sdist, and fetch only the submodules needed for its headers.
-RUN { git clone --depth 1 --branch v2.1.1.post3 \
-            https://github.com/deepseek-ai/DeepGEMM.git /tmp/DeepGEMM \
+ARG DEEPGEMM_GIT_SHA=c9f8b34dcdacc20aa746b786f983492c51072870
+RUN { mkdir -p /tmp/DeepGEMM \
         && cd /tmp/DeepGEMM \
+        && git init -q \
+        && git remote add origin https://github.com/deepseek-ai/DeepGEMM.git \
+        && git fetch --depth 1 origin "${DEEPGEMM_GIT_SHA}" \
+        && git checkout -q FETCH_HEAD \
         && git submodule update --init --depth 1 third-party/cutlass third-party/fmt \
         && DG_FORCE_BUILD=1 python -m pip install --no-cache-dir --no-build-isolation --no-deps \
             -c /tmp/constraints.txt -c /tmp/torch-cu129.txt .; } \

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -37,6 +37,20 @@ DOCKER_BUILDKIT=1 docker build \
 Tag with the tilelang commit's **short SHA** (`:65dbc98`). If you rebuild the same commit,
 add a numeric suffix (`:65dbc98-2`).
 
+## Roll out an updated runner image
+
+Changes to this Dockerfile are not picked up by CI automatically. After a Dockerfile change
+lands, rebuild and tag the image from a GPU host using the build command above, then push it:
+
+```bash
+docker push ghcr.io/tile-ai/tileops-runner:<new-tag>
+```
+
+Then update the runner launcher configuration in TileOpsGov (`ci/runner-launcher/common.env`,
+the `IMAGE=` value) to point at the new tag, and restart/redeploy the local runner launcher.
+Merging the TileOPs PR only changes the image recipe; the live self-hosted runners keep using
+their existing image until that local Docker rollout is done.
+
 ### Build args
 
 | Arg                | Default                                | Purpose                                                   |

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -88,6 +88,23 @@ docker run --rm --gpus all ghcr.io/tile-ai/tileops-runner:65dbc98 python - <<'PY
 import torch
 print("torch", torch.__version__, "cuda", torch.version.cuda)   # expect 2.10.0+cu129, cuda 12.9
 import tilelang; print("tilelang", tilelang.__version__)
+import flashinfer, flashinfer_cubin
+print("flashinfer", flashinfer.__version__)
+from pathlib import Path
+cubin_dir = Path(flashinfer_cubin.get_cubin_dir())
+probe_dir = cubin_dir / "flashinfer" / "trtllm" / "gemm" / "_tileops_write_probe"
+probe_dir.mkdir(parents=True, exist_ok=True)
+(probe_dir / "probe.txt").write_text("ok")
+print("flashinfer cubin write OK")
+
+import selective_scan_cuda
+import mamba_ssm
+from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+assert mamba_chunk_scan_combined is not None
+print("mamba", mamba_ssm.__version__)
+
+import deep_gemm
+print("deep_gemm", deep_gemm.__version__)
 
 # cuBLAS probe: matmul / bmm / einsum on the GPU
 a = torch.randn(512, 512, device="cuda", dtype=torch.float16)

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -71,7 +71,7 @@ Set exactly one of `TILELANG_GIT_SHA` / `TILELANG_VERSION`; the build fails fast
 | `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.** |
 | `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                           |
 | `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                       |
-| `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed.      |
+| `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1` + mamba-ssm `2.3.1`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed. |
 | `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                        |
 | `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                        |
 

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -46,10 +46,9 @@ lands, rebuild and tag the image from a GPU host using the build command above, 
 docker push ghcr.io/tile-ai/tileops-runner:<new-tag>
 ```
 
-Then update the runner launcher configuration in TileOpsGov (`ci/runner-launcher/common.env`,
-the `IMAGE=` value) to point at the new tag, and restart/redeploy the local runner launcher.
-Merging the TileOPs PR only changes the image recipe; the live self-hosted runners keep using
-their existing image until that local Docker rollout is done.
+Then redeploy the self-hosted runner launcher to use the new tag (maintainer task, done
+outside this repository). Merging the TileOPs PR only changes the image recipe; the live
+self-hosted runners keep using their existing image until that manual rollout is done.
 
 ### Build args
 
@@ -66,14 +65,14 @@ Set exactly one of `TILELANG_GIT_SHA` / `TILELANG_VERSION`; the build fails fast
 
 ### Stages (`--target`)
 
-| Stage       | Contents                                                                                                                                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.**                |
-| `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                                          |
-| `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                                      |
-| `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1` + mamba-ssm `2.3.1`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed. |
-| `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                                       |
-| `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                                       |
+| Stage       | Contents                                                                                                                                                                                                                         |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.**                                         |
+| `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                                                                   |
+| `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                                                               |
+| `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1` + mamba-ssm `2.3.1` + DeepGEMM `2.1.1.post3`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed. |
+| `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                                                                |
+| `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                                                                |
 
 Build an earlier stage for debugging with `--target runtime` (etc.).
 

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -52,14 +52,15 @@ self-hosted runners keep using their existing image until that manual rollout is
 
 ### Build args
 
-| Arg                | Default                                | Purpose                                                   |
-| ------------------ | -------------------------------------- | --------------------------------------------------------- |
-| `TILELANG_GIT_SHA` | *(none)*                               | tilelang commit to shallow-clone and compile (main mode). |
-| `TILELANG_VERSION` | *(none)*                               | tilelang PyPI version to `pip install` (release mode).    |
-| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04` | Public CUDA `devel` base (Python 3.12 via deadsnakes).    |
-| `MAX_JOBS`         | `64`                                   | Parallelism for the tilelang / FA2 / FA3 source builds.   |
-| `NVCC_THREADS`     | `4`                                    | Per-`nvcc` threads.                                       |
-| `RUNNER_VERSION`   | `2.334.0`                              | GitHub Actions runner version baked into `final`.         |
+| Arg                | Default                                    | Purpose                                                                   |
+| ------------------ | ------------------------------------------ | ------------------------------------------------------------------------- |
+| `TILELANG_GIT_SHA` | *(none)*                                   | tilelang commit to shallow-clone and compile (main mode).                 |
+| `TILELANG_VERSION` | *(none)*                                   | tilelang PyPI version to `pip install` (release mode).                    |
+| `BASE_IMAGE`       | `nvidia/cuda:12.9.1-devel-ubuntu22.04`     | Public CUDA `devel` base (Python 3.12 via deadsnakes).                    |
+| `MAX_JOBS`         | `64`                                       | Parallelism for the tilelang / FA2 / FA3 source builds.                   |
+| `NVCC_THREADS`     | `4`                                        | Per-`nvcc` threads.                                                       |
+| `DEEPGEMM_GIT_SHA` | `c9f8b34dcdacc20aa746b786f983492c51072870` | DeepGEMM commit for the grouped-GEMM benchmark baseline (`v2.1.1.post3`). |
+| `RUNNER_VERSION`   | `2.334.0`                                  | GitHub Actions runner version baked into `final`.                         |
 
 Set exactly one of `TILELANG_GIT_SHA` / `TILELANG_VERSION`; the build fails fast if neither is set.
 

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -66,14 +66,14 @@ Set exactly one of `TILELANG_GIT_SHA` / `TILELANG_VERSION`; the build fails fast
 
 ### Stages (`--target`)
 
-| Stage       | Contents                                                                                                                                                                                 |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.** |
-| `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                           |
-| `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                       |
+| Stage       | Contents                                                                                                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runtime`   | Python 3.12 + torch / torchvision / torchaudio `2.10.0 / 0.25.0 / 2.10.0 +cu129` + triton `3.6.0` + tilelang build/runtime deps (incl. `apache-tvm-ffi 0.1.11`). **No tilelang itself.**                |
+| `post-fa3`  | `runtime` + pytest / pytest-xdist / ruff + FlashAttention-3 (built from the `hopper/` source).                                                                                                          |
+| `fa2`       | `post-fa3` + FlashAttention-2 (`flash-attn 2.8.3`, source-built in its own layer so changes to the bench loop never recompile it).                                                                      |
 | `fullstack` | `fa2` + flash-linear-attention `0.4.2` + vLLM `0.19.1` + mamba-ssm `2.3.1`, then flashinfer-python/-cubin upgraded to `0.6.11.post2` (`--no-deps`, so torch stays +cu129). sgl-kernel is not installed. |
-| `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                        |
-| `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                        |
+| `tilelang`  | `fullstack` + the tilelang wheel (`--no-deps`), then the build-time guard. Built **last** so a SHA bump rebuilds only this layer.                                                                       |
+| `final`     | `tilelang` + the GitHub Actions runner (no TileOPs source baked).                                                                                                                                       |
 
 Build an earlier stage for debugging with `--target runtime` (etc.).
 


### PR DESCRIPTION
## Summary
- fix the current nightly benchmark failure in the FP8 GEMM FlashInfer baseline
- make the `flashinfer-cubin` cubin directories writable by the unprivileged `ci-runner` user without touching packaged `.cubin` files
- add `mamba-ssm==2.3.1` for the official Mamba Triton benchmark baseline, including its import-time CUDA extension, addressing #1643 for the TileOps CI runner image
- add DeepGEMM `v2.1.1.post3` for the grouped-GEMM benchmark baseline requested in #1643
- document that runner image rollout is manual and happens outside this repository

## Problem
The nightly benchmark is currently failing in the FP8 GEMM benchmark cases. Those benchmark cases call the FlashInfer baseline through `flashinfer.mm_fp8(...)`. Before the benchmark can compare performance, FlashInfer tries to prepare TRTLLM GEMM cubin entries under the directory returned by `flashinfer_cubin.get_cubin_dir()`.

In the self-hosted runner image, `flashinfer-cubin` is installed by pip during the Docker build while the build is still running as root. As a result, its packaged cubin directories under site-packages are root-owned. Later, GitHub Actions jobs run as the unprivileged `ci-runner` user. When the nightly benchmark reaches the FlashInfer FP8 baseline, that user cannot create/populate cubin subdirectories, for example:

```text
/usr/local/lib/python3.12/dist-packages/flashinfer_cubin/cubins/flashinfer/trtllm/gemm
```

So the benchmark fails with a permission error before the actual performance comparison runs. A workflow-only cache/env change is not sufficient for this failure mode because when the `flashinfer-cubin` package is installed, FlashInfer uses that packaged cubin directory first. The root-owned directories therefore need to be fixed inside the runner image.

Separately, #1643 points out that the runner image does not include `mamba-ssm`, so the Mamba/Mamba-2 benchmarks cannot use the official `mamba_ssm.ops.triton.*` baseline. A follow-up comment on #1643 also requests DeepGEMM for the grouped-GEMM benchmark baseline. This PR handles the TileOPs CI runner image side of those dependency requests.

## Fix
In the final runner image stage, after creating `ci-runner`, resolve `flashinfer_cubin.get_cubin_dir()` inside the image, pre-create the TRTLLM GEMM cubin subdirectory, and chown only directory inodes under the cubin root. This gives FlashInfer writable directories for current and sibling cubin subtrees without recursively chowning packaged `.cubin` files, avoiding Docker layer bloat from OverlayFS copy-up.

For the Mamba benchmark baseline, install `mamba-ssm==2.3.1` in the `fullstack` stage as a benchmark dependency. The install uses `MAMBA_FORCE_BUILD=TRUE`, `--no-build-isolation`, `--no-deps`, and the existing torch cu129 constraints. `mamba_ssm` imports `selective_scan_cuda` at package import time, so the CUDA extension is built and included even though the TileOps benchmarks use the official `mamba_ssm.ops.triton.*` modules. I intentionally did not use the current latest `mamba-ssm==2.3.2.post1` because that release declares `tilelang==0.1.8` and `apache-tvm-ffi<=0.1.9`, which conflicts with this runner image's TileOps/tilelang runtime stack.

For the grouped-GEMM benchmark baseline, install DeepGEMM from the official `deepseek-ai/DeepGEMM` source as a benchmark dependency, pinned to commit `c9f8b34dcdacc20aa746b786f983492c51072870` (the `v2.1.1.post3` tag target). The install uses `--no-build-isolation --no-deps` and fetches only the required header submodules. The PyPI `deep_gemm==1.0.0` sdist is stale relative to the current upstream version used for this benchmark surface.

For TileLang source builds, explicitly initialize `3rdparty/composable_kernel` together with `3rdparty/cutlass` and `3rdparty/tvm`. Without that, CMake can trigger a hidden network fetch for the missing submodule during the wheel build. The wheel build also passes `CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS}` so the local image rebuild can use the intended build parallelism.

## Rollout note
This repository does not build the self-hosted runner image in CI. After this lands, a maintainer still needs to rebuild and push the runner image from a GPU host, then redeploy the self-hosted runner launcher to use the new tag outside this repository.

Merging this TileOPs PR only changes the image recipe. The live self-hosted runners keep using their existing image until that manual rollout is done.

## Test
- `pre-commit run mdformat --files .github/runner/README.md`
- `git diff --check`
- Local GPU-host runner image build completed from the updated recipe using pre-cloned source/tarball BuildKit contexts for network-heavy inputs; final image id `sha256:73768b2992f26cde6703b6eb15bba9f9438048a5a9e416154bf893275776f326`.
- Runtime probe inside the built image passed: torch `2.10.0+cu129`, CUDA `12.9`, tilelang `0.1.11+cu129.git65dbc983`, FlashInfer cubin write probe, `selective_scan_cuda`, mamba `2.3.1`, and DeepGEMM `2.1.1`.
- The verified image was retagged locally to `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`; `ci-runner-gpu2` and `ci-runner-gpu3` were recreated from that tag and now run image id `sha256:73768b2992f26cde6703b6eb15bba9f9438048a5a9e416154bf893275776f326`.
