### PR TITLE
[Maintain][GEMM] Add mid-m band (m=16/32/64/96) NT bf16 workloads

### DIFF
--- a/tileops/manifest/gemm.yaml
+++ b/tileops/manifest/gemm.yaml
@@ -37,6 +37,13 @@ GemmOp:
   - {m: 4096, n: 4096, k: 7168, trans_a: false, trans_b: true, dtypes: [float16, bfloat16], label: "ds-v3-prefill-attn-proj"}
   - {m: 4096, n: 7168, k: 16384, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "k-dominant-7168x16384"}
   - {m: 4096, n: 24576, k: 1536, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "wide-n-24576"}
+  # Mid-m band: samples of m = 9..127, the token-count gap below the
+  # decode/prefill sweep (m in {128, 1024, 4096}); n/k reuse the
+  # DeepSeek-V3 projection shapes above.
+  - {m: 16, n: 4096, k: 7168, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "mid-m16-attn"}
+  - {m: 32, n: 4096, k: 7168, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "mid-m32-attn"}
+  - {m: 64, n: 7168, k: 2048, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "mid-m64-down"}
+  - {m: 96, n: 2112, k: 7168, trans_a: false, trans_b: true, dtypes: [bfloat16], label: "mid-m96-gate-up"}
 
   roofline:
     func: "tileops.perf.formulas.gemm_fwd_roofline"


### PR DESCRIPTION
## What

Add four mid-m (m ∈ {16, 32, 64, 96}) NT bf16 workloads to the `GemmOp` manifest entry, filling the coverage gap between the small-m fast paths (m ≤ 8) and the decode/prefill sweep (m ∈ {128, 1024, 4096}).

The n/k pairs reuse the DeepSeek-V3 projection shapes already present in the sweep:

| label | m | n | k |
|---|---|---|---|
| mid-m16-attn | 16 | 4096 | 7168 |
| mid-m32-attn | 32 | 4096 | 7168 |
| mid-m64-down | 64 | 7168 | 2048 |
| mid-m96-gate-up | 96 | 2112 | 7168 |

## Why

The m = 9..127 band has no manifest coverage today, and it is the target of the upcoming dense-GEMM work (analytic config selection, mid-m kernel structure). Acceptance for that work is gated on "all manifest workloads, no regression", which requires the band to be represented.

Baseline measured on H200 (CUPTI kernel-only timing with per-iteration L2 flush; per-rep interleaved ours-vs-baseline ratios; baseline = min(torch.matmul default, cuBLASLt searched-best)): the current generic path runs these four shapes at 0.48 / 0.48 / 0.67 / 0.35 of cuBLAS respectively.

## Scope

Manifest-only, per the manifest trust model (workloads edits on an implemented op require a standalone human-reviewed PR): one file, +7 lines (3 comment lines + 4 entries). No code, test, or benchmark files touched.

## Verification

- `scripts/validate_manifest.py --check-op GemmOp` passes (the only warning is the pre-existing `_infer_output_shapes` advisory, unrelated to workloads).
- `load_workloads("GemmOp")` returns 12 entries (was 8).
- `tests/ops/test_gemm.py` is hand-parametrized, so the test matrix is unchanged; `benchmarks/ops/bench_gemm.py` is manifest-driven and gains 4 bench rows.
- Correctness of the four shapes on the current generic kernel path verified locally (max rel err ≤ 3e-3 vs torch.matmul).

Refs #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)