### PR TITLE
[Perf][Cumsum] add adaptive parallel scan for small-M large-N workloads

### DIFF
--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -50,7 +50,7 @@ def _make_op(shape: tuple, dtype: torch.dtype, op_kind: str):
         "cumprod": CumprodFwdOp,
     }
     cls = op_map[op_kind]
-    return cls(N=shape[-1], dtype=dtype, dim=-1)
+    return cls(dtype=dtype, dim=-1)
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -410,13 +410,19 @@ def test_cumsum_parallel_scan_row_ownership(M: int, N: int) -> None:
         pytest.param(64, 16384, torch.float16),  # parallel branch — regression case
     ],
 )
-def test_cumsum_torch_compile_fullgraph(M: int, N: int, dtype: torch.dtype) -> None:
-    """torch.compile(fullgraph=True) must succeed for both sequential and parallel branches.
+def test_cumsum_compile_fullgraph_warm_cache(M: int, N: int, dtype: torch.dtype) -> None:
+    """torch.compile(fullgraph=True) must succeed on a warm kernel cache.
 
     N=512 exercises _cumulative_fwd_wrapped (sequential custom_op).
     N=16384 exercises _cumulative_parallel_fwd_wrapped (parallel custom_op) —
     this is the regression case: without the custom_op boundary, torch.compile
     raises 'unsupported Function.call' when tracing the raw JIT callables.
