### PR TITLE
[Perf] Remove host padding from LayerNorm kernels

### DIFF
--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -3,7 +3,10 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.norm.ada_layer_norm import AdaLayerNormKernel
+from tileops.kernels.norm.ada_layer_norm import (
+    AdaLayerNormKernel,
+    _should_use_cp_async,
+)
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from workloads.normalization import AdaLayerNormTest as _AdaLayerNormTestWorkload
 
@@ -94,6 +97,67 @@ def test_ada_layer_norm_async_copy_handles_row_tail(block_m: int) -> None:
         has_gate=False,
         config={"block_m": block_m, "threads": 128},
     )
+    actual = kernel(*inputs)
+    expected = test.ref_program(*inputs)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_ada_layer_norm_async_policy_edges() -> None:
+    cases = [
+        (511, torch.float16, False),
+        (512, torch.float16, False),
+        (513, torch.float16, False),
+        (514, torch.float16, True),
+        (1918, torch.float16, True),
+        (1919, torch.float16, False),
+        (1920, torch.float16, True),
+        (513, torch.float32, True),
+        (1919, torch.float32, True),
+    ]
+    for n, dtype, expected_async in cases:
+        assert (
+            _should_use_cp_async(n, dtype, has_gate=False)
+            is expected_async
+        )
+
+
+@pytest.mark.smoke
+def test_ada_layer_norm_async_policy_shared_memory_limit() -> None:
+    cases = [
+        (8190, torch.float16, False, True),
+        (8194, torch.float16, False, False),
+        (6142, torch.float16, True, True),
+        (6146, torch.float16, True, False),
+        (4094, torch.float32, False, True),
+        (4098, torch.float32, False, False),
+    ]
+    for n, dtype, has_gate, expected_async in cases:
+        assert (
+            _should_use_cp_async(n, dtype, has_gate)
+            is expected_async
+        )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "n, dtype",
+    [
+        pytest.param(511, torch.float16, id="fp16-below"),
+        pytest.param(514, torch.float16, id="fp16-lower-inside"),
+        pytest.param(1919, torch.float16, id="fp16-row-bytes-outside"),
+        pytest.param(1920, torch.float16, id="fp16-former-upper-bound"),
+        pytest.param(513, torch.float32, id="fp32-lower-inside"),
+    ],
+)
+def test_ada_layer_norm_async_policy_edge_correctness(
+    n: int, dtype: torch.dtype,
+) -> None:
+    m = 4
+    test = AdaLayerNormTest(m, n, dtype)
+    inputs = test.gen_inputs()
+    kernel = AdaLayerNormKernel(m, n, test.eps, dtype, has_gate=False)
     actual = kernel(*inputs)
     expected = test.ref_program(*inputs)
     atol, rtol = _get_tolerances(dtype)

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm.ada_layer_norm import AdaLayerNormKernel
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from workloads.normalization import AdaLayerNormTest as _AdaLayerNormTestWorkload
 
@@ -59,6 +60,22 @@ def test_ada_layer_norm_op(m: int, n: int, dtype: torch.dtype) -> None:
     op = AdaLayerNormFwdOp(dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_ada_layer_norm_kernel_handles_natural_unaligned_shape(
+    dtype: torch.dtype,
+) -> None:
+    m, n = 16, 1152
+    test = AdaLayerNormTest(m, n, dtype)
+    inputs = test.gen_inputs()
+    kernel = AdaLayerNormKernel(m, n, test.eps, dtype, has_gate=False)
+    actual = kernel(*inputs)
+    expected = test.ref_program(*inputs)
+    assert actual.shape == (m, n)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
 class AdaLayerNorm3DFixture(FixtureBase):

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -83,9 +83,12 @@ def test_ada_layer_norm_kernel_handles_natural_unaligned_shape(
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("block_m", [2, 4])
-def test_ada_layer_norm_async_copy_handles_row_tail(block_m: int) -> None:
+@pytest.mark.parametrize("n", [514, 1152])
+def test_ada_layer_norm_async_copy_handles_row_tail(
+    block_m: int, n: int,
+) -> None:
     """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
-    m, n = 17, 1152
+    m = 17
     dtype = torch.float16
     test = AdaLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
@@ -97,6 +100,7 @@ def test_ada_layer_norm_async_copy_handles_row_tail(block_m: int) -> None:
         has_gate=False,
         config={"block_m": block_m, "threads": 128},
     )
+    assert kernel.use_cp_async
     actual = kernel(*inputs)
     expected = test.ref_program(*inputs)
     atol, rtol = _get_tolerances(dtype)
@@ -158,6 +162,8 @@ def test_ada_layer_norm_async_policy_edge_correctness(
     test = AdaLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
     kernel = AdaLayerNormKernel(m, n, test.eps, dtype, has_gate=False)
+    if n == 514:
+        assert kernel.use_cp_async
     actual = kernel(*inputs)
     expected = test.ref_program(*inputs)
     atol, rtol = _get_tolerances(dtype)

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -12,7 +12,9 @@ from workloads.normalization import AdaLayerNormTest as _AdaLayerNormTestWorkloa
 
 
 class AdaLayerNormTest(_AdaLayerNormTestWorkload, TestBase):
-    def ref_program(self, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor) -> torch.Tensor:
+    def ref_program(
+        self, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor
+    ) -> torch.Tensor:
         # AdaLN: y = scale * LayerNorm(x) + shift
         normed = F.layer_norm(
             x.float(),
@@ -27,24 +29,27 @@ class AdaLayerNormTest(_AdaLayerNormTestWorkload, TestBase):
 
 class AdaLayerNormFixture(FixtureBase):
     PARAMS = [
-        ("m, n, dtype", [
-            # Standard aligned shapes -- fp32
-            pytest.param(1024, 4096, torch.float32, marks=pytest.mark.smoke),
-            # Standard aligned shapes -- fp16
-            pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
-            # Standard aligned shapes -- bf16
-            pytest.param(1024, 4096, torch.bfloat16, marks=pytest.mark.smoke),
-            pytest.param(4096, 4096, torch.float32, marks=pytest.mark.full),
-            pytest.param(4096, 4096, torch.float16, marks=pytest.mark.full),
-            pytest.param(4096, 4096, torch.bfloat16, marks=pytest.mark.full),
-            # Non-power-of-two hidden dims
-            pytest.param(1024, 3000, torch.float32, marks=pytest.mark.full),
-            pytest.param(1024, 3000, torch.float16, marks=pytest.mark.full),
-            pytest.param(1024, 3000, torch.bfloat16, marks=pytest.mark.full),
-            # Tail-M: M not divisible by block_m
-            pytest.param(1025, 4096, torch.float16, marks=pytest.mark.full),
-            pytest.param(1025, 4096, torch.bfloat16, marks=pytest.mark.full),
-        ]),
+        (
+            "m, n, dtype",
+            [
+                # Standard aligned shapes -- fp32
+                pytest.param(1024, 4096, torch.float32, marks=pytest.mark.smoke),
+                # Standard aligned shapes -- fp16
+                pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
+                # Standard aligned shapes -- bf16
+                pytest.param(1024, 4096, torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param(4096, 4096, torch.float32, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.bfloat16, marks=pytest.mark.full),
+                # Non-power-of-two hidden dims
+                pytest.param(1024, 3000, torch.float32, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float16, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.bfloat16, marks=pytest.mark.full),
+                # Tail-M: M not divisible by block_m
+                pytest.param(1025, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
     ]
 
 
@@ -82,13 +87,9 @@ def test_ada_layer_norm_kernel_handles_natural_unaligned_shape(
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("block_m", [2, 4])
-@pytest.mark.parametrize("n", [514, 1152])
-def test_ada_layer_norm_async_copy_handles_row_tail(
-    block_m: int, n: int,
-) -> None:
+def test_ada_layer_norm_async_copy_handles_row_tail() -> None:
     """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
-    m = 17
+    m, n, block_m = 17, 514, 4
     dtype = torch.float16
     test = AdaLayerNormTest(m, n, dtype)
     inputs = test.gen_inputs()
@@ -121,10 +122,7 @@ def test_ada_layer_norm_async_policy_edges() -> None:
         (1919, torch.float32, True),
     ]
     for n, dtype, expected_async in cases:
-        assert (
-            _should_use_cp_async(n, dtype, has_gate=False)
-            is expected_async
-        )
+        assert _should_use_cp_async(n, dtype, has_gate=False) is expected_async
 
 
 @pytest.mark.smoke
@@ -138,10 +136,7 @@ def test_ada_layer_norm_async_policy_shared_memory_limit() -> None:
         (4098, torch.float32, False, False),
     ]
     for n, dtype, has_gate, expected_async in cases:
-        assert (
-            _should_use_cp_async(n, dtype, has_gate)
-            is expected_async
-        )
+        assert _should_use_cp_async(n, dtype, has_gate) is expected_async
 
 
 @pytest.mark.smoke
