### PR TITLE
[Fix][Engram] Fix inter-block global memory write-read data race in `EngramGateConvBwdKernel`

### DIFF
--- a/tests/ops/test_engram.py
+++ b/tests/ops/test_engram.py
@@ -148,6 +148,7 @@ class EngramGateConvBwdFixture(FixtureBase):
             pytest.param(1, 32, 256, torch.bfloat16, False, marks=pytest.mark.smoke),
             pytest.param(2, 64, 512, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16, 256, torch.bfloat16, False, marks=pytest.mark.full),
+            pytest.param(2, 512, 256, torch.float16, False, marks=pytest.mark.full),
         ]),
     ]
 
@@ -160,6 +161,14 @@ def test_engram_gate_conv_bwd(M, seq_len, d, dtype, tune):
     atol = 2e-1 if dtype == torch.float16 else 3e-1
     rtol = 2e-1
     test.check(op, *inputs, atol=atol, rtol=rtol)
+
+    # A data race varies run to run; allclose can still pass, so require two runs to match.
+    run1 = [o.clone() for o in op(*inputs)]
+    run2 = [o.clone() for o in op(*inputs)]
+    for i, name in ((0, "dH"), (1, "dk"), (2, "dv")):
+        max_err = (run1[i].float() - run2[i].float()).abs().max()
+        assert torch.equal(run1[i], run2[i]), \
+            f"{name} non-deterministic across runs (data race): max_err={max_err:.4e}"
 
 
 def _rmsnorm_decode(x, w, eps=1e-6):

--- a/tileops/kernels/engram/engram_bwd.py
+++ b/tileops/kernels/engram/engram_bwd.py
@@ -40,7 +40,7 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
     KS = CONV_KERNEL_SIZE
 
     @tilelang.jit(
-        out_idx=[12, 13, 14, 15, 16, 17, 18],
+        out_idx=[12, 13, 14, 15, 16, 17, 18, 19],
         compile_flags=["-O3", "-DENABLE_BF16"],
     )
     def _func(threads):
@@ -66,6 +66,7 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
             drms_w_v: T.Tensor((d_padded,), accum_dtype),
             dconv_w: T.Tensor((KS, d_padded), accum_dtype),
             dvhat_buf: T.Tensor((M, seq_len, d_padded), accum_dtype),
+            dvhat_out: T.Tensor((M, seq_len, d_padded), accum_dtype),
         ):
             # ======== Zero-init accumulated outputs ========
             with T.Kernel(1, threads=threads) as (bx,):
@@ -207,7 +208,7 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
 
                 # Store total d(vhat)
                 for j in T.Parallel(d_padded):
-                    dvhat_buf[bid, tid, j] = dvhat_local[j]
+                    dvhat_out[bid, tid, j] = dvhat_local[j]
 
             # ======== Pass 2: gate backward ========
             with T.Kernel(seq_len, M, threads=threads) as (bx, by):
@@ -233,7 +234,7 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
                 tid = bx
 
                 for j in T.Parallel(d_padded):
-                    dvhat_local[j] = dvhat_buf[bid, tid, j]
+                    dvhat_local[j] = dvhat_out[bid, tid, j]
                     v_local[j] = T.cast(v[bid, tid, j], accum_dtype)
                     h_local[j] = T.cast(H[bid, tid, j], accum_dtype)
                     k_local[j] = T.cast(k[bid, tid, j], accum_dtype)
@@ -332,11 +333,12 @@ def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
             drms_w_v: T.Tensor((d_padded,), accum_dtype),
             dconv_w: T.Tensor((KS, d_padded), accum_dtype),
             dvhat_buf: T.Tensor((M, seq_len, d_padded), accum_dtype),
+            dvhat_out: T.Tensor((M, seq_len, d_padded), accum_dtype),
         ):
             _gate_conv_bwd(
                 dY, H, k, v, rms_w_h, rms_w_v, conv_w,
                 vhat, alpha, rrms_h, rrms_k, rrms_v,
-                dH, dk, dv, drms_w_h, drms_w_v, dconv_w, dvhat_buf,
+                dH, dk, dv, drms_w_h, drms_w_v, dconv_w, dvhat_buf, dvhat_out,
             )
 
         return main
@@ -387,6 +389,7 @@ def _(M, seq_len, d, eps, dtype_str, threads,
         torch.empty((d_padded,), dtype=torch.float32, device=device),       # drms_w_v
         torch.empty((CONV_KERNEL_SIZE, d_padded), dtype=torch.float32, device=device),  # dconv_w
         torch.empty((M, seq_len, d_padded), dtype=torch.float32, device=device),  # dvhat_buf
+        torch.empty((M, seq_len, d_padded), dtype=torch.float32, device=device),  # dvhat_out
     ]
 
 


### PR DESCRIPTION
In [`EngramGateConvBwdKernel`](https://github.com/tile-ai/TileOPs/blob/48782d50e698c00d053e8cd0b2f2625e6ca54bdd/tileops/kernels/engram/engram_bwd.py#L148-L210)'s Pass 1b, each block reads its neighbours' rows of `dvhat_buf` while overwriting its own, with no cross-block barrier between them — an inter-block global-memory write-read race. Once the grid (`seq_len * M` blocks) oversubscribes the SMs, `dH` / `dk` / `dv` come out non-deterministic and wrong.

This PR fixes this race by storing `d(vhat)` to a separate `dvhat_out` buffer (read back in Pass 2), leaving `dvhat_buf` read-only within Pass 1b. The computed values and other kernel behaviors are unchanged, with no measured perf change.


### Bug Fix

- Fixes #1729


### Regression Test

Adds a `seq_len=512` (1024-block) config that exposes the race and a determinism assertion (a second run must match `dH` / `dk` / `dv`; `allclose` is masked by its `rtol` tolerance). Fails on the current kernel, passes on the fix. `scripts/test_node_delta.py`: 13 -> 14 (+1).