+
+    Not compile-contract evidence (see tests/compile_contract.py): the
+    contract covers a *cold* ``torch.compile(op, fullgraph=True)``, which
+    would trace CumulativeKernel construction inside the graph. This test
+    pre-warms the cache instead, so CumsumFwdOp must not declare
+    ``torch_compile_fullgraph`` in the manifest on its strength.
     """
     from tileops.ops.reduction.cumulative import CumsumFwdOp
 

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -332,8 +332,50 @@ def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
 
     # Verify correctness
     ref = x.float().cumsum(dim=-1).to(dtype)
-    assert torch.allclose(y, ref, atol=1e-2, rtol=1e-2), \
+    assert torch.allclose(y, ref, **_tol(dtype)), \
         f"Parallel scan failed for shape ({M}, {N}), max_diff={torch.abs(y - ref).max()}"
+
+    # Verify that the parallel backend was actually selected
+    kernel = op._get_kernel(M, N, dtype, x.device.index)
+    assert kernel.use_parallel, \
+        f"Expected parallel backend for shape ({M}, {N}) but got sequential"
+    expected_block_n = 256 if N > 16384 else 128
+    assert kernel.config["block_n"] == expected_block_n, \
+        f"Expected block_n={expected_block_n} for N={N}, got {kernel.config['block_n']}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "M, N, expected_backend",
+    [
+        (64, 8192, "sequential"),   # Boundary: N=8192 should use sequential
+        (128, 16384, "sequential"), # Boundary: M=128 should use sequential
+    ],
+)
+def test_cumsum_dispatch_boundary(M: int, N: int, expected_backend: str) -> None:
+    """Verify dispatch predicate boundaries select the correct backend."""
+    from tileops.ops.reduction.cumulative import CumsumFwdOp
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    x = torch.randn(M, N, dtype=dtype, device=device)
+
+    op = CumsumFwdOp(dtype=dtype, dim=-1)
+    y = op(x)
+
+    # Verify correctness
+    ref = x.float().cumsum(dim=-1).to(dtype)
+    assert torch.allclose(y, ref, **_tol(dtype)), \
+        f"Boundary test failed for shape ({M}, {N}), max_diff={torch.abs(y - ref).max()}"
+
+    # Verify the expected backend was selected
+    kernel = op._get_kernel(M, N, dtype, x.device.index)
+    if expected_backend == "parallel":
+        assert kernel.use_parallel, \
+            f"Expected parallel backend for ({M}, {N}) but got sequential"
+    else:
+        assert not kernel.use_parallel, \
+            f"Expected sequential backend for ({M}, {N}) but got parallel"
 
 
 @pytest.mark.smoke
@@ -389,7 +431,7 @@ def test_cumsum_torch_compile_fullgraph(M: int, N: int, dtype: torch.dtype) -> N
     y = compiled(x)
 
     ref = x.float().cumsum(dim=-1).to(dtype)
-    assert torch.allclose(y, ref, atol=1e-2, rtol=1e-2), \
+    assert torch.allclose(y, ref, **_tol(dtype)), \
         f"Compiled output mismatch for shape ({M},{N}): max_diff={torch.abs(y - ref).max()}"
 
 

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -336,22 +336,22 @@ def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("N", [16384, 32768])
-def test_cumsum_parallel_scan_all_ones(N: int) -> None:
-    """Test carry propagation across multiple tiles with all-ones input."""
+@pytest.mark.parametrize("M, N", [(1, 32768), (127, 16384)])
+def test_cumsum_parallel_scan_row_ownership(M: int, N: int) -> None:
+    """Test carry propagation and per-row ownership across multiple tiles."""
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     device = torch.device("cuda")
-    M = 1
-    x = torch.ones(M, N, dtype=torch.float32, device=device)
+    row_values = torch.arange(1, M + 1, dtype=torch.float32, device=device).unsqueeze(1)
+    x = row_values.expand(-1, N).contiguous()
 
     op = CumsumFwdOp(dtype=torch.float32, dim=-1)
     y = op(x)
 
-    # All-ones cumsum should produce [1, 2, 3, ..., N]
-    expected = torch.arange(1, N + 1, dtype=torch.float32, device=device).unsqueeze(0)
+    # Row r contains the constant r + 1, so its cumsum is (r + 1) * [1, ..., N].
+    expected = row_values * torch.arange(1, N + 1, dtype=torch.float32, device=device)
     assert torch.allclose(y, expected, atol=1e-3, rtol=1e-3), \
-        f"Carry propagation failed: y[0,512]={y[0,512]}, expected=513; y[0,-1]={y[0,-1]}, expected={N}"
+        f"Carry propagation failed for shape ({M}, {N}), max_diff={torch.abs(y - expected).max()}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -310,5 +310,49 @@ def test_cumprod_dim_axis1(
         f"cumprod dim=1 max err: {(y - ref).abs().max()}"
 
 
+# Test coverage for parallel scan path (N > 8192)
+@pytest.mark.parametrize(
+    "M, N, dtype",
+    [
+        pytest.param(64, 16384, torch.float32, marks=pytest.mark.smoke),   # block_n=128 path
+        pytest.param(64, 32768, torch.bfloat16, marks=pytest.mark.smoke),  # block_n=256 path
+        pytest.param(32, 16384, torch.float16, marks=pytest.mark.smoke),   # Different M
+    ],
+)
+def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
+    """Test parallel scan backend for small-M, large-N workloads."""
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    device = torch.device("cuda")
+    x = torch.randn(M, N, dtype=dtype, device=device)
+
+    op = CumsumFwdOp(dtype=dtype, dim=-1)
+    y = op(x)
+
+    # Verify correctness
+    ref = x.float().cumsum(dim=-1).to(dtype)
+    assert torch.allclose(y, ref, atol=1e-2, rtol=1e-2), \
+        f"Parallel scan failed for shape ({M}, {N}), max_diff={torch.abs(y - ref).max()}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("N", [16384, 32768])
+def test_cumsum_parallel_scan_all_ones(N: int) -> None:
+    """Test carry propagation across multiple tiles with all-ones input."""
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    device = torch.device("cuda")
+    M = 1
+    x = torch.ones(M, N, dtype=torch.float32, device=device)
+
+    op = CumsumFwdOp(dtype=torch.float32, dim=-1)
+    y = op(x)
+
+    # All-ones cumsum should produce [1, 2, 3, ..., N]
+    expected = torch.arange(1, N + 1, dtype=torch.float32, device=device).unsqueeze(0)
+    assert torch.allclose(y, expected, atol=1e-3, rtol=1e-3), \
+        f"Carry propagation failed: y[0,512]={y[0,512]}, expected=513; y[0,-1]={y[0,-1]}, expected={N}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -354,5 +354,39 @@ def test_cumsum_parallel_scan_all_ones(N: int) -> None:
         f"Carry propagation failed: y[0,512]={y[0,512]}, expected=513; y[0,-1]={y[0,-1]}, expected={N}"
 
 
+# ---------------------------------------------------------------------------
+# torch.compile regression: parallel scan branch must be compile-safe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "M, N, dtype",
+    [
+        pytest.param(64, 512, torch.float16),    # sequential branch — baseline
+        pytest.param(64, 16384, torch.float16),  # parallel branch — regression case
+    ],
+)
+def test_cumsum_torch_compile_fullgraph(M: int, N: int, dtype: torch.dtype) -> None:
+    """torch.compile(fullgraph=True) must succeed for both sequential and parallel branches.
+
+    N=512 exercises _cumulative_fwd_wrapped (sequential custom_op).
+    N=16384 exercises _cumulative_parallel_fwd_wrapped (parallel custom_op) —
+    this is the regression case: without the custom_op boundary, torch.compile
+    raises 'unsupported Function.call' when tracing the raw JIT callables.
+    """
+    from tileops.ops.reduction.cumsum import CumsumFwdOp
+
+    op = CumsumFwdOp(dtype=dtype, dim=-1)
+    compiled = torch.compile(op, fullgraph=True)
+
+    x = torch.randn(M, N, dtype=dtype, device="cuda")
+    y = compiled(x)
+
+    ref = x.float().cumsum(dim=-1).to(dtype)
+    assert torch.allclose(y, ref, atol=1e-2, rtol=1e-2), \
+        f"Compiled output mismatch for shape ({M},{N}): max_diff={torch.abs(y - ref).max()}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -378,9 +378,13 @@ def test_cumsum_torch_compile_fullgraph(M: int, N: int, dtype: torch.dtype) -> N
     from tileops.ops.reduction.cumsum import CumsumFwdOp
 
     op = CumsumFwdOp(dtype=dtype, dim=-1)
-    compiled = torch.compile(op, fullgraph=True)
-
     x = torch.randn(M, N, dtype=dtype, device="cuda")
+
+    # Pre-warm the kernel cache before compiling so construction never
+    # happens inside the compiled region.
+    op(x)
+
+    compiled = torch.compile(op, fullgraph=True)
     y = compiled(x)
 
     ref = x.float().cumsum(dim=-1).to(dtype)

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -310,127 +310,76 @@ def test_cumprod_dim_axis1(
         f"cumprod dim=1 max err: {(y - ref).abs().max()}"
 
 
-# Test coverage for parallel scan path (N > 8192)
-@pytest.mark.parametrize(
-    "M, N, dtype",
-    [
-        pytest.param(64, 16384, torch.float32, marks=pytest.mark.smoke),   # block_n=128 path
-        pytest.param(64, 32768, torch.bfloat16, marks=pytest.mark.smoke),  # block_n=256 path
-        pytest.param(32, 16384, torch.float16, marks=pytest.mark.smoke),   # Different M
-        pytest.param(64, 8200, torch.float32, marks=pytest.mark.smoke),    # N%block_n!=0: exercises _needs_mask partial-tail branch
-    ],
-)
-def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
-    """Test parallel scan backend for small-M, large-N workloads."""
-    from tileops.ops.reduction.cumulative import CumsumFwdOp
-
-    device = torch.device("cuda")
-    x = torch.randn(M, N, dtype=dtype, device=device)
-
-    op = CumsumFwdOp(dtype=dtype, dim=-1)
-    y = op(x)
-
-    # Verify correctness
-    ref = x.float().cumsum(dim=-1).to(dtype)
-    assert torch.allclose(y, ref, **_tol(dtype)), \
-        f"Parallel scan failed for shape ({M}, {N}), max_diff={torch.abs(y - ref).max()}"
-
-    # Verify that the parallel backend was actually selected
-    kernel = op._get_kernel(M, N, dtype, x.device.index)
-    assert kernel.use_parallel, \
-        f"Expected parallel backend for shape ({M}, {N}) but got sequential"
-    expected_block_n = 256 if N > 16384 else 128
-    assert kernel.config["block_n"] == expected_block_n, \
-        f"Expected block_n={expected_block_n} for N={N}, got {kernel.config['block_n']}"
-
-
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    "M, N, expected_backend",
+    "M, N, dtype, parallel",
     [
-        (64, 8192, "sequential"),   # Boundary: N=8192 should use sequential
-        (128, 16384, "sequential"), # Boundary: M=128 should use sequential
+        (64, 16384, torch.float32, True),      # block_n=128
+        (64, 32768, torch.bfloat16, True),     # block_n=256
+        (32, 16384, torch.float16, True),      # fp16 intermediate
+        (64, 8200, torch.float32, True),       # N % block_n != 0: masked tail
+        (64, 8192, torch.bfloat16, False),     # N boundary
+        (128, 16384, torch.bfloat16, False),   # M boundary
     ],
 )
-def test_cumsum_dispatch_boundary(M: int, N: int, expected_backend: str) -> None:
-    """Verify dispatch predicate boundaries select the correct backend."""
+def test_cumsum_backend_dispatch(M: int, N: int, dtype: torch.dtype, parallel: bool) -> None:
+    """Each shape takes the expected backend and matches torch.cumsum."""
     from tileops.ops.reduction.cumulative import CumsumFwdOp
 
-    device = torch.device("cuda")
-    dtype = torch.bfloat16
-    x = torch.randn(M, N, dtype=dtype, device=device)
-
+    x = torch.randn(M, N, dtype=dtype, device="cuda")
     op = CumsumFwdOp(dtype=dtype, dim=-1)
     y = op(x)
 
-    # Verify correctness
     ref = x.float().cumsum(dim=-1).to(dtype)
     assert torch.allclose(y, ref, **_tol(dtype)), \
-        f"Boundary test failed for shape ({M}, {N}), max_diff={torch.abs(y - ref).max()}"
+        f"({M}, {N}) {dtype}: max_diff={torch.abs(y - ref).max()}"
 
-    # Verify the expected backend was selected
     kernel = op._get_kernel(M, N, dtype, x.device.index)
-    if expected_backend == "parallel":
-        assert kernel.use_parallel, \
-            f"Expected parallel backend for ({M}, {N}) but got sequential"
-    else:
-        assert not kernel.use_parallel, \
-            f"Expected sequential backend for ({M}, {N}) but got parallel"
+    assert kernel.use_parallel == parallel, f"({M}, {N}): unexpected backend"
+    if parallel:
+        assert kernel.config["block_n"] == (256 if N > 16384 else 128)
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("M, N", [(1, 32768), (127, 16384)])
 def test_cumsum_parallel_scan_row_ownership(M: int, N: int) -> None:
-    """Test carry propagation and per-row ownership across multiple tiles."""
+    """Carry propagation stays per-row across tiles and partial row blocks."""
     from tileops.ops.reduction.cumulative import CumsumFwdOp
 
-    device = torch.device("cuda")
-    row_values = torch.arange(1, M + 1, dtype=torch.float32, device=device).unsqueeze(1)
+    row_values = torch.arange(1, M + 1, dtype=torch.float32, device="cuda").unsqueeze(1)
     x = row_values.expand(-1, N).contiguous()
 
-    op = CumsumFwdOp(dtype=torch.float32, dim=-1)
-    y = op(x)
+    y = CumsumFwdOp(dtype=torch.float32, dim=-1)(x)
 
-    # Row r contains the constant r + 1, so its cumsum is (r + 1) * [1, ..., N].
-    expected = row_values * torch.arange(1, N + 1, dtype=torch.float32, device=device)
+    # Row r holds the constant r + 1, so its cumsum is (r + 1) * [1, ..., N].
+    expected = row_values * torch.arange(1, N + 1, dtype=torch.float32, device="cuda")
     assert torch.allclose(y, expected, atol=1e-3, rtol=1e-3), \
-        f"Carry propagation failed for shape ({M}, {N}), max_diff={torch.abs(y - expected).max()}"
-
-
-# ---------------------------------------------------------------------------
-# torch.compile regression: parallel scan branch must be compile-safe
-# ---------------------------------------------------------------------------
+        f"({M}, {N}): max_diff={torch.abs(y - expected).max()}"
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "M, N, dtype",
     [
-        pytest.param(64, 512, torch.float16),    # sequential branch — baseline
-        pytest.param(64, 16384, torch.float16),  # parallel branch — regression case
+        pytest.param(64, 512, torch.float16),    # sequential custom_op
+        pytest.param(64, 16384, torch.float16),  # parallel custom_op
     ],
 )
 def test_cumsum_compile_fullgraph_warm_cache(M: int, N: int, dtype: torch.dtype) -> None:
     """torch.compile(fullgraph=True) must succeed on a warm kernel cache.
 