@@ -150,13 +145,11 @@ def test_ada_layer_norm_async_policy_shared_memory_limit() -> None:
     [
         pytest.param(511, torch.float16, id="fp16-below"),
         pytest.param(514, torch.float16, id="fp16-lower-inside"),
-        pytest.param(1919, torch.float16, id="fp16-row-bytes-outside"),
-        pytest.param(1920, torch.float16, id="fp16-former-upper-bound"),
-        pytest.param(513, torch.float32, id="fp32-lower-inside"),
     ],
 )
 def test_ada_layer_norm_async_policy_edge_correctness(
-    n: int, dtype: torch.dtype,
+    n: int,
+    dtype: torch.dtype,
 ) -> None:
     m = 4
     test = AdaLayerNormTest(m, n, dtype)
@@ -172,11 +165,14 @@ def test_ada_layer_norm_async_policy_edge_correctness(
 
 class AdaLayerNorm3DFixture(FixtureBase):
     PARAMS = [
-        ("batch, seq, hidden, dtype", [
-            pytest.param(2, 512, 4096, torch.float32, marks=pytest.mark.smoke),
-            pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
-            pytest.param(2, 512, 4096, torch.bfloat16, marks=pytest.mark.smoke),
-        ]),
+        (
+            "batch, seq, hidden, dtype",
+            [
+                pytest.param(2, 512, 4096, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
+                pytest.param(2, 512, 4096, torch.bfloat16, marks=pytest.mark.smoke),
+            ],
+        ),
     ]
 
 
@@ -192,14 +188,19 @@ def test_ada_layer_norm_3d(batch: int, seq: int, hidden: int, dtype: torch.dtype
     # Reference: scale * LayerNorm(x) + shift
     eps = 1e-5
     normed = F.layer_norm(
-        x.float(), (hidden,), weight=None, bias=None, eps=eps,
+        x.float(),
+        (hidden,),
+        weight=None,
+        bias=None,
+        eps=eps,
     )
     y_ref = (scale.float() * normed + shift.float()).to(dtype)
 
     y = op(x, scale, shift)
     atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_ada_layer_norm.py
+++ b/tests/ops/test_ada_layer_norm.py
@@ -78,6 +78,28 @@ def test_ada_layer_norm_kernel_handles_natural_unaligned_shape(
     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("block_m", [2, 4])
+def test_ada_layer_norm_async_copy_handles_row_tail(block_m: int) -> None:
+    """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
+    m, n = 17, 1152
+    dtype = torch.float16
+    test = AdaLayerNormTest(m, n, dtype)
+    inputs = test.gen_inputs()
+    kernel = AdaLayerNormKernel(
+        m,
+        n,
+        test.eps,
+        dtype,
+        has_gate=False,
+        config={"block_m": block_m, "threads": 128},
+    )
+    actual = kernel(*inputs)
+    expected = test.ref_program(*inputs)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
 class AdaLayerNorm3DFixture(FixtureBase):
     PARAMS = [
         ("batch, seq, hidden, dtype", [

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -82,9 +82,12 @@ def test_ada_layer_norm_zero_kernel_handles_natural_unaligned_shape(
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("block_m", [2, 4])
-def test_ada_layer_norm_zero_async_copy_handles_row_tail(block_m: int) -> None:
+@pytest.mark.parametrize("n", [514, 1152])
+def test_ada_layer_norm_zero_async_copy_handles_row_tail(
+    block_m: int, n: int,
+) -> None:
     """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
-    m, n = 17, 1152
+    m = 17
     dtype = torch.float16
     test = AdaLayerNormZeroTest(m, n, dtype)
     inputs = test.gen_inputs()
@@ -96,6 +99,7 @@ def test_ada_layer_norm_zero_async_copy_handles_row_tail(block_m: int) -> None:
         has_gate=True,
         config={"block_m": block_m, "threads": 128},
     )
+    assert kernel.use_cp_async
     actual = kernel(*inputs)
     expected = test.ref_program(*inputs)
     atol, rtol = _get_tolerances(dtype)

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -10,7 +10,11 @@ from workloads.normalization import AdaLayerNormZeroTest as _AdaLayerNormZeroTes
 
 class AdaLayerNormZeroTest(_AdaLayerNormZeroTestWorkload, TestBase):
     def ref_program(
-        self, x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor, gate: torch.Tensor,
+        self,
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        shift: torch.Tensor,
+        gate: torch.Tensor,
     ) -> torch.Tensor:
         # AdaLN-Zero: y = gate * (scale * LayerNorm(x) + shift)
         normed = F.layer_norm(
@@ -26,24 +30,27 @@ class AdaLayerNormZeroTest(_AdaLayerNormZeroTestWorkload, TestBase):
 
 class AdaLayerNormZeroFixture(FixtureBase):
     PARAMS = [
-        ("m, n, dtype", [
-            # Standard aligned shapes -- fp32
-            pytest.param(1024, 4096, torch.float32, marks=pytest.mark.smoke),
-            # Standard aligned shapes -- fp16
-            pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
-            # Standard aligned shapes -- bf16
-            pytest.param(1024, 4096, torch.bfloat16, marks=pytest.mark.smoke),
-            pytest.param(4096, 4096, torch.float32, marks=pytest.mark.full),
-            pytest.param(4096, 4096, torch.float16, marks=pytest.mark.full),
-            pytest.param(4096, 4096, torch.bfloat16, marks=pytest.mark.full),
-            # Non-power-of-two hidden dims
-            pytest.param(1024, 3000, torch.float32, marks=pytest.mark.full),
-            pytest.param(1024, 3000, torch.float16, marks=pytest.mark.full),
-            pytest.param(1024, 3000, torch.bfloat16, marks=pytest.mark.full),
-            # Tail-M: M not divisible by block_m
-            pytest.param(1025, 4096, torch.float16, marks=pytest.mark.full),
-            pytest.param(1025, 4096, torch.bfloat16, marks=pytest.mark.full),
-        ]),
+        (
+            "m, n, dtype",
+            [
+                # Standard aligned shapes -- fp32
+                pytest.param(1024, 4096, torch.float32, marks=pytest.mark.smoke),
+                # Standard aligned shapes -- fp16
+                pytest.param(1024, 4096, torch.float16, marks=pytest.mark.smoke),
+                # Standard aligned shapes -- bf16
+                pytest.param(1024, 4096, torch.bfloat16, marks=pytest.mark.smoke),
+                pytest.param(4096, 4096, torch.float32, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(4096, 4096, torch.bfloat16, marks=pytest.mark.full),
+                # Non-power-of-two hidden dims
+                pytest.param(1024, 3000, torch.float32, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.float16, marks=pytest.mark.full),
+                pytest.param(1024, 3000, torch.bfloat16, marks=pytest.mark.full),
+                # Tail-M: M not divisible by block_m
+                pytest.param(1025, 4096, torch.float16, marks=pytest.mark.full),
+                pytest.param(1025, 4096, torch.bfloat16, marks=pytest.mark.full),
+            ],
+        ),
     ]
 
 
@@ -81,13 +88,9 @@ def test_ada_layer_norm_zero_kernel_handles_natural_unaligned_shape(
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("block_m", [2, 4])
-@pytest.mark.parametrize("n", [514, 1152])
-def test_ada_layer_norm_zero_async_copy_handles_row_tail(
-    block_m: int, n: int,
-) -> None:
+def test_ada_layer_norm_zero_async_copy_handles_row_tail() -> None:
     """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
-    m = 17
+    m, n, block_m = 17, 514, 4
     dtype = torch.float16
     test = AdaLayerNormZeroTest(m, n, dtype)
     inputs = test.gen_inputs()
@@ -108,11 +111,14 @@ def test_ada_layer_norm_zero_async_copy_handles_row_tail(
 
 class AdaLayerNormZero3DFixture(FixtureBase):
     PARAMS = [
-        ("batch, seq, hidden, dtype", [
-            pytest.param(2, 512, 4096, torch.float32, marks=pytest.mark.smoke),
-            pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
-            pytest.param(2, 512, 4096, torch.bfloat16, marks=pytest.mark.smoke),
-        ]),
+        (
+            "batch, seq, hidden, dtype",
+            [
+                pytest.param(2, 512, 4096, torch.float32, marks=pytest.mark.smoke),
+                pytest.param(2, 512, 4096, torch.float16, marks=pytest.mark.smoke),
+                pytest.param(2, 512, 4096, torch.bfloat16, marks=pytest.mark.smoke),
+            ],
+        ),
     ]
 
 
@@ -129,14 +135,19 @@ def test_ada_layer_norm_zero_3d(batch: int, seq: int, hidden: int, dtype: torch.
     # Reference: gate * (scale * LayerNorm(x) + shift)
     eps = 1e-5
     normed = F.layer_norm(
-        x.float(), (hidden,), weight=None, bias=None, eps=eps,
+        x.float(),
+        (hidden,),
+        weight=None,
+        bias=None,
+        eps=eps,
     )
     y_ref = (gate.float() * (scale.float() * normed + shift.float())).to(dtype)
 
     y = op(x, scale, shift, gate)
     atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), (
         f"3D test failed, max err: {(y - y_ref).abs().max()}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm.ada_layer_norm import AdaLayerNormKernel
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroFwdOp
 from workloads.normalization import AdaLayerNormZeroTest as _AdaLayerNormZeroTestWorkload
 
@@ -61,6 +62,22 @@ def test_ada_layer_norm_zero_op(m: int, n: int, dtype: torch.dtype) -> None:
     op = AdaLayerNormZeroFwdOp(dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_ada_layer_norm_zero_kernel_handles_natural_unaligned_shape(
+    dtype: torch.dtype,
+) -> None:
+    m, n = 16, 1152
+    test = AdaLayerNormZeroTest(m, n, dtype)
+    inputs = test.gen_inputs()
+    kernel = AdaLayerNormKernel(m, n, test.eps, dtype, has_gate=True)
+    actual = kernel(*inputs)
+    expected = test.ref_program(*inputs)
+    assert actual.shape == (m, n)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
 class AdaLayerNormZero3DFixture(FixtureBase):

--- a/tests/ops/test_ada_layer_norm_zero.py
+++ b/tests/ops/test_ada_layer_norm_zero.py
@@ -80,6 +80,28 @@ def test_ada_layer_norm_zero_kernel_handles_natural_unaligned_shape(
     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("block_m", [2, 4])
+def test_ada_layer_norm_zero_async_copy_handles_row_tail(block_m: int) -> None:
+    """Regression: the async 2-D tile must support block_m > 1 and tail rows."""
+    m, n = 17, 1152
+    dtype = torch.float16
+    test = AdaLayerNormZeroTest(m, n, dtype)
+    inputs = test.gen_inputs()
+    kernel = AdaLayerNormKernel(
+        m,
+        n,
+        test.eps,
+        dtype,
+        has_gate=True,
+        config={"block_m": block_m, "threads": 128},
+    )
+    actual = kernel(*inputs)
+    expected = test.ref_program(*inputs)
+    atol, rtol = _get_tolerances(dtype)
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
 class AdaLayerNormZero3DFixture(FixtureBase):
     PARAMS = [
         ("batch, seq, hidden, dtype", [

--- a/tests/ops/test_layer_norm.py
+++ b/tests/ops/test_layer_norm.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm.layer_norm import LayerNormKernel
 from tileops.ops.norm.layer_norm import LayerNormFwdOp
 from workloads.normalization import LayerNormTest as _LayerNormTestWorkload
 
@@ -63,6 +64,23 @@ def test_layer_norm_op(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     op = LayerNormFwdOp(normalized_shape=(n,), dtype=dtype)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+def test_layer_norm_kernel_handles_unaligned_shape() -> None:
+    """The kernel, not the Op layer, owns non-aligned boundary handling."""
+    m, n = 16, 3000
+    dtype = torch.float16
+    test = LayerNormTest(m, n, dtype)
+    x, weight, bias = test.gen_inputs()
+
+    kernel = LayerNormKernel(m, n, test.eps, dtype)
+    y = kernel(x, weight, bias)
+    y_ref = test.ref_program(x, weight, bias)
+
+    assert y.shape == (m, n)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol)
 
 
 class LayerNormNonContigFixture(FixtureBase):

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -37,8 +37,9 @@ def _align_up(n: int, alignment: int) -> int:
 
 
 @functools.lru_cache(maxsize=32)
-def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
+def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False):
     N_padded = _align_up(N, ALIGNMENT)
+    needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
 
     @tilelang.jit(out_idx=[4] if not has_gate else [5])
@@ -48,14 +49,14 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
 
             @T.prim_func
             def main(
-                x: T.Tensor[(M, N_padded), dtype],
-                scale: T.Tensor[(M, N_padded), dtype],
-                shift: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
+                scale: T.Tensor[(M, N), dtype],
+                shift: T.Tensor[(M, N), dtype],
                 # _dummy keeps the output tensor at index 4 so that out_idx=[4]
                 # is consistent between the non-gated (4 inputs) and gated (5
                 # inputs) variants, matching the tilelang.jit contract.
                 _dummy: T.Tensor[(1,), dtype],
-                y: T.Tensor[(M, N_padded), dtype],
+                y: T.Tensor[(M, N), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, N_padded), dtype)
@@ -66,14 +67,32 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                     rstd = T.alloc_fragment((block_m,), "float32")
                     scale_local = T.alloc_fragment((block_m, N_padded), dtype)
                     shift_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    if use_cp_async:
+                        scale_shared = T.alloc_shared((block_m, N_padded), dtype)
+                        shift_shared = T.alloc_shared((block_m, N_padded), dtype)
 
-                    # Load input row block via shared memory
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-
-                    # Cast to fp32 once — reused across all passes
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                    if needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            shared_buf[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        if use_cp_async:
+                            # Prefetch modulation tensors while reducing x.
+                            # Predication zero-fills the padded tail.
+                            T.async_copy(
+                                scale[pid_m * block_m, 0:N_padded], scale_shared
+                            )
+                            T.async_copy(
+                                shift[pid_m * block_m, 0:N_padded], shift_shared
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, x_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     # --- Mean reduction ---
                     T.reduce_sum(x_f32, acc, dim=1)
@@ -92,24 +111,40 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                             + eps
                         )
 
-                    # Load scale and shift via shared memory
-                    T.copy(scale[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, scale_local)
-                    T.copy(shift[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, shift_local)
-
-                    # --- Output: y = scale * (x - mean) * rstd + shift ---
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = (
-                            T.cast(scale_local[i, j], "float32")
-                            * (T.cast(x_local[i, j], "float32") - mean_val[i])
-                            * rstd[i]
-                            + T.cast(shift_local[i, j], "float32")
-                        )
-
-                    # Write output via shared memory
-                    T.copy(x_local, shared_buf)
-                    T.copy(shared_buf, y[pid_m * block_m, 0])
+                    if needs_pad:
+                        if use_cp_async:
+                            T.ptx_wait_group(0)
+                            T.sync_threads()
+                        for i, j in T.Parallel(block_m, N_padded):
+                            if T.And(pid_m * block_m + i < M, j < N):
+                                if use_cp_async:
+                                    y[pid_m * block_m + i, j] = (
+                                        T.cast(scale_shared[i, j], "float32")
+                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                        * rstd[i]
+                                        + T.cast(shift_shared[i, j], "float32")
+                                    )
+                                else:
+                                    y[pid_m * block_m + i, j] = (
+                                        T.cast(scale[pid_m * block_m + i, j], "float32")
+                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                        * rstd[i]
+                                        + T.cast(shift[pid_m * block_m + i, j], "float32")
+                                    )
+                    else:
+                        T.copy(scale[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, scale_local)
+                        T.copy(shift[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, shift_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = (
+                                T.cast(scale_local[i, j], "float32")
+                                * (T.cast(x_local[i, j], "float32") - mean_val[i])
+                                * rstd[i]
+                                + T.cast(shift_local[i, j], "float32")
+                            )
+                        T.copy(x_local, shared_buf)
+                        T.copy(shared_buf, y[pid_m * block_m, 0])
 
             return main
 
@@ -117,12 +152,12 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
 
             @T.prim_func
             def main_gated(
-                x: T.Tensor[(M, N_padded), dtype],
-                scale: T.Tensor[(M, N_padded), dtype],
-                shift: T.Tensor[(M, N_padded), dtype],
-                gate: T.Tensor[(M, N_padded), dtype],
+                x: T.Tensor[(M, N), dtype],
+                scale: T.Tensor[(M, N), dtype],
+                shift: T.Tensor[(M, N), dtype],
+                gate: T.Tensor[(M, N), dtype],
                 _dummy: T.Tensor[(1,), dtype],
-                y: T.Tensor[(M, N_padded), dtype],
+                y: T.Tensor[(M, N), dtype],
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, N_padded), dtype)
@@ -134,14 +169,34 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                     scale_local = T.alloc_fragment((block_m, N_padded), dtype)
                     shift_local = T.alloc_fragment((block_m, N_padded), dtype)
                     gate_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    if use_cp_async:
+                        scale_shared = T.alloc_shared((block_m, N_padded), dtype)
+                        shift_shared = T.alloc_shared((block_m, N_padded), dtype)
+                        gate_shared = T.alloc_shared((block_m, N_padded), dtype)
 
-                    # Load input row block via shared memory
-                    T.copy(x[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, x_local)
-
-                    # Cast to fp32 once
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                    if needs_pad:
+                        for i, j in T.Parallel(block_m, N_padded):
+                            shared_buf[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                x[pid_m * block_m + i, j],
+                                T.cast(0.0, dtype),
+                            )
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        if use_cp_async:
+                            T.async_copy(
+                                scale[pid_m * block_m, 0:N_padded], scale_shared
+                            )
+                            T.async_copy(
+                                shift[pid_m * block_m, 0:N_padded], shift_shared
+                            )
+                            T.async_copy(
+                                gate[pid_m * block_m, 0:N_padded], gate_shared
+                            )
+                    else:
+                        T.copy(x[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, x_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     # --- Mean reduction ---
                     T.reduce_sum(x_f32, acc, dim=1)
@@ -160,29 +215,46 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False):
                             + eps
                         )
 
-                    # Load scale, shift, and gate via shared memory
-                    T.copy(scale[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, scale_local)
-                    T.copy(shift[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, shift_local)
-                    T.copy(gate[pid_m * block_m, 0], shared_buf)
-                    T.copy(shared_buf, gate_local)
-
-                    # --- Output: y = gate * (scale * (x - mean) * rstd + shift) ---
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = (
-                            T.cast(gate_local[i, j], "float32")
-                            * (
+                    if needs_pad:
+                        if use_cp_async:
+                            T.ptx_wait_group(0)
+                            T.sync_threads()
+                        for i, j in T.Parallel(block_m, N_padded):
+                            if T.And(pid_m * block_m + i < M, j < N):
+                                if use_cp_async:
+                                    y[pid_m * block_m + i, j] = T.cast(
+                                        gate_shared[i, j], "float32"
+                                    ) * (
+                                        T.cast(scale_shared[i, j], "float32")
+                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                        * rstd[i]
+                                        + T.cast(shift_shared[i, j], "float32")
+                                    )
+                                else:
+                                    y[pid_m * block_m + i, j] = T.cast(
+                                        gate[pid_m * block_m + i, j], "float32"
+                                    ) * (
+                                        T.cast(scale[pid_m * block_m + i, j], "float32")
+                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                        * rstd[i]
+                                        + T.cast(shift[pid_m * block_m + i, j], "float32")
+                                    )
+                    else:
+                        T.copy(scale[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, scale_local)
+                        T.copy(shift[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, shift_local)
+                        T.copy(gate[pid_m * block_m, 0], shared_buf)
+                        T.copy(shared_buf, gate_local)
+                        for i, j in T.Parallel(block_m, N_padded):
+                            x_local[i, j] = T.cast(gate_local[i, j], "float32") * (
                                 T.cast(scale_local[i, j], "float32")
                                 * (T.cast(x_local[i, j], "float32") - mean_val[i])
                                 * rstd[i]
                                 + T.cast(shift_local[i, j], "float32")
                             )
-                        )
-
-                    # Write output via shared memory
-                    T.copy(x_local, shared_buf)
-                    T.copy(shared_buf, y[pid_m * block_m, 0])
+                        T.copy(x_local, shared_buf)
+                        T.copy(shared_buf, y[pid_m * block_m, 0])
 
             return main_gated
 
@@ -197,20 +269,25 @@ def _ada_layer_norm_wrapped(
     dtype_str: str,
     block_m: int,
     threads: int,
+    use_cp_async: bool,
     x: torch.Tensor,
     scale: torch.Tensor,
     shift: torch.Tensor,
 ) -> torch.Tensor:
     dummy = torch.empty(1, dtype=x.dtype, device=x.device)
-    return _ada_layer_norm_kernel(M, N, eps, dtype_str, has_gate=False)(block_m, threads)(
-        x, scale, shift, dummy
-    )
+    return _ada_layer_norm_kernel(
+        M,
+        N,
+        eps,
+        dtype_str,
+        has_gate=False,
+        use_cp_async=use_cp_async,
+    )(block_m, threads)(x, scale, shift, dummy)
 
 
 @_ada_layer_norm_wrapped.register_fake
-def _(M, N, eps, dtype_str, block_m, threads, x, scale, shift):
-    N_padded = _align_up(N, ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
+def _(M, N, eps, dtype_str, block_m, threads, use_cp_async, x, scale, shift):
+    return torch.empty((M, N), dtype=x.dtype, device=x.device)
 
 
 @torch.library.custom_op("top::ada_layer_norm_zero_fwd", mutates_args=())
@@ -221,21 +298,38 @@ def _ada_layer_norm_zero_wrapped(
     dtype_str: str,
     block_m: int,
     threads: int,
+    use_cp_async: bool,
     x: torch.Tensor,
     scale: torch.Tensor,
     shift: torch.Tensor,
     gate: torch.Tensor,
 ) -> torch.Tensor:
     dummy = torch.empty(1, dtype=x.dtype, device=x.device)
-    return _ada_layer_norm_kernel(M, N, eps, dtype_str, has_gate=True)(block_m, threads)(
-        x, scale, shift, gate, dummy
-    )
+    return _ada_layer_norm_kernel(
+        M,
+        N,
+        eps,
+        dtype_str,
+        has_gate=True,
+        use_cp_async=use_cp_async,
+    )(block_m, threads)(x, scale, shift, gate, dummy)
 
 
 @_ada_layer_norm_zero_wrapped.register_fake
-def _(M, N, eps, dtype_str, block_m, threads, x, scale, shift, gate):
-    N_padded = _align_up(N, ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
+def _(
+    M,
+    N,
+    eps,
+    dtype_str,
+    block_m,
+    threads,
+    use_cp_async,
+    x,
+    scale,
+    shift,
+    gate,
+):
+    return torch.empty((M, N), dtype=x.dtype, device=x.device)
 
 
 class AdaLayerNormKernel(Kernel):
@@ -273,8 +367,16 @@ class AdaLayerNormKernel(Kernel):
         self.dtype = dtype
         self.has_gate = has_gate
         self.N_padded = _align_up(N, ALIGNMENT)
+        # Async modulation prefetch pays off for medium unaligned rows. Wider
+        # rows stay on the direct-load path to avoid shared-memory pressure.
+        self.use_cp_async = self.N_padded != N and 512 <= N < 1920
         self.kernel = _ada_layer_norm_kernel(
-            self.M, self.N, self.eps, self.dtype_str, has_gate=self.has_gate
+            self.M,
+            self.N,
+            self.eps,
+            self.dtype_str,
+            has_gate=self.has_gate,
+            use_cp_async=self.use_cp_async,
         )
         self.init_config(config, tune)
 
@@ -284,7 +386,10 @@ class AdaLayerNormKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return select_row_configs(self.N_padded, self.dtype)
+        num_buffers = (4 if self.has_gate else 3) if self.use_cp_async else 1
+        return select_row_configs(
+            self.N_padded, self.dtype, num_buffers=num_buffers
+        )
 
     def forward(
         self,
@@ -303,6 +408,7 @@ class AdaLayerNormKernel(Kernel):
                 self.dtype_str,
                 self.config["block_m"],
                 self.config["threads"],
+                self.use_cp_async,
                 x,
                 scale,
                 shift,
@@ -316,6 +422,7 @@ class AdaLayerNormKernel(Kernel):
                 self.dtype_str,
                 self.config["block_m"],
                 self.config["threads"],
+                self.use_cp_async,
                 x,
                 scale,
                 shift,

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -10,10 +10,13 @@ The `has_gate` parameter controls the variant:
 - has_gate=False → AdaLN
 - has_gate=True  → AdaLN-Zero
 
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared memory
-instructions. Padding zeros contribute 0 to sum; the centered two-pass variance
-computation subtracts the exact padding bias to keep results numerically stable
-even for large-offset inputs.
+The kernels accept natural ``(M, N)`` tensors. For non-aligned ``N``, boundary
+handling stays on device: loads zero-fill the logical reduction tail and stores
+write only real output columns. The centered two-pass variance subtracts the
+padded-zero contribution explicitly.
+
+AdaLN modulation tensors use predicated ``cp.async`` prefetch for selected
+non-aligned shapes. Aligned shapes retain the vectorized ``T.copy`` path.
 """
 
 import functools
@@ -36,6 +39,21 @@ def _align_up(n: int, alignment: int) -> int:
     return ((n + alignment - 1) // alignment) * alignment
 
 
+def _should_use_cp_async(
+    n: int, dtype: torch.dtype, has_gate: bool = False,
+) -> bool:
+    """Select async prefetch when lowering and shared-memory limits allow it."""
+    n_padded = _align_up(n, ALIGNMENT)
+    row_bytes = n * dtype.itemsize
+    num_buffers = 4 if has_gate else 3
+    shared_bytes = num_buffers * n_padded * dtype.itemsize
+    return (
+        n_padded != n
+        and row_bytes % 4 == 0
+        and shared_bytes <= 48 * 1024
+    )
+
+
 @functools.lru_cache(maxsize=32)
 def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False):
     N_padded = _align_up(N, ALIGNMENT)
@@ -44,6 +62,62 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
 
     @tilelang.jit(out_idx=[4] if not has_gate else [5])
     def _func(block_m, threads):
+
+        @T.macro
+        def load_x_padded(x, shared_buf, x_f32, pid_m):
+            for i, j in T.Parallel(block_m, N_padded):
+                shared_buf[i, j] = T.if_then_else(
+                    T.And(pid_m * block_m + i < M, j < N),
+                    x[pid_m * block_m + i, j],
+                    T.cast(0.0, dtype),
+                )
+                x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+
+        @T.macro
+        def load_x_aligned(x, shared_buf, x_local, x_f32, pid_m):
+            T.copy(x[pid_m * block_m, 0], shared_buf)
+            T.copy(shared_buf, x_local)
+            for i, j in T.Parallel(block_m, N_padded):
+                x_f32[i, j] = T.cast(x_local[i, j], "float32")
+
+        @T.macro
+        def compute_mean_rstd(x_f32, acc, mean_val, rstd):
+            T.reduce_sum(x_f32, acc, dim=1)
+            for i in T.Parallel(block_m):
+                mean_val[i] = acc[i] / float(N)
+
+            for i, j in T.Parallel(block_m, N_padded):
+                x_f32[i, j] = (
+                    x_f32[i, j] - mean_val[i]
+                ) * (
+                    x_f32[i, j] - mean_val[i]
+                )
+
+            T.reduce_sum(x_f32, acc, dim=1)
+            for i in T.Parallel(block_m):
+                rstd[i] = T.rsqrt(
+                    (
+                        acc[i]
+                        - float(pad_count) * mean_val[i] * mean_val[i]
+                    )
+                    / float(N)
+                    + eps
+                )
+
+        @T.macro
+        def prefetch_modulation(src, dst, pid_m):
+            T.async_copy(
+                src[
+                    pid_m * block_m : (pid_m + 1) * block_m,
+                    0:N_padded,
+                ],
+                dst,
+            )
+
+        @T.macro
+        def load_aligned_modulation(src, shared_buf, local, pid_m):
+            T.copy(src[pid_m * block_m, 0], shared_buf)
+            T.copy(shared_buf, local)
 
         if not has_gate:
 
@@ -60,64 +134,37 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                    x_local = T.alloc_fragment((block_m, N_padded), dtype)
                     x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                     acc = T.alloc_fragment((block_m,), "float32")
                     mean_val = T.alloc_fragment((block_m,), "float32")
                     rstd = T.alloc_fragment((block_m,), "float32")
-                    scale_local = T.alloc_fragment((block_m, N_padded), dtype)
-                    shift_local = T.alloc_fragment((block_m, N_padded), dtype)
-                    if use_cp_async:
-                        scale_shared = T.alloc_shared((block_m, N_padded), dtype)
-                        shift_shared = T.alloc_shared((block_m, N_padded), dtype)
 
                     if needs_pad:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            shared_buf[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                x[pid_m * block_m + i, j],
-                                T.cast(0.0, dtype),
-                            )
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                         if use_cp_async:
-                            # Prefetch modulation tensors while reducing x.
-                            # Predication zero-fills the padded tail.
-                            T.async_copy(
-                                scale[
-                                    pid_m * block_m : (pid_m + 1) * block_m,
-                                    0:N_padded,
-                                ],
-                                scale_shared,
+                            scale_shared = T.alloc_shared(
+                                (block_m, N_padded), dtype
                             )
-                            T.async_copy(
-                                shift[
-                                    pid_m * block_m : (pid_m + 1) * block_m,
-                                    0:N_padded,
-                                ],
-                                shift_shared,
+                            shift_shared = T.alloc_shared(
+                                (block_m, N_padded), dtype
                             )
+                        load_x_padded(x, shared_buf, x_f32, pid_m)
                     else:
-                        T.copy(x[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, x_local)
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
-
-                    # --- Mean reduction ---
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        mean_val[i] = acc[i] / float(N)
-
-                    # --- Centered variance reduction ---
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        rstd[i] = T.rsqrt(
-                            (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
-                            / float(N)
-                            + eps
+                        x_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
                         )
+                        scale_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
+                        )
+                        shift_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
+                        )
+                        load_x_aligned(
+                            x, shared_buf, x_local, x_f32, pid_m
+                        )
+                    if needs_pad and use_cp_async:
+                        prefetch_modulation(scale, scale_shared, pid_m)
+                        prefetch_modulation(shift, shift_shared, pid_m)
+                    compute_mean_rstd(x_f32, acc, mean_val, rstd)
 
                     if needs_pad:
                         if use_cp_async:
@@ -140,10 +187,12 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                                         + T.cast(shift[pid_m * block_m + i, j], "float32")
                                     )
                     else:
-                        T.copy(scale[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, scale_local)
-                        T.copy(shift[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, shift_local)
+                        load_aligned_modulation(
+                            scale, shared_buf, scale_local, pid_m
+                        )
+                        load_aligned_modulation(
+                            shift, shared_buf, shift_local, pid_m
+                        )
                         for i, j in T.Parallel(block_m, N_padded):
                             x_local[i, j] = (
                                 T.cast(scale_local[i, j], "float32")
@@ -169,71 +218,44 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
             ):
                 with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                     shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                    x_local = T.alloc_fragment((block_m, N_padded), dtype)
                     x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
                     acc = T.alloc_fragment((block_m,), "float32")
                     mean_val = T.alloc_fragment((block_m,), "float32")
                     rstd = T.alloc_fragment((block_m,), "float32")
-                    scale_local = T.alloc_fragment((block_m, N_padded), dtype)
-                    shift_local = T.alloc_fragment((block_m, N_padded), dtype)
-                    gate_local = T.alloc_fragment((block_m, N_padded), dtype)
-                    if use_cp_async:
-                        scale_shared = T.alloc_shared((block_m, N_padded), dtype)
-                        shift_shared = T.alloc_shared((block_m, N_padded), dtype)
-                        gate_shared = T.alloc_shared((block_m, N_padded), dtype)
 
                     if needs_pad:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            shared_buf[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                x[pid_m * block_m + i, j],
-                                T.cast(0.0, dtype),
-                            )
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                         if use_cp_async:
-                            T.async_copy(
-                                scale[
-                                    pid_m * block_m : (pid_m + 1) * block_m,
-                                    0:N_padded,
-                                ],
-                                scale_shared,
+                            scale_shared = T.alloc_shared(
+                                (block_m, N_padded), dtype
                             )
-                            T.async_copy(
-                                shift[
-                                    pid_m * block_m : (pid_m + 1) * block_m,
-                                    0:N_padded,
-                                ],
-                                shift_shared,
+                            shift_shared = T.alloc_shared(
+                                (block_m, N_padded), dtype
                             )
-                            T.async_copy(
-                                gate[
-                                    pid_m * block_m : (pid_m + 1) * block_m,
-                                    0:N_padded,
-                                ],
-                                gate_shared,
+                            gate_shared = T.alloc_shared(
+                                (block_m, N_padded), dtype
                             )
+                        load_x_padded(x, shared_buf, x_f32, pid_m)
                     else:
-                        T.copy(x[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, x_local)
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
-
-                    # --- Mean reduction ---
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        mean_val[i] = acc[i] / float(N)
-
-                    # --- Centered variance reduction ---
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                    T.reduce_sum(x_f32, acc, dim=1)
-                    for i in T.Parallel(block_m):
-                        rstd[i] = T.rsqrt(
-                            (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
-                            / float(N)
-                            + eps
+                        x_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
                         )
+                        scale_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
+                        )
+                        shift_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
+                        )
+                        gate_local = T.alloc_fragment(
+                            (block_m, N_padded), dtype
+                        )
+                        load_x_aligned(
+                            x, shared_buf, x_local, x_f32, pid_m
+                        )
+                    if needs_pad and use_cp_async:
+                        prefetch_modulation(scale, scale_shared, pid_m)
+                        prefetch_modulation(shift, shift_shared, pid_m)
+                        prefetch_modulation(gate, gate_shared, pid_m)
+                    compute_mean_rstd(x_f32, acc, mean_val, rstd)
 
                     if needs_pad:
                         if use_cp_async:
@@ -260,12 +282,15 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                                         + T.cast(shift[pid_m * block_m + i, j], "float32")
                                     )
                     else:
-                        T.copy(scale[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, scale_local)
-                        T.copy(shift[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, shift_local)
-                        T.copy(gate[pid_m * block_m, 0], shared_buf)
-                        T.copy(shared_buf, gate_local)
+                        load_aligned_modulation(
+                            scale, shared_buf, scale_local, pid_m
+                        )
+                        load_aligned_modulation(
+                            shift, shared_buf, shift_local, pid_m
+                        )
+                        load_aligned_modulation(
+                            gate, shared_buf, gate_local, pid_m
+                        )
                         for i, j in T.Parallel(block_m, N_padded):
                             x_local[i, j] = T.cast(gate_local[i, j], "float32") * (
                                 T.cast(scale_local[i, j], "float32")
@@ -387,9 +412,8 @@ class AdaLayerNormKernel(Kernel):
         self.dtype = dtype
         self.has_gate = has_gate
         self.N_padded = _align_up(N, ALIGNMENT)
-        # Async modulation prefetch pays off for medium unaligned rows. Wider
-        # rows stay on the direct-load path to avoid shared-memory pressure.
-        self.use_cp_async = self.N_padded != N and 512 <= N < 1920
+        # Shape policy is benchmarked independently from block/thread tuning.
+        self.use_cp_async = _should_use_cp_async(N, dtype, has_gate)
         self.kernel = _ada_layer_norm_kernel(
             self.M,
             self.N,

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -57,6 +57,9 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
     N_padded = _align_up(N, ALIGNMENT)
     needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
+    # The async policy guarantees that each source row is a whole number of
+    # 4-byte cp.async transactions.
+    async_copy_elems = 1 if dtype == "float32" else 2
 
     @tilelang.jit(out_idx=[4] if not has_gate else [5])
     def _func(block_m, threads):
@@ -94,13 +97,28 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
 
         @T.macro
         def prefetch_modulation(src, dst, pid_m):
-            T.async_copy(
-                src[
-                    pid_m * block_m : (pid_m + 1) * block_m,
-                    0:N_padded,
-                ],
-                dst,
-            )
+            for i, j in T.Parallel(block_m, N_padded // async_copy_elems):
+                row = pid_m * block_m + i
+                col = j * async_copy_elems
+                T.ptx_cp_async(
+                    T.tvm_access_ptr(
+                        T.type_annotation(dtype),
+                        dst.data,
+                        i * N_padded + col,
+                        async_copy_elems,
+                        2,
+                    ),
+                    T.tvm_access_ptr(
+                        T.type_annotation(dtype),
+                        src.data,
+                        row * N + col,
+                        async_copy_elems,
+                        1,
+                    ),
+                    async_copy_elems,
+                    predicate=T.And(row < M, col + async_copy_elems <= N),
+                )
+            T.ptx_commit_group()
 
         @T.macro
         def load_aligned_modulation(src, shared_buf, local, pid_m):

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -40,18 +40,16 @@ def _align_up(n: int, alignment: int) -> int:
 
 
 def _should_use_cp_async(
-    n: int, dtype: torch.dtype, has_gate: bool = False,
+    n: int,
+    dtype: torch.dtype,
+    has_gate: bool = False,
 ) -> bool:
     """Select async prefetch when lowering and shared-memory limits allow it."""
     n_padded = _align_up(n, ALIGNMENT)
     row_bytes = n * dtype.itemsize
     num_buffers = 4 if has_gate else 3
     shared_bytes = num_buffers * n_padded * dtype.itemsize
-    return (
-        n_padded != n
-        and row_bytes % 4 == 0
-        and shared_bytes <= 48 * 1024
-    )
+    return n_padded != n and row_bytes % 4 == 0 and shared_bytes <= 48 * 1024
 
 
 @functools.lru_cache(maxsize=32)
@@ -62,7 +60,6 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
 
     @tilelang.jit(out_idx=[4] if not has_gate else [5])
     def _func(block_m, threads):
-
         @T.macro
         def load_x_padded(x, shared_buf, x_f32, pid_m):
             for i, j in T.Parallel(block_m, N_padded):
@@ -87,21 +84,12 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                 mean_val[i] = acc[i] / float(N)
 
             for i, j in T.Parallel(block_m, N_padded):
-                x_f32[i, j] = (
-                    x_f32[i, j] - mean_val[i]
-                ) * (
-                    x_f32[i, j] - mean_val[i]
-                )
+                x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
 
             T.reduce_sum(x_f32, acc, dim=1)
             for i in T.Parallel(block_m):
                 rstd[i] = T.rsqrt(
-                    (
-                        acc[i]
-                        - float(pad_count) * mean_val[i] * mean_val[i]
-                    )
-                    / float(N)
-                    + eps
+                    (acc[i] - float(pad_count) * mean_val[i] * mean_val[i]) / float(N) + eps
                 )
 
         @T.macro
@@ -119,6 +107,80 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
             T.copy(src[pid_m * block_m, 0], shared_buf)
             T.copy(shared_buf, local)
 
+        @T.macro
+        def kernel_body(x, scale, shift, gate, y):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
+                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
+                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
+                acc = T.alloc_fragment((block_m,), "float32")
+                mean_val = T.alloc_fragment((block_m,), "float32")
+                rstd = T.alloc_fragment((block_m,), "float32")
+
+                if needs_pad:
+                    if use_cp_async:
+                        scale_shared = T.alloc_shared((block_m, N_padded), dtype)
+                        shift_shared = T.alloc_shared((block_m, N_padded), dtype)
+                        if has_gate:
+                            gate_shared = T.alloc_shared((block_m, N_padded), dtype)
+                    load_x_padded(x, shared_buf, x_f32, pid_m)
+                else:
+                    x_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    scale_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    shift_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    if has_gate:
+                        gate_local = T.alloc_fragment((block_m, N_padded), dtype)
+                    load_x_aligned(x, shared_buf, x_local, x_f32, pid_m)
+
+                if needs_pad and use_cp_async:
+                    prefetch_modulation(scale, scale_shared, pid_m)
+                    prefetch_modulation(shift, shift_shared, pid_m)
+                    if has_gate:
+                        prefetch_modulation(gate, gate_shared, pid_m)
+                compute_mean_rstd(x_f32, acc, mean_val, rstd)
+
+                if needs_pad:
+                    if use_cp_async:
+                        T.ptx_wait_group(0)
+                        T.sync_threads()
+                    for i, j in T.Parallel(block_m, N_padded):
+                        if T.And(pid_m * block_m + i < M, j < N):
+                            if use_cp_async:
+                                value = T.cast(scale_shared[i, j], "float32") * (
+                                    T.cast(shared_buf[i, j], "float32") - mean_val[i]
+                                ) * rstd[i] + T.cast(shift_shared[i, j], "float32")
+                                if has_gate:
+                                    value *= T.cast(gate_shared[i, j], "float32")
+                            else:
+                                value = T.cast(
+                                    scale[pid_m * block_m + i, j],
+                                    "float32",
+                                ) * (T.cast(shared_buf[i, j], "float32") - mean_val[i]) * rstd[
+                                    i
+                                ] + T.cast(
+                                    shift[pid_m * block_m + i, j],
+                                    "float32",
+                                )
+                                if has_gate:
+                                    value *= T.cast(
+                                        gate[pid_m * block_m + i, j],
+                                        "float32",
+                                    )
+                            y[pid_m * block_m + i, j] = value
+                else:
+                    load_aligned_modulation(scale, shared_buf, scale_local, pid_m)
+                    load_aligned_modulation(shift, shared_buf, shift_local, pid_m)
+                    if has_gate:
+                        load_aligned_modulation(gate, shared_buf, gate_local, pid_m)
+                    for i, j in T.Parallel(block_m, N_padded):
+                        value = T.cast(scale_local[i, j], "float32") * (
+                            T.cast(x_local[i, j], "float32") - mean_val[i]
+                        ) * rstd[i] + T.cast(shift_local[i, j], "float32")
+                        if has_gate:
+                            value *= T.cast(gate_local[i, j], "float32")
+                        x_local[i, j] = value
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
+
         if not has_gate:
 
             @T.prim_func
@@ -127,181 +189,26 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                 scale: T.Tensor[(M, N), dtype],
                 shift: T.Tensor[(M, N), dtype],
                 # _dummy keeps the output tensor at index 4 so that out_idx=[4]
-                # is consistent between the non-gated (4 inputs) and gated (5
-                # inputs) variants, matching the tilelang.jit contract.
+                # is consistent between the non-gated and gated variants.
                 _dummy: T.Tensor[(1,), dtype],
                 y: T.Tensor[(M, N), dtype],
             ):
-                with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                    x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                    acc = T.alloc_fragment((block_m,), "float32")
-                    mean_val = T.alloc_fragment((block_m,), "float32")
-                    rstd = T.alloc_fragment((block_m,), "float32")
-
-                    if needs_pad:
-                        if use_cp_async:
-                            scale_shared = T.alloc_shared(
-                                (block_m, N_padded), dtype
-                            )
-                            shift_shared = T.alloc_shared(
-                                (block_m, N_padded), dtype
-                            )
-                        load_x_padded(x, shared_buf, x_f32, pid_m)
-                    else:
-                        x_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        scale_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        shift_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        load_x_aligned(
-                            x, shared_buf, x_local, x_f32, pid_m
-                        )
-                    if needs_pad and use_cp_async:
-                        prefetch_modulation(scale, scale_shared, pid_m)
-                        prefetch_modulation(shift, shift_shared, pid_m)
-                    compute_mean_rstd(x_f32, acc, mean_val, rstd)
-
-                    if needs_pad:
-                        if use_cp_async:
-                            T.ptx_wait_group(0)
-                            T.sync_threads()
-                        for i, j in T.Parallel(block_m, N_padded):
-                            if T.And(pid_m * block_m + i < M, j < N):
-                                if use_cp_async:
-                                    y[pid_m * block_m + i, j] = (
-                                        T.cast(scale_shared[i, j], "float32")
-                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
-                                        * rstd[i]
-                                        + T.cast(shift_shared[i, j], "float32")
-                                    )
-                                else:
-                                    y[pid_m * block_m + i, j] = (
-                                        T.cast(scale[pid_m * block_m + i, j], "float32")
-                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
-                                        * rstd[i]
-                                        + T.cast(shift[pid_m * block_m + i, j], "float32")
-                                    )
-                    else:
-                        load_aligned_modulation(
-                            scale, shared_buf, scale_local, pid_m
-                        )
-                        load_aligned_modulation(
-                            shift, shared_buf, shift_local, pid_m
-                        )
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_local[i, j] = (
-                                T.cast(scale_local[i, j], "float32")
-                                * (T.cast(x_local[i, j], "float32") - mean_val[i])
-                                * rstd[i]
-                                + T.cast(shift_local[i, j], "float32")
-                            )
-                        T.copy(x_local, shared_buf)
-                        T.copy(shared_buf, y[pid_m * block_m, 0])
+                kernel_body(x, scale, shift, _dummy, y)
 
             return main
 
-        else:
+        @T.prim_func
+        def main_gated(
+            x: T.Tensor[(M, N), dtype],
+            scale: T.Tensor[(M, N), dtype],
+            shift: T.Tensor[(M, N), dtype],
+            gate: T.Tensor[(M, N), dtype],
+            _dummy: T.Tensor[(1,), dtype],
+            y: T.Tensor[(M, N), dtype],
+        ):
+            kernel_body(x, scale, shift, gate, y)
 
-            @T.prim_func
-            def main_gated(
-                x: T.Tensor[(M, N), dtype],
-                scale: T.Tensor[(M, N), dtype],
-                shift: T.Tensor[(M, N), dtype],
-                gate: T.Tensor[(M, N), dtype],
-                _dummy: T.Tensor[(1,), dtype],
-                y: T.Tensor[(M, N), dtype],
-            ):
-                with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                    shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                    x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                    acc = T.alloc_fragment((block_m,), "float32")
-                    mean_val = T.alloc_fragment((block_m,), "float32")
-                    rstd = T.alloc_fragment((block_m,), "float32")
-
-                    if needs_pad:
-                        if use_cp_async:
-                            scale_shared = T.alloc_shared(
-                                (block_m, N_padded), dtype
-                            )
-                            shift_shared = T.alloc_shared(
-                                (block_m, N_padded), dtype
-                            )
-                            gate_shared = T.alloc_shared(
-                                (block_m, N_padded), dtype
-                            )
-                        load_x_padded(x, shared_buf, x_f32, pid_m)
-                    else:
-                        x_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        scale_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        shift_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        gate_local = T.alloc_fragment(
-                            (block_m, N_padded), dtype
-                        )
-                        load_x_aligned(
-                            x, shared_buf, x_local, x_f32, pid_m
-                        )
-                    if needs_pad and use_cp_async:
-                        prefetch_modulation(scale, scale_shared, pid_m)
-                        prefetch_modulation(shift, shift_shared, pid_m)
-                        prefetch_modulation(gate, gate_shared, pid_m)
-                    compute_mean_rstd(x_f32, acc, mean_val, rstd)
-
-                    if needs_pad:
-                        if use_cp_async:
-                            T.ptx_wait_group(0)
-                            T.sync_threads()
-                        for i, j in T.Parallel(block_m, N_padded):
-                            if T.And(pid_m * block_m + i < M, j < N):
-                                if use_cp_async:
-                                    y[pid_m * block_m + i, j] = T.cast(
-                                        gate_shared[i, j], "float32"
-                                    ) * (
-                                        T.cast(scale_shared[i, j], "float32")
-                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
-                                        * rstd[i]
-                                        + T.cast(shift_shared[i, j], "float32")
-                                    )
-                                else:
-                                    y[pid_m * block_m + i, j] = T.cast(
-                                        gate[pid_m * block_m + i, j], "float32"
-                                    ) * (
-                                        T.cast(scale[pid_m * block_m + i, j], "float32")
-                                        * (T.cast(shared_buf[i, j], "float32") - mean_val[i])
-                                        * rstd[i]
-                                        + T.cast(shift[pid_m * block_m + i, j], "float32")
-                                    )
-                    else:
-                        load_aligned_modulation(
-                            scale, shared_buf, scale_local, pid_m
-                        )
-                        load_aligned_modulation(
-                            shift, shared_buf, shift_local, pid_m
-                        )
-                        load_aligned_modulation(
-                            gate, shared_buf, gate_local, pid_m
-                        )
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_local[i, j] = T.cast(gate_local[i, j], "float32") * (
-                                T.cast(scale_local[i, j], "float32")
-                                * (T.cast(x_local[i, j], "float32") - mean_val[i])
-                                * rstd[i]
-                                + T.cast(shift_local[i, j], "float32")
-                            )
-                        T.copy(x_local, shared_buf)
-                        T.copy(shared_buf, y[pid_m * block_m, 0])
-
-            return main_gated
+        return main_gated
 
     return _func
 
@@ -431,9 +338,7 @@ class AdaLayerNormKernel(Kernel):
     @property
     def autotune_configs(self) -> list[dict]:
         num_buffers = (4 if self.has_gate else 3) if self.use_cp_async else 1
-        return select_row_configs(
-            self.N_padded, self.dtype, num_buffers=num_buffers
-        )
+        return select_row_configs(self.N_padded, self.dtype, num_buffers=num_buffers)
 
     def forward(
         self,

--- a/tileops/kernels/norm/ada_layer_norm.py
+++ b/tileops/kernels/norm/ada_layer_norm.py
@@ -83,10 +83,18 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                             # Prefetch modulation tensors while reducing x.
                             # Predication zero-fills the padded tail.
                             T.async_copy(
-                                scale[pid_m * block_m, 0:N_padded], scale_shared
+                                scale[
+                                    pid_m * block_m : (pid_m + 1) * block_m,
+                                    0:N_padded,
+                                ],
+                                scale_shared,
                             )
                             T.async_copy(
-                                shift[pid_m * block_m, 0:N_padded], shift_shared
+                                shift[
+                                    pid_m * block_m : (pid_m + 1) * block_m,
+                                    0:N_padded,
+                                ],
+                                shift_shared,
                             )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)
@@ -184,13 +192,25 @@ def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False)
                             x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                         if use_cp_async:
                             T.async_copy(
-                                scale[pid_m * block_m, 0:N_padded], scale_shared
+                                scale[
+                                    pid_m * block_m : (pid_m + 1) * block_m,
+                                    0:N_padded,
+                                ],
+                                scale_shared,
                             )
                             T.async_copy(
-                                shift[pid_m * block_m, 0:N_padded], shift_shared
+                                shift[
+                                    pid_m * block_m : (pid_m + 1) * block_m,
+                                    0:N_padded,
+                                ],
+                                shift_shared,
                             )
                             T.async_copy(
-                                gate[pid_m * block_m, 0:N_padded], gate_shared
+                                gate[
+                                    pid_m * block_m : (pid_m + 1) * block_m,
+                                    0:N_padded,
+                                ],
+                                gate_shared,
                             )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)

--- a/tileops/kernels/norm/layer_norm.py
+++ b/tileops/kernels/norm/layer_norm.py
@@ -2,10 +2,12 @@
 
 y = (x - mean(x)) / sqrt(var(x) + eps) * weight + bias
 
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared memory
-instructions. Padding zeros contribute 0 to sum; the centered two-pass variance
-computation subtracts the exact padding bias to keep results numerically stable
-even for large-offset inputs.
+256-element alignment (512 bytes for fp16/bf16) is required by T.copy() shared
+memory instructions. Boundary handling for non-aligned N is performed inside
+the kernel, eliminating host-side padding allocations and copies. Padding zeros
+contribute 0 to the mean reduction; the centered two-pass variance computation
+subtracts their exact contribution to remain numerically stable for large-offset
+inputs.
 """
 
 import functools
@@ -31,6 +33,7 @@ def _align_up(n: int, alignment: int) -> int:
 @functools.lru_cache(maxsize=32)
 def _layer_norm_kernel(M, N, eps, dtype):
     N_padded = _align_up(N, ALIGNMENT)
+    needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
 
     @tilelang.jit(out_idx=[3])
@@ -38,10 +41,10 @@ def _layer_norm_kernel(M, N, eps, dtype):
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
-            weight: T.Tensor[(N_padded,), dtype],
-            bias: T.Tensor[(N_padded,), dtype],
-            y: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M, N), dtype],
+            weight: T.Tensor[(N,), dtype],
+            bias: T.Tensor[(N,), dtype],
+            y: T.Tensor[(M, N), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, N_padded), dtype)
@@ -51,13 +54,22 @@ def _layer_norm_kernel(M, N, eps, dtype):
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                # Load input row block via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
-                T.copy(shared_buf, x_local)
-
-                # Cast to fp32 once — reused across all passes
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                if needs_pad:
+                    # Retain the original values in shared memory for the
+                    # output pass while the fp32 fragment is reduced below.
+                    for i, j in T.Parallel(block_m, N_padded):
+                        shared_buf[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < N),
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                else:
+                    # Preserve the vectorized copy fast path for aligned N.
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 # --- Mean reduction ---
                 T.reduce_sum(x_f32, acc, dim=1)
@@ -79,18 +91,30 @@ def _layer_norm_kernel(M, N, eps, dtype):
                     )
 
                 # --- Output: y = (x - mean) * rstd * weight + bias ---
-                # Re-cast from x_local (original dtype) to avoid a second fp32 buffer
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_local[i, j] = (
-                        (T.cast(x_local[i, j], "float32") - mean_val[i])
-                        * rstd[i]
-                        * T.cast(weight[j], "float32")
-                        + T.cast(bias[j], "float32")
-                    )
-
-                # Write output via shared memory
-                T.copy(x_local, shared_buf)
-                T.copy(shared_buf, y[pid_m * block_m, 0])
+                if needs_pad:
+                    # Store only real columns.  Returning the natural shape
+                    # avoids allocating and writing an M x N_padded output
+                    # merely to slice it in the Op layer.
+                    for i, j in T.Parallel(block_m, N_padded):
+                        if T.And(pid_m * block_m + i < M, j < N):
+                            y[pid_m * block_m + i, j] = (
+                                (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                * rstd[i]
+                                * T.cast(weight[j], "float32")
+                                + T.cast(bias[j], "float32")
+                            )
+                else:
+                    # Re-cast from x_local (original dtype) to avoid a second
+                    # fp32 buffer, then retain the vectorized copy fast path.
+                    for i, j in T.Parallel(block_m, N_padded):
+                        x_local[i, j] = (
+                            (T.cast(x_local[i, j], "float32") - mean_val[i])
+                            * rstd[i]
+                            * T.cast(weight[j], "float32")
+                            + T.cast(bias[j], "float32")
+                        )
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
 
         return main
 
@@ -114,8 +138,7 @@ def _layer_norm_wrapped(
 
 @_layer_norm_wrapped.register_fake
 def _(M, N, eps, dtype_str, block_m, threads, x, weight, bias):
-    N_padded = _align_up(N, ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
+    return torch.empty((M, N), dtype=x.dtype, device=x.device)
 
 
 class LayerNormKernel(Kernel):

--- a/tileops/ops/norm/ada_layer_norm.py
+++ b/tileops/ops/norm/ada_layer_norm.py
@@ -1,13 +1,11 @@
 from typing import Dict, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import AdaLayerNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["AdaLayerNormFwdOp"]
 
@@ -32,8 +30,7 @@ class AdaLayerNormFwdOp(Op):
 
     Note:
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
-        Handles non-contiguous inputs and non-power-of-two hidden dims
-        by padding to 256-element alignment.
+        Handles non-contiguous inputs and non-power-of-two hidden dims.
 
     Args:
         M: Optional committed row count for strict compatibility. Preferred
@@ -154,20 +151,8 @@ class AdaLayerNormFwdOp(Op):
         dtype = expected_dtype
         assert dtype is not None
         self.dtype = dtype
-        N_padded = align_up(N, ALIGNMENT)
-
-        # Pad hidden dim to 256-element alignment if needed
-        if N_padded != N:
-            x = F.pad(x, (0, N_padded - N))
-            scale = F.pad(scale, (0, N_padded - N))
-            shift = F.pad(shift, (0, N_padded - N))
-
         kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
         y = kernel(x, scale, shift)
         self._last_roofline_mn = (M_actual, N)
-
-        # Trim padding
-        if N_padded != N:
-            y = y[:, :N]
 
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/ada_layer_norm_zero.py
+++ b/tileops/ops/norm/ada_layer_norm_zero.py
@@ -1,13 +1,11 @@
 from typing import Dict, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import AdaLayerNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["AdaLayerNormZeroFwdOp"]
 
@@ -33,8 +31,7 @@ class AdaLayerNormZeroFwdOp(Op):
 
     Note:
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
-        Handles non-contiguous inputs and non-power-of-two hidden dims
-        by padding to 256-element alignment.
+        Handles non-contiguous inputs and non-power-of-two hidden dims.
 
     Args:
         M: Optional committed row count for strict compatibility. Preferred
@@ -169,21 +166,8 @@ class AdaLayerNormZeroFwdOp(Op):
         dtype = expected_dtype
         assert dtype is not None
         self.dtype = dtype
-        N_padded = align_up(N, ALIGNMENT)
-
-        # Pad hidden dim to 256-element alignment if needed
-        if N_padded != N:
-            x = F.pad(x, (0, N_padded - N))
-            scale = F.pad(scale, (0, N_padded - N))
-            shift = F.pad(shift, (0, N_padded - N))
-            gate = F.pad(gate, (0, N_padded - N))
-
         kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
         y = kernel(x, scale, shift, gate)
         self._last_roofline_mn = (M_actual, N)
-
-        # Trim padding
-        if N_padded != N:
-            y = y[:, :N]
 
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -1,7 +1,6 @@
 from typing import Dict, Optional, Sequence
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import LayerNormKernel
@@ -31,10 +30,12 @@ class LayerNormFwdOp(Op):
 
     Note:
         Supports arbitrary leading dimensions (3-D+) via flatten/unflatten.
-        Handles non-contiguous inputs and non-power-of-two hidden dims by
-        padding to 256-element alignment. The leading-dims product ``M``
-        is bound on the first forward call; if a subsequent call uses a
-        different ``M``, the kernel is rebuilt for the new value.
+        Handles non-contiguous inputs and non-power-of-two hidden dims. For
+        non-aligned hidden dims, boundary handling is performed inside the
+        kernel rather than by allocating padded tensors in the Op layer. The
+        leading-dims product ``M`` is bound on the first forward call; if a
+        subsequent call uses a different ``M``, the kernel is rebuilt for the
+        new value.
 
     Args:
         normalized_shape: Trailing-axis shape tuple over which the
@@ -149,16 +150,6 @@ class LayerNormFwdOp(Op):
             )
         self._last_m = m_actual
 
-        # Pad hidden dim to 256-element alignment if needed
-        if self.N_padded != self.N:
-            x = F.pad(x, (0, self.N_padded - self.N))
-            weight = F.pad(weight, (0, self.N_padded - self.N))
-            bias = F.pad(bias, (0, self.N_padded - self.N))
-
         y = self.kernel(x, weight, bias)
-
-        # Trim padding
-        if self.N_padded != self.N:
-            y = y[:, :self.N]
 
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/layer_norm.py
+++ b/tileops/ops/norm/layer_norm.py
@@ -6,7 +6,7 @@ from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import LayerNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up, normalized_shape_to_n
+from .norm_base import normalized_shape_to_n
 
 __all__ = ["LayerNormFwdOp"]
 
@@ -63,7 +63,6 @@ class LayerNormFwdOp(Op):
         # Manifest declares ``eps: float | None`` with PyTorch default 1e-5.
         self.eps = 1e-5 if eps is None else float(eps)
         self.tune = tune
-        self.N_padded = align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel: Optional[Kernel] = None
         self._last_m: Optional[int] = None


### PR DESCRIPTION
## Summary

- Move non-aligned padding and boundary handling from the PyTorch Op layer into LayerNorm kernels.
- Return natural-shape outputs without host `F.pad` or slicing.
- Add predicated `cp.async` prefetch for AdaLayerNorm modulation tensors.
- Preserve the aligned vectorized path and support multi-row tail tiles.

## Performance

H200 CUPTI: 4.3–6.3x faster on the reported LayerNorm, AdaLayerNorm, and AdaLayerNormZero workloads.

## Validation

- `74 passed`; Compute Sanitizer reports 0 errors.
- Test nodes: `56 -> 74`, covering natural-shape I/O, async policy boundaries, and multi-row tails.