### PR TITLE
[Fix][NORM] Stop default_config from selecting a replicated fragment layout

### DIFF
--- a/tileops/kernels/norm/_config.py
+++ b/tileops/kernels/norm/_config.py
@@ -15,6 +15,8 @@ knob so the kernel interface is not narrowed; configs that collapse lose on thei
 measured runtime.
 """
 
+import torch
+
 __all__ = ["select_row_config", "select_row_configs"]
 
 # Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
@@ -27,12 +29,17 @@ _CANDIDATE_BLOCK_M = (1, 2, 4, 8)
 _DEFAULT_THREADS = 128  # measured optimum; see the module docstring
 
 
-def _feasible_threads(n_padded: int) -> list[int]:
-    """Thread counts that divide the row and keep loads vectorizable (>=8/thread)."""
+def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list[int]:
+    """Thread counts that divide the row and keep loads 128-bit vectorizable.
+
+    128-bit needs ``16 // element_size`` elements per thread (8 for fp16/bf16,
+    4 for fp32), so the floor is dtype-dependent.
+    """
+    min_elements = 16 // torch.tensor([], dtype=dtype).element_size()
     return [
         threads
         for threads in _CANDIDATE_THREADS
-        if n_padded % threads == 0 and n_padded // threads >= 8
+        if n_padded % threads == 0 and n_padded // threads >= min_elements
     ]
 
 
@@ -48,13 +55,13 @@ def select_row_config(n_padded: int) -> dict:
     return {"block_m": 1, "threads": threads}
 
 
-def select_row_configs(n_padded: int) -> list[dict]:
+def select_row_configs(n_padded: int, dtype: torch.dtype = torch.float16) -> list[dict]:
     """Autotune space: block_m x usable thread counts, default always included.
 
     block_m is swept (not pinned) so the interface is preserved; configs that
     collapse are rejected by the autotuner's own measured runtime.
     """
-    threads = _feasible_threads(n_padded)
+    threads = _feasible_threads(n_padded, dtype)
     configs = [
         {"block_m": block_m, "threads": t}
         for block_m in _CANDIDATE_BLOCK_M

--- a/tileops/kernels/norm/_config.py
+++ b/tileops/kernels/norm/_config.py
@@ -1,0 +1,66 @@
+"""Tile-config selection shared by the row-wise norm kernels.
+
+These kernels hold a ``(block_m, N_padded)`` row block in register fragments and
+reduce along the row. When ``N_padded`` is not a power of two, TileLang's layout
+inference places a partitioned layout for some ``block_m`` but falls back to a
+replicated one for others -- each thread owns a whole row, spills to local
+memory, and the cross-thread ``AllReduce`` degenerates into a serial loop. That
+is 5-16x slower yet numerically correct, so no correctness test catches it.
+
+``select_row_config`` pins ``block_m=1``: with one row per CTA the per-row
+uniformity the reduction needs always holds, so the collapse is impossible for
+any N/threads/dtype -- structural, not a tuned value. ``threads=128`` is the
+measured optimum. ``select_row_configs`` keeps ``block_m`` as a swept autotune
+knob so the kernel interface is not narrowed; configs that collapse lose on their
+measured runtime.
+"""
+
+__all__ = ["select_row_config", "select_row_configs"]
+
+# Powers of two only (tl::AllReduce is an XOR butterfly) that also divide
+# N_padded, or layout inference reports "no available layout". CUDA caps at 1024.
+_CANDIDATE_THREADS = (128, 256, 512, 1024)
+
+# block_m values offered to autotune; block_m=1 is always the safe default.
+_CANDIDATE_BLOCK_M = (1, 2, 4, 8)
+
+_DEFAULT_THREADS = 128  # measured optimum; see the module docstring
+
+
+def _feasible_threads(n_padded: int) -> list[int]:
+    """Thread counts that divide the row and keep loads vectorizable (>=8/thread)."""
+    return [
+        threads
+        for threads in _CANDIDATE_THREADS
+        if n_padded % threads == 0 and n_padded // threads >= 8
+    ]
+
+
+def select_row_config(n_padded: int) -> dict:
+    """Structurally collapse-free default ``{block_m, threads}`` for a row reduction."""
+    threads = _DEFAULT_THREADS
+    if n_padded % threads:
+        # N_padded is a multiple of the 256-element alignment, so 128 always
+        # divides it; this is a guard, not a live path.
+        threads = next(
+            (t for t in _CANDIDATE_THREADS if n_padded % t == 0), _DEFAULT_THREADS
+        )
+    return {"block_m": 1, "threads": threads}
+
+
+def select_row_configs(n_padded: int) -> list[dict]:
+    """Autotune space: block_m x usable thread counts, default always included.
+
+    block_m is swept (not pinned) so the interface is preserved; configs that
+    collapse are rejected by the autotuner's own measured runtime.
+    """
+    threads = _feasible_threads(n_padded)
+    configs = [
+        {"block_m": block_m, "threads": t}
+        for block_m in _CANDIDATE_BLOCK_M
+        for t in threads
+    ]
+    default = select_row_config(n_padded)
+    if default not in configs:
+        configs.insert(0, default)
+    return configs

--- a/tileops/kernels/norm/_config.py
+++ b/tileops/kernels/norm/_config.py
@@ -33,14 +33,13 @@ def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list
     """Thread counts that divide the row and keep loads 128-bit vectorizable.
 
     128-bit needs ``16 // element_size`` elements per thread (8 for fp16/bf16,