-    N=512 exercises _cumulative_fwd_wrapped (sequential custom_op).
-    N=16384 exercises _cumulative_parallel_fwd_wrapped (parallel custom_op) —
-    this is the regression case: without the custom_op boundary, torch.compile
-    raises 'unsupported Function.call' when tracing the raw JIT callables.
+    Guards the custom_op boundary: tracing the raw JIT callables instead
+    raises 'unsupported Function.call'.
 
-    Not compile-contract evidence (see tests/compile_contract.py): the
-    contract covers a *cold* ``torch.compile(op, fullgraph=True)``, which
-    would trace CumulativeKernel construction inside the graph. This test
-    pre-warms the cache instead, so CumsumFwdOp must not declare
-    ``torch_compile_fullgraph`` in the manifest on its strength.
+    Not compile-contract evidence (see tests/compile_contract.py) — that
+    contract covers a *cold* compile, which would trace kernel construction
+    inside the graph. Pre-warming here sidesteps it, so CumsumFwdOp must not
+    declare ``torch_compile_fullgraph`` on this test's strength.
     """
     from tileops.ops.reduction.cumulative import CumsumFwdOp
 
     op = CumsumFwdOp(dtype=dtype, dim=-1)
     x = torch.randn(M, N, dtype=dtype, device="cuda")
-
-    # Pre-warm the kernel cache before compiling so construction never
-    # happens inside the compiled region.
     op(x)
 
     compiled = torch.compile(op, fullgraph=True)

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -317,6 +317,7 @@ def test_cumprod_dim_axis1(
         pytest.param(64, 16384, torch.float32, marks=pytest.mark.smoke),   # block_n=128 path
         pytest.param(64, 32768, torch.bfloat16, marks=pytest.mark.smoke),  # block_n=256 path
         pytest.param(32, 16384, torch.float16, marks=pytest.mark.smoke),   # Different M
+        pytest.param(64, 8200, torch.float32, marks=pytest.mark.smoke),    # N%block_n!=0: exercises _needs_mask partial-tail branch
     ],
 )
 def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:

--- a/tests/ops/test_cumulative.py
+++ b/tests/ops/test_cumulative.py
@@ -322,7 +322,7 @@ def test_cumprod_dim_axis1(
 )
 def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
     """Test parallel scan backend for small-M, large-N workloads."""
-    from tileops.ops.reduction.cumsum import CumsumFwdOp
+    from tileops.ops.reduction.cumulative import CumsumFwdOp
 
     device = torch.device("cuda")
     x = torch.randn(M, N, dtype=dtype, device=device)
@@ -340,7 +340,7 @@ def test_cumsum_parallel_scan(M: int, N: int, dtype: torch.dtype) -> None:
 @pytest.mark.parametrize("M, N", [(1, 32768), (127, 16384)])
 def test_cumsum_parallel_scan_row_ownership(M: int, N: int) -> None:
     """Test carry propagation and per-row ownership across multiple tiles."""
-    from tileops.ops.reduction.cumsum import CumsumFwdOp
+    from tileops.ops.reduction.cumulative import CumsumFwdOp
 
     device = torch.device("cuda")
     row_values = torch.arange(1, M + 1, dtype=torch.float32, device=device).unsqueeze(1)
@@ -376,7 +376,7 @@ def test_cumsum_torch_compile_fullgraph(M: int, N: int, dtype: torch.dtype) -> N
     this is the regression case: without the custom_op boundary, torch.compile
     raises 'unsupported Function.call' when tracing the raw JIT callables.
     """
-    from tileops.ops.reduction.cumsum import CumsumFwdOp
+    from tileops.ops.reduction.cumulative import CumsumFwdOp
 
     op = CumsumFwdOp(dtype=dtype, dim=-1)
     x = torch.randn(M, N, dtype=dtype, device="cuda")

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -381,8 +381,7 @@ class CumulativeKernel(Kernel):
         if self.use_parallel:
             # Parallel scan config: larger tiles for better parallelism
             block_n = 256 if self.N > 16384 else 128
-            block_m = 16
-            elem_size = torch.tensor([], dtype=self.dtype).element_size()
+            block_m = max(1, min(16, self.M))
             smem_per_row = (block_n + _SMEM_PAD) * 4  # float32 intermediate
             max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
             block_m = min(block_m, max_block_m)

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -564,8 +564,13 @@ def _parallel_scan_carry_kernel(M: int, n_tiles: int):
             tile_sums: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
             tile_carries: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
         ):
-            with T.Kernel(M, threads=threads) as row:  # noqa: SIM117
-                # Each thread handles one complete row
+            with T.Kernel(T.ceildiv(M, threads), threads=threads) as pid:  # noqa: SIM117
+                tx = T.get_thread_binding()
+                row = pid * threads + tx
+
+                # Give every row a unique thread owner.  The block index alone
+                # cannot identify a thread, so using it as ``row`` would make
+                # every thread in the block race on the same output locations.
                 with T.If(row < M):
                     with T.Then():
                         # Exclusive scan: first element is 0

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -332,6 +332,7 @@ class CumulativeKernel(Kernel):
             self.kernel_local = _parallel_scan_local_kernel(M, N, op_kind, self.dtype_str)
             self.kernel_propagate = _parallel_scan_propagate_kernel(M, N, self.dtype_str)
             self.kernel = None  # Not used for parallel
+            tune = False  # Disable autotuning for parallel path (uses optimized defaults)
         else:
             # Sequential scan (original implementation)
             self.kernel = _cumulative_kernel(M, N, op_kind, self.dtype_str)
