### PR TITLE
[CI][Nightly] Restore benchmark and op test coverage

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -10,46 +10,6 @@ collect_ignore_glob = [
     "ops/attention/bench_deepseek_nsa*.py",
 ]
 
-TILELANG_019_BENCH_SKIP_REASON = (
-    "Skipped under tilelang 0.1.9: known benchmark regressions in autodiff/"
-    "codegen lowering produce incorrect numerics or compile failures; "
-    "re-enable when the benchmark runs cleanly against current tilelang."
-)
-
-TILELANG_019_BENCH_PATHS = {
-    # Linear attention / recurrent ops.
-    "benchmarks/ops/bench_engram.py",
-    # Attention.
-    "benchmarks/ops/attention/bench_gqa_decode.py",
-    "benchmarks/ops/attention/bench_gqa_decode_paged.py",
-    "benchmarks/ops/attention/bench_gqa_sliding_window.py",
-    "benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py",
-    "benchmarks/ops/attention/bench_mha.py",
-    # Other operators.
-    "benchmarks/ops/bench_fft.py",
-    "benchmarks/ops/bench_mhc_post.py",
-    "benchmarks/ops/bench_mhc_pre.py",
-    "benchmarks/ops/bench_rope.py",
-    "benchmarks/ops/bench_topk_selector.py",
-    # Normalization.
-    "benchmarks/ops/bench_batch_norm.py",
-    "benchmarks/ops/bench_fused_add_layer_norm.py",
-    "benchmarks/ops/bench_instance_norm.py",
-    # MoE.
-    "benchmarks/ops/bench_moe_permute.py",
-    "benchmarks/ops/bench_moe_permute_align.py",
-    # GEMM.
-    "benchmarks/ops/bench_grouped_gemm.py",
-}
-
-TILELANG_019_BENCH_PREFIXES = ()
-
-TILELANG_019_BENCH_NODEIDS = {
-    "benchmarks/ops/bench_gemm.py::test_gemm_bench[wide-fp16]",
-    "benchmarks/ops/bench_group_norm.py::test_group_norm_bench[tail-spatial-g16-float16]",
-}
-
-
 def _normalized_benchmark_nodeid(item: pytest.Item) -> str:
     nodeid = item.nodeid
     if nodeid.startswith("benchmarks/"):
