### PR TITLE
[Fix][Bench] Isolate L2 flush from profiler kernel timing

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -85,9 +85,10 @@ _bench_results = threading.local()
 
 
 # Name of the ``record_function`` annotation wrapping the timed call. Kineto
-# projects this scope onto the device timeline, so kernels the call launches
-# fall inside its window while the L2-flush ``cache.zero_()`` (enqueued outside
-# the scope) does not.
+# projects this scope onto the device timeline. The L2-flush ``cache.zero_()``
+# is synchronized to completion before the window opens (see ``bench_kernel``),
+# so its device event cannot fall inside a window regardless of how the
+# projection behaves; kernels the timed call launches do.
 _KERNEL_REGION = "tileops_bench_kernel"
 
 
@@ -238,11 +239,16 @@ def bench_kernel(
     # leak across the warmup/active boundary.  A plain per-trial context records
     # exactly the calls we want — no schedule, no on_trace_ready callback.
     #
-    # Only the timed call is wrapped in record_function(_KERNEL_REGION), so the
-    # L2-flush cache.zero_() enqueued just before it is attributed by scope (not
-    # kernel name) and excluded.  Flush and call share the stream, so the flush
-    # completes before the call begins (L2 cold) without a sync between them; we
-    # sync only after the call so its kernels are recorded before the next flush.
+    # Only the timed call is wrapped in record_function(_KERNEL_REGION).  The
+    # parser attributes device events purely by timestamp interval, and Kineto's
+    # projection of the annotation window onto the device timeline is not
+    # guaranteed to exclude a flush merely enqueued before the window (issue
+    # #1723: under cold TileLang cache + autotune the flush event was observed
+    # inside the window, adding one flush duration per measured repeat).  We
+    # therefore synchronize after cache.zero_() so the flush completes before
+    # the window opens; L2 is still cold for the measured call, and the extra
+    # sync only adds host-side latency, never device time.  The post-call sync
+    # keeps the measured kernels recorded before the next flush.
     trial_means: list[float] = []
     try:
         with suppress_stdout_stderr():
@@ -258,6 +264,10 @@ def bench_kernel(
                 ) as profiler:
                     for i in range(n_repeat):
                         cache.zero_()
+                        # Drain the flush so its device event ends before the
+                        # timed window opens; without this, projection quirks
+                        # can place it inside the window (see comment above).
+                        torch.cuda.synchronize()
                         with torch.profiler.record_function(_KERNEL_REGION):
                             _run(i)
                         torch.cuda.synchronize()  # kernel recorded in isolation


### PR DESCRIPTION
## Summary

Fixes #1723.

`bench_kernel`'s CUPTI timing loop enqueued the L2-flush `cache.zero_()` immediately before opening the `record_function(_KERNEL_REGION)` window and relied on Kineto projecting the annotation window such that the flush event falls outside it. That assumption is not guaranteed: `_sum_kernel_time_us()` attributes device events purely by timestamp interval, and under cold TileLang cache + autotune the flush event was observed inside the window, adding one flush duration (~0.058 ms) per measured repeat — avg_pool2d reported 0.058–0.066 ms instead of the expected ~0.004–0.005 ms.

## Changes

- `benchmarks/benchmark_base.py::bench_kernel`: `torch.cuda.synchronize()` after `cache.zero_()`, so the flush completes before the timed window opens. This removes the flush from the window semantics entirely, independent of how Kineto projects the annotation onto the device timeline.
- Updated the two comments that documented the old (disproven) "enqueued outside the scope ⇒ excluded" assumption.
- Benchmark semantics unchanged: L2 is still flushed before every measured call; the extra sync only adds host-side latency, never device time. The CUDA-events fallback path is untouched (its stream-ordered events already exclude the flush).

## Validation

- `ruff check` passes; related unit tests (`test_benchmark_record`, `test_workloads_to_params`, `test_validate_manifest`): 238 passed.
- Warm-cache `test_avg_pool2d_bench`: 3 passed, 0.0043 / 0.0045 / 0.0038 ms (baseline preserved).
- 5 cold-cache rounds (`rm -rf ~/.tilelang` before each) of `python -m pytest benchmarks/ops/bench_pool.py::test_avg_pool2d_bench -q`:

| round | vision-3x3-s2 | vision-5x5-s2 | ceil-divisor-bf16 |
| --- | --- | --- | --- |
| 1 | 0.0046 | 0.0044 | 0.0040 |
| 2 | 0.0048 | 0.0059 | 0.0044 |
| 3 | 0.0046 | 0.0045 | 0.0038 |
| 4 | 0.0046 | 0.0045 | 0.0041 |
| 5 | 0.0043 | 0.0045 | 0.0038 |

No ~0.058–0.066 ms artifact in any round; L2 flush retained.

## Note on reproducibility

On current HEAD (torch 2.10.0+cu129, H200) the artifact itself no longer reproduces: an instrumented `_sum_kernel_time_us` over 3 cold-cache runs (900+ annotation windows) shows Kineto projecting tight windows that exactly span the measured kernel, with zero flush events counted. The original artifact therefore depended on a different/perturbed projection state (e.g. window anchored at the CPU annotation start, or CUPTI timestamp disorder after heavy JIT activity). This fix is robust regardless of projection behavior, since the flush is drained before the window opens.