@@ -407,12 +408,7 @@ class CumulativeKernel(Kernel):
             threads = self.config["threads"]
             n_tiles = self.N_padded // block_n
 
-            # Allocate intermediate buffers
-            y_local = torch.empty((self.M, self.N_padded), dtype=torch.float32, device=x.device)
-            tile_sums = torch.empty((self.M, n_tiles), dtype=torch.float32, device=x.device)
-            y_final = torch.empty((self.M, self.N_padded), dtype=self.dtype, device=x.device)
-
-            # Pass 1: Local scan within each tile
+            # Pass 1: Local scan within each tile (JIT kernel auto-allocates outputs)
             local_fn = self.kernel_local(block_m, block_n, threads)
             y_local, tile_sums = local_fn(x)
 
@@ -422,7 +418,7 @@ class CumulativeKernel(Kernel):
             if n_tiles > 1:
                 tile_carries_exclusive[:, 1:] = tile_carries[:, :-1]
 
-            # Pass 3: Propagate carries
+            # Pass 3: Propagate carries (JIT kernel auto-allocates output)
             propagate_fn = self.kernel_propagate(block_m, block_n, threads)
             y_final = propagate_fn(y_local, tile_carries_exclusive)
 

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -329,9 +329,9 @@ class CumulativeKernel(Kernel):
 
         if self.use_parallel:
             # Three-pass parallel scan
-            n_tiles = align_up(N, DEFAULT_ALIGNMENT) // 256  # Using default block_n=256
+            # Note: n_tiles will be determined from config after init_config()
             self.kernel_local = _parallel_scan_local_kernel(M, N, op_kind, self.dtype_str)
-            self.kernel_carry = _parallel_scan_carry_kernel(M, n_tiles)
+            self.kernel_carry = None  # Will be created after config is known
             self.kernel_propagate = _parallel_scan_propagate_kernel(M, N, self.dtype_str)
             self.kernel = None  # Not used for parallel
 
@@ -353,6 +353,11 @@ class CumulativeKernel(Kernel):
             self.kernel_propagate = None
 
         self.init_config(config, tune)
+
+        # Create carry kernel after config is known (need block_n for n_tiles)
+        if self.use_parallel:
+            n_tiles = self.N_padded // self.config["block_n"]
+            self.kernel_carry = _parallel_scan_carry_kernel(M, n_tiles)
 
     @property
     def default_config(self) -> dict:
@@ -425,7 +430,7 @@ class CumulativeKernel(Kernel):
             y_local, tile_sums = local_fn(x)
 
             # Pass 2: Exclusive scan of tile sums (TileLang kernel)
-            carry_fn = self.kernel_carry(block_m, threads)
+            carry_fn = self.kernel_carry(threads)
             tile_carries_exclusive = carry_fn(tile_sums)
 
             # Pass 3: Propagate carries (JIT kernel auto-allocates output)
@@ -546,22 +551,24 @@ def _parallel_scan_carry_kernel(M: int, n_tiles: int):
 
     Uses sequential scan since n_tiles is typically small (e.g., 128-256).
     Output is exclusive scan: out[i, 0] = 0, out[i, j] = cumsum(in[i, :j])
+
+    Each thread processes one complete row to avoid data races.
     """
     @tilelang.jit(out_idx=[1])
-    def _func(block_m, threads):
+    def _func(threads):
         @T.prim_func
         def main(
             tile_sums: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
             tile_carries: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
         ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                # Sequential scan along n_tiles dimension for each row
-                for i in T.Parallel(block_m):
-                    row = pid_m * block_m + i
-                    with T.If(row < M), T.Then():
+            with T.Kernel(M, threads=threads) as row:  # noqa: SIM117
+                # Each thread handles one complete row
+                with T.If(row < M):
+                    with T.Then():
                         # Exclusive scan: first element is 0
                         tile_carries[row, 0] = T.float32(0.0)
-                        running_sum = T.float32(0.0)
+                        # Mutable accumulator for loop-carried state
+                        running_sum = T.alloc_var("float32", init=0.0)
                         # Sequential loop over tiles
                         for j in T.Serial(n_tiles - 1):
                             running_sum = running_sum + tile_sums[row, j]

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -258,6 +258,31 @@ def _cumulative_kernel(M: int, N: int, op_kind: str, dtype: str):
 # custom_op wrappers for torch.compile compatibility
 
 
+@torch.library.custom_op("top::cumulative_parallel_fwd", mutates_args=())
+def _cumulative_parallel_fwd_wrapped(
+    M: int,
+    N: int,
+    dtype_str: str,
+    block_m: int,
+    block_n: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    n_tiles = align_up(N, DEFAULT_ALIGNMENT) // block_n
+    local_fn = _parallel_scan_local_kernel(M, N, "sum", dtype_str)(block_m, block_n, threads)
+    y_local, tile_sums = local_fn(x)
+    carry_fn = _parallel_scan_carry_kernel(M, n_tiles)(threads)
+    tile_carries_exclusive = carry_fn(tile_sums)
+    propagate_fn = _parallel_scan_propagate_kernel(M, N, dtype_str)(block_m, block_n, threads)
+    return propagate_fn(y_local, tile_carries_exclusive)
+
+
+@_cumulative_parallel_fwd_wrapped.register_fake
+def _(M, N, dtype_str, block_m, block_n, threads, x):
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
+
+
 @torch.library.custom_op("top::cumulative_fwd", mutates_args=())
 def _cumulative_fwd_wrapped(
     M: int,
@@ -328,11 +353,6 @@ class CumulativeKernel(Kernel):
         self.use_parallel = (M < 128 and N > 8192 and op_kind == "sum")
 
         if self.use_parallel:
-            # Three-pass parallel scan
-            # Note: n_tiles will be determined from config after init_config()
-            self.kernel_local = _parallel_scan_local_kernel(M, N, op_kind, self.dtype_str)
-            self.kernel_carry = None  # Will be created after config is known
-            self.kernel_propagate = _parallel_scan_propagate_kernel(M, N, self.dtype_str)
             self.kernel = None  # Not used for parallel
 
             # Parallel backend does not support autotuning yet
@@ -348,16 +368,8 @@ class CumulativeKernel(Kernel):
         else:
             # Sequential scan (original implementation)
             self.kernel = _cumulative_kernel(M, N, op_kind, self.dtype_str)
-            self.kernel_local = None
-            self.kernel_carry = None
-            self.kernel_propagate = None
 
         self.init_config(config, tune)
-
-        # Create carry kernel after config is known (need block_n for n_tiles)
-        if self.use_parallel:
-            n_tiles = self.N_padded // self.config["block_n"]
-            self.kernel_carry = _parallel_scan_carry_kernel(M, n_tiles)
 
     @property
     def default_config(self) -> dict:
@@ -420,24 +432,15 @@ class CumulativeKernel(Kernel):
             Output tensor of shape (M, N_padded).
         """
         if self.use_parallel:
-            # Three-pass parallel scan
-            block_m = self.config["block_m"]
-            block_n = self.config["block_n"]
-            threads = self.config["threads"]
-
-            # Pass 1: Local scan within each tile (JIT kernel auto-allocates outputs)
-            local_fn = self.kernel_local(block_m, block_n, threads)
-            y_local, tile_sums = local_fn(x)
-
-            # Pass 2: Exclusive scan of tile sums (TileLang kernel)
-            carry_fn = self.kernel_carry(threads)
-            tile_carries_exclusive = carry_fn(tile_sums)
-
-            # Pass 3: Propagate carries (JIT kernel auto-allocates output)
-            propagate_fn = self.kernel_propagate(block_m, block_n, threads)
-            y_final = propagate_fn(y_local, tile_carries_exclusive)
-
-            return y_final
+            return _cumulative_parallel_fwd_wrapped(
+                self.M,
+                self.N,
+                self.dtype_str,
+                self.config["block_m"],
+                self.config["block_n"],
+                self.config["threads"],
+                x,
+            )
         else:
             # Sequential scan (original implementation)
             return _cumulative_fwd_wrapped(

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -322,41 +322,56 @@ class CumulativeKernel(Kernel):
         self.op_kind = op_kind
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.kernel = _cumulative_kernel(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_str,
-        )
+
+        # Adaptive dispatch: use parallel scan for small-M, large-N
+        # Only for cumsum (cumprod not yet supported for parallel)
+        self.use_parallel = (M < 128 and N > 8192 and op_kind == "sum")
+
+        if self.use_parallel:
+            # Three-pass parallel scan
+            self.kernel_local = _parallel_scan_local_kernel(M, N, op_kind, self.dtype_str)
+            self.kernel_propagate = _parallel_scan_propagate_kernel(M, N, self.dtype_str)
+            self.kernel = None  # Not used for parallel
+        else:
+            # Sequential scan (original implementation)
+            self.kernel = _cumulative_kernel(M, N, op_kind, self.dtype_str)
+            self.kernel_local = None
+            self.kernel_propagate = None
+
         self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
-        """Select default config based on shape for optimal SM utilization.
+        """Select default config based on shape and backend.
 
-        Based on NCU profiling showing that small M suffers from poor SM utilization.
-        For M < 128, use smaller block_m to launch more thread blocks.
+        For parallel scan: use larger block_n for better parallelism.
+        For sequential scan: use adaptive block_m based on M.
         """
-        block_n = _DEFAULT_BLOCK_N
-        elem_size = torch.tensor([], dtype=self.dtype).element_size()
-        # Account for padding in shared memory budget calculation
-        smem_per_row = 2 * (block_n + _SMEM_PAD) * elem_size
-        max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-
-        # Shape-adaptive block_m for better SM utilization
-        if self.M < 128:
-            # Small M: use block_m=2 for better SM utilization
-            # NCU shows block_m=2 gives 28% SM util vs 3.5% for block_m=16
-            # Cap by self.M to avoid wasting resources on very small shapes, ensuring at least 1
-            block_m = max(1, min(self.M, min(2, max_block_m)))
+        if self.use_parallel:
+            # Parallel scan config: larger tiles for better parallelism
+            block_n = 256 if self.N > 16384 else 128
+            block_m = 16
+            elem_size = torch.tensor([], dtype=self.dtype).element_size()
+            smem_per_row = (block_n + _SMEM_PAD) * 4  # float32 intermediate
+            max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
+            block_m = min(block_m, max_block_m)
+            return {"block_m": block_m, "block_n": block_n, "threads": 256}
         else:
-            # Large M: use larger block_m for memory efficiency
-            block_m = 1
-            for bm in [1, 2, 4, 8, 16]:
-                if bm <= max_block_m:
-                    block_m = bm
+            # Sequential scan config (original logic)
+            block_n = _DEFAULT_BLOCK_N
+            elem_size = torch.tensor([], dtype=self.dtype).element_size()
+            smem_per_row = 2 * (block_n + _SMEM_PAD) * elem_size
+            max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
 
-        return {"block_m": block_m, "block_n": block_n, "threads": 128}
+            if self.M < 128:
+                block_m = max(1, min(self.M, min(2, max_block_m)))
+            else:
+                block_m = 1
+                for bm in [1, 2, 4, 8, 16]:
+                    if bm <= max_block_m:
+                        block_m = bm
+
+            return {"block_m": block_m, "block_n": block_n, "threads": 128}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -376,7 +391,7 @@ class CumulativeKernel(Kernel):
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the cumulative scan kernel.
+        """Run the cumulative scan kernel (sequential or parallel).
 
         Args:
             x: Input tensor of shape (M, N).  Alignment padding is
@@ -385,13 +400,176 @@ class CumulativeKernel(Kernel):
         Returns:
             Output tensor of shape (M, N_padded).
         """
-        return _cumulative_fwd_wrapped(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["block_n"],
-            self.config["threads"],
-            x,
-        )
+        if self.use_parallel:
+            # Three-pass parallel scan
+            block_m = self.config["block_m"]
+            block_n = self.config["block_n"]
+            threads = self.config["threads"]
+            n_tiles = self.N_padded // block_n
+
+            # Allocate intermediate buffers
+            y_local = torch.empty((self.M, self.N_padded), dtype=torch.float32, device=x.device)
+            tile_sums = torch.empty((self.M, n_tiles), dtype=torch.float32, device=x.device)
+            y_final = torch.empty((self.M, self.N_padded), dtype=self.dtype, device=x.device)
+
+            # Pass 1: Local scan within each tile
+            local_fn = self.kernel_local(block_m, block_n, threads)
+            y_local, tile_sums = local_fn(x)
+
+            # Pass 2: Exclusive scan of tile sums (PyTorch)
+            tile_carries = torch.cumsum(tile_sums, dim=1, dtype=torch.float32)
+            tile_carries_exclusive = torch.zeros_like(tile_carries)
+            if n_tiles > 1:
+                tile_carries_exclusive[:, 1:] = tile_carries[:, :-1]
+
+            # Pass 3: Propagate carries
+            propagate_fn = self.kernel_propagate(block_m, block_n, threads)
+            y_final = propagate_fn(y_local, tile_carries_exclusive)
+
+            return y_final
+        else:
+            # Sequential scan (original implementation)
+            return _cumulative_fwd_wrapped(
+                self.M,
+                self.N,
+                self.op_kind,
+                self.dtype_str,
+                self.config["block_m"],
+                self.config["block_n"],
+                self.config["threads"],
+                x,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Parallel scan kernels for small-M, large-N workloads
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=32)
+def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
+    """Pass 1: Local scan within each tile (parallel across all tiles).
+
+    Grid: (M/block_m, N_padded/block_n) for massive parallelism.
+    Each thread block independently scans one tile.
+    """
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+    _identity = 0.0 if op_kind == "sum" else 1.0
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func(block_m, block_n, threads):
+        n_tiles = N_padded // block_n
+        _needs_mask = (n_tiles * block_n) > N
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M, N), dtype],
+            y_local: T.Tensor[(M, N_padded), "float32"],  # noqa: F821
+            tile_sums: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), n_tiles, threads=threads) as (pid_m, tile_idx):
+                tile_shared = T.alloc_shared((block_m, block_n + _SMEM_PAD), "float32")
+                tile_frag = T.alloc_fragment((block_m, block_n), "float32")
+
+                # Load tile
+                if _needs_mask:
+                    with T.If((tile_idx + 1) * block_n <= N):
+                        with T.Then():
+                            for i, j in T.Parallel(block_m, block_n):
+                                row = pid_m * block_m + i
+                                col = tile_idx * block_n + j
+                                tile_shared[i, j] = T.if_then_else(
+                                    row < M,
+                                    T.cast(x[row, col], "float32"),
+                                    T.cast(_identity, "float32"),
+                                )
+                        with T.Else():
+                            for i, j in T.Parallel(block_m, block_n):
+                                row = pid_m * block_m + i
+                                col = tile_idx * block_n + j
+                                tile_shared[i, j] = T.if_then_else(
+                                    T.And(row < M, col < N),
+                                    T.cast(x[row, col], "float32"),
+                                    T.cast(_identity, "float32"),
+                                )
+                else:
+                    for i, j in T.Parallel(block_m, block_n):
+                        row = pid_m * block_m + i
+                        col = tile_idx * block_n + j
+                        tile_shared[i, j] = T.if_then_else(
+                            row < M,
+                            T.cast(x[row, col], "float32"),
+                            T.cast(_identity, "float32"),
+                        )
+
+                T.sync_threads()
+
+                # Copy to fragment and scan
+                for i, j in T.Parallel(block_m, block_n):
+                    tile_frag[i, j] = tile_shared[i, j]
+                T.sync_threads()
+
+                T.cumsum(tile_frag, dim=1)
+                T.sync_threads()
+
+                # Copy back
+                for i, j in T.Parallel(block_m, block_n):
+                    tile_shared[i, j] = tile_frag[i, j]
+                T.sync_threads()
+
+                # Write results
+                for i, j in T.Parallel(block_m, block_n):
+                    row = pid_m * block_m + i
+                    col = tile_idx * block_n + j
+                    with T.If(row < M), T.Then():
+                        y_local[row, col] = tile_shared[i, j]
+
+                for i in T.Parallel(block_m):
+                    row = pid_m * block_m + i
+                    with T.If(row < M), T.Then():
+                        tile_sums[row, tile_idx] = tile_shared[i, block_n - 1]
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _parallel_scan_propagate_kernel(M: int, N: int, dtype: str):
+    """Pass 3: Add carry values and cast to output dtype."""
+    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+
+    @tilelang.jit(out_idx=[2])
+    def _func(block_m, block_n, threads):
+        n_tiles = N_padded // block_n
+
+        @T.prim_func
+        def main(
+            y_local: T.Tensor[(M, N_padded), "float32"],  # noqa: F821
+            tile_carries: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
+            y_final: T.Tensor[(M, N_padded), dtype],
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), n_tiles, threads=threads) as (pid_m, tile_idx):
+                tile_shared = T.alloc_shared((block_m, block_n + _SMEM_PAD), "float32")
+
+                # Load y_local
+                for i, j in T.Parallel(block_m, block_n):
+                    row = pid_m * block_m + i
+                    col = tile_idx * block_n + j
+                    with T.If(row < M), T.Then():
+                        tile_shared[i, j] = y_local[row, col]
+
+                T.sync_threads()
+
+                # Add carry and write
+                for i, j in T.Parallel(block_m, block_n):
+                    row = pid_m * block_m + i
+                    col = tile_idx * block_n + j
+                    with T.If(row < M), T.Then():
+                        carry = tile_carries[row, tile_idx]
+                        result_f32 = tile_shared[i, j] + carry
+                        y_final[row, col] = T.cast(result_f32, dtype)
+
+        return main
+
+    return _func

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -329,14 +329,27 @@ class CumulativeKernel(Kernel):
 
         if self.use_parallel:
             # Three-pass parallel scan
+            n_tiles = align_up(N, DEFAULT_ALIGNMENT) // 256  # Using default block_n=256
             self.kernel_local = _parallel_scan_local_kernel(M, N, op_kind, self.dtype_str)
+            self.kernel_carry = _parallel_scan_carry_kernel(M, n_tiles)
             self.kernel_propagate = _parallel_scan_propagate_kernel(M, N, self.dtype_str)
             self.kernel = None  # Not used for parallel
-            tune = False  # Disable autotuning for parallel path (uses optimized defaults)
+
+            # Parallel backend does not support autotuning yet
+            if tune:
+                import warnings
+                warnings.warn(
+                    f"Autotuning is not supported for parallel scan backend "
+                    f"(shape {M}×{N}). Using optimized defaults.",
+                    UserWarning,
+                    stacklevel=2
+                )
+                tune = False
         else:
             # Sequential scan (original implementation)
             self.kernel = _cumulative_kernel(M, N, op_kind, self.dtype_str)
             self.kernel_local = None
+            self.kernel_carry = None
             self.kernel_propagate = None
 
         self.init_config(config, tune)
@@ -406,17 +419,14 @@ class CumulativeKernel(Kernel):
             block_m = self.config["block_m"]
             block_n = self.config["block_n"]
             threads = self.config["threads"]
-            n_tiles = self.N_padded // block_n
 
             # Pass 1: Local scan within each tile (JIT kernel auto-allocates outputs)
             local_fn = self.kernel_local(block_m, block_n, threads)
             y_local, tile_sums = local_fn(x)
 
-            # Pass 2: Exclusive scan of tile sums (PyTorch)
-            tile_carries = torch.cumsum(tile_sums, dim=1, dtype=torch.float32)
-            tile_carries_exclusive = torch.zeros_like(tile_carries)
-            if n_tiles > 1:
-                tile_carries_exclusive[:, 1:] = tile_carries[:, :-1]
+            # Pass 2: Exclusive scan of tile sums (TileLang kernel)
+            carry_fn = self.kernel_carry(block_m, threads)
+            tile_carries_exclusive = carry_fn(tile_sums)
 
             # Pass 3: Propagate carries (JIT kernel auto-allocates output)
             propagate_fn = self.kernel_propagate(block_m, block_n, threads)
@@ -524,6 +534,38 @@ def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
                     row = pid_m * block_m + i
                     with T.If(row < M), T.Then():
                         tile_sums[row, tile_idx] = tile_shared[i, block_n - 1]
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _parallel_scan_carry_kernel(M: int, n_tiles: int):
+    """Pass 2: Exclusive cumsum on tile boundary values (small array M x n_tiles).
+
+    Uses sequential scan since n_tiles is typically small (e.g., 128-256).
+    Output is exclusive scan: out[i, 0] = 0, out[i, j] = cumsum(in[i, :j])
+    """
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m, threads):
+        @T.prim_func
+        def main(
+            tile_sums: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
+            tile_carries: T.Tensor[(M, n_tiles), "float32"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                # Sequential scan along n_tiles dimension for each row
+                for i in T.Parallel(block_m):
+                    row = pid_m * block_m + i
+                    with T.If(row < M), T.Then():
+                        # Exclusive scan: first element is 0
+                        tile_carries[row, 0] = T.float32(0.0)
+                        running_sum = T.float32(0.0)
+                        # Sequential loop over tiles
+                        for j in T.Serial(n_tiles - 1):
+                            running_sum = running_sum + tile_sums[row, j]
+                            tile_carries[row, j + 1] = running_sum
 
         return main
 

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -571,16 +571,15 @@ def _parallel_scan_carry_kernel(M: int, n_tiles: int):
                 # Give every row a unique thread owner.  The block index alone
                 # cannot identify a thread, so using it as ``row`` would make
                 # every thread in the block race on the same output locations.
-                with T.If(row < M):
-                    with T.Then():
-                        # Exclusive scan: first element is 0
-                        tile_carries[row, 0] = T.float32(0.0)
-                        # Mutable accumulator for loop-carried state
-                        running_sum = T.alloc_var("float32", init=0.0)
-                        # Sequential loop over tiles
-                        for j in T.Serial(n_tiles - 1):
-                            running_sum = running_sum + tile_sums[row, j]
-                            tile_carries[row, j + 1] = running_sum
+                with T.If(row < M), T.Then():
+                    # Exclusive scan: first element is 0
+                    tile_carries[row, 0] = T.float32(0.0)
+                    # Mutable accumulator for loop-carried state
+                    running_sum = T.alloc_var("float32", init=0.0)
+                    # Sequential loop over tiles
+                    for j in T.Serial(n_tiles - 1):
+                        running_sum = running_sum + tile_sums[row, j]
+                        tile_carries[row, j + 1] = running_sum
 
         return main
 

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -31,6 +31,7 @@ Shared memory padding:
 
 import functools
 import itertools
+import warnings
 from typing import Optional
 
 import tilelang
@@ -348,46 +349,35 @@ class CumulativeKernel(Kernel):
         self.dtype = dtype
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
 
-        # Adaptive dispatch: use parallel scan for small-M, large-N
-        # Only for cumsum (cumprod not yet supported for parallel)
+        # Parallel scan only pays off for small-M, large-N; cumprod has no
+        # parallel implementation.
         self.use_parallel = (M < 128 and N > 8192 and op_kind == "sum")
 
         if self.use_parallel:
-            self.kernel = None  # Not used for parallel
-
-            # Parallel backend does not support autotuning yet
+            self.kernel = None
             if tune:
-                import warnings
                 warnings.warn(
-                    f"Autotuning is not supported for parallel scan backend "
-                    f"(shape {M}×{N}). Using optimized defaults.",
+                    f"Autotuning is unsupported for the parallel scan backend "
+                    f"(shape {M}x{N}); using default config.",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
                 tune = False
         else:
-            # Sequential scan (original implementation)
             self.kernel = _cumulative_kernel(M, N, op_kind, self.dtype_str)
 
         self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
-        """Select default config based on shape and backend.
-
-        For parallel scan: use larger block_n for better parallelism.
-        For sequential scan: use adaptive block_m based on M.
-        """
+        """Select the default config for the selected backend and shape."""
         if self.use_parallel:
-            # Parallel scan config: larger tiles for better parallelism
             block_n = 256 if self.N > 16384 else 128
-            block_m = max(1, min(16, self.M))
-            smem_per_row = (block_n + _SMEM_PAD) * 4  # float32 intermediate
+            smem_per_row = (block_n + _SMEM_PAD) * 4  # fp32 intermediate
             max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-            block_m = min(block_m, max_block_m)
+            block_m = max(1, min(16, self.M, max_block_m))
             return {"block_m": block_m, "block_n": block_n, "threads": 256}
         else:
-            # Sequential scan config (original logic)
             block_n = _DEFAULT_BLOCK_N
             elem_size = torch.tensor([], dtype=self.dtype).element_size()
             smem_per_row = 2 * (block_n + _SMEM_PAD) * elem_size
@@ -441,7 +431,6 @@ class CumulativeKernel(Kernel):
                 x,
             )
         else:
-            # Sequential scan (original implementation)
             return _cumulative_fwd_wrapped(
                 self.M,
                 self.N,
@@ -461,10 +450,9 @@ class CumulativeKernel(Kernel):
 
 @functools.lru_cache(maxsize=32)
 def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
-    """Pass 1: Local scan within each tile (parallel across all tiles).
+    """Pass 1: scan each tile independently, emitting its total to ``tile_sums``.
 
-    Grid: (M/block_m, N_padded/block_n) for massive parallelism.
-    Each thread block independently scans one tile.
+    Grid is (ceildiv(M, block_m), n_tiles), so all tiles scan concurrently.
     """
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
     _identity = 0.0 if op_kind == "sum" else 1.0
@@ -484,40 +472,17 @@ def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
                 tile_shared = T.alloc_shared((block_m, block_n + _SMEM_PAD), "float32")
                 tile_frag = T.alloc_fragment((block_m, block_n), "float32")
 
-                # Load tile
-                if _needs_mask:
-                    with T.If((tile_idx + 1) * block_n <= N):
-                        with T.Then():
-                            for i, j in T.Parallel(block_m, block_n):
-                                row = pid_m * block_m + i
-                                col = tile_idx * block_n + j
-                                tile_shared[i, j] = T.if_then_else(
-                                    row < M,
-                                    T.cast(x[row, col], "float32"),
-                                    T.cast(_identity, "float32"),
-                                )
-                        with T.Else():
-                            for i, j in T.Parallel(block_m, block_n):
-                                row = pid_m * block_m + i
-                                col = tile_idx * block_n + j
-                                tile_shared[i, j] = T.if_then_else(
-                                    T.And(row < M, col < N),
-                                    T.cast(x[row, col], "float32"),
-                                    T.cast(_identity, "float32"),
-                                )
-                else:
-                    for i, j in T.Parallel(block_m, block_n):
-                        row = pid_m * block_m + i
-                        col = tile_idx * block_n + j
-                        tile_shared[i, j] = T.if_then_else(
-                            row < M,
-                            T.cast(x[row, col], "float32"),
-                            T.cast(_identity, "float32"),
-                        )
-
+                for i, j in T.Parallel(block_m, block_n):
+                    row = pid_m * block_m + i
+                    col = tile_idx * block_n + j
+                    in_bounds = T.And(row < M, col < N) if _needs_mask else row < M
+                    tile_shared[i, j] = T.if_then_else(
+                        in_bounds,
+                        T.cast(x[row, col], "float32"),
+                        T.cast(_identity, "float32"),
+                    )
                 T.sync_threads()
 
-                # Copy to fragment and scan
                 for i, j in T.Parallel(block_m, block_n):
                     tile_frag[i, j] = tile_shared[i, j]
                 T.sync_threads()
@@ -525,12 +490,12 @@ def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
                 T.cumsum(tile_frag, dim=1)
                 T.sync_threads()
 
-                # Copy back
+                # Back through shared memory: the tile_sums writer below reads
+                # column block_n - 1, which lives in another thread's registers.
                 for i, j in T.Parallel(block_m, block_n):
                     tile_shared[i, j] = tile_frag[i, j]
                 T.sync_threads()
 
-                # Write results
                 for i, j in T.Parallel(block_m, block_n):
                     row = pid_m * block_m + i
                     col = tile_idx * block_n + j
@@ -549,12 +514,11 @@ def _parallel_scan_local_kernel(M: int, N: int, op_kind: str, dtype: str):
 
 @functools.lru_cache(maxsize=32)
 def _parallel_scan_carry_kernel(M: int, n_tiles: int):
-    """Pass 2: Exclusive cumsum on tile boundary values (small array M x n_tiles).
+    """Pass 2: exclusive scan of the per-tile totals.
 
-    Uses sequential scan since n_tiles is typically small (e.g., 128-256).
-    Output is exclusive scan: out[i, 0] = 0, out[i, j] = cumsum(in[i, :j])
-
-    Each thread processes one complete row to avoid data races.
+    ``out[i, 0] = 0``, ``out[i, j] = sum(in[i, :j])``.  Scanned serially since
+    ``n_tiles`` is small (128-256); one thread owns one row, so the writes
+    cannot race.
     """
     @tilelang.jit(out_idx=[1])
     def _func(threads):
@@ -567,15 +531,9 @@ def _parallel_scan_carry_kernel(M: int, n_tiles: int):
                 tx = T.get_thread_binding()
                 row = pid * threads + tx
 
-                # Give every row a unique thread owner.  The block index alone
-                # cannot identify a thread, so using it as ``row`` would make
-                # every thread in the block race on the same output locations.
                 with T.If(row < M), T.Then():
-                    # Exclusive scan: first element is 0
                     tile_carries[row, 0] = T.float32(0.0)
-                    # Mutable accumulator for loop-carried state
                     running_sum = T.alloc_var("float32", init=0.0)
-                    # Sequential loop over tiles
                     for j in T.Serial(n_tiles - 1):
                         running_sum = running_sum + tile_sums[row, j]
                         tile_carries[row, j + 1] = running_sum
@@ -587,7 +545,7 @@ def _parallel_scan_carry_kernel(M: int, n_tiles: int):
 
 @functools.lru_cache(maxsize=32)
 def _parallel_scan_propagate_kernel(M: int, N: int, dtype: str):
-    """Pass 3: Add carry values and cast to output dtype."""
+    """Pass 3: add each tile's carry and cast to the output dtype."""
     N_padded = align_up(N, DEFAULT_ALIGNMENT)
 
     @tilelang.jit(out_idx=[2])
@@ -601,25 +559,13 @@ def _parallel_scan_propagate_kernel(M: int, N: int, dtype: str):
             y_final: T.Tensor[(M, N_padded), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), n_tiles, threads=threads) as (pid_m, tile_idx):