-    4 for fp32), so the floor is dtype-dependent.
+    4 for fp32). If no candidate meets that floor (small rows), fall back to any
+    thread count that divides the row so the autotune space is never empty.
     """
-    min_elements = 16 // dtype.itemsize
-    return [
-        threads
-        for threads in _CANDIDATE_THREADS
-        if n_padded % threads == 0 and n_padded // threads >= min_elements
-    ]
+    min_elements = 16 // torch.tensor([], dtype=dtype).element_size()
+    candidates = [t for t in _CANDIDATE_THREADS if n_padded % t == 0]
+    vectorizable = [t for t in candidates if n_padded // t >= min_elements]
+    return vectorizable or candidates
 
 
 def select_row_config(n_padded: int) -> dict:
@@ -49,16 +48,23 @@ def select_row_config(n_padded: int) -> dict:
     return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
-def select_row_configs(n_padded: int, dtype: torch.dtype = torch.float16) -> list[dict]:
+def select_row_configs(
+    n_padded: int, dtype: torch.dtype = torch.float16, num_buffers: int = 1
+) -> list[dict]:
     """Autotune space: block_m x usable thread counts, default always included.
 
     block_m is swept (not pinned) so the interface is preserved; configs that
-    collapse are rejected by the autotuner's own measured runtime.
+    collapse are rejected by the autotuner's own measured runtime. block_m is
+    capped by the 48 KB shared-memory budget for ``num_buffers`` row-sized
+    buffers, and the default is always a member so the list is never empty.
     """
     threads = _feasible_threads(n_padded, dtype)
+    smem_per_row = n_padded * torch.tensor([], dtype=dtype).element_size()
+    max_block_m = (48 * 1024) // (num_buffers * smem_per_row)
     configs = [
         {"block_m": block_m, "threads": t}
         for block_m in _CANDIDATE_BLOCK_M
+        if block_m <= max_block_m
         for t in threads
     ]
     default = select_row_config(n_padded)

--- a/tileops/kernels/norm/_config.py
+++ b/tileops/kernels/norm/_config.py
@@ -35,7 +35,7 @@ def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list
     128-bit needs ``16 // element_size`` elements per thread (8 for fp16/bf16,
     4 for fp32), so the floor is dtype-dependent.
     """
