### PR TITLE
[Fix][NORM] Fix global memory write-read data race in `BatchNormFwdTrainKernel`

### DIFF
--- a/tests/ops/test_batch_norm.py
+++ b/tests/ops/test_batch_norm.py
@@ -76,6 +76,8 @@ class BatchNormFwdFixture(FixtureBase):
             # Non-aligned spatial: H*W=900, exercises partial-tile path
             pytest.param(8, 64, (30, 30), torch.float16, True, marks=pytest.mark.full),
             pytest.param(8, 64, (30, 30), torch.bfloat16, True, marks=pytest.mark.full),
+            # High channel count oversubscribes the SMs, exposing the running-stat update race.
+            pytest.param(16, 1024, (512,), torch.float16, True, marks=pytest.mark.full),
         ]),
     ]
 
@@ -129,6 +131,13 @@ def test_batch_norm_fwd(N, C, spatial, dtype, training):
         f"fwd mismatch (training={training}): max_err={max_err:.4e}"
 
     if training:
+        # allclose is masked when running_mean starts near the batch mean; check determinism.
+        rm2, rv2 = running_mean_ref.clone(), running_var_ref.clone()
+        op(x, rm2, rv2, weight, bias)
+        det_err = (running_mean.float() - rm2.float()).abs().max()
+        assert torch.equal(running_mean, rm2) and torch.equal(running_var, rv2), \
+            f"running stats non-deterministic across runs: max_err={det_err:.4e}"
+
         rm_err = (running_mean.float() - ref_rm.float()).abs().max()
         assert torch.allclose(running_mean.float(), ref_rm.float(), atol=atol, rtol=rtol), \
             f"running_mean mismatch: max_err={rm_err:.4e}"

--- a/tileops/kernels/norm/batch_norm.py
+++ b/tileops/kernels/norm/batch_norm.py
@@ -172,8 +172,10 @@ def _batch_norm_fwd_train_kernel(
                 # (Bessel's correction: biased_var * L / (L - 1)).
                 mom = T.cast(momentum, accum_dtype)
                 unbiased_var = var_val * T.cast(L, accum_dtype) / (T.cast(L, accum_dtype) - T.cast(1.0, accum_dtype))
-                running_mean[bc] = (T.cast(1.0, accum_dtype) - mom) * running_mean[bc] + mom * mean_val
-                running_var[bc] = (T.cast(1.0, accum_dtype) - mom) * running_var[bc] + mom * unbiased_var
+                # One writer per block: this running-stat RMW races if every thread runs it.
+                if T.get_thread_binding() == 0:
+                    running_mean[bc] = (T.cast(1.0, accum_dtype) - mom) * running_mean[bc] + mom * mean_val
+                    running_var[bc] = (T.cast(1.0, accum_dtype) - mom) * running_var[bc] + mom * unbiased_var
 
                 # Pass 2 – normalize.
                 if block_l >= L:


### PR DESCRIPTION
[`BatchNormFwdTrainKernel`](https://github.com/tile-ai/TileOPs/blob/48782d50e698c00d053e8cd0b2f2625e6ca54bdd/tileops/kernels/norm/batch_norm.py#L175-L176) updates `running_mean` / `running_var` with a read-modify-write run by every thread of the block, with no barrier between one thread's write and another's read — an intra-block global-memory write-read race on `running_mean[bc]`. Once the channel count oversubscribes the SMs, the running statistics come out non-deterministic (and wrong once `running_mean` is nonzero).

This PR guards the update to one thread (`T.get_thread_binding() == 0`). The stored values are
block-uniform, so it is behavior-preserving, with no measured perf change.


### Bug Fix

- Fixes #1727 


### Regression Test

Adds a `C=1024` config that exposes the race and a determinism assertion (a second run must match;
`allclose` is masked by the `running_mean=0` init). Fails on the current kernel, passes on the fix.
`scripts/test_node_delta.py`: 19 -> 20 (+1).
