### PR TITLE
[Fix][Manifest] Retarget ClampMax source test

### DIFF
--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -552,7 +552,7 @@ ClampMaxFwdOp:
     kernel_map:
       clamp_tensor: ClampTensorFwdKernel
     op: tileops/ops/elementwise/clamp.py
-    test: tests/ops/test_special_elementwise.py
+    test: tests/ops/test_special_elementwise_conformance.py
     bench: benchmarks/ops/bench_independent_elementwise.py
     bench_manifest_driven: true
 


### PR DESCRIPTION
### Summary

- Retarget `ClampMaxFwdOp.source.test` to `tests/ops/test_special_elementwise_conformance.py`.
- Align the manifest with the current location of the dedicated ClampMax conformance tests.
- Restore per-operator test discovery for manifest-driven and case-aware reports without changing the implementation or benchmark mapping.

### Why

`ClampMaxFwdOp` is already implemented and has dedicated conformance coverage, including tensor inputs, PyTorch-aligned initialization, and NaN propagation.

However, the manifest still points `ClampMaxFwdOp.source.test` to `tests/ops/test_special_elementwise.py`, while the relevant tests are located in `tests/ops/test_special_elementwise_conformance.py`.

Tools that use `source.test` to discover operator cases can therefore fail to associate the existing ClampMax tests with `ClampMaxFwdOp` and report `no case`, even though the operator implementation and tests are present.

This metadata-only fix keeps the manifest aligned with the current test layout.

### Validation

- `python scripts/validate_manifest.py --check-op ClampMaxFwdOp`
- `python -m pytest --collect-only -q tests/ops/test_special_elementwise_conformance.py -k 'clamp'`
- `git diff --check`
- TileOPs-MUSA fork conformance:
  `TILEOPS_BACKEND=musa TILEOPS_TARGET=musa python -m pytest tests/ops/test_special_elementwise_conformance.py -k 'clamp'`
  (`32 passed, 49 deselected`)