@@ -89,7 +49,6 @@ def pytest_sessionfinish(session, exitstatus):
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    tilelang_019_skip = pytest.mark.skip(reason=TILELANG_019_BENCH_SKIP_REASON)
     fp8_e4m3_skip = pytest.mark.skip(
         reason=(
             "Skipped under tilelang 0.1.9: fp8 e4m3 benchmark fails due to "
@@ -101,18 +60,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
         nodeid = _normalized_benchmark_nodeid(item)
         path = nodeid.split("::", 1)[0]
-
-        if path in TILELANG_019_BENCH_PATHS:
-            item.add_marker(tilelang_019_skip)
-            continue
-
-        if nodeid.startswith(TILELANG_019_BENCH_PREFIXES):
-            item.add_marker(tilelang_019_skip)
-            continue
-
-        if nodeid in TILELANG_019_BENCH_NODEIDS:
-            item.add_marker(tilelang_019_skip)
-            continue
 
         if (
             path == "benchmarks/ops/bench_elementwise_fp8.py"

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -24,6 +24,15 @@ class _FakeSquareDenseKernel(Kernel):
         return None
 
 
+class _FakeLegacyMhaBwdKernel(Kernel):
+    def __init__(self, batch: int, heads: int, seq_len: int, dim: int,
+                 is_causal: bool, dtype: torch.dtype, tune: bool = False) -> None:
+        super().__init__()
+
+    def forward(self, *args: object, **kwargs: object) -> object:
+        return None
+
+
 class MhaBwdTest(_MhaBwdTestWorkload, TestBase):
     def ref_program(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, o: torch.Tensor,
                     grad_output: torch.Tensor,
@@ -140,6 +149,20 @@ def test_mha_fwd_preserves_gqa_square_dense_fast_path(
     )
 
     assert isinstance(op.kernel, _FakeSquareDenseKernel)
+
+
+@pytest.mark.smoke
+def test_mha_bwd_rejects_legacy_kernel_map_keys() -> None:
+    with pytest.raises(ValueError, match="legacy MHA backward kernel_map keys"):
+        MultiHeadAttentionBwdOp(
+            batch=1,
+            heads=8,
+            seq_len=128,
+            dim=64,
+            is_causal=False,
+            dtype=torch.float16,
+            kernel_map={"mha_bwd_kernel": _FakeLegacyMhaBwdKernel},
+        )
 
 
 @MhaBwdFixture

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -145,7 +145,6 @@ def test_mha_fwd_preserves_gqa_square_dense_fast_path(
 @MhaBwdFixture
 def test_mha_bwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
-    pytest.skip("MHA backward fails under tilelang 0.1.9 due to autodiff lowering regression; re-enable when backward produces numerically correct grads.")
     test = MhaBwdTest(batch, heads, seq_len, dim, causal, dtype)
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -89,9 +89,9 @@ MultiHeadAttentionBwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_bwd.py
     kernel_map:
-      mha_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
-      mha_bwd_kernel: MHABwdKernel
-      mha_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
+      gqa_bwd_preprocess_kernel: FlashAttnBwdPreprocessKernel
+      gqa_bwd_kernel: GQABwdKernel
+      gqa_bwd_postprocess_kernel: FlashAttnBwdPostprocessKernel
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
     bench: benchmarks/ops/attention/bench_mha.py

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -6,9 +6,9 @@ import torch.nn.functional as F
 from tileops.kernels.attention import (
     FlashAttnBwdPostprocessKernel,
     FlashAttnBwdPreprocessKernel,
+    GQABwdKernel,
+    GQABwdWgmmaPipelinedKernel,
     GQAFwdWsPersistentCausalKernel,
-    MHABwdKernel,
-    MHABwdWgmmaPipelinedKernel,
     MHADecodeKernel,
     MHADecodePagedKernel,
 )
@@ -16,7 +16,11 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.utils import is_hopper
 
 from ..op_base import Op
-from .gqa import GroupedQueryAttentionFwdOp, _select_gqa_prefill_fwd_kernel_cls
+from .gqa import (
+    GroupedQueryAttentionBwdOp,
+    GroupedQueryAttentionFwdOp,
+    _select_gqa_prefill_fwd_kernel_cls,
+)
 
 __all__ = [
     "MultiHeadAttentionBwdOp",
@@ -99,7 +103,11 @@ class MultiHeadAttentionFwdOp(Op):
 
 
 class MultiHeadAttentionBwdOp(Op):
-    """Layout: BSHD"""
+    """Layout: BSHD.
+
+    MHA backward is the ``heads_kv == heads`` specialization of GQA backward,
+    matching the forward path's dispatch through GQA.
+    """
 
     def __init__(self,
                  batch: int,
@@ -118,35 +126,53 @@ class MultiHeadAttentionBwdOp(Op):
 
         self.dtype = dtype
 
-        self.dispatch_kernel(kernel_map)
-        self.prep_kernel = self.kernel_map["mha_bwd_preprocess_kernel"](batch, heads, seq_len, dim,
-                                                                        self.dtype)
-        self.kernel = self.kernel_map["mha_bwd_kernel"](
-            batch, heads, seq_len, dim, is_causal, self.dtype, tune=tune)
-        if not is_hopper():
-            self.post_kernel = self.kernel_map["mha_bwd_postprocess_kernel"](batch, heads, seq_len,
-                                                                             dim, self.dtype)
+        self._gqa_op = GroupedQueryAttentionBwdOp(
+            batch=batch,
+            heads=heads,
+            heads_kv=heads,
+            seq_len=seq_len,
+            dim=dim,
+            is_causal=is_causal,
+            dtype=dtype,
+            kernel_map=self._gqa_kernel_map(kernel_map),
+            tune=tune,
+        )
+        self.kernel_map = self._gqa_op.kernel_map
+        self.prep_kernel = self._gqa_op.prep_kernel
+        self.kernel = self._gqa_op.kernel
+        if hasattr(self._gqa_op, "post_kernel"):
+            self.post_kernel = self._gqa_op.post_kernel
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
-            "mha_bwd_preprocess_kernel":
+            "gqa_bwd_preprocess_kernel":
                 FlashAttnBwdPreprocessKernel,
-            "mha_bwd_kernel":
-                MHABwdWgmmaPipelinedKernel if is_hopper() else MHABwdKernel,
-            "mha_bwd_postprocess_kernel":
+            "gqa_bwd_kernel":
+                GQABwdWgmmaPipelinedKernel if is_hopper() else GQABwdKernel,
+            "gqa_bwd_postprocess_kernel":
                 FlashAttnBwdPostprocessKernel if not is_hopper() else None,
         }
+
+    @staticmethod
+    def _gqa_kernel_map(kernel_map: Optional[Dict[str, Kernel]]) -> Optional[Dict[str, Kernel]]:
+        if kernel_map is None:
+            return None
+        translated = dict(kernel_map)
+        aliases = {
+            "mha_bwd_preprocess_kernel": "gqa_bwd_preprocess_kernel",
+            "mha_bwd_kernel": "gqa_bwd_kernel",
+            "mha_bwd_postprocess_kernel": "gqa_bwd_postprocess_kernel",
+        }
+        for old_key, new_key in aliases.items():
+            if old_key in translated and new_key not in translated:
+                translated[new_key] = translated.pop(old_key)
+        return translated
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, o: torch.Tensor,
                 do: torch.Tensor,
                 lse: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        do = do.contiguous()
-        delta = self.prep_kernel(o, do)
-        dq = torch.zeros_like(q, dtype=torch.float32)
-        dk, dv = self.kernel(q, k, v, do, lse, delta, dq)
-        dq = dq.to(self.dtype) if is_hopper() else self.post_kernel(dq)
-        return dq, dk, dv
+        return self._gqa_op(q, k, v, o, do, lse)
 
 
 class MultiHeadAttentionDecodeWithKVCacheFwdOp(Op):

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -109,6 +109,12 @@ class MultiHeadAttentionBwdOp(Op):
     matching the forward path's dispatch through GQA.
     """
 
+    _LEGACY_KERNEL_MAP_KEYS = frozenset({
+        "mha_bwd_preprocess_kernel",
+        "mha_bwd_kernel",
+        "mha_bwd_postprocess_kernel",
+    })
+
     def __init__(self,
                  batch: int,
                  heads: int,
@@ -159,16 +165,14 @@ class MultiHeadAttentionBwdOp(Op):
     def _gqa_kernel_map(kernel_map: Optional[Dict[str, Kernel]]) -> Optional[Dict[str, Kernel]]:
         if kernel_map is None:
             return None
-        translated = dict(kernel_map)
-        aliases = {
-            "mha_bwd_preprocess_kernel": "gqa_bwd_preprocess_kernel",
-            "mha_bwd_kernel": "gqa_bwd_kernel",
-            "mha_bwd_postprocess_kernel": "gqa_bwd_postprocess_kernel",
-        }
-        for old_key, new_key in aliases.items():
-            if old_key in translated and new_key not in translated:
-                translated[new_key] = translated.pop(old_key)
-        return translated
+        legacy_keys = MultiHeadAttentionBwdOp._LEGACY_KERNEL_MAP_KEYS.intersection(kernel_map)
+        if legacy_keys:
+            keys = ", ".join(sorted(legacy_keys))
+            raise ValueError(
+                "MultiHeadAttentionBwdOp delegates to GroupedQueryAttentionBwdOp; "
+                f"legacy MHA backward kernel_map keys are not compatible: {keys}. "
+                "Use gqa_bwd_* keys with kernels that implement the GQA backward ABI.")
+        return dict(kernel_map)
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, o: torch.Tensor,
                 do: torch.Tensor,

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -126,6 +126,7 @@ class MultiHeadAttentionBwdOp(Op):
 
         self.dtype = dtype
 
+        self.dispatch_kernel(self._gqa_kernel_map(kernel_map))
         self._gqa_op = GroupedQueryAttentionBwdOp(
             batch=batch,
             heads=heads,
@@ -134,7 +135,7 @@ class MultiHeadAttentionBwdOp(Op):
             dim=dim,
             is_causal=is_causal,
             dtype=dtype,
-            kernel_map=self._gqa_kernel_map(kernel_map),
+            kernel_map=self.kernel_map,
             tune=tune,
         )
         self.kernel_map = self._gqa_op.kernel_map

--- a/workloads/attention/mha.py
+++ b/workloads/attention/mha.py
@@ -1,6 +1,7 @@
 import torch
 
 from tileops.ops import MultiHeadAttentionFwdOp
+from workloads.attention.gqa import _compute_gqa_square_lse
 from workloads.workload_base import WorkloadBase
 
 
@@ -48,9 +49,19 @@ class MhaBwdTest(WorkloadBase):
         fwd_op = MultiHeadAttentionFwdOp(self.batch, self.heads, self.seq_len, self.dim,
                                          self.is_causal, self.dtype)
         with torch.no_grad():
-            o, lse = fwd_op(q, k, v)
+            result = fwd_op(q, k, v)
+            o = result[0] if isinstance(result, tuple) else result
+            lse = _compute_gqa_square_lse(
+                q,
+                k,
+                heads=self.heads,
+                heads_kv=self.heads,
+                dim=self.dim,
+                is_causal=self.is_causal,
+            )
 
         return q, k, v, o, grad_output, lse
+
 
 class MhaFwdTest(WorkloadBase):
 


### PR DESCRIPTION
Closes #1696

## Summary
- restore the nightly benchmark surface that was still hidden behind the old benchmark denylist
- restore MHA backward full op-test coverage by removing the runtime skip from `test_mha_bwd`
- route `MultiHeadAttentionBwdOp` through `GroupedQueryAttentionBwdOp` with `heads_kv == heads`, matching the existing MHA forward dispatch through GQA
- update the MHA backward workload to derive `lse` consistently with the GQA square-attention path
- update the MHA backward manifest source metadata to reference the `gqa_bwd_*` kernel map

## Problem
Earlier kernel-side fixes restored the relevant smoke coverage, but the broader nightly surfaces were not fully re-enabled afterward. In particular, benchmark cases were still hidden behind the old tilelang 0.1.9-era denylist, and MHA backward full op-test cases were still skipped at runtime.

As a result, the latest nightly run could pass while still reporting skipped benchmark and full-test coverage for code paths that should now be exercised again.

When the MHA backward skip is removed, the workload exposes a separate interface mismatch: input generation still assumes MHA forward returns exactly `(o, lse)`, while the maintained MHA forward path is backed by GQA.

## Fix
Remove the stale benchmark denylist from `benchmarks/conftest.py`, keeping the separate fp8 e4m3 benchmark skip because that still has an explicit unsupported/lowering reason.

`MultiHeadAttentionBwdOp` now delegates to `GroupedQueryAttentionBwdOp` with `heads_kv=heads`. The wrapper keeps the public MHA entry point and preserves the Op-level `dispatch_kernel(...)` contract. Legacy `mha_bwd_*` kernel-map override keys are now rejected explicitly because those kernels use the old MHA backward ABI and cannot be safely passed to the GQA backward op.

`MhaBwdTest.gen_inputs()` now extracts `o` defensively from the forward result and computes `lse` with the same square-attention helper used by the GQA backward workload.