-                tile_shared = T.alloc_shared((block_m, block_n + _SMEM_PAD), "float32")
-
-                # Load y_local
                 for i, j in T.Parallel(block_m, block_n):
                     row = pid_m * block_m + i
                     col = tile_idx * block_n + j
                     with T.If(row < M), T.Then():
-                        tile_shared[i, j] = y_local[row, col]
-
-                T.sync_threads()
-
-                # Add carry and write
-                for i, j in T.Parallel(block_m, block_n):
-                    row = pid_m * block_m + i
-                    col = tile_idx * block_n + j
-                    with T.If(row < M), T.Then():
-                        carry = tile_carries[row, tile_idx]
-                        result_f32 = tile_shared[i, j] + carry
-                        y_final[row, col] = T.cast(result_f32, dtype)
+                        y_final[row, col] = T.cast(
+                            y_local[row, col] + tile_carries[row, tile_idx], dtype
+                        )
 
         return main
 

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -79,11 +79,8 @@ class CumulativeOp(Op):
     ) -> Kernel:
         """Return a kernel built for (M, N, dtype), caching by specialization.
 
-        Deliberately not decorated with ``@torch.compiler.disable``, which
-        ``torch.compile(fullgraph=True)`` rejects. On a cache miss this builds a
-        Kernel, so a caller compiling with ``fullgraph=True`` must warm the cache
-        for every (M, N, dtype, device) it will feed the compiled callable —
-        otherwise construction is traced inside the compiled region.
+        A cache miss builds a Kernel, so a ``fullgraph=True`` caller must warm
+        every (M, N, dtype, device) it will feed the compiled callable.
         """
         key = (M, N, dtype, device_index)
         if key not in self._kernel_cache:
