### PR TITLE
[Refactor][Ops] Infer static metadata from forward inputs

### DIFF
--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -221,7 +221,7 @@ def test_deltanet_vs_fla_fwd(
     inputs = test.gen_inputs()  # q, k, v, beta (BHSD)
 
     # --- TileOPs (BHSD) ---
-    op = DeltaNetFwdOp(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune=tune)
+    op = DeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -299,10 +299,10 @@ def test_deltanet_vs_fla_bwd(
     do = torch.randn(B, H, S, DV, device="cuda", dtype=dtype) * 0.1
 
     # --- TileOPs: fwd to get S, Aw, Au, w, u; then profile bwd only ---
-    fwd_op = DeltaNetFwdOp(B, H, S, DK, DV, BC, dtype)
+    fwd_op = DeltaNetFwdOp(chunk_size=BC)
     _o, S_fwd, Aw, Au, w_fwd, u_fwd = fwd_op.forward(q, k, v, beta)
 
-    bwd_op = DeltaNetBwdOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    bwd_op = DeltaNetBwdOp(chunk_size=BC, tune=tune)
     result = bm.profile(bwd_op.forward, do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd)
     BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
 
@@ -387,7 +387,7 @@ def test_deltanet_vs_fla_fwdbwd(
     B, H, S, DK, DV, BC = batch, heads, seq_len, dim_k, dim_v, chunk_size
 
     # --- TileOPs: combined fwd+bwd via DeltaNetOp ---
-    op = DeltaNetOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    op = DeltaNetOp(chunk_size=BC, tune=tune)
 
     q = (torch.randn(B, H, S, DK, device="cuda", dtype=dtype) * 0.1).detach().requires_grad_(True)
     k = (torch.randn(B, H, S, DK, device="cuda", dtype=dtype) * 0.1).detach().requires_grad_(True)

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -98,7 +98,7 @@ def test_deltanet_decode_bench(
     test = _DeltaNetDecodeTestBaseline(batch, heads, dim_k, dim_v, dtype)
     inputs = test.gen_inputs()
 
-    op = DeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    op = DeltaNetDecodeOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -5,71 +5,43 @@ Uses p=0.5 (default) as representative drop rate.
 """
 
 from math import prod
-from typing import Optional
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
 from tileops.ops.dropout import DropoutOp
-from workloads.workload_base import FixtureBase
+from workloads.workload_base import WorkloadBase
 
-# DNN-realistic shapes: (tokens, hidden_dim). The third entry is non-pow2
-# (LLaMA-7B intermediate=11008) so the op exercises a non-pow2 shape.
-_SHAPES = [(1024, 4096), (1024, 10240), (1024, 11008)]
-_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-_P = 0.5
+_OP_NAME = "DropoutOp"
 
 
-class DropoutBenchCase:
-    def __init__(self, shape: tuple, dtype: torch.dtype):
+class DropoutBenchCase(WorkloadBase):
+    def __init__(self, shape: tuple, dtype: torch.dtype, p: float = 0.5):
         self.shape = shape
         self.n_total = prod(shape)
         self.dtype = dtype
+        self.p = p
 
     def gen_inputs(self) -> tuple[torch.Tensor, ...]:
         return (torch.randn(self.shape, device="cuda", dtype=self.dtype),)
 
-
-class DropoutBenchmark(BenchmarkBase[DropoutBenchCase]):
-    def calculate_flops(self) -> Optional[float]:
-        # RNG + compare + scale — not compute-bound, return element count
-        return self.workload.n_total
-
-    def calculate_memory(self) -> Optional[float]:
-        # Read x + write y
-        return self.workload.n_total * self.workload.dtype.itemsize * 2
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return F.dropout(x, p=self.p, training=True)
 
 
-def _dropout_params():
-    params = []
-    for shape in _SHAPES:
-        for dtype in _DTYPES:
-            mark = pytest.mark.smoke if (shape == _SHAPES[0] and dtype == torch.float16) else pytest.mark.full
-            params.append(pytest.param(shape, dtype, marks=mark))
-    return params
-
-
-class DropoutBenchFixture(FixtureBase):
-    PARAMS = [("shape, dtype", _dropout_params())]
-
-
-@DropoutBenchFixture
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_OP_NAME))
 def test_dropout_bench(shape: tuple, dtype: torch.dtype) -> None:
-    n_total = prod(shape)
     test = DropoutBenchCase(shape, dtype)
-    bm = DropoutBenchmark(test)
     (x,) = test.gen_inputs()
 
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=_P, seed=42)
+    op = DropoutOp(p=test.p, seed=42)
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, x)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    def baseline_fn(x):
-        return F.dropout(x, p=_P, training=True)
-
-    result_bl = bm.profile(baseline_fn, x)
+    result_bl = bm.profile(test.ref_program, x)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -1,13 +1,15 @@
-import math
-from typing import Optional
-
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    workloads_to_params,
+)
 from tileops.ops import FFTC2COp
 from workloads.fft import FFTTest
-from workloads.workload_base import FixtureBase
+
+_OP_NAME = "FFTC2COp"
 
 
 class _FFTTestBaseline(FFTTest):
@@ -17,50 +19,20 @@ class _FFTTestBaseline(FFTTest):
         return torch.fft.fft(x, dim=-1)
 
 
-class FFTBenchmarkFixture(FixtureBase):
-    PARAMS = [
-        ("n, dtype, tune, batch_shape", [
-            (4096, torch.complex64, True, ()),
-            (16384, torch.complex64, True, ()),
-            (65536, torch.complex64, True, ()),
-            (262144, torch.complex64, True, ()),
-            (1048576, torch.complex64, True, ()),
-            (4096, torch.complex64, True, (64,)),
-            (4096, torch.complex64, True, (256,)),
-            (1024, torch.complex64, True, (1024,)),
-            (4096, torch.complex128, True, ()),
-            (65536, torch.complex128, True, ()),
-            (4096, torch.complex128, True, (64,)),
-        ]),
-    ]
-
-
-class FFTBenchmark(BenchmarkBase[FFTTest]):
-
-    def calculate_flops(self) -> Optional[float]:
-        n = self.workload.n
-        batch = math.prod(self.workload.batch_shape) if self.workload.batch_shape else 1
-        return batch * 5.0 * n * math.log2(n)
-
-    def calculate_memory(self) -> Optional[float]:
-        n = self.workload.n
-        dtype = self.workload.dtype
-        batch = math.prod(self.workload.batch_shape) if self.workload.batch_shape else 1
-        return batch * 2 * n * torch.empty(1, dtype=dtype).element_size()
-
-
-@FFTBenchmarkFixture
-def test_fft_bench(n: int, dtype: torch.dtype, tune: bool, batch_shape: tuple) -> None:
+@pytest.mark.parametrize("shape, dtype", workloads_to_params(_OP_NAME))
+def test_fft_bench(shape: tuple, dtype: torch.dtype) -> None:
+    n = shape[-1]
+    batch_shape = shape[:-1]
     test = _FFTTestBaseline(n, dtype, batch_shape=batch_shape)
-    bm = FFTBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FFTC2COp(n, dtype=dtype, tune=tune)
+    op = FFTC2COp(tune=True)
 
     # Warmup: trigger JIT compilation before timed profiling
     op(*inputs)
     torch.cuda.synchronize()
 
+    bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -81,15 +81,7 @@ def test_fp8_lightning_indexer_bench(batch: int, seq_len: int, heads: int, index
     bm = FP8LightningIndexerBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FP8LightningIndexerOp(batch=batch,
-                              seq_len=seq_len,
-                              heads=heads,
-                              index_dim=index_dim,
-                              seq_len_kv=seq_len_kv,
-                              kv_group=kv_group,
-                              clean_logits=clean_logits,
-                              config=config,
-                              tune=tune)
+    op = FP8LightningIndexerOp(clean_logits=clean_logits, config=config, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -48,12 +48,7 @@ def test_fp8_quant_bench(batch: int, seq_len_kv: int, kv_group: int, index_dim: 
     bm = FP8QuantBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = FP8QuantOp(batch=batch,
-                    seq_len_kv=seq_len_kv,
-                    kv_group=kv_group,
-                    index_dim=index_dim,
-                    in_dtype=in_dtype,
-                    tune=tune)
+    op = FP8QuantOp(tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -254,7 +254,7 @@ def test_gated_deltanet_vs_fla_fwd(
     inputs = test.gen_inputs()  # q, k, v, g, beta  (BHSD)
 
     # --- TileOPs (BHSD) ---
-    op = GatedDeltaNetFwdOp(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune=tune)
+    op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -344,10 +344,10 @@ def test_gated_deltanet_vs_fla_bwd(
     do = torch.randn(B, H, S, DV, device="cuda", dtype=dtype) * 0.1
 
     # --- TileOPs: fwd to get S, then profile bwd only ---
-    fwd_op = GatedDeltaNetFwdOp(B, H, S, DK, DV, BC, dtype)
+    fwd_op = GatedDeltaNetFwdOp(chunk_size=BC)
     _o, S_fwd, _Aw, _Au = fwd_op.forward(q, k, v, g, beta)
 
-    bwd_op = GatedDeltaNetBwdOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    bwd_op = GatedDeltaNetBwdOp(chunk_size=BC, tune=tune)
     result = bm.profile(bwd_op.forward, do, q, k, v, g, beta, S_fwd)
     BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
 
@@ -444,7 +444,7 @@ def test_gated_deltanet_vs_fla_fwdbwd(
     B, H, S, DK, DV, BC = batch, heads, seq_len, dim_k, dim_v, chunk_size
 
     # --- TileOPs: combined fwd+bwd via GatedDeltaNetOp ---
-    op = GatedDeltaNetOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    op = GatedDeltaNetOp(chunk_size=BC, tune=tune)
 
     q = (torch.randn(B, H, S, DK, device="cuda", dtype=dtype) * 0.1).detach().requires_grad_(True)
     k = (torch.randn(B, H, S, DK, device="cuda", dtype=dtype) * 0.1).detach().requires_grad_(True)

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -191,17 +191,7 @@ def test_gated_deltanet_prefill_fwd_bench(
     )
     inputs = test.gen_inputs()
 
-    op = GatedDeltaNetPrefillFwdOp(
-        batch,
-        heads,
-        seq_len,
-        dim_k,
-        dim_v,
-        chunk_size,
-        dtype,
-        tune=tune,
-        layout=layout,
-    )
+    op = GatedDeltaNetPrefillFwdOp(chunk_size=chunk_size, tune=tune, layout=layout)
     bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
 

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -108,7 +108,7 @@ def test_gated_deltanet_decode_bench(
     test = _GatedDeltaNetDecodeTestBaseline(batch, heads, dim_k, dim_v, dtype)
     inputs = test.gen_inputs()
 
-    op = GatedDeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    op = GatedDeltaNetDecodeOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -163,8 +163,7 @@ def test_gla_fwd_bench(
 
     # --- TileOPs ---
     scale = dim_k ** -0.5
-    op = GLAFwdOp(batch, seq_len, heads, dim_k, dim_v, chunk_size,
-                   scale=scale, dtype=dtype, tune=tune)
+    op = GLAFwdOp(chunk_size=chunk_size, scale=scale, tune=tune)
     result = bm.profile(op.forward, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -240,12 +239,12 @@ def test_gla_bwd_bench(
     do = torch.randn(B, T, H, V, device="cuda", dtype=dtype) * 0.1
 
     # --- TileOPs: fwd to get h, then profile bwd only ---
-    fwd_op = GLAFwdOp(B, T, H, K, V, BC, scale=scale, dtype=dtype)
+    fwd_op = GLAFwdOp(chunk_size=BC, scale=scale)
     fwd_op.forward(q, k, v, g)
     h = fwd_op.kernel._h_out
     dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
 
-    bwd_op = GLABwdOp(B, T, H, K, V, BC, scale=scale, dtype=dtype, tune=tune)
+    bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
     result = bm.profile(bwd_op.forward, q, k, v, g, h, do, dht)
     BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
 
@@ -333,8 +332,8 @@ def test_gla_fwdbwd_bench(
     do = torch.randn(B, T, H, V, device="cuda", dtype=dtype) * 0.1
 
     # --- TileOPs: fwd + bwd ---
-    fwd_op = GLAFwdOp(B, T, H, K, V, BC, scale=scale, dtype=dtype)
-    bwd_op = GLABwdOp(B, T, H, K, V, BC, scale=scale, dtype=dtype, tune=tune)
+    fwd_op = GLAFwdOp(chunk_size=BC, scale=scale)
+    bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
 
     def tileops_fwdbwd():
         fwd_op.forward(q, k, v, g)

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -116,7 +116,7 @@ def test_gla_decode_bench(
     inputs = test.gen_inputs()
 
     # --- TileOPs ---
-    op = GLADecodeOp(batch, heads, dim_k, dim_v, scale=scale, dtype=dtype, tune=tune)
+    op = GLADecodeOp(scale=scale, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -134,8 +134,7 @@ def _run_variant_bench(name: str, batch_sum: int, batch_count: int, N: int, K: i
     bm = GroupedGemmBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = GroupedGemmOp(batch_sum, batch_count, N, K, dtype,
-                       transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
+    op = GroupedGemmOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(name, locals(), result, tag="tileops")
 
@@ -208,8 +207,7 @@ def test_grouped_gemm_complete_bench(batch_sum: int, batch_count: int, N: int, K
         variant_test = _GroupedGemmTestBaseline(batch_sum, batch_count, N, K, dtype,
                                        transpose_a, transpose_b)
         inputs = variant_test.gen_inputs()
-        op = GroupedGemmOp(batch_sum, batch_count, N, K, dtype,
-                           transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
+        op = GroupedGemmOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
         tileops_results.append(bm.profile(op, *inputs))
         baseline_results.append(bm.profile(variant_test.ref_program, *inputs))
 

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -114,8 +114,7 @@ def test_da_cumsum_fwd_bench(batch, num_chunks, chunk_len, n_heads, has_dt_bias,
     inputs = test.gen_inputs()  # (dt_raw, A, dt_bias)
 
     op = DaCumsumFwdOp(
-        batch, num_chunks, chunk_len, n_heads,
-        seq_len=num_chunks * chunk_len,
+        chunk_len=chunk_len,
         has_dt_bias=has_dt_bias,
         dt_softplus=dt_softplus,
         dtype=dtype,
@@ -321,9 +320,7 @@ def test_ssd_chunk_scan_fwd_bench(
     inputs = test.gen_inputs()  # x, cb, dA_cumsum, C, prev_states, dt
 
     # ── TileOPs kernel ──
-    op = SSDChunkScanFwdOp(
-        batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune=tune,
-    )
+    op = SSDChunkScanFwdOp(tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -461,10 +458,7 @@ def test_ssd_chunk_state_fwd_bench(
     bm = SSDChunkStateFwdBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = SSDChunkStateFwdOp(
-        batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype,
-        has_seq_idx=has_seq_idx, tune=tune,
-    )
+    op = SSDChunkStateFwdOp(has_seq_idx=has_seq_idx, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -591,7 +585,7 @@ def test_ssd_state_passing_fwd_bench(
     inputs = test.gen_inputs()
     states, dA_chunk_cumsum, initial_states = inputs
 
-    op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
+    op = SSDStatePassingFwdOp(tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
@@ -740,7 +734,7 @@ def test_ssd_decode_bench(
     state_for_op = state.clone()
     state_bl = state.clone()
 
-    op = SSDDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
+    op = SSDDecodeOp(tune=tune)
     result = bm.profile(op, A, dt, x, B_in, C_in, state_for_op)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -92,13 +92,6 @@ def test_mamba2_fwd_bench(batch, seqlen, n_heads, d_head, d_state, n_groups,
 
     # ── TileOPs ──────────────────────────────────────────────────────────────
     op = Mamba2FwdOp(
-        batch=batch,
-        seqlen=seqlen,
-        n_heads=n_heads,
-        d_head=d_head,
-        d_state=d_state,
-        n_groups=n_groups,
-        dtype=dtype,
         chunk_size=chunk_size,
         dt_softplus=dt_softplus,
         has_initial_states=False,

--- a/benchmarks/ops/bench_mhc_post.py
+++ b/benchmarks/ops/bench_mhc_post.py
@@ -50,7 +50,7 @@ def test_mhc_post_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
     bm = MHCPostBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = MHCPostOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
+    op = MHCPostOp(tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_mhc_pre.py
+++ b/benchmarks/ops/bench_mhc_pre.py
@@ -93,7 +93,7 @@ def test_mhc_pre_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
     bm = MHCPreBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = MHCPreOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
+    op = MHCPreOp(tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -93,7 +93,7 @@ def test_rope_bench(shape: tuple[int, int], dtype: torch.dtype) -> None:
     (x,) = test.gen_inputs()
 
     seq_len, head_dim = shape
-    op = RopeNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype)
+    op = RopeNeoxOp()
     result = bm.profile(op, x)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -53,15 +53,7 @@ def test_topk_selector_bench(batch: int, seq_len: int, seq_len_kv: int, kv_group
     bm = TopkSelectorBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = TopkSelectorOp(
-        batch=batch,
-        seq_len=seq_len,
-        seq_len_kv=seq_len_kv,
-        kv_group=kv_group,
-        topk=topk,
-        in_dtype=in_dtype,
-        out_dtype=out_dtype,
-        tune=tune)
+    op = TopkSelectorOp(topk=topk, tune=tune)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/tests/ops/attention/test_gqa_prefill_paged.py
+++ b/tests/ops/attention/test_gqa_prefill_paged.py
@@ -64,11 +64,7 @@ def _apply_neox_rope_position_ids(
     rotary_dim: int | None = None,
 ) -> torch.Tensor:
     op = RopeNeoxPositionIdsOp(
-        num_tokens=x.shape[0],
-        num_heads=x.shape[1],
-        head_dim=x.shape[2],
         max_position=max_position,
-        dtype=x.dtype,
         rotary_dim=rotary_dim,
     )
     return op(x, position_ids)

--- a/tests/ops/test_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_deltanet_chunkwise_bwd.py
@@ -102,7 +102,7 @@ def test_deltanet_bwd(
 
     # Forward to get S for backward kernel
     from tileops.ops import DeltaNetFwdOp
-    fwd_op = DeltaNetFwdOp(B, H, S, DK, DV, BC, dtype)
+    fwd_op = DeltaNetFwdOp(chunk_size=BC)
     _o, S_fwd, Aw, Au, w_fwd, u_fwd = fwd_op.forward(q, k, v, beta)
     do = torch.randn(B, H, S, DV, device="cuda", dtype=dtype) * 0.1
 
@@ -111,7 +111,7 @@ def test_deltanet_bwd(
     ref_outputs = (ref_dq, ref_dk, ref_dv, ref_dbeta)
 
     # Kernel
-    op = DeltaNetBwdOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    op = DeltaNetBwdOp(chunk_size=BC, tune=tune)
     op_outputs = op.forward(do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd)
 
     tols = _get_tolerances(dtype)

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -138,7 +138,7 @@ def test_deltanet_fwd(
 ) -> None:
     torch.manual_seed(42)
     test = DeltaNetFwdTest(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
-    op = DeltaNetFwdOp(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune=tune)
+    op = DeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     tols = _get_tolerances(dtype)
     inputs = test.gen_inputs()
     ref_o = test.ref_program(*inputs)

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -268,18 +268,11 @@ def test_deltanet_decode_raw_cuda_dispatch_selects_raw_on_supported_sm90(
 ) -> None:
     _mock_dispatch_arch(monkeypatch, 90)
 
-    op = DeltaNetDecodeOp(
-        1,
-        32,
-        128,
-        128,
-        dtype=dtype,
-        kernel_map=_dispatch_kernel_map(),
-        tune=tune,
-    )
+    op = DeltaNetDecodeOp(kernel_map=_dispatch_kernel_map(), tune=tune)
+    kernel = op._get_kernel(1, 32, 128, 128, dtype, device_index=None)
 
-    assert isinstance(op.kernel, _RawDispatchKernel)
-    assert op.kernel.kwargs["tune"] is tune
+    assert isinstance(kernel, _RawDispatchKernel)
+    assert kernel.kwargs["tune"] is tune
 
 
 @pytest.mark.smoke
@@ -288,17 +281,10 @@ def test_deltanet_decode_raw_cuda_dispatch_falls_back_on_unsupported_sm(
 ) -> None:
     _mock_dispatch_arch(monkeypatch, 80)
 
-    op = DeltaNetDecodeOp(
-        1,
-        32,
-        128,
-        128,
-        dtype=torch.bfloat16,
-        kernel_map=_dispatch_kernel_map(),
-        tune=False,
-    )
+    op = DeltaNetDecodeOp(kernel_map=_dispatch_kernel_map(), tune=False)
+    kernel = op._get_kernel(1, 32, 128, 128, torch.bfloat16, device_index=None)
 
-    assert isinstance(op.kernel, _DefaultDispatchKernel)
+    assert isinstance(kernel, _DefaultDispatchKernel)
 
 
 @pytest.mark.smoke
@@ -310,18 +296,11 @@ def test_deltanet_decode_raw_cuda_dispatch_falls_back_on_non_128_shapes(
 ) -> None:
     _mock_dispatch_arch(monkeypatch, 90)
 
-    op = DeltaNetDecodeOp(
-        1,
-        32,
-        dim_k,
-        dim_v,
-        dtype=torch.bfloat16,
-        kernel_map=_dispatch_kernel_map(),
-        tune=False,
-    )
+    op = DeltaNetDecodeOp(kernel_map=_dispatch_kernel_map(), tune=False)
+    kernel = op._get_kernel(1, 32, dim_k, dim_v, torch.bfloat16, device_index=None)
 
-    assert isinstance(op.kernel, _DefaultDispatchKernel)
-    assert op.kernel.kwargs["tune"] is False
+    assert isinstance(kernel, _DefaultDispatchKernel)
+    assert kernel.kwargs["tune"] is False
 
 
 @pytest.mark.smoke
@@ -330,18 +309,11 @@ def test_deltanet_decode_raw_cuda_dispatch_uses_fp32_kernel_for_fp32(
 ) -> None:
     _mock_dispatch_arch(monkeypatch, 90)
 
-    op = DeltaNetDecodeOp(
-        1,
-        32,
-        128,
-        128,
-        dtype=torch.float32,
-        kernel_map=_dispatch_kernel_map(),
-        tune=False,
-    )
+    op = DeltaNetDecodeOp(kernel_map=_dispatch_kernel_map(), tune=False)
+    kernel = op._get_kernel(1, 32, 128, 128, torch.float32, device_index=None)
 
-    assert isinstance(op.kernel, _FP32DispatchKernel)
-    assert op.kernel.kwargs["tune"] is False
+    assert isinstance(kernel, _FP32DispatchKernel)
+    assert kernel.kwargs["tune"] is False
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_deltanet_recurrence.py
+++ b/tests/ops/test_deltanet_recurrence.py
@@ -96,7 +96,7 @@ def test_deltanet_decode(
 ) -> None:
     torch.manual_seed(42)
     test = DeltaNetDecodeTest(batch, heads, dim_k, dim_v, dtype)
-    op = DeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    op = DeltaNetDecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), **tols)
 
@@ -115,7 +115,7 @@ def test_deltanet_decode_multi_step(
     num_steps = 8
     B, H, DK, DV = batch, heads, dim_k, dim_v
 
-    op = DeltaNetDecodeOp(B, H, DK, DV, dtype, tune=tune)
+    op = DeltaNetDecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
 
     state_op = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
@@ -153,7 +153,7 @@ def test_deltanet_decode_rejects_manifest_shape_mismatch() -> None:
     beta = torch.empty(2, 3)
     state = torch.empty(2, 3, 4, 5)
 
-    with pytest.raises(ValueError, match="q must have shape"):
+    with pytest.raises(ValueError, match="k must have shape"):
         op.forward(q, k, v, beta, state)
 
 
@@ -178,10 +178,11 @@ def test_deltanet_decode_raw_cuda_real_128x128_smoke(dtype: torch.dtype) -> None
 
     torch.manual_seed(42)
     test = DeltaNetDecodeTest(2, 4, 128, 128, dtype)
-    op = DeltaNetDecodeOp(2, 4, 128, 128, dtype, tune=False)
-
+    op = DeltaNetDecodeOp(tune=False)
+    inputs = test.gen_inputs()
+    op(*inputs)
     assert isinstance(op.kernel, DeltaNetDecodeRawCudaFlaStyleKernel)
-    test.check(op, *test.gen_inputs(), **_get_tolerances(dtype))
+    test.check(op, *inputs, **_get_tolerances(dtype))
 
 
 @pytest.mark.smoke
@@ -195,10 +196,8 @@ def test_deltanet_decode_raw_cuda_real_128x128_multi_step_smoke(
     torch.manual_seed(42)
     num_steps = 8
     B, H, DK, DV = 2, 4, 128, 128
-    op = DeltaNetDecodeOp(B, H, DK, DV, dtype, tune=False)
+    op = DeltaNetDecodeOp(tune=False)
     tols = _get_tolerances(dtype)
-
-    assert isinstance(op.kernel, DeltaNetDecodeRawCudaFlaStyleKernel)
 
     state_op = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
     state_ref = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
@@ -215,6 +214,8 @@ def test_deltanet_decode_raw_cuda_real_128x128_multi_step_smoke(
 
         with torch.no_grad():
             o_op, state_op = op(q, k, v, beta, state_op)
+
+        assert isinstance(op.kernel, DeltaNetDecodeRawCudaFlaStyleKernel)
 
         torch.testing.assert_close(o_op, o_ref, **tols)
         torch.testing.assert_close(state_op, state_ref, **tols)

--- a/tests/ops/test_dropout.py
+++ b/tests/ops/test_dropout.py
@@ -72,7 +72,7 @@ def test_dropout_statistical_rate(n_total: int, dtype: torch.dtype, p: float) ->
     from tileops.ops.dropout import DropoutOp
 
     x = torch.ones(n_total, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=42)
+    op = DropoutOp(p=p, seed=42)
     y = op(x)
 
     # Count zeros (dropped elements)
@@ -94,7 +94,7 @@ def test_dropout_scale_factor(n_total: int, dtype: torch.dtype, p: float) -> Non
     from tileops.ops.dropout import DropoutOp
 
     x = torch.ones(n_total, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=123)
+    op = DropoutOp(p=p, seed=123)
     y = op(x)
 
     # Non-zero elements should be scaled by 1/(1-p)
@@ -122,8 +122,8 @@ def test_dropout_deterministic_replay(n_total: int, dtype: torch.dtype, p: float
     from tileops.ops.dropout import DropoutOp
 
     x = torch.randn(n_total, dtype=dtype, device="cuda")
-    op1 = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=777)
-    op2 = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=777)
+    op1 = DropoutOp(p=p, seed=777)
+    op2 = DropoutOp(p=p, seed=777)
     y1 = op1(x)
     y2 = op2(x)
     assert torch.equal(y1, y2), "Deterministic replay failed: same seed produced different outputs"
@@ -135,8 +135,8 @@ def test_dropout_different_seeds(n_total: int, dtype: torch.dtype, p: float) -> 
     from tileops.ops.dropout import DropoutOp
 
     x = torch.ones(n_total, dtype=dtype, device="cuda")
-    op1 = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=42)
-    op2 = DropoutOp(N_total=n_total, dtype=dtype, p=p, seed=99)
+    op1 = DropoutOp(p=p, seed=42)
+    op2 = DropoutOp(p=p, seed=99)
     y1 = op1(x)
     y2 = op2(x)
     assert not torch.equal(y1, y2), "Different seeds produced identical outputs"
@@ -148,7 +148,7 @@ def test_dropout_p0_identity(n_total: int, dtype: torch.dtype) -> None:
     from tileops.ops.dropout import DropoutOp
 
     x = torch.randn(n_total, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=0.0, seed=42)
+    op = DropoutOp(p=0.0, seed=42)
     y = op(x)
     torch.testing.assert_close(y, x)
 
@@ -159,7 +159,7 @@ def test_dropout_p1_all_zeros(n_total: int, dtype: torch.dtype) -> None:
     from tileops.ops.dropout import DropoutOp
 
     x = torch.randn(n_total, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=1.0, seed=42)
+    op = DropoutOp(p=1.0, seed=42)
     y = op(x)
     assert torch.equal(y, torch.zeros_like(x)), "p=1 should produce all zeros"
 
@@ -170,7 +170,7 @@ def test_dropout_training_false(n_total: int, dtype: torch.dtype) -> None:
     from tileops.ops.dropout import DropoutOp
 
     x = torch.randn(n_total, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=0.5, seed=42, training=False)
+    op = DropoutOp(p=0.5, seed=42, training=False)
     y = op(x)
     torch.testing.assert_close(y, x)
 
@@ -182,7 +182,7 @@ def test_dropout_preserves_shape(n_total: int, dtype: torch.dtype) -> None:
 
     shape = (100, n_total // 100)
     x = torch.randn(shape, dtype=dtype, device="cuda")
-    op = DropoutOp(N_total=n_total, dtype=dtype, p=0.3, seed=42)
+    op = DropoutOp(p=0.3, seed=42)
     y = op(x)
     assert y.shape == x.shape, f"Shape mismatch: {y.shape} vs {x.shape}"
     assert y.dtype == x.dtype, f"Dtype mismatch: {y.dtype} vs {x.dtype}"

--- a/tests/ops/test_fft.py
+++ b/tests/ops/test_fft.py
@@ -31,7 +31,7 @@ class FFTFixture(FixtureBase):
 @FFTFixture
 def test_fft_c2c(n: int, dtype: torch.dtype, tune: bool, batch_shape: tuple) -> None:
     test = FFTTest(n, dtype, batch_shape=batch_shape)
-    op = FFTC2COp(n, dtype=dtype, tune=tune)
+    op = FFTC2COp(tune=tune)
     if dtype == torch.complex64:
         tolerances = {"atol": 1e-4, "rtol": 1e-4}
     else:

--- a/tests/ops/test_fp8_lightning_indexer.py
+++ b/tests/ops/test_fp8_lightning_indexer.py
@@ -84,16 +84,7 @@ def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_k
                  kv_group: int, clean_logits: bool, config: Optional[dict], tune: bool) -> None:
     test = FP8LightningIndexerTest(batch, seq_len, heads, index_dim, seq_len_kv, kv_group,
                                   clean_logits, config)
-    op = FP8LightningIndexerOp(
-        batch=batch,
-        seq_len=seq_len,
-        heads=heads,
-        index_dim=index_dim,
-        seq_len_kv=seq_len_kv,
-        kv_group=kv_group,
-        clean_logits=clean_logits,
-        config=config,
-        tune=tune)
+    op = FP8LightningIndexerOp(clean_logits=clean_logits, config=config, tune=tune)
     test.check(op, *test.gen_inputs(), compare=FP8LightningIndexerTest._validate_tensor_match)
 
 

--- a/tests/ops/test_fp8_lightning_indexer.py
+++ b/tests/ops/test_fp8_lightning_indexer.py
@@ -88,5 +88,22 @@ def test_indexer(batch: int, seq_len: int, heads: int, index_dim: int, seq_len_k
     test.check(op, *test.gen_inputs(), compare=FP8LightningIndexerTest._validate_tensor_match)
 
 
+@pytest.mark.smoke
+def test_indexer_rejects_bf16_inputs_with_external_scale() -> None:
+    op = FP8LightningIndexerOp()
+    batch, seq_len, heads, index_dim, seq_len_kv, kv_group = 1, 8, 4, 16, 16, 1
+    index_q = torch.randn(
+        batch, seq_len, heads, index_dim, device="cuda", dtype=torch.bfloat16)
+    index_k = torch.randn(
+        batch, seq_len_kv, kv_group, index_dim, device="cuda", dtype=torch.bfloat16)
+    weights = torch.randn(seq_len, heads, device="cuda", dtype=torch.float32)
+    cu_seqlen_ks = torch.zeros(seq_len, device="cuda", dtype=torch.int32)
+    cu_seqlen_ke = torch.full((seq_len,), seq_len_kv, device="cuda", dtype=torch.int32)
+    index_k_scale = torch.ones(batch, seq_len_kv, kv_group, device="cuda", dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="float8_e4m3fn"):
+        op(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, index_k_scale)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_fp8_quant.py
+++ b/tests/ops/test_fp8_quant.py
@@ -44,13 +44,7 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
 def test_fp8_quant_op(batch: int, seq_len_kv: int, kv_group: int, index_dim: int,
                       in_dtype: torch.dtype, tune: bool) -> None:
     test = FP8QuantTest(batch, seq_len_kv, kv_group, index_dim, in_dtype)
-    op = FP8QuantOp(
-        batch=batch,
-        seq_len_kv=seq_len_kv,
-        kv_group=kv_group,
-        index_dim=index_dim,
-        in_dtype=in_dtype,
-        tune=tune)
+    op = FP8QuantOp(tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)
 
 

--- a/tests/ops/test_gated_deltanet_chunkwise_bwd.py
+++ b/tests/ops/test_gated_deltanet_chunkwise_bwd.py
@@ -108,7 +108,7 @@ def test_gated_deltanet_bwd(
 
     # Forward to get S for backward kernel
     from tileops.ops import GatedDeltaNetFwdOp
-    fwd_op = GatedDeltaNetFwdOp(B, H, S, DK, DV, BC, dtype)
+    fwd_op = GatedDeltaNetFwdOp(chunk_size=BC)
     _o, S_fwd, _Aw, _Au = fwd_op.forward(q, k, v, g, beta)
     do = torch.randn(B, H, S, DV, device="cuda", dtype=dtype) * 0.1
 
@@ -117,7 +117,7 @@ def test_gated_deltanet_bwd(
     ref_outputs = (ref_dq, ref_dk, ref_dv, ref_dg, ref_dbeta)
 
     # Kernel
-    op = GatedDeltaNetBwdOp(B, H, S, DK, DV, BC, dtype, tune=tune)
+    op = GatedDeltaNetBwdOp(chunk_size=BC, tune=tune)
     op_outputs = op.forward(do, q, k, v, g, beta, S_fwd)
 
     tols = _get_tolerances(dtype)

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -160,7 +160,7 @@ def test_gated_deltanet_fwd(
 ) -> None:
     torch.manual_seed(42)
     test = GatedDeltaNetFwdTest(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
-    op = GatedDeltaNetFwdOp(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype, tune=tune)
+    op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     tols = _get_tolerances(dtype)
     inputs = test.gen_inputs()
     ref_o = test.ref_program(*inputs)

--- a/tests/ops/test_gated_deltanet_prefill.py
+++ b/tests/ops/test_gated_deltanet_prefill.py
@@ -267,17 +267,7 @@ def test_gated_deltanet_prefill_fwd(
 ) -> None:
     torch.manual_seed(42)
     test = GatedDeltaNetPrefillFwdTest(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
-    op = GatedDeltaNetPrefillFwdOp(
-        batch,
-        heads,
-        seq_len,
-        dim_k,
-        dim_v,
-        chunk_size,
-        dtype,
-        layout="bhtd",
-        tune=tune,
-    )
+    op = GatedDeltaNetPrefillFwdOp(chunk_size=chunk_size, layout="bhtd", tune=tune)
     test.check(op, *test.gen_inputs(), **_get_tolerances(dtype))
 
 
@@ -290,27 +280,8 @@ def test_gated_deltanet_prefill_bthd_layout_matches_bhtd() -> None:
     test = GatedDeltaNetPrefillFwdTest(B, H, S, DK, DV, BC, dtype)
     q, k, v, g, beta = test.gen_inputs()
 
-    bhtd_op = GatedDeltaNetPrefillFwdOp(
-        B,
-        H,
-        S,
-        DK,
-        DV,
-        BC,
-        dtype,
-        layout="bhtd",
-        tune=False,
-    )
-    bthd_op = GatedDeltaNetPrefillFwdOp(
-        B,
-        H,
-        S,
-        DK,
-        DV,
-        BC,
-        dtype,
-        tune=False,
-    )
+    bhtd_op = GatedDeltaNetPrefillFwdOp(chunk_size=BC, layout="bhtd", tune=False)
+    bthd_op = GatedDeltaNetPrefillFwdOp(chunk_size=BC, tune=False)
 
     o_bhtd, state_bhtd = bhtd_op(q, k, v, g, beta)
     q_bthd = q.permute(0, 2, 1, 3)
@@ -347,28 +318,8 @@ def test_gated_deltanet_prefill_bthd_blocksolve_path_matches_bhtd(
     test = GatedDeltaNetPrefillFwdTest(B, H, S, DK, DV, BC, dtype)
     q, k, v, g, beta = test.gen_inputs()
 
-    bhtd_op = GatedDeltaNetPrefillFwdOp(
-        B,
-        H,
-        S,
-        DK,
-        DV,
-        BC,
-        dtype,
-        layout="bhtd",
-        tune=False,
-    )
-    bthd_op = GatedDeltaNetPrefillFwdOp(
-        B,
-        H,
-        S,
-        DK,
-        DV,
-        BC,
-        dtype,
-        tune=False,
-        layout="bthd",
-    )
+    bhtd_op = GatedDeltaNetPrefillFwdOp(chunk_size=BC, layout="bhtd", tune=False)
+    bthd_op = GatedDeltaNetPrefillFwdOp(chunk_size=BC, tune=False, layout="bthd")
 
     o_bhtd, state_bhtd = bhtd_op(q, k, v, g, beta)
     o_bthd, state_bthd = bthd_op(

--- a/tests/ops/test_gated_deltanet_recurrence.py
+++ b/tests/ops/test_gated_deltanet_recurrence.py
@@ -103,7 +103,7 @@ def test_gated_deltanet_decode(
 ) -> None:
     torch.manual_seed(42)
     test = GatedDeltaNetDecodeTest(batch, heads, dim_k, dim_v, dtype)
-    op = GatedDeltaNetDecodeOp(batch, heads, dim_k, dim_v, dtype, tune=tune)
+    op = GatedDeltaNetDecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), **tols)
 
@@ -122,7 +122,7 @@ def test_gated_deltanet_decode_multi_step(
     num_steps = 8
     B, H, DK, DV = batch, heads, dim_k, dim_v
 
-    op = GatedDeltaNetDecodeOp(B, H, DK, DV, dtype, tune=tune)
+    op = GatedDeltaNetDecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
 
     state_op = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)

--- a/tests/ops/test_gla_chunkwise_bwd.py
+++ b/tests/ops/test_gla_chunkwise_bwd.py
@@ -165,13 +165,16 @@ def test_gla_bwd(
             assert cos > 0.99, f"FLA vs ref {name} cosine too low: {cos:.6f}"
 
     # --- TileOPs kernel backward ---
-    fwd_op = GLAFwdOp(B, T, H, K, V, BC, scale=scale,
-                       output_final_state=False, dtype=dtype)
+    fwd_op = GLAFwdOp(
+        chunk_size=BC,
+        scale=scale,
+        output_final_state=False,
+    )
     o_fwd, _ = fwd_op.forward(q, k, v, g)
     h = fwd_op.kernel._h_out  # [B, NT+1, H, K, V] in fp32
 
     dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
-    bwd_op = GLABwdOp(B, T, H, K, V, BC, scale=scale, dtype=dtype, tune=tune)
+    bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
     op_dq, op_dk, op_dv, op_dg = bwd_op.forward(q, k, v, g, h, do, dht)
     op_grads = {"dq": op_dq, "dk": op_dk, "dv": op_dv, "dg": op_dg}
 

--- a/tests/ops/test_gla_chunkwise_fwd.py
+++ b/tests/ops/test_gla_chunkwise_fwd.py
@@ -106,8 +106,12 @@ def test_gla_fwd(
         assert cos > 0.99, f"FLA vs ref o cosine too low: {cos:.6f}"
 
     # --- TileOPs ---
-    fwd_op = GLAFwdOp(B, T, H, K, V, BC, scale=scale,
-                       output_final_state=False, dtype=dtype, tune=tune)
+    fwd_op = GLAFwdOp(
+        chunk_size=BC,
+        scale=scale,
+        output_final_state=False,
+        tune=tune,
+    )
     op_o, _ = fwd_op.forward(q, k, v, g)
 
     tols = get_tolerances(dtype)

--- a/tests/ops/test_gla_recurrence.py
+++ b/tests/ops/test_gla_recurrence.py
@@ -94,7 +94,7 @@ def test_gla_decode(
 ) -> None:
     torch.manual_seed(42)
     test = GLADecodeTest(batch, heads, dim_k, dim_v, dtype)
-    op = GLADecodeOp(batch, heads, dim_k, dim_v, dtype=dtype, tune=tune)
+    op = GLADecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), **tols)
 
@@ -113,7 +113,7 @@ def test_gla_decode_multi_step(
     num_steps = 8
     B, H, DK, DV = batch, heads, dim_k, dim_v
 
-    op = GLADecodeOp(B, H, DK, DV, dtype=dtype, tune=tune)
+    op = GLADecodeOp(tune=tune)
     tols = _get_tolerances(dtype)
 
     state_op = torch.zeros(B, H, DK, DV, device="cuda", dtype=dtype)
@@ -160,7 +160,7 @@ def test_gla_decode_vs_fla(
     state = torch.randn(B, H, DK, DV, device="cuda", dtype=dtype) * 0.1
 
     # TileOPs
-    op = GLADecodeOp(B, H, DK, DV, scale=scale, dtype=dtype, tune=tune)
+    op = GLADecodeOp(scale=scale, tune=tune)
     with torch.no_grad():
         o_tile, s_tile = op(q, k, v, gk, state)
 

--- a/tests/ops/test_grouped_gemm.py
+++ b/tests/ops/test_grouped_gemm.py
@@ -106,9 +106,7 @@ class GroupedGemmFixture(FixtureBase):
 def test_grouped_gemm(batch_sum: int, batch_count: int, N: int, K: int, dtype: torch.dtype,
                       transpose_a: bool, transpose_b: bool, tune: bool) -> None:
     test = GroupedGemmTest(batch_sum, batch_count, N, K, dtype, transpose_a, transpose_b)
-    op = GroupedGemmOp(
-        batch_sum, batch_count, N, K, dtype, transpose_a=transpose_a, transpose_b=transpose_b,
-        tune=tune)
+    op = GroupedGemmOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=tune)
     test.check(op, *test.gen_inputs())
 
 

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -142,8 +142,7 @@ def test_da_cumsum_fwd(batch, num_chunks, chunk_len, n_heads, has_dt_bias, dt_so
         has_dt_bias=has_dt_bias, dt_softplus=dt_softplus, dtype=dtype,
     )
     op = DaCumsumFwdOp(
-        batch, num_chunks, chunk_len, n_heads,
-        seq_len=num_chunks * chunk_len,
+        chunk_len=chunk_len,
         has_dt_bias=has_dt_bias,
         dt_softplus=dt_softplus,
         dtype=dtype,
@@ -237,7 +236,7 @@ class SSDChunkScanFwdTest(SSDChunkScanFwdWorkload, TestBase):
 @SSDChunkScanFwdFixture
 def test_ssd_chunk_scan_fwd(batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune):
     test = SSDChunkScanFwdTest(batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype)
-    op = SSDChunkScanFwdOp(batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
+    op = SSDChunkScanFwdOp(tune=tune)
     inputs = test.gen_inputs()
     atol = 1e-3 if dtype == torch.float16 else 2e-3
     rtol = 1e-5
@@ -293,10 +292,7 @@ def test_ssd_chunk_state_fwd(
     test = SSDChunkStateFwdTest(
         batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, has_seq_idx,
     )
-    op = SSDChunkStateFwdOp(
-        batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype,
-        has_seq_idx=has_seq_idx, tune=tune,
-    )
+    op = SSDChunkStateFwdOp(has_seq_idx=has_seq_idx, tune=tune)
     inputs = test.gen_inputs()
     atol = 1e-3 if dtype == torch.float16 else 1.6e-2
     rtol = 1e-3
@@ -322,7 +318,7 @@ def test_ssd_chunk_state_fwd_seq_end_negative():
     seq_idx = torch.ones(b, seq_len, dtype=torch.int32, device="cuda")
     seq_idx[:, :Q] = -1
 
-    op = SSDChunkStateFwdOp(b, c, Q, h, p, n, g, dtype, has_seq_idx=True)
+    op = SSDChunkStateFwdOp(has_seq_idx=True)
     out = op(x, Bmat, dt, dA_cumsum, seq_idx)
     ref = ssd_chunk_state_fwd_ref(x, Bmat, dt, dA_cumsum, g, seq_idx=seq_idx)
 
@@ -370,7 +366,7 @@ class SSDStatePassingFwdTest(SSDStatePassingFwdWorkload, TestBase):
 @SSDStatePassingFwdFixture
 def test_ssd_state_passing_fwd(batch, num_chunks, n_heads, d_state, dtype, tune):
     test = SSDStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
-    op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=tune)
+    op = SSDStatePassingFwdOp(tune=tune)
     inputs = test.gen_inputs()
     atol = 1e-3 if dtype == torch.float16 else 1.6e-2
     rtol = 1e-3
@@ -388,9 +384,10 @@ def test_ssd_state_passing_fwd_vectorize(config, dtype):
     """Exercises the vectorize=True code path (lo/hi split per thread)."""
     batch, num_chunks, n_heads, d_state = 2, 4, 8, 128
     test = SSDStatePassingFwdTest(batch, num_chunks, n_heads, d_state, dtype)
-    op = SSDStatePassingFwdOp(batch, num_chunks, n_heads, d_state, dtype=dtype, tune=False)
-    op.kernel.config = config
+    op = SSDStatePassingFwdOp(tune=False)
     inputs = test.gen_inputs()
+    op(*inputs)
+    op.kernel.config = config
     atol = 1e-3 if dtype == torch.float16 else 1.6e-2
     test.check(op, *inputs, atol=atol, rtol=1e-3)
 
@@ -457,7 +454,7 @@ class SSDDecodeTest(SSDDecodeWorkload, TestBase):
 @SSDDecodeFixture
 def test_ssd_decode(batch, n_heads, d_head, d_state, n_groups, dtype, tune):
     test = SSDDecodeTest(batch, n_heads, d_head, d_state, n_groups, dtype)
-    op = SSDDecodeOp(batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune)
+    op = SSDDecodeOp(tune=tune)
     A, dt, x, B_in, C_in, state = test.gen_inputs()
 
     # Run reference on a clone of state so the two runs start from the same point.
@@ -588,13 +585,6 @@ def test_mamba2_fwd_e2e(batch, seqlen, n_heads, d_head, d_state, n_groups, chunk
     dt_bias = torch.randn(n_heads,                          dtype=torch.float32,  device=dev) * 0.1
 
     op = Mamba2FwdOp(
-        batch=batch,
-        seqlen=seqlen,
-        n_heads=n_heads,
-        d_head=d_head,
-        d_state=d_state,
-        n_groups=n_groups,
-        dtype=dtype,
         chunk_size=chunk_size,
         dt_softplus=True,
         has_initial_states=False,

--- a/tests/ops/test_mhc_post.py
+++ b/tests/ops/test_mhc_post.py
@@ -44,7 +44,7 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
 def test_mhc_post_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
                      tune: bool) -> None:
     test = MHCPostTest(batch, n_expand, c_x, dtype)
-    op = MHCPostOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
+    op = MHCPostOp(tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)
 
 

--- a/tests/ops/test_mhc_pre.py
+++ b/tests/ops/test_mhc_pre.py
@@ -86,7 +86,7 @@ def _cosine_compare(output: torch.Tensor, output_ref: torch.Tensor) -> None:
 def test_mhc_pre_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
                     tune: bool) -> None:
     test = MHCPreTest(batch, n_expand, c_x, dtype)
-    op = MHCPreOp(batch, n_expand, c_x, dtype=dtype, tune=tune)
+    op = MHCPreOp(tune=tune)
     test.check(op, *test.gen_inputs(), compare=_cosine_compare)
 
 

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -405,6 +405,28 @@ def test_rope_neox_position_ids_validates_range() -> None:
         op(x, torch.tensor([0, 8], device="cuda", dtype=torch.int32))
 
 
+@pytest.mark.smoke
+def test_rope_neox_position_ids_none_rotary_dim_reinfers_head_dim() -> None:
+    from tileops.ops.rope import RopeNeoxPositionIdsOp
+
+    max_position = 64
+    position_ids = torch.arange(8, device="cuda", dtype=torch.int32)
+    op = RopeNeoxPositionIdsOp(max_position=max_position, rotary_dim=None)
+
+    x1 = torch.randn(8, 2, 16, device="cuda", dtype=torch.float16)
+    cos1, sin1 = _compute_freqs_cis_base(16, max_position, dtype=x1.dtype, device="cuda")
+    ref1 = ref_rope_neox_position_ids(x1, cos1, sin1, position_ids.long(), rotary_dim=None)
+    torch.testing.assert_close(op(x1, position_ids), ref1, atol=5e-3, rtol=1e-5)
+    assert op.rotary_dim == 16
+
+    x2 = torch.randn(8, 2, 32, device="cuda", dtype=torch.float16)
+    cos2, sin2 = _compute_freqs_cis_base(32, max_position, dtype=x2.dtype, device="cuda")
+    ref2 = ref_rope_neox_position_ids(x2, cos2, sin2, position_ids.long(), rotary_dim=None)
+    torch.testing.assert_close(op(x2, position_ids), ref2, atol=5e-3, rtol=1e-5)
+    assert op.rotary_dim == 32
+    assert op._requested_rotary_dim is None
+
+
 # ---------------------------------------------------------------------------
 # Non-neox (RoFormer) RoPE tests
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_rope.py
+++ b/tests/ops/test_rope.py
@@ -356,7 +356,7 @@ def test_rope_neox_1d(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNeoxOp
 
     test = RopeTest("neox", "1d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="1d")
+    op = RopeNeoxOp(layout="1d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -367,8 +367,7 @@ def test_rope_neox_2d(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNeoxOp
 
     test = RopeTest("neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                    batch=batch, num_heads=num_heads)
+    op = RopeNeoxOp(layout="2d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -389,11 +388,7 @@ def test_rope_neox_position_ids_thd(rotary_dim: int | None) -> None:
     ref = ref_rope_neox_position_ids(x, cos, sin, position_ids.long(), rotary_dim=rotary_dim)
 
     op = RopeNeoxPositionIdsOp(
-        num_tokens=num_tokens,
-        num_heads=num_heads,
-        head_dim=head_dim,
         max_position=max_position,
-        dtype=dtype,
         rotary_dim=rotary_dim,
     )
     output = op(x, position_ids)
@@ -404,13 +399,7 @@ def test_rope_neox_position_ids_thd(rotary_dim: int | None) -> None:
 def test_rope_neox_position_ids_validates_range() -> None:
     from tileops.ops.rope import RopeNeoxPositionIdsOp
 
-    op = RopeNeoxPositionIdsOp(
-        num_tokens=2,
-        num_heads=1,
-        head_dim=16,
-        max_position=8,
-        dtype=torch.float16,
-    )
+    op = RopeNeoxPositionIdsOp(max_position=8)
     x = torch.randn(2, 1, 16, device="cuda", dtype=torch.float16)
     with pytest.raises(ValueError, match="position_ids"):
         op(x, torch.tensor([0, 8], device="cuda", dtype=torch.int32))
@@ -427,7 +416,7 @@ def test_rope_non_neox_1d(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNonNeoxOp
 
     test = RopeTest("non_neox", "1d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="1d")
+    op = RopeNonNeoxOp(layout="1d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -438,8 +427,7 @@ def test_rope_non_neox_2d(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNonNeoxOp
 
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                       batch=batch, num_heads=num_heads)
+    op = RopeNonNeoxOp(layout="2d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -458,8 +446,7 @@ def test_rope_llama31_1d(batch: int, seq_len: int, num_heads: int,
              "original_max_position": 8192}
     test = RopeTest("rope_llama31", "1d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeLlama31Op(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="1d",
-                       **extra)
+    op = RopeLlama31Op(layout="1d", **extra)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -473,8 +460,7 @@ def test_rope_llama31_2d(batch: int, seq_len: int, num_heads: int,
              "original_max_position": 8192}
     test = RopeTest("rope_llama31", "2d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeLlama31Op(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                       batch=batch, num_heads=num_heads, **extra)
+    op = RopeLlama31Op(layout="2d", **extra)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -493,7 +479,7 @@ def test_rope_yarn_1d(batch: int, seq_len: int, num_heads: int,
              "beta_fast": 32.0, "beta_slow": 1.0, "attn_factor": 1.0}
     test = RopeTest("yarn_rope", "1d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeYarnOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="1d", **extra)
+    op = RopeYarnOp(layout="1d", **extra)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -507,8 +493,7 @@ def test_rope_yarn_2d(batch: int, seq_len: int, num_heads: int,
              "beta_fast": 32.0, "beta_slow": 1.0, "attn_factor": 1.0}
     test = RopeTest("yarn_rope", "2d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeYarnOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                    batch=batch, num_heads=num_heads, **extra)
+    op = RopeYarnOp(layout="2d", **extra)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -532,8 +517,8 @@ def test_rope_longrope_1d(batch: int, seq_len: int, num_heads: int,
              "original_max_position_embeddings": orig_max_pos}
     test = RopeTest("longrope", "1d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeLongRopeOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="1d",
-                        rescale_factors=rescale, max_position_embeddings=max_pos,
+    op = RopeLongRopeOp(layout="1d", rescale_factors=rescale,
+                        max_position_embeddings=max_pos,
                         original_max_position_embeddings=orig_max_pos)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
@@ -553,8 +538,7 @@ def test_rope_longrope_2d(batch: int, seq_len: int, num_heads: int,
              "original_max_position_embeddings": orig_max_pos}
     test = RopeTest("longrope", "2d", batch, seq_len, num_heads, head_dim, dtype,
                     extra_kwargs=extra)
-    op = RopeLongRopeOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                        batch=batch, num_heads=num_heads, rescale_factors=rescale,
+    op = RopeLongRopeOp(layout="2d", rescale_factors=rescale,
                         max_position_embeddings=max_pos,
                         original_max_position_embeddings=orig_max_pos)
     atol, rtol = _get_tolerances(dtype)
@@ -573,8 +557,7 @@ def test_rope_neox_edge(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNeoxOp
 
     test = RopeTest("neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                    batch=batch, num_heads=num_heads)
+    op = RopeNeoxOp(layout="2d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -586,8 +569,7 @@ def test_rope_non_neox_edge(batch: int, seq_len: int, num_heads: int,
     from tileops.ops.rope import RopeNonNeoxOp
 
     test = RopeTest("non_neox", "2d", batch, seq_len, num_heads, head_dim, dtype)
-    op = RopeNonNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=dtype, layout="2d",
-                       batch=batch, num_heads=num_heads)
+    op = RopeNonNeoxOp(layout="2d")
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -598,16 +580,13 @@ def test_rope_non_neox_edge(batch: int, seq_len: int, num_heads: int,
 
 
 @pytest.mark.smoke
-def test_rope_rejects_wrong_shape_2d() -> None:
-    """A same-numel but wrong-shape 2D tensor must be rejected."""
+def test_rope_rejects_wrong_rank_2d() -> None:
+    """A tensor with the wrong rank for 2D layout must be rejected."""
     from tileops.ops.rope import RopeNeoxOp
 
-    # Op configured for batch=2, seq_len=2, num_heads=1, head_dim=4
-    op = RopeNeoxOp(seq_len=2, head_dim=4, dtype=torch.float16, layout="2d",
-                    batch=2, num_heads=1)
-    # Wrong shape: (1, 4, 1, 4) has same numel (16) as (2, 2, 1, 4) but different layout
-    x = torch.randn(1, 4, 1, 4, device="cuda", dtype=torch.float16)
-    with pytest.raises(ValueError, match="Expected input shape"):
+    op = RopeNeoxOp(layout="2d")
+    x = torch.randn(4, 4, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="2d layout expects"):
         op(x)
 
 
@@ -617,7 +596,7 @@ def test_rope_noncontiguous_1d_works() -> None:
     from tileops.ops.rope import RopeNeoxOp
 
     seq_len, head_dim = 4, 8
-    op = RopeNeoxOp(seq_len=seq_len, head_dim=head_dim, dtype=torch.float32, layout="1d")
+    op = RopeNeoxOp(layout="1d")
 
     # Create a non-contiguous view: transpose makes it non-contiguous
     base = torch.randn(head_dim, seq_len, device="cuda", dtype=torch.float32)

--- a/tests/ops/test_topk_selector.py
+++ b/tests/ops/test_topk_selector.py
@@ -52,14 +52,7 @@ def test_topk_selector_op(batch: int,
     in_dtype = str2dtype[in_dtype_str]
     out_dtype = str2dtype[out_dtype_str]
     test = TopkSelectorTest(batch, seq_len, seq_len_kv, kv_group, topk, in_dtype, out_dtype)
-    op = TopkSelectorOp(batch=batch,
-                        seq_len=seq_len,
-                        seq_len_kv=seq_len_kv,
-                        kv_group=kv_group,
-                        topk=topk,
-                        in_dtype=in_dtype,
-                        out_dtype=out_dtype,
-                        tune=tune)
+    op = TopkSelectorOp(topk=topk, tune=tune)
     test.check(op, *test.gen_inputs(), compare=_set_compare)
 
 

--- a/tileops/manifest/attention_indexing.yaml
+++ b/tileops/manifest/attention_indexing.yaml
@@ -16,24 +16,20 @@ FP8LightningIndexerOp:
     outputs:
       logits: {dtype: "float32", shape: "[batch, seq_len, seq_len_kv, kv_group]"}
     params:
-      batch: {type: int}
-      seq_len: {type: int}
-      heads: {type: int}
-      index_dim: {type: int}
-      seq_len_kv: {type: int}
-      kv_group: {type: int}
       clean_logits: {type: bool, default: true}
       config: {type: "dict | None", default: null}
     dtype_combos:
     - {index_q: bfloat16, index_k: bfloat16, weights: float32, cu_seqlen_ks: int32, cu_seqlen_ke: int32, index_k_scale: float32}
     - {index_q: float8_e4m3fn, index_k: float8_e4m3fn, weights: float32, cu_seqlen_ks: int32, cu_seqlen_ke: int32, index_k_scale: float32}
     shape_rules:
-    - "index_q.shape == (batch, seq_len, heads, index_dim)"
-    - "index_k.shape == (batch, seq_len_kv, kv_group, index_dim)"
-    - "weights.shape == (seq_len, heads)"
-    - "cu_seqlen_ks.shape == (seq_len,)"
-    - "cu_seqlen_ke.shape == (seq_len,)"
-    - "index_k_scale.shape == (batch, seq_len_kv, kv_group)"
+    - "index_q.ndim == 4 and index_k.ndim == 4"
+    - "index_q.shape[0] == index_k.shape[0]"
+    - "index_q.shape[3] == index_k.shape[3]"
+    - "index_q.shape[2] % index_k.shape[2] == 0"
+    - "weights.shape == (index_q.shape[1], index_q.shape[2])"
+    - "cu_seqlen_ks.shape == (index_q.shape[1],)"
+    - "cu_seqlen_ke.shape == (index_q.shape[1],)"
+    - "index_k_scale.shape == (index_q.shape[0], index_k.shape[1], index_k.shape[2])"
 
   workloads:
   - {batch: 1, seq_len: 8192, heads: 32, index_dim: 64, seq_len_kv: 8192, kv_group: 1, clean_logits: true, dtypes: [bfloat16], label: "lightning-indexer-bf16-s8k-h32-d64"}
@@ -64,18 +60,12 @@ TopkSelectorOp:
     outputs:
       indexes: {dtype: "int32", shape: "[batch, seq_len, kv_group, topk]"}
     params:
-      batch: {type: int}
-      seq_len: {type: int}
-      seq_len_kv: {type: int}
-      kv_group: {type: int}
       topk: {type: int}
-      in_dtype: {type: torch.dtype}
-      out_dtype: {type: torch.dtype}
     shape_rules:
-    - "index_score.shape == (batch, seq_len, seq_len_kv, kv_group)"
-    - "starts.shape == (batch, seq_len)"
-    - "ends.shape == (batch, seq_len)"
-    - "0 < topk <= seq_len_kv"
+    - "index_score.ndim == 4"
+    - "starts.shape == (index_score.shape[0], index_score.shape[1])"
+    - "ends.shape == (index_score.shape[0], index_score.shape[1])"
+    - "0 < topk <= index_score.shape[2]"
 
   workloads:
   - {batch: 1, seq_len: 32768, seq_len_kv: 65536, kv_group: 1, topk: 1024, in_dtype: float32, out_dtype: int32, dtypes: [float32], label: "topk1024-s32k-kv64k"}

--- a/tileops/manifest/attention_indexing.yaml
+++ b/tileops/manifest/attention_indexing.yaml
@@ -12,14 +12,13 @@ FP8LightningIndexerOp:
       weights: {dtype: "float32", shape: "[seq_len, heads]"}
       cu_seqlen_ks: {dtype: "int32", shape: "[seq_len]"}
       cu_seqlen_ke: {dtype: "int32", shape: "[seq_len]"}
-      index_k_scale: {dtype: "float32", shape: "[batch, seq_len_kv, kv_group]"}
+      index_k_scale: {dtype: "float32", shape: "[batch, seq_len_kv, kv_group]", optional: true}
     outputs:
       logits: {dtype: "float32", shape: "[batch, seq_len, seq_len_kv, kv_group]"}
     params:
       clean_logits: {type: bool, default: true}
       config: {type: "dict | None", default: null}
     dtype_combos:
-    - {index_q: bfloat16, index_k: bfloat16, weights: float32, cu_seqlen_ks: int32, cu_seqlen_ke: int32, index_k_scale: float32}
     - {index_q: float8_e4m3fn, index_k: float8_e4m3fn, weights: float32, cu_seqlen_ks: int32, cu_seqlen_ke: int32, index_k_scale: float32}
     shape_rules:
     - "index_q.ndim == 4 and index_k.ndim == 4"

--- a/tileops/manifest/gemm.yaml
+++ b/tileops/manifest/gemm.yaml
@@ -123,21 +123,18 @@ GroupedGemmOp:
     outputs:
       output: {dtype: "same_as(a)", shape: "[batch_sum, N] | [batch_count, N, K]"}
     params:
-      batch_sum: {type: int}
-      batch_count: {type: int}
-      n: {type: int}
-      k: {type: int}
       transpose_a: {type: bool, default: false}
       transpose_b: {type: bool, default: true}
     shape_rules:
-    - "batch_sizes.shape == (batch_count,)"
-    - "batch_offsets.shape == (batch_count,)"
-    - "batch_padded_offsets.shape == (batch_count,)"
-    - "a.shape == (batch_sum, k) if not transpose_a else a.shape == (batch_sum, n)"
-    - "b.shape == (batch_count, n, k) if (not transpose_a and transpose_b) else True"
-    - "b.shape == (batch_count, k, n) if (not transpose_a and not transpose_b) else True"
-    - "b.shape == (k, batch_sum) if (transpose_a and transpose_b) else True"
-    - "b.shape == (batch_sum, k) if (transpose_a and not transpose_b) else True"
+    - "batch_sizes.ndim == 1"
+    - "batch_offsets.shape == batch_sizes.shape"
+    - "batch_padded_offsets.shape == batch_sizes.shape"
+    - "a.ndim == 2"
+    - "b.ndim == (2 if transpose_a else 3)"
+    - "a.shape[0] > 0 and a.shape[1] > 0"
+    - "b.shape[0] == batch_sizes.shape[0] if (not transpose_a) else True"
+    - "b.shape[2 if transpose_b else 1] == a.shape[1] if (not transpose_a) else True"
+    - "b.shape[1 if transpose_b else 0] == a.shape[0] if transpose_a else True"
 
   workloads:
   - {batch_sum: 4096, batch_count: 16, n: 4096, k: 4096, dtype: float16, transpose_a: false, transpose_b: true, dtypes: [float16], label: "nt-batch16-m4096-n4096-k4096-fp16"}

--- a/tileops/manifest/position_encoding.yaml
+++ b/tileops/manifest/position_encoding.yaml
@@ -1,8 +1,8 @@
 # Position-encoding operators.
 #
 # These ops already exist in tileops/ops/rope.py. The manifest keeps the
-# current runtime surface as source of truth: construction binds the static
-# sequence/head dimensions and forward applies the rotation to input tensors.
+# current runtime surface as source of truth: construction binds RoPE variant
+# config, while forward infers tensor dimensions from input metadata.
 
 RopeNeoxOp:
   ref_api: "none"
@@ -15,16 +15,12 @@ RopeNeoxOp:
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
     params:
-      seq_len: {type: int}
-      head_dim: {type: int}
-      dtype: {type: torch.dtype}
       layout: {type: str, default: "1d"}
-      batch: {type: int, default: 1}
-      num_heads: {type: int, default: 1}
       base: {type: float, default: 10000.0}
     shape_rules:
-    - "x.shape == (seq_len, head_dim) or x.shape == (batch, seq_len, num_heads, head_dim)"
-    - "head_dim % 2 == 0"
+    - "layout == '1d' implies x.ndim == 2"
+    - "layout == '2d' implies x.ndim == 4"
+    - "x.shape[-1] % 2 == 0"
 
   workloads:
   - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "neox-1d-2k-d64-fp16"}
@@ -55,16 +51,12 @@ RopeNonNeoxOp:
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
     params:
-      seq_len: {type: int}
-      head_dim: {type: int}
-      dtype: {type: torch.dtype}
       layout: {type: str, default: "1d"}
-      batch: {type: int, default: 1}
-      num_heads: {type: int, default: 1}
       base: {type: float, default: 10000.0}
     shape_rules:
-    - "x.shape == (seq_len, head_dim) or x.shape == (batch, seq_len, num_heads, head_dim)"
-    - "head_dim % 2 == 0"
+    - "layout == '1d' implies x.ndim == 2"
+    - "layout == '2d' implies x.ndim == 4"
+    - "x.shape[-1] % 2 == 0"
 
   workloads:
   - {seq_len: 2048, head_dim: 64, dtype: float16, layout: "1d", dtypes: [float16], label: "non-neox-1d-2k-d64-fp16"}
@@ -94,20 +86,16 @@ RopeLlama31Op:
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
     params:
-      seq_len: {type: int}
-      head_dim: {type: int}
-      dtype: {type: torch.dtype}
       layout: {type: str, default: "1d"}
-      batch: {type: int, default: 1}
-      num_heads: {type: int, default: 1}
       base: {type: float, default: 10000.0}
       scale_factor: {type: float, default: 8.0}
       low_freq_factor: {type: float, default: 1.0}
       high_freq_factor: {type: float, default: 4.0}
       original_max_position: {type: int, default: 8192}
     shape_rules:
-    - "x.shape == (seq_len, head_dim) or x.shape == (batch, seq_len, num_heads, head_dim)"
-    - "head_dim % 2 == 0"
+    - "layout == '1d' implies x.ndim == 2"
+    - "layout == '2d' implies x.ndim == 4"
+    - "x.shape[-1] % 2 == 0"
 
   workloads:
   - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "llama31-1d-8k-d128-bf16"}
@@ -137,12 +125,7 @@ RopeYarnOp:
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
     params:
-      seq_len: {type: int}
-      head_dim: {type: int}
-      dtype: {type: torch.dtype}
       layout: {type: str, default: "1d"}
-      batch: {type: int, default: 1}
-      num_heads: {type: int, default: 1}
       base: {type: float, default: 10000.0}
       scale: {type: float, default: 16.0}
       original_max_position: {type: int, default: 4096}
@@ -150,8 +133,9 @@ RopeYarnOp:
       beta_slow: {type: float, default: 1.0}
       attn_factor: {type: float, default: 1.0}
     shape_rules:
-    - "x.shape == (seq_len, head_dim) or x.shape == (batch, seq_len, num_heads, head_dim)"
-    - "head_dim % 2 == 0"
+    - "layout == '1d' implies x.ndim == 2"
+    - "layout == '2d' implies x.ndim == 4"
+    - "x.shape[-1] % 2 == 0"
 
   workloads:
   - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "yarn-1d-8k-d128-bf16"}
@@ -181,19 +165,15 @@ RopeLongRopeOp:
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
     params:
-      seq_len: {type: int}
-      head_dim: {type: int}
-      dtype: {type: torch.dtype}
       layout: {type: str, default: "1d"}
-      batch: {type: int, default: 1}
-      num_heads: {type: int, default: 1}
       base: {type: float, default: 10000.0}
       rescale_factors: {type: "torch.Tensor | None", default: null}
       max_position_embeddings: {type: int, default: 4096}
       original_max_position_embeddings: {type: int, default: 4096}
     shape_rules:
-    - "x.shape == (seq_len, head_dim) or x.shape == (batch, seq_len, num_heads, head_dim)"
-    - "head_dim % 2 == 0"
+    - "layout == '1d' implies x.ndim == 2"
+    - "layout == '2d' implies x.ndim == 4"
+    - "x.shape[-1] % 2 == 0"
 
   workloads:
   - {seq_len: 8192, head_dim: 128, dtype: bfloat16, layout: "1d", dtypes: [bfloat16], label: "longrope-1d-8k-d128-bf16"}
@@ -223,18 +203,14 @@ RopeNeoxPositionIdsOp:
     outputs:
       output: {dtype: "same_as(x)", shape: "[num_tokens, num_heads, head_dim]"}
     params:
-      num_tokens: {type: int}
-      num_heads: {type: int}
-      head_dim: {type: int}
       max_position: {type: int}
-      dtype: {type: torch.dtype}
       base: {type: float, default: 10000.0}
       rotary_dim: {type: "int | None", default: null}
     shape_rules:
-    - "x.shape == (num_tokens, num_heads, head_dim)"
-    - "position_ids.shape == (num_tokens,)"
-    - "head_dim % 2 == 0"
-    - "rotary_dim is None or (rotary_dim > 0 and rotary_dim % 2 == 0 and rotary_dim <= head_dim)"
+    - "x.ndim == 3"
+    - "position_ids.shape == (x.shape[0],)"
+    - "x.shape[-1] % 2 == 0"
+    - "rotary_dim is None or (rotary_dim > 0 and rotary_dim % 2 == 0 and rotary_dim <= x.shape[-1])"
 
   workloads:
   - {num_tokens: 2048, num_heads: 32, head_dim: 128, max_position: 4096, dtype: float16, dtypes: [float16], label: "position-ids-s2k-h32-d128-fp16"}

--- a/tileops/manifest/position_encoding.yaml
+++ b/tileops/manifest/position_encoding.yaml
@@ -18,8 +18,8 @@ RopeNeoxOp:
       layout: {type: str, default: "1d"}
       base: {type: float, default: 10000.0}
     shape_rules:
-    - "layout == '1d' implies x.ndim == 2"
-    - "layout == '2d' implies x.ndim == 4"
+    - "layout != '1d' or x.ndim == 2"
+    - "layout != '2d' or x.ndim == 4"
     - "x.shape[-1] % 2 == 0"
 
   workloads:
@@ -54,8 +54,8 @@ RopeNonNeoxOp:
       layout: {type: str, default: "1d"}
       base: {type: float, default: 10000.0}
     shape_rules:
-    - "layout == '1d' implies x.ndim == 2"
-    - "layout == '2d' implies x.ndim == 4"
+    - "layout != '1d' or x.ndim == 2"
+    - "layout != '2d' or x.ndim == 4"
     - "x.shape[-1] % 2 == 0"
 
   workloads:
@@ -93,8 +93,8 @@ RopeLlama31Op:
       high_freq_factor: {type: float, default: 4.0}
       original_max_position: {type: int, default: 8192}
     shape_rules:
-    - "layout == '1d' implies x.ndim == 2"
-    - "layout == '2d' implies x.ndim == 4"
+    - "layout != '1d' or x.ndim == 2"
+    - "layout != '2d' or x.ndim == 4"
     - "x.shape[-1] % 2 == 0"
 
   workloads:
@@ -133,8 +133,8 @@ RopeYarnOp:
       beta_slow: {type: float, default: 1.0}
       attn_factor: {type: float, default: 1.0}
     shape_rules:
-    - "layout == '1d' implies x.ndim == 2"
-    - "layout == '2d' implies x.ndim == 4"
+    - "layout != '1d' or x.ndim == 2"
+    - "layout != '2d' or x.ndim == 4"
     - "x.shape[-1] % 2 == 0"
 
   workloads:
@@ -171,8 +171,8 @@ RopeLongRopeOp:
       max_position_embeddings: {type: int, default: 4096}
       original_max_position_embeddings: {type: int, default: 4096}
     shape_rules:
-    - "layout == '1d' implies x.ndim == 2"
-    - "layout == '2d' implies x.ndim == 4"
+    - "layout != '1d' or x.ndim == 2"
+    - "layout != '2d' or x.ndim == 4"
     - "x.shape[-1] % 2 == 0"
 
   workloads:

--- a/tileops/manifest/quantization.yaml
+++ b/tileops/manifest/quantization.yaml
@@ -14,15 +14,9 @@ FP8QuantOp:
     outputs:
       scale_tensor: {dtype: "float32", shape: "[batch, seq_len_kv, kv_group]"}
       output_tensor: {dtype: "float8_e4m3fn", shape: "[batch, seq_len_kv, kv_group, index_dim]"}
-    params:
-      batch: {type: int}
-      seq_len_kv: {type: int}
-      kv_group: {type: int}
-      index_dim: {type: int}
-      in_dtype: {type: torch.dtype}
     shape_rules:
-    - "input_tensor.shape == (batch, seq_len_kv, kv_group, index_dim)"
-    - "index_dim > 0"
+    - "input_tensor.ndim == 4"
+    - "input_tensor.shape[3] > 0"
 
   workloads:
   - {batch: 1, seq_len_kv: 8192, kv_group: 1, index_dim: 64, in_dtype: float16, dtypes: [float16], label: "kv-index-8k-d64-fp16"}

--- a/tileops/manifest/regularization.yaml
+++ b/tileops/manifest/regularization.yaml
@@ -11,21 +11,19 @@ DropoutOp:
     outputs:
       output: {dtype: "same_as(x)"}
     params:
-      N_total: {type: int}
-      dtype: {type: torch.dtype}
       p: {type: float, default: 0.5}
       seed: {type: int, default: 0}
       training: {type: bool, default: true}
     shape_rules:
-    - "N_total > 0"
+    - "x.numel() > 0"
     - "0.0 <= p <= 1.0"
 
   workloads:
   # Normal kernel path. p=0, p=1, and training=false are short-circuit paths
   # and should be tested separately from release-facing roofline workloads.
-  - {N_total: 4194304, dtype: float16, p: 0.5, training: true, dtypes: [float16], label: "tokens-1k-hidden-4k-fp16"}
-  - {N_total: 10485760, dtype: bfloat16, p: 0.5, training: true, dtypes: [bfloat16], label: "tokens-1k-hidden-10k-bf16"}
-  - {N_total: 4194304, dtype: float32, p: 0.1, training: true, dtypes: [float32], label: "tokens-1k-hidden-4k-fp32-p01"}
+  - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float16], label: "tokens-1k-hidden-4k-fp16"}
+  - {input_shape: [1024, 10240], p: 0.5, training: true, dtypes: [bfloat16], label: "tokens-1k-hidden-10k-bf16"}
+  - {input_shape: [1024, 4096], p: 0.5, training: true, dtypes: [float32], label: "tokens-1k-hidden-4k-fp32"}
 
   roofline:
     func: "tileops.perf.formulas.dropout_roofline"
@@ -37,4 +35,4 @@ DropoutOp:
     op: tileops/ops/dropout.py
     test: tests/ops/test_dropout.py
     bench: benchmarks/ops/bench_dropout.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true

--- a/tileops/manifest/sequence_modeling.yaml
+++ b/tileops/manifest/sequence_modeling.yaml
@@ -221,8 +221,8 @@ MHCPreOp:
     - "phi.ndim == 2 and x.ndim == 2 and b.ndim == 1"
     - "phi.shape[0] == x.shape[1]"
     - "b.shape[0] == phi.shape[1]"
-    - "exists n_expand > 0 such that phi.shape[1] == n_expand * n_expand + 2 * n_expand"
-    - "x.shape[1] % n_expand == 0"
+    - "phi.shape[1] > 0"
+    - "x.shape[1] > 0"
 
   workloads:
   - {batch: 1, n_expand: 4, c_x: 1280, alpha_pre: 1.0, alpha_post: 1.0, alpha_res: 1.0, sinkhorn_repeat: 1, dtype: bfloat16, dtypes: [bfloat16], label: "pre-small"}

--- a/tileops/manifest/sequence_modeling.yaml
+++ b/tileops/manifest/sequence_modeling.yaml
@@ -177,17 +177,14 @@ FFTC2COp:
       x: {dtype: "complex64 | complex128", shape: "[..., n]"}
     outputs:
       output: {dtype: "same_as(x)", shape: "same_as(x)"}
-    params:
-      n: {type: int}
     shape_rules:
-    - "x.shape[-1] == n"
-    - "n > 0"
-    - "n & (n - 1) == 0"
+    - "x.shape[-1] > 0"
+    - "x.shape[-1] & (x.shape[-1] - 1) == 0"
 
   workloads:
-  - {n: 4096, dtype: complex64, batch_shape: [], dtypes: [complex64], label: "fft-4k-c64-unbatched"}
-  - {n: 4096, dtype: complex64, batch_shape: [64], dtypes: [complex64], label: "fft-4k-c64-b64"}
-  - {n: 4096, dtype: complex128, batch_shape: [64], dtypes: [complex128], label: "fft-4k-c128-b64"}
+  - {input_shape: [4096], dtypes: [complex64], label: "fft-4k-c64-unbatched"}
+  - {input_shape: [64, 4096], dtypes: [complex64], label: "fft-4k-c64-b64"}
+  - {input_shape: [64, 4096], dtypes: [complex128], label: "fft-4k-c128-b64"}
 
   roofline:
     func: "tileops.perf.formulas.fft_c2c_roofline"
@@ -199,7 +196,7 @@ FFTC2COp:
     op: tileops/ops/fft.py
     test: tests/ops/test_fft.py
     bench: benchmarks/ops/bench_fft.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 MHCPreOp:
   ref_api: "none"
@@ -215,18 +212,17 @@ MHCPreOp:
       x_res: {dtype: "bfloat16", shape: "[batch, n_expand * c_x]"}
       x_layer: {dtype: "bfloat16", shape: "[batch, c_x]"}
     params:
-      batch: {type: int}
-      n_expand: {type: int}
-      c_x: {type: int}
       alpha_pre: {type: float}
       alpha_post: {type: float}
       alpha_res: {type: float}
       sinkhorn_repeat: {type: int}
       sinkhorn_eps: {type: float, default: 0.02}
     shape_rules:
-    - "phi.shape == (n_expand * c_x, n_expand * n_expand + 2 * n_expand)"
-    - "x.shape == (batch, n_expand * c_x)"
-    - "b.shape == (n_expand * n_expand + 2 * n_expand,)"
+    - "phi.ndim == 2 and x.ndim == 2 and b.ndim == 1"
+    - "phi.shape[0] == x.shape[1]"
+    - "b.shape[0] == phi.shape[1]"
+    - "exists n_expand > 0 such that phi.shape[1] == n_expand * n_expand + 2 * n_expand"
+    - "x.shape[1] % n_expand == 0"
 
   workloads:
   - {batch: 1, n_expand: 4, c_x: 1280, alpha_pre: 1.0, alpha_post: 1.0, alpha_res: 1.0, sinkhorn_repeat: 1, dtype: bfloat16, dtypes: [bfloat16], label: "pre-small"}
@@ -257,14 +253,11 @@ MHCPostOp:
       x_res: {dtype: "bfloat16", shape: "[batch, n_expand * c_x]"}
     outputs:
       x_out: {dtype: "bfloat16", shape: "[batch, n_expand * c_x]"}
-    params:
-      batch: {type: int}
-      n_expand: {type: int}
-      c_x: {type: int}
     shape_rules:
-    - "x_layer_out.shape == (batch, c_x)"
-    - "h_post.shape == (batch, n_expand)"
-    - "x_res.shape == (batch, n_expand * c_x)"
+    - "x_layer_out.ndim == 2 and h_post.ndim == 2 and x_res.ndim == 2"
+    - "h_post.shape[0] == x_layer_out.shape[0]"
+    - "x_res.shape[0] == x_layer_out.shape[0]"
+    - "x_res.shape[1] == h_post.shape[1] * x_layer_out.shape[1]"
 
   workloads:
   - {batch: 1, n_expand: 4, c_x: 1280, dtype: bfloat16, dtypes: [bfloat16], label: "post-small"}

--- a/tileops/ops/da_cumsum.py
+++ b/tileops/ops/da_cumsum.py
@@ -34,11 +34,7 @@ class DaCumsumFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        num_chunks: int,
         chunk_len: int,
-        n_heads: int,
-        seq_len: int,
         dtype: torch.dtype = torch.float32,
         dt_softplus: bool = False,
         has_dt_bias: bool = False,
@@ -47,29 +43,62 @@ class DaCumsumFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
-        self.batch = batch
-        self.num_chunks = num_chunks
+        self.batch = None
+        self.num_chunks = None
         self.chunk_len = chunk_len
-        self.n_heads = n_heads
-        self.seq_len = seq_len
+        self.n_heads = None
+        self.seq_len = None
         self.dtype = dtype
         self.dt_softplus = dt_softplus
         self.has_dt_bias = has_dt_bias
         self.dt_min = dt_min
         self.dt_max = dt_max
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["da_cumsum_fwd"](
-            batch, num_chunks, chunk_len, n_heads, seq_len, dtype,
-            dt_softplus=dt_softplus,
-            has_dt_bias=has_dt_bias,
-            dt_min=dt_min,
-            dt_max=dt_max,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"da_cumsum_fwd": DaCumsumFwdKernel}
+
+    def _get_kernel(
+        self,
+        batch: int,
+        num_chunks: int,
+        n_heads: int,
+        seq_len: int,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            num_chunks,
+            self.chunk_len,
+            n_heads,
+            seq_len,
+            self.dtype,
+            self.dt_softplus,
+            self.has_dt_bias,
+            self.dt_min,
+            self.dt_max,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["da_cumsum_fwd"](
+                batch,
+                num_chunks,
+                self.chunk_len,
+                n_heads,
+                seq_len,
+                self.dtype,
+                dt_softplus=self.dt_softplus,
+                has_dt_bias=self.has_dt_bias,
+                dt_min=self.dt_min,
+                dt_max=self.dt_max,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -94,6 +123,24 @@ class DaCumsumFwdOp(Op):
             raise ValueError("dt must be a CUDA tensor")
         if dt.dtype != torch.float32:
             raise ValueError(f"Expected float32 dt, got {dt.dtype}")
+        if dt.ndim != 3:
+            raise ValueError("dt must have shape [batch, seq_len, n_heads]")
+        batch, seq_len, n_heads = dt.shape
+        if seq_len % self.chunk_len != 0:
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_len ({self.chunk_len})"
+            )
+        if A.shape != (n_heads,):
+            raise ValueError("A must have shape [n_heads]")
+        if self.has_dt_bias and dt_bias is not None and dt_bias.shape != (n_heads,):
+            raise ValueError("dt_bias must have shape [n_heads]")
+
+        self.batch = batch
+        self.seq_len = seq_len
+        self.n_heads = n_heads
+        self.num_chunks = seq_len // self.chunk_len
+        self.kernel = self._get_kernel(
+            batch, self.num_chunks, n_heads, seq_len, dt.device.index)
 
         dt = dt.contiguous()
         A = A.contiguous()

--- a/tileops/ops/deltanet.py
+++ b/tileops/ops/deltanet.py
@@ -42,45 +42,88 @@ class DeltaNetFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(
-                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-            )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        fwd_kernel_cls = self.kernel_map["DeltaNetFwdKernel"]
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = fwd_kernel_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "DeltaNetFwdKernel": DeltaNetFwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["DeltaNetFwdKernel"](
+                batch,
+                heads,
+                seq_len,
+                self.chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
+    def _bind_from_inputs(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> None:
+        if not all(tensor.is_cuda for tensor in (q, k, v, beta)):
+            raise ValueError("q, k, v, and beta must be CUDA tensors")
+        if q.ndim != 4:
+            raise ValueError("q must have shape [batch, heads, seq_len, dim_k]")
+        batch, heads, seq_len, dim_k = q.shape
+        if k.shape != (batch, heads, seq_len, dim_k):
+            raise ValueError("k must match q shape")
+        if v.ndim != 4 or v.shape[:3] != (batch, heads, seq_len):
+            raise ValueError("v must have shape [batch, heads, seq_len, dim_v]")
+        if beta.shape != (batch, heads, seq_len):
+            raise ValueError("beta must have shape [batch, heads, seq_len]")
+        dtype = q.dtype
+        for name, tensor in (("k", k), ("v", v), ("beta", beta)):
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+        if seq_len % self.chunk_size != 0:
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_size ({self.chunk_size})"
+            )
+
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = v.shape[-1]
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, self.dim_v, dtype, q.device.index)
 
     def forward(
         self,
@@ -100,6 +143,7 @@ class DeltaNetFwdOp(Op):
         Returns:
             Tuple of (o, S, Aw, Au).
         """
+        self._bind_from_inputs(q, k, v, beta)
         o, S, Aw, Au, w, u = self.kernel(q, k, v, beta)
         return o, S, Aw, Au, w, u
 
@@ -123,43 +167,92 @@ class DeltaNetBwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        bwd_kernel_cls = self.kernel_map["DeltaNetBwdKernel"]
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = bwd_kernel_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "DeltaNetBwdKernel": DeltaNetBwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["DeltaNetBwdKernel"](
+                batch,
+                heads,
+                seq_len,
+                self.chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
+    def _bind_from_inputs(
+        self,
+        do: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> None:
+        if not all(tensor.is_cuda for tensor in (do, q, k, v, beta)):
+            raise ValueError("do, q, k, v, and beta must be CUDA tensors")
+        if q.ndim != 4:
+            raise ValueError("q must have shape [batch, heads, seq_len, dim_k]")
+        batch, heads, seq_len, dim_k = q.shape
+        if k.shape != (batch, heads, seq_len, dim_k):
+            raise ValueError("k must match q shape")
+        if v.ndim != 4 or v.shape[:3] != (batch, heads, seq_len):
+            raise ValueError("v must have shape [batch, heads, seq_len, dim_v]")
+        dim_v = v.shape[-1]
+        if do.shape != (batch, heads, seq_len, dim_v):
+            raise ValueError("do must have shape [batch, heads, seq_len, dim_v]")
+        if beta.shape != (batch, heads, seq_len):
+            raise ValueError("beta must have shape [batch, heads, seq_len]")
+        dtype = q.dtype
+        for name, tensor in (("do", do), ("k", k), ("v", v), ("beta", beta)):
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+        if seq_len % self.chunk_size != 0:
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_size ({self.chunk_size})"
+            )
+
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
 
     def forward(
         self,
@@ -191,6 +284,7 @@ class DeltaNetBwdOp(Op):
         Returns:
             Tuple of (dq, dk, dv, dbeta).
         """
+        self._bind_from_inputs(do, q, k, v, beta)
         dq, dk, dv, dbeta = self.kernel(do, q, k, v, beta, S, Aw, Au, w, u)
         return dq, dk, dv, dbeta
 
@@ -235,42 +329,24 @@ class DeltaNetOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(
-                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-            )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        fwd_cls = self.kernel_map["DeltaNetFwdKernel"]
-        bwd_cls = self.kernel_map["DeltaNetBwdKernel"]
-        self.fwd_kernel = fwd_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype, tune=tune,
-        )
-        self.bwd_kernel = bwd_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype, tune=tune,
-        )
+        self._fwd_kernel_cache: Dict[tuple, Kernel] = {}
+        self._bwd_kernel_cache: Dict[tuple, Kernel] = {}
+        self.fwd_kernel = None
+        self.bwd_kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -278,6 +354,56 @@ class DeltaNetOp(Op):
             "DeltaNetFwdKernel": DeltaNetFwdKernel,
             "DeltaNetBwdKernel": DeltaNetBwdKernel,
         }
+
+    def _bind_from_inputs(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> None:
+        if not all(tensor.is_cuda for tensor in (q, k, v, beta)):
+            raise ValueError("q, k, v, and beta must be CUDA tensors")
+        batch, heads, seq_len, dim_k = q.shape
+        if k.shape != (batch, heads, seq_len, dim_k):
+            raise ValueError("k must match q shape")
+        if v.ndim != 4 or v.shape[:3] != (batch, heads, seq_len):
+            raise ValueError("v must have shape [batch, heads, seq_len, dim_v]")
+        if beta.shape != (batch, heads, seq_len):
+            raise ValueError("beta must have shape [batch, heads, seq_len]")
+        dtype = q.dtype
+        if seq_len % self.chunk_size != 0:
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_size ({self.chunk_size})"
+            )
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = v.shape[-1]
+        self.dtype = dtype
+
+        key = (
+            batch,
+            heads,
+            seq_len,
+            self.chunk_size,
+            dim_k,
+            self.dim_v,
+            dtype,
+            q.device.index,
+            self.tune,
+        )
+        if key not in self._fwd_kernel_cache:
+            kernel_dtype = Kernel.dtype_to_str(dtype)
+            self._fwd_kernel_cache[key] = self.kernel_map["DeltaNetFwdKernel"](
+                batch, heads, seq_len, self.chunk_size, dim_k, self.dim_v,
+                dtype=kernel_dtype, tune=self.tune)
+            self._bwd_kernel_cache[key] = self.kernel_map["DeltaNetBwdKernel"](
+                batch, heads, seq_len, self.chunk_size, dim_k, self.dim_v,
+                dtype=kernel_dtype, tune=self.tune)
+        self.fwd_kernel = self._fwd_kernel_cache[key]
+        self.bwd_kernel = self._bwd_kernel_cache[key]
 
     def forward(
         self,
@@ -297,6 +423,7 @@ class DeltaNetOp(Op):
         Returns:
             Output tensor o [B, H, S, DV] (supports .backward()).
         """
+        self._bind_from_inputs(q, k, v, beta)
         return _DeltaNetFunction.apply(
             q, k, v, beta, self.fwd_kernel, self.bwd_kernel,
         )

--- a/tileops/ops/deltanet.py
+++ b/tileops/ops/deltanet.py
@@ -372,6 +372,9 @@ class DeltaNetOp(Op):
         if beta.shape != (batch, heads, seq_len):
             raise ValueError("beta must have shape [batch, heads, seq_len]")
         dtype = q.dtype
+        for name, tensor in (("k", k), ("v", v), ("beta", beta)):
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
         if seq_len % self.chunk_size != 0:
             raise ValueError(
                 f"seq_len ({seq_len}) must be divisible by chunk_size ({self.chunk_size})"

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -62,6 +62,7 @@ class DeltaNetDecodeOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._active_sig: Optional[tuple] = None
         self.kernel = None
 
     @property
@@ -199,8 +200,28 @@ class DeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        self._validate_dtypes(q, k, v, beta, state)
-        self._validate_shapes(q, k, v, beta, state)
+        sig = (
+            q.shape,
+            k.shape,
+            v.shape,
+            beta.shape,
+            state.shape,
+            q.dtype,
+            k.dtype,
+            v.dtype,
+            beta.dtype,
+            state.dtype,
+            q.device,
+            k.device,
+            v.device,
+            beta.device,
+            state.device,
+            getattr(self, "tune", None),
+        )
+        if sig != getattr(self, "_active_sig", None):
+            self._validate_dtypes(q, k, v, beta, state)
+            self._validate_shapes(q, k, v, beta, state)
+            self._active_sig = sig
         o, new_state = self.kernel(q, k, v, beta, state)
         self._validate_output_shapes(o, new_state)
         return o, new_state

--- a/tileops/ops/deltanet_recurrence.py
+++ b/tileops/ops/deltanet_recurrence.py
@@ -50,39 +50,19 @@ class DeltaNetDecodeOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        dim_k: int,
-        dim_v: int,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.dim_k = dim_k
-        self.dim_v = dim_v
-        self.dtype = dtype
+        self.batch = None
+        self.heads = None
+        self.dim_k = None
+        self.dim_v = None
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        # Dispatch:
-        #   fp32 -> FP32 kernel (no TF32)
-        #   fp16/bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
-        #   other fp16/bf16 shapes -> default TileLang kernel
-        use_raw_cuda_decode = self._should_use_raw_cuda_decode(dim_k, dim_v, dtype)
-        if dtype == torch.float32:
-            kernel_cls = self.kernel_map["DeltaNetDecodeFP32Kernel"]
-        elif use_raw_cuda_decode:
-            kernel_cls = self.kernel_map["DeltaNetDecodeRawCudaFlaStyleKernel"]
-        else:
-            kernel_cls = self.kernel_map["DeltaNetDecodeKernel"]
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = kernel_cls(
-            batch, heads, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -95,6 +75,34 @@ class DeltaNetDecodeOp(Op):
                 DeltaNetDecodeRawCudaFlaStyleKernel
             )
         return kernels
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            use_raw_cuda_decode = self._should_use_raw_cuda_decode(dim_k, dim_v, dtype)
+            if dtype == torch.float32:
+                kernel_cls = self.kernel_map["DeltaNetDecodeFP32Kernel"]
+            elif use_raw_cuda_decode:
+                kernel_cls = self.kernel_map["DeltaNetDecodeRawCudaFlaStyleKernel"]
+            else:
+                kernel_cls = self.kernel_map["DeltaNetDecodeKernel"]
+            self._kernel_cache[key] = kernel_cls(
+                batch,
+                heads,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def _infer_output_shapes(
         self,
@@ -118,11 +126,12 @@ class DeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        dtype = q.dtype
+        if dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {dtype}")
         for name, tensor in (("q", q), ("k", k), ("v", v), ("beta", beta), ("state", state)):
-            if tensor.dtype != self.dtype:
-                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
 
     def _validate_shapes(
         self,
@@ -132,10 +141,16 @@ class DeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        q_shape = (self.batch, self.heads, self.dim_k)
-        v_shape = (self.batch, self.heads, self.dim_v)
-        beta_shape = (self.batch, self.heads)
-        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if q.ndim != 3:
+            raise ValueError("q must have shape [batch, heads, dim_k]")
+        batch, heads, dim_k = q.shape
+        if v.ndim != 3 or v.shape[:2] != (batch, heads):
+            raise ValueError("v must have shape [batch, heads, dim_v]")
+        dim_v = v.shape[2]
+        q_shape = (batch, heads, dim_k)
+        v_shape = (batch, heads, dim_v)
+        beta_shape = (batch, heads)
+        state_shape = (batch, heads, dim_k, dim_v)
         expected_shapes = (
             ("q", q, q_shape),
             ("k", k, q_shape),
@@ -147,9 +162,15 @@ class DeltaNetDecodeOp(Op):
             if tuple(tensor.shape) != expected:
                 raise ValueError(
                     f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
-                )
+        )
         if not all(tensor.is_cuda for tensor in (q, k, v, beta, state)):
             raise ValueError("q, k, v, beta, and state must be CUDA tensors")
+        self.batch = batch
+        self.heads = heads
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = q.dtype
+        self.kernel = self._get_kernel(batch, heads, dim_k, dim_v, q.dtype, q.device.index)
 
     def _validate_output_shapes(
         self,

--- a/tileops/ops/dropout.py
+++ b/tileops/ops/dropout.py
@@ -39,8 +39,6 @@ class DropoutOp(Op):
     by default) for per-thread random number generation.
 
     Args:
-        N_total: Total number of elements (flattened).
-        dtype: Torch dtype (float16, bfloat16, float32).
         p: Drop probability in [0, 1].
         seed: Integer seed for RNG.
         training: If False, dropout is disabled (identity pass-through).
@@ -53,8 +51,6 @@ class DropoutOp(Op):
 
     def __init__(
         self,
-        N_total: int,
-        dtype: torch.dtype,
         p: float = 0.5,
         seed: int = 0,
         training: bool = True,
@@ -63,11 +59,12 @@ class DropoutOp(Op):
     ):
         if not (0.0 <= p <= 1.0):
             raise ValueError(f"Dropout probability must be in [0, 1], got {p}")
-        self.N_total = N_total
-        self.dtype = dtype
+        self.N_total = None
+        self.dtype = None
         self.p = p
         self.seed = seed
         self.training = training
+        self.tune = tune
 
         # Skip kernel build when dropout has no effect (identity or all-zeros)
         self._skip = not training or p == 0.0
@@ -75,14 +72,8 @@ class DropoutOp(Op):
 
         # Always populate kernel_map for Op base class consistency
         self.dispatch_kernel(kernel_map)
-
-        # Build kernel only when dropout is actually active
-        if not self._skip and not self._all_zero:
-            self.kernel = self.kernel_map[self._op_name](
-                N_total, dtype, p=p, seed=seed, tune=tune,
-            )
-        else:
-            self.kernel = None
+        self._kernel_cache: Dict[tuple[int, torch.dtype, int | None], Kernel] = {}
+        self.kernel = None
 
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -94,27 +85,38 @@ class DropoutOp(Op):
     @property
     def total_memory(self) -> float:
         """Read x + write y."""
+        if self.N_total is None or self.dtype is None:
+            raise RuntimeError(
+                "DropoutOp.total_memory requires a prior forward() call to bind input shape and dtype"
+            )
         return self.N_total * self.dtype.itemsize * 2
 
+    def _get_kernel(self, x: torch.Tensor) -> Kernel:
+        key = (x.numel(), x.dtype, x.device.index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map[self._op_name](
+                x.numel(), x.dtype, p=self.p, seed=self.seed, tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.N_total = x.numel()
+        self.dtype = x.dtype
         if self._skip:
             return x.clone()
         if self._all_zero:
             return torch.zeros_like(x)
         orig_shape = x.shape
         x_flat = x.contiguous().reshape(-1)
+        self.kernel = self._get_kernel(x_flat)
         y_flat = self.kernel(x_flat)
         return y_flat.reshape(orig_shape)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if not x.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        if x.numel() != self.N_total:
-            raise ValueError(
-                f"Expected {self.N_total} elements, got {x.numel()}"
-            )
+        if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise ValueError(f"x.dtype must be float16, bfloat16, or float32, got {x.dtype}")
         wrapped = type(self)._wrapped
         if wrapped is not None:
             return wrapped(x, self._instance_key)

--- a/tileops/ops/fft.py
+++ b/tileops/ops/fft.py
@@ -25,38 +25,42 @@ class FFTC2COp(Op):
     for optimal GPU performance.
 
     Args:
-        n: FFT size (number of complex samples, must be a power of 2)
-        dtype: Data type for computation (default: torch.complex64)
         tune: Whether to enable autotuning (default: False)
         kernel_map: Optional custom kernel mapping for testing
     """
 
     def __init__(self,
-                 n: int,
-                 dtype: torch.dtype = torch.complex64,
                  tune: bool = False,
                  kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
-        self.n = n
-        self.dtype = dtype
+        self.n = None
+        self.dtype = None
         self._tune = tune
 
         self.dispatch_kernel(kernel_map)
-        self._kernel_cache: Dict[int, Kernel] = {}
-        # Default kernel for Op base class compatibility
-        self.kernel = self._get_kernel(1)
+        self._kernel_cache: Dict[tuple[int, int, torch.dtype, int | None], Kernel] = {}
+        self._twiddle_cache: Dict[tuple[int, torch.dtype, int | None], tuple[torch.Tensor, torch.Tensor]] = {}
+        self.kernel = None
 
-        # Pre-compute twiddle LUT on CPU and move to GPU once (shared across batch sizes)
-        self.twiddle_real, self.twiddle_imag = self._build_lut(n, dtype)
-
-    def _get_kernel(self, batch_size: int) -> Kernel:
-        if batch_size not in self._kernel_cache:
-            self._kernel_cache[batch_size] = self.kernel_map["fft_c2c_kernel"](
-                self.n, batch_size, self.dtype, tune=self._tune,
+    def _get_kernel(
+        self,
+        n: int,
+        batch_size: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (n, batch_size, dtype, device_index)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fft_c2c_kernel"](
+                n, batch_size, dtype, tune=self._tune,
             )
-        return self._kernel_cache[batch_size]
+        return self._kernel_cache[key]
 
     @staticmethod
-    def _build_lut(n: int, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    def _build_lut(
+        n: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Pre-compute the full twiddle factor LUT for all butterfly stages.
 
@@ -77,9 +81,15 @@ class FFTC2COp(Op):
             k_vals = torch.arange(half_m, dtype=torch.float64)
             angles[half_m - 1:2 * half_m - 1] = -2.0 * math.pi * k_vals / m
 
-        lut_real = torch.cos(angles).to(real_dtype).cuda()
-        lut_imag = torch.sin(angles).to(real_dtype).cuda()
+        lut_real = torch.cos(angles).to(real_dtype).to(device)
+        lut_imag = torch.sin(angles).to(real_dtype).to(device)
         return lut_real, lut_imag
+
+    def _get_lut(self, n: int, dtype: torch.dtype, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+        key = (n, dtype, device.index)
+        if key not in self._twiddle_cache:
+            self._twiddle_cache[key] = self._build_lut(n, dtype, device)
+        return self._twiddle_cache[key]
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -95,16 +105,30 @@ class FFTC2COp(Op):
         Returns:
             Output tensor of same shape as input with FFT applied along last dimension
         """
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.dtype not in (torch.complex64, torch.complex128):
+            raise ValueError(f"x.dtype must be complex64 or complex128, got {x.dtype}")
+        if x.ndim == 0:
+            raise ValueError("x must be at least 1D")
+        n = x.shape[-1]
+        if n <= 0 or n & (n - 1) != 0:
+            raise ValueError(f"FFT size must be a positive power of 2, got {n}")
+
         x_real = x.real.contiguous()
         x_imag = x.imag.contiguous()
         original_shape = x.shape
 
         # Flatten all batch dimensions into a single batch dimension
         batch_size = x_real[..., 0].numel() if x.ndim > 1 else 1
-        x_real = x_real.reshape(batch_size, self.n)
-        x_imag = x_imag.reshape(batch_size, self.n)
+        x_real = x_real.reshape(batch_size, n)
+        x_imag = x_imag.reshape(batch_size, n)
 
-        kernel = self._get_kernel(batch_size)
+        self.n = n
+        self.dtype = x.dtype
+        self.twiddle_real, self.twiddle_imag = self._get_lut(n, x.dtype, x.device)
+        kernel = self._get_kernel(n, batch_size, x.dtype, x.device.index)
+        self.kernel = kernel
         y_real, y_imag = kernel(x_real, x_imag,
                                 self.twiddle_real, self.twiddle_imag)
 

--- a/tileops/ops/fp8_lightning_indexer.py
+++ b/tileops/ops/fp8_lightning_indexer.py
@@ -13,31 +13,103 @@ __all__ = ["FP8LightningIndexerOp"]
 class FP8LightningIndexerOp(Op):
 
     def __init__(self,
-                 batch,
-                 seq_len,
-                 heads,
-                 index_dim,
-                 seq_len_kv,
-                 kv_group,
                  clean_logits=True,
                  config: Optional[dict] = None,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune=False) -> None:
+        self.batch = None
+        self.seq_len = None
+        self.heads = None
+        self.index_dim = None
+        self.seq_len_kv = None
+        self.kv_group = None
+        self.clean_logits = clean_logits
+        self.config = config
+        self.tune = tune
+
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"fp8_lightning_indexer_kernel": FP8LightningIndexerKernel}
+
+    @property
+    def _config_cache_key(self) -> tuple:
+        if not self.config:
+            return ()
+        return tuple(sorted((key, repr(value)) for key, value in self.config.items()))
+
+    def _get_kernel(
+        self,
+        batch: int,
+        seq_len: int,
+        heads: int,
+        index_dim: int,
+        seq_len_kv: int,
+        kv_group: int,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            seq_len,
+            heads,
+            index_dim,
+            seq_len_kv,
+            kv_group,
+            self.clean_logits,
+            self._config_cache_key,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fp8_lightning_indexer_kernel"](
+                batch,
+                seq_len,
+                heads,
+                index_dim,
+                seq_len_kv,
+                kv_group,
+                self.clean_logits,
+                self.config,
+                tune=self.tune)
+        return self._kernel_cache[key]
+
+    def _resolve_and_bind(
+        self,
+        index_q: torch.Tensor,
+        index_k: torch.Tensor,
+        weights: torch.Tensor,
+        cu_seqlen_ks: torch.Tensor,
+        cu_seqlen_ke: torch.Tensor,
+        index_k_scale: Optional[torch.Tensor],
+    ) -> None:
+        if not index_q.is_cuda or not index_k.is_cuda:
+            raise ValueError("FP8LightningIndexerOp expects CUDA inputs")
+        if index_q.ndim != 4 or index_k.ndim != 4:
+            raise ValueError("FP8LightningIndexerOp expects index_q/index_k to be 4D tensors")
+        batch, seq_len, heads, index_dim = index_q.shape
+        k_batch, seq_len_kv, kv_group, k_dim = index_k.shape
+        if k_batch != batch or k_dim != index_dim:
+            raise ValueError("index_q and index_k must agree on batch and index_dim")
+        if heads % kv_group != 0:
+            raise ValueError("heads must be divisible by kv_group")
+        if weights.shape != (seq_len, heads):
+            raise ValueError("weights must have shape [seq_len, heads]")
+        if cu_seqlen_ks.shape != (seq_len,) or cu_seqlen_ke.shape != (seq_len,):
+            raise ValueError("cu_seqlen_ks/cu_seqlen_ke must have shape [seq_len]")
+        if index_k_scale is not None and index_k_scale.shape != (batch, seq_len_kv, kv_group):
+            raise ValueError("index_k_scale must have shape [batch, seq_len_kv, kv_group]")
+
         self.batch = batch
         self.seq_len = seq_len
         self.heads = heads
         self.index_dim = index_dim
         self.seq_len_kv = seq_len_kv
         self.kv_group = kv_group
-        self.clean_logits = clean_logits
-
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fp8_lightning_indexer_kernel"](
-            batch, seq_len, heads, index_dim, seq_len_kv, kv_group, clean_logits, config, tune=tune)
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"fp8_lightning_indexer_kernel": FP8LightningIndexerKernel}
+        self.kernel = self._get_kernel(
+            batch, seq_len, heads, index_dim, seq_len_kv, kv_group, index_q.device.index)
 
     def torch_quant_forward(self, index_q: torch.Tensor, index_k: torch.Tensor,
                             weights: torch.Tensor, cu_seqlen_ks: torch.Tensor,
@@ -59,6 +131,8 @@ class FP8LightningIndexerOp(Op):
                 cu_seqlen_ks: torch.Tensor,
                 cu_seqlen_ke: torch.Tensor,
                 index_k_scale: Optional[torch.Tensor] = None) -> torch.Tensor:
+        self._resolve_and_bind(
+            index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke, index_k_scale)
         if index_k_scale is None:
             return self.torch_quant_forward(index_q, index_k, weights, cu_seqlen_ks, cu_seqlen_ke)
         return self.tl_quant_forward(index_q, index_k, index_k_scale, weights, cu_seqlen_ks,

--- a/tileops/ops/fp8_lightning_indexer.py
+++ b/tileops/ops/fp8_lightning_indexer.py
@@ -108,6 +108,10 @@ class FP8LightningIndexerOp(Op):
                 raise ValueError("index_k_scale must have shape [batch, seq_len_kv, kv_group]")
             if index_k_scale.dtype != torch.float32:
                 raise ValueError(f"index_k_scale must be float32, got {index_k_scale.dtype}")
+            if index_q.dtype != torch.float8_e4m3fn or index_k.dtype != torch.float8_e4m3fn:
+                raise ValueError(
+                    "index_q and index_k must be float8_e4m3fn when index_k_scale is provided"
+                )
 
         self.batch = batch
         self.seq_len = seq_len

--- a/tileops/ops/fp8_lightning_indexer.py
+++ b/tileops/ops/fp8_lightning_indexer.py
@@ -97,10 +97,17 @@ class FP8LightningIndexerOp(Op):
             raise ValueError("heads must be divisible by kv_group")
         if weights.shape != (seq_len, heads):
             raise ValueError("weights must have shape [seq_len, heads]")
+        if weights.dtype != torch.float32:
+            raise ValueError(f"weights must be float32, got {weights.dtype}")
         if cu_seqlen_ks.shape != (seq_len,) or cu_seqlen_ke.shape != (seq_len,):
             raise ValueError("cu_seqlen_ks/cu_seqlen_ke must have shape [seq_len]")
-        if index_k_scale is not None and index_k_scale.shape != (batch, seq_len_kv, kv_group):
-            raise ValueError("index_k_scale must have shape [batch, seq_len_kv, kv_group]")
+        if cu_seqlen_ks.dtype != torch.int32 or cu_seqlen_ke.dtype != torch.int32:
+            raise ValueError("cu_seqlen_ks and cu_seqlen_ke must be int32")
+        if index_k_scale is not None:
+            if index_k_scale.shape != (batch, seq_len_kv, kv_group):
+                raise ValueError("index_k_scale must have shape [batch, seq_len_kv, kv_group]")
+            if index_k_scale.dtype != torch.float32:
+                raise ValueError(f"index_k_scale must be float32, got {index_k_scale.dtype}")
 
         self.batch = batch
         self.seq_len = seq_len

--- a/tileops/ops/fp8_quant.py
+++ b/tileops/ops/fp8_quant.py
@@ -13,25 +13,54 @@ __all__ = ["FP8QuantOp"]
 class FP8QuantOp(Op):
 
     def __init__(self,
-                 batch,
-                 seq_len_kv,
-                 kv_group,
-                 index_dim,
-                 in_dtype: torch.dtype,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False):
-        self.batch = batch
-        self.seq_len_kv = seq_len_kv
-        self.kv_group = kv_group
-        self.index_dim = index_dim
-        self.in_dtype = in_dtype
+        self.batch = None
+        self.seq_len_kv = None
+        self.kv_group = None
+        self.index_dim = None
+        self.in_dtype = None
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["fp8_quant_kernel"](
-            self.batch, self.seq_len_kv, self.kv_group, self.index_dim, self.in_dtype, tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fp8_quant_kernel": FP8QuantKernel}
 
+    def _get_kernel(
+        self,
+        batch: int,
+        seq_len_kv: int,
+        kv_group: int,
+        index_dim: int,
+        in_dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, seq_len_kv, kv_group, index_dim, in_dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["fp8_quant_kernel"](
+                batch, seq_len_kv, kv_group, index_dim, in_dtype, tune=self.tune)
+        return self._kernel_cache[key]
+
     def forward(self, input_tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if not input_tensor.is_cuda:
+            raise ValueError("FP8QuantOp expects a CUDA input tensor")
+        if input_tensor.ndim != 4:
+            raise ValueError("FP8QuantOp expects input_tensor shape [B, S, G, D]")
+        if input_tensor.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise ValueError(f"FP8QuantOp does not support dtype {input_tensor.dtype}")
+
+        batch, seq_len_kv, kv_group, index_dim = input_tensor.shape
+        if min(batch, seq_len_kv, kv_group, index_dim) <= 0:
+            raise ValueError("FP8QuantOp input dimensions must be positive")
+
+        self.batch = batch
+        self.seq_len_kv = seq_len_kv
+        self.kv_group = kv_group
+        self.index_dim = index_dim
+        self.in_dtype = input_tensor.dtype
+        self.kernel = self._get_kernel(
+            batch, seq_len_kv, kv_group, index_dim, input_tensor.dtype, input_tensor.device.index)
         return self.kernel(input_tensor)

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -211,6 +211,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
         self.seq_len = None
         self.dim_k = None
         self.dim_v = None
+        self._requested_chunk_size = chunk_size
         self.chunk_size = chunk_size
         self.dtype = None
         self.layout = layout

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -219,6 +219,7 @@ class GatedDeltaNetPrefillFwdOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._active_sig: Optional[tuple] = None
         self.kernel = None
 
     @property
@@ -388,8 +389,30 @@ class GatedDeltaNetPrefillFwdOp(Op):
         v = v.contiguous()
         g = g.contiguous()
         beta = beta.contiguous()
-        self._validate_dtypes(q, k, v, g, beta)
-        self._validate_shapes(q, k, v, g, beta)
+        sig = (
+            q.shape,
+            k.shape,
+            v.shape,
+            g.shape,
+            beta.shape,
+            q.dtype,
+            k.dtype,
+            v.dtype,
+            g.dtype,
+            beta.dtype,
+            q.device,
+            k.device,
+            v.device,
+            g.device,
+            beta.device,
+            self.layout,
+            self._requested_chunk_size,
+            getattr(self, "tune", None),
+        )
+        if sig != getattr(self, "_active_sig", None):
+            self._validate_dtypes(q, k, v, g, beta)
+            self._validate_shapes(q, k, v, g, beta)
+            self._active_sig = sig
         return self.kernel(q, k, v, g, beta)
 
 
@@ -680,6 +703,7 @@ class GatedDeltaNetDecodeOp(Op):
 
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._active_sig: Optional[tuple] = None
         self.kernel = None
 
     @property
@@ -828,8 +852,31 @@ class GatedDeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        self._validate_dtypes(q, k, v, g, beta, state)
-        self._validate_shapes(q, k, v, g, beta, state)
+        sig = (
+            q.shape,
+            k.shape,
+            v.shape,
+            g.shape,
+            beta.shape,
+            state.shape,
+            q.dtype,
+            k.dtype,
+            v.dtype,
+            g.dtype,
+            beta.dtype,
+            state.dtype,
+            q.device,
+            k.device,
+            v.device,
+            g.device,
+            beta.device,
+            state.device,
+            getattr(self, "tune", None),
+        )
+        if sig != getattr(self, "_active_sig", None):
+            self._validate_dtypes(q, k, v, g, beta, state)
+            self._validate_shapes(q, k, v, g, beta, state)
+            self._active_sig = sig
         o, new_state = self.kernel(q, k, v, g, beta, state)
         self._validate_output_shapes(o, new_state)
         return o, new_state

--- a/tileops/ops/gated_deltanet.py
+++ b/tileops/ops/gated_deltanet.py
@@ -26,6 +26,42 @@ __all__ = [
 ]
 
 
+def _resolve_gated_bhsd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    chunk_size: int,
+    do: Optional[torch.Tensor] = None,
+) -> tuple[int, int, int, int, int, torch.dtype]:
+    if not all(tensor.is_cuda for tensor in (q, k, v, g, beta)):
+        raise ValueError("q, k, v, g, and beta must be CUDA tensors")
+    if q.ndim != 4:
+        raise ValueError("q must have shape [batch, heads, seq_len, dim_k]")
+    batch, heads, seq_len, dim_k = q.shape
+    if k.shape != (batch, heads, seq_len, dim_k):
+        raise ValueError("k must match q shape")
+    if v.ndim != 4 or v.shape[:3] != (batch, heads, seq_len):
+        raise ValueError("v must have shape [batch, heads, seq_len, dim_v]")
+    dim_v = v.shape[-1]
+    if g.shape != (batch, heads, seq_len):
+        raise ValueError("g must have shape [batch, heads, seq_len]")
+    if beta.shape != (batch, heads, seq_len):
+        raise ValueError("beta must have shape [batch, heads, seq_len]")
+    if do is not None and do.shape != (batch, heads, seq_len, dim_v):
+        raise ValueError("do must have shape [batch, heads, seq_len, dim_v]")
+    dtype = q.dtype
+    for name, tensor in (("k", k), ("v", v), ("g", g), ("beta", beta)):
+        if tensor.dtype != dtype:
+            raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+    if do is not None and do.dtype != dtype:
+        raise ValueError(f"do.dtype must be {dtype}, got {do.dtype}")
+    if seq_len % chunk_size != 0:
+        raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+    return batch, heads, seq_len, dim_k, dim_v, dtype
+
+
 class GatedDeltaNetFwdOp(Op):
     """Gated DeltaNet forward operator.
 
@@ -64,45 +100,53 @@ class GatedDeltaNetFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
+        self._requested_chunk_size = chunk_size
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(
-                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-            )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        fwd_kernel_cls = self.kernel_map["GatedDeltaNetFwdKernel"]
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = fwd_kernel_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "GatedDeltaNetFwdKernel": GatedDeltaNetFwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["GatedDeltaNetFwdKernel"](
+                batch,
+                heads,
+                seq_len,
+                self.chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -124,6 +168,16 @@ class GatedDeltaNetFwdOp(Op):
         Returns:
             Tuple of (o, S, Aw, Au).
         """
+        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
+            q, k, v, g, beta, self.chunk_size)
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         o, S, Aw, Au = self.kernel(q, k, v, g, beta)
         return o, S, Aw, Au
 
@@ -146,51 +200,25 @@ class GatedDeltaNetPrefillFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: Optional[int] = None,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
         layout: str = "bthd",
     ) -> None:
         layout = self._normalize_layout(layout)
-        if chunk_size is None:
-            streams = batch * heads
-            chunk_size = 128 if streams <= 8 and seq_len % 128 == 0 else 64
-
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
+        self.dtype = None
         self.layout = layout
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(
-                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-            )
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        kernel_cls = self.kernel_map["GatedDeltaNetPrefillFwdKernel"]
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = kernel_cls(
-            batch,
-            heads,
-            seq_len,
-            chunk_size,
-            dim_k,
-            dim_v,
-            dtype=kernel_dtype,
-            layout=layout,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -245,11 +273,49 @@ class GatedDeltaNetPrefillFwdOp(Op):
         g: torch.Tensor,
         beta: torch.Tensor,
     ) -> None:
-        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        dtype = q.dtype
+        if dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {dtype}")
         for name, tensor in (("q", q), ("k", k), ("v", v), ("g", g), ("beta", beta)):
-            if tensor.dtype != self.dtype:
-                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        chunk_size: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            heads,
+            seq_len,
+            chunk_size,
+            dim_k,
+            dim_v,
+            dtype,
+            self.layout,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["GatedDeltaNetPrefillFwdKernel"](
+                batch,
+                heads,
+                seq_len,
+                chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                layout=self.layout,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def _validate_shapes(
         self,
@@ -260,13 +326,19 @@ class GatedDeltaNetPrefillFwdOp(Op):
         beta: torch.Tensor,
     ) -> None:
         if self.layout == "bthd":
-            q_shape = (self.batch, self.seq_len, self.heads, self.dim_k)
-            v_shape = (self.batch, self.seq_len, self.heads, self.dim_v)
-            gate_shape = (self.batch, self.seq_len, self.heads)
+            if q.ndim != 4:
+                raise ValueError("q must have shape [batch, seq_len, heads, dim_k]")
+            batch, seq_len, heads, dim_k = q.shape
+            q_shape = (batch, seq_len, heads, dim_k)
+            v_shape = (batch, seq_len, heads, v.shape[-1])
+            gate_shape = (batch, seq_len, heads)
         else:
-            q_shape = (self.batch, self.heads, self.seq_len, self.dim_k)
-            v_shape = (self.batch, self.heads, self.seq_len, self.dim_v)
-            gate_shape = (self.batch, self.heads, self.seq_len)
+            if q.ndim != 4:
+                raise ValueError("q must have shape [batch, heads, seq_len, dim_k]")
+            batch, heads, seq_len, dim_k = q.shape
+            q_shape = (batch, heads, seq_len, dim_k)
+            v_shape = (batch, heads, seq_len, v.shape[-1])
+            gate_shape = (batch, heads, seq_len)
         if tuple(q.shape) != q_shape:
             raise ValueError(f"q must have shape {q_shape}, got {tuple(q.shape)}")
         if tuple(k.shape) != q_shape:
@@ -279,6 +351,23 @@ class GatedDeltaNetPrefillFwdOp(Op):
             raise ValueError(f"beta must have shape {gate_shape}, got {tuple(beta.shape)}")
         if not all(tensor.is_cuda for tensor in (q, k, v, g, beta)):
             raise ValueError("q, k, v, g, and beta must be CUDA tensors")
+        chunk_size = self._requested_chunk_size
+        if chunk_size is None:
+            streams = batch * heads
+            chunk_size = 128 if streams <= 8 and seq_len % 128 == 0 else 64
+        if seq_len % chunk_size != 0:
+            raise ValueError(
+                f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
+            )
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = v.shape[-1]
+        self.chunk_size = chunk_size
+        self.dtype = q.dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, chunk_size, dim_k, self.dim_v, q.dtype, q.device.index)
 
     def eval_roofline(self) -> tuple[int, int]:
         from tileops.perf.formulas import gated_deltanet_prefill_fwd_roofline
@@ -322,43 +411,52 @@ class GatedDeltaNetBwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        if seq_len % chunk_size != 0:
-            raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        bwd_kernel_cls = self.kernel_map["GatedDeltaNetBwdKernel"]
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = bwd_kernel_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "GatedDeltaNetBwdKernel": GatedDeltaNetBwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        seq_len: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, seq_len, self.chunk_size, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["GatedDeltaNetBwdKernel"](
+                batch,
+                heads,
+                seq_len,
+                self.chunk_size,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -384,6 +482,16 @@ class GatedDeltaNetBwdOp(Op):
         Returns:
             Tuple of (dq, dk, dv, dg, dbeta).
         """
+        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
+            q, k, v, g, beta, self.chunk_size, do=do)
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, heads, seq_len, dim_k, dim_v, dtype, q.device.index)
         dq, dk, dv, dg, dbeta = self.kernel(do, q, k, v, g, beta, S)
         return dq, dk, dv, dg, dbeta
 
@@ -414,7 +522,7 @@ class GatedDeltaNetOp(Op):
 
     This makes end-to-end benchmarking against FLA straightforward::
 
-        op = GatedDeltaNetOp(B, H, S, DK, DV, chunk_size, dtype)
+        op = GatedDeltaNetOp(chunk_size=chunk_size)
         o = op(q, k, v, g, beta)   # forward
         o.backward(do)              # backward via TileOPs kernels
 
@@ -434,41 +542,24 @@ class GatedDeltaNetOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        seq_len: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.seq_len = seq_len
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.seq_len = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
-        self.dtype = dtype
-
-        assert seq_len % chunk_size == 0, (
-            f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-        )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        fwd_cls = self.kernel_map["GatedDeltaNetFwdKernel"]
-        bwd_cls = self.kernel_map["GatedDeltaNetBwdKernel"]
-        self.fwd_kernel = fwd_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype, tune=tune,
-        )
-        self.bwd_kernel = bwd_cls(
-            batch, heads, seq_len, chunk_size, dim_k, dim_v,
-            dtype=kernel_dtype, tune=tune,
-        )
+        self._fwd_kernel_cache: Dict[tuple, Kernel] = {}
+        self._bwd_kernel_cache: Dict[tuple, Kernel] = {}
+        self.fwd_kernel = None
+        self.bwd_kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -476,6 +567,44 @@ class GatedDeltaNetOp(Op):
             "GatedDeltaNetFwdKernel": GatedDeltaNetFwdKernel,
             "GatedDeltaNetBwdKernel": GatedDeltaNetBwdKernel,
         }
+
+    def _bind_from_inputs(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> None:
+        batch, heads, seq_len, dim_k, dim_v, dtype = _resolve_gated_bhsd(
+            q, k, v, g, beta, self.chunk_size)
+        self.batch = batch
+        self.heads = heads
+        self.seq_len = seq_len
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        key = (
+            batch,
+            heads,
+            seq_len,
+            self.chunk_size,
+            dim_k,
+            dim_v,
+            dtype,
+            q.device.index,
+            self.tune,
+        )
+        if key not in self._fwd_kernel_cache:
+            kernel_dtype = Kernel.dtype_to_str(dtype)
+            self._fwd_kernel_cache[key] = self.kernel_map["GatedDeltaNetFwdKernel"](
+                batch, heads, seq_len, self.chunk_size, dim_k, dim_v,
+                dtype=kernel_dtype, tune=self.tune)
+            self._bwd_kernel_cache[key] = self.kernel_map["GatedDeltaNetBwdKernel"](
+                batch, heads, seq_len, self.chunk_size, dim_k, dim_v,
+                dtype=kernel_dtype, tune=self.tune)
+        self.fwd_kernel = self._fwd_kernel_cache[key]
+        self.bwd_kernel = self._bwd_kernel_cache[key]
 
     def forward(
         self,
@@ -497,6 +626,7 @@ class GatedDeltaNetOp(Op):
         Returns:
             Output tensor o [B, H, S, DV] (supports .backward()).
         """
+        self._bind_from_inputs(q, k, v, g, beta)
         return _GatedDeltaNetFunction.apply(
             q, k, v, g, beta, self.fwd_kernel, self.bwd_kernel,
         )
@@ -537,38 +667,19 @@ class GatedDeltaNetDecodeOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        dim_k: int,
-        dim_v: int,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.dim_k = dim_k
-        self.dim_v = dim_v
-        self.dtype = dtype
+        self.batch = None
+        self.heads = None
+        self.dim_k = None
+        self.dim_v = None
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        # Dispatch:
-        #   fp32 -> FP32 kernel (no TF32)
-        #   bf16 DK=DV=128 on Hopper -> raw CUDA warp-per-Vtile kernel
-        #   other fp16/bf16 shapes -> default TileLang kernel
-        if dtype == torch.float32:
-            kernel_cls = self.kernel_map["GatedDeltaNetDecodeFP32Kernel"]
-        elif self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, tune):
-            kernel_cls = self.kernel_map["GatedDeltaNetDecodeRawCudaFlaStyleKernel"]
-        else:
-            kernel_cls = self.kernel_map["GatedDeltaNetDecodeKernel"]
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = kernel_cls(
-            batch, heads, dim_k, dim_v,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -581,6 +692,33 @@ class GatedDeltaNetDecodeOp(Op):
                 GatedDeltaNetDecodeRawCudaFlaStyleKernel
             )
         return kernels
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, dim_k, dim_v, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            if dtype == torch.float32:
+                kernel_cls = self.kernel_map["GatedDeltaNetDecodeFP32Kernel"]
+            elif self._should_use_raw_cuda_decode(dim_k, dim_v, dtype, self.tune):
+                kernel_cls = self.kernel_map["GatedDeltaNetDecodeRawCudaFlaStyleKernel"]
+            else:
+                kernel_cls = self.kernel_map["GatedDeltaNetDecodeKernel"]
+            self._kernel_cache[key] = kernel_cls(
+                batch,
+                heads,
+                dim_k,
+                dim_v,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def _infer_output_shapes(
         self,
@@ -606,8 +744,9 @@ class GatedDeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        dtype = q.dtype
+        if dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {dtype}")
         for name, tensor in (
             ("q", q),
             ("k", k),
@@ -616,8 +755,8 @@ class GatedDeltaNetDecodeOp(Op):
             ("beta", beta),
             ("state", state),
         ):
-            if tensor.dtype != self.dtype:
-                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
 
     def _validate_shapes(
         self,
@@ -628,10 +767,16 @@ class GatedDeltaNetDecodeOp(Op):
         beta: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        q_shape = (self.batch, self.heads, self.dim_k)
-        v_shape = (self.batch, self.heads, self.dim_v)
-        gate_shape = (self.batch, self.heads)
-        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if q.ndim != 3:
+            raise ValueError("q must have shape [batch, heads, dim_k]")
+        batch, heads, dim_k = q.shape
+        if v.ndim != 3 or v.shape[:2] != (batch, heads):
+            raise ValueError("v must have shape [batch, heads, dim_v]")
+        dim_v = v.shape[2]
+        q_shape = (batch, heads, dim_k)
+        v_shape = (batch, heads, dim_v)
+        gate_shape = (batch, heads)
+        state_shape = (batch, heads, dim_k, dim_v)
         expected_shapes = (
             ("q", q, q_shape),
             ("k", k, q_shape),
@@ -644,9 +789,15 @@ class GatedDeltaNetDecodeOp(Op):
             if tuple(tensor.shape) != expected:
                 raise ValueError(
                     f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
-                )
+        )
         if not all(tensor.is_cuda for tensor in (q, k, v, g, beta, state)):
             raise ValueError("q, k, v, g, beta, and state must be CUDA tensors")
+        self.batch = batch
+        self.heads = heads
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = q.dtype
+        self.kernel = self._get_kernel(batch, heads, dim_k, dim_v, q.dtype, q.device.index)
 
     def _validate_output_shapes(
         self,

--- a/tileops/ops/gated_linear_attn.py
+++ b/tileops/ops/gated_linear_attn.py
@@ -26,36 +26,21 @@ class GLADecodeOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        heads: int,
-        dim_k: int,
-        dim_v: int,
         scale: float = -1.0,
-        dtype: torch.dtype = torch.float32,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.heads = heads
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.heads = None
+        self.dim_k = None
+        self.dim_v = None
         self.scale = scale
-        self.dtype = dtype
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        # Dispatch: fp32 → FP32 kernel (no TF32), fp16/bf16 → TC kernel
-        if dtype == torch.float32:
-            kernel_cls = self.kernel_map["GLADecodeFP32Kernel"]
-        else:
-            kernel_cls = self.kernel_map["GLADecodeKernel"]
-        kernel_dtype = Kernel.dtype_to_str(dtype)
-        self.kernel = kernel_cls(
-            batch, heads, dim_k, dim_v,
-            scale=scale,
-            dtype=kernel_dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -63,6 +48,32 @@ class GLADecodeOp(Op):
             "GLADecodeKernel": GLADecodeKernel,
             "GLADecodeFP32Kernel": GLADecodeFP32Kernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        heads: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, heads, dim_k, dim_v, self.scale, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            if dtype == torch.float32:
+                kernel_cls = self.kernel_map["GLADecodeFP32Kernel"]
+            else:
+                kernel_cls = self.kernel_map["GLADecodeKernel"]
+            self._kernel_cache[key] = kernel_cls(
+                batch,
+                heads,
+                dim_k,
+                dim_v,
+                scale=self.scale,
+                dtype=Kernel.dtype_to_str(dtype),
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def _infer_output_shapes(
         self,
@@ -86,11 +97,12 @@ class GLADecodeOp(Op):
         gk: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        if self.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-            raise ValueError(f"Unsupported dtype: {self.dtype}")
+        dtype = q.dtype
+        if dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported dtype: {dtype}")
         for name, tensor in (("q", q), ("k", k), ("v", v), ("gk", gk), ("state", state)):
-            if tensor.dtype != self.dtype:
-                raise ValueError(f"{name}.dtype must be {self.dtype}, got {tensor.dtype}")
+            if tensor.dtype != dtype:
+                raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
 
     def _validate_shapes(
         self,
@@ -100,9 +112,15 @@ class GLADecodeOp(Op):
         gk: torch.Tensor,
         state: torch.Tensor,
     ) -> None:
-        q_shape = (self.batch, self.heads, self.dim_k)
-        v_shape = (self.batch, self.heads, self.dim_v)
-        state_shape = (self.batch, self.heads, self.dim_k, self.dim_v)
+        if q.ndim != 3:
+            raise ValueError("q must have shape [batch, heads, dim_k]")
+        batch, heads, dim_k = q.shape
+        if v.ndim != 3 or v.shape[:2] != (batch, heads):
+            raise ValueError("v must have shape [batch, heads, dim_v]")
+        dim_v = v.shape[2]
+        q_shape = (batch, heads, dim_k)
+        v_shape = (batch, heads, dim_v)
+        state_shape = (batch, heads, dim_k, dim_v)
         expected_shapes = (
             ("q", q, q_shape),
             ("k", k, q_shape),
@@ -114,9 +132,15 @@ class GLADecodeOp(Op):
             if tuple(tensor.shape) != expected:
                 raise ValueError(
                     f"{name} must have shape {expected}, got {tuple(tensor.shape)}"
-                )
+        )
         if not all(tensor.is_cuda for tensor in (q, k, v, gk, state)):
             raise ValueError("q, k, v, gk, and state must be CUDA tensors")
+        self.batch = batch
+        self.heads = heads
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = q.dtype
+        self.kernel = self._get_kernel(batch, heads, dim_k, dim_v, q.dtype, q.device.index)
 
     def _validate_output_shapes(
         self,

--- a/tileops/ops/gla.py
+++ b/tileops/ops/gla.py
@@ -10,6 +10,39 @@ from .op_base import Op
 __all__ = ["GLABwdOp", "GLAFwdOp"]
 
 
+def _resolve_gla_bthd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    chunk_size: int,
+    do: Optional[torch.Tensor] = None,
+) -> tuple[int, int, int, int, int, torch.dtype]:
+    if not all(tensor.is_cuda for tensor in (q, k, v, g)):
+        raise ValueError("q, k, v, and g must be CUDA tensors")
+    if q.ndim != 4:
+        raise ValueError("q must have shape [batch, seq_len, heads, dim_k]")
+    batch, seq_len, heads, dim_k = q.shape
+    if k.shape != (batch, seq_len, heads, dim_k):
+        raise ValueError("k must match q shape")
+    if v.ndim != 4 or v.shape[:3] != (batch, seq_len, heads):
+        raise ValueError("v must have shape [batch, seq_len, heads, dim_v]")
+    dim_v = v.shape[-1]
+    if g.shape != (batch, seq_len, heads, dim_k):
+        raise ValueError("g must match q shape")
+    if do is not None and do.shape != (batch, seq_len, heads, dim_v):
+        raise ValueError("do must have shape [batch, seq_len, heads, dim_v]")
+    dtype = q.dtype
+    for name, tensor in (("k", k), ("v", v), ("g", g)):
+        if tensor.dtype != dtype:
+            raise ValueError(f"{name}.dtype must be {dtype}, got {tensor.dtype}")
+    if do is not None and do.dtype != dtype:
+        raise ValueError(f"do.dtype must be {dtype}, got {do.dtype}")
+    if seq_len % chunk_size != 0:
+        raise ValueError(f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})")
+    return batch, seq_len, heads, dim_k, dim_v, dtype
+
+
 class GLAFwdOp(Op):
     """GLA (Gated Linear Attention) forward operator.
 
@@ -33,48 +66,70 @@ class GLAFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        seq_len: int,
-        heads: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
         scale: float = -1.0,
         output_final_state: bool = False,
-        dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.seq_len = seq_len
-        self.heads = heads
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.seq_len = None
+        self.heads = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
         self.scale = scale
         self.output_final_state = output_final_state
-        self.dtype = dtype
-
-        assert seq_len % chunk_size == 0, (
-            f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-        )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        fwd_kernel_cls = self.kernel_map["GLAFwdKernel"]
-        self.kernel = fwd_kernel_cls(
-            batch, seq_len, heads, dim_k, dim_v, chunk_size,
-            scale=scale,
-            output_final_state=output_final_state,
-            dtype=dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "GLAFwdKernel": GLAFwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        seq_len: int,
+        heads: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            seq_len,
+            heads,
+            dim_k,
+            dim_v,
+            self.chunk_size,
+            self.scale,
+            self.output_final_state,
+            dtype,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["GLAFwdKernel"](
+                batch,
+                seq_len,
+                heads,
+                dim_k,
+                dim_v,
+                self.chunk_size,
+                scale=self.scale,
+                output_final_state=self.output_final_state,
+                dtype=dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -96,6 +151,16 @@ class GLAFwdOp(Op):
         Returns:
             Tuple of (o, final_state). final_state is None if output_final_state=False.
         """
+        batch, seq_len, heads, dim_k, dim_v, dtype = _resolve_gla_bthd(
+            q, k, v, g, self.chunk_size)
+        self.batch = batch
+        self.seq_len = seq_len
+        self.heads = heads
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, seq_len, heads, dim_k, dim_v, dtype, q.device.index)
         return self.kernel(q, k, v, g, initial_state)
 
 
@@ -123,45 +188,66 @@ class GLABwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        seq_len: int,
-        heads: int,
-        dim_k: int,
-        dim_v: int,
         chunk_size: int = 64,
         scale: float = -1.0,
-        dtype: torch.dtype = torch.float16,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self.batch = batch
-        self.seq_len = seq_len
-        self.heads = heads
-        self.dim_k = dim_k
-        self.dim_v = dim_v
+        self.batch = None
+        self.seq_len = None
+        self.heads = None
+        self.dim_k = None
+        self.dim_v = None
         self.chunk_size = chunk_size
         self.scale = scale
-        self.dtype = dtype
-
-        assert seq_len % chunk_size == 0, (
-            f"seq_len ({seq_len}) must be divisible by chunk_size ({chunk_size})"
-        )
+        self.dtype = None
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-
-        bwd_kernel_cls = self.kernel_map["GLABwdKernel"]
-        self.kernel = bwd_kernel_cls(
-            batch, seq_len, heads, dim_k, dim_v, chunk_size,
-            scale=scale,
-            dtype=dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "GLABwdKernel": GLABwdKernel,
         }
+
+    def _get_kernel(
+        self,
+        batch: int,
+        seq_len: int,
+        heads: int,
+        dim_k: int,
+        dim_v: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            seq_len,
+            heads,
+            dim_k,
+            dim_v,
+            self.chunk_size,
+            self.scale,
+            dtype,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["GLABwdKernel"](
+                batch,
+                seq_len,
+                heads,
+                dim_k,
+                dim_v,
+                self.chunk_size,
+                scale=self.scale,
+                dtype=dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -189,4 +275,14 @@ class GLABwdOp(Op):
         Returns:
             Tuple of (dq, dk, dv, dg).
         """
+        batch, seq_len, heads, dim_k, dim_v, dtype = _resolve_gla_bthd(
+            q, k, v, g, self.chunk_size, do=do)
+        self.batch = batch
+        self.seq_len = seq_len
+        self.heads = heads
+        self.dim_k = dim_k
+        self.dim_v = dim_v
+        self.dtype = dtype
+        self.kernel = self._get_kernel(
+            batch, seq_len, heads, dim_k, dim_v, dtype, q.device.index)
         return self.kernel(q, k, v, g, h, do, dht, has_initial_state)

--- a/tileops/ops/grouped_gemm.py
+++ b/tileops/ops/grouped_gemm.py
@@ -22,37 +22,115 @@ class GroupedGemmOp(Op):
     """
 
     def __init__(self,
-                 batch_sum: int,
-                 batch_count: int,
-                 n: int,
-                 k: int,
-                 dtype: torch.dtype = torch.float16,
                  transpose_a: bool = False,
                  transpose_b: bool = True,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False):
-        self.batch_sum = batch_sum
-        self.batch_count = batch_count
-        self.N = n
-        self.K = k
-        self.dtype = dtype
+        self.batch_sum = None
+        self.batch_count = None
+        self.N = None
+        self.K = None
+        self.dtype = None
         self.transpose_a = transpose_a
         self.transpose_b = transpose_b
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["grouped_gemm_kernel"](
-            batch_sum,
-            batch_count,
-            n,
-            k,
-            dtype=dtype,
-            transpose_a=transpose_a,
-            transpose_b=transpose_b,
-            tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict:
         return {"grouped_gemm_kernel": GroupedGemmKernel}
 
+    def _resolve_spec(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        batch_sizes: torch.Tensor,
+        batch_offsets: torch.Tensor,
+        batch_padded_offsets: torch.Tensor,
+    ) -> tuple[int, int, int, int, torch.dtype, int | None]:
+        if not a.is_cuda or not b.is_cuda:
+            raise ValueError("a and b must be CUDA tensors")
+        if a.dtype != b.dtype:
+            raise ValueError(f"a and b must have the same dtype, got {a.dtype} and {b.dtype}")
+        if a.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(f"a.dtype must be float16 or bfloat16, got {a.dtype}")
+        if batch_sizes.ndim != 1 or batch_offsets.ndim != 1 or batch_padded_offsets.ndim != 1:
+            raise ValueError("batch metadata tensors must be 1D")
+        batch_count = batch_sizes.shape[0]
+        if batch_offsets.shape[0] != batch_count or batch_padded_offsets.shape[0] != batch_count:
+            raise ValueError("batch metadata tensors must have matching lengths")
+        if batch_sizes.dtype != torch.int32 or batch_offsets.dtype != torch.int32 or batch_padded_offsets.dtype != torch.int32:
+            raise ValueError("batch metadata tensors must use int32 dtype")
+
+        if not self.transpose_a:
+            if a.ndim != 2 or b.ndim != 3:
+                raise ValueError("GroupedGemmOp expects 2D a and 3D b when transpose_a=False")
+            batch_sum, k = a.shape
+            if b.shape[0] != batch_count:
+                raise ValueError(f"b.shape[0] must match batch_count={batch_count}, got {b.shape[0]}")
+            if self.transpose_b:
+                n, b_k = b.shape[1], b.shape[2]
+            else:
+                b_k, n = b.shape[1], b.shape[2]
+            if b_k != k:
+                raise ValueError(f"GroupedGemmOp expected K={k}, got b K dimension {b_k}")
+        else:
+            if a.ndim != 2 or b.ndim != 2:
+                raise ValueError("GroupedGemmOp expects 2D a and b when transpose_a=True")
+            batch_sum, n = a.shape
+            if self.transpose_b:
+                k, b_batch_sum = b.shape
+            else:
+                b_batch_sum, k = b.shape
+            if b_batch_sum != batch_sum:
+                raise ValueError(
+                    f"GroupedGemmOp expected b batch_sum dimension {batch_sum}, got {b_batch_sum}"
+                )
+        return batch_sum, batch_count, n, k, a.dtype, a.device.index
+
+    def _get_kernel(
+        self,
+        batch_sum: int,
+        batch_count: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch_sum,
+            batch_count,
+            n,
+            k,
+            dtype,
+            device_index,
+            self.transpose_a,
+            self.transpose_b,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["grouped_gemm_kernel"](
+                batch_sum,
+                batch_count,
+                n,
+                k,
+                dtype=dtype,
+                transpose_a=self.transpose_a,
+                transpose_b=self.transpose_b,
+                tune=self.tune)
+        return self._kernel_cache[key]
+
     def forward(self, a: torch.Tensor, b: torch.Tensor, batch_sizes: torch.Tensor,
                 batch_offsets: torch.Tensor, batch_padded_offsets: torch.Tensor) -> torch.Tensor:
+        batch_sum, batch_count, n, k, dtype, device_index = self._resolve_spec(
+            a, b, batch_sizes, batch_offsets, batch_padded_offsets,
+        )
+        self.batch_sum = batch_sum
+        self.batch_count = batch_count
+        self.N = n
+        self.K = k
+        self.dtype = dtype
+        self.kernel = self._get_kernel(batch_sum, batch_count, n, k, dtype, device_index)
         return self.kernel(a, b, batch_sizes, batch_offsets, batch_padded_offsets)

--- a/tileops/ops/mamba2_fwd.py
+++ b/tileops/ops/mamba2_fwd.py
@@ -61,59 +61,27 @@ class Mamba2FwdOp:
 
     def __init__(
         self,
-        batch: int,
-        seqlen: int,
-        n_heads: int,
-        d_head: int,
-        d_state: int,
-        n_groups: int,
-        dtype: torch.dtype,
         chunk_size: int = 256,
         dt_softplus: bool = True,
         has_initial_states: bool = False,
         tune: bool = False,
     ):
-        if seqlen % chunk_size != 0:
-            raise ValueError(f"seqlen ({seqlen}) must be divisible by chunk_size ({chunk_size})")
-        if n_heads % n_groups != 0:
-            raise ValueError(f"n_heads ({n_heads}) must be divisible by n_groups ({n_groups})")
-
-        self.batch = batch
-        self.seqlen = seqlen
+        self.batch = None
+        self.seqlen = None
         self.chunk_size = chunk_size
-        self.num_chunks = seqlen // chunk_size
-        self.n_heads = n_heads
-        self.d_head = d_head
-        self.d_state = d_state
-        self.n_groups = n_groups
-        self.dtype = dtype
+        self.num_chunks = None
+        self.n_heads = None
+        self.d_head = None
+        self.d_state = None
+        self.n_groups = None
+        self.dtype = None
         self.dt_softplus = dt_softplus
         self.has_initial_states = has_initial_states
-        self._heads_per_group = n_heads // n_groups
+        self._heads_per_group = None
+        self.tune = tune
 
-        num_chunks = self.num_chunks
-
-        self._da_cumsum_op = DaCumsumFwdOp(
-            batch=batch,
-            num_chunks=num_chunks,
-            chunk_len=chunk_size,
-            n_heads=n_heads,
-            seq_len=seqlen,
-            dtype=dtype,
-            dt_softplus=dt_softplus,
-            has_dt_bias=True,   # always pass dt_bias; caller passes zeros if unused
-            tune=tune,
-        )
-
+        self._da_cumsum_ops: dict[torch.dtype, DaCumsumFwdOp] = {}
         self._chunk_state_op = SSDChunkStateFwdOp(
-            batch=batch,
-            num_chunks=num_chunks,
-            chunk_len=chunk_size,
-            n_heads=n_heads,
-            d_head=d_head,
-            d_state=d_state,
-            n_groups=n_groups,
-            dtype=dtype,
             has_seq_idx=False,
             tune=tune,
         )
@@ -122,52 +90,51 @@ class Mamba2FwdOp:
         # Flatten P*N into a single state dim so SSDStatePassingFwdOp is used
         # instead of a Python loop, keeping everything on the GPU.
         self._state_passing_op = SSDStatePassingFwdOp(
-            batch=batch,
-            num_chunks=num_chunks,
-            n_heads=n_heads,
-            d_state=d_head * d_state,   # flat state: P*N
-            dtype=torch.float32,
             has_initial_states=has_initial_states,
             tune=tune,
         )
 
-        self._chunk_scan_op = SSDChunkScanFwdOp(
-            batch=batch,
-            num_chunks=num_chunks,
-            chunk_len=chunk_size,
-            n_heads=n_heads,
-            d_head=d_head,
-            d_state=d_state,
-            n_groups=n_groups,
-            dtype=dtype,
-            tune=tune,
-        )
-
-        # CB Producer Op - replaces torch.compile einsum
-        self._cb_producer_op = CBProducerOp(
-            batch=batch,
-            num_chunks=num_chunks,
-            n_groups=n_groups,
-            chunk_len=chunk_size,
-            d_state=d_state,
-            dtype=dtype,
-            tune=tune,
-        )
+        self._chunk_scan_op = SSDChunkScanFwdOp(tune=tune)
+        self._cb_producer_ops: dict[tuple, CBProducerOp] = {}
 
         # Pre-allocated zero tensors — avoids FillFunctor kernel launches on the
         # hot path for optional inputs that are commonly omitted.
-        # Allocated on CPU here; moved to the right CUDA device on first forward.
-        self._zero_dt_bias_cpu = torch.zeros(n_heads, dtype=torch.float32)
-        self._zero_init_flat_cpu = torch.zeros(
-            batch, n_heads, d_head * d_state, dtype=torch.float32,
-        )
-        # seq_idx placeholder for SSDChunkStateFwdOp (has_seq_idx=False path still
-        # passes the tensor; pre-allocating avoids a FillFunctor<int> each call).
-        self._zero_seq_idx_cpu = torch.zeros(batch, seqlen, dtype=torch.int32)
-
         self._zero_dt_bias: Optional[torch.Tensor]   = None
         self._zero_init_flat: Optional[torch.Tensor] = None
         self._zero_seq_idx: Optional[torch.Tensor]   = None
+
+    def _get_da_cumsum_op(self, dtype: torch.dtype) -> DaCumsumFwdOp:
+        if dtype not in self._da_cumsum_ops:
+            self._da_cumsum_ops[dtype] = DaCumsumFwdOp(
+                chunk_len=self.chunk_size,
+                dtype=dtype,
+                dt_softplus=self.dt_softplus,
+                has_dt_bias=True,
+                tune=self.tune,
+            )
+        return self._da_cumsum_ops[dtype]
+
+    def _get_cb_producer_op(
+        self,
+        batch: int,
+        num_chunks: int,
+        n_groups: int,
+        d_state: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> CBProducerOp:
+        key = (batch, num_chunks, n_groups, self.chunk_size, d_state, dtype, device_index, self.tune)
+        if key not in self._cb_producer_ops:
+            self._cb_producer_ops[key] = CBProducerOp(
+                batch=batch,
+                num_chunks=num_chunks,
+                n_groups=n_groups,
+                chunk_len=self.chunk_size,
+                d_state=d_state,
+                dtype=dtype,
+                tune=self.tune,
+            )
+        return self._cb_producer_ops[key]
 
     # ------------------------------------------------------------------
     # Forward
@@ -206,29 +173,72 @@ class Mamba2FwdOp:
                 "has_initial_states=False — the kernel ignores it, which would "
                 "silently produce wrong results.  Reconstruct with has_initial_states=True."
             )
+        if not x.is_cuda:
+            raise ValueError("x must be a CUDA tensor")
+        if x.ndim != 4:
+            raise ValueError("x must have shape [batch, seqlen, n_heads, d_head]")
         batch, seqlen, n_heads, d_head = x.shape
-        chunk_size   = self.chunk_size
-        num_chunks   = seqlen // chunk_size
-        d_state      = self.d_state
-        dev          = x.device
+        chunk_size = self.chunk_size
+        if seqlen % chunk_size != 0:
+            raise ValueError(f"seqlen ({seqlen}) must be divisible by chunk_size ({chunk_size})")
+        num_chunks = seqlen // chunk_size
+        if B.ndim != 4 or B.shape[0] != batch or B.shape[1] != seqlen:
+            raise ValueError("B must have shape [batch, seqlen, n_groups, d_state]")
+        n_groups, d_state = B.shape[2], B.shape[3]
+        if n_heads % n_groups != 0:
+            raise ValueError(f"n_heads ({n_heads}) must be divisible by n_groups ({n_groups})")
+        if C.shape != (batch, seqlen, n_groups, d_state):
+            raise ValueError("C must have shape [batch, seqlen, n_groups, d_state]")
+        if dt.shape != (batch, seqlen, n_heads):
+            raise ValueError("dt must have shape [batch, seqlen, n_heads]")
+        if A.shape != (n_heads,):
+            raise ValueError("A must have shape [n_heads]")
+        if dt_bias is not None and dt_bias.shape != (n_heads,):
+            raise ValueError("dt_bias must have shape [n_heads]")
+        if initial_states is not None and initial_states.shape != (batch, n_heads, d_head, d_state):
+            raise ValueError("initial_states must have shape [batch, n_heads, d_head, d_state]")
+        dev = x.device
 
-        # Ensure pre-allocated tensors live on the right device.
-        if self._zero_dt_bias is None or self._zero_dt_bias.device != dev:
-            self._zero_dt_bias    = self._zero_dt_bias_cpu.to(dev)
-            self._zero_init_flat  = self._zero_init_flat_cpu.to(dev)
-            self._zero_seq_idx    = self._zero_seq_idx_cpu.to(dev)
+        self.batch = batch
+        self.seqlen = seqlen
+        self.num_chunks = num_chunks
+        self.n_heads = n_heads
+        self.d_head = d_head
+        self.d_state = d_state
+        self.n_groups = n_groups
+        self.dtype = x.dtype
+        self._heads_per_group = n_heads // n_groups
+
+        if self._zero_dt_bias is None or self._zero_dt_bias.shape != (n_heads,) or self._zero_dt_bias.device != dev:
+            self._zero_dt_bias = torch.zeros(n_heads, dtype=torch.float32, device=dev)
+        init_shape = (batch, n_heads, d_head * d_state)
+        if (
+            self._zero_init_flat is None
+            or self._zero_init_flat.shape != init_shape
+            or self._zero_init_flat.device != dev
+        ):
+            self._zero_init_flat = torch.zeros(init_shape, dtype=torch.float32, device=dev)
+        seq_idx_shape = (batch, seqlen)
+        if (
+            self._zero_seq_idx is None
+            or self._zero_seq_idx.shape != seq_idx_shape
+            or self._zero_seq_idx.device != dev
+        ):
+            self._zero_seq_idx = torch.zeros(seq_idx_shape, dtype=torch.int32, device=dev)
         # ── 1. DaCumsum ──────────────────────────────────────────────────────
         if dt_bias is None:
             dt_bias = self._zero_dt_bias
 
-        dt_out, dA_cumsum = self._da_cumsum_op.forward(dt, A, dt_bias)
+        dt_out, dA_cumsum = self._get_da_cumsum_op(x.dtype).forward(dt, A, dt_bias)
         # dt_out:    (B, H, C, Q)  dtype
         # dA_cumsum: (B, H, C, Q)  float32
 
         # ── 2. CB matrix ─────────────────────────────────────────────────────
         # cb[b,c,g,l,s] = C[b,c*Q+l,g,:] @ B[b,c*Q+s,g,:]^T  for s <= l, else 0.
         # Pass contiguous C and B directly to avoid reshape/permute/contiguous overhead
-        cb = self._cb_producer_op.forward(C, B)  # (B, C, G, Q, Q)  dtype (direct output, no cast needed)
+        cb_producer_op = self._get_cb_producer_op(
+            batch, num_chunks, n_groups, d_state, x.dtype, x.device.index)
+        cb = cb_producer_op.forward(C, B)  # (B, C, G, Q, Q)  dtype (direct output, no cast needed)
 
         # ── 3. SSDChunkState ─────────────────────────────────────────────────
         # Pass pre-allocated seq_idx zeros; avoids a FillFunctor<int> per call.

--- a/tileops/ops/mamba2_fwd.py
+++ b/tileops/ops/mamba2_fwd.py
@@ -197,6 +197,10 @@ class Mamba2FwdOp:
             raise ValueError("dt_bias must have shape [n_heads]")
         if initial_states is not None and initial_states.shape != (batch, n_heads, d_head, d_state):
             raise ValueError("initial_states must have shape [batch, n_heads, d_head, d_state]")
+        if B.dtype != x.dtype:
+            raise ValueError(f"B.dtype must be {x.dtype}, got {B.dtype}")
+        if C.dtype != x.dtype:
+            raise ValueError(f"C.dtype must be {x.dtype}, got {C.dtype}")
         dev = x.device
 
         self.batch = batch

--- a/tileops/ops/mhc.py
+++ b/tileops/ops/mhc.py
@@ -135,6 +135,10 @@ class MHCPostOp(Op):
             raise ValueError(
                 f"x_res.shape[1] must equal n_expand * c_x={n_expand * c_x}, got {x_res.shape[1]}"
             )
+        if x_res.dtype != x_layer_out.dtype:
+            raise ValueError(
+                f"x_res.dtype must match x_layer_out.dtype ({x_layer_out.dtype}), got {x_res.dtype}"
+            )
         self.batch = batch
         self.n_expand = n_expand
         self.c_x = c_x

--- a/tileops/ops/mhc.py
+++ b/tileops/ops/mhc.py
@@ -1,3 +1,4 @@
+import math
 from typing import Dict, Optional
 
 import torch
@@ -14,24 +15,46 @@ class MHCPreOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,
-                 batch,
-                 n_expand,
-                 c_x,
-                 dtype: torch.dtype = torch.float32,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
-        self.batch = batch
-        self.n_expand = n_expand
-        self.c_x = c_x
-        self.dtype = dtype
+        self.batch = None
+        self.n_expand = None
+        self.c_x = None
+        self.dtype = None
         self.weights_dtype = torch.float32
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["mhc_pre_kernel"](batch, n_expand, c_x, self.dtype, tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"mhc_pre_kernel": MHCPreKernel}
+
+    @staticmethod
+    def _n_expand_from_phi_dim(phi_dim: int) -> int:
+        n_expand = int(math.isqrt(phi_dim + 1) - 1)
+        if n_expand <= 0 or n_expand * n_expand + 2 * n_expand != phi_dim:
+            raise ValueError(
+                "phi.shape[1] must equal n_expand * n_expand + 2 * n_expand"
+            )
+        return n_expand
+
+    def _get_kernel(
+        self,
+        batch: int,
+        n_expand: int,
+        c_x: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, n_expand, c_x, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["mhc_pre_kernel"](
+                batch, n_expand, c_x, dtype, tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(self,
                 phi: torch.Tensor,
@@ -43,6 +66,22 @@ class MHCPreOp(Op):
                 sinkhorn_repeat: int,
                 sinkhorn_eps: float = 0.02) -> torch.Tensor:
 
+        if phi.ndim != 2 or x.ndim != 2 or b.ndim != 1:
+            raise ValueError("MHCPreOp expects phi/x/b shapes [D, P], [B, D], [P]")
+        batch, x_dim = x.shape
+        if phi.shape[0] != x_dim:
+            raise ValueError(f"phi.shape[0] must match x.shape[1]={x_dim}, got {phi.shape[0]}")
+        n_expand = self._n_expand_from_phi_dim(phi.shape[1])
+        if b.shape[0] != phi.shape[1]:
+            raise ValueError(f"b.shape[0] must match phi.shape[1]={phi.shape[1]}, got {b.shape[0]}")
+        if x_dim % n_expand != 0:
+            raise ValueError(f"x.shape[1]={x_dim} must be divisible by n_expand={n_expand}")
+        c_x = x_dim // n_expand
+        self.batch = batch
+        self.n_expand = n_expand
+        self.c_x = c_x
+        self.dtype = x.dtype
+        self.kernel = self._get_kernel(batch, n_expand, c_x, x.dtype, x.device.index)
         return self.kernel(phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat,
                            sinkhorn_eps)
 
@@ -51,27 +90,54 @@ class MHCPostOp(Op):
     """Layout: BSHD"""
 
     def __init__(self,
-                 batch,
-                 n_expand,
-                 c_x,
-                 dtype: torch.dtype = torch.float32,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
-        self.batch = batch
-        self.n_expand = n_expand
-        self.c_x = c_x
-        self.dtype = dtype
+        self.batch = None
+        self.n_expand = None
+        self.c_x = None
+        self.dtype = None
         self.weights_dtype = torch.float32
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["mhc_post_kernel"](
-            batch, n_expand, c_x, self.dtype, tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"mhc_post_kernel": MHCPostKernel}
 
+    def _get_kernel(
+        self,
+        batch: int,
+        n_expand: int,
+        c_x: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, n_expand, c_x, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["mhc_post_kernel"](
+                batch, n_expand, c_x, dtype, tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
     def forward(self, x_layer_out: torch.Tensor, h_post: torch.Tensor,
                 x_res: torch.Tensor) -> torch.Tensor:
 
+        if x_layer_out.ndim != 2 or h_post.ndim != 2 or x_res.ndim != 2:
+            raise ValueError("MHCPostOp expects x_layer_out/h_post/x_res to be 2D tensors")
+        batch, c_x = x_layer_out.shape
+        if h_post.shape[0] != batch or x_res.shape[0] != batch:
+            raise ValueError("MHCPostOp inputs must have matching batch dimensions")
+        n_expand = h_post.shape[1]
+        if x_res.shape[1] != n_expand * c_x:
+            raise ValueError(
+                f"x_res.shape[1] must equal n_expand * c_x={n_expand * c_x}, got {x_res.shape[1]}"
+            )
+        self.batch = batch
+        self.n_expand = n_expand
+        self.c_x = c_x
+        self.dtype = x_layer_out.dtype
+        self.kernel = self._get_kernel(batch, n_expand, c_x, x_layer_out.dtype, x_layer_out.device.index)
         return self.kernel(x_layer_out, h_post, x_res)

--- a/tileops/ops/rope.py
+++ b/tileops/ops/rope.py
@@ -635,6 +635,8 @@ class RopeNeoxPositionIdsOp(Op):
             raise ValueError("RopeNeoxPositionIdsOp expects input shape [tokens, heads, head_dim]")
         self.num_tokens, self.num_heads, self.head_dim = x.shape
         rotary_dim = self.head_dim if self.rotary_dim is None else self.rotary_dim
+        if rotary_dim % 2 != 0:
+            raise ValueError("rotary_dim (or head_dim if rotary_dim is None) must be even")
         if rotary_dim > self.head_dim:
             raise ValueError("rotary_dim must not exceed head_dim")
         self.rotary_dim = rotary_dim

--- a/tileops/ops/rope.py
+++ b/tileops/ops/rope.py
@@ -555,6 +555,7 @@ class RopeNeoxPositionIdsOp(Op):
         self.num_tokens = None
         self.num_heads = None
         self.head_dim = None
+        self._requested_rotary_dim = rotary_dim
         self.rotary_dim = rotary_dim
         self.max_position = max_position
         self.dtype = None
@@ -634,7 +635,11 @@ class RopeNeoxPositionIdsOp(Op):
         if x.ndim != 3:
             raise ValueError("RopeNeoxPositionIdsOp expects input shape [tokens, heads, head_dim]")
         self.num_tokens, self.num_heads, self.head_dim = x.shape
-        rotary_dim = self.head_dim if self.rotary_dim is None else self.rotary_dim
+        rotary_dim = (
+            self.head_dim
+            if self._requested_rotary_dim is None
+            else self._requested_rotary_dim
+        )
         if rotary_dim % 2 != 0:
             raise ValueError("rotary_dim (or head_dim if rotary_dim is None) must be even")
         if rotary_dim > self.head_dim:

--- a/tileops/ops/rope.py
+++ b/tileops/ops/rope.py
@@ -354,32 +354,23 @@ class _RopeOpBase(Op):
 
     def __init__(
         self,
-        seq_len: int,
-        head_dim: int,
-        dtype: torch.dtype,
         layout: str = "1d",
-        batch: int = 1,
-        num_heads: int = 1,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        self.seq_len = seq_len
-        self.head_dim = head_dim
-        self.dtype = dtype
+        self.seq_len = None
+        self.head_dim = None
+        self.dtype = None
         self.layout = layout
-        self.batch = batch
-        self.num_heads = num_heads
+        self.batch = None
+        self.num_heads = None
+        self.tune = tune
 
-        # Lazy cos/sin cache: computed on first forward call per device
-        self._cos_cache: Optional[torch.Tensor] = None
-        self._sin_cache: Optional[torch.Tensor] = None
-        self._cache_device: Optional[torch.device] = None
+        self._freq_cache: Dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            seq_len=seq_len, head_dim=head_dim, dtype=dtype,
-            layout=layout, batch=batch, num_heads=num_heads, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
@@ -387,10 +378,10 @@ class _RopeOpBase(Op):
 
     def _get_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         """Return cached cos/sin tables, recomputing if device changed."""
-        if self._cos_cache is None or self._cache_device != device:
-            self._cos_cache, self._sin_cache = self._compute_cos_sin(device=device)
-            self._cache_device = device
-        return self._cos_cache, self._sin_cache
+        key = (self.seq_len, self.head_dim, self.dtype, device)
+        if key not in self._freq_cache:
+            self._freq_cache[key] = self._compute_cos_sin(device=device)
+        return self._freq_cache[key]
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute variant-specific cos/sin frequency tables.
@@ -415,6 +406,8 @@ class _RopeOpBase(Op):
     @property
     def total_memory(self) -> float:
         """Read x + cos + sin + write y."""
+        if self.seq_len is None or self.head_dim is None or self.dtype is None:
+            raise RuntimeError("RoPE memory stats are available after the first forward()")
         half = self.head_dim // 2
         elem = self.dtype.itemsize
         cos_sin_elems = self.seq_len * half * 2
@@ -424,6 +417,29 @@ class _RopeOpBase(Op):
             x_elems = self.batch * self.seq_len * self.num_heads * self.head_dim
         return (2 * x_elems + cos_sin_elems) * elem
 
+    def _get_kernel(self, device_index: int | None) -> Kernel:
+        key = (
+            self.seq_len,
+            self.head_dim,
+            self.dtype,
+            self.layout,
+            self.batch,
+            self.num_heads,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map[self._op_name](
+                seq_len=self.seq_len,
+                head_dim=self.head_dim,
+                dtype=self.dtype,
+                layout=self.layout,
+                batch=self.batch,
+                num_heads=self.num_heads,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
+
     def _validate_and_prepare(self, x: torch.Tensor) -> torch.Tensor:
         """Validate input shape/dtype/device and return a contiguous tensor.
 
@@ -432,17 +448,24 @@ class _RopeOpBase(Op):
         """
         if not x.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
         if self.layout == "1d":
-            expected = (self.seq_len, self.head_dim)
+            if x.ndim != 2:
+                raise ValueError("RoPE 1d layout expects input shape [seq_len, head_dim]")
+            self.seq_len, self.head_dim = x.shape
+            self.batch = 1
+            self.num_heads = 1
         else:
-            expected = (self.batch, self.seq_len, self.num_heads, self.head_dim)
-        if tuple(x.shape) != expected:
-            raise ValueError(
-                f"Expected input shape {expected} for layout "
-                f"'{self.layout}', got {tuple(x.shape)}"
-            )
+            if self.layout != "2d":
+                raise ValueError(f"Unsupported RoPE layout {self.layout!r}")
+            if x.ndim != 4:
+                raise ValueError(
+                    "RoPE 2d layout expects input shape [batch, seq_len, num_heads, head_dim]"
+                )
+            self.batch, self.seq_len, self.num_heads, self.head_dim = x.shape
+        if self.head_dim <= 0 or self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be positive and even")
+        self.dtype = x.dtype
+        self.kernel = self._get_kernel(x.device.index)
         return x.contiguous()
 
     def _eager_forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -499,14 +522,12 @@ class RopeNeoxOp(_RopeOpBase):
     _op_name = "rope_neox"
     kernel_cls = RopeNeoxKernel
 
-    def __init__(self, seq_len: int, head_dim: int, dtype: torch.dtype,
-                 layout: str = "1d", batch: int = 1, num_heads: int = 1,
+    def __init__(self, layout: str = "1d",
                  base: float = 10000.0,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False):
         self.base = base
-        super().__init__(seq_len, head_dim, dtype, layout, batch, num_heads,
-                         kernel_map, tune)
+        super().__init__(layout, kernel_map, tune)
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         return _base_freqs(self.head_dim, self.seq_len, base=self.base,
@@ -521,44 +542,29 @@ class RopeNeoxPositionIdsOp(Op):
 
     def __init__(
         self,
-        num_tokens: int,
-        num_heads: int,
-        head_dim: int,
         max_position: int,
-        dtype: torch.dtype,
         base: float = 10000.0,
         rotary_dim: Optional[int] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        rotary_dim = head_dim if rotary_dim is None else rotary_dim
-        if rotary_dim <= 0:
+        if rotary_dim is not None and rotary_dim <= 0:
             raise ValueError("rotary_dim must be positive")
-        if rotary_dim % 2 != 0:
+        if rotary_dim is not None and rotary_dim % 2 != 0:
             raise ValueError("rotary_dim must be even")
-        if rotary_dim > head_dim:
-            raise ValueError("rotary_dim must not exceed head_dim")
-        self.num_tokens = num_tokens
-        self.num_heads = num_heads
-        self.head_dim = head_dim
+        self.num_tokens = None
+        self.num_heads = None
+        self.head_dim = None
         self.rotary_dim = rotary_dim
         self.max_position = max_position
-        self.dtype = dtype
+        self.dtype = None
         self.base = base
-        self._cos_cache: Optional[torch.Tensor] = None
-        self._sin_cache: Optional[torch.Tensor] = None
-        self._cache_device: Optional[torch.device] = None
+        self.tune = tune
+        self._freq_cache: Dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map[self._op_name](
-            num_tokens=num_tokens,
-            num_heads=num_heads,
-            head_dim=head_dim,
-            rotary_dim=rotary_dim,
-            max_position=max_position,
-            dtype=dtype,
-            tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
@@ -569,6 +575,13 @@ class RopeNeoxPositionIdsOp(Op):
 
     @property
     def total_memory(self) -> float:
+        if (
+            self.num_tokens is None
+            or self.num_heads is None
+            or self.head_dim is None
+            or self.dtype is None
+        ):
+            raise RuntimeError("RoPE memory stats are available after the first forward()")
         half = self.rotary_dim // 2
         elem = self.dtype.itemsize
         x_elems = self.num_tokens * self.num_heads * self.head_dim
@@ -577,16 +590,39 @@ class RopeNeoxPositionIdsOp(Op):
         return (2 * x_elems + cos_sin_elems) * elem + pos_elems * torch.int32.itemsize
 
     def _get_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
-        if self._cos_cache is None or self._cache_device != device:
-            self._cos_cache, self._sin_cache = _base_freqs(
+        key = (self.rotary_dim, self.max_position, self.dtype, device)
+        if key not in self._freq_cache:
+            self._freq_cache[key] = _base_freqs(
                 self.rotary_dim,
                 self.max_position,
                 base=self.base,
                 dtype=self.dtype,
                 device=device,
             )
-            self._cache_device = device
-        return self._cos_cache, self._sin_cache
+        return self._freq_cache[key]
+
+    def _get_kernel(self, device_index: int | None) -> Kernel:
+        key = (
+            self.num_tokens,
+            self.num_heads,
+            self.head_dim,
+            self.rotary_dim,
+            self.max_position,
+            self.dtype,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map[self._op_name](
+                num_tokens=self.num_tokens,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                rotary_dim=self.rotary_dim,
+                max_position=self.max_position,
+                dtype=self.dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def _validate_and_prepare(
         self,
@@ -595,11 +631,14 @@ class RopeNeoxPositionIdsOp(Op):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if not x.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x.dtype {self.dtype}, got {x.dtype}")
-        expected = (self.num_tokens, self.num_heads, self.head_dim)
-        if tuple(x.shape) != expected:
-            raise ValueError(f"Expected input shape {expected}, got {tuple(x.shape)}")
+        if x.ndim != 3:
+            raise ValueError("RopeNeoxPositionIdsOp expects input shape [tokens, heads, head_dim]")
+        self.num_tokens, self.num_heads, self.head_dim = x.shape
+        rotary_dim = self.head_dim if self.rotary_dim is None else self.rotary_dim
+        if rotary_dim > self.head_dim:
+            raise ValueError("rotary_dim must not exceed head_dim")
+        self.rotary_dim = rotary_dim
+        self.dtype = x.dtype
         if not position_ids.is_cuda:
             raise ValueError("position_ids must be a CUDA tensor")
         if tuple(position_ids.shape) != (self.num_tokens,):
@@ -616,6 +655,7 @@ class RopeNeoxPositionIdsOp(Op):
             or bool(torch.any(position_ids >= self.max_position).item())
         ):
             raise ValueError("position_ids must be in [0, max_position)")
+        self.kernel = self._get_kernel(x.device.index)
         return x.contiguous(), position_ids.to(torch.int32).contiguous()
 
     def _eager_forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
@@ -652,14 +692,12 @@ class RopeNonNeoxOp(_RopeOpBase):
     _op_name = "rope_non_neox"
     kernel_cls = RopeNonNeoxKernel
 
-    def __init__(self, seq_len: int, head_dim: int, dtype: torch.dtype,
-                 layout: str = "1d", batch: int = 1, num_heads: int = 1,
+    def __init__(self, layout: str = "1d",
                  base: float = 10000.0,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False):
         self.base = base
-        super().__init__(seq_len, head_dim, dtype, layout, batch, num_heads,
-                         kernel_map, tune)
+        super().__init__(layout, kernel_map, tune)
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         return _base_freqs(self.head_dim, self.seq_len, base=self.base,
@@ -693,8 +731,7 @@ class RopeLlama31Op(_RopeOpBase):
     _op_name = "rope_llama31"
     kernel_cls = RopeLlama31Kernel
 
-    def __init__(self, seq_len: int, head_dim: int, dtype: torch.dtype,
-                 layout: str = "1d", batch: int = 1, num_heads: int = 1,
+    def __init__(self, layout: str = "1d",
                  base: float = 10000.0, scale_factor: float = 8.0,
                  low_freq_factor: float = 1.0, high_freq_factor: float = 4.0,
                  original_max_position: int = 8192,
@@ -705,8 +742,7 @@ class RopeLlama31Op(_RopeOpBase):
         self.low_freq_factor = low_freq_factor
         self.high_freq_factor = high_freq_factor
         self.original_max_position = original_max_position
-        super().__init__(seq_len, head_dim, dtype, layout, batch, num_heads,
-                         kernel_map, tune)
+        super().__init__(layout, kernel_map, tune)
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         return _llama31_freqs(
@@ -747,8 +783,7 @@ class RopeYarnOp(_RopeOpBase):
     _op_name = "rope_yarn"
     kernel_cls = RopeYarnKernel
 
-    def __init__(self, seq_len: int, head_dim: int, dtype: torch.dtype,
-                 layout: str = "1d", batch: int = 1, num_heads: int = 1,
+    def __init__(self, layout: str = "1d",
                  base: float = 10000.0, scale: float = 16.0,
                  original_max_position: int = 4096,
                  beta_fast: float = 32.0, beta_slow: float = 1.0,
@@ -761,8 +796,7 @@ class RopeYarnOp(_RopeOpBase):
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
         self.attn_factor = attn_factor
-        super().__init__(seq_len, head_dim, dtype, layout, batch, num_heads,
-                         kernel_map, tune)
+        super().__init__(layout, kernel_map, tune)
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         return _yarn_freqs(
@@ -803,8 +837,7 @@ class RopeLongRopeOp(_RopeOpBase):
     _op_name = "rope_longrope"
     kernel_cls = RopeLongRopeKernel
 
-    def __init__(self, seq_len: int, head_dim: int, dtype: torch.dtype,
-                 layout: str = "1d", batch: int = 1, num_heads: int = 1,
+    def __init__(self, layout: str = "1d",
                  base: float = 10000.0,
                  rescale_factors: Optional[torch.Tensor] = None,
                  max_position_embeddings: int = 4096,
@@ -815,8 +848,7 @@ class RopeLongRopeOp(_RopeOpBase):
         self.rescale_factors = rescale_factors
         self.max_position_embeddings = max_position_embeddings
         self.original_max_position_embeddings = original_max_position_embeddings
-        super().__init__(seq_len, head_dim, dtype, layout, batch, num_heads,
-                         kernel_map, tune)
+        super().__init__(layout, kernel_map, tune)
 
     def _compute_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         return _longrope_freqs(

--- a/tileops/ops/ssd_chunk_scan.py
+++ b/tileops/ops/ssd_chunk_scan.py
@@ -32,6 +32,28 @@ class SSDChunkScanFwdOp(Op):
 
     def __init__(
         self,
+        tune: bool = False,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+    ):
+        self.batch = None
+        self.num_chunks = None
+        self.chunk_len = None
+        self.n_heads = None
+        self.d_head = None
+        self.d_state = None
+        self.n_groups = None
+        self.dtype = None
+        self.tune = tune
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {"ssd_chunk_scan_fwd": SSDChunkScanFwdKernel}
+
+    def _get_kernel(
+        self,
         batch: int,
         num_chunks: int,
         chunk_len: int,
@@ -40,29 +62,33 @@ class SSDChunkScanFwdOp(Op):
         d_state: int,
         n_groups: int,
         dtype: torch.dtype,
-        tune: bool = False,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-    ):
-        self.batch = batch
-        self.num_chunks = num_chunks
-        self.chunk_len = chunk_len
-        self.n_heads = n_heads
-        self.d_head = d_head
-        self.d_state = d_state
-        self.n_groups = n_groups
-        if n_heads % n_groups != 0:
-            raise ValueError(
-                f"n_heads ({n_heads}) must be divisible by n_groups ({n_groups})"
-            )
-        self.dtype = dtype
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ssd_chunk_scan_fwd"](
-            batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype, tune=tune,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            num_chunks,
+            chunk_len,
+            n_heads,
+            d_head,
+            d_state,
+            n_groups,
+            dtype,
+            device_index,
+            self.tune,
         )
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"ssd_chunk_scan_fwd": SSDChunkScanFwdKernel}
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ssd_chunk_scan_fwd"](
+                batch,
+                num_chunks,
+                chunk_len,
+                n_heads,
+                d_head,
+                d_state,
+                n_groups,
+                dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -88,8 +114,39 @@ class SSDChunkScanFwdOp(Op):
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected dtype {self.dtype}, got {x.dtype}")
+        if x.ndim != 4:
+            raise ValueError("x must have shape [batch, seq_len, n_heads, d_head]")
+        batch, seq_len, n_heads, d_head = x.shape
+        if dA_cumsum.ndim != 4:
+            raise ValueError("dA_cumsum must have shape [batch, n_heads, num_chunks, chunk_len]")
+        if dA_cumsum.shape[0] != batch or dA_cumsum.shape[1] != n_heads:
+            raise ValueError("dA_cumsum must match x batch and n_heads")
+        num_chunks, chunk_len = dA_cumsum.shape[2], dA_cumsum.shape[3]
+        if seq_len != num_chunks * chunk_len:
+            raise ValueError("x seq_len must equal num_chunks * chunk_len")
+        if C.ndim != 4 or C.shape[0] != batch or C.shape[1] != seq_len:
+            raise ValueError("C must have shape [batch, seq_len, n_groups, d_state]")
+        n_groups, d_state = C.shape[2], C.shape[3]
+        if n_heads % n_groups != 0:
+            raise ValueError("n_heads must be divisible by n_groups")
+        if cb.shape != (batch, num_chunks, n_groups, chunk_len, chunk_len):
+            raise ValueError("cb must have shape [batch, num_chunks, n_groups, chunk_len, chunk_len]")
+        if prev_states.shape != (batch, num_chunks, n_heads, d_head, d_state):
+            raise ValueError("prev_states must have shape [batch, num_chunks, n_heads, d_head, d_state]")
+        if dt.shape != (batch, n_heads, num_chunks, chunk_len):
+            raise ValueError("dt must have shape [batch, n_heads, num_chunks, chunk_len]")
+
+        self.batch = batch
+        self.num_chunks = num_chunks
+        self.chunk_len = chunk_len
+        self.n_heads = n_heads
+        self.d_head = d_head
+        self.d_state = d_state
+        self.n_groups = n_groups
+        self.dtype = x.dtype
+        self.kernel = self._get_kernel(
+            batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, x.dtype,
+            x.device.index)
 
         x = x.contiguous()
         cb = cb.contiguous()

--- a/tileops/ops/ssd_chunk_state.py
+++ b/tileops/ops/ssd_chunk_state.py
@@ -38,6 +38,32 @@ class SSDChunkStateFwdOp(Op):
 
     def __init__(
         self,
+        has_seq_idx: bool = False,
+        tune: bool = False,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+    ):
+        self.batch = None
+        self.num_chunks = None
+        self.chunk_len = None
+        self.n_heads = None
+        self.d_head = None
+        self.d_state = None
+        self.n_groups = None
+        self.dtype = None
+        self.has_seq_idx = has_seq_idx
+        self.tune = tune
+        self.dispatch_kernel(kernel_map)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "ssd_chunk_state_fwd": SSDChunkStateFwdKernel,
+        }
+
+    def _get_kernel(
+        self,
         batch: int,
         num_chunks: int,
         chunk_len: int,
@@ -46,30 +72,35 @@ class SSDChunkStateFwdOp(Op):
         d_state: int,
         n_groups: int,
         dtype: torch.dtype,
-        has_seq_idx: bool = False,
-        tune: bool = False,
-        kernel_map: Optional[Dict[str, Kernel]] = None,
-    ):
-        self.batch = batch
-        self.num_chunks = num_chunks
-        self.chunk_len = chunk_len
-        self.n_heads = n_heads
-        self.d_head = d_head
-        self.d_state = d_state
-        self.n_groups = n_groups
-        self.dtype = dtype
-        self.has_seq_idx = has_seq_idx
-        self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ssd_chunk_state_fwd"](
-            batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, dtype,
-            has_seq_idx=has_seq_idx, tune=tune,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            num_chunks,
+            chunk_len,
+            n_heads,
+            d_head,
+            d_state,
+            n_groups,
+            dtype,
+            self.has_seq_idx,
+            device_index,
+            self.tune,
         )
-
-    @property
-    def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {
-            "ssd_chunk_state_fwd": SSDChunkStateFwdKernel,
-        }
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ssd_chunk_state_fwd"](
+                batch,
+                num_chunks,
+                chunk_len,
+                n_heads,
+                d_head,
+                d_state,
+                n_groups,
+                dtype,
+                has_seq_idx=self.has_seq_idx,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -93,8 +124,37 @@ class SSDChunkStateFwdOp(Op):
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected dtype {self.dtype}, got {x.dtype}")
+        if x.ndim != 4:
+            raise ValueError("x must have shape [batch, seq_len, n_heads, d_head]")
+        batch, seq_len, n_heads, d_head = x.shape
+        if dt.ndim != 4:
+            raise ValueError("dt must have shape [batch, n_heads, num_chunks, chunk_len]")
+        if dt.shape[0] != batch or dt.shape[1] != n_heads:
+            raise ValueError("dt must match x batch and n_heads")
+        num_chunks, chunk_len = dt.shape[2], dt.shape[3]
+        if seq_len != num_chunks * chunk_len:
+            raise ValueError("x seq_len must equal num_chunks * chunk_len")
+        if Bmat.ndim != 4 or Bmat.shape[0] != batch or Bmat.shape[1] != seq_len:
+            raise ValueError("Bmat must have shape [batch, seq_len, n_groups, d_state]")
+        n_groups, d_state = Bmat.shape[2], Bmat.shape[3]
+        if n_heads % n_groups != 0:
+            raise ValueError("n_heads must be divisible by n_groups")
+        if dA_cumsum.shape != (batch, n_heads, num_chunks, chunk_len):
+            raise ValueError("dA_cumsum must have shape [batch, n_heads, num_chunks, chunk_len]")
+        if seq_idx is not None and seq_idx.shape != (batch, seq_len):
+            raise ValueError("seq_idx must have shape [batch, seq_len]")
+
+        self.batch = batch
+        self.num_chunks = num_chunks
+        self.chunk_len = chunk_len
+        self.n_heads = n_heads
+        self.d_head = d_head
+        self.d_state = d_state
+        self.n_groups = n_groups
+        self.dtype = x.dtype
+        self.kernel = self._get_kernel(
+            batch, num_chunks, chunk_len, n_heads, d_head, d_state, n_groups, x.dtype,
+            x.device.index)
 
         x = x.contiguous()
         Bmat = Bmat.contiguous()

--- a/tileops/ops/ssd_decode.py
+++ b/tileops/ops/ssd_decode.py
@@ -37,33 +37,39 @@ class SSDDecodeOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        n_heads: int,
-        d_head: int,
-        d_state: int,
-        n_groups: int = 1,
-        dtype: torch.dtype = torch.float16,
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
-        self.batch = batch
-        self.n_heads = n_heads
-        self.d_head = d_head
-        self.d_state = d_state
-        self.n_groups = n_groups
-        if n_heads % n_groups != 0:
-            raise ValueError(
-                f"n_heads ({n_heads}) must be divisible by n_groups ({n_groups})"
-            )
-        self.dtype = dtype
+        self.batch = None
+        self.n_heads = None
+        self.d_head = None
+        self.d_state = None
+        self.n_groups = None
+        self.dtype = None
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ssd_decode"](
-            batch, n_heads, d_head, d_state, n_groups, dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ssd_decode": SSDDecodeKernel}
+
+    def _get_kernel(
+        self,
+        batch: int,
+        n_heads: int,
+        d_head: int,
+        d_state: int,
+        n_groups: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, n_heads, d_head, d_state, n_groups, dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ssd_decode"](
+                batch, n_heads, d_head, d_state, n_groups, dtype, tune=self.tune)
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -89,14 +95,40 @@ class SSDDecodeOp(Op):
         """
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
-        if x.dtype != self.dtype:
-            raise ValueError(f"Expected x dtype {self.dtype}, got {x.dtype}")
+        if x.ndim != 3:
+            raise ValueError("x must have shape [batch, n_heads, d_head]")
+        batch, n_heads, d_head = x.shape
+        if state.ndim != 4:
+            raise ValueError("state must have shape [batch, n_heads, d_head, d_state]")
+        if state.shape[:3] != (batch, n_heads, d_head):
+            raise ValueError("state must match x batch, n_heads, and d_head")
+        d_state = state.shape[3]
+        if B_in.ndim != 3 or B_in.shape[0] != batch or B_in.shape[2] != d_state:
+            raise ValueError("B_in must have shape [batch, n_groups, d_state]")
+        n_groups = B_in.shape[1]
+        if n_heads % n_groups != 0:
+            raise ValueError("n_heads must be divisible by n_groups")
+        if C_in.shape != (batch, n_groups, d_state):
+            raise ValueError("C_in must have shape [batch, n_groups, d_state]")
+        if A.shape != (n_heads, d_head, d_state):
+            raise ValueError("A must have shape [n_heads, d_head, d_state]")
+        if dt.shape != (batch, n_heads, d_head):
+            raise ValueError("dt must have shape [batch, n_heads, d_head]")
         if dt.dtype != torch.float32:
             raise ValueError(f"Expected float32 dt, got {dt.dtype}")
         if state.dtype != torch.float32:
             raise ValueError(f"Expected float32 state, got {state.dtype}")
         if not state.is_contiguous():
             raise ValueError("state must be contiguous for in-place update")
+
+        self.batch = batch
+        self.n_heads = n_heads
+        self.d_head = d_head
+        self.d_state = d_state
+        self.n_groups = n_groups
+        self.dtype = x.dtype
+        self.kernel = self._get_kernel(
+            batch, n_heads, d_head, d_state, n_groups, x.dtype, x.device.index)
 
         A = A.contiguous()
         dt = dt.contiguous()

--- a/tileops/ops/ssd_state_passing.py
+++ b/tileops/ops/ssd_state_passing.py
@@ -31,30 +31,55 @@ class SSDStatePassingFwdOp(Op):
 
     def __init__(
         self,
-        batch: int,
-        num_chunks: int,
-        n_heads: int,
-        d_state: int,
         has_initial_states: bool = True,
-        dtype: torch.dtype = torch.float16,
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
-        self.batch = batch
-        self.num_chunks = num_chunks
-        self.n_heads = n_heads
-        self.d_state = d_state
+        self.batch = None
+        self.num_chunks = None
+        self.n_heads = None
+        self.d_state = None
         self.has_initial_states = has_initial_states
-        self.dtype = dtype
+        self.dtype = None
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["ssd_state_passing_fwd"](
-            batch, num_chunks, n_heads, d_state,
-            has_initial_states=has_initial_states, dtype=dtype, tune=tune,
-        )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"ssd_state_passing_fwd": SSDStatePassingFwdKernel}
+
+    def _get_kernel(
+        self,
+        batch: int,
+        num_chunks: int,
+        n_heads: int,
+        d_state: int,
+        dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (
+            batch,
+            num_chunks,
+            n_heads,
+            d_state,
+            self.has_initial_states,
+            dtype,
+            device_index,
+            self.tune,
+        )
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["ssd_state_passing_fwd"](
+                batch,
+                num_chunks,
+                n_heads,
+                d_state,
+                has_initial_states=self.has_initial_states,
+                dtype=dtype,
+                tune=self.tune,
+            )
+        return self._kernel_cache[key]
 
     def forward(
         self,
@@ -75,8 +100,21 @@ class SSDStatePassingFwdOp(Op):
         """
         if not states.is_cuda:
             raise ValueError("states must be a CUDA tensor")
-        if states.dtype != self.dtype:
-            raise ValueError(f"Expected dtype {self.dtype}, got {states.dtype}")
+        if states.ndim != 4:
+            raise ValueError("states must have shape [batch, num_chunks, n_heads, d_state]")
+        batch, num_chunks, n_heads, d_state = states.shape
+        if dA_chunk_cumsum.shape != (batch, n_heads, num_chunks):
+            raise ValueError("dA_chunk_cumsum must have shape [batch, n_heads, num_chunks]")
+        if initial_states.shape != (batch, n_heads, d_state):
+            raise ValueError("initial_states must have shape [batch, n_heads, d_state]")
+
+        self.batch = batch
+        self.num_chunks = num_chunks
+        self.n_heads = n_heads
+        self.d_state = d_state
+        self.dtype = states.dtype
+        self.kernel = self._get_kernel(
+            batch, num_chunks, n_heads, d_state, states.dtype, states.device.index)
 
         states = states.contiguous()
         dA_chunk_cumsum = dA_chunk_cumsum.contiguous()

--- a/tileops/ops/topk_selector.py
+++ b/tileops/ops/topk_selector.py
@@ -13,38 +13,70 @@ __all__ = ["TopkSelectorOp"]
 class TopkSelectorOp(Op):
 
     def __init__(self,
-                 batch: int,
-                 seq_len: int,
-                 seq_len_kv: int,
-                 kv_group: int,
                  topk: int,
-                 in_dtype: torch.dtype,
-                 out_dtype: torch.dtype,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
-        self.batch = batch
-        self.seq_len = seq_len
-        self.seq_len_kv = seq_len_kv
-        self.kv_group = kv_group
+        self.batch = None
+        self.seq_len = None
+        self.seq_len_kv = None
+        self.kv_group = None
         self.topk = topk
-        self.in_dtype = in_dtype
-        self.out_dtype = out_dtype
+        self.in_dtype = None
+        self.out_dtype = torch.int32
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["topk_selector_kernel"](
-            self.batch,
-            self.seq_len,
-            self.seq_len_kv,
-            self.kv_group,
-            self.topk,
-            self.in_dtype,
-            self.out_dtype,
-            tune=tune)
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self.kernel = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"topk_selector_kernel": TopkSelectorKernel}
 
+    def _get_kernel(
+        self,
+        batch: int,
+        seq_len: int,
+        seq_len_kv: int,
+        kv_group: int,
+        in_dtype: torch.dtype,
+        device_index: int | None,
+    ) -> Kernel:
+        key = (batch, seq_len, seq_len_kv, kv_group, self.topk, in_dtype, device_index, self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map["topk_selector_kernel"](
+                batch,
+                seq_len,
+                seq_len_kv,
+                kv_group,
+                self.topk,
+                in_dtype,
+                self.out_dtype,
+                tune=self.tune)
+        return self._kernel_cache[key]
+
     def forward(self, index_score, starts, ends) -> torch.Tensor:
+        if not index_score.is_cuda:
+            raise ValueError("TopkSelectorOp expects CUDA inputs")
+        if index_score.ndim != 4:
+            raise ValueError("TopkSelectorOp expects index_score shape [B, S, S_kv, G]")
+        if starts.ndim != 2 or ends.ndim != 2:
+            raise ValueError("TopkSelectorOp expects starts/ends shape [B, S]")
+        if starts.dtype != torch.int32 or ends.dtype != torch.int32:
+            raise ValueError("TopkSelectorOp expects int32 starts/ends tensors")
+
+        batch, seq_len, seq_len_kv, kv_group = index_score.shape
+        if starts.shape != (batch, seq_len) or ends.shape != (batch, seq_len):
+            raise ValueError("TopkSelectorOp starts/ends must match index_score batch/seq_len")
+        if not 0 < self.topk <= seq_len_kv:
+            raise ValueError(f"topk must satisfy 0 < topk <= seq_len_kv={seq_len_kv}")
+
+        self.batch = batch
+        self.seq_len = seq_len
+        self.seq_len_kv = seq_len_kv
+        self.kv_group = kv_group
+        self.in_dtype = index_score.dtype
+        self.kernel = self._get_kernel(
+            batch, seq_len, seq_len_kv, kv_group, index_score.dtype, index_score.device.index)
 
         return self.kernel(index_score, starts, ends)

--- a/tileops/ops/topk_selector.py
+++ b/tileops/ops/topk_selector.py
@@ -62,6 +62,8 @@ class TopkSelectorOp(Op):
             raise ValueError("TopkSelectorOp expects index_score shape [B, S, S_kv, G]")
         if starts.ndim != 2 or ends.ndim != 2:
             raise ValueError("TopkSelectorOp expects starts/ends shape [B, S]")
+        if not starts.is_cuda or not ends.is_cuda:
+            raise ValueError("starts and ends must be CUDA tensors")
         if starts.dtype != torch.int32 or ends.dtype != torch.int32:
             raise ValueError("TopkSelectorOp expects int32 starts/ends tensors")
 


### PR DESCRIPTION
## Problem

Operator constructors duplicate shape and dtype metadata already available from `forward()` inputs. Closes #1679.

## Solution

- Infer static tensor metadata from inputs and lazily cache kernels by resolved signature.
- Keep semantic configuration such as `chunk_size`, layout, scale, RoPE settings, and `topk` in constructors.
- Update manifests, tests, and benchmarks for the input-inferred APIs.
- Add validation and hot-path signature reuse for affected regularization, FFT, GEMM, MHC, indexing, RoPE, Mamba/SSD, GLA, and DeltaNet ops.

MoE constructors remain out of scope.

## Validation

- `py_compile`, Ruff, and `git diff --check`
- Manifest schema, shape, dtype, and benchmark validation
- `pytest -q tests/ops -m smoke`: 2342 passed, 5 skipped
- GitHub CI, including GPU smoke: passed
