### PR TITLE
[Refactor][MoE] Separate dispatched expert compute

### DIFF
--- a/benchmarks/ops/_moe_bench_utils.py
+++ b/benchmarks/ops/_moe_bench_utils.py
@@ -1,0 +1,167 @@
+"""Small shared primitives for MoE benchmark entry points."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+def cuda_time_ms(fn: Callable[[], Any], *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    begin = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    begin.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return begin.elapsed_time(end) / iters
+
+
+def host_time_ms(fn: Callable[[], Any], *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    begin = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - begin) * 1e3 / iters
+
+
+def measure_dispatch(
+    run_fresh: Callable[[], Any],
+    *,
+    warmup: int,
+    iters: int,
+    make_cached: Callable[[Any], Callable[[], Any]] | None = None,
+    validate_cached: Callable[[Any, Any], None] | None = None,
+) -> tuple[Any, float, float | None]:
+    """Measure fresh dispatch and an optional cached-handle path."""
+    fresh_result = run_fresh()
+    fresh_ms = cuda_time_ms(run_fresh, warmup=warmup, iters=iters)
+    if make_cached is None:
+        return fresh_result, fresh_ms, None
+    run_cached = make_cached(fresh_result)
+    cached_result = run_cached()
+    cached_ms = cuda_time_ms(run_cached, warmup=warmup, iters=iters)
+    if validate_cached is not None:
+        validate_cached(fresh_result, cached_result)
+    return fresh_result, fresh_ms, cached_ms
+
+
+def make_routing_inputs(
+    num_tokens: int,
+    hidden_size: int,
+    top_k: int,
+    num_experts: int,
+    *,
+    distribution: str = "uniform",
+    topk_dtype: torch.dtype = torch.int32,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    noise = torch.rand(num_tokens, num_experts, device="cuda")
+    if distribution == "uniform":
+        scores = noise
+    elif distribution == "hotspot":
+        scores = torch.linspace(4.0, -4.0, num_experts, device="cuda").unsqueeze(0) + noise
+    elif distribution == "longtail":
+        ranks = torch.arange(1, num_experts + 1, device="cuda")
+        scores = -torch.log(ranks).unsqueeze(0) + noise
+    else:
+        raise ValueError(f"unknown distribution {distribution!r}")
+    hidden = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device="cuda")
+    topk_ids = scores.topk(top_k, dim=-1).indices.to(topk_dtype)
+    weights = torch.softmax(torch.randn(num_tokens, top_k, device="cuda"), dim=-1)
+    return hidden, topk_ids, weights
+
+
+def make_expert_sizes(
+    num_pairs: int,
+    num_experts: int,
+    distribution: str,
+) -> list[int]:
+    if distribution == "uniform":
+        return [
+            num_pairs // num_experts + (expert < num_pairs % num_experts)
+            for expert in range(num_experts)
+        ]
+    generator = torch.Generator(device="cpu").manual_seed(42)
+    if distribution == "longtail":
+        probabilities = 1 / torch.arange(1, num_experts + 1, dtype=torch.float64).pow(1.2)
+    elif distribution == "hotspot":
+        hot_experts = max(1, num_experts // 8)
+        probabilities = torch.full((num_experts,), 0.2 / num_experts)
+        probabilities[:hot_experts] += 0.8 / hot_experts
+    elif distribution == "router-like":
+        probabilities = torch.softmax(torch.randn(num_experts, generator=generator) * 1.5, dim=0)
+    else:
+        raise ValueError(f"unknown distribution {distribution!r}")
+    assignments = torch.multinomial(
+        probabilities,
+        num_samples=num_pairs,
+        replacement=True,
+        generator=generator,
+    )
+    return torch.bincount(assignments, minlength=num_experts).tolist()
+
+
+def expert_mlp_reference(
+    hidden: torch.Tensor,
+    w_gate_up: torch.Tensor,
+    w_down: torch.Tensor,
+    sizes: list[int],
+) -> torch.Tensor:
+    output = torch.empty(
+        hidden.shape[0],
+        hidden.shape[1],
+        device=hidden.device,
+        dtype=torch.float32,
+    )
+    ffn_size = w_down.shape[-1]
+    start = 0
+    for expert, size in enumerate(sizes):
+        if size == 0:
+            continue
+        rows = hidden[start : start + size].float()
+        gate_up = rows @ w_gate_up[expert].float().t()
+        activated = F.silu(gate_up[:, :ffn_size]) * gate_up[:, ffn_size:]
+        output[start : start + size] = activated @ w_down[expert].float().t()
+        start += size
+    return output
+
+
+def check_output(
+    name: str,
+    actual: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    max_range_relative_tolerance: float,
+    relative_l2_tolerance: float,
+) -> tuple[float, float, float, float]:
+    actual = actual.float()
+    if not torch.isfinite(actual).all():
+        raise AssertionError(f"{name}: output contains NaN or Inf")
+    error = actual - reference
+    max_abs = error.abs().max().item()
+    rmse = error.square().mean().sqrt().item()
+    relative_l2 = (
+        torch.linalg.vector_norm(error) / torch.linalg.vector_norm(reference).clamp_min(1e-12)
+    ).item()
+    max_range_relative = max_abs / reference.abs().max().clamp_min(1e-12).item()
+    if max_range_relative > max_range_relative_tolerance or relative_l2 > relative_l2_tolerance:
+        raise AssertionError(
+            f"{name}: max_abs={max_abs}, rmse={rmse}, "
+            f"relative_l2={relative_l2}, "
+            f"max_range_relative={max_range_relative}"
+        )
+    return max_abs, rmse, relative_l2, max_range_relative
+
+
+def effective_tflops(logical_flops: int, elapsed_ms: float) -> float:
+    return logical_flops / (elapsed_ms / 1e3) / 1e12

--- a/benchmarks/ops/bench_deepep_dispatch.py
+++ b/benchmarks/ops/bench_deepep_dispatch.py
@@ -1,0 +1,163 @@
+"""Single-node multi-GPU DeepEP V2 dispatch benchmark for the M6 adapter.
+
+Example:
+    torchrun --standalone --nproc-per-node=8 \
+        benchmarks/ops/bench_deepep_dispatch.py \
+        --tokens 1 8 32 128 --hidden-size 7168 --num-experts 256 --top-k 8
+
+Only dispatch is timed.  Expert compute and combine are deliberately excluded.
+The script requires DeepEP V2, but TileOps itself does not depend on DeepEP.
+"""
+
+import argparse
+import json
+import os
+
+import torch
+import torch.distributed as dist
+
+from tileops.ops.moe import DeepEPDispatchAdapter
+
+WARMUP = 10
+ITERS = 50
+
+
+def _time_ms(fn) -> float:
+    for _ in range(WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    begin = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    begin.record()
+    for _ in range(ITERS):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return begin.elapsed_time(end) / ITERS
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hidden-size", type=int, default=7168)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--top-k", type=int, default=8)
+    parser.add_argument("--tokens", type=int, nargs="+", default=[1, 8, 32, 128, 512])
+    parser.add_argument("--num-sms", type=int, default=0)
+    args = parser.parse_args()
+
+    try:
+        from deep_ep import ElasticBuffer
+    except ImportError as exc:
+        raise RuntimeError("bench_deepep_dispatch.py requires a DeepEP V2 installation") from exc
+
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    group = dist.group.WORLD
+    world_size = dist.get_world_size(group)
+    rank = dist.get_rank(group)
+    if args.num_experts % world_size != 0:
+        raise ValueError(
+            f"num_experts must be divisible by world_size; got {args.num_experts} and {world_size}"
+        )
+    if args.top_k > args.num_experts:
+        raise ValueError("top_k cannot exceed num_experts")
+
+    max_tokens = max(args.tokens)
+    buffer = ElasticBuffer(
+        group,
+        num_max_tokens_per_rank=max_tokens,
+        hidden=args.hidden_size,
+        num_topk=args.top_k,
+        use_fp8_dispatch=False,
+    )
+    adapter = DeepEPDispatchAdapter(
+        buffer,
+        num_experts=args.num_experts,
+        num_local_experts=args.num_experts // world_size,
+        num_max_tokens_per_rank=max_tokens,
+        num_sms=args.num_sms,
+    )
+
+    for num_tokens in args.tokens:
+        torch.manual_seed(2026 + rank)
+        hidden = torch.randn(
+            num_tokens,
+            args.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        topk_ids = (
+            torch.rand(num_tokens, args.num_experts, device="cuda")
+            .topk(args.top_k, dim=-1)
+            .indices.to(torch.int64)
+        )
+        topk_weights = torch.softmax(torch.randn(num_tokens, args.top_k, device="cuda"), dim=-1)
+        offsets = torch.empty(
+            args.num_experts // world_size + 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        def run(
+            hidden=hidden,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            offsets=offsets,
+        ):
+            return adapter.dispatch(
+                hidden,
+                topk_ids,
+                topk_weights,
+                expert_offsets=offsets,
+            )
+
+        result = run()
+        dispatch_fresh_ms = _time_ms(run)
+        cached_offsets = torch.empty_like(offsets)
+
+        def run_cached(
+            hidden=hidden,
+            topk_weights=topk_weights,
+            offsets=cached_offsets,
+            cached_handle=result.combine_handle,
+        ):
+            return adapter.dispatch(
+                hidden,
+                None,
+                topk_weights,
+                expert_offsets=offsets,
+                cached_handle=cached_handle,
+            )
+
+        cached_result = run_cached()
+        dispatch_cached_ms = _time_ms(run_cached)
+        torch.testing.assert_close(
+            cached_result.batch.expert_offsets,
+            result.batch.expert_offsets,
+        )
+        valid_rows = int(result.batch.valid_rows.item())
+        physical_rows = result.batch.capacity
+        sent_pairs = num_tokens * args.top_k
+        record = {
+            "rank": rank,
+            "world_size": world_size,
+            "tokens": num_tokens,
+            "top_k": args.top_k,
+            "num_experts": args.num_experts,
+            "num_local_experts": args.num_experts // world_size,
+            "hidden_size": args.hidden_size,
+            "sent_pairs": sent_pairs,
+            "received_pairs": valid_rows,
+            "physical_rows": physical_rows,
+            "dispatch_fresh_allocating_ms": round(dispatch_fresh_ms, 4),
+            "dispatch_cached_allocating_ms": round(dispatch_cached_ms, 4),
+        }
+        print(json.dumps(record), flush=True)
+        dist.barrier(group)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ops/bench_deepep_dispatch.py
+++ b/benchmarks/ops/bench_deepep_dispatch.py
@@ -16,24 +16,14 @@ import os
 import torch
 import torch.distributed as dist
 
+from benchmarks.ops._moe_bench_utils import (
+    make_routing_inputs,
+    measure_dispatch,
+)
 from tileops.ops.moe import DeepEPDispatchAdapter
 
 WARMUP = 10
 ITERS = 50
-
-
-def _time_ms(fn) -> float:
-    for _ in range(WARMUP):
-        fn()
-    torch.cuda.synchronize()
-    begin = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    begin.record()
-    for _ in range(ITERS):
-        fn()
-    end.record()
-    torch.cuda.synchronize()
-    return begin.elapsed_time(end) / ITERS
 
 
 def main() -> None:
@@ -81,25 +71,20 @@ def main() -> None:
 
     for num_tokens in args.tokens:
         torch.manual_seed(2026 + rank)
-        hidden = torch.randn(
+        hidden, topk_ids, topk_weights = make_routing_inputs(
             num_tokens,
             args.hidden_size,
-            dtype=torch.bfloat16,
-            device="cuda",
+            args.top_k,
+            args.num_experts,
+            topk_dtype=torch.int64,
         )
-        topk_ids = (
-            torch.rand(num_tokens, args.num_experts, device="cuda")
-            .topk(args.top_k, dim=-1)
-            .indices.to(torch.int64)
-        )
-        topk_weights = torch.softmax(torch.randn(num_tokens, args.top_k, device="cuda"), dim=-1)
         offsets = torch.empty(
             args.num_experts // world_size + 1,
             dtype=torch.int32,
             device="cuda",
         )
 
-        def run(
+        def run_fresh(
             hidden=hidden,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
@@ -112,33 +97,39 @@ def main() -> None:
                 expert_offsets=offsets,
             )
 
-        result = run()
-        dispatch_fresh_ms = _time_ms(run)
-        cached_offsets = torch.empty_like(offsets)
-
-        def run_cached(
-            hidden=hidden,
-            topk_weights=topk_weights,
-            offsets=cached_offsets,
-            cached_handle=result.combine_handle,
+        def make_cached(
+            result,
+            offsets=offsets,
+            cached_hidden=hidden,
+            cached_weights=topk_weights,
         ):
-            return adapter.dispatch(
-                hidden,
-                None,
-                topk_weights,
-                expert_offsets=offsets,
-                cached_handle=cached_handle,
+            cached_offsets = torch.empty_like(offsets)
+
+            def run_cached():
+                return adapter.dispatch(
+                    cached_hidden,
+                    None,
+                    cached_weights,
+                    expert_offsets=cached_offsets,
+                    cached_handle=result.combine_handle,
+                )
+
+            return run_cached
+
+        def validate_cached(result, cached_result):
+            torch.testing.assert_close(
+                cached_result.batch.expert_offsets,
+                result.batch.expert_offsets,
             )
 
-        cached_result = run_cached()
-        dispatch_cached_ms = _time_ms(run_cached)
-        torch.testing.assert_close(
-            cached_result.batch.expert_offsets,
-            result.batch.expert_offsets,
+        result, fresh_ms, cached_ms = measure_dispatch(
+            run_fresh,
+            warmup=WARMUP,
+            iters=ITERS,
+            make_cached=make_cached,
+            validate_cached=validate_cached,
         )
-        valid_rows = int(result.batch.valid_rows.item())
-        physical_rows = result.batch.capacity
-        sent_pairs = num_tokens * args.top_k
+        assert cached_ms is not None
         record = {
             "rank": rank,
             "world_size": world_size,
@@ -147,15 +138,14 @@ def main() -> None:
             "num_experts": args.num_experts,
             "num_local_experts": args.num_experts // world_size,
             "hidden_size": args.hidden_size,
-            "sent_pairs": sent_pairs,
-            "received_pairs": valid_rows,
-            "physical_rows": physical_rows,
-            "dispatch_fresh_allocating_ms": round(dispatch_fresh_ms, 4),
-            "dispatch_cached_allocating_ms": round(dispatch_cached_ms, 4),
+            "sent_pairs": num_tokens * args.top_k,
+            "received_pairs": int(result.batch.valid_rows.item()),
+            "physical_rows": result.batch.capacity,
+            "dispatch_fresh_allocating_ms": round(fresh_ms, 4),
+            "dispatch_cached_allocating_ms": round(cached_ms, 4),
         }
         print(json.dumps(record), flush=True)
         dist.barrier(group)
-
     dist.destroy_process_group()
 
 

--- a/benchmarks/ops/bench_dispatched_expert.py
+++ b/benchmarks/ops/bench_dispatched_expert.py
@@ -4,8 +4,10 @@ import torch
 
 from tileops.ops.moe import (
     DispatchedExpertMLPFwdOp,
+    ExpertBatch,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
+from tileops.ops.moe.routed_expert import MoePermuteNopadFwdOp
 
 DTYPE = torch.bfloat16
 E, TOP_K, H, F = 128, 8, 2048, 1024
@@ -29,23 +31,28 @@ def _time_ms(fn) -> float:
 def _run_shape(num_tokens: int) -> tuple[float, ...]:
     num_pairs = num_tokens * TOP_K
     hidden = torch.randn(num_tokens, H, device="cuda", dtype=DTYPE)
-    expert_input = torch.randn(num_pairs, H, device="cuda", dtype=DTYPE)
     w_gate_up = (
         torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
     )
     w_down = torch.randn(E, H, F, device="cuda", dtype=DTYPE) * 0.02
-    true_sizes = torch.full(
-        (E,), num_pairs // E, device="cuda", dtype=torch.int32
-    )
-    true_sizes[: num_pairs % E] += 1
-    true_offsets = torch.empty(E, device="cuda", dtype=torch.int32)
-    true_offsets[0] = 0
-    true_offsets[1:] = torch.cumsum(true_sizes[:-1], dim=0)
-    topk_ids = torch.randint(
-        0, E, (num_tokens, TOP_K), device="cuda", dtype=torch.int32
-    )
+    # Select unique experts per token and materialize the exact expert-major
+    # batch used by the full path. Pure/full timings therefore differ only by
+    # routing work, not by expert-size distribution.
+    topk_ids = torch.rand(
+        num_tokens, E, device="cuda"
+    ).topk(TOP_K, dim=-1).indices.to(torch.int32)
     topk_weights = torch.softmax(
         torch.randn(num_tokens, TOP_K, device="cuda"), dim=-1
+    )
+    permute = MoePermuteNopadFwdOp(
+        total_tokens=num_tokens,
+        top_k=TOP_K,
+        num_experts=E,
+        hidden_size=H,
+        dtype=DTYPE,
+    )
+    expert_input, true_offsets, true_sizes, _, _ = permute(
+        hidden, topk_ids
     )
     output_unfused = torch.empty(
         num_tokens, H, device="cuda", dtype=DTYPE
@@ -114,9 +121,62 @@ def _run_shape(num_tokens: int) -> tuple[float, ...]:
         )
     )
     logical_flops = 6 * num_pairs * H * F
-    pure_tflops = logical_flops / (timings[1] / 1e3) / 1e12
-    full_tflops = logical_flops / (timings[3] / 1e3) / 1e12
-    return (*timings, pure_tflops, full_tflops)
+    tflops = tuple(
+        logical_flops / (timing / 1e3) / 1e12
+        for timing in timings
+    )
+    return (*timings, *tflops)
+
+
+def _run_capacity_sweep(capacity: int = 16_384) -> None:
+    hidden = torch.randn(capacity, H, device="cuda", dtype=DTYPE)
+    w_gate_up = (
+        torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
+    )
+    w_down = torch.randn(E, H, F, device="cuda", dtype=DTYPE) * 0.02
+    unfused = DispatchedExpertMLPFwdOp(
+        capacity, E, H, F, DTYPE, use_fused_activation=False
+    )
+    fused = DispatchedExpertMLPFwdOp(
+        capacity, E, H, F, DTYPE, use_fused_activation=True
+    )
+    print(
+        "capacity,valid_rows,utilization,"
+        "capacity_unfused_ms,capacity_fused_ms,"
+        "unfused_effective_TFLOPS,fused_effective_TFLOPS"
+    )
+    for valid_rows in (0, capacity // 64, capacity // 8, capacity):
+        sizes = [
+            valid_rows // E + (expert < valid_rows % E)
+            for expert in range(E)
+        ]
+        offsets = [0]
+        for size in sizes:
+            offsets.append(offsets[-1] + size)
+        batch = ExpertBatch(
+            hidden=hidden,
+            expert_offsets=torch.tensor(
+                offsets, device="cuda", dtype=torch.int32
+            ),
+        )
+        unfused_ms = _time_ms(
+            lambda batch=batch: unfused.forward_batch(
+                batch, w_gate_up, w_down
+            )
+        )
+        fused_ms = _time_ms(
+            lambda batch=batch: fused.forward_batch(
+                batch, w_gate_up, w_down
+            )
+        )
+        logical_flops = 6 * valid_rows * H * F
+        print(
+            f"{capacity},{valid_rows},{valid_rows / capacity:.6f},"
+            f"{unfused_ms:.4f},{fused_ms:.4f},"
+            f"{logical_flops / (unfused_ms / 1e3) / 1e12:.2f},"
+            f"{logical_flops / (fused_ms / 1e3) / 1e12:.2f}",
+            flush=True,
+        )
 
 
 def main() -> None:
@@ -130,13 +190,15 @@ def main() -> None:
     print(
         "T,M,pure_unfused_ms,pure_fused_ms,"
         "full_unfused_ms,full_fused_ms,"
-        "pure_fused_effective_TFLOPS,full_fused_effective_TFLOPS"
+        "pure_unfused_effective_TFLOPS,pure_fused_effective_TFLOPS,"
+        "full_unfused_effective_TFLOPS,full_fused_effective_TFLOPS"
     )
     for num_tokens in (128, 1024):
         values = _run_shape(num_tokens)
         formatted = ",".join(f"{value:.4f}" for value in values)
         print(f"{num_tokens},{num_tokens * TOP_K},{formatted}", flush=True)
         torch.cuda.empty_cache()
+    _run_capacity_sweep()
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_dispatched_expert.py
+++ b/benchmarks/ops/bench_dispatched_expert.py
@@ -1,0 +1,143 @@
+"""H100 microbenchmark for the communication-independent expert MLP."""
+
+import torch
+
+from tileops.ops.moe import (
+    DispatchedExpertMLPFwdOp,
+    FusedMoEExpertsNopadPersistent3WGFwdOp,
+)
+
+DTYPE = torch.bfloat16
+E, TOP_K, H, F = 128, 8, 2048, 1024
+WARMUP, ITERS = 20, 100
+
+
+def _time_ms(fn) -> float:
+    for _ in range(WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    begin = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    begin.record()
+    for _ in range(ITERS):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return begin.elapsed_time(end) / ITERS
+
+
+def _run_shape(num_tokens: int) -> tuple[float, ...]:
+    num_pairs = num_tokens * TOP_K
+    hidden = torch.randn(num_tokens, H, device="cuda", dtype=DTYPE)
+    expert_input = torch.randn(num_pairs, H, device="cuda", dtype=DTYPE)
+    w_gate_up = (
+        torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
+    )
+    w_down = torch.randn(E, H, F, device="cuda", dtype=DTYPE) * 0.02
+    true_sizes = torch.full(
+        (E,), num_pairs // E, device="cuda", dtype=torch.int32
+    )
+    true_sizes[: num_pairs % E] += 1
+    true_offsets = torch.empty(E, device="cuda", dtype=torch.int32)
+    true_offsets[0] = 0
+    true_offsets[1:] = torch.cumsum(true_sizes[:-1], dim=0)
+    topk_ids = torch.randint(
+        0, E, (num_tokens, TOP_K), device="cuda", dtype=torch.int32
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, TOP_K, device="cuda"), dim=-1
+    )
+    output_unfused = torch.empty(
+        num_tokens, H, device="cuda", dtype=DTYPE
+    )
+    output_fused = torch.empty_like(output_unfused)
+    workspace = torch.empty(0, device="cuda", dtype=DTYPE)
+
+    pure_unfused = DispatchedExpertMLPFwdOp(
+        num_pairs, E, H, F, DTYPE, use_fused_activation=False
+    )
+    pure_fused = DispatchedExpertMLPFwdOp(
+        num_pairs, E, H, F, DTYPE, use_fused_activation=True
+    )
+    full_unfused = FusedMoEExpertsNopadPersistent3WGFwdOp(
+        num_tokens, E, TOP_K, H, F, dtype=DTYPE, use_fused_activation=False
+    )
+    full_fused = FusedMoEExpertsNopadPersistent3WGFwdOp(
+        num_tokens, E, TOP_K, H, F, dtype=DTYPE, use_fused_activation=True
+    )
+
+    def run_pure_unfused():
+        return pure_unfused(
+            expert_input, w_gate_up, w_down, true_sizes, true_offsets
+        )
+
+    def run_pure_fused():
+        return pure_fused(
+            expert_input, w_gate_up, w_down, true_sizes, true_offsets
+        )
+
+    def run_full_unfused():
+        return full_unfused.forward(
+            output_unfused,
+            hidden,
+            w_gate_up,
+            w_down,
+            topk_weights,
+            topk_ids,
+            None,
+            workspace,
+            workspace,
+            E,
+        )
+
+    def run_full_fused():
+        return full_fused.forward(
+            output_fused,
+            hidden,
+            w_gate_up,
+            w_down,
+            topk_weights,
+            topk_ids,
+            None,
+            workspace,
+            workspace,
+            E,
+        )
+
+    timings = tuple(
+        _time_ms(fn)
+        for fn in (
+            run_pure_unfused,
+            run_pure_fused,
+            run_full_unfused,
+            run_full_fused,
+        )
+    )
+    logical_flops = 6 * num_pairs * H * F
+    pure_tflops = logical_flops / (timings[1] / 1e3) / 1e12
+    full_tflops = logical_flops / (timings[3] / 1e3) / 1e12
+    return (*timings, pure_tflops, full_tflops)
+
+
+def main() -> None:
+    assert torch.cuda.is_available()
+    torch.manual_seed(42)
+    torch.set_grad_enabled(False)
+    print(
+        f"GPU={torch.cuda.get_device_name()} dtype={DTYPE} "
+        f"E={E} K={TOP_K} H={H} F={F}"
+    )
+    print(
+        "T,M,pure_unfused_ms,pure_fused_ms,"
+        "full_unfused_ms,full_fused_ms,"
+        "pure_fused_effective_TFLOPS,full_fused_effective_TFLOPS"
+    )
+    for num_tokens in (128, 1024):
+        values = _run_shape(num_tokens)
+        formatted = ",".join(f"{value:.4f}" for value in values)
+        print(f"{num_tokens},{num_tokens * TOP_K},{formatted}", flush=True)
+        torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ops/bench_dispatched_expert.py
+++ b/benchmarks/ops/bench_dispatched_expert.py
@@ -1,180 +1,51 @@
-"""H100 microbenchmark for the communication-independent expert MLP."""
+"""Dynamic-capacity benchmark for the dispatched expert MLP."""
 
 import torch
 
-from tileops.ops.moe import (
-    DispatchedExpertMLPFwdOp,
-    ExpertBatch,
-    FusedMoEExpertsNopadPersistent3WGFwdOp,
-)
-from tileops.ops.moe.routed_expert import MoePermuteNopadFwdOp
+from benchmarks.ops._moe_bench_utils import cuda_time_ms, effective_tflops
+from tileops.ops.moe import DispatchedExpertMLPFwdOp, ExpertBatch
 
 DTYPE = torch.bfloat16
-E, TOP_K, H, F = 128, 8, 2048, 1024
+E, H, F = 128, 2048, 1024
 WARMUP, ITERS = 20, 100
-
-
-def _time_ms(fn) -> float:
-    for _ in range(WARMUP):
-        fn()
-    torch.cuda.synchronize()
-    begin = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    begin.record()
-    for _ in range(ITERS):
-        fn()
-    end.record()
-    torch.cuda.synchronize()
-    return begin.elapsed_time(end) / ITERS
-
-
-def _run_shape(num_tokens: int) -> tuple[float, ...]:
-    num_pairs = num_tokens * TOP_K
-    hidden = torch.randn(num_tokens, H, device="cuda", dtype=DTYPE)
-    w_gate_up = (
-        torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
-    )
-    w_down = torch.randn(E, H, F, device="cuda", dtype=DTYPE) * 0.02
-    # Select unique experts per token and materialize the exact expert-major
-    # batch used by the full path. Pure/full timings therefore differ only by
-    # routing work, not by expert-size distribution.
-    topk_ids = torch.rand(
-        num_tokens, E, device="cuda"
-    ).topk(TOP_K, dim=-1).indices.to(torch.int32)
-    topk_weights = torch.softmax(
-        torch.randn(num_tokens, TOP_K, device="cuda"), dim=-1
-    )
-    permute = MoePermuteNopadFwdOp(
-        total_tokens=num_tokens,
-        top_k=TOP_K,
-        num_experts=E,
-        hidden_size=H,
-        dtype=DTYPE,
-    )
-    expert_input, true_offsets, true_sizes, _, _ = permute(
-        hidden, topk_ids
-    )
-    output_unfused = torch.empty(
-        num_tokens, H, device="cuda", dtype=DTYPE
-    )
-    output_fused = torch.empty_like(output_unfused)
-    workspace = torch.empty(0, device="cuda", dtype=DTYPE)
-
-    pure_unfused = DispatchedExpertMLPFwdOp(
-        num_pairs, E, H, F, DTYPE, use_fused_activation=False
-    )
-    pure_fused = DispatchedExpertMLPFwdOp(
-        num_pairs, E, H, F, DTYPE, use_fused_activation=True
-    )
-    full_unfused = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        num_tokens, E, TOP_K, H, F, dtype=DTYPE, use_fused_activation=False
-    )
-    full_fused = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        num_tokens, E, TOP_K, H, F, dtype=DTYPE, use_fused_activation=True
-    )
-
-    def run_pure_unfused():
-        return pure_unfused(
-            expert_input, w_gate_up, w_down, true_sizes, true_offsets
-        )
-
-    def run_pure_fused():
-        return pure_fused(
-            expert_input, w_gate_up, w_down, true_sizes, true_offsets
-        )
-
-    def run_full_unfused():
-        return full_unfused.forward(
-            output_unfused,
-            hidden,
-            w_gate_up,
-            w_down,
-            topk_weights,
-            topk_ids,
-            None,
-            workspace,
-            workspace,
-            E,
-        )
-
-    def run_full_fused():
-        return full_fused.forward(
-            output_fused,
-            hidden,
-            w_gate_up,
-            w_down,
-            topk_weights,
-            topk_ids,
-            None,
-            workspace,
-            workspace,
-            E,
-        )
-
-    timings = tuple(
-        _time_ms(fn)
-        for fn in (
-            run_pure_unfused,
-            run_pure_fused,
-            run_full_unfused,
-            run_full_fused,
-        )
-    )
-    logical_flops = 6 * num_pairs * H * F
-    tflops = tuple(
-        logical_flops / (timing / 1e3) / 1e12
-        for timing in timings
-    )
-    return (*timings, *tflops)
 
 
 def _run_capacity_sweep(capacity: int = 16_384) -> None:
     hidden = torch.randn(capacity, H, device="cuda", dtype=DTYPE)
-    w_gate_up = (
-        torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
-    )
+    w_gate_up = torch.randn(E, 2 * F, H, device="cuda", dtype=DTYPE) * 0.02
     w_down = torch.randn(E, H, F, device="cuda", dtype=DTYPE) * 0.02
-    unfused = DispatchedExpertMLPFwdOp(
-        capacity, E, H, F, DTYPE, use_fused_activation=False
-    )
-    fused = DispatchedExpertMLPFwdOp(
-        capacity, E, H, F, DTYPE, use_fused_activation=True
-    )
+    unfused = DispatchedExpertMLPFwdOp(capacity, E, H, F, DTYPE, use_fused_activation=False)
+    fused = DispatchedExpertMLPFwdOp(capacity, E, H, F, DTYPE, use_fused_activation=True)
     print(
         "capacity,valid_rows,utilization,"
         "capacity_unfused_ms,capacity_fused_ms,"
         "unfused_effective_TFLOPS,fused_effective_TFLOPS"
     )
     for valid_rows in (0, capacity // 64, capacity // 8, capacity):
-        sizes = [
-            valid_rows // E + (expert < valid_rows % E)
-            for expert in range(E)
-        ]
+        sizes = [valid_rows // E + (expert < valid_rows % E) for expert in range(E)]
         offsets = [0]
         for size in sizes:
             offsets.append(offsets[-1] + size)
         batch = ExpertBatch(
             hidden=hidden,
-            expert_offsets=torch.tensor(
-                offsets, device="cuda", dtype=torch.int32
-            ),
+            expert_offsets=torch.tensor(offsets, device="cuda", dtype=torch.int32),
         )
-        unfused_ms = _time_ms(
-            lambda batch=batch: unfused.forward_batch(
-                batch, w_gate_up, w_down
-            )
+        unfused_ms = cuda_time_ms(
+            lambda batch=batch: unfused.forward_batch(batch, w_gate_up, w_down),
+            warmup=WARMUP,
+            iters=ITERS,
         )
-        fused_ms = _time_ms(
-            lambda batch=batch: fused.forward_batch(
-                batch, w_gate_up, w_down
-            )
+        fused_ms = cuda_time_ms(
+            lambda batch=batch: fused.forward_batch(batch, w_gate_up, w_down),
+            warmup=WARMUP,
+            iters=ITERS,
         )
         logical_flops = 6 * valid_rows * H * F
         print(
             f"{capacity},{valid_rows},{valid_rows / capacity:.6f},"
             f"{unfused_ms:.4f},{fused_ms:.4f},"
-            f"{logical_flops / (unfused_ms / 1e3) / 1e12:.2f},"
-            f"{logical_flops / (fused_ms / 1e3) / 1e12:.2f}",
+            f"{effective_tflops(logical_flops, unfused_ms):.2f},"
+            f"{effective_tflops(logical_flops, fused_ms):.2f}",
             flush=True,
         )
 
@@ -183,21 +54,7 @@ def main() -> None:
     assert torch.cuda.is_available()
     torch.manual_seed(42)
     torch.set_grad_enabled(False)
-    print(
-        f"GPU={torch.cuda.get_device_name()} dtype={DTYPE} "
-        f"E={E} K={TOP_K} H={H} F={F}"
-    )
-    print(
-        "T,M,pure_unfused_ms,pure_fused_ms,"
-        "full_unfused_ms,full_fused_ms,"
-        "pure_unfused_effective_TFLOPS,pure_fused_effective_TFLOPS,"
-        "full_unfused_effective_TFLOPS,full_fused_effective_TFLOPS"
-    )
-    for num_tokens in (128, 1024):
-        values = _run_shape(num_tokens)
-        formatted = ",".join(f"{value:.4f}" for value in values)
-        print(f"{num_tokens},{num_tokens * TOP_K},{formatted}", flush=True)
-        torch.cuda.empty_cache()
+    print(f"GPU={torch.cuda.get_device_name()} dtype={DTYPE} E={E} H={H} F={F}")
     _run_capacity_sweep()
 
 

--- a/benchmarks/ops/bench_dispatched_expert_deepgemm.py
+++ b/benchmarks/ops/bench_dispatched_expert_deepgemm.py
@@ -1,137 +1,32 @@
 """Compute-only BF16 Expert MLP comparison with DeepGEMM ordinary MoE."""
 
 import argparse
-import time
 
 import deep_gemm
 import torch
 import torch.nn.functional as F
 
+from benchmarks.ops._moe_bench_utils import (
+    check_output,
+    cuda_time_ms,
+    effective_tflops,
+    expert_mlp_reference,
+    host_time_ms,
+    make_expert_sizes,
+)
 from tileops.ops.moe import DispatchedExpertMLPFwdOp
 
 DTYPE = torch.bfloat16
 WARMUP, ITERS = 10, 50
 MAX_RANGE_REL_TOL = 0.02
 RELATIVE_L2_TOL = 0.01
-
-
-def _time_ms(fn) -> float:
-    for _ in range(WARMUP):
-        fn()
-    torch.cuda.synchronize()
-    begin = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    begin.record()
-    for _ in range(ITERS):
-        fn()
-    end.record()
-    torch.cuda.synchronize()
-    return begin.elapsed_time(end) / ITERS
-
-
-def _host_time_ms(fn, *, warmup: int = 2, iters: int = 10) -> float:
-    for _ in range(warmup):
-        fn()
-    torch.cuda.synchronize()
-    begin = time.perf_counter()
-    for _ in range(iters):
-        fn()
-    torch.cuda.synchronize()
-    return (time.perf_counter() - begin) * 1e3 / iters
-
-
-def _make_sizes(
-    num_pairs: int,
-    num_experts: int,
-    distribution: str,
-) -> list[int]:
-    if distribution == "uniform":
-        return [
-            num_pairs // num_experts + (expert < num_pairs % num_experts)
-            for expert in range(num_experts)
-        ]
-
-    generator = torch.Generator(device="cpu").manual_seed(42)
-    if distribution == "longtail":
-        probabilities = 1 / torch.arange(
-            1, num_experts + 1, dtype=torch.float64
-        ).pow(1.2)
-    elif distribution == "hotspot":
-        hot_experts = max(1, num_experts // 8)
-        probabilities = torch.full((num_experts,), 0.2 / num_experts)
-        probabilities[:hot_experts] += 0.8 / hot_experts
-    elif distribution == "router-like":
-        # Deterministic synthetic categorical routing distribution.
-        probabilities = torch.softmax(
-            torch.randn(num_experts, generator=generator) * 1.5, dim=0
-        )
-    else:
-        raise ValueError(f"unknown distribution: {distribution}")
-    assignments = torch.multinomial(
-        probabilities,
-        num_samples=num_pairs,
-        replacement=True,
-        generator=generator,
-    )
-    return torch.bincount(assignments, minlength=num_experts).tolist()
-
-
-def _fp32_reference(
-    hidden: torch.Tensor,
-    w_gate_up: torch.Tensor,
-    w_down: torch.Tensor,
-    sizes: list[int],
-) -> torch.Tensor:
-    """Independent per-expert FP32 reference in tight row order."""
-    output = torch.empty(
-        hidden.shape[0],
-        hidden.shape[1],
-        device=hidden.device,
-        dtype=torch.float32,
-    )
-    ffn_size = w_down.shape[-1]
-    start = 0
-    for expert, size in enumerate(sizes):
-        if size == 0:
-            continue
-        rows = hidden[start : start + size].float()
-        gate_up = rows @ w_gate_up[expert].float().t()
-        activated = F.silu(gate_up[:, :ffn_size]) * gate_up[:, ffn_size:]
-        output[start : start + size] = (
-            activated @ w_down[expert].float().t()
-        )
-        start += size
-    return output
-
-
-def _check_output(
-    name: str,
-    actual: torch.Tensor,
-    reference: torch.Tensor,
-) -> tuple[float, float, float, float]:
-    actual_fp32 = actual.float()
-    if not torch.isfinite(actual_fp32).all():
-        raise AssertionError(f"{name}: output contains NaN or Inf")
-    error = actual_fp32 - reference
-    max_abs = error.abs().max().item()
-    rmse = error.square().mean().sqrt().item()
-    relative_l2 = (
-        torch.linalg.vector_norm(error)
-        / torch.linalg.vector_norm(reference).clamp_min(1e-12)
-    ).item()
-    max_range_relative = (
-        max_abs / reference.abs().max().clamp_min(1e-12).item()
-    )
-    if (
-        max_range_relative > MAX_RANGE_REL_TOL
-        or relative_l2 > RELATIVE_L2_TOL
-    ):
-        raise AssertionError(
-            f"{name}: max_abs={max_abs}, rmse={rmse}, "
-            f"relative_l2={relative_l2}, "
-            f"max_range_relative={max_range_relative}"
-        )
-    return max_abs, rmse, relative_l2, max_range_relative
+MODELS = {
+    "synthetic": (128, 8, 2048, 1024, [128, 1024]),
+    "glm5": (256, 8, 6144, 2048, [1, 32, 256, 512, 1024, 2048]),
+    "deepseek-v3": (256, 8, 7168, 2048, [1, 32, 256, 512, 1024, 2048]),
+    "qwen3-235b": (128, 8, 7168, 2048, [1, 16, 128, 256, 512, 1024]),
+    "qwen35-397b": (512, 10, 4096, 1024, [1, 52, 410, 820, 1639, 3277]),
+}
 
 
 def _run(
@@ -141,25 +36,17 @@ def _run(
     hidden_size: int,
     ffn_size: int,
     distribution: str,
-) -> None:
+) -> str:
     E, H, F_DIM = num_experts, hidden_size, ffn_size
-    sizes = _make_sizes(num_pairs, E, distribution)
-    alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(
-        max(1, num_pairs // E)
-    )
+    sizes = make_expert_sizes(num_pairs, E, distribution)
+    alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(max(1, num_pairs // E))
     deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
-    aligned_sizes = [
-        (size + alignment - 1) // alignment * alignment for size in sizes
-    ]
+    aligned_sizes = [(size + alignment - 1) // alignment * alignment for size in sizes]
     physical_rows = sum(aligned_sizes)
 
     tight = torch.randn(num_pairs, H, device="cuda", dtype=DTYPE)
-    w_gate_up = (
-        torch.randn(E, 2 * F_DIM, H, device="cuda", dtype=DTYPE) * 0.02
-    )
-    w_down = (
-        torch.randn(E, H, F_DIM, device="cuda", dtype=DTYPE) * 0.02
-    )
+    w_gate_up = torch.randn(E, 2 * F_DIM, H, device="cuda", dtype=DTYPE) * 0.02
+    w_down = torch.randn(E, H, F_DIM, device="cuda", dtype=DTYPE) * 0.02
     true_sizes = torch.tensor(sizes, device="cuda", dtype=torch.int32)
     true_offsets = torch.tensor(
         [sum(sizes[:expert]) for expert in range(E)],
@@ -173,9 +60,7 @@ def _run(
     def pack_aligned():
         aligned.zero_()
         tight_start = physical_start = 0
-        for expert, (size, aligned_size) in enumerate(
-            zip(sizes, aligned_sizes, strict=True)
-        ):
+        for expert, (size, aligned_size) in enumerate(zip(sizes, aligned_sizes, strict=True)):
             aligned[physical_start : physical_start + size].copy_(
                 tight[tight_start : tight_start + size]
             )
@@ -185,12 +70,8 @@ def _run(
 
     pack_aligned()
 
-    gate_up = torch.empty(
-        physical_rows, 2 * F_DIM, device="cuda", dtype=DTYPE
-    )
-    activated = torch.empty(
-        physical_rows, F_DIM, device="cuda", dtype=DTYPE
-    )
+    gate_up = torch.empty(physical_rows, 2 * F_DIM, device="cuda", dtype=DTYPE)
+    activated = torch.empty(physical_rows, F_DIM, device="cuda", dtype=DTYPE)
     output = torch.empty(physical_rows, H, device="cuda", dtype=DTYPE)
 
     tileops_unfused = DispatchedExpertMLPFwdOp(
@@ -200,19 +81,13 @@ def _run(
         num_pairs, E, H, F_DIM, DTYPE, use_fused_activation=True
     )
     if not tileops_fused.use_fused_activation:
-        raise RuntimeError(
-            f"{case_name}: requested TileOps fused activation is not eligible"
-        )
+        raise RuntimeError(f"{case_name}: requested TileOps fused activation is not eligible")
 
     def run_tileops_unfused():
-        return tileops_unfused(
-            tight, w_gate_up, w_down, true_sizes, true_offsets
-        )
+        return tileops_unfused(tight, w_gate_up, w_down, true_sizes, true_offsets)
 
     def run_tileops_fused():
-        return tileops_fused(
-            tight, w_gate_up, w_down, true_sizes, true_offsets
-        )
+        return tileops_fused(tight, w_gate_up, w_down, true_sizes, true_offsets)
 
     def run_gemm1_into(destination):
         deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
@@ -265,7 +140,7 @@ def _run(
         return local_output
 
     # Validate every reported backend against an independent FP32 reference.
-    reference = _fp32_reference(tight, w_gate_up, w_down, sizes)
+    reference = expert_mlp_reference(tight, w_gate_up, w_down, sizes)
     tileops_unfused_output = run_tileops_unfused()
     tileops_fused_output = run_tileops_fused()
     run_deepgemm_pipeline()
@@ -278,28 +153,45 @@ def _run(
         tight_start += size
         physical_start += aligned_size
     torch.cuda.synchronize()
-    tileops_unfused_error = _check_output(
-        "TileOps unfused", tileops_unfused_output, reference
+    check_kwargs = {
+        "max_range_relative_tolerance": MAX_RANGE_REL_TOL,
+        "relative_l2_tolerance": RELATIVE_L2_TOL,
+    }
+    tileops_unfused_error = check_output(
+        "TileOps unfused",
+        tileops_unfused_output,
+        reference,
+        **check_kwargs,
     )
-    tileops_fused_error = _check_output(
-        "TileOps fused", tileops_fused_output, reference
+    tileops_fused_error = check_output(
+        "TileOps fused",
+        tileops_fused_output,
+        reference,
+        **check_kwargs,
     )
-    deepgemm_error = _check_output("DeepGEMM", deepgemm_valid, reference)
+    deepgemm_error = check_output(
+        "DeepGEMM",
+        deepgemm_valid,
+        reference,
+        **check_kwargs,
+    )
 
-    pack_ms = _host_time_ms(pack_aligned)
-    tileops_unfused_ms = _time_ms(run_tileops_unfused)
-    tileops_fused_ms = _time_ms(run_tileops_fused)
-    gemm1_ms = _time_ms(run_gemm1)
-    activation_ms = _time_ms(run_activation)
-    gemm2_ms = _time_ms(run_gemm2)
-    deepgemm_preallocated_ms = _time_ms(run_deepgemm_pipeline)
-    deepgemm_allocating_ms = _time_ms(run_deepgemm_allocating_pipeline)
+    pack_ms = host_time_ms(pack_aligned, warmup=2, iters=10)
+    tileops_unfused_ms = cuda_time_ms(run_tileops_unfused, warmup=WARMUP, iters=ITERS)
+    tileops_fused_ms = cuda_time_ms(run_tileops_fused, warmup=WARMUP, iters=ITERS)
+    gemm1_ms = cuda_time_ms(run_gemm1, warmup=WARMUP, iters=ITERS)
+    activation_ms = cuda_time_ms(run_activation, warmup=WARMUP, iters=ITERS)
+    gemm2_ms = cuda_time_ms(run_gemm2, warmup=WARMUP, iters=ITERS)
+    deepgemm_preallocated_ms = cuda_time_ms(run_deepgemm_pipeline, warmup=WARMUP, iters=ITERS)
+    deepgemm_allocating_ms = cuda_time_ms(
+        run_deepgemm_allocating_pipeline, warmup=WARMUP, iters=ITERS
+    )
 
     logical_flops = 6 * num_pairs * H * F_DIM
     physical_flops = 6 * physical_rows * H * F_DIM
     empty_experts = sum(size == 0 for size in sizes)
     sizes_tensor = torch.tensor(sizes, dtype=torch.float32)
-    print(
+    return (
         f"{case_name},{distribution},{num_pairs / E:.4f},"
         f"{min(sizes)},{max(sizes)},{sizes_tensor.std(unbiased=False).item():.4f},"
         f"{num_pairs},{physical_rows},{empty_experts},"
@@ -308,11 +200,11 @@ def _run(
         f"{tileops_unfused_ms:.4f},{tileops_fused_ms:.4f},"
         f"{gemm1_ms:.4f},{activation_ms:.4f},{gemm2_ms:.4f},"
         f"{deepgemm_preallocated_ms:.4f},{deepgemm_allocating_ms:.4f},"
-        f"{logical_flops / (tileops_unfused_ms / 1e3) / 1e12:.2f},"
-        f"{logical_flops / (tileops_fused_ms / 1e3) / 1e12:.2f},"
-        f"{logical_flops / (deepgemm_preallocated_ms / 1e3) / 1e12:.2f},"
-        f"{logical_flops / (deepgemm_allocating_ms / 1e3) / 1e12:.2f},"
-        f"{physical_flops / (deepgemm_preallocated_ms / 1e3) / 1e12:.2f},"
+        f"{effective_tflops(logical_flops, tileops_unfused_ms):.2f},"
+        f"{effective_tflops(logical_flops, tileops_fused_ms):.2f},"
+        f"{effective_tflops(logical_flops, deepgemm_preallocated_ms):.2f},"
+        f"{effective_tflops(logical_flops, deepgemm_allocating_ms):.2f},"
+        f"{effective_tflops(physical_flops, deepgemm_preallocated_ms):.2f},"
         f"{tileops_unfused_error[0]:.6f},"
         f"{tileops_unfused_error[1]:.6f},"
         f"{tileops_unfused_error[2]:.6f},"
@@ -323,8 +215,7 @@ def _run(
         f"{tileops_fused_error[3]:.6f},"
         f"{deepgemm_error[0]:.6f},{deepgemm_error[1]:.6f},"
         f"{deepgemm_error[2]:.6f},{deepgemm_error[3]:.6f},"
-        f"{num_pairs}",
-        flush=True,
+        f"{num_pairs}"
     )
 
 
@@ -332,13 +223,7 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--model",
-        choices=(
-            "synthetic",
-            "glm5",
-            "deepseek-v3",
-            "qwen3-235b",
-            "qwen35-397b",
-        ),
+        choices=tuple(MODELS),
         default="synthetic",
     )
     parser.add_argument(
@@ -368,21 +253,7 @@ def main() -> None:
     torch.set_float32_matmul_precision("highest")
     torch.set_grad_enabled(False)
     args = _parse_args()
-    if args.model == "glm5":
-        num_experts, top_k, hidden_size, ffn_size = 256, 8, 6144, 2048
-        token_counts = args.tokens or [1, 32, 256, 512, 1024, 2048]
-    elif args.model == "deepseek-v3":
-        num_experts, top_k, hidden_size, ffn_size = 256, 8, 7168, 2048
-        token_counts = args.tokens or [1, 32, 256, 512, 1024, 2048]
-    elif args.model == "qwen3-235b":
-        num_experts, top_k, hidden_size, ffn_size = 128, 8, 7168, 2048
-        token_counts = args.tokens or [1, 16, 128, 256, 512, 1024]
-    elif args.model == "qwen35-397b":
-        num_experts, top_k, hidden_size, ffn_size = 512, 10, 4096, 1024
-        token_counts = args.tokens or [1, 52, 410, 820, 1639, 3277]
-    else:
-        num_experts, top_k, hidden_size, ffn_size = 128, 8, 2048, 1024
-        token_counts = args.tokens or [128, 1024]
+    num_experts, top_k, hidden_size, ffn_size, default_tokens = MODELS[args.model]
     print(
         f"GPU={torch.cuda.get_device_name()} dtype={DTYPE} "
         f"model={args.model} E={num_experts} K={top_k} "
@@ -407,20 +278,24 @@ def main() -> None:
         "deepgemm_max_range_relative,"
         "valid_rows_checked"
     )
+    token_counts = args.tokens or default_tokens
     cases = (
-        [(f"M={m}", m * num_experts) for m in args.m]
+        [(f"M={rows}", rows * num_experts) for rows in args.m]
         if args.m
         else [(f"T={tokens}", tokens * top_k) for tokens in token_counts]
     )
     for distribution in args.distribution:
         for case_name, num_pairs in cases:
-            _run(
-                case_name,
-                num_pairs,
-                num_experts,
-                hidden_size,
-                ffn_size,
-                distribution,
+            print(
+                _run(
+                    case_name,
+                    num_pairs,
+                    num_experts,
+                    hidden_size,
+                    ffn_size,
+                    distribution,
+                ),
+                flush=True,
             )
             torch.cuda.empty_cache()
 

--- a/benchmarks/ops/bench_dispatched_expert_deepgemm.py
+++ b/benchmarks/ops/bench_dispatched_expert_deepgemm.py
@@ -1,0 +1,330 @@
+"""Compute-only BF16 Expert MLP comparison with DeepGEMM ordinary MoE."""
+
+import argparse
+import time
+
+import deep_gemm
+import torch
+import torch.nn.functional as F
+
+from tileops.ops.moe import DispatchedExpertMLPFwdOp
+
+DTYPE = torch.bfloat16
+WARMUP, ITERS = 10, 50
+
+
+def _time_ms(fn) -> float:
+    for _ in range(WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    begin = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    begin.record()
+    for _ in range(ITERS):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return begin.elapsed_time(end) / ITERS
+
+
+def _host_time_ms(fn, *, warmup: int = 2, iters: int = 10) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    begin = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - begin) * 1e3 / iters
+
+
+def _make_sizes(
+    num_pairs: int,
+    num_experts: int,
+    distribution: str,
+) -> list[int]:
+    if distribution == "uniform":
+        return [
+            num_pairs // num_experts + (expert < num_pairs % num_experts)
+            for expert in range(num_experts)
+        ]
+
+    generator = torch.Generator(device="cpu").manual_seed(42)
+    if distribution == "longtail":
+        probabilities = 1 / torch.arange(
+            1, num_experts + 1, dtype=torch.float64
+        ).pow(1.2)
+    elif distribution == "hotspot":
+        hot_experts = max(1, num_experts // 8)
+        probabilities = torch.full((num_experts,), 0.2 / num_experts)
+        probabilities[:hot_experts] += 0.8 / hot_experts
+    elif distribution == "router":
+        # Deterministic router-like trace: correlated expert logits produce
+        # a reproducible non-uniform assignment with naturally empty experts.
+        probabilities = torch.softmax(
+            torch.randn(num_experts, generator=generator) * 1.5, dim=0
+        )
+    else:
+        raise ValueError(f"unknown distribution: {distribution}")
+    assignments = torch.multinomial(
+        probabilities,
+        num_samples=num_pairs,
+        replacement=True,
+        generator=generator,
+    )
+    return torch.bincount(assignments, minlength=num_experts).tolist()
+
+
+def _run(
+    case_name: str,
+    num_pairs: int,
+    num_experts: int,
+    hidden_size: int,
+    ffn_size: int,
+    distribution: str,
+) -> None:
+    E, H, F_DIM = num_experts, hidden_size, ffn_size
+    sizes = _make_sizes(num_pairs, E, distribution)
+    alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(
+        max(1, num_pairs // E)
+    )
+    deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
+    aligned_sizes = [
+        (size + alignment - 1) // alignment * alignment for size in sizes
+    ]
+    physical_rows = sum(aligned_sizes)
+
+    tight = torch.randn(num_pairs, H, device="cuda", dtype=DTYPE)
+    w_gate_up = (
+        torch.randn(E, 2 * F_DIM, H, device="cuda", dtype=DTYPE) * 0.02
+    )
+    w_down = (
+        torch.randn(E, H, F_DIM, device="cuda", dtype=DTYPE) * 0.02
+    )
+    true_sizes = torch.tensor(sizes, device="cuda", dtype=torch.int32)
+    true_offsets = torch.tensor(
+        [sum(sizes[:expert]) for expert in range(E)],
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    aligned = torch.empty(physical_rows, H, device="cuda", dtype=DTYPE)
+    psum = torch.empty(E, device="cuda", dtype=torch.int32)
+
+    def pack_aligned():
+        aligned.zero_()
+        tight_start = physical_start = 0
+        for expert, (size, aligned_size) in enumerate(
+            zip(sizes, aligned_sizes, strict=True)
+        ):
+            aligned[physical_start : physical_start + size].copy_(
+                tight[tight_start : tight_start + size]
+            )
+            psum[expert] = physical_start + size
+            tight_start += size
+            physical_start += aligned_size
+
+    pack_aligned()
+
+    gate_up = torch.empty(
+        physical_rows, 2 * F_DIM, device="cuda", dtype=DTYPE
+    )
+    activated = torch.empty(
+        physical_rows, F_DIM, device="cuda", dtype=DTYPE
+    )
+    output = torch.empty(physical_rows, H, device="cuda", dtype=DTYPE)
+
+    tileops_unfused = DispatchedExpertMLPFwdOp(
+        num_pairs, E, H, F_DIM, DTYPE, use_fused_activation=False
+    )
+    tileops_fused = DispatchedExpertMLPFwdOp(
+        num_pairs, E, H, F_DIM, DTYPE, use_fused_activation=True
+    )
+
+    def run_tileops_unfused():
+        return tileops_unfused(
+            tight, w_gate_up, w_down, true_sizes, true_offsets
+        )
+
+    def run_tileops_fused():
+        return tileops_fused(
+            tight, w_gate_up, w_down, true_sizes, true_offsets
+        )
+
+    def run_gemm1():
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            aligned,
+            w_gate_up,
+            gate_up,
+            psum,
+            use_psum_layout=True,
+            expected_m_for_psum_layout=max(1, num_pairs // E),
+        )
+
+    def run_activation():
+        torch.mul(
+            F.silu(gate_up[:, :F_DIM]),
+            gate_up[:, F_DIM:],
+            out=activated,
+        )
+
+    def run_gemm2():
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            activated,
+            w_down,
+            output,
+            psum,
+            use_psum_layout=True,
+            expected_m_for_psum_layout=max(1, num_pairs // E),
+        )
+
+    def run_deepgemm_pipeline():
+        run_gemm1()
+        run_activation()
+        run_gemm2()
+
+    # Correctness compares only valid logical rows; aligned padding is omitted.
+    tileops_reference = run_tileops_unfused()
+    run_deepgemm_pipeline()
+    deepgemm_valid = torch.empty_like(tileops_reference)
+    tight_start = physical_start = 0
+    for size, aligned_size in zip(sizes, aligned_sizes, strict=True):
+        deepgemm_valid[tight_start : tight_start + size].copy_(
+            output[physical_start : physical_start + size]
+        )
+        tight_start += size
+        physical_start += aligned_size
+    torch.cuda.synchronize()
+    abs_diff = (tileops_reference.float() - deepgemm_valid.float()).abs()
+    max_diff = abs_diff.max().item()
+    relative_diff = max_diff / max(
+        tileops_reference.float().abs().max().item(), 1e-12
+    )
+    if not torch.allclose(
+        tileops_reference.float(),
+        deepgemm_valid.float(),
+        atol=8e-2,
+        rtol=8e-2,
+    ):
+        raise AssertionError(
+            f"{case_name}/{distribution}: TileOps and DeepGEMM disagree; "
+            f"max_diff={max_diff}, relative_diff={relative_diff}"
+        )
+
+    pack_ms = _host_time_ms(pack_aligned)
+    tileops_unfused_ms = _time_ms(run_tileops_unfused)
+    tileops_fused_ms = _time_ms(run_tileops_fused)
+    gemm1_ms = _time_ms(run_gemm1)
+    activation_ms = _time_ms(run_activation)
+    gemm2_ms = _time_ms(run_gemm2)
+    deepgemm_total_ms = _time_ms(run_deepgemm_pipeline)
+
+    logical_flops = 6 * num_pairs * H * F_DIM
+    physical_flops = 6 * physical_rows * H * F_DIM
+    empty_experts = sum(size == 0 for size in sizes)
+    sizes_tensor = torch.tensor(sizes, dtype=torch.float32)
+    print(
+        f"{case_name},{distribution},{num_pairs / E:.4f},"
+        f"{min(sizes)},{max(sizes)},{sizes_tensor.std(unbiased=False).item():.4f},"
+        f"{num_pairs},{physical_rows},{empty_experts},"
+        f"{physical_rows / num_pairs - 1:.4f},"
+        f"{pack_ms:.4f},"
+        f"{tileops_unfused_ms:.4f},{tileops_fused_ms:.4f},"
+        f"{gemm1_ms:.4f},{activation_ms:.4f},{gemm2_ms:.4f},"
+        f"{deepgemm_total_ms:.4f},"
+        f"{logical_flops / (tileops_fused_ms / 1e3) / 1e12:.2f},"
+        f"{logical_flops / (deepgemm_total_ms / 1e3) / 1e12:.2f},"
+        f"{physical_flops / (deepgemm_total_ms / 1e3) / 1e12:.2f},"
+        f"{max_diff:.6f},{relative_diff:.6f},{num_pairs}",
+        flush=True,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model",
+        choices=(
+            "synthetic",
+            "glm5",
+            "deepseek-v3",
+            "qwen3-235b",
+            "qwen35-397b",
+        ),
+        default="synthetic",
+    )
+    parser.add_argument(
+        "--tokens",
+        type=int,
+        nargs="+",
+        help="Token counts; defaults depend on --model.",
+    )
+    parser.add_argument(
+        "--m",
+        type=int,
+        nargs="+",
+        help="Exact logical rows per expert; takes precedence over --tokens.",
+    )
+    parser.add_argument(
+        "--distribution",
+        choices=("uniform", "longtail", "hotspot", "router"),
+        nargs="+",
+        default=("uniform",),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    assert torch.cuda.is_available()
+    torch.manual_seed(42)
+    torch.set_grad_enabled(False)
+    args = _parse_args()
+    if args.model == "glm5":
+        num_experts, top_k, hidden_size, ffn_size = 256, 8, 6144, 2048
+        token_counts = args.tokens or [1, 32, 256, 512, 1024, 2048]
+    elif args.model == "deepseek-v3":
+        num_experts, top_k, hidden_size, ffn_size = 256, 8, 7168, 2048
+        token_counts = args.tokens or [1, 32, 256, 512, 1024, 2048]
+    elif args.model == "qwen3-235b":
+        num_experts, top_k, hidden_size, ffn_size = 128, 8, 7168, 2048
+        token_counts = args.tokens or [1, 16, 128, 256, 512, 1024]
+    elif args.model == "qwen35-397b":
+        num_experts, top_k, hidden_size, ffn_size = 512, 10, 4096, 1024
+        token_counts = args.tokens or [1, 52, 410, 820, 1639, 3277]
+    else:
+        num_experts, top_k, hidden_size, ffn_size = 128, 8, 2048, 1024
+        token_counts = args.tokens or [128, 1024]
+    print(
+        f"GPU={torch.cuda.get_device_name()} dtype={DTYPE} "
+        f"model={args.model} E={num_experts} K={top_k} "
+        f"H={hidden_size} F={ffn_size}"
+    )
+    print(
+        "case,distribution,mean_M,min_M,max_M,std_M,"
+        "logical_rows,physical_rows,empty_experts,padding_ratio,pack_ms,"
+        "tileops_unfused_ms,tileops_fused_ms,"
+        "deepgemm_gemm1_ms,activation_ms,deepgemm_gemm2_ms,"
+        "deepgemm_total_ms,tileops_effective_TFLOPS,"
+        "deepgemm_effective_TFLOPS,deepgemm_physical_TFLOPS,"
+        "max_diff,relative_diff,valid_rows_checked"
+    )
+    cases = (
+        [(f"M={m}", m * num_experts) for m in args.m]
+        if args.m
+        else [(f"T={tokens}", tokens * top_k) for tokens in token_counts]
+    )
+    for distribution in args.distribution:
+        for case_name, num_pairs in cases:
+            _run(
+                case_name,
+                num_pairs,
+                num_experts,
+                hidden_size,
+                ffn_size,
+                distribution,
+            )
+            torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ops/bench_dispatched_expert_deepgemm.py
+++ b/benchmarks/ops/bench_dispatched_expert_deepgemm.py
@@ -11,6 +11,8 @@ from tileops.ops.moe import DispatchedExpertMLPFwdOp
 
 DTYPE = torch.bfloat16
 WARMUP, ITERS = 10, 50
+MAX_RANGE_REL_TOL = 0.02
+RELATIVE_L2_TOL = 0.01
 
 
 def _time_ms(fn) -> float:
@@ -58,9 +60,8 @@ def _make_sizes(
         hot_experts = max(1, num_experts // 8)
         probabilities = torch.full((num_experts,), 0.2 / num_experts)
         probabilities[:hot_experts] += 0.8 / hot_experts
-    elif distribution == "router":
-        # Deterministic router-like trace: correlated expert logits produce
-        # a reproducible non-uniform assignment with naturally empty experts.
+    elif distribution == "router-like":
+        # Deterministic synthetic categorical routing distribution.
         probabilities = torch.softmax(
             torch.randn(num_experts, generator=generator) * 1.5, dim=0
         )
@@ -73,6 +74,64 @@ def _make_sizes(
         generator=generator,
     )
     return torch.bincount(assignments, minlength=num_experts).tolist()
+
+
+def _fp32_reference(
+    hidden: torch.Tensor,
+    w_gate_up: torch.Tensor,
+    w_down: torch.Tensor,
+    sizes: list[int],
+) -> torch.Tensor:
+    """Independent per-expert FP32 reference in tight row order."""
+    output = torch.empty(
+        hidden.shape[0],
+        hidden.shape[1],
+        device=hidden.device,
+        dtype=torch.float32,
+    )
+    ffn_size = w_down.shape[-1]
+    start = 0
+    for expert, size in enumerate(sizes):
+        if size == 0:
+            continue
+        rows = hidden[start : start + size].float()
+        gate_up = rows @ w_gate_up[expert].float().t()
+        activated = F.silu(gate_up[:, :ffn_size]) * gate_up[:, ffn_size:]
+        output[start : start + size] = (
+            activated @ w_down[expert].float().t()
+        )
+        start += size
+    return output
+
+
+def _check_output(
+    name: str,
+    actual: torch.Tensor,
+    reference: torch.Tensor,
+) -> tuple[float, float, float, float]:
+    actual_fp32 = actual.float()
+    if not torch.isfinite(actual_fp32).all():
+        raise AssertionError(f"{name}: output contains NaN or Inf")
+    error = actual_fp32 - reference
+    max_abs = error.abs().max().item()
+    rmse = error.square().mean().sqrt().item()
+    relative_l2 = (
+        torch.linalg.vector_norm(error)
+        / torch.linalg.vector_norm(reference).clamp_min(1e-12)
+    ).item()
+    max_range_relative = (
+        max_abs / reference.abs().max().clamp_min(1e-12).item()
+    )
+    if (
+        max_range_relative > MAX_RANGE_REL_TOL
+        or relative_l2 > RELATIVE_L2_TOL
+    ):
+        raise AssertionError(
+            f"{name}: max_abs={max_abs}, rmse={rmse}, "
+            f"relative_l2={relative_l2}, "
+            f"max_range_relative={max_range_relative}"
+        )
+    return max_abs, rmse, relative_l2, max_range_relative
 
 
 def _run(
@@ -140,6 +199,10 @@ def _run(
     tileops_fused = DispatchedExpertMLPFwdOp(
         num_pairs, E, H, F_DIM, DTYPE, use_fused_activation=True
     )
+    if not tileops_fused.use_fused_activation:
+        raise RuntimeError(
+            f"{case_name}: requested TileOps fused activation is not eligible"
+        )
 
     def run_tileops_unfused():
         return tileops_unfused(
@@ -151,42 +214,62 @@ def _run(
             tight, w_gate_up, w_down, true_sizes, true_offsets
         )
 
-    def run_gemm1():
+    def run_gemm1_into(destination):
         deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
             aligned,
             w_gate_up,
-            gate_up,
+            destination,
             psum,
             use_psum_layout=True,
             expected_m_for_psum_layout=max(1, num_pairs // E),
         )
+
+    def run_activation_into(gate_up_input, destination):
+        torch.mul(
+            F.silu(gate_up_input[:, :F_DIM]),
+            gate_up_input[:, F_DIM:],
+            out=destination,
+        )
+
+    def run_gemm2_into(activation_input, destination):
+        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
+            activation_input,
+            w_down,
+            destination,
+            psum,
+            use_psum_layout=True,
+            expected_m_for_psum_layout=max(1, num_pairs // E),
+        )
+
+    def run_gemm1():
+        run_gemm1_into(gate_up)
 
     def run_activation():
-        torch.mul(
-            F.silu(gate_up[:, :F_DIM]),
-            gate_up[:, F_DIM:],
-            out=activated,
-        )
+        run_activation_into(gate_up, activated)
 
     def run_gemm2():
-        deep_gemm.m_grouped_bf16_gemm_nt_contiguous(
-            activated,
-            w_down,
-            output,
-            psum,
-            use_psum_layout=True,
-            expected_m_for_psum_layout=max(1, num_pairs // E),
-        )
+        run_gemm2_into(activated, output)
 
     def run_deepgemm_pipeline():
         run_gemm1()
         run_activation()
         run_gemm2()
 
-    # Correctness compares only valid logical rows; aligned padding is omitted.
-    tileops_reference = run_tileops_unfused()
+    def run_deepgemm_allocating_pipeline():
+        local_gate_up = torch.empty_like(gate_up)
+        local_activated = torch.empty_like(activated)
+        local_output = torch.empty_like(output)
+        run_gemm1_into(local_gate_up)
+        run_activation_into(local_gate_up, local_activated)
+        run_gemm2_into(local_activated, local_output)
+        return local_output
+
+    # Validate every reported backend against an independent FP32 reference.
+    reference = _fp32_reference(tight, w_gate_up, w_down, sizes)
+    tileops_unfused_output = run_tileops_unfused()
+    tileops_fused_output = run_tileops_fused()
     run_deepgemm_pipeline()
-    deepgemm_valid = torch.empty_like(tileops_reference)
+    deepgemm_valid = torch.empty_like(tileops_unfused_output)
     tight_start = physical_start = 0
     for size, aligned_size in zip(sizes, aligned_sizes, strict=True):
         deepgemm_valid[tight_start : tight_start + size].copy_(
@@ -195,21 +278,13 @@ def _run(
         tight_start += size
         physical_start += aligned_size
     torch.cuda.synchronize()
-    abs_diff = (tileops_reference.float() - deepgemm_valid.float()).abs()
-    max_diff = abs_diff.max().item()
-    relative_diff = max_diff / max(
-        tileops_reference.float().abs().max().item(), 1e-12
+    tileops_unfused_error = _check_output(
+        "TileOps unfused", tileops_unfused_output, reference
     )
-    if not torch.allclose(
-        tileops_reference.float(),
-        deepgemm_valid.float(),
-        atol=8e-2,
-        rtol=8e-2,
-    ):
-        raise AssertionError(
-            f"{case_name}/{distribution}: TileOps and DeepGEMM disagree; "
-            f"max_diff={max_diff}, relative_diff={relative_diff}"
-        )
+    tileops_fused_error = _check_output(
+        "TileOps fused", tileops_fused_output, reference
+    )
+    deepgemm_error = _check_output("DeepGEMM", deepgemm_valid, reference)
 
     pack_ms = _host_time_ms(pack_aligned)
     tileops_unfused_ms = _time_ms(run_tileops_unfused)
@@ -217,7 +292,8 @@ def _run(
     gemm1_ms = _time_ms(run_gemm1)
     activation_ms = _time_ms(run_activation)
     gemm2_ms = _time_ms(run_gemm2)
-    deepgemm_total_ms = _time_ms(run_deepgemm_pipeline)
+    deepgemm_preallocated_ms = _time_ms(run_deepgemm_pipeline)
+    deepgemm_allocating_ms = _time_ms(run_deepgemm_allocating_pipeline)
 
     logical_flops = 6 * num_pairs * H * F_DIM
     physical_flops = 6 * physical_rows * H * F_DIM
@@ -231,11 +307,23 @@ def _run(
         f"{pack_ms:.4f},"
         f"{tileops_unfused_ms:.4f},{tileops_fused_ms:.4f},"
         f"{gemm1_ms:.4f},{activation_ms:.4f},{gemm2_ms:.4f},"
-        f"{deepgemm_total_ms:.4f},"
+        f"{deepgemm_preallocated_ms:.4f},{deepgemm_allocating_ms:.4f},"
+        f"{logical_flops / (tileops_unfused_ms / 1e3) / 1e12:.2f},"
         f"{logical_flops / (tileops_fused_ms / 1e3) / 1e12:.2f},"
-        f"{logical_flops / (deepgemm_total_ms / 1e3) / 1e12:.2f},"
-        f"{physical_flops / (deepgemm_total_ms / 1e3) / 1e12:.2f},"
-        f"{max_diff:.6f},{relative_diff:.6f},{num_pairs}",
+        f"{logical_flops / (deepgemm_preallocated_ms / 1e3) / 1e12:.2f},"
+        f"{logical_flops / (deepgemm_allocating_ms / 1e3) / 1e12:.2f},"
+        f"{physical_flops / (deepgemm_preallocated_ms / 1e3) / 1e12:.2f},"
+        f"{tileops_unfused_error[0]:.6f},"
+        f"{tileops_unfused_error[1]:.6f},"
+        f"{tileops_unfused_error[2]:.6f},"
+        f"{tileops_unfused_error[3]:.6f},"
+        f"{tileops_fused_error[0]:.6f},"
+        f"{tileops_fused_error[1]:.6f},"
+        f"{tileops_fused_error[2]:.6f},"
+        f"{tileops_fused_error[3]:.6f},"
+        f"{deepgemm_error[0]:.6f},{deepgemm_error[1]:.6f},"
+        f"{deepgemm_error[2]:.6f},{deepgemm_error[3]:.6f},"
+        f"{num_pairs}",
         flush=True,
     )
 
@@ -267,7 +355,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--distribution",
-        choices=("uniform", "longtail", "hotspot", "router"),
+        choices=("uniform", "longtail", "hotspot", "router-like"),
         nargs="+",
         default=("uniform",),
     )
@@ -277,6 +365,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     assert torch.cuda.is_available()
     torch.manual_seed(42)
+    torch.set_float32_matmul_precision("highest")
     torch.set_grad_enabled(False)
     args = _parse_args()
     if args.model == "glm5":
@@ -304,9 +393,19 @@ def main() -> None:
         "logical_rows,physical_rows,empty_experts,padding_ratio,pack_ms,"
         "tileops_unfused_ms,tileops_fused_ms,"
         "deepgemm_gemm1_ms,activation_ms,deepgemm_gemm2_ms,"
-        "deepgemm_total_ms,tileops_effective_TFLOPS,"
-        "deepgemm_effective_TFLOPS,deepgemm_physical_TFLOPS,"
-        "max_diff,relative_diff,valid_rows_checked"
+        "deepgemm_preallocated_ms,deepgemm_allocating_ms,"
+        "tileops_unfused_effective_TFLOPS,"
+        "tileops_fused_effective_TFLOPS,"
+        "deepgemm_preallocated_effective_TFLOPS,"
+        "deepgemm_allocating_effective_TFLOPS,"
+        "deepgemm_physical_TFLOPS,"
+        "tileops_unfused_max_abs,tileops_unfused_rmse,"
+        "tileops_unfused_relative_l2,tileops_unfused_max_range_relative,"
+        "tileops_fused_max_abs,tileops_fused_rmse,"
+        "tileops_fused_relative_l2,tileops_fused_max_range_relative,"
+        "deepgemm_max_abs,deepgemm_rmse,deepgemm_relative_l2,"
+        "deepgemm_max_range_relative,"
+        "valid_rows_checked"
     )
     cases = (
         [(f"M={m}", m * num_experts) for m in args.m]

--- a/benchmarks/ops/bench_expert_dispatch.py
+++ b/benchmarks/ops/bench_expert_dispatch.py
@@ -1,0 +1,118 @@
+"""Dispatch-only benchmark for the tight local M6 reference path.
+
+DeepEP communication is intentionally not emulated here.  A real DeepEP run
+must report communication and adapter normalization separately; this benchmark
+measures the local count/prefix-sum/scatter/gather primitive used as the
+world-size-one reference.
+"""
+
+import argparse
+
+import torch
+
+from tileops.ops.moe import LocalExpertDispatcher
+
+WARMUP = 20
+ITERS = 100
+
+
+def _time_ms(fn) -> float:
+    for _ in range(WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    begin = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    begin.record()
+    for _ in range(ITERS):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return begin.elapsed_time(end) / ITERS
+
+
+def _make_topk_ids(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    distribution: str,
+) -> torch.Tensor:
+    if distribution == "uniform":
+        scores = torch.rand(num_tokens, num_experts, device="cuda")
+    elif distribution == "hotspot":
+        logits = torch.linspace(4.0, -4.0, num_experts, device="cuda")
+        scores = logits.unsqueeze(0) + torch.rand(num_tokens, num_experts, device="cuda")
+    elif distribution == "longtail":
+        ranks = torch.arange(1, num_experts + 1, device="cuda")
+        logits = -torch.log(ranks)
+        scores = logits.unsqueeze(0) + torch.rand(num_tokens, num_experts, device="cuda")
+    else:
+        raise ValueError(f"unknown distribution {distribution!r}")
+    return scores.topk(top_k, dim=-1).indices.to(torch.int32)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hidden-size", type=int, default=7168)
+    parser.add_argument("--num-experts", type=int, default=256)
+    parser.add_argument("--top-k", type=int, default=8)
+    parser.add_argument("--tokens", type=int, nargs="+", default=[1, 8, 32, 128, 512, 2048])
+    parser.add_argument(
+        "--distributions",
+        nargs="+",
+        choices=["uniform", "longtail", "hotspot"],
+        default=["uniform", "longtail", "hotspot"],
+    )
+    args = parser.parse_args()
+
+    print(
+        "tokens,top_k,num_experts,hidden_size,distribution,"
+        "effective_rows,physical_rows,dispatch_allocating_ms,effective_GBps"
+    )
+    for num_tokens in args.tokens:
+        hidden = torch.randn(
+            num_tokens,
+            args.hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        weights = torch.softmax(torch.randn(num_tokens, args.top_k, device="cuda"), dim=-1)
+        for distribution in args.distributions:
+            topk_ids = _make_topk_ids(
+                num_tokens,
+                args.top_k,
+                args.num_experts,
+                distribution,
+            )
+            dispatcher = LocalExpertDispatcher(
+                args.num_experts,
+                total_tokens=num_tokens,
+                top_k=args.top_k,
+                hidden_size=args.hidden_size,
+                dtype=torch.bfloat16,
+            )
+
+            def run(
+                dispatcher=dispatcher,
+                hidden=hidden,
+                topk_ids=topk_ids,
+                weights=weights,
+            ):
+                return dispatcher.dispatch(hidden, topk_ids, weights)
+
+            result = run()
+            torch.cuda.synchronize()
+            dispatch_ms = _time_ms(run)
+            effective_rows = num_tokens * args.top_k
+            physical_rows = result.batch.capacity
+            # One source read and one dispatched write for every routed row.
+            logical_bytes = 2 * effective_rows * args.hidden_size * hidden.element_size()
+            effective_gbps = logical_bytes / (dispatch_ms / 1e3) / 1e9
+            print(
+                f"{num_tokens},{args.top_k},{args.num_experts},"
+                f"{args.hidden_size},{distribution},{effective_rows},"
+                f"{physical_rows},{dispatch_ms:.4f},{effective_gbps:.2f}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ops/bench_expert_dispatch.py
+++ b/benchmarks/ops/bench_expert_dispatch.py
@@ -10,44 +10,25 @@ import argparse
 
 import torch
 
+from benchmarks.ops._moe_bench_utils import (
+    make_routing_inputs,
+    measure_dispatch,
+)
 from tileops.ops.moe import LocalExpertDispatcher
 
 WARMUP = 20
 ITERS = 100
-
-
-def _time_ms(fn) -> float:
-    for _ in range(WARMUP):
-        fn()
-    torch.cuda.synchronize()
-    begin = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    begin.record()
-    for _ in range(ITERS):
-        fn()
-    end.record()
-    torch.cuda.synchronize()
-    return begin.elapsed_time(end) / ITERS
-
-
-def _make_topk_ids(
-    num_tokens: int,
-    top_k: int,
-    num_experts: int,
-    distribution: str,
-) -> torch.Tensor:
-    if distribution == "uniform":
-        scores = torch.rand(num_tokens, num_experts, device="cuda")
-    elif distribution == "hotspot":
-        logits = torch.linspace(4.0, -4.0, num_experts, device="cuda")
-        scores = logits.unsqueeze(0) + torch.rand(num_tokens, num_experts, device="cuda")
-    elif distribution == "longtail":
-        ranks = torch.arange(1, num_experts + 1, device="cuda")
-        logits = -torch.log(ranks)
-        scores = logits.unsqueeze(0) + torch.rand(num_tokens, num_experts, device="cuda")
-    else:
-        raise ValueError(f"unknown distribution {distribution!r}")
-    return scores.topk(top_k, dim=-1).indices.to(torch.int32)
+FIELDS = (
+    "tokens",
+    "top_k",
+    "num_experts",
+    "hidden_size",
+    "distribution",
+    "effective_rows",
+    "physical_rows",
+    "dispatch_allocating_ms",
+    "effective_GBps",
+)
 
 
 def main() -> None:
@@ -64,24 +45,15 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    print(
-        "tokens,top_k,num_experts,hidden_size,distribution,"
-        "effective_rows,physical_rows,dispatch_allocating_ms,effective_GBps"
-    )
+    print(",".join(FIELDS))
     for num_tokens in args.tokens:
-        hidden = torch.randn(
-            num_tokens,
-            args.hidden_size,
-            dtype=torch.bfloat16,
-            device="cuda",
-        )
-        weights = torch.softmax(torch.randn(num_tokens, args.top_k, device="cuda"), dim=-1)
         for distribution in args.distributions:
-            topk_ids = _make_topk_ids(
+            hidden, topk_ids, weights = make_routing_inputs(
                 num_tokens,
+                args.hidden_size,
                 args.top_k,
                 args.num_experts,
-                distribution,
+                distribution=distribution,
             )
             dispatcher = LocalExpertDispatcher(
                 args.num_experts,
@@ -99,19 +71,21 @@ def main() -> None:
             ):
                 return dispatcher.dispatch(hidden, topk_ids, weights)
 
-            result = run()
-            torch.cuda.synchronize()
-            dispatch_ms = _time_ms(run)
+            result, fresh_ms, _ = measure_dispatch(run, warmup=WARMUP, iters=ITERS)
             effective_rows = num_tokens * args.top_k
-            physical_rows = result.batch.capacity
-            # One source read and one dispatched write for every routed row.
             logical_bytes = 2 * effective_rows * args.hidden_size * hidden.element_size()
-            effective_gbps = logical_bytes / (dispatch_ms / 1e3) / 1e9
-            print(
-                f"{num_tokens},{args.top_k},{args.num_experts},"
-                f"{args.hidden_size},{distribution},{effective_rows},"
-                f"{physical_rows},{dispatch_ms:.4f},{effective_gbps:.2f}"
+            values = (
+                num_tokens,
+                args.top_k,
+                args.num_experts,
+                args.hidden_size,
+                distribution,
+                effective_rows,
+                result.batch.capacity,
+                f"{fresh_ms:.4f}",
+                f"{logical_bytes / (fresh_ms / 1e3) / 1e9:.2f}",
             )
+            print(",".join(map(str, values)), flush=True)
 
 
 if __name__ == "__main__":

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -734,6 +734,71 @@ def _make_fused_gated_explicit(
     return kernel
 
 
+@functools.lru_cache(maxsize=32)
+def _make_fused_gated_direct_bounded(
+    M, N, dtype, op_func, threads=256, output_dtype=None,
+):
+    """FusedGated direct with a device-side valid row count."""
+    out_dtype = output_dtype or dtype
+
+    @tilelang.jit(out_idx=[2])
+    def kernel(threads_arg):
+        @T.prim_func
+        def main(
+            x: T.Tensor((M, 2 * N), dtype),
+            valid_rows: T.Tensor((1,), "int32"),
+            y: T.Tensor((M, N), out_dtype),
+        ):
+            col_blocks = T.ceildiv(N, threads_arg)
+            with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
+                row = bx // col_blocks
+                col_block = bx % col_blocks
+                for i in T.Parallel(threads_arg):
+                    col = col_block * threads_arg + i
+                    if row < valid_rows[0]:
+                        gate = x[row, col]
+                        value = x[row, N + col]
+                        y[row, col] = op_func(gate, value)
+
+        return main
+
+    return kernel
+
+
+@functools.lru_cache(maxsize=32)
+def _make_fused_gated_explicit_bounded(
+    M, N, dtype, op_func, threads=256, num_per_thread=8,
+    output_dtype=None,
+):
+    """FusedGated explicit_parallel with a device-side valid row count."""
+    block_N = threads * num_per_thread
+    out_dtype = output_dtype or dtype
+
+    @tilelang.jit(out_idx=[2])
+    def kernel(threads_arg, npt_arg):
+        @T.prim_func
+        def main(
+            x: T.Tensor((M, 2 * N), dtype),
+            valid_rows: T.Tensor((1,), "int32"),
+            y: T.Tensor((M, N), out_dtype),
+        ):
+            col_blocks = T.ceildiv(N, block_N)
+            with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
+                row = bx // col_blocks
+                col_block = bx % col_blocks
+                for i, j in T.Parallel(threads_arg, npt_arg):
+                    col = (col_block * threads_arg + i) * npt_arg + j
+                    if row < valid_rows[0]:
+                        gate = x[row, col]
+                        value = x[row, N + col]
+                        y[row, col] = op_func(gate, value)
+
+        return main
+
+    return kernel
+
+
+# ---------------------------------------------------------------------------
 # Template base classes
 
 
@@ -1365,9 +1430,52 @@ class FusedGatedKernel(Kernel):
             self._compiled_fn = self.kernel(cfg["threads"])
         else:
             self._compiled_fn = self.kernel(cfg["threads"], cfg["num_per_thread"])
+        self._bounded_compiled_fn = None
 
     def forward(self, x):
         result = self._compiled_fn(x)
+        if self._fp8_output_dtype is not None:
+            result = result.to(self._fp8_output_dtype)
+        return result
+
+    def forward_rows(self, x, valid_rows):
+        """Apply the gated activation only to ``valid_rows`` leading rows.
+
+        ``valid_rows`` remains a CUDA int32 tensor so one compiled capacity
+        can be replayed with different received row counts without host sync.
+        Rows in the returned capacity tail are unspecified.
+        """
+        if valid_rows.dtype != torch.int32 or valid_rows.numel() != 1:
+            raise ValueError("valid_rows must be a one-element torch.int32 tensor")
+        if valid_rows.device != x.device:
+            raise ValueError("valid_rows and x must be on the same device")
+        if self._bounded_compiled_fn is None:
+            cfg = self.config
+            effective_op = self._get_effective_op_func()
+            if self.strategy == "direct":
+                bounded_kernel = _make_fused_gated_direct_bounded(
+                    self.M,
+                    self.N,
+                    self.dtype_str,
+                    effective_op,
+                    threads=cfg["threads"],
+                    output_dtype=self._kernel_output_dtype,
+                )
+                self._bounded_compiled_fn = bounded_kernel(cfg["threads"])
+            else:
+                bounded_kernel = _make_fused_gated_explicit_bounded(
+                    self.M,
+                    self.N,
+                    self.dtype_str,
+                    effective_op,
+                    cfg["threads"],
+                    cfg["num_per_thread"],
+                    output_dtype=self._kernel_output_dtype,
+                )
+                self._bounded_compiled_fn = bounded_kernel(
+                    cfg["threads"], cfg["num_per_thread"]
+                )
+        result = self._bounded_compiled_fn(x, valid_rows.reshape(1))
         if self._fp8_output_dtype is not None:
             result = result.to(self._fp8_output_dtype)
         return result

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -650,52 +650,34 @@ def _make_binary_explicit(
 # Strategy factory: FusedGated
 
 
-@functools.lru_cache(maxsize=32)
-def _make_fused_gated_direct(M, N, dtype, op_func, threads=256, output_dtype=None):
-    """FusedGated direct: 1 element per thread. x[:, :N] is gate, x[:, N:] is value.
+def _fused_gated_col(col_block, thread, item, threads, num_per_thread):
+    """Shared compile-time column mapping for all fused-gated row policies."""
+    return (col_block * threads + thread) * num_per_thread + item
 
-    ``op_func(gate, value)`` is the compound operation that applies the
-    activation to *gate* and multiplies by *value*.  For fp8 dtypes the
-    caller wraps it via ``_wrap_fp8_accumulation`` so this factory stays
-    fp8-agnostic.
 
-    Args:
-        output_dtype: TileLang dtype string for the output tensor. Defaults to dtype.
-    """
-    out_dtype = output_dtype or dtype
+def _make_fused_gated_store(N, op_func):
+    """Create the single fused-gated pointwise epilogue implementation."""
 
-    @tilelang.jit(out_idx=[1])
-    def kernel(threads_arg):
-        @T.prim_func
-        def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
-            if M <= 65535:
-                with T.Kernel(T.ceildiv(N, threads_arg), M, threads=threads_arg) as (bx, by):
-                    for i in T.Parallel(threads_arg):
-                        col = bx * threads_arg + i
-                        gate = x[by, col]
-                        value = x[by, N + col]
-                        y[by, col] = op_func(gate, value)
-            else:
-                col_blocks = T.ceildiv(N, threads_arg)
-                with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
-                    row = bx // col_blocks
-                    col_block = bx % col_blocks
-                    for i in T.Parallel(threads_arg):
-                        col = col_block * threads_arg + i
-                        gate = x[row, col]
-                        value = x[row, N + col]
-                        y[row, col] = op_func(gate, value)
+    @T.macro
+    def store(x, y, row, col):
+        gate = x[row, col]
+        value = x[row, N + col]
+        y[row, col] = op_func(gate, value)
 
-        return main
-
-    return kernel
+    return store
 
 
 @functools.lru_cache(maxsize=32)
-def _make_fused_gated_explicit(
-    M, N, dtype, op_func, threads=256, num_per_thread=8, output_dtype=None
+def _make_fused_gated(
+    M,
+    N,
+    dtype,
+    op_func,
+    threads=256,
+    num_per_thread=8,
+    output_dtype=None,
 ):
-    """FusedGated explicit_parallel: N elements per thread.
+    """Build the normal-row FusedGated strategy.
 
     ``op_func(gate, value)`` is the compound operation (see
     ``_make_fused_gated_direct``).  fp8 accumulation belongs to the caller, which
@@ -706,6 +688,7 @@ def _make_fused_gated_explicit(
     """
     block_N = threads * num_per_thread
     out_dtype = output_dtype or dtype