@@ -150,10 +147,8 @@ class CumsumFwdOp(CumulativeOp):
     Output has the same shape and dtype as ``x``. Alignment padding is
     handled inside the kernel via masked loads.
 
-    The implementation automatically selects between two backends based on
-    input shape: a sequential scan for most workloads, or a parallel three-pass
-    scan (local prefix + carry propagation + final adjustment) for small-M,
-    large-N cases (M < 128 and N > 8192) to improve SM utilization.
+    Shapes with ``M < 128 and N > 8192`` take a three-pass parallel scan for
+    SM utilization; every other shape takes the sequential scan.
 
     Args:
         dtype: Optional data type (float32, float16, or bfloat16).

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -148,6 +148,11 @@ class CumsumFwdOp(CumulativeOp):
     Output has the same shape and dtype as ``x``. Alignment padding is
     handled inside the kernel via masked loads.
 
+    The implementation automatically selects between two backends based on
+    input shape: a sequential scan for most workloads, or a parallel three-pass
+    scan (local prefix + carry propagation + final adjustment) for small-M,
+    large-N cases (M < 128 and N > 8192) to improve SM utilization.
+
     Args:
         dtype: Optional data type (float32, float16, or bfloat16).
             Preferred API infers it from ``x``.

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -79,9 +79,11 @@ class CumulativeOp(Op):
     ) -> Kernel:
         """Return a kernel built for (M, N, dtype), caching by specialization.
 
-        Note: Not decorated with @torch.compiler.disable to allow torch.compile(fullgraph=True).
-        Pre-warming the cache before compilation ensures kernel construction happens outside
-        the compiled region.
+        Deliberately not decorated with ``@torch.compiler.disable``, which
+        ``torch.compile(fullgraph=True)`` rejects. On a cache miss this builds a
+        Kernel, so a caller compiling with ``fullgraph=True`` must warm the cache
+        for every (M, N, dtype, device) it will feed the compiled callable —
+        otherwise construction is traced inside the compiled region.
         """
         key = (M, N, dtype, device_index)
         if key not in self._kernel_cache:

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -74,6 +74,7 @@ class CumulativeOp(Op):
         # Read x + write y = 2 * M * N elements.
         return (M * N, 2 * M * N * elem_bytes)
 
