### PR TITLE
[Fix][GatedDeltaNet] Enable bf16 prefill blocksolve path

### DIFF
--- a/tests/ops/test_gated_deltanet_prefill.py
+++ b/tests/ops/test_gated_deltanet_prefill.py
@@ -337,10 +337,12 @@ def test_gated_deltanet_prefill_bthd_layout_matches_bhtd() -> None:
 
 
 @pytest.mark.smoke
-def test_gated_deltanet_prefill_bthd_blocksolve_path_matches_bhtd() -> None:
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gated_deltanet_prefill_bthd_blocksolve_path_matches_bhtd(
+    dtype: torch.dtype,
+) -> None:
     torch.manual_seed(42)
     B, H, S, DK, DV, BC = 1, 16, 128, 128, 128, 64
-    dtype = torch.float16
 
     test = GatedDeltaNetPrefillFwdTest(B, H, S, DK, DV, BC, dtype)
     q, k, v, g, beta = test.gen_inputs()

--- a/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_prefill.py
@@ -1466,7 +1466,7 @@ def _gated_deltanet_prefill_wrapped_kernel(
             chunk_size == 64
             and dim_k == 128
             and dim_v == 128
-            and dtype == "float16"
+            and dtype in ("float16", "bfloat16")
         )
         use_partitioned_prefill = (
             os.environ.get(


### PR DESCRIPTION
Fixes #1721.

## Summary

- Allow the Gated DeltaNet BTHD prefill blocksolve/partitioned path to run for both `float16` and `bfloat16`.
- Extend the existing BTHD blocksolve-path test to cover both dtypes.

## Context

Nightly benchmark output showed an odd short-shape split for `GatedDeltaNetPrefillFwdOp`:

- `S=4096,H=16,fp16`: slower path in the archived run
- `S=4096,H=16,bf16`: much faster

The root cause is that the BTHD blocksolve/partitioned prefill path was gated on `dtype == "float16"`, so bf16 used a different generic path. This PR makes fp16 and bf16 follow the same blocksolve dispatch condition for `chunk_size=64, DK=DV=128`.

## Validation

Ran locally with the official TileOps runner image, without installing or upgrading dependencies:

```bash
ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10
```

Runtime reported by the container:

- Python 3.12.13
- Torch 2.10.0+cu129
- TileLang 0.1.11+cu129.git65dbc983
- CUDA 12.9
- GPU: NVIDIA H200

Commands / results:

```bash
pytest -q tests/ops/test_gated_deltanet_prefill.py::test_gated_deltanet_prefill_bthd_blocksolve_path_matches_bhtd -s
# 2 passed
```

Targeted fallback benchmark after the dispatch unification:

```bash
pytest -q benchmarks/ops/bench_gated_deltanet_prefill.py \
  -k "fallback-gdn-prefill-b1-s4k-h16-d128-bthd" -s
# 2 passed
```

Measured rows from `profile_run.log`:

| dtype | TileOps latency | FLA latency | speedup_vs_fla |
| --- | ---: | ---: | ---: |
| `torch.float16` | 0.0972 ms | 0.2895 ms | 2.9779x |
| `torch.bfloat16` | 0.0974 ms | 0.2716 ms | 2.7894x |

These numbers confirm that fp16 and bf16 now take comparable paths for the 4K/H16 fallback row instead of diverging by dtype.