+    store = _make_fused_gated_store(N, op_func)
 
     @tilelang.jit(out_idx=[1])
     def kernel(threads_arg, npt_arg):
@@ -714,20 +697,16 @@ def _make_fused_gated_explicit(
             if M <= 65535:
                 with T.Kernel(T.ceildiv(N, block_N), M, threads=threads_arg) as (bx, by):
                     for i, j in T.Parallel(threads_arg, npt_arg):
-                        col = (bx * threads_arg + i) * npt_arg + j
-                        gate = x[by, col]
-                        value = x[by, N + col]
-                        y[by, col] = op_func(gate, value)
+                        col = _fused_gated_col(bx, i, j, threads_arg, npt_arg)
+                        store(x, y, by, col)
             else:
                 col_blocks = T.ceildiv(N, block_N)
                 with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
                     row = bx // col_blocks
                     col_block = bx % col_blocks
                     for i, j in T.Parallel(threads_arg, npt_arg):
-                        col = (col_block * threads_arg + i) * npt_arg + j
-                        gate = x[row, col]
-                        value = x[row, N + col]
-                        y[row, col] = op_func(gate, value)
+                        col = _fused_gated_col(col_block, i, j, threads_arg, npt_arg)
+                        store(x, y, row, col)
 
         return main
 
@@ -735,46 +714,25 @@ def _make_fused_gated_explicit(
 
 
 @functools.lru_cache(maxsize=32)
-def _make_fused_gated_direct_bounded(
-    M, N, dtype, op_func, grid_rows, threads=256, output_dtype=None,
-):
-    """Persistent FusedGated direct with a device-side valid row count."""
-    out_dtype = output_dtype or dtype
-
-    @tilelang.jit(out_idx=[2])
-    def kernel(threads_arg):
-        @T.prim_func
-        def main(
-            x: T.Tensor((M, 2 * N), dtype),
-            valid_rows: T.Tensor((1,), "int32"),
-            y: T.Tensor((M, N), out_dtype),
-        ):
-            col_blocks = T.ceildiv(N, threads_arg)
-            with T.Kernel(grid_rows * col_blocks, threads=threads_arg) as bx:
-                worker_row = bx // col_blocks
-                col_block = bx % col_blocks
-                for row_iter in T.serial(T.ceildiv(M, grid_rows)):
-                    row = worker_row + row_iter * grid_rows
-                    for i in T.Parallel(threads_arg):
-                        col = col_block * threads_arg + i
-                        if row < valid_rows[0]:
-                            gate = x[row, col]
-                            value = x[row, N + col]
-                            y[row, col] = op_func(gate, value)
-
-        return main
-
-    return kernel
-
-
-@functools.lru_cache(maxsize=32)
-def _make_fused_gated_explicit_bounded(
-    M, N, dtype, op_func, grid_rows, threads=256, num_per_thread=8,
+def _make_fused_gated_bounded(
+    M,
+    N,
+    dtype,
+    op_func,
+    grid_rows,
+    threads=256,
+    num_per_thread=8,
     output_dtype=None,
 ):
-    """Persistent FusedGated explicit_parallel with a device row count."""
+    """Persistent FusedGated with a device row count.
+
+    ``num_per_thread=1`` is the direct strategy. Keeping that choice static
+    shares the pointwise source without adding a runtime bounded/strategy
+    branch.
+    """
     block_N = threads * num_per_thread
     out_dtype = output_dtype or dtype
+    store = _make_fused_gated_store(N, op_func)
 
     @tilelang.jit(out_idx=[2])
     def kernel(threads_arg, npt_arg):
@@ -791,11 +749,9 @@ def _make_fused_gated_explicit_bounded(
                 for row_iter in T.serial(T.ceildiv(M, grid_rows)):
                     row = worker_row + row_iter * grid_rows
                     for i, j in T.Parallel(threads_arg, npt_arg):
-                        col = (col_block * threads_arg + i) * npt_arg + j
+                        col = _fused_gated_col(col_block, i, j, threads_arg, npt_arg)
                         if row < valid_rows[0]:
-                            gate = x[row, col]
-                            value = x[row, N + col]
-                            y[row, col] = op_func(gate, value)
+                            store(x, y, row, col)
 
         return main
 
@@ -1351,16 +1307,17 @@ class FusedGatedKernel(Kernel):
         cfg = self.default_config
         effective_op = self._get_effective_op_func()
         if strategy == "direct":
-            return _make_fused_gated_direct(
+            return _make_fused_gated(
                 self.M,
                 self.N,
                 self.dtype_str,
                 effective_op,
                 threads=cfg["threads"],
+                num_per_thread=1,
                 output_dtype=self._kernel_output_dtype,
             )
         elif strategy == "explicit_parallel":
-            return _make_fused_gated_explicit(
+            return _make_fused_gated(
                 self.M,
                 self.N,
                 self.dtype_str,
@@ -1431,7 +1388,7 @@ class FusedGatedKernel(Kernel):
         # to avoid JIT lookup overhead on every forward() call.
         cfg = self.config
         if self.strategy == "direct":
-            self._compiled_fn = self.kernel(cfg["threads"])
+            self._compiled_fn = self.kernel(cfg["threads"], 1)
         else:
             self._compiled_fn = self.kernel(cfg["threads"], cfg["num_per_thread"])
         self._bounded_compiled_fn = None
@@ -1456,23 +1413,22 @@ class FusedGatedKernel(Kernel):
         if self._bounded_compiled_fn is None:
             cfg = self.config
             effective_op = self._get_effective_op_func()
-            sm_count = torch.cuda.get_device_properties(
-                x.device
-            ).multi_processor_count
+            sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
             grid_rows = min(self.M, 16 * sm_count)
             if self.strategy == "direct":
-                bounded_kernel = _make_fused_gated_direct_bounded(
+                bounded_kernel = _make_fused_gated_bounded(
                     self.M,
                     self.N,
                     self.dtype_str,
                     effective_op,
                     grid_rows,
                     threads=cfg["threads"],
+                    num_per_thread=1,
                     output_dtype=self._kernel_output_dtype,
                 )
-                self._bounded_compiled_fn = bounded_kernel(cfg["threads"])
+                self._bounded_compiled_fn = bounded_kernel(cfg["threads"], 1)
             else:
-                bounded_kernel = _make_fused_gated_explicit_bounded(
+                bounded_kernel = _make_fused_gated_bounded(
                     self.M,
                     self.N,
                     self.dtype_str,
@@ -1482,9 +1438,7 @@ class FusedGatedKernel(Kernel):
                     cfg["num_per_thread"],
                     output_dtype=self._kernel_output_dtype,
                 )
-                self._bounded_compiled_fn = bounded_kernel(
-                    cfg["threads"], cfg["num_per_thread"]
-                )
+                self._bounded_compiled_fn = bounded_kernel(cfg["threads"], cfg["num_per_thread"])
         result = self._bounded_compiled_fn(x, valid_rows.reshape(1))
         if self._fp8_output_dtype is not None:
             result = result.to(self._fp8_output_dtype)

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -736,9 +736,9 @@ def _make_fused_gated_explicit(
 
 @functools.lru_cache(maxsize=32)
 def _make_fused_gated_direct_bounded(
-    M, N, dtype, op_func, threads=256, output_dtype=None,
+    M, N, dtype, op_func, grid_rows, threads=256, output_dtype=None,
 ):
-    """FusedGated direct with a device-side valid row count."""
+    """Persistent FusedGated direct with a device-side valid row count."""
     out_dtype = output_dtype or dtype
 
     @tilelang.jit(out_idx=[2])
@@ -750,15 +750,17 @@ def _make_fused_gated_direct_bounded(
             y: T.Tensor((M, N), out_dtype),
         ):
             col_blocks = T.ceildiv(N, threads_arg)
-            with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
-                row = bx // col_blocks
+            with T.Kernel(grid_rows * col_blocks, threads=threads_arg) as bx:
+                worker_row = bx // col_blocks
                 col_block = bx % col_blocks
-                for i in T.Parallel(threads_arg):
-                    col = col_block * threads_arg + i
-                    if row < valid_rows[0]:
-                        gate = x[row, col]
-                        value = x[row, N + col]
-                        y[row, col] = op_func(gate, value)
+                for row_iter in T.serial(T.ceildiv(M, grid_rows)):
+                    row = worker_row + row_iter * grid_rows
+                    for i in T.Parallel(threads_arg):
+                        col = col_block * threads_arg + i
+                        if row < valid_rows[0]:
+                            gate = x[row, col]
+                            value = x[row, N + col]
+                            y[row, col] = op_func(gate, value)
 
         return main
 
@@ -767,10 +769,10 @@ def _make_fused_gated_direct_bounded(
 
 @functools.lru_cache(maxsize=32)
 def _make_fused_gated_explicit_bounded(
-    M, N, dtype, op_func, threads=256, num_per_thread=8,
+    M, N, dtype, op_func, grid_rows, threads=256, num_per_thread=8,
     output_dtype=None,
 ):
-    """FusedGated explicit_parallel with a device-side valid row count."""
+    """Persistent FusedGated explicit_parallel with a device row count."""
     block_N = threads * num_per_thread
     out_dtype = output_dtype or dtype
 
@@ -783,15 +785,17 @@ def _make_fused_gated_explicit_bounded(
             y: T.Tensor((M, N), out_dtype),
         ):
             col_blocks = T.ceildiv(N, block_N)
-            with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
-                row = bx // col_blocks
+            with T.Kernel(grid_rows * col_blocks, threads=threads_arg) as bx:
+                worker_row = bx // col_blocks
                 col_block = bx % col_blocks
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    col = (col_block * threads_arg + i) * npt_arg + j
-                    if row < valid_rows[0]:
-                        gate = x[row, col]
-                        value = x[row, N + col]
-                        y[row, col] = op_func(gate, value)
+                for row_iter in T.serial(T.ceildiv(M, grid_rows)):
+                    row = worker_row + row_iter * grid_rows
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        col = (col_block * threads_arg + i) * npt_arg + j
+                        if row < valid_rows[0]:
+                            gate = x[row, col]
+                            value = x[row, N + col]
+                            y[row, col] = op_func(gate, value)
 
         return main
 
@@ -1452,12 +1456,17 @@ class FusedGatedKernel(Kernel):
         if self._bounded_compiled_fn is None:
             cfg = self.config
             effective_op = self._get_effective_op_func()
+            sm_count = torch.cuda.get_device_properties(
+                x.device
+            ).multi_processor_count
+            grid_rows = min(self.M, 16 * sm_count)
             if self.strategy == "direct":
                 bounded_kernel = _make_fused_gated_direct_bounded(
                     self.M,
                     self.N,
                     self.dtype_str,
                     effective_op,
+                    grid_rows,
                     threads=cfg["threads"],
                     output_dtype=self._kernel_output_dtype,
                 )
@@ -1468,6 +1477,7 @@ class FusedGatedKernel(Kernel):
                     self.N,
                     self.dtype_str,
                     effective_op,
+                    grid_rows,
                     cfg["threads"],
                     cfg["num_per_thread"],
                     output_dtype=self._kernel_output_dtype,

--- a/src/tileops/kernels/elementwise.py
+++ b/src/tileops/kernels/elementwise.py
@@ -668,12 +668,23 @@ def _make_fused_gated_direct(M, N, dtype, op_func, threads=256, output_dtype=Non
     def kernel(threads_arg):
         @T.prim_func
         def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
-            with T.Kernel(T.ceildiv(N, threads_arg), M, threads=threads_arg) as (bx, by):
-                for i in T.Parallel(threads_arg):
-                    col = bx * threads_arg + i
-                    gate = x[by, col]
-                    value = x[by, N + col]
-                    y[by, col] = op_func(gate, value)
+            if M <= 65535:
+                with T.Kernel(T.ceildiv(N, threads_arg), M, threads=threads_arg) as (bx, by):
+                    for i in T.Parallel(threads_arg):
+                        col = bx * threads_arg + i
+                        gate = x[by, col]
+                        value = x[by, N + col]
+                        y[by, col] = op_func(gate, value)
+            else:
+                col_blocks = T.ceildiv(N, threads_arg)
+                with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
+                    row = bx // col_blocks
+                    col_block = bx % col_blocks
+                    for i in T.Parallel(threads_arg):
+                        col = col_block * threads_arg + i
+                        gate = x[row, col]
+                        value = x[row, N + col]
+                        y[row, col] = op_func(gate, value)
 
         return main
 
@@ -700,12 +711,23 @@ def _make_fused_gated_explicit(
     def kernel(threads_arg, npt_arg):
         @T.prim_func
         def main(x: T.Tensor((M, 2 * N), dtype), y: T.Tensor((M, N), out_dtype)):
-            with T.Kernel(T.ceildiv(N, block_N), M, threads=threads_arg) as (bx, by):
-                for i, j in T.Parallel(threads_arg, npt_arg):
-                    col = (bx * threads_arg + i) * npt_arg + j
-                    gate = x[by, col]
-                    value = x[by, N + col]
-                    y[by, col] = op_func(gate, value)
+            if M <= 65535:
+                with T.Kernel(T.ceildiv(N, block_N), M, threads=threads_arg) as (bx, by):
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        col = (bx * threads_arg + i) * npt_arg + j
+                        gate = x[by, col]
+                        value = x[by, N + col]
+                        y[by, col] = op_func(gate, value)
+            else:
+                col_blocks = T.ceildiv(N, block_N)
+                with T.Kernel(M * col_blocks, threads=threads_arg) as bx:
+                    row = bx // col_blocks
+                    col_block = bx % col_blocks
+                    for i, j in T.Parallel(threads_arg, npt_arg):
+                        col = (col_block * threads_arg + i) * npt_arg + j
+                        gate = x[row, col]
+                        value = x[row, N + col]
+                        y[row, col] = op_func(gate, value)
 
         return main
 

--- a/src/tileops/ops/moe/__init__.py
+++ b/src/tileops/ops/moe/__init__.py
@@ -5,12 +5,16 @@ from .fused_topk import FusedTopKOp
 from .permute_align import MoePermuteAlignFwdOp
 from .prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from .routed_expert import (
+    DeepEPDispatchAdapter,
     DispatchedExpertMLPFwdOp,
     ExpertBatch,
     ExpertBatchOutput,
+    ExpertDispatchResult,
     FusedMoEExperts,
     FusedMoEExpertsModular,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
+    LocalDispatchHandle,
+    LocalExpertDispatcher,
     MoeGroupedGemmNopad3WGFusedActFwdOp,
     MoeGroupedGemmNopadFwdOp,
     MoePermuteNopadFwdOp,
@@ -23,9 +27,11 @@ from .routed_expert.abc import FusedMoEPrepareAndFinalize
 from .shared_fused_moe import SharedFusedMoE
 
 __all__ = [
+    "DeepEPDispatchAdapter",
     "DispatchedExpertMLPFwdOp",
     "ExpertBatch",
     "ExpertBatchOutput",
+    "ExpertDispatchResult",
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
@@ -34,6 +40,8 @@ __all__ = [
     "FusedMoeFwdCbFwdOp",
     "FusedMoeFwdOp",
     "FusedTopKOp",
+    "LocalDispatchHandle",
+    "LocalExpertDispatcher",
     "MoEPrepareAndFinalizeNoDPEP",
     "MoeGroupedGemmNopad3WGFusedActFwdOp",
     "MoeGroupedGemmNopadFwdOp",

--- a/src/tileops/ops/moe/__init__.py
+++ b/src/tileops/ops/moe/__init__.py
@@ -1,36 +1,41 @@
 """MoE operator package."""
 
-from .abc import (
-    FusedMoEExperts,
-    FusedMoEExpertsModular,
-    FusedMoEPrepareAndFinalize,
-    PrepareResult,
-    WeightedReduce,
-    WeightedReduceNoOp,
-)
-from .fused_moe import FusedMoe, FusedMoeFwdOp
+from .fused_moe import FusedMoe, FusedMoeFwdCbFwdOp, FusedMoeFwdOp
 from .fused_topk import FusedTopKOp
 from .permute_align import MoePermuteAlignFwdOp
 from .prepare_finalize.no_dp_ep import MoEPrepareAndFinalizeNoDPEP
 from .routed_expert import (
+    DispatchedExpertMLPFwdOp,
+    ExpertBatch,
+    ExpertBatchOutput,
+    FusedMoEExperts,
+    FusedMoEExpertsModular,
     FusedMoEExpertsNopadPersistent3WGFwdOp,
-    MoeGateUpFwdOp,
+    MoeGroupedGemmNopad3WGFusedActFwdOp,
     MoeGroupedGemmNopadFwdOp,
     MoePermuteNopadFwdOp,
     MoeUnpermuteFwdOp,
+    PrepareResult,
+    WeightedReduce,
+    WeightedReduceNoOp,
 )
+from .routed_expert.abc import FusedMoEPrepareAndFinalize
 from .shared_fused_moe import SharedFusedMoE
 
 __all__ = [
+    "DispatchedExpertMLPFwdOp",
+    "ExpertBatch",
+    "ExpertBatchOutput",
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
     "FusedMoEPrepareAndFinalize",
     "FusedMoe",
+    "FusedMoeFwdCbFwdOp",
     "FusedMoeFwdOp",
     "FusedTopKOp",
     "MoEPrepareAndFinalizeNoDPEP",
-    "MoeGateUpFwdOp",
+    "MoeGroupedGemmNopad3WGFusedActFwdOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteAlignFwdOp",
     "MoePermuteNopadFwdOp",

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -26,6 +26,8 @@ from torch import Tensor
 from tileops.ops.op_base import Op
 
 __all__ = [
+    "ExpertBatch",
+    "ExpertBatchOutput",
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
     "FusedMoEPrepareAndFinalize",
@@ -33,6 +35,65 @@ __all__ = [
     "WeightedReduce",
     "WeightedReduceNoOp",
 ]
+
+
+@dataclass(frozen=True)
+class ExpertBatch:
+    """Canonical communication-to-compute contract for routed expert rows.
+
+    ``hidden`` uses a tight expert-major layout. Expert ``e`` owns rows
+    ``expert_offsets[e]:expert_offsets[e + 1]``; adjacent equal offsets encode
+    an empty expert. TileOps borrows all input buffers for the duration of the
+    call and does not mutate them.
+    """
+
+    hidden: Tensor
+    expert_offsets: Tensor
+    valid_rows: Tensor | None = None
+    layout: str = "tight"
+
+    def __post_init__(self) -> None:
+        if self.hidden.ndim != 2:
+            raise ValueError(
+                f"hidden must be rank 2 [capacity, H], got {self.hidden.shape}"
+            )
+        if self.expert_offsets.ndim != 1:
+            raise ValueError(
+                "expert_offsets must be rank 1 [E_local + 1], got "
+                f"{self.expert_offsets.shape}"
+            )
+        if self.expert_offsets.dtype != torch.int32:
+            raise ValueError(
+                "expert_offsets must use torch.int32, got "
+                f"{self.expert_offsets.dtype}"
+            )
+        if self.hidden.device != self.expert_offsets.device:
+            raise ValueError("hidden and expert_offsets must be on the same device")
+        if self.layout != "tight":
+            raise ValueError(
+                f"only layout='tight' is supported, got {self.layout!r}"
+            )
+        if self.valid_rows is not None:
+            if self.valid_rows.numel() != 1:
+                raise ValueError("valid_rows must be a scalar tensor")
+            if self.valid_rows.device != self.hidden.device:
+                raise ValueError(
+                    "valid_rows and hidden must be on the same device"
+                )
+
+    @property
+    def capacity(self) -> int:
+        return self.hidden.shape[0]
+
+
+@dataclass(frozen=True)
+class ExpertBatchOutput:
+    """Expert MLP output; routing weights have not been applied."""
+
+    hidden: Tensor
+    valid_rows: Tensor | None = None
+    row_order_preserved: bool = True
+    routing_weights_applied: bool = False
 
 
 def _validate_fused_moe_experts_dtypes(

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -56,25 +56,20 @@ class ExpertBatch:
 
     def __post_init__(self) -> None:
         if self.hidden.ndim != 2:
-            raise ValueError(
-                f"hidden must be rank 2 [capacity, H], got {self.hidden.shape}"
-            )
+            raise ValueError(f"hidden must be rank 2 [capacity, H], got {self.hidden.shape}")
         if self.expert_offsets.ndim != 1:
             raise ValueError(
-                "expert_offsets must be rank 1 [E_local + 1], got "
-                f"{self.expert_offsets.shape}"
+                f"expert_offsets must be rank 1 [E_local + 1], got {self.expert_offsets.shape}"
             )
         if self.expert_offsets.dtype != torch.int32:
             raise ValueError(
-                "expert_offsets must use torch.int32, got "
-                f"{self.expert_offsets.dtype}"
+                f"expert_offsets must use torch.int32, got {self.expert_offsets.dtype}"
             )
         if self.hidden.device != self.expert_offsets.device:
             raise ValueError("hidden and expert_offsets must be on the same device")
         if self.layout != "tight":
-            raise ValueError(
-                f"only layout='tight' is supported, got {self.layout!r}"
-            )
+            raise ValueError(f"only layout='tight' is supported, got {self.layout!r}")
+
     @property
     def capacity(self) -> int:
         return self.hidden.shape[0]

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -43,15 +43,15 @@ class ExpertBatch:
 
     ``hidden`` uses a tight expert-major layout. Expert ``e`` owns rows
     ``expert_offsets[e]:expert_offsets[e + 1]``; adjacent equal offsets encode
-    an empty expert. When supplied, ``valid_rows`` is a device scalar equal to
-    ``expert_offsets[-1]``; both may change between CUDA Graph replays while
-    capacity and tensor addresses stay fixed. TileOps borrows all input buffers
-    for the duration of the call and does not mutate them.
+    an empty expert. ``valid_rows`` is the device-side
+    ``expert_offsets[-1:]`` view, making offsets the single source of truth.
+    Offsets may change between CUDA Graph replays while capacity and tensor
+    addresses stay fixed. TileOps borrows all input buffers for the duration
+    of the call and does not mutate them.
     """
 
     hidden: Tensor
     expert_offsets: Tensor
-    valid_rows: Tensor | None = None
     layout: str = "tight"
 
     def __post_init__(self) -> None:
@@ -75,22 +75,14 @@ class ExpertBatch:
             raise ValueError(
                 f"only layout='tight' is supported, got {self.layout!r}"
             )
-        if self.valid_rows is not None:
-            if self.valid_rows.numel() != 1:
-                raise ValueError("valid_rows must contain one element")
-            if self.valid_rows.dtype != torch.int32:
-                raise ValueError(
-                    "valid_rows must use torch.int32, got "
-                    f"{self.valid_rows.dtype}"
-                )
-            if self.valid_rows.device != self.hidden.device:
-                raise ValueError(
-                    "valid_rows and hidden must be on the same device"
-                )
-
     @property
     def capacity(self) -> int:
         return self.hidden.shape[0]
+
+    @property
+    def valid_rows(self) -> Tensor:
+        """One-element device view of the valid tight-row count."""
+        return self.expert_offsets[-1:]
 
 
 @dataclass(frozen=True)

--- a/src/tileops/ops/moe/abc.py
+++ b/src/tileops/ops/moe/abc.py
@@ -43,8 +43,10 @@ class ExpertBatch:
 
     ``hidden`` uses a tight expert-major layout. Expert ``e`` owns rows
     ``expert_offsets[e]:expert_offsets[e + 1]``; adjacent equal offsets encode
-    an empty expert. TileOps borrows all input buffers for the duration of the
-    call and does not mutate them.
+    an empty expert. When supplied, ``valid_rows`` is a device scalar equal to
+    ``expert_offsets[-1]``; both may change between CUDA Graph replays while
+    capacity and tensor addresses stay fixed. TileOps borrows all input buffers
+    for the duration of the call and does not mutate them.
     """
 
     hidden: Tensor
@@ -75,7 +77,12 @@ class ExpertBatch:
             )
         if self.valid_rows is not None:
             if self.valid_rows.numel() != 1:
-                raise ValueError("valid_rows must be a scalar tensor")
+                raise ValueError("valid_rows must contain one element")
+            if self.valid_rows.dtype != torch.int32:
+                raise ValueError(
+                    "valid_rows must use torch.int32, got "
+                    f"{self.valid_rows.dtype}"
+                )
             if self.valid_rows.device != self.hidden.device:
                 raise ValueError(
                     "valid_rows and hidden must be on the same device"

--- a/src/tileops/ops/moe/routed_expert/__init__.py
+++ b/src/tileops/ops/moe/routed_expert/__init__.py
@@ -1,17 +1,35 @@
 """Routed expert implementations and supporting operations."""
 
+from .abc import (
+    ExpertBatch,
+    ExpertBatchOutput,
+    FusedMoEExperts,
+    FusedMoEExpertsModular,
+    PrepareResult,
+    WeightedReduce,
+    WeightedReduceNoOp,
+)
+from .dispatched_expert import DispatchedExpertMLPFwdOp
 from .fused_routed_expert import (
     FusedMoEExpertsNopadPersistent3WGFwdOp,
 )
-from .gate_up import MoeGateUpFwdOp
 from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
+from .moe_grouped_gemm_nopad_fused_act import MoeGroupedGemmNopad3WGFusedActFwdOp
 from .permute_nopad import MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
+    "DispatchedExpertMLPFwdOp",
+    "ExpertBatch",
+    "ExpertBatchOutput",
+    "FusedMoEExperts",
+    "FusedMoEExpertsModular",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
-    "MoeGateUpFwdOp",
+    "MoeGroupedGemmNopad3WGFusedActFwdOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteNopadFwdOp",
     "MoeUnpermuteFwdOp",
+    "PrepareResult",
+    "WeightedReduce",
+    "WeightedReduceNoOp",
 ]

--- a/src/tileops/ops/moe/routed_expert/__init__.py
+++ b/src/tileops/ops/moe/routed_expert/__init__.py
@@ -9,6 +9,12 @@ from .abc import (
     WeightedReduce,
     WeightedReduceNoOp,
 )
+from .dispatch import (
+    DeepEPDispatchAdapter,
+    ExpertDispatchResult,
+    LocalDispatchHandle,
+    LocalExpertDispatcher,
+)
 from .dispatched_expert import DispatchedExpertMLPFwdOp
 from .fused_routed_expert import (
     FusedMoEExpertsNopadPersistent3WGFwdOp,
@@ -19,12 +25,16 @@ from .permute_nopad import MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
 __all__ = [
+    "DeepEPDispatchAdapter",
     "DispatchedExpertMLPFwdOp",
     "ExpertBatch",
     "ExpertBatchOutput",
+    "ExpertDispatchResult",
     "FusedMoEExperts",
     "FusedMoEExpertsModular",
     "FusedMoEExpertsNopadPersistent3WGFwdOp",
+    "LocalDispatchHandle",
+    "LocalExpertDispatcher",
     "MoeGroupedGemmNopad3WGFusedActFwdOp",
     "MoeGroupedGemmNopadFwdOp",
     "MoePermuteNopadFwdOp",

--- a/src/tileops/ops/moe/routed_expert/dispatch.py
+++ b/src/tileops/ops/moe/routed_expert/dispatch.py
@@ -1,0 +1,349 @@
+"""Dispatch adapters that normalize routed rows to a tight ``ExpertBatch``.
+
+The compute contract remains communication independent.  Communication
+backends are adapted here and their opaque combine handles never enter the
+expert MLP.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import torch
+from torch import Tensor
+
+from .abc import ExpertBatch
+from .permute_nopad import MoePermuteNopadFwdOp
+
+__all__ = [
+    "DeepEPDispatchAdapter",
+    "ExpertDispatchResult",
+    "LocalDispatchHandle",
+    "LocalExpertDispatcher",
+]
+
+
+class _DeepEPEvent(Protocol):
+    def current_stream_wait(self) -> None: ...
+
+
+class _DeepEPBuffer(Protocol):
+    def dispatch(self, x: Tensor, **kwargs: Any) -> tuple[Any, ...]: ...
+
+
+@dataclass(frozen=True)
+class LocalDispatchHandle:
+    """Metadata required to invert a local dispatch.
+
+    ``forward_mapping`` maps each flattened source ``(token, top-k slot)`` pair
+    to its row in the tight expert-major batch.  Routing weights are deliberately
+    kept in :class:`ExpertDispatchResult` and are not applied by dispatch.
+    """
+
+    forward_mapping: Tensor
+    num_tokens: int
+    top_k: int
+
+
+@dataclass(frozen=True)
+class ExpertDispatchResult:
+    """Normalized output of a local or external expert dispatch.
+
+    ``routing_weights`` has one entry per physical row in ``batch.hidden``.
+    Only rows before ``batch.valid_rows`` are defined.  ``combine_handle`` is
+    owned by the dispatch backend and must be passed back to that backend; the
+    TileOps expert compute path never inspects it.
+    """
+
+    batch: ExpertBatch
+    routing_weights: Tensor
+    combine_handle: object
+    event: object | None = None
+
+    def __post_init__(self) -> None:
+        if self.routing_weights.ndim != 1:
+            raise ValueError(
+                f"routing_weights must be rank 1 [capacity], got {self.routing_weights.shape}"
+            )
+        if self.routing_weights.shape[0] != self.batch.capacity:
+            raise ValueError(
+                "routing_weights capacity must equal batch capacity; got "
+                f"{self.routing_weights.shape[0]} and {self.batch.capacity}"
+            )
+        if self.routing_weights.dtype != torch.float32:
+            raise ValueError(
+                f"routing_weights must use torch.float32, got {self.routing_weights.dtype}"
+            )
+        if self.routing_weights.device != self.batch.hidden.device:
+            raise ValueError("routing_weights and batch.hidden must be on the same device")
+
+
+class LocalExpertDispatcher:
+    """World-size-one reference dispatcher with tight expert-major output."""
+
+    def __init__(
+        self,
+        num_experts: int,
+        *,
+        total_tokens: int | None = None,
+        top_k: int | None = None,
+        hidden_size: int | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        if num_experts <= 0:
+            raise ValueError(f"num_experts must be positive, got {num_experts}")
+        self.num_experts = num_experts
+        self._permute = MoePermuteNopadFwdOp(
+            total_tokens=total_tokens,
+            top_k=top_k,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            dtype=dtype,
+        )
+
+    def dispatch(
+        self,
+        hidden_states: Tensor,
+        topk_ids: Tensor,
+        topk_weights: Tensor,
+    ) -> ExpertDispatchResult:
+        """Expand every routed pair and sort it by local expert.
+
+        Duplicate expert selections are preserved as distinct routed pairs.
+        ``topk_ids`` must contain local expert IDs in ``[0, num_experts)``.
+        """
+        _validate_routing_inputs(hidden_states, topk_ids, topk_weights)
+        if topk_ids.dtype != torch.int32:
+            raise ValueError(
+                f"LocalExpertDispatcher requires topk_ids.dtype torch.int32, got {topk_ids.dtype}"
+            )
+
+        permuted, true_offsets, true_sizes, _, forward_mapping = self._permute(
+            hidden_states, topk_ids
+        )
+        expert_offsets = torch.empty(
+            self.num_experts + 1, dtype=torch.int32, device=hidden_states.device
+        )
+        expert_offsets[:-1].copy_(true_offsets)
+        expert_offsets[-1:].copy_(true_offsets[-1:] + true_sizes[-1:])
+
+        dispatched_weights = torch.empty(
+            topk_ids.numel(), dtype=torch.float32, device=hidden_states.device
+        )
+        dispatched_weights.scatter_(
+            0,
+            forward_mapping.to(torch.int64),
+            topk_weights.flatten(),
+        )
+        handle = LocalDispatchHandle(
+            forward_mapping=forward_mapping,
+            num_tokens=hidden_states.shape[0],
+            top_k=topk_ids.shape[1],
+        )
+        return ExpertDispatchResult(
+            batch=ExpertBatch(hidden=permuted, expert_offsets=expert_offsets),
+            routing_weights=dispatched_weights,
+            combine_handle=handle,
+        )
+
+
+class DeepEPDispatchAdapter:
+    """Adapt a DeepEP V2 ``ElasticBuffer`` dispatch to ``ExpertBatch``.
+
+    The adapter intentionally imports no DeepEP package.  The caller owns and
+    injects an initialized ``ElasticBuffer``.  Dispatch uses DeepEP's expanded
+    layout with ``expert_alignment=1``: one row per routed pair, grouped by
+    local expert, without inter-expert padding.  The received activation buffer
+    is therefore borrowed directly by ``ExpertBatch`` without a data copy.
+
+    ``do_cpu_sync=False`` keeps the received row count on the GPU.  DeepEP's
+    inclusive per-expert prefix sum is converted to TileOps' exclusive
+    ``[0, end_0, ..., end_E]`` convention on the current CUDA stream.
+    """
+
+    def __init__(
+        self,
+        buffer: _DeepEPBuffer,
+        *,
+        num_experts: int,
+        num_local_experts: int,
+        num_max_tokens_per_rank: int,
+        num_sms: int = 0,
+        topk_ids_dtype: torch.dtype = torch.int64,
+    ) -> None:
+        if num_experts <= 0:
+            raise ValueError(f"num_experts must be positive, got {num_experts}")
+        if num_local_experts <= 0:
+            raise ValueError(f"num_local_experts must be positive, got {num_local_experts}")
+        if num_local_experts > num_experts:
+            raise ValueError(
+                "num_local_experts cannot exceed num_experts; got "
+                f"{num_local_experts} and {num_experts}"
+            )
+        if num_max_tokens_per_rank <= 0:
+            raise ValueError(
+                f"num_max_tokens_per_rank must be positive, got {num_max_tokens_per_rank}"
+            )
+        if topk_ids_dtype not in (torch.int32, torch.int64):
+            raise ValueError(
+                f"topk_ids_dtype must be torch.int32 or torch.int64, got {topk_ids_dtype}"
+            )
+        self.buffer = buffer
+        self.num_experts = num_experts
+        self.num_local_experts = num_local_experts
+        self.num_max_tokens_per_rank = num_max_tokens_per_rank
+        self.num_sms = num_sms
+        self.topk_ids_dtype = topk_ids_dtype
+
+    def dispatch(
+        self,
+        hidden_states: Tensor,
+        topk_ids: Tensor | None,
+        topk_weights: Tensor,
+        *,
+        expert_offsets: Tensor | None = None,
+        cached_handle: object | None = None,
+    ) -> ExpertDispatchResult:
+        """Run asynchronous DeepEP dispatch and normalize its GPU metadata.
+
+        ``expert_offsets`` may be supplied by a graph-aware caller to keep its
+        address stable across replays.  Waiting uses a CUDA stream dependency;
+        it does not synchronize the host.  To reuse a decode layout, pass the
+        prior ``combine_handle`` as ``cached_handle`` and set ``topk_ids=None``.
+        """
+        if hidden_states.dtype != torch.bfloat16:
+            raise ValueError(
+                "DeepEP BF16 dispatch requires hidden_states.dtype "
+                f"torch.bfloat16, got {hidden_states.dtype}"
+            )
+        if cached_handle is None:
+            if topk_ids is None:
+                raise ValueError("topk_ids is required when cached_handle is not provided")
+            _validate_routing_inputs(hidden_states, topk_ids, topk_weights)
+            if topk_ids.dtype != self.topk_ids_dtype:
+                raise ValueError(
+                    "DeepEP topk_ids dtype must match the adapter's configured "
+                    f"topk_ids_dtype {self.topk_ids_dtype}, got {topk_ids.dtype}"
+                )
+        else:
+            if topk_ids is not None:
+                raise ValueError("topk_ids must be None when cached_handle is provided")
+            _validate_cached_routing_inputs(hidden_states, topk_weights, cached_handle)
+            if not getattr(cached_handle, "do_expand", False):
+                raise ValueError("cached_handle must come from an expanded DeepEP dispatch")
+            if getattr(cached_handle, "expert_alignment", None) != 1:
+                raise ValueError("cached_handle must use expert_alignment=1")
+
+        recv_x, recv_topk_ids, recv_weights, handle, event = self.buffer.dispatch(
+            hidden_states,
+            topk_idx=topk_ids,
+            topk_weights=topk_weights,
+            num_experts=self.num_experts,
+            num_max_tokens_per_rank=self.num_max_tokens_per_rank,
+            expert_alignment=1,
+            num_sms=self.num_sms,
+            async_with_compute_stream=True,
+            do_cpu_sync=False,
+            do_expand=True,
+            handle=cached_handle,
+        )
+
+        if isinstance(recv_x, tuple):
+            raise ValueError("DeepEP returned FP8 data/scales; this M6 adapter supports BF16 only")
+        if recv_topk_ids is not None:
+            raise RuntimeError("DeepEP expanded dispatch unexpectedly returned recv_topk_idx")
+        if recv_weights is None:
+            raise RuntimeError("DeepEP dispatch did not return routing weights required by combine")
+        if not hasattr(event, "current_stream_wait"):
+            raise TypeError("DeepEP dispatch event must provide current_stream_wait()")
+
+        event.current_stream_wait()
+        inclusive_offsets = getattr(handle, "psum_num_recv_tokens_per_expert", None)
+        if not isinstance(inclusive_offsets, Tensor):
+            raise TypeError("DeepEP handle must expose psum_num_recv_tokens_per_expert")
+        if inclusive_offsets.shape != (self.num_local_experts,):
+            raise ValueError(
+                "DeepEP per-expert prefix sum must have shape "
+                f"[{self.num_local_experts}], got {inclusive_offsets.shape}"
+            )
+        if inclusive_offsets.dtype != torch.int32:
+            raise ValueError(
+                f"DeepEP per-expert prefix sum must use torch.int32, got {inclusive_offsets.dtype}"
+            )
+        if inclusive_offsets.device != recv_x.device:
+            raise ValueError("DeepEP prefix sum and received activations must share a device")
+
+        if expert_offsets is None:
+            expert_offsets = torch.empty(
+                self.num_local_experts + 1,
+                dtype=torch.int32,
+                device=recv_x.device,
+            )
+        else:
+            _validate_offsets_buffer(expert_offsets, self.num_local_experts, recv_x.device)
+        expert_offsets[0].zero_()
+        expert_offsets[1:].copy_(inclusive_offsets)
+
+        return ExpertDispatchResult(
+            batch=ExpertBatch(hidden=recv_x, expert_offsets=expert_offsets),
+            routing_weights=recv_weights,
+            combine_handle=handle,
+            event=event,
+        )
+
+
+def _validate_routing_inputs(
+    hidden_states: Tensor,
+    topk_ids: Tensor,
+    topk_weights: Tensor,
+) -> None:
+    if not hidden_states.is_cuda:
+        raise ValueError("hidden_states must be a CUDA tensor")
+    if not topk_ids.is_cuda or not topk_weights.is_cuda:
+        raise ValueError("topk_ids and topk_weights must be CUDA tensors")
+    if not (hidden_states.device == topk_ids.device == topk_weights.device):
+        raise ValueError("hidden_states, topk_ids, and topk_weights must share a device")
+    if hidden_states.ndim != 2:
+        raise ValueError(f"hidden_states must be rank 2 [T, H], got {hidden_states.shape}")
+    if topk_ids.ndim != 2:
+        raise ValueError(f"topk_ids must be rank 2 [T, K], got {topk_ids.shape}")
+    if topk_weights.shape != topk_ids.shape:
+        raise ValueError(
+            "topk_weights must have the same shape as topk_ids; got "
+            f"{topk_weights.shape} and {topk_ids.shape}"
+        )
+    if topk_ids.shape[0] != hidden_states.shape[0]:
+        raise ValueError(
+            "routing token count must equal hidden_states token count; got "
+            f"{topk_ids.shape[0]} and {hidden_states.shape[0]}"
+        )
+    if topk_weights.dtype != torch.float32:
+        raise ValueError(f"topk_weights must use torch.float32, got {topk_weights.dtype}")
+
+
+def _validate_cached_routing_inputs(
+    hidden_states: Tensor,
+    topk_weights: Tensor,
+    cached_handle: object,
+) -> None:
+    cached_topk_ids = getattr(cached_handle, "topk_idx", None)
+    if not isinstance(cached_topk_ids, Tensor):
+        raise TypeError("cached_handle must expose its device topk_idx tensor")
+    _validate_routing_inputs(hidden_states, cached_topk_ids, topk_weights)
+
+
+def _validate_offsets_buffer(
+    expert_offsets: Tensor,
+    num_local_experts: int,
+    device: torch.device,
+) -> None:
+    if expert_offsets.shape != (num_local_experts + 1,):
+        raise ValueError(
+            "expert_offsets buffer must have shape "
+            f"[{num_local_experts + 1}], got {expert_offsets.shape}"
+        )
+    if expert_offsets.dtype != torch.int32:
+        raise ValueError(f"expert_offsets buffer must use torch.int32, got {expert_offsets.dtype}")
+    if expert_offsets.device != device:
+        raise ValueError("expert_offsets buffer and received activations must share a device")

--- a/src/tileops/ops/moe/routed_expert/dispatched_expert.py
+++ b/src/tileops/ops/moe/routed_expert/dispatched_expert.py
@@ -170,13 +170,37 @@ class DispatchedExpertMLPFwdOp(Op):
         true_offsets: Tensor,
     ) -> Tensor:
         """Return ``[num_pairs, hidden_size]`` without changing row order."""
+        return self._forward(
+            expert_input,
+            w_gate_up,
+            w_down,
+            true_sizes,
+            true_offsets,
+            valid_rows=None,
+        )
+
+    def _forward(
+        self,
+        expert_input: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        true_sizes: Tensor,
+        true_offsets: Tensor,
+        valid_rows: Tensor | None,
+    ) -> Tensor:
         gate_up = self._gemm_gate_up(
             expert_input, w_gate_up, true_sizes, true_offsets
         )
         act = (
             gate_up
             if self.use_fused_activation
-            else self._activation_op(gate_up)
+            else (
+                self._activation_op(gate_up)
+                if valid_rows is None
+                else self._activation_op.kernel.forward_rows(
+                    gate_up, valid_rows
+                )
+            )
         )
         return self._gemm_down(act, w_down, true_sizes, true_offsets)
 
@@ -188,8 +212,9 @@ class DispatchedExpertMLPFwdOp(Op):
     ) -> ExpertBatchOutput:
         """Run the MLP from canonical ``expert_offsets[E_local + 1]``.
 
-        Offset differencing stays on the input device. ``valid_rows`` is
-        carried through as metadata; current kernels still process capacity.
+        Offset differencing and the received row count stay on the input
+        device. Grouped GEMMs schedule only expert tiles described by the
+        offsets; the standalone activation is bounded by ``valid_rows``.
         """
         if batch.capacity != self.num_pairs:
             raise ValueError(
@@ -209,11 +234,17 @@ class DispatchedExpertMLPFwdOp(Op):
             )
         true_offsets = batch.expert_offsets[:-1]
         true_sizes = batch.expert_offsets[1:] - true_offsets
-        hidden = self.forward(
+        valid_rows = (
+            batch.valid_rows
+            if batch.valid_rows is not None
+            else batch.expert_offsets[-1:]
+        )
+        hidden = self._forward(
             batch.hidden,
             w_gate_up,
             w_down,
             true_sizes,
             true_offsets,
+            valid_rows,
         )
-        return ExpertBatchOutput(hidden=hidden, valid_rows=batch.valid_rows)
+        return ExpertBatchOutput(hidden=hidden, valid_rows=valid_rows)

--- a/src/tileops/ops/moe/routed_expert/dispatched_expert.py
+++ b/src/tileops/ops/moe/routed_expert/dispatched_expert.py
@@ -115,21 +115,25 @@ class DispatchedExpertMLPFwdOp(Op):
             if kernel_cls is not GroupedGemmPersistent3WGKernel:
                 raise ValueError(
                     "use_fused_activation=True requires the 3WG persistent gate_up GEMM, "
-                    f"got {kernel_cls.__name__}")
+                    f"got {kernel_cls.__name__}"
+                )
             if gemm_override is not None and gemm_override is not GroupedGemmPersistent3WGKernel:
                 raise ValueError(
                     "use_fused_activation=True cannot honour a moe_grouped_gemm_kernel "
                     f"override ({gemm_override.__name__}): the fused gate_up wrapper keys off "
                     "moe_grouped_gemm_fused_act_kernel, so the override would reach the down "
-                    "GEMM alone and leave the pipeline inconsistent")
+                    "GEMM alone and leave the pipeline inconsistent"
+                )
             if activation not in ("silu_and_mul", "gelu_and_mul"):
                 raise ValueError(
                     "use_fused_activation=True supports activation in "
-                    f"{{silu_and_mul, gelu_and_mul}}, got {activation!r}")
+                    f"{{silu_and_mul, gelu_and_mul}}, got {activation!r}"
+                )
             if ffn_size % fused_block_n != 0:
                 raise ValueError(
                     f"use_fused_activation=True requires ffn_size % {fused_block_n} == 0, "
-                    f"got ffn_size={ffn_size}")
+                    f"got ffn_size={ffn_size}"
+                )
 
         if self.use_fused_activation:
             from .moe_grouped_gemm_nopad_fused_act import (

--- a/src/tileops/ops/moe/routed_expert/dispatched_expert.py
+++ b/src/tileops/ops/moe/routed_expert/dispatched_expert.py
@@ -1,0 +1,219 @@
+"""Communication-independent expert MLP for tight expert-major batches."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+import torch
+from torch import Tensor
+
+from tileops.kernels.grouped_gemm import GroupedGemmPersistent3WGKernel
+from tileops.kernels.grouped_gemm.grouped_gemm_persistent_3wg import (
+    _DEFAULT_CONFIG as _3WG_DEFAULT_CONFIG,
+)
+from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.moe.moe_grouped_gemm_nopad import MoeGroupedGemmNopadKernel
+from tileops.kernels.moe.moe_grouped_gemm_persistent_3wg_fused_act import (
+    _DEFAULT_CONFIG as _FUSED_ACT_DEFAULT_CONFIG,
+)
+from tileops.ops.moe._activation import build_activation_op
+from tileops.ops.op_base import Op
+
+from .abc import ExpertBatch, ExpertBatchOutput
+from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
+
+__all__ = ["DispatchedExpertMLPFwdOp"]
+
+_logger = logging.getLogger(__name__)
+
+
+class DispatchedExpertMLPFwdOp(Op):
+    """Run an expert MLP over a pre-dispatched tight expert-major batch.
+
+    ``expert_input`` is partitioned into contiguous expert segments described
+    by ``true_offsets`` and ``true_sizes``. Empty experts are represented by a
+    zero size. Output row ``i`` always corresponds to input row ``i``.
+
+    This computation boundary deliberately has no routing, communication, or
+    weighted-reduction inputs. In particular, routing weights are not applied.
+    """
+
+    def __init__(
+        self,
+        num_pairs: int,
+        num_experts: int,
+        hidden_size: int,
+        ffn_size: int,
+        dtype: torch.dtype = torch.bfloat16,
+        gemm_kernel: Optional[type] = None,
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        *,
+        activation: str = "silu_and_mul",
+        use_fused_activation: bool = False,
+    ):
+        self.dispatch_kernel(kernel_map)
+        self.num_pairs = num_pairs
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.ffn_size = ffn_size
+        self.dtype = dtype
+        self.activation = activation
+
+        kernel_cls = gemm_kernel or GroupedGemmPersistent3WGKernel
+        block_n = _3WG_DEFAULT_CONFIG["block_n"]
+        block_k = _3WG_DEFAULT_CONFIG["block_k"]
+        gate_up_n = ffn_size * 2
+        if kernel_cls is GroupedGemmPersistent3WGKernel:
+            gate_up_ok = gate_up_n % block_n == 0 and hidden_size % block_k == 0
+            down_ok = hidden_size % block_n == 0 and ffn_size % block_k == 0
+            if not (gate_up_ok and down_ok):
+                _logger.warning(
+                    "DispatchedExpertMLPFwdOp: dims not aligned to 3WG block "
+                    "(gate_up_n=%d, hidden_size=%d, ffn_size=%d; block_n=%d, "
+                    "block_k=%d) — falling back to MoeGroupedGemmNopadKernel.",
+                    gate_up_n,
+                    hidden_size,
+                    ffn_size,
+                    block_n,
+                    block_k,
+                )
+                kernel_cls = MoeGroupedGemmNopadKernel
+
+        # A caller can steer the gate_up GEMM either via gemm_kernel (already
+        # folded into kernel_cls) or via kernel_map["moe_grouped_gemm_kernel"]
+        # (merged into the unfused gate_up / down ops below). The fused gate_up
+        # wrapper keys off "moe_grouped_gemm_fused_act_kernel" and cannot honor a
+        # "moe_grouped_gemm_kernel" override, so enabling fusion alongside a
+        # non-3WG override would produce a fused 3WG gate_up next to an
+        # overridden down GEMM. That combination is refused below.
+        gemm_override = (kernel_map or {}).get("moe_grouped_gemm_kernel")
+        self.use_fused_activation = use_fused_activation
+        if use_fused_activation:
+            # Fusion is what the caller asked for, so a request this op cannot
+            # honour is refused rather than quietly downgraded: a caller who
+            # wanted the fused epilogue and silently got the separate one reads
+            # the unfused result as the fused one. Each condition is reported on
+            # its own, because "not eligible" over six conjuncts says nothing
+            # about which one to fix.
+            #
+            # Whether the device can run the fused kernel is not asked here.
+            # MoeGroupedGemmPersistent3WGFusedActKernel states the architectures
+            # it is built for, and refuses when it is built — construction reads
+            # no device property.
+            fused_block_n = _FUSED_ACT_DEFAULT_CONFIG["block_n"]
+            if kernel_cls is not GroupedGemmPersistent3WGKernel:
+                raise ValueError(
+                    "use_fused_activation=True requires the 3WG persistent gate_up GEMM, "
+                    f"got {kernel_cls.__name__}")
+            if gemm_override is not None and gemm_override is not GroupedGemmPersistent3WGKernel:
+                raise ValueError(
+                    "use_fused_activation=True cannot honour a moe_grouped_gemm_kernel "
+                    f"override ({gemm_override.__name__}): the fused gate_up wrapper keys off "
+                    "moe_grouped_gemm_fused_act_kernel, so the override would reach the down "
+                    "GEMM alone and leave the pipeline inconsistent")
+            if activation not in ("silu_and_mul", "gelu_and_mul"):
+                raise ValueError(
+                    "use_fused_activation=True supports activation in "
+                    f"{{silu_and_mul, gelu_and_mul}}, got {activation!r}")
+            if ffn_size % fused_block_n != 0:
+                raise ValueError(
+                    f"use_fused_activation=True requires ffn_size % {fused_block_n} == 0, "
+                    f"got ffn_size={ffn_size}")
+
+        if self.use_fused_activation:
+            from .moe_grouped_gemm_nopad_fused_act import (
+                MoeGroupedGemmNopad3WGFusedActFwdOp,
+            )
+
+            self._gemm_gate_up = MoeGroupedGemmNopad3WGFusedActFwdOp(
+                numel=num_pairs,
+                num_experts=num_experts,
+                ffn=ffn_size,
+                k=hidden_size,
+                activation=activation,
+                kernel_map=kernel_map,
+            )
+            self._activation_op = None
+        else:
+            self._gemm_gate_up = MoeGroupedGemmNopadFwdOp(
+                numel=num_pairs,
+                num_experts=num_experts,
+                n=ffn_size * 2,
+                k=hidden_size,
+                kernel_map={"moe_grouped_gemm_kernel": kernel_cls, **(kernel_map or {})},
+            )
+            self._activation_op = build_activation_op(
+                activation,
+                M=num_pairs,
+                N=ffn_size,
+                kernel_map=kernel_map,
+            )
+        self._gemm_down = MoeGroupedGemmNopadFwdOp(
+            numel=num_pairs,
+            num_experts=num_experts,
+            n=hidden_size,
+            k=ffn_size,
+            kernel_map={"moe_grouped_gemm_kernel": kernel_cls, **(kernel_map or {})},
+        )
+
+    @property
+    def default_kernel_map(self) -> dict:
+        return {}
+
+    def forward(
+        self,
+        expert_input: Tensor,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+        true_sizes: Tensor,
+        true_offsets: Tensor,
+    ) -> Tensor:
+        """Return ``[num_pairs, hidden_size]`` without changing row order."""
+        gate_up = self._gemm_gate_up(
+            expert_input, w_gate_up, true_sizes, true_offsets
+        )
+        act = (
+            gate_up
+            if self.use_fused_activation
+            else self._activation_op(gate_up)
+        )
+        return self._gemm_down(act, w_down, true_sizes, true_offsets)
+
+    def forward_batch(
+        self,
+        batch: ExpertBatch,
+        w_gate_up: Tensor,
+        w_down: Tensor,
+    ) -> ExpertBatchOutput:
+        """Run the MLP from canonical ``expert_offsets[E_local + 1]``.
+
+        Offset differencing stays on the input device. ``valid_rows`` is
+        carried through as metadata; current kernels still process capacity.
+        """
+        if batch.capacity != self.num_pairs:
+            raise ValueError(
+                f"batch capacity must equal num_pairs={self.num_pairs}, "
+                f"got {batch.capacity}"
+            )
+        if batch.hidden.shape[1] != self.hidden_size:
+            raise ValueError(
+                f"batch hidden size must equal {self.hidden_size}, "
+                f"got {batch.hidden.shape[1]}"
+            )
+        if batch.expert_offsets.numel() != self.num_experts + 1:
+            raise ValueError(
+                "expert_offsets must contain num_experts + 1 entries; "
+                f"expected {self.num_experts + 1}, "
+                f"got {batch.expert_offsets.numel()}"
+            )
+        true_offsets = batch.expert_offsets[:-1]
+        true_sizes = batch.expert_offsets[1:] - true_offsets
+        hidden = self.forward(
+            batch.hidden,
+            w_gate_up,
+            w_down,
+            true_sizes,
+            true_offsets,
+        )
+        return ExpertBatchOutput(hidden=hidden, valid_rows=batch.valid_rows)

--- a/src/tileops/ops/moe/routed_expert/dispatched_expert.py
+++ b/src/tileops/ops/moe/routed_expert/dispatched_expert.py
@@ -234,11 +234,7 @@ class DispatchedExpertMLPFwdOp(Op):
             )
         true_offsets = batch.expert_offsets[:-1]
         true_sizes = batch.expert_offsets[1:] - true_offsets
-        valid_rows = (
-            batch.valid_rows
-            if batch.valid_rows is not None
-            else batch.expert_offsets[-1:]
-        )
+        valid_rows = batch.valid_rows
         hidden = self._forward(
             batch.hidden,
             w_gate_up,

--- a/src/tileops/ops/moe/routed_expert/dispatched_expert.py
+++ b/src/tileops/ops/moe/routed_expert/dispatched_expert.py
@@ -60,7 +60,11 @@ class DispatchedExpertMLPFwdOp(Op):
         self.dtype = dtype
         self.activation = activation
 
-        kernel_cls = gemm_kernel or GroupedGemmPersistent3WGKernel
+        requested_kernel_cls = (kernel_map or {}).get(
+            "moe_grouped_gemm_kernel",
+            gemm_kernel or GroupedGemmPersistent3WGKernel,
+        )
+        kernel_cls = requested_kernel_cls
         block_n = _3WG_DEFAULT_CONFIG["block_n"]
         block_k = _3WG_DEFAULT_CONFIG["block_k"]
         gate_up_n = ffn_size * 2
@@ -80,13 +84,19 @@ class DispatchedExpertMLPFwdOp(Op):
                 )
                 kernel_cls = MoeGroupedGemmNopadKernel
 
+        # Resolve the GEMM implementation exactly once. In particular, the
+        # caller's original override must not be merged after an alignment
+        # fallback and silently reinstate an ineligible kernel.
+        effective_gemm_kernel_map = {
+            **(kernel_map or {}),
+            "moe_grouped_gemm_kernel": kernel_cls,
+        }
         # A caller can steer the gate_up GEMM either via gemm_kernel (already
-        # folded into kernel_cls) or via kernel_map["moe_grouped_gemm_kernel"]
-        # (merged into the unfused gate_up / down ops below). The fused gate_up
-        # wrapper keys off "moe_grouped_gemm_fused_act_kernel" and cannot honor a
-        # "moe_grouped_gemm_kernel" override, so enabling fusion alongside a
-        # non-3WG override would produce a fused 3WG gate_up next to an
-        # overridden down GEMM. That combination is refused below.
+        # folded into kernel_cls) or via kernel_map["moe_grouped_gemm_kernel"].
+        # The fused gate_up wrapper keys off "moe_grouped_gemm_fused_act_kernel"
+        # and cannot honor a "moe_grouped_gemm_kernel" override, so enabling
+        # fusion alongside a non-3WG override would produce a fused 3WG gate_up
+        # next to an overridden down GEMM. That combination is refused below.
         gemm_override = (kernel_map or {}).get("moe_grouped_gemm_kernel")
         self.use_fused_activation = use_fused_activation
         if use_fused_activation:
@@ -132,7 +142,7 @@ class DispatchedExpertMLPFwdOp(Op):
                 ffn=ffn_size,
                 k=hidden_size,
                 activation=activation,
-                kernel_map=kernel_map,
+                kernel_map=effective_gemm_kernel_map,
             )
             self._activation_op = None
         else:
@@ -141,7 +151,7 @@ class DispatchedExpertMLPFwdOp(Op):
                 num_experts=num_experts,
                 n=ffn_size * 2,
                 k=hidden_size,
-                kernel_map={"moe_grouped_gemm_kernel": kernel_cls, **(kernel_map or {})},
+                kernel_map=effective_gemm_kernel_map,
             )
             self._activation_op = build_activation_op(
                 activation,
@@ -154,7 +164,7 @@ class DispatchedExpertMLPFwdOp(Op):
             num_experts=num_experts,
             n=hidden_size,
             k=ffn_size,
-            kernel_map={"moe_grouped_gemm_kernel": kernel_cls, **(kernel_map or {})},
+            kernel_map=effective_gemm_kernel_map,
         )
 
     @property
@@ -188,18 +198,14 @@ class DispatchedExpertMLPFwdOp(Op):
         true_offsets: Tensor,
         valid_rows: Tensor | None,
     ) -> Tensor:
-        gate_up = self._gemm_gate_up(
-            expert_input, w_gate_up, true_sizes, true_offsets
-        )
+        gate_up = self._gemm_gate_up(expert_input, w_gate_up, true_sizes, true_offsets)
         act = (
             gate_up
             if self.use_fused_activation
             else (
                 self._activation_op(gate_up)
                 if valid_rows is None
-                else self._activation_op.kernel.forward_rows(
-                    gate_up, valid_rows
-                )
+                else self._activation_op.kernel.forward_rows(gate_up, valid_rows)
             )
         )
         return self._gemm_down(act, w_down, true_sizes, true_offsets)
@@ -218,13 +224,11 @@ class DispatchedExpertMLPFwdOp(Op):
         """
         if batch.capacity != self.num_pairs:
             raise ValueError(
-                f"batch capacity must equal num_pairs={self.num_pairs}, "
-                f"got {batch.capacity}"
+                f"batch capacity must equal num_pairs={self.num_pairs}, got {batch.capacity}"
             )
         if batch.hidden.shape[1] != self.hidden_size:
             raise ValueError(
-                f"batch hidden size must equal {self.hidden_size}, "
-                f"got {batch.hidden.shape[1]}"
+                f"batch hidden size must equal {self.hidden_size}, got {batch.hidden.shape[1]}"
             )
         if batch.expert_offsets.numel() != self.num_experts + 1:
             raise ValueError(

--- a/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
+++ b/src/tileops/ops/moe/routed_expert/fused_routed_expert.py
@@ -1,105 +1,136 @@
-"""FusedMoEExperts implementation: nopad + 3WG persistent variant.
-
-Registers no operator of its own: a composite is not the unit of replacement,
-so its graph is its leaves' operators.
-"""
+"""FusedMoEExperts implementation: nopad + 3WG persistent variant."""
 
 from __future__ import annotations
 
 from typing import Dict, Optional
 
-import torch
 from torch import Tensor
 
 from tileops.kernels.kernel_base import Kernel
 
-from ...op_base import Op
-from ..abc import (
+from .abc import (
     FusedMoEExpertsModular,
     WeightedReduce,
     WeightedReduceNoOp,
     _validate_fused_moe_experts_dtypes,
 )
-from .gate_up import MoeGateUpFwdOp
-from .moe_grouped_gemm_nopad import MoeGroupedGemmNopadFwdOp
+from .dispatched_expert import DispatchedExpertMLPFwdOp
 from .permute_nopad import MoePermuteNopadFwdOp
 from .unpermute import MoeUnpermuteFwdOp
 
-__all__ = ["FusedMoEExpertsNopadPersistent3WGFwdOp"]
+__all__ = [
+    "FusedMoEExpertsNopadPersistent3WGFwdOp",
+]
 
 
 class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
     """Expert GEMM using tight (T*K rows, no-pad) layout with 3WG persistent kernel.
 
-    Internal pipeline: MoePermuteNopadFwdOp -> MoeGateUpFwdOp -> down GEMM ->
-    MoeUnpermuteFwdOp (weighted reduction included). Every stage is built at
-    construction, so ``forward`` resolves nothing and stays traceable.
+    Internal pipeline: MoePermuteNopadFwdOp → gate_up GEMM (3WG; activation
+    fused into the epilogue when use_fused_activation=True, else a separate
+    silu_and_mul/gelu_and_mul step) → down GEMM (3WG) → MoeUnpermuteFwdOp
+    (weighted reduction included).
 
     forward() output shape is (T, H): reduction is done internally by
     MoeUnpermuteFwdOp, so make_weighted_reduce() returns WeightedReduceNoOp.
 
+    Performance note: the 3WG persistent kernel is throughput-tuned for
+    prefill-scale workloads; small-batch decode (num_tokens ≲ 512) may run
+    a few percent behind tile-scheduler kernels. Decode-heavy deployments
+    can pass ``gemm_kernel=MoeGroupedGemmNopadKernel`` to bypass 3WG and
+    use the lighter tile-scheduler path explicitly.
+
     Args:
         num_tokens: Number of input tokens T (rows of hidden_states).
         num_experts: Total number of experts E in the routing table.
-        num_experts_local: Number of those experts this rank owns; the weights
-            and both grouped GEMMs are sized by it. Equal to ``num_experts``
-            outside expert parallelism.
         top_k: Number of experts each token is routed to (K).
         hidden_size: Model hidden dimension H (GEMM contraction dim for
             gate_up, output dim for down).
         ffn_size: Per-expert FFN intermediate dimension F.
         routed_scaling_factor: Scalar applied to the final reduced output.
             Defaults to 1.0 (no scaling).
+        expert_map: Optional global→local expert id map for expert parallelism
+            (EP). Entries < 0 mark experts not owned by this rank.
+        gemm_kernel: Optional override for the grouped-GEMM kernel class.
+            Defaults to GroupedGemmPersistent3WGKernel; pass
+            MoeGroupedGemmNopadKernel to force the tile-scheduler path.
         kernel_map: Optional kernel overrides forwarded to the inner Ops.
         activation: Gated activation applied to gate_up: 'silu_and_mul' or
             'gelu_and_mul'.
+        use_fused_activation: If True, fuse the activation into the gate_up
+            GEMM epilogue via MoeGroupedGemmPersistent3WGFusedActKernel (avoids
+            materializing the [numel, 2*ffn] gate_up in global memory). Raises
+            when this op cannot honour it: the 3WG kernel must be the gate_up
+            GEMM with no conflicting moe_grouped_gemm_kernel override,
+            activation must be silu_and_mul or gelu_and_mul, and ffn_size must
+            be a multiple of the fused kernel's block_n (128). Whether the
+            device can run the fused kernel is answered when that kernel is
+            built, not here. Default False
+            reproduces the unfused pipeline exactly. Performance: at production
+            FFN sizes (H200, bf16) this is a small win in both regimes —
+            roughly 1.02-1.05x for compute-bound prefill and ~1.05x for
+            memory-bound decode — from eliminating the gate_up global
+            round-trip; benefits grow as the token count shrinks.
 
-    Example:
-        >>> experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
-        ...     num_tokens=512, num_experts=128, num_experts_local=128, top_k=8,
-        ...     hidden_size=7168, ffn_size=2048,
-        ... )
+    Example (decode-optimized opt-out):
+        from tileops.kernels.moe.moe_grouped_gemm_nopad import (
+            MoeGroupedGemmNopadKernel,
+        )
+        experts = FusedMoEExpertsNopadPersistent3WGFwdOp(
+            num_tokens=T, num_experts=E, top_k=K,
+            hidden_size=H, ffn_size=F,
+            gemm_kernel=MoeGroupedGemmNopadKernel,
+        )
     """
 
     def __init__(
         self,
         num_tokens: int,
         num_experts: int,
-        num_experts_local: int,
         top_k: int,
         hidden_size: int,
         ffn_size: int,
         routed_scaling_factor: float = 1.0,
+        expert_map: Optional[Tensor] = None,
+        gemm_kernel: Optional[type] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         *,
         activation: str = "silu_and_mul",
+        use_fused_activation: bool = False,
     ):
         self.dispatch_kernel(kernel_map)
         self.num_tokens = num_tokens
         self.num_experts = num_experts
-        self.num_experts_local = num_experts_local
         self.top_k = top_k
         self.hidden_size = hidden_size
         self.ffn_size = ffn_size
-        self.activation = activation
-        self._routed_scaling_factor = routed_scaling_factor
         numel = num_tokens * top_k
+        num_experts_local = (
+            int((expert_map >= 0).sum().item()) if expert_map is not None else num_experts
+        )
 
-        self._gate_up = MoeGateUpFwdOp(
-            numel=numel,
+        self._permute = MoePermuteNopadFwdOp(
+            num_experts=num_experts,
+            expert_map=expert_map,
+            kernel_map=kernel_map,
+        )
+        self.activation = activation
+        self._expert_mlp = DispatchedExpertMLPFwdOp(
+            num_pairs=numel,
             num_experts=num_experts_local,
-            ffn=ffn_size,
-            k=hidden_size,
+            hidden_size=hidden_size,
+            ffn_size=ffn_size,
+            gemm_kernel=gemm_kernel,
+            kernel_map=kernel_map,
             activation=activation,
-            kernel_map=kernel_map,
+            use_fused_activation=use_fused_activation,
         )
-        self._gemm_down = MoeGroupedGemmNopadFwdOp(
-            numel=numel,
-            num_experts=num_experts_local,
-            n=hidden_size,
-            k=ffn_size,
-            kernel_map=kernel_map,
-        )
+        self.use_fused_activation = self._expert_mlp.use_fused_activation
+        # Keep these implementation attributes available for callers/tests
+        # that inspected the legacy composite op.
+        self._gemm_gate_up = self._expert_mlp._gemm_gate_up
+        self._activation_op = self._expert_mlp._activation_op
+        self._gemm_down = self._expert_mlp._gemm_down
         self._unpermute = MoeUnpermuteFwdOp(
             total_tokens=num_tokens,
             top_k=top_k,
@@ -108,27 +139,7 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             kernel_map=kernel_map,
             routed_scaling_factor=routed_scaling_factor,
         )
-        self._permute = MoePermuteNopadFwdOp(
-            num_experts=num_experts,
-            num_experts_local=num_experts_local,
-            kernel_map=kernel_map,
-        )
-
-    def kernel_delegates(self) -> tuple[Op, ...]:
-        return (self._permute, self._gate_up, self._gemm_down, self._unpermute)
-
-    def eval_roofline(self) -> tuple[int, int]:
-        """Manifest ``roofline``: three F x H weight planes per local expert."""
-        if self.dtype is None:
-            raise ValueError(
-                f"{type(self).__name__}.eval_roofline() requires a prior forward() to bind dtype"
-            )
-        flops = self.num_tokens * self.top_k * 6 * self.ffn_size * self.hidden_size
-        nbytes = (
-            self.num_experts_local * 3 * self.ffn_size * self.hidden_size
-            + 2 * self.num_tokens * self.hidden_size
-        ) * self.dtype.itemsize
-        return int(flops), int(nbytes)
+        self._routed_scaling_factor = routed_scaling_factor
 
     def _validate_dtypes(
         self,
@@ -138,10 +149,9 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         w_down: Tensor,
         topk_weights: Tensor,
         topk_ids: Tensor,
+        expert_map: Tensor | None,
         workspace1: Tensor,
         workspace2: Tensor,
-        *,
-        expert_map: Optional[Tensor] = None,
     ) -> None:
         # hidden_states is the dtype anchor: the helper requires output,
         # w_gate_up and w_down to agree with it.
@@ -154,23 +164,16 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             w_down,
             topk_weights,
             topk_ids,
+            expert_map,
             workspace1,
             workspace2,
         )
-        if expert_map is not None and expert_map.dtype != torch.int32:
-            raise ValueError(f"Expected expert_map.dtype == int32, got {expert_map.dtype}")
-        self._reject_non_empty_workspaces(workspace1, workspace2)
-
-    def _reject_non_empty_workspaces(
-        self,
-        workspace1: Tensor,
-        workspace2: Tensor,
-    ) -> None:
-        """workspace_shapes() returns ((0,), (0,)); anything else is a mismatch."""
+        # workspace_shapes() returns ((0,), (0,)) for this implementation; flag
+        # callers that pass non-empty workspaces (likely a pipeline mismatch).
         if workspace1.numel() != 0 or workspace2.numel() != 0:
             raise ValueError(
                 "workspace1 and workspace2 must be empty (numel == 0) for "
-                f"{type(self).__name__}; got "
+                "FusedMoEExpertsNopadPersistent3WGFwdOp; got "
                 f"workspace1.numel()={workspace1.numel()}, "
                 f"workspace2.numel()={workspace2.numel()}."
             )
@@ -204,20 +207,11 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
         w_down: Tensor,
         topk_weights: Tensor,
         topk_ids: Tensor,
+        expert_map: Tensor | None,
         workspace1: Tensor,
         workspace2: Tensor,
-        expert_map: Optional[Tensor] = None,
-        *,
         num_experts: int,
     ) -> None:
-        """Run the expert pipeline, writing the reduced result into ``output``.
-
-        Args:
-            expert_map: [E] int32 global-to-local expert ids under expert
-                parallelism; ``None`` when this rank owns every expert. The
-                permute stage rejects a map that does not cover exactly the
-                local ids.
-        """
         self._validate_dtypes(
             output,
             hidden_states,
@@ -225,15 +219,12 @@ class FusedMoEExpertsNopadPersistent3WGFwdOp(FusedMoEExpertsModular):
             w_down,
             topk_weights,
             topk_ids,
+            expert_map,
             workspace1,
             workspace2,
-            expert_map=expert_map,
         )
-        perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(
-            hidden_states, topk_ids, expert_map
-        )
-        act = self._gate_up(perm_h, w_gate_up, true_sizes, true_offsets)
-        mm2 = self._gemm_down(act, w_down, true_sizes, true_offsets)
+        perm_h, true_offsets, true_sizes, _, fwd_idx = self._permute(hidden_states, topk_ids)
+        mm2 = self._expert_mlp(perm_h, w_gate_up, w_down, true_sizes, true_offsets)
         # Unpermute reduces into ``output`` directly and folds
         # ``routed_scaling_factor`` into its prim_func — no separate copy/scale.
         self._unpermute(mm2, fwd_idx, topk_weights, out=output)

--- a/tests/ops/test_dispatched_expert.py
+++ b/tests/ops/test_dispatched_expert.py
@@ -1,0 +1,214 @@
+"""Tests for the communication-independent dispatched expert MLP."""
+
+import inspect
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tileops.ops.moe import (
+    DispatchedExpertMLPFwdOp,
+    ExpertBatch,
+    ExpertBatchOutput,
+)
+
+
+def _reference(hidden, w_gate_up, w_down, sizes):
+    outputs = []
+    start = 0
+    ffn_size = w_down.shape[-1]
+    for expert, size in enumerate(sizes):
+        rows = hidden[start : start + size].float()
+        gate_up = rows @ w_gate_up[expert].float().t()
+        act = F.silu(gate_up[:, :ffn_size]) * gate_up[:, ffn_size:]
+        outputs.append(act @ w_down[expert].float().t())
+        start += size
+    return torch.cat(outputs).to(hidden.dtype)
+
+
+@pytest.mark.smoke
+def test_public_interface_has_no_routing_or_communication_inputs():
+    parameters = inspect.signature(DispatchedExpertMLPFwdOp.forward).parameters
+    assert tuple(parameters) == (
+        "self",
+        "expert_input",
+        "w_gate_up",
+        "w_down",
+        "true_sizes",
+        "true_offsets",
+    )
+    forbidden = {"topk_ids", "topk_weights", "rank", "world_size", "handle"}
+    assert forbidden.isdisjoint(parameters)
+    batch_parameters = inspect.signature(
+        DispatchedExpertMLPFwdOp.forward_batch
+    ).parameters
+    assert tuple(batch_parameters) == ("self", "batch", "w_gate_up", "w_down")
+    assert forbidden.isdisjoint(batch_parameters)
+
+
+@pytest.mark.smoke
+def test_expert_batch_contract_rejects_non_tight_layout():
+    with pytest.raises(ValueError, match="layout='tight'"):
+        ExpertBatch(
+            hidden=torch.empty(4, 8),
+            expert_offsets=torch.tensor([0, 2, 4], dtype=torch.int32),
+            layout="aligned",
+        )
+
+
+@pytest.mark.smoke
+def test_expert_batch_output_contract_defaults():
+    hidden = torch.empty(4, 8)
+    output = ExpertBatchOutput(hidden=hidden)
+    assert output.hidden is hidden
+    assert output.row_order_preserved
+    assert not output.routing_weights_applied
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("sizes", [[4, 4, 4, 4], [0, 2, 13, 1]])
+@pytest.mark.smoke
+def test_dispatched_expert_matches_reference_and_preserves_rows(dtype, sizes):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    torch.manual_seed(0)
+    num_experts = len(sizes)
+    num_pairs = sum(sizes)
+    hidden_size, ffn_size = 128, 96
+    hidden = torch.randn(
+        num_pairs, hidden_size, device="cuda", dtype=dtype
+    ) * 0.1
+    w_gate_up = torch.randn(
+        num_experts, 2 * ffn_size, hidden_size, device="cuda", dtype=dtype
+    ) * 0.02
+    w_down = torch.randn(
+        num_experts, hidden_size, ffn_size, device="cuda", dtype=dtype
+    ) * 0.02
+    true_sizes = torch.tensor(sizes, device="cuda", dtype=torch.int32)
+    true_offsets = torch.tensor(
+        [sum(sizes[:expert]) for expert in range(num_experts)],
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    op = DispatchedExpertMLPFwdOp(
+        num_pairs=num_pairs,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        dtype=dtype,
+    )
+    output = op(hidden, w_gate_up, w_down, true_sizes, true_offsets)
+    reference = _reference(hidden, w_gate_up, w_down, sizes)
+
+    assert output.shape == hidden.shape
+    assert output.dtype == dtype
+    assert torch.allclose(output.float(), reference.float(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+def test_expert_batch_mock_dispatch_combine_applies_weights_once():
+    """A mock multi-source dispatch/combine is equivalent to explicit MoE."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    torch.manual_seed(1)
+    tokens, hidden_size, ffn_size, num_experts, top_k = 8, 128, 96, 4, 2
+    dtype = torch.bfloat16
+    hidden = torch.randn(
+        tokens, hidden_size, device="cuda", dtype=dtype
+    ) * 0.1
+    w_gate_up = torch.randn(
+        num_experts,
+        2 * ffn_size,
+        hidden_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    w_down = torch.randn(
+        num_experts,
+        hidden_size,
+        ffn_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    topk_ids = torch.tensor(
+        [[0, 2], [1, 2], [2, 0], [0, 1], [2, 1], [1, 0], [0, 2], [2, 1]],
+        device="cuda",
+        dtype=torch.int64,
+    )
+    topk_weights = torch.softmax(
+        torch.randn(tokens, top_k, device="cuda"), dim=-1
+    )
+
+    # Mock dispatch: pairs from two source ranks are sorted expert-major.
+    source_tokens = torch.arange(tokens, device="cuda").repeat_interleave(top_k)
+    source_ranks = (torch.arange(tokens, device="cuda") % 2).repeat_interleave(
+        top_k
+    )
+    flat_experts = topk_ids.flatten()
+    order = torch.argsort(flat_experts, stable=True)
+    dispatched = hidden[source_tokens[order]]
+    counts = torch.bincount(flat_experts, minlength=num_experts).to(torch.int32)
+    expert_offsets = torch.cat(
+        (
+            torch.zeros(1, device="cuda", dtype=torch.int32),
+            torch.cumsum(counts, dim=0, dtype=torch.int32),
+        )
+    )
+    batch = ExpertBatch(
+        hidden=dispatched,
+        expert_offsets=expert_offsets,
+        layout="tight",
+    )
+    # The reverse handle is external metadata and is never passed to TileOps.
+    reverse_handle = {
+        "source_tokens": source_tokens[order],
+        "source_ranks": source_ranks[order],
+        "weights": topk_weights.flatten()[order],
+    }
+
+    op = DispatchedExpertMLPFwdOp(
+        num_pairs=tokens * top_k,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        dtype=dtype,
+    )
+    expert_output = op.forward_batch(batch, w_gate_up, w_down)
+
+    sizes = counts.cpu().tolist()
+    unweighted_reference = _reference(
+        dispatched, w_gate_up, w_down, sizes
+    )
+    assert expert_output.row_order_preserved
+    assert not expert_output.routing_weights_applied
+    assert torch.allclose(
+        expert_output.hidden.float(),
+        unweighted_reference.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+    # Mock combine: reverse source-token mapping and apply routing weight once.
+    combined = torch.zeros(
+        tokens, hidden_size, device="cuda", dtype=torch.float32
+    )
+    combined.index_add_(
+        0,
+        reverse_handle["source_tokens"],
+        expert_output.hidden.float()
+        * reverse_handle["weights"].float().unsqueeze(1),
+    )
+    combined_reference = torch.zeros_like(combined)
+    combined_reference.index_add_(
+        0,
+        reverse_handle["source_tokens"],
+        unweighted_reference.float()
+        * reverse_handle["weights"].float().unsqueeze(1),
+    )
+    assert torch.equal(
+        reverse_handle["source_ranks"].unique().cpu(), torch.tensor([0, 1])
+    )
+    assert torch.allclose(combined, combined_reference, atol=1e-2, rtol=1e-2)

--- a/tests/ops/test_dispatched_expert.py
+++ b/tests/ops/test_dispatched_expert.py
@@ -65,6 +65,24 @@ def test_expert_batch_output_contract_defaults():
     assert not output.routing_weights_applied
 
 
+@pytest.mark.smoke
+def test_expert_batch_valid_rows_contract():
+    hidden = torch.empty(4, 8)
+    offsets = torch.tensor([0, 2, 4], dtype=torch.int32)
+    with pytest.raises(ValueError, match="one element"):
+        ExpertBatch(
+            hidden=hidden,
+            expert_offsets=offsets,
+            valid_rows=torch.tensor([3, 4], dtype=torch.int32),
+        )
+    with pytest.raises(ValueError, match="torch.int32"):
+        ExpertBatch(
+            hidden=hidden,
+            expert_offsets=offsets,
+            valid_rows=torch.tensor(4, dtype=torch.int64),
+        )
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("sizes", [[4, 4, 4, 4], [0, 2, 13, 1]])
 @pytest.mark.smoke
@@ -212,3 +230,167 @@ def test_expert_batch_mock_dispatch_combine_applies_weights_once():
         reverse_handle["source_ranks"].unique().cpu(), torch.tensor([0, 1])
     )
     assert torch.allclose(combined, combined_reference, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("use_fused_activation", [False, True])
+@pytest.mark.parametrize("sizes", [[0, 3, 5, 2], [0, 0, 0, 0]])
+def test_expert_batch_capacity_processes_only_device_valid_rows(
+    use_fused_activation, sizes,
+):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if use_fused_activation and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("fused activation requires SM90")
+
+    torch.manual_seed(2)
+    capacity, hidden_size, ffn_size, num_experts = 24, 256, 128, 4
+    valid_count = sum(sizes)
+    dtype = torch.bfloat16
+    hidden = torch.randn(
+        capacity, hidden_size, device="cuda", dtype=dtype
+    ) * 0.1
+    # An invalid tail must not affect valid rows.
+    hidden[valid_count:].fill_(float("nan"))
+    w_gate_up = torch.randn(
+        num_experts,
+        2 * ffn_size,
+        hidden_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    w_down = torch.randn(
+        num_experts,
+        hidden_size,
+        ffn_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    host_offsets = [0]
+    for size in sizes:
+        host_offsets.append(host_offsets[-1] + size)
+    offsets = torch.tensor(
+        host_offsets, device="cuda", dtype=torch.int32
+    )
+    valid_rows = torch.tensor(
+        valid_count, device="cuda", dtype=torch.int32
+    )
+    batch = ExpertBatch(hidden, offsets, valid_rows=valid_rows)
+    op = DispatchedExpertMLPFwdOp(
+        num_pairs=capacity,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        dtype=dtype,
+        use_fused_activation=use_fused_activation,
+    )
+
+    output = op.forward_batch(batch, w_gate_up, w_down)
+    reference = _reference(
+        hidden[:valid_count], w_gate_up, w_down, sizes
+    )
+
+    assert output.hidden.shape == (capacity, hidden_size)
+    assert output.valid_rows is valid_rows
+    assert torch.isfinite(output.hidden[:valid_count]).all()
+    assert torch.allclose(
+        output.hidden[:valid_count].float(),
+        reference.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+@pytest.mark.smoke
+def test_expert_batch_cuda_graph_replays_different_valid_rows():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    torch.manual_seed(3)
+    capacity, hidden_size, ffn_size, num_experts = 24, 128, 96, 4
+    dtype = torch.bfloat16
+    hidden = torch.empty(
+        capacity, hidden_size, device="cuda", dtype=dtype
+    )
+    offsets = torch.empty(
+        num_experts + 1, device="cuda", dtype=torch.int32
+    )
+    valid_rows = torch.empty((), device="cuda", dtype=torch.int32)
+    w_gate_up = torch.randn(
+        num_experts,
+        2 * ffn_size,
+        hidden_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    w_down = torch.randn(
+        num_experts,
+        hidden_size,
+        ffn_size,
+        device="cuda",
+        dtype=dtype,
+    ) * 0.02
+    batch = ExpertBatch(hidden, offsets, valid_rows=valid_rows)
+    op = DispatchedExpertMLPFwdOp(
+        num_pairs=capacity,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        dtype=dtype,
+    )
+
+    def set_batch(sizes):
+        count = sum(sizes)
+        hidden[:count].copy_(
+            torch.randn(
+                count, hidden_size, device="cuda", dtype=dtype
+            ) * 0.1
+        )
+        hidden[count:].fill_(float("nan"))
+        host_offsets = [0]
+        for size in sizes:
+            host_offsets.append(host_offsets[-1] + size)
+        offsets.copy_(
+            torch.tensor(host_offsets, device="cuda", dtype=torch.int32)
+        )
+        valid_rows.fill_(count)
+        return count
+
+    first_sizes = [2, 0, 3, 2]
+    first_count = set_batch(first_sizes)
+    # Compile and warm allocator state before capture.
+    op.forward_batch(batch, w_gate_up, w_down)
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(2):
+            op.forward_batch(batch, w_gate_up, w_down)
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = op.forward_batch(batch, w_gate_up, w_down).hidden
+    graph.replay()
+    first_reference = _reference(
+        hidden[:first_count], w_gate_up, w_down, first_sizes
+    )
+    assert torch.allclose(
+        captured[:first_count].float(),
+        first_reference.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+    second_sizes = [0, 4, 1, 6]
+    second_count = set_batch(second_sizes)
+    graph.replay()
+    second_reference = _reference(
+        hidden[:second_count], w_gate_up, w_down, second_sizes
+    )
+    assert torch.isfinite(captured[:second_count]).all()
+    assert torch.allclose(
+        captured[:second_count].float(),
+        second_reference.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )

--- a/tests/ops/test_dispatched_expert.py
+++ b/tests/ops/test_dispatched_expert.py
@@ -66,21 +66,15 @@ def test_expert_batch_output_contract_defaults():
 
 
 @pytest.mark.smoke
-def test_expert_batch_valid_rows_contract():
+def test_expert_batch_valid_rows_is_offsets_view():
     hidden = torch.empty(4, 8)
     offsets = torch.tensor([0, 2, 4], dtype=torch.int32)
-    with pytest.raises(ValueError, match="one element"):
-        ExpertBatch(
-            hidden=hidden,
-            expert_offsets=offsets,
-            valid_rows=torch.tensor([3, 4], dtype=torch.int32),
-        )
-    with pytest.raises(ValueError, match="torch.int32"):
-        ExpertBatch(
-            hidden=hidden,
-            expert_offsets=offsets,
-            valid_rows=torch.tensor(4, dtype=torch.int64),
-        )
+    batch = ExpertBatch(hidden=hidden, expert_offsets=offsets)
+
+    assert batch.valid_rows.shape == (1,)
+    assert batch.valid_rows.data_ptr() == offsets[-1:].data_ptr()
+    offsets[-1] = 3
+    assert batch.valid_rows.item() == 3
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
@@ -272,10 +266,7 @@ def test_expert_batch_capacity_processes_only_device_valid_rows(
     offsets = torch.tensor(
         host_offsets, device="cuda", dtype=torch.int32
     )
-    valid_rows = torch.tensor(
-        valid_count, device="cuda", dtype=torch.int32
-    )
-    batch = ExpertBatch(hidden, offsets, valid_rows=valid_rows)
+    batch = ExpertBatch(hidden, offsets)
     op = DispatchedExpertMLPFwdOp(
         num_pairs=capacity,
         num_experts=num_experts,
@@ -291,7 +282,7 @@ def test_expert_batch_capacity_processes_only_device_valid_rows(
     )
 
     assert output.hidden.shape == (capacity, hidden_size)
-    assert output.valid_rows is valid_rows
+    assert output.valid_rows.data_ptr() == offsets[-1:].data_ptr()
     assert torch.isfinite(output.hidden[:valid_count]).all()
     assert torch.allclose(
         output.hidden[:valid_count].float(),
@@ -302,12 +293,17 @@ def test_expert_batch_capacity_processes_only_device_valid_rows(
 
 
 @pytest.mark.smoke
-def test_expert_batch_cuda_graph_replays_different_valid_rows():
+@pytest.mark.parametrize("use_fused_activation", [False, True])
+def test_expert_batch_cuda_graph_replays_different_valid_rows(
+    use_fused_activation,
+):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
+    if use_fused_activation and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("fused activation requires SM90")
 
     torch.manual_seed(3)
-    capacity, hidden_size, ffn_size, num_experts = 24, 128, 96, 4
+    capacity, hidden_size, ffn_size, num_experts = 24, 256, 128, 4
     dtype = torch.bfloat16
     hidden = torch.empty(
         capacity, hidden_size, device="cuda", dtype=dtype
@@ -315,7 +311,6 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows():
     offsets = torch.empty(
         num_experts + 1, device="cuda", dtype=torch.int32
     )
-    valid_rows = torch.empty((), device="cuda", dtype=torch.int32)
     w_gate_up = torch.randn(
         num_experts,
         2 * ffn_size,
@@ -330,13 +325,14 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows():
         device="cuda",
         dtype=dtype,
     ) * 0.02
-    batch = ExpertBatch(hidden, offsets, valid_rows=valid_rows)
+    batch = ExpertBatch(hidden, offsets)
     op = DispatchedExpertMLPFwdOp(
         num_pairs=capacity,
         num_experts=num_experts,
         hidden_size=hidden_size,
         ffn_size=ffn_size,
         dtype=dtype,
+        use_fused_activation=use_fused_activation,
     )
 
     def set_batch(sizes):
@@ -353,7 +349,6 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows():
         offsets.copy_(
             torch.tensor(host_offsets, device="cuda", dtype=torch.int32)
         )
-        valid_rows.fill_(count)
         return count
 
     first_sizes = [2, 0, 3, 2]

--- a/tests/ops/test_dispatched_expert.py
+++ b/tests/ops/test_dispatched_expert.py
@@ -1,15 +1,13 @@
 """Tests for the communication-independent dispatched expert MLP."""
 
-import inspect
-
 import pytest
 import torch
 import torch.nn.functional as F
 
+from tileops.kernels.grouped_gemm import GroupedGemmPersistent3WGKernel
 from tileops.ops.moe import (
     DispatchedExpertMLPFwdOp,
     ExpertBatch,
-    ExpertBatchOutput,
 )
 
 
@@ -27,26 +25,6 @@ def _reference(hidden, w_gate_up, w_down, sizes):
 
 
 @pytest.mark.smoke
-def test_public_interface_has_no_routing_or_communication_inputs():
-    parameters = inspect.signature(DispatchedExpertMLPFwdOp.forward).parameters
-    assert tuple(parameters) == (
-        "self",
-        "expert_input",
-        "w_gate_up",
-        "w_down",
-        "true_sizes",
-        "true_offsets",
-    )
-    forbidden = {"topk_ids", "topk_weights", "rank", "world_size", "handle"}
-    assert forbidden.isdisjoint(parameters)
-    batch_parameters = inspect.signature(
-        DispatchedExpertMLPFwdOp.forward_batch
-    ).parameters
-    assert tuple(batch_parameters) == ("self", "batch", "w_gate_up", "w_down")
-    assert forbidden.isdisjoint(batch_parameters)
-
-
-@pytest.mark.smoke
 def test_expert_batch_contract_rejects_non_tight_layout():
     with pytest.raises(ValueError, match="layout='tight'"):
         ExpertBatch(
@@ -54,15 +32,6 @@ def test_expert_batch_contract_rejects_non_tight_layout():
             expert_offsets=torch.tensor([0, 2, 4], dtype=torch.int32),
             layout="aligned",
         )
-
-
-@pytest.mark.smoke
-def test_expert_batch_output_contract_defaults():
-    hidden = torch.empty(4, 8)
-    output = ExpertBatchOutput(hidden=hidden)
-    assert output.hidden is hidden
-    assert output.row_order_preserved
-    assert not output.routing_weights_applied
 
 
 @pytest.mark.smoke
@@ -79,8 +48,13 @@ def test_expert_batch_valid_rows_is_offsets_view():
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("sizes", [[4, 4, 4, 4], [0, 2, 13, 1]])
+@pytest.mark.parametrize("explicit_3wg_override", [False, True])
 @pytest.mark.smoke
-def test_dispatched_expert_matches_reference_and_preserves_rows(dtype, sizes):
+def test_dispatched_expert_matches_reference_and_preserves_rows(
+    dtype,
+    sizes,
+    explicit_3wg_override,
+):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
 
@@ -88,15 +62,11 @@ def test_dispatched_expert_matches_reference_and_preserves_rows(dtype, sizes):
     num_experts = len(sizes)
     num_pairs = sum(sizes)
     hidden_size, ffn_size = 128, 96
-    hidden = torch.randn(
-        num_pairs, hidden_size, device="cuda", dtype=dtype
-    ) * 0.1
-    w_gate_up = torch.randn(
-        num_experts, 2 * ffn_size, hidden_size, device="cuda", dtype=dtype
-    ) * 0.02
-    w_down = torch.randn(
-        num_experts, hidden_size, ffn_size, device="cuda", dtype=dtype
-    ) * 0.02
+    hidden = torch.randn(num_pairs, hidden_size, device="cuda", dtype=dtype) * 0.1
+    w_gate_up = (
+        torch.randn(num_experts, 2 * ffn_size, hidden_size, device="cuda", dtype=dtype) * 0.02
+    )
+    w_down = torch.randn(num_experts, hidden_size, ffn_size, device="cuda", dtype=dtype) * 0.02
     true_sizes = torch.tensor(sizes, device="cuda", dtype=torch.int32)
     true_offsets = torch.tensor(
         [sum(sizes[:expert]) for expert in range(num_experts)],
@@ -110,6 +80,11 @@ def test_dispatched_expert_matches_reference_and_preserves_rows(dtype, sizes):
         hidden_size=hidden_size,
         ffn_size=ffn_size,
         dtype=dtype,
+        kernel_map=(
+            {"moe_grouped_gemm_kernel": GroupedGemmPersistent3WGKernel}
+            if explicit_3wg_override
+            else None
+        ),
     )
     output = op(hidden, w_gate_up, w_down, true_sizes, true_offsets)
     reference = _reference(hidden, w_gate_up, w_down, sizes)
@@ -120,117 +95,11 @@ def test_dispatched_expert_matches_reference_and_preserves_rows(dtype, sizes):
 
 
 @pytest.mark.smoke
-def test_expert_batch_mock_dispatch_combine_applies_weights_once():
-    """A mock multi-source dispatch/combine is equivalent to explicit MoE."""
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required")
-
-    torch.manual_seed(1)
-    tokens, hidden_size, ffn_size, num_experts, top_k = 8, 128, 96, 4, 2
-    dtype = torch.bfloat16
-    hidden = torch.randn(
-        tokens, hidden_size, device="cuda", dtype=dtype
-    ) * 0.1
-    w_gate_up = torch.randn(
-        num_experts,
-        2 * ffn_size,
-        hidden_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
-    w_down = torch.randn(
-        num_experts,
-        hidden_size,
-        ffn_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
-    topk_ids = torch.tensor(
-        [[0, 2], [1, 2], [2, 0], [0, 1], [2, 1], [1, 0], [0, 2], [2, 1]],
-        device="cuda",
-        dtype=torch.int64,
-    )
-    topk_weights = torch.softmax(
-        torch.randn(tokens, top_k, device="cuda"), dim=-1
-    )
-
-    # Mock dispatch: pairs from two source ranks are sorted expert-major.
-    source_tokens = torch.arange(tokens, device="cuda").repeat_interleave(top_k)
-    source_ranks = (torch.arange(tokens, device="cuda") % 2).repeat_interleave(
-        top_k
-    )
-    flat_experts = topk_ids.flatten()
-    order = torch.argsort(flat_experts, stable=True)
-    dispatched = hidden[source_tokens[order]]
-    counts = torch.bincount(flat_experts, minlength=num_experts).to(torch.int32)
-    expert_offsets = torch.cat(
-        (
-            torch.zeros(1, device="cuda", dtype=torch.int32),
-            torch.cumsum(counts, dim=0, dtype=torch.int32),
-        )
-    )
-    batch = ExpertBatch(
-        hidden=dispatched,
-        expert_offsets=expert_offsets,
-        layout="tight",
-    )
-    # The reverse handle is external metadata and is never passed to TileOps.
-    reverse_handle = {
-        "source_tokens": source_tokens[order],
-        "source_ranks": source_ranks[order],
-        "weights": topk_weights.flatten()[order],
-    }
-
-    op = DispatchedExpertMLPFwdOp(
-        num_pairs=tokens * top_k,
-        num_experts=num_experts,
-        hidden_size=hidden_size,
-        ffn_size=ffn_size,
-        dtype=dtype,
-    )
-    expert_output = op.forward_batch(batch, w_gate_up, w_down)
-
-    sizes = counts.cpu().tolist()
-    unweighted_reference = _reference(
-        dispatched, w_gate_up, w_down, sizes
-    )
-    assert expert_output.row_order_preserved
-    assert not expert_output.routing_weights_applied
-    assert torch.allclose(
-        expert_output.hidden.float(),
-        unweighted_reference.float(),
-        atol=1e-2,
-        rtol=1e-2,
-    )
-
-    # Mock combine: reverse source-token mapping and apply routing weight once.
-    combined = torch.zeros(
-        tokens, hidden_size, device="cuda", dtype=torch.float32
-    )
-    combined.index_add_(
-        0,
-        reverse_handle["source_tokens"],
-        expert_output.hidden.float()
-        * reverse_handle["weights"].float().unsqueeze(1),
-    )
-    combined_reference = torch.zeros_like(combined)
-    combined_reference.index_add_(
-        0,
-        reverse_handle["source_tokens"],
-        unweighted_reference.float()
-        * reverse_handle["weights"].float().unsqueeze(1),
-    )
-    assert torch.equal(
-        reverse_handle["source_ranks"].unique().cpu(), torch.tensor([0, 1])
-    )
-    assert torch.allclose(combined, combined_reference, atol=1e-2, rtol=1e-2)
-
-
-@pytest.mark.smoke
 @pytest.mark.parametrize("use_fused_activation", [False, True])
 @pytest.mark.parametrize("sizes", [[0, 3, 5, 2], [0, 0, 0, 0]])
 def test_expert_batch_capacity_processes_only_device_valid_rows(
-    use_fused_activation, sizes,
+    use_fused_activation,
+    sizes,
 ):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
@@ -241,31 +110,33 @@ def test_expert_batch_capacity_processes_only_device_valid_rows(
     capacity, hidden_size, ffn_size, num_experts = 24, 256, 128, 4
     valid_count = sum(sizes)
     dtype = torch.bfloat16
-    hidden = torch.randn(
-        capacity, hidden_size, device="cuda", dtype=dtype
-    ) * 0.1
+    hidden = torch.randn(capacity, hidden_size, device="cuda", dtype=dtype) * 0.1
     # An invalid tail must not affect valid rows.
     hidden[valid_count:].fill_(float("nan"))
-    w_gate_up = torch.randn(
-        num_experts,
-        2 * ffn_size,
-        hidden_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
-    w_down = torch.randn(
-        num_experts,
-        hidden_size,
-        ffn_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
+    w_gate_up = (
+        torch.randn(
+            num_experts,
+            2 * ffn_size,
+            hidden_size,
+            device="cuda",
+            dtype=dtype,
+        )
+        * 0.02
+    )
+    w_down = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            ffn_size,
+            device="cuda",
+            dtype=dtype,
+        )
+        * 0.02
+    )
     host_offsets = [0]
     for size in sizes:
         host_offsets.append(host_offsets[-1] + size)
-    offsets = torch.tensor(
-        host_offsets, device="cuda", dtype=torch.int32
-    )
+    offsets = torch.tensor(host_offsets, device="cuda", dtype=torch.int32)
     batch = ExpertBatch(hidden, offsets)
     op = DispatchedExpertMLPFwdOp(
         num_pairs=capacity,
@@ -277,9 +148,7 @@ def test_expert_batch_capacity_processes_only_device_valid_rows(
     )
 
     output = op.forward_batch(batch, w_gate_up, w_down)
-    reference = _reference(
-        hidden[:valid_count], w_gate_up, w_down, sizes
-    )
+    reference = _reference(hidden[:valid_count], w_gate_up, w_down, sizes)
 
     assert output.hidden.shape == (capacity, hidden_size)
     assert output.valid_rows.data_ptr() == offsets[-1:].data_ptr()
@@ -305,26 +174,28 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows(
     torch.manual_seed(3)
     capacity, hidden_size, ffn_size, num_experts = 24, 256, 128, 4
     dtype = torch.bfloat16
-    hidden = torch.empty(
-        capacity, hidden_size, device="cuda", dtype=dtype
+    hidden = torch.empty(capacity, hidden_size, device="cuda", dtype=dtype)
+    offsets = torch.empty(num_experts + 1, device="cuda", dtype=torch.int32)
+    w_gate_up = (
+        torch.randn(
+            num_experts,
+            2 * ffn_size,
+            hidden_size,
+            device="cuda",
+            dtype=dtype,
+        )
+        * 0.02
     )
-    offsets = torch.empty(
-        num_experts + 1, device="cuda", dtype=torch.int32
+    w_down = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            ffn_size,
+            device="cuda",
+            dtype=dtype,
+        )
+        * 0.02
     )
-    w_gate_up = torch.randn(
-        num_experts,
-        2 * ffn_size,
-        hidden_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
-    w_down = torch.randn(
-        num_experts,
-        hidden_size,
-        ffn_size,
-        device="cuda",
-        dtype=dtype,
-    ) * 0.02
     batch = ExpertBatch(hidden, offsets)
     op = DispatchedExpertMLPFwdOp(
         num_pairs=capacity,
@@ -337,18 +208,12 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows(
 
     def set_batch(sizes):
         count = sum(sizes)
-        hidden[:count].copy_(
-            torch.randn(
-                count, hidden_size, device="cuda", dtype=dtype
-            ) * 0.1
-        )
+        hidden[:count].copy_(torch.randn(count, hidden_size, device="cuda", dtype=dtype) * 0.1)
         hidden[count:].fill_(float("nan"))
         host_offsets = [0]
         for size in sizes:
             host_offsets.append(host_offsets[-1] + size)
-        offsets.copy_(
-            torch.tensor(host_offsets, device="cuda", dtype=torch.int32)
-        )
+        offsets.copy_(torch.tensor(host_offsets, device="cuda", dtype=torch.int32))
         return count
 
     first_sizes = [2, 0, 3, 2]
@@ -366,9 +231,7 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows(
     with torch.cuda.graph(graph):
         captured = op.forward_batch(batch, w_gate_up, w_down).hidden
     graph.replay()
-    first_reference = _reference(
-        hidden[:first_count], w_gate_up, w_down, first_sizes
-    )
+    first_reference = _reference(hidden[:first_count], w_gate_up, w_down, first_sizes)
     assert torch.allclose(
         captured[:first_count].float(),
         first_reference.float(),
@@ -379,9 +242,7 @@ def test_expert_batch_cuda_graph_replays_different_valid_rows(
     second_sizes = [0, 4, 1, 6]
     second_count = set_batch(second_sizes)
     graph.replay()
-    second_reference = _reference(
-        hidden[:second_count], w_gate_up, w_down, second_sizes
-    )
+    second_reference = _reference(hidden[:second_count], w_gate_up, w_down, second_sizes)
     assert torch.isfinite(captured[:second_count]).all()
     assert torch.allclose(
         captured[:second_count].float(),

--- a/tests/ops/test_expert_dispatch.py
+++ b/tests/ops/test_expert_dispatch.py
@@ -1,0 +1,304 @@
+"""Correctness tests for tight local and DeepEP dispatch adapters."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tileops.ops.moe import (
+    DeepEPDispatchAdapter,
+    DispatchedExpertMLPFwdOp,
+    ExpertDispatchResult,
+    LocalDispatchHandle,
+    LocalExpertDispatcher,
+)
+
+
+def _routing(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+    *,
+    hidden_size: int = 16,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    hidden = (
+        torch.arange(num_tokens * hidden_size, device="cuda", dtype=torch.float32)
+        .reshape(num_tokens, hidden_size)
+        .to(dtype)
+    )
+    scores = torch.rand(num_tokens, num_experts, device="cuda")
+    topk_ids = scores.topk(top_k, dim=-1).indices.to(torch.int32)
+    weights = torch.softmax(torch.randn(num_tokens, top_k, device="cuda"), dim=-1)
+    return hidden, topk_ids, weights
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("num_tokens,top_k,num_experts", [(5, 2, 4), (3, 1, 8)])
+def test_local_dispatch_is_tight_and_reversible(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+) -> None:
+    hidden, topk_ids, weights = _routing(num_tokens, top_k, num_experts)
+    result = LocalExpertDispatcher(num_experts).dispatch(hidden, topk_ids, weights)
+
+    assert isinstance(result, ExpertDispatchResult)
+    assert isinstance(result.combine_handle, LocalDispatchHandle)
+    assert result.batch.layout == "tight"
+    assert result.batch.capacity == num_tokens * top_k
+    assert result.batch.expert_offsets.dtype == torch.int32
+    assert result.routing_weights.dtype == torch.float32
+
+    flat_ids = topk_ids.flatten()
+    counts = torch.bincount(flat_ids.to(torch.int64), minlength=num_experts)
+    expected_offsets = torch.cat(
+        (
+            torch.zeros(1, dtype=torch.int64, device="cuda"),
+            counts.cumsum(0),
+        )
+    ).to(torch.int32)
+    torch.testing.assert_close(result.batch.expert_offsets, expected_offsets)
+
+    mapping = result.combine_handle.forward_mapping.to(torch.int64)
+    source_rows = torch.arange(num_tokens, device="cuda").unsqueeze(1).expand(-1, top_k).flatten()
+    torch.testing.assert_close(result.batch.hidden[mapping], hidden[source_rows])
+    torch.testing.assert_close(result.routing_weights[mapping], weights.flatten())
+
+
+@pytest.mark.smoke
+def test_local_dispatch_reference_combine_applies_weights_once() -> None:
+    hidden, topk_ids, weights = _routing(7, 3, 6)
+    result = LocalExpertDispatcher(6).dispatch(hidden, topk_ids, weights)
+    handle = result.combine_handle
+    assert isinstance(handle, LocalDispatchHandle)
+
+    # Stand in for an expert function that preserves row order.
+    expert_output = result.batch.hidden.float() * 2.0
+    pair_output = expert_output[handle.forward_mapping.to(torch.int64)]
+    combined = (
+        pair_output.reshape(handle.num_tokens, handle.top_k, -1) * weights.unsqueeze(-1)
+    ).sum(dim=1)
+    reference = hidden.float() * 2.0 * weights.sum(dim=1, keepdim=True)
+    torch.testing.assert_close(combined, reference)
+
+
+@pytest.mark.smoke
+def test_local_dispatch_output_is_consumed_directly_by_m5() -> None:
+    num_tokens, top_k, num_experts = 4, 2, 4
+    hidden_size, ffn_size = 128, 128
+    hidden, topk_ids, weights = _routing(num_tokens, top_k, num_experts, hidden_size=hidden_size)
+    hidden = torch.randn_like(hidden) * 0.1
+    result = LocalExpertDispatcher(num_experts).dispatch(hidden, topk_ids, weights)
+    w_gate_up = (
+        torch.randn(
+            num_experts,
+            2 * ffn_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        * 0.02
+    )
+    w_down = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            ffn_size,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        * 0.02
+    )
+    op = DispatchedExpertMLPFwdOp(
+        num_pairs=result.batch.capacity,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        ffn_size=ffn_size,
+        dtype=torch.bfloat16,
+    )
+    output = op.forward_batch(result.batch, w_gate_up, w_down)
+
+    reference = torch.empty_like(output.hidden)
+    offsets = result.batch.expert_offsets.cpu().tolist()
+    for expert in range(num_experts):
+        start, end = offsets[expert], offsets[expert + 1]
+        gate_up = result.batch.hidden[start:end].float() @ w_gate_up[expert].float().T
+        activated = F.silu(gate_up[:, :ffn_size]) * gate_up[:, ffn_size:]
+        reference[start:end] = (activated @ w_down[expert].float().T).to(reference.dtype)
+
+    assert output.valid_rows is not None
+    torch.testing.assert_close(output.valid_rows, result.batch.valid_rows)
+    torch.testing.assert_close(
+        output.hidden,
+        reference,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+class _FakeEvent:
+    def __init__(self) -> None:
+        self.waited = False
+
+    def current_stream_wait(self) -> None:
+        self.waited = True
+
+
+class _FakeDeepEPBuffer:
+    def __init__(self, num_local_experts: int, capacity_tail: int = 3) -> None:
+        self.num_local_experts = num_local_experts
+        self.capacity_tail = capacity_tail
+        self.kwargs = None
+        self.event = _FakeEvent()
+        self.recv_x = None
+
+    def dispatch(self, hidden_states, **kwargs):
+        self.kwargs = kwargs
+        cached_handle = kwargs["handle"]
+        topk_ids = kwargs["topk_idx"] if cached_handle is None else cached_handle.topk_idx
+        weights = kwargs["topk_weights"]
+        flat_ids = topk_ids.flatten()
+        order = torch.argsort(flat_ids, stable=True)
+        source_rows = (
+            torch.arange(hidden_states.shape[0], device=hidden_states.device)
+            .unsqueeze(1)
+            .expand_as(topk_ids)
+            .flatten()
+        )
+        valid_x = hidden_states[source_rows[order]]
+        valid_weights = weights.flatten()[order]
+        self.recv_x = torch.empty(
+            valid_x.shape[0] + self.capacity_tail,
+            hidden_states.shape[1],
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        self.recv_x[: valid_x.shape[0]].copy_(valid_x)
+        recv_weights = torch.empty(
+            valid_weights.shape[0] + self.capacity_tail,
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        recv_weights[: valid_weights.shape[0]].copy_(valid_weights)
+        counts = torch.bincount(flat_ids, minlength=self.num_local_experts).to(torch.int32)
+        handle = cached_handle or SimpleNamespace(
+            do_expand=True,
+            expert_alignment=1,
+            topk_idx=topk_ids,
+            psum_num_recv_tokens_per_expert=counts.cumsum(0, dtype=torch.int32),
+        )
+        return self.recv_x, None, recv_weights, handle, self.event
+
+
+@pytest.mark.smoke
+def test_deepep_adapter_uses_unpadded_expanded_layout_without_copy() -> None:
+    num_experts = 4
+    hidden, topk_ids, weights = _routing(5, 2, num_experts)
+    topk_ids = topk_ids.to(torch.int64)
+    buffer = _FakeDeepEPBuffer(num_experts)
+    offsets_buffer = torch.empty(num_experts + 1, dtype=torch.int32, device="cuda")
+    result = DeepEPDispatchAdapter(
+        buffer,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        num_max_tokens_per_rank=32,
+        num_sms=12,
+    ).dispatch(
+        hidden,
+        topk_ids,
+        weights,
+        expert_offsets=offsets_buffer,
+    )
+
+    assert buffer.kwargs is not None
+    assert buffer.kwargs["do_expand"] is True
+    assert buffer.kwargs["expert_alignment"] == 1
+    assert buffer.kwargs["do_cpu_sync"] is False
+    assert buffer.kwargs["async_with_compute_stream"] is True
+    assert buffer.kwargs["num_sms"] == 12
+    assert buffer.kwargs["topk_idx"] is topk_ids
+    assert buffer.kwargs["handle"] is None
+    assert buffer.event.waited
+    assert result.batch.hidden is buffer.recv_x
+    assert result.batch.expert_offsets is offsets_buffer
+    assert result.batch.capacity == topk_ids.numel() + buffer.capacity_tail
+    assert result.batch.valid_rows.item() == topk_ids.numel()
+
+    counts = torch.bincount(topk_ids.flatten().to(torch.int64), minlength=num_experts)
+    expected_offsets = torch.cat(
+        (
+            torch.zeros(1, dtype=torch.int64, device="cuda"),
+            counts.cumsum(0),
+        )
+    ).to(torch.int32)
+    torch.testing.assert_close(result.batch.expert_offsets, expected_offsets)
+
+
+@pytest.mark.smoke
+def test_deepep_adapter_reuses_expanded_decode_handle() -> None:
+    num_experts = 4
+    hidden, topk_ids, weights = _routing(5, 2, num_experts)
+    topk_ids = topk_ids.to(torch.int64)
+    buffer = _FakeDeepEPBuffer(num_experts)
+    adapter = DeepEPDispatchAdapter(
+        buffer,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        num_max_tokens_per_rank=32,
+    )
+    first = adapter.dispatch(hidden, topk_ids, weights)
+    cached_offsets = torch.empty(num_experts + 1, dtype=torch.int32, device="cuda")
+    second = adapter.dispatch(
+        hidden + 1,
+        None,
+        weights,
+        expert_offsets=cached_offsets,
+        cached_handle=first.combine_handle,
+    )
+
+    assert buffer.kwargs["topk_idx"] is None
+    assert buffer.kwargs["handle"] is first.combine_handle
+    assert second.combine_handle is first.combine_handle
+    assert second.batch.expert_offsets is cached_offsets
+    torch.testing.assert_close(second.batch.expert_offsets, first.batch.expert_offsets)
+
+
+@pytest.mark.smoke
+def test_deepep_adapter_does_not_hide_topk_dtype_conversion() -> None:
+    hidden, topk_ids, weights = _routing(4, 2, 4)
+    adapter = DeepEPDispatchAdapter(
+        _FakeDeepEPBuffer(4),
+        num_experts=4,
+        num_local_experts=4,
+        num_max_tokens_per_rank=16,
+    )
+    with pytest.raises(ValueError, match="topk_ids_dtype"):
+        adapter.dispatch(hidden, topk_ids, weights)
+
+
+@pytest.mark.smoke
+def test_deepep_adapter_rejects_non_device_prefix_sum() -> None:
+    hidden, topk_ids, weights = _routing(4, 2, 4)
+    topk_ids = topk_ids.to(torch.int64)
+
+    class BadBuffer:
+        def dispatch(self, hidden_states, **kwargs):
+            event = _FakeEvent()
+            handle = SimpleNamespace(psum_num_recv_tokens_per_expert=[1, 2, 3, 4])
+            recv_weights = torch.empty(
+                hidden_states.shape[0] * kwargs["topk_idx"].shape[1],
+                dtype=torch.float32,
+                device=hidden_states.device,
+            )
+            return hidden_states.repeat_interleave(2, 0), None, recv_weights, handle, event
+
+    adapter = DeepEPDispatchAdapter(
+        BadBuffer(),
+        num_experts=4,
+        num_local_experts=4,
+        num_max_tokens_per_rank=16,
+    )
+    with pytest.raises(TypeError, match="psum_num_recv_tokens_per_expert"):
+        adapter.dispatch(hidden, topk_ids, weights)

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -111,9 +111,7 @@ def test_silu_and_mul_device_bounded_rows(strategy: str) -> None:
     reference = F.silu(x[:valid, :n].float()) * x[:valid, n:].float()
 
     assert torch.isfinite(output[:valid]).all()
-    assert torch.allclose(
-        output[:valid].float(), reference, atol=1.6e-2, rtol=1.6e-2
-    )
+    assert torch.allclose(output[:valid].float(), reference, atol=1.6e-2, rtol=1.6e-2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -83,12 +83,11 @@ def test_silu_and_mul_lazy_op_rebinds_shape() -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("strategy", ["direct", "explicit_parallel"])
-def test_silu_and_mul_supports_more_than_65535_rows(strategy: str) -> None:
+def test_silu_and_mul_supports_more_than_65535_rows() -> None:
     """Large dispatched batches must not exceed CUDA's grid.y limit."""
     m, n, dtype = 65_536, 128, torch.bfloat16
     test = SiluAndMulTest(m, n, dtype)
-    op = SiluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy=strategy)
+    op = SiluAndMulFwdOp(M=m, N=n)
     atol, rtol = _get_tolerances(dtype)
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
@@ -105,7 +104,7 @@ def test_silu_and_mul_device_bounded_rows(strategy: str) -> None:
         M=m,
         N=n,
         dtype=torch.bfloat16,
-        strategy=strategy,
+        config={"strategy": strategy},
     )
 
     output = kernel.forward_rows(x, valid_rows)

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -82,6 +82,18 @@ def test_silu_and_mul_lazy_op_rebinds_shape() -> None:
         assert (op.M, op.N, op.dtype) == (m, n, torch.float16)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("strategy", ["direct", "explicit_parallel"])
+def test_silu_and_mul_supports_more_than_65535_rows(strategy: str) -> None:
+    """Large dispatched batches must not exceed CUDA's grid.y limit."""
+    m, n, dtype = 65_536, 128, torch.bfloat16
+    test = SiluAndMulTest(m, n, dtype)
+    op = SiluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy=strategy)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
 # GeluAndMul
 
 

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -93,6 +93,30 @@ def test_silu_and_mul_supports_more_than_65535_rows(strategy: str) -> None:
     test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("strategy", ["direct", "explicit_parallel"])
+def test_silu_and_mul_device_bounded_rows(strategy: str) -> None:
+    """A CUDA scalar bounds work while the compiled capacity stays fixed."""
+    m, n, valid = 32, 128, 11
+    x = torch.randn(m, 2 * n, device="cuda", dtype=torch.bfloat16)
+    x[valid:].fill_(float("nan"))
+    valid_rows = torch.tensor(valid, device="cuda", dtype=torch.int32)
+    kernel = SiluAndMulFwdKernel(
+        M=m,
+        N=n,
+        dtype=torch.bfloat16,
+        strategy=strategy,
+    )
+
+    output = kernel.forward_rows(x, valid_rows)
+    reference = F.silu(x[:valid, :n].float()) * x[:valid, n:].float()
+
+    assert torch.isfinite(output[:valid]).all()
+    assert torch.allclose(
+        output[:valid].float(), reference, atol=1.6e-2, rtol=1.6e-2
+    )
+
+
 # ---------------------------------------------------------------------------
 # GeluAndMul
 


### PR DESCRIPTION
## Summary

- Extract communication-independent dispatched-expert MLP compute for tight expert-major batches.
- Compose routed expert execution from local dispatch, expert compute, and combine while preserving the public API.
- Add GPU-resident dynamic row counts, static capacity, and CUDA Graph replay.
- Add local dispatch and an optional DeepEP V2 adapter without introducing a runtime DeepEP dependency.
- Keep routing weights and opaque combine handles outside expert compute.

## Review follow-up

- Resolve one effective grouped-GEMM kernel before constructing gate-up/down sub-ops, so an explicit override cannot undo the alignment fallback.
- Consolidate normal and device-bounded fused-gated paths around one column mapping and one pointwise epilogue while keeping distinct compiled signatures and no runtime row-policy branch.
- Remove exact-signature/dataclass-default tests and the duplicate hand-written mock dispatch/combine test; retain behavioral reference, capacity-tail, graph-replay, and real local-dispatch integration coverage.
- Consolidate benchmark timing, routing setup, expert distributions, FP32 reference checks, and TFLOPS calculation in a 167-line shared helper.
- Reduce the four benchmark entry points plus shared helper from roughly 915 to 778 lines, and remove the redundant pure/full compute benchmark while retaining the dynamic-capacity sweep and TileOps-vs-DeepGEMM comparison.

## Validation

- 24 dispatched-expert and dispatch-adapter smoke tests pass.
- Normal large-row and device-bounded direct/explicit fused-gated tests pass.
- Local dispatch benchmark smoke passes.
- TileOps-vs-DeepGEMM `M=1` smoke passes with FP32 correctness checks.
- DeepEP V2 2-rank fresh and cached-handle dispatch pass on 2× H200 using the non-Gin path.
- Ruff, Ruff format for benchmark files, Python compilation, and `git diff --check` pass.

## Scope

- BF16 tight/no-pad expert compute only; FP8/FP4 and padded-direct compute remain out of scope.
- TileOps does not acquire a runtime DeepEP dependency; callers inject the DeepEP buffer.
- Capacity-tail values remain unspecified; consumers use the GPU-resident `expert_offsets[-1:]` valid-row view.