+    @torch.compiler.disable
     def _get_kernel(
         self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
     ) -> Kernel:

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -74,11 +74,15 @@ class CumulativeOp(Op):
         # Read x + write y = 2 * M * N elements.
         return (M * N, 2 * M * N * elem_bytes)
 
-    @torch.compiler.disable
     def _get_kernel(
         self, M: int, N: int, dtype: torch.dtype, device_index: int | None,
     ) -> Kernel:
-        """Return a kernel built for (M, N, dtype), caching by specialization."""
+        """Return a kernel built for (M, N, dtype), caching by specialization.
+
+        Note: Not decorated with @torch.compiler.disable to allow torch.compile(fullgraph=True).
+        Pre-warming the cache before compilation ensures kernel construction happens outside
+        the compiled region.
+        """
         key = (M, N, dtype, device_index)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["cumulative_fwd"](


### PR DESCRIPTION
## Summary

- add an adaptive three-pass TileLang cumsum for `M < 128 and N > 8192`; other shapes and cumprod keep the sequential implementation
- fp32 intermediates, carry geometry derived from the selected tile config, warn when autotuning is requested for the parallel backend

## Test plan

- [x] pre-commit passed
- [x] `tests/ops/test_cumulative.py` 49 passed on H200; `gpu-smoke` green
- [x] backend asserted per shape: `block_n=128`/`256`, masked tail (N=8200), fp32/fp16/bf16, and the sequential boundaries N=8192 / M=128
- [x] `torch.compile(fullgraph=True)` covered on a warm cache for both `custom_op` branches — not registered in `tests/compile_contract.py` (that contract is cold-compile), so no `torch_compile_fullgraph` declaration

## Test node delta

`scripts/test_node_delta.py tests/ops/test_cumulative.py --base upstream/main`: 39 -> 49, +25.6%.

## Benchmark

`benchmarks/ops/bench_cumulative.py`, H200, torch 2.9.1+cu128. Only (64, 32768) takes the parallel backend.

| shape | dtype | TileOPs | PyTorch |
| --- | --- | --- | --- |
| (64, 32768) | bfloat16 | 0.0307 ms | 0.0690 ms |
| (2048, 4096) | float16 | 0.0449 ms | 0.1474 ms |
| (2048, 4096) | bfloat16 | 0.0440 ms | 0.1478 ms |

Wall-clock, end-to-end (`perf_counter` + `synchronize`), so launch overhead is included: at (64, 32768) CUPTI reports ~0.020 ms of GPU time across the three kernels vs ~0.031 ms wall-clock. PyTorch's figure is a single CUB `DeviceScan`.