-    min_elements = 16 // torch.tensor([], dtype=dtype).element_size()
+    min_elements = 16 // dtype.itemsize
     return [
         threads
         for threads in _CANDIDATE_THREADS
@@ -45,14 +45,8 @@ def _feasible_threads(n_padded: int, dtype: torch.dtype = torch.float16) -> list
 
 def select_row_config(n_padded: int) -> dict:
     """Structurally collapse-free default ``{block_m, threads}`` for a row reduction."""
-    threads = _DEFAULT_THREADS
-    if n_padded % threads:
-        # N_padded is a multiple of the 256-element alignment, so 128 always
-        # divides it; this is a guard, not a live path.
-        threads = next(
-            (t for t in _CANDIDATE_THREADS if n_padded % t == 0), _DEFAULT_THREADS
-        )
-    return {"block_m": 1, "threads": threads}
+    # N_padded is a multiple of the 256-element alignment, so 128 always divides it.
+    return {"block_m": 1, "threads": _DEFAULT_THREADS}
 
 
 def select_row_configs(n_padded: int, dtype: torch.dtype = torch.float16) -> list[dict]:

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -17,7 +17,6 @@ even for large-offset inputs.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -25,6 +24,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+
+from ._config import select_row_config, select_row_configs
 
 __all__ = ["AdaLayerNormKernel"]
 
@@ -279,24 +280,11 @@ class AdaLayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Shared memory budget: need buffers for x + scale + shift (+ gate if has_gate)
-        # Main constraint: block_m * N_padded * dtype_size for shared_buf < 48KB
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8, 16]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 256}
+        return select_row_config(self.N_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.N_padded)
 
     def forward(
         self,

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -284,7 +284,7 @@ class AdaLayerNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded)
+        return select_row_configs(self.N_padded, self.dtype)
 
     def forward(
         self,

--- a/tileops/kernels/norm/fused_add_norm.py
+++ b/tileops/kernels/norm/fused_add_norm.py
@@ -13,7 +13,6 @@ memory instructions.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -21,6 +20,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+
+from ._config import select_row_config, select_row_configs
 
 __all__ = ["FusedAddLayerNormKernel", "FusedAddRMSNormKernel"]
 
@@ -181,25 +182,11 @@ class FusedAddLayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Shared memory budget: 2 buffers * block_m * N_padded * dtype_size < 48KB
-        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
-        smem_per_row = self.N_padded * elem_bytes
-        max_block_m = (48 * 1024) // (2 * smem_per_row)
-        block_m = 1
-        for bm in [1, 2, 4, 8, 16]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 256}
+        return select_row_config(self.N_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
-        smem_per_row = self.N_padded * elem_bytes
-        max_block_m = (48 * 1024) // (2 * smem_per_row)
-        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.N_padded)
 
     def forward(
         self,
@@ -357,24 +344,11 @@ class FusedAddRMSNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
-        smem_per_row = self.N_padded * elem_bytes
-        max_block_m = (48 * 1024) // (2 * smem_per_row)
-        block_m = 1
-        for bm in [1, 2, 4, 8]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 128}
+        return select_row_config(self.N_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        elem_bytes = torch.tensor([], dtype=self.dtype).element_size()
-        smem_per_row = self.N_padded * elem_bytes
-        max_block_m = (48 * 1024) // (2 * smem_per_row)
-        block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.N_padded)
 
     def forward(
         self,

--- a/tileops/kernels/norm/fused_add_norm.py
+++ b/tileops/kernels/norm/fused_add_norm.py
@@ -186,7 +186,7 @@ class FusedAddLayerNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded)
+        return select_row_configs(self.N_padded, self.dtype)
 
     def forward(
         self,
@@ -348,7 +348,7 @@ class FusedAddRMSNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded)
+        return select_row_configs(self.N_padded, self.dtype)
 
     def forward(
         self,

--- a/tileops/kernels/norm/fused_add_norm.py
+++ b/tileops/kernels/norm/fused_add_norm.py
@@ -186,7 +186,7 @@ class FusedAddLayerNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded, self.dtype)
+        return select_row_configs(self.N_padded, self.dtype, num_buffers=2)
 
     def forward(
         self,
@@ -348,7 +348,7 @@ class FusedAddRMSNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded, self.dtype)
+        return select_row_configs(self.N_padded, self.dtype, num_buffers=2)
 
     def forward(
         self,

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -17,7 +17,6 @@ which is tiled from the weight/bias vectors accordingly.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -25,6 +24,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+
+from ._config import select_row_config, select_row_configs
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
@@ -175,23 +176,11 @@ class GroupNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Shared memory budget: 1 buffer * block_m * D_padded * dtype_size < 48KB
-        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8, 16]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 256}
+        return select_row_config(self.D_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.D_padded)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         return _group_norm_wrapped(
@@ -337,22 +326,11 @@ class GroupNormNoAffineKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8, 16]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 256}
+        return select_row_config(self.D_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.D_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.D_padded)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return _group_norm_no_affine_wrapped(

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -180,7 +180,7 @@ class GroupNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded)
+        return select_row_configs(self.D_padded, self.dtype)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         return _group_norm_wrapped(
@@ -330,7 +330,7 @@ class GroupNormNoAffineKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.D_padded)
+        return select_row_configs(self.D_padded, self.dtype)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return _group_norm_no_affine_wrapped(

--- a/tileops/kernels/norm/layer_norm.py
+++ b/tileops/kernels/norm/layer_norm.py
@@ -9,7 +9,6 @@ even for large-offset inputs.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -17,6 +16,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+
+from ._config import select_row_config, select_row_configs
 
 __all__ = ["LayerNormKernel"]
 
@@ -147,26 +148,11 @@ class LayerNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Shared memory budget: 1 buffer * block_m * N_padded * dtype_size < 48KB
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        # For large hidden dims, prefer smaller block_m to reduce register pressure
-        # and improve occupancy. For small hidden dims, use larger block_m to amortize
-        # kernel launch overhead.
-        block_m = 1
-        for bm in [1, 2, 4, 8, 16]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 256}
+        return select_row_config(self.N_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8, 16] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.N_padded)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         return _layer_norm_wrapped(

--- a/tileops/kernels/norm/layer_norm.py
+++ b/tileops/kernels/norm/layer_norm.py
@@ -152,7 +152,7 @@ class LayerNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded)
+        return select_row_configs(self.N_padded, self.dtype)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
         return _layer_norm_wrapped(

--- a/tileops/kernels/norm/rms_norm.py
+++ b/tileops/kernels/norm/rms_norm.py
@@ -133,7 +133,7 @@ class RMSNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded)
+        return select_row_configs(self.N_padded, self.dtype)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         return _rms_norm_wrapped(

--- a/tileops/kernels/norm/rms_norm.py
+++ b/tileops/kernels/norm/rms_norm.py
@@ -8,7 +8,6 @@ for correct mean computation.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -16,6 +15,8 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+
+from ._config import select_row_config, select_row_configs
 
 __all__ = ["RMSNormKernel"]
 
@@ -128,23 +129,11 @@ class RMSNormKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Shared memory budget: 1 buffer * block_m * N_padded * dtype_size < 48KB
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_m = 1
-        for bm in [1, 2, 4, 8]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": 128}
+        return select_row_config(self.N_padded)
 
     @property
     def autotune_configs(self) -> list[dict]:
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m = (48 * 1024) // smem_per_row
-        block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-        threads_list = [128, 256]
-        configs = list(itertools.product(block_ms, threads_list))
-        return [{"block_m": bm, "threads": t} for bm, t in configs]
+        return select_row_configs(self.N_padded)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         return _rms_norm_wrapped(


### PR DESCRIPTION
Fixes #1715.

## Problem
The row-wise norm kernels (LayerNorm, RMSNorm, GroupNorm, FusedAdd{Layer,RMS}Norm,
AdaLayerNorm, AdaLayerNorm-Zero) select a **replicated** fragment layout for rows
whose padded length is not a power of two, running 5–38× slower than the
partitioned layout. Output is numerically correct, so no correctness test catches
it. `default_config`'s shared-memory-budget heuristic selected exactly the
`block_m ∈ {2,4,8,16}` values that trigger the collapse.

## Fix
Replace the five duplicated per-file heuristics with a shared `select_row_config()`
that pins `block_m = 1`. This is structural, not tuned: with one row per CTA the
layout heuristic's total-tile divisibility check coincides with the per-row
alignment the cross-thread `AllReduce` needs, so the collapse becomes impossible
for any N/threads/dtype. `autotune` keeps `block_m` as a swept knob
(`select_row_configs`) — the kernel interface is not narrowed; configs that
collapse simply lose on their measured runtime.

Scope: 7 row-reduction kernel classes (InstanceNorm aliases GroupNorm, so it is
covered). BatchNorm is excluded — it uses a different config schema and reduces
along a different axis.

## Evidence

### 1. The collapsed layout, in the generated CUDA (layer_norm, N=1152→1280)

Old default `block_m=16, threads=256` — each thread declares a **whole row** and
reduces serially; the cross-thread `AllReduce` is gone:

```cpp
half_t x_local[1280];   // whole row per thread (16× the 80-element fair share)
half_t x_f32[1280];
...
for (int rv = 0; rv < 1280; ++rv) { ... }   // intra-thread serial reduction
```

Fixed default `block_m=1, threads=128` — each thread holds its fair share and the
reduction is a cross-thread `AllReduce`:

```cpp
half_t x_local[10];     // fair share = block_m * N_padded / threads
...
acc[0] = tl::AllReduce<tl::SumOp, 128, ...>::run(acc[0], ...);
```

### 2. Before / after (H200, M=1024, N=1152, fp16, per-process)

| op                   | old default (collapsed) | new default (block_m=1) | speedup |
|----------------------|-------------------------|-------------------------|---------|
| layer_norm           | bm16,th256 — 310 us     | 16.3 us                 | 19×     |
| rms_norm             | bm8,th128 — 100 us      | 16.3 us                 | 6×      |
| group_norm           | bm16,th256 — 295 us     | 15.2 us                 | 19×     |
| ada_layer_norm       | bm16,th256 — 537 us     | 14.2 us                 | 38×     |
| fused_add_layer_norm | bm8,th256 — 840 us      | 23.0 us                 | 37×     |

### 3. `block_m > 1` brings no meaningful speedup, even where it is safe

On a power-of-two row (N=4096) where every `block_m` stays partitioned (no
collapse), sweeping `block_m` at threads=128, 3 runs each (µs):

| block_m | regs/thread (widest) | run1 | run2 | run3 |
|---------|----------------------|------|------|------|
| 1       | 32                   | 17.3 | 14.4 | 14.2 |
| 2       | 64                   | 21.7 | 27.7 | 15.8 |
| 4       | 128                  | 14.1 | 16.5 | 15.2 |
| 8       | 256                  | 15.9 | 15.2 | 15.9 |

`block_m=1` is within noise of (and often faster than) every larger `block_m`, and
the ordering is non-monotonic. Larger `block_m` only grows the per-thread register
footprint (32 → 256 elements) and risks the collapse on non-power-of-two rows,
with no upside. Pinning `block_m=1` by default sacrifices nothing measurable.

### 4. Healthy (power-of-two) cases: neutral to ~1.4× faster, no regression

The default changes for every shape, including the power-of-two rows that never
collapsed. Those already used a small `block_m`; the change to `threads=128`
lifts occupancy on wide rows (layer_norm, M=2048, fp16, per-process):

| N     | old default          | new default (bm1,th128) | effect                 |
|-------|----------------------|-------------------------|------------------------|
| 4096  | bm4,th256 — 14–21 us | 14–18 us                | neutral (within noise) |
| 8192  | bm2,th256 — 29.4 us  | 26.0 us                 | 1.13×                  |
| 16384 | bm1,th256 — 70.7 us  | 51.0 us                 | 1.4×                   |

No healthy case regresses; the gain grows with N and comes from `threads`, not
`block_m`.

## Verification
- norm numeric suite (smoke): 84 passed, 0 failed.
- pre-commit (incl. gitleaks): green.
