### PR TITLE
[Perf][Elementwise] vectorize bool bitwise storage path

### DIFF
--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -280,6 +280,80 @@ class LerpTensorManifestWorkload:
         return x, end, weight
 
 
+def _numel(shape: tuple[int, ...]) -> int:
+    return prod(shape) if shape else 1
+
+
+def _broadcast_kind(
+    input_shape: tuple[int, ...],
+    other_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+) -> str:
+    if input_shape == output_shape and other_shape == output_shape:
+        return "same_shape"
+    if _numel(input_shape) == 1 or _numel(other_shape) == 1:
+        return "scalar_broadcast"
+
+    def _one_side_kind(dense_shape: tuple[int, ...], rhs_shape: tuple[int, ...]) -> str | None:
+        if dense_shape != output_shape:
+            return None
+        if (
+            len(output_shape) >= 4
+            and len(rhs_shape) >= 3
+            and rhs_shape[-2:] == (1, 1)
+            and rhs_shape[-3] == output_shape[-3]
+            and all(dim == 1 for dim in rhs_shape[:-3])
+        ):
+            return "channel_broadcast"
+        if (
+            len(output_shape) >= 2
+            and len(rhs_shape) >= 1
+            and rhs_shape[-1] == output_shape[-1]
+            and all(dim == 1 for dim in rhs_shape[:-1])
+        ):
+            return "last_dim_broadcast"
+        return None
+
+    rhs_kind = _one_side_kind(input_shape, other_shape)
+    if rhs_kind is not None:
+        return rhs_kind
+    lhs_kind = _one_side_kind(other_shape, input_shape)
+    if lhs_kind is not None:
+        return "lhs_" + lhs_kind
+    return "broadcast"
+
+
+def _manifest_params(bm: ManifestBenchmark) -> dict:
+    workload = bm.workload
+    params = {}
+    for attr in (
+        "shape",
+        "input_shape",
+        "other_shape",
+        "condition_shape",
+        "mask_shape",
+        "min_shape",
+        "max_shape",
+        "weight_shape",
+        "end_shape",
+        "dtype",
+    ):
+        if hasattr(workload, attr):
+            params[attr] = getattr(workload, attr)
+
+    input_shape = params.get("input_shape")
+    other_shape = params.get("other_shape")
+    if input_shape is not None and other_shape is not None:
+        output_shape = params.get("shape") or tuple(
+            torch.broadcast_shapes(input_shape, other_shape)
+        )
+        params["output_shape"] = output_shape
+        params["broadcast_kind"] = _broadcast_kind(
+            input_shape, other_shape, output_shape,
+        )
+    return params
+
+
 def _record_unary(
     op,
     bm: ManifestBenchmark,
@@ -287,9 +361,9 @@ def _record_unary(
     baseline_fn: Callable,
 ) -> None:
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, _manifest_params(bm), result, tag="tileops")
     result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, _manifest_params(bm), result_bl, tag="torch")
 
 
 def _record_binary(
@@ -299,9 +373,9 @@ def _record_binary(
     baseline_fn: Callable,
 ) -> None:
     result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    BenchmarkReport.record(op, _manifest_params(bm), result, tag="tileops")
     result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    BenchmarkReport.record(op, _manifest_params(bm), result_bl, tag="torch")
 
 
 _RELU_OP = "ReluFwdOp"

--- a/tests/ops/test_bitwise.py
+++ b/tests/ops/test_bitwise.py
@@ -173,8 +173,8 @@ class BoolBitwiseFixture(FixtureBase):
 def test_bool_bitwise_fast_path(
     op_name, op_cls, ref_fn, a_shape, b_shape,
 ) -> None:
-    a = torch.randint(0, 2, a_shape, dtype=torch.bool, device="cuda")
-    b = torch.randint(0, 2, b_shape, dtype=torch.bool, device="cuda")
+    a = torch.randint(0, 2, a_shape, device="cuda").bool()
+    b = torch.randint(0, 2, b_shape, device="cuda").bool()
     op = op_cls(a_shape=a_shape, b_shape=b_shape, dtype=torch.bool)
     ref = ref_fn(a, b)
     with torch.no_grad():

--- a/tests/ops/test_bitwise.py
+++ b/tests/ops/test_bitwise.py
@@ -153,6 +153,36 @@ def test_bitwise_broadcast(
     _exact_compare(out, ref)
 
 
+class BoolBitwiseFixture(FixtureBase):
+    PARAMS = [
+        ("op_name, op_cls, ref_fn, a_shape, b_shape", [
+            pytest.param(
+                name, cls, ref, a_s, b_s,
+                marks=pytest.mark.smoke if a_s == b_s else pytest.mark.full,
+            )
+            for a_s, b_s in [
+                ((2048, 4096), (2048, 4096)),
+                ((2, 512, 768), (1, 1, 768)),
+            ]
+            for name, cls, ref in _BITWISE_OPS
+        ]),
+    ]
+
+
+@BoolBitwiseFixture
+def test_bool_bitwise_fast_path(
+    op_name, op_cls, ref_fn, a_shape, b_shape,
+) -> None:
+    a = torch.randint(0, 2, a_shape, dtype=torch.bool, device="cuda")
+    b = torch.randint(0, 2, b_shape, dtype=torch.bool, device="cuda")
+    op = op_cls(a_shape=a_shape, b_shape=b_shape, dtype=torch.bool)
+    ref = ref_fn(a, b)
+    with torch.no_grad():
+        out = op(a, b)
+    assert out.dtype == torch.bool
+    _exact_compare(out, ref)
+
+
 # ---------------------------------------------------------------------------
 # BitwiseNot op
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -608,8 +608,8 @@ def test_bitwise_binary_compile(op_cls, ref_fn, name):
 def test_bool_bitwise_binary_compile(op_cls, ref_fn, name):
     """Compile-smoke for bool bitwise ops using the uint8 storage path."""
     shape = _SMALL
-    a = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
-    b = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    a = torch.randint(0, 2, shape, device="cuda").bool()
+    b = torch.randint(0, 2, shape, device="cuda").bool()
     op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
     compiled_op = torch.compile(op, fullgraph=True)
     out = compiled_op(a, b)

--- a/tests/ops/test_elementwise_compile.py
+++ b/tests/ops/test_elementwise_compile.py
@@ -604,6 +604,20 @@ def test_bitwise_binary_compile(op_cls, ref_fn, name):
     assert torch.equal(out, ref)
 
 
+@pytest.mark.parametrize("op_cls, ref_fn, name", _BITWISE_BINARY_OPS)
+def test_bool_bitwise_binary_compile(op_cls, ref_fn, name):
+    """Compile-smoke for bool bitwise ops using the uint8 storage path."""
+    shape = _SMALL
+    a = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    b = torch.randint(0, 2, shape, dtype=torch.bool, device="cuda")
+    op = op_cls(a_shape=shape, b_shape=shape, dtype=torch.bool)
+    compiled_op = torch.compile(op, fullgraph=True)
+    out = compiled_op(a, b)
+    ref = ref_fn(a, b)
+    assert out.dtype == torch.bool
+    assert torch.equal(out, ref)
+
+
 # --- Remaining fused gated ops ---
 
 _FUSED_GATED_OPS = [

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -115,8 +115,11 @@ __all__ = [
     "LogicalOrBoolStorageFwdKernel",
     "LogicalOrFwdKernel",
     # --- bitwise ---
+    "BitwiseAndBoolStorageFwdKernel",
     "BitwiseAndFwdKernel",
+    "BitwiseOrBoolStorageFwdKernel",
     "BitwiseOrFwdKernel",
+    "BitwiseXorBoolStorageFwdKernel",
     "BitwiseXorFwdKernel",
     # --- fused gated ---
     "SiluAndMulFwdKernel",
@@ -1834,6 +1837,14 @@ class BitwiseAndFwdKernel(BinaryKernel):
         return a & b
 
 
+class BitwiseAndBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise bitwise AND on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_and(a, b)
+
+
 class BitwiseOrFwdKernel(BinaryKernel):
     """Element-wise bitwise OR: y = a | b (integer inputs)."""
 
@@ -1844,6 +1855,14 @@ class BitwiseOrFwdKernel(BinaryKernel):
         return a | b
 
 
+class BitwiseOrBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise bitwise OR on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_or(a, b)
+
+
 class BitwiseXorFwdKernel(BinaryKernel):
     """Element-wise bitwise XOR: y = a ^ b (integer inputs)."""
 
@@ -1852,6 +1871,14 @@ class BitwiseXorFwdKernel(BinaryKernel):
     @staticmethod
     def op_func(a, b):
         return a ^ b
+
+
+class BitwiseXorBoolStorageFwdKernel(_Uint8StorageBinaryKernel):
+    """Element-wise bitwise XOR on uint8-backed bool storage."""
+
+    @staticmethod
+    def op_func(a, b):
+        return T.bitwise_xor(a, b)
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/ops/elementwise/bitwise.py
+++ b/tileops/ops/elementwise/bitwise.py
@@ -1,34 +1,84 @@
 """Element-wise bitwise ops."""
 
+import torch
+
 from tileops.kernels.elementwise import (
+    BitwiseAndBoolStorageFwdKernel,
     BitwiseAndFwdKernel,
     BitwiseNotFwdKernel,
+    BitwiseOrBoolStorageFwdKernel,
     BitwiseOrFwdKernel,
+    BitwiseXorBoolStorageFwdKernel,
     BitwiseXorFwdKernel,
 )
 
 from ._base import BinaryOp, UnaryOp
 
 
-class BitwiseAndFwdOp(BinaryOp):
+class _BoolStorageBitwiseBinaryOp(BinaryOp):
+    """Binary bitwise op with a uint8-backed fast path for bool tensors."""
+
+    _bool_storage = False
+    bool_storage_kernel_cls = None
+
+    @property
+    def default_kernel_map(self):
+        kernel_map = {self._op_name: self.kernel_cls}
+        if self.bool_storage_kernel_cls is not None:
+            kernel_map[f"{self._op_name}_bool_storage"] = self.bool_storage_kernel_cls
+        return kernel_map
+
+    def _build_kernel_instance(
+        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+    ):
+        self._bool_storage = (
+            self.dtype == torch.bool and self.bool_storage_kernel_cls is not None
+        )
+        if self._bool_storage:
+            return self.kernel_map[f"{self._op_name}_bool_storage"](
+                self.N_total, torch.uint8, coalesced_shape, a_strides, b_strides,
+                self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            )
+        return super()._build_kernel_instance(
+            coalesced_shape, a_strides, b_strides, strategy, tune,
+        )
+
+    def _eager_forward(
+        self,
+        input: torch.Tensor,  # noqa: A002
+        other: torch.Tensor,
+    ) -> torch.Tensor:
+        if getattr(self, "_bool_storage", False):
+            result = self.kernel(
+                input.contiguous().view(-1).view(torch.uint8),
+                other.contiguous().view(-1).view(torch.uint8),
+            )
+            return result.view(torch.bool).reshape(self.out_shape)
+        return super()._eager_forward(input, other)
+
+
+class BitwiseAndFwdOp(_BoolStorageBitwiseBinaryOp):
     """Element-wise bitwise AND with broadcast: y = a & b."""
 
     _op_name = "bitwise_and"
     kernel_cls = BitwiseAndFwdKernel
+    bool_storage_kernel_cls = BitwiseAndBoolStorageFwdKernel
 
 
-class BitwiseOrFwdOp(BinaryOp):
+class BitwiseOrFwdOp(_BoolStorageBitwiseBinaryOp):
     """Element-wise bitwise OR with broadcast: y = a | b."""
 
     _op_name = "bitwise_or"
     kernel_cls = BitwiseOrFwdKernel
+    bool_storage_kernel_cls = BitwiseOrBoolStorageFwdKernel
 
 
-class BitwiseXorFwdOp(BinaryOp):
+class BitwiseXorFwdOp(_BoolStorageBitwiseBinaryOp):
     """Element-wise bitwise XOR with broadcast: y = a ^ b."""
 
     _op_name = "bitwise_xor"
     kernel_cls = BitwiseXorFwdKernel
+    bool_storage_kernel_cls = BitwiseXorBoolStorageFwdKernel
 
 
 class BitwiseNotFwdOp(UnaryOp):


### PR DESCRIPTION
Refs #1702. Does not close it; #1702 remains the broader broadcast elementwise umbrella.

## Summary

- Add uint8-backed bool-storage kernels for `bitwise_and`, `bitwise_or`, and `bitwise_xor`.
- Route public `torch.bool` bitwise binary inputs through the uint8 storage path, then view outputs back to `torch.bool`.
- Keep integer bitwise paths unchanged.
- Add manifest benchmark metadata (`input_shape`, `other_shape`, `output_shape`, `broadcast_kind`) so broadcast and same-shape cases are visible in reports.
- Add eager and `torch.compile(fullgraph=True)` coverage for bool bitwise ops.

## Notes from #1705 / #1708

- Avoids exposing raw bool tensors to TileLang vectorized kernels, so we do not hit the `boolx<N>` lowering issue from #1705.
- Keeps the normal `BinaryOp.__init__` initialization path; the bool-storage path only customizes `_build_kernel_instance` and `_eager_forward`.
- Adds a class-level `_bool_storage = False` default to avoid the ordering-coupling issue called out in #1708.

## Benchmark

H200, official TileOpsGov runner image `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`, no tilelang/torch/dependency changes. Baseline is latest `origin/main` at `1a3866c`.

| op | workload | before | after | delta | after vs torch |
| --- | --- | --- | --- | --- | --- |
| BitwiseAndFwdOp bool | same_shape | 0.0290 ms / 0.8690 TB/s | 0.0091 ms / 2.7596 TB/s | -68.6% | torch 0.0101 ms |
| BitwiseOrFwdOp bool | same_shape | 0.0288 ms / 0.8726 TB/s | 0.0090 ms / 2.7860 TB/s | -68.8% | torch 0.0099 ms |
| BitwiseXorFwdOp bool | same_shape | 0.0288 ms / 0.8724 TB/s | 0.0090 ms / 2.7919 TB/s | -68.8% | torch 0.0101 ms |
| BitwiseAndFwdOp bool | channel_broadcast | 0.0421 ms / 0.6108 TB/s | 0.0089 ms / 2.8994 TB/s | -78.9% | torch 0.0464 ms |
| BitwiseOrFwdOp bool | channel_broadcast | 0.0417 ms / 0.6158 TB/s | 0.0088 ms / 2.9122 TB/s | -78.9% | torch 0.0455 ms |
| BitwiseXorFwdOp bool | channel_broadcast | 0.0420 ms / 0.6112 TB/s | 0.0091 ms / 2.8128 TB/s | -78.3% | torch 0.0464 ms |

## Test plan

All test runs used `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10` unless noted otherwise.

- [x] `python3 -m ruff check tileops/kernels/elementwise.py tileops/ops/elementwise/bitwise.py tests/ops/test_bitwise.py tests/ops/test_elementwise_compile.py benchmarks/ops/bench_elementwise_manifest.py`
- [x] `python3 scripts/validate_manifest.py` (advisory warnings only; manifest checks passed)
- [x] `git diff --check`
- [x] `pytest -q tests/ops/test_bitwise.py tests/ops/test_elementwise_compile.py::test_bitwise_binary_compile tests/ops/test_elementwise_compile.py::test_bool_bitwise_binary_compile --tb=short`: 41 passed
- [x] `pytest -q tests/ops/test_elementwise_binary_broadcast.py tests/ops/test_logical.py tests/ops/test_comparison.py --tb=short`: 115 passed
- [x] `pytest -q benchmarks/ops/bench_elementwise_manifest.py -k 'bitwise_and_manifest_bench or bitwise_or_manifest_bench or bitwise_xor_manifest_bench' --tb=short`: 18 passed
- [x] `pre-commit run --files benchmarks/ops/bench_elementwise_manifest.py tests/ops/test_bitwise.py tests/ops/test_elementwise_compile.py tileops/kernels/elementwise.py tileops/ops/elementwise/bitwise.py`
