### PR TITLE
[Refactor][Benchmark] derive workload shape keys from manifest signature

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -19,28 +19,37 @@ import pytest
 import torch
 from torch.autograd.profiler import DeviceType
 
-from tileops.manifest import load_workloads
+from tileops.manifest import load_manifest, load_workloads
 
-# Shape keys accepted for the harness's single tensor input. ``x_shape``
-# is the generic name; ``input_shape`` matches ops whose PyTorch functional
-# signature names the tensor ``input`` (e.g. ``F.dropout(input, ...)``),
-# which the manifest mirrors verbatim. A workload must declare exactly one.
-_WORKLOAD_SHAPE_KEYS: tuple[str, ...] = ("x_shape", "input_shape")
+# Workload dict keys owned by the benchmark harness itself, independent of
+# any op signature: ``dtypes`` expands the pytest parametrization; ``label``
+# names the test id. The per-op shape key (``{input}_shape``, derived from
+# the manifest ``signature.inputs``) is computed in
+# :func:`_single_input_shape_key` — the harness hardcodes no input names.
+_WORKLOAD_HARNESS_KEYS: frozenset[str] = frozenset({"dtypes", "label"})
 
-# Workload dict keys reserved by the benchmark harness. Everything else on
-# a workload entry (e.g. ``dim``, ``keepdim``, ``correction``) is treated
-# as an op-call parameter.
-#
-# The current harness is explicitly scoped to **single-tensor-input ops**
-# (input named ``x`` or ``input``; see :data:`_WORKLOAD_SHAPE_KEYS`).
-# Multi-input ops (e.g. attention families that declare ``q_shape`` /
-# ``kv_shape``) are not supported: :func:`workloads_to_params` will raise
-# ``KeyError`` if no accepted shape key is present. Extending to
-# signature-aware tensor binding is tracked as a follow-up and must also
-# update ``docs/design/manifest.md``.
-_WORKLOAD_META_KEYS: frozenset[str] = frozenset(
-    {*_WORKLOAD_SHAPE_KEYS, "dtypes", "label"}
-)
+
+def _single_input_shape_key(op_name: str) -> str:
+    """Return the workload shape key for *op_name*'s single tensor input.
+
+    The manifest ``signature.inputs`` is the authority on tensor-input
+    names; the workload entry must carry ``{input}_shape`` for that one
+    input. Multi-input ops (attention families with ``q_shape`` /
+    ``kv_shape`` conventions) are served by family-specific bench harnesses
+    and are rejected here.
+    """
+    entry = load_manifest().get(op_name)
+    if entry is None:
+        raise KeyError(f"op {op_name!r} not found in the manifest")
+    inputs = list(((entry.get("signature") or {}).get("inputs") or {}))
+    if len(inputs) != 1:
+        raise KeyError(
+            f"workloads_to_params({op_name!r}) only supports ops whose "
+            f"manifest signature declares exactly one tensor input; found "
+            f"{inputs or 'none'}. Multi-input ops need a family-specific "
+            "bench harness."
+        )
+    return f"{inputs[0]}_shape"
 
 # ---------------------------------------------------------------------------
 # Benchmark capability protocols
@@ -451,25 +460,20 @@ class BenchmarkBase(Generic[W], ABC):
 # ---------------------------------------------------------------------------
 
 
-def _workload_extra_params(w: dict) -> dict[str, Any]:
+def _workload_extra_params(w: dict, shape_key: str) -> dict[str, Any]:
     """Return op-specific params attached to a manifest workload entry.
 
-    A workload entry may carry optional op-call parameter values beyond
-    ``x_shape`` / ``dtypes`` / ``label`` (e.g. ``dim``, ``keepdim``,
+    A workload entry may carry op-call parameter values beyond the shape
+    key / ``dtypes`` / ``label`` (e.g. ``dim``, ``keepdim``,
     ``correction``). These are forwarded to the op constructor by benchmark
-    files that opt into ``include_extra=True``.
-
-    Only the reserved meta keys (the accepted shape keys, ``dtypes``,
-    ``label``) and dunder-style metadata keys are stripped; everything else
-    — including any other ``*_shape`` keys — is surfaced as an op param.
-    This matches the single-tensor-input harness contract documented in
-    :data:`_WORKLOAD_META_KEYS`; multi-input ops with ``q_shape`` /
-    ``kv_shape`` are out of scope and would need a dedicated harness.
+    files that opt into ``include_extra=True``. Dunder-style metadata keys
+    are stripped alongside the harness-owned keys.
     """
+    reserved = _WORKLOAD_HARNESS_KEYS | {shape_key}
     return {
         k: v
         for k, v in w.items()
-        if k not in _WORKLOAD_META_KEYS and not k.startswith("__")
+        if k not in reserved and not k.startswith("__")
     }
 
 
@@ -487,20 +491,32 @@ def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
     benchmark needs to drive op calls from manifest-declared workload params.
     """
     workloads = load_workloads(op_name)
+    shape_key = _single_input_shape_key(op_name)
+    declared_params = frozenset(
+        (load_manifest()[op_name].get("signature") or {}).get("params") or {}
+    )
+    allowed = declared_params | _WORKLOAD_HARNESS_KEYS | {shape_key}
     params = []
     for w in workloads:
-        shape_keys = [k for k in _WORKLOAD_SHAPE_KEYS if k in w]
-        if len(shape_keys) != 1:
+        if shape_key not in w:
             raise KeyError(
-                f"workloads_to_params({op_name!r}) only supports "
-                "single-tensor-input ops; the workload must declare exactly "
-                f"one of {'/'.join(_WORKLOAD_SHAPE_KEYS)} (found "
-                f"{shape_keys or 'none'}). Multi-input ops with "
-                "q_shape/kv_shape/... are out of scope for this harness."
+                f"workload {w.get('label', w)!r} of {op_name!r} does not "
+                f"declare {shape_key!r} (derived from the manifest "
+                "signature's tensor input name)."
             )
-        shape = tuple(w[shape_keys[0]])
+        unknown = sorted(
+            k for k in w if k not in allowed and not k.startswith("__")
+        )
+        if unknown:
+            raise KeyError(
+                f"workload {w.get('label', w)!r} of {op_name!r} has keys "
+                f"{unknown} that are neither harness keys "
+                f"({sorted(_WORKLOAD_HARNESS_KEYS | {shape_key})}) nor "
+                f"declared signature params ({sorted(declared_params)})."
+            )
+        shape = tuple(w[shape_key])
         label = w.get("label", "x".join(str(s) for s in shape))
-        extra = _workload_extra_params(w) if include_extra else {}
+        extra = _workload_extra_params(w, shape_key) if include_extra else {}
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)
             # Copy ``extra`` per parametrization so accidental mutation in

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -1,5 +1,7 @@
+import contextlib
 import logging
 import subprocess
+import sys
 import threading
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -19,18 +21,25 @@ from torch.autograd.profiler import DeviceType
 
 from tileops.manifest import load_workloads
 
+# Shape keys accepted for the harness's single tensor input. ``x_shape``
+# is the generic name; ``input_shape`` matches ops whose PyTorch functional
+# signature names the tensor ``input`` (e.g. ``F.dropout(input, ...)``),
+# which the manifest mirrors verbatim. A workload must declare exactly one.
+_WORKLOAD_SHAPE_KEYS: tuple[str, ...] = ("x_shape", "input_shape")
+
 # Workload dict keys reserved by the benchmark harness. Everything else on
 # a workload entry (e.g. ``dim``, ``keepdim``, ``correction``) is treated
 # as an op-call parameter.
 #
-# The current harness is explicitly scoped to **single-input ops whose
-# sole tensor input is named ``x``**. Multi-input ops (e.g. attention
-# families that declare ``q_shape`` / ``kv_shape``) are not supported:
-# :func:`workloads_to_params` will raise ``KeyError`` if ``x_shape`` is
-# absent. Extending to signature-aware tensor binding is tracked as a
-# follow-up and must also update ``docs/design/manifest.md``.
+# The current harness is explicitly scoped to **single-tensor-input ops**
+# (input named ``x`` or ``input``; see :data:`_WORKLOAD_SHAPE_KEYS`).
+# Multi-input ops (e.g. attention families that declare ``q_shape`` /
+# ``kv_shape``) are not supported: :func:`workloads_to_params` will raise
+# ``KeyError`` if no accepted shape key is present. Extending to
+# signature-aware tensor binding is tracked as a follow-up and must also
+# update ``docs/design/manifest.md``.
 _WORKLOAD_META_KEYS: frozenset[str] = frozenset(
-    {"x_shape", "dtypes", "label"}
+    {*_WORKLOAD_SHAPE_KEYS, "dtypes", "label"}
 )
 
 # ---------------------------------------------------------------------------
@@ -150,6 +159,34 @@ def _get_l2_flush_cache() -> torch.Tensor:
     return _l2_flush_cache
 
 
+def _native_output_suppressor():
+    """Return an fd-level output suppressor only when it cannot clobber a
+    redirected stream.
+
+    tilelang's ``suppress_stdout_stderr`` silences C++-level profiler chatter
+    by ``dup2``-ing ``os.devnull`` over ``sys.stdout.fileno()`` /
+    ``sys.stderr.fileno()``. Under pytest's default fd capture those filenos
+    are the capture tmpfiles, so the redirect corrupts pytest's capture
+    stream: any later read of the capture (e.g. a timeout plugin's watchdog
+    thread snapshotting output before dumping stacks) fails with ``EBADF``,
+    and the diagnostic — plus the run's collected results — is lost.
+
+    Returns the fd-level suppressor only when stdout/stderr still point at
+    the process-level descriptors 1 and 2 (standalone runs, ``pytest -s``).
+    Under capture, a no-op context is returned; the capture already hides
+    the chatter.
+    """
+    try:
+        if sys.stdout.fileno() == 1 and sys.stderr.fileno() == 2:
+            from tilelang.profiler.bench import suppress_stdout_stderr
+            return suppress_stdout_stderr()
+    except (AttributeError, OSError, ValueError):
+        # Streams without a real descriptor (io.StringIO, capsys) or with
+        # fileno() unsupported: fd-level suppression is impossible.
+        pass
+    return contextlib.nullcontext()
+
+
 # ---------------------------------------------------------------------------
 # NVIDIA SOL-ExecBench–style benchmark
 # ---------------------------------------------------------------------------
@@ -193,8 +230,6 @@ def bench_kernel(
             f"bench_kernel expects a tuple of args, got {type(args).__name__}. "
             "Check that gen_inputs() returns a tuple."
         )
-
-    from tilelang.profiler.bench import suppress_stdout_stderr
 
     cache = _get_l2_flush_cache()
     has_args = len(args) > 0
@@ -251,7 +286,7 @@ def bench_kernel(
     # keeps the measured kernels recorded before the next flush.
     trial_means: list[float] = []
     try:
-        with suppress_stdout_stderr():
+        with _native_output_suppressor():
             for _ in range(n_trials):
                 with torch.profiler.profile(
                     # CPU activity is required for Kineto to project the
@@ -424,10 +459,10 @@ def _workload_extra_params(w: dict) -> dict[str, Any]:
     ``correction``). These are forwarded to the op constructor by benchmark
     files that opt into ``include_extra=True``.
 
-    Only the reserved meta keys (``x_shape``, ``dtypes``, ``label``) and
-    dunder-style metadata keys are stripped; everything else — including
-    any other ``*_shape`` keys — is surfaced as an op param. This matches
-    the single-input ``x_shape``-only harness contract documented in
+    Only the reserved meta keys (the accepted shape keys, ``dtypes``,
+    ``label``) and dunder-style metadata keys are stripped; everything else
+    — including any other ``*_shape`` keys — is surfaced as an op param.
+    This matches the single-tensor-input harness contract documented in
     :data:`_WORKLOAD_META_KEYS`; multi-input ops with ``q_shape`` /
     ``kv_shape`` are out of scope and would need a dedicated harness.
     """
@@ -454,14 +489,16 @@ def workloads_to_params(op_name: str, include_extra: bool = False) -> list:
     workloads = load_workloads(op_name)
     params = []
     for w in workloads:
-        if "x_shape" not in w:
+        shape_keys = [k for k in _WORKLOAD_SHAPE_KEYS if k in w]
+        if len(shape_keys) != 1:
             raise KeyError(
-                f"workloads_to_params({op_name!r}) only supports single-input "
-                "ops whose tensor input is named 'x' (workload must declare "
-                "'x_shape'); multi-input ops with q_shape/kv_shape/... are "
-                "out of scope for this harness."
+                f"workloads_to_params({op_name!r}) only supports "
+                "single-tensor-input ops; the workload must declare exactly "
+                f"one of {'/'.join(_WORKLOAD_SHAPE_KEYS)} (found "
+                f"{shape_keys or 'none'}). Multi-input ops with "
+                "q_shape/kv_shape/... are out of scope for this harness."
             )
-        shape = tuple(w["x_shape"])
+        shape = tuple(w[shape_keys[0]])
         label = w.get("label", "x".join(str(s) for s in shape))
         extra = _workload_extra_params(w) if include_extra else {}
         for dtype_str in w["dtypes"]:

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -494,7 +494,7 @@ def test_softplus_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> 
     _record_unary(op, bm, inputs, lambda x: F.softplus(x, 1.0, 20.0))
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SIGMOID_OP), "x_shape"))
+@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_SIGMOID_OP)))
 def test_sigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = UnaryManifestWorkload(shape, dtype)
     inputs = test.gen_inputs()
@@ -503,7 +503,7 @@ def test_sigmoid_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> N
     _record_unary(op, bm, inputs, torch.sigmoid)
 
 
-@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_TANH_OP), "x_shape"))
+@pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_TANH_OP)))
 def test_tanh_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> None:
     test = UnaryManifestWorkload(shape, dtype)
     inputs = test.gen_inputs()

--- a/benchmarks/tests/test_roofline_workload_protocol.py
+++ b/benchmarks/tests/test_roofline_workload_protocol.py
@@ -200,7 +200,8 @@ def test_workloads_to_params_include_extra_propagates_dim():
     # Direct unit test on the helper (no manifest mutation required).
     assert _workload_extra_params(
         {"x_shape": [4, 4], "dtypes": ["float16"], "label": "t",
-         "dim": 0, "keepdim": True}
+         "dim": 0, "keepdim": True},
+        "x_shape",
     ) == {"dim": 0, "keepdim": True}
 
     # End-to-end with the manifest: include_extra=True must still yield

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -102,6 +102,8 @@ dtype_combos:
 
 **R20. `static_dims`.** For arbitrary-rank ops (no `shape` declaration), `static_dims` declares values the user commits to at Op construction time. Each entry maps an `__init__` keyword name to a single-axis shape expression `<tensor>.shape[<const_or_param>]`. See [`static_dims`](#static_dims) for full semantics, rules, and examples.
 
+**R21. Workload keys derive from the signature.** For single-tensor-input ops whose workloads carry a shape, the shape key is exactly `{input}_shape` for the `signature.inputs` name, and every other workload key is a declared `signature.params` name (plus reserved `dtypes` / `label`). See [Workload entry schema](#workload-entry-schema).
+
 ## `static_dims`
 
 `static_dims` declares what becomes statically known at the moment the user constructs the Op instance. It is **per-op**, not per-family.
@@ -478,10 +480,18 @@ consumption.
 ### Workload entry schema
 
 Each entry under `workloads:` is a mapping. Shape keys take the form
-`<tensor_name>_shape` (e.g. `x_shape`, `q_shape`, `kv_shape`) — one per
-tensor input in the workload. `dtypes` and `label` are also reserved.
-Any other key becomes an **op-call parameter** forwarded to the op's
-`__init__`.
+`<tensor_name>_shape`, where `<tensor_name>` MUST be a `signature.inputs`
+key — the workload shape key is derived from the signature, never chosen
+independently. `dtypes` and `label` are also reserved. Any other key
+becomes an **op-call parameter** forwarded to the op's `__init__` and MUST
+be a declared `signature.params` name.
+
+For single-tensor-input ops this contract is enforced by the validator and
+by the generic benchmark harness (`workloads_to_params`): the workload
+declares exactly `{input}_shape`, and unknown keys are rejected. Multi-input
+families whose workloads use aggregate conventions (e.g. attention's
+`kv_shape` covering `k` and `v`) are consumed by family-specific bench
+harnesses and are outside the generic contract.
 
 | Key                   | Required | Meaning                                                                                                  |
 | --------------------- | -------- | -------------------------------------------------------------------------------------------------------- |

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -207,6 +207,56 @@ def _check_shape_rule_callables(
     return errors
 
 
+def _check_single_input_workload_keys(
+    op_name: str, sig: dict, workloads: list,
+) -> list[str]:
+    """Enforce the generic-harness workload-key contract (R21).
+
+    Scope: ops whose ``signature.inputs`` declares exactly one tensor input
+    AND whose workloads carry any ``*_shape`` key (i.e. ops shaped for the
+    generic single-tensor benchmark harness). For those, every workload
+    must key its shape as ``{input}_shape``, and every other key must be a
+    declared ``signature.params`` name, ``dtypes``, ``label``, or
+    dunder-prefixed metadata. Multi-input family conventions
+    (``q_shape``/``kv_shape``) and workloads that carry no shape key
+    (dimension-parameterized families) are out of scope.
+    """
+    inputs = sig.get("inputs")
+    if not isinstance(inputs, dict) or len(inputs) != 1:
+        return []
+    if not any(
+        isinstance(w, dict) and any(k.endswith("_shape") for k in w)
+        for w in workloads
+    ):
+        return []
+    shape_key = f"{next(iter(inputs))}_shape"
+    params = sig.get("params")
+    allowed = (
+        {shape_key, "dtypes", "label"}
+        | (set(params) if isinstance(params, dict) else set())
+    )
+    errors: list[str] = []
+    for i, w in enumerate(workloads):
+        if not isinstance(w, dict):
+            continue
+        if shape_key not in w:
+            errors.append(
+                f"[schema] {op_name}: workloads[{i}] missing {shape_key!r} "
+                "(shape key is derived from the signature's tensor input "
+                "name)"
+            )
+        unknown = sorted(
+            k for k in w if k not in allowed and not k.startswith("__")
+        )
+        if unknown:
+            errors.append(
+                f"[schema] {op_name}: workloads[{i}] has unknown keys "
+                f"{unknown}; allowed are {shape_key!r}, 'dtypes', 'label', "
+                "and declared signature params"
+            )
+    return errors
+
+
 def check_l0(
     op_name: str, entry: dict, *, warnings: list[str] | None = None,
 ) -> list[str]:
@@ -376,6 +426,12 @@ def check_l0(
                 errors.append(
                     f"[schema] {op_name}: workloads[{i}] missing 'dtypes'"
                 )
+        if isinstance(entry.get("signature"), dict):
+            errors.extend(
+                _check_single_input_workload_keys(
+                    op_name, entry["signature"], workloads
+                )
+            )
     elif "workloads" in entry:
         errors.append(f"[schema] {op_name}: workloads must be a list")
 

--- a/tests/test_bench_native_suppression.py
+++ b/tests/test_bench_native_suppression.py
@@ -1,0 +1,65 @@
+"""Contract tests for :func:`benchmarks.benchmark_base._native_output_suppressor`.
+
+``bench_kernel`` silences C++-level profiler chatter with an fd-level
+redirect (tilelang's ``suppress_stdout_stderr``). That redirect targets
+``sys.stdout.fileno()`` / ``sys.stderr.fileno()``; when a test harness has
+already replaced those streams (pytest fd capture), redirecting the
+underlying descriptors corrupts the harness's capture stream. The helper
+must therefore return the fd-level suppressor only when stdout/stderr still
+point at the process-level descriptors 1 and 2, and a no-op context
+otherwise.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+
+import pytest
+
+from benchmarks.benchmark_base import _native_output_suppressor
+
+pytestmark = pytest.mark.smoke
+
+
+class _FakeStream:
+    """Stream stub reporting a fixed underlying file descriptor."""
+
+    def __init__(self, fd: int):
+        self._fd = fd
+
+    def fileno(self) -> int:
+        return self._fd
+
+
+def test_suppresses_when_streams_are_process_fds(monkeypatch):
+    """Standalone runs (stdout->fd 1, stderr->fd 2) get the fd-level
+    suppressor. The context is not entered: doing so would redirect the
+    real process fds."""
+    monkeypatch.setattr(sys, "stdout", _FakeStream(1))
+    monkeypatch.setattr(sys, "stderr", _FakeStream(2))
+
+    ctx = _native_output_suppressor()
+    assert not isinstance(ctx, contextlib.nullcontext)
+
+
+def test_noop_when_streams_are_redirected(monkeypatch):
+    """Captured runs (fileno is a capture tmpfile, not fd 1/2) must get a
+    no-op context so the capture descriptors are never clobbered."""
+    monkeypatch.setattr(sys, "stdout", _FakeStream(7))
+    monkeypatch.setattr(sys, "stderr", _FakeStream(8))
+
+    ctx = _native_output_suppressor()
+    assert isinstance(ctx, contextlib.nullcontext)
+
+
+def test_noop_when_streams_have_no_fileno(monkeypatch):
+    """Streams without a real descriptor (e.g. ``io.StringIO`` under
+    ``capsys``) raise from ``fileno()``; the helper must degrade to a
+    no-op context instead of propagating."""
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+
+    ctx = _native_output_suppressor()
+    assert isinstance(ctx, contextlib.nullcontext)

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -586,6 +586,61 @@ class TestSchema:
         )
 
 
+class TestSingleInputWorkloadKeys:
+    """Workload shape keys derive from signature.inputs; unknown keys fail."""
+
+    @staticmethod
+    def _sig(input_name="input", params=("dim",)):
+        return {
+            "inputs": {input_name: {"dtype": "float16"}},
+            "outputs": {"output": {"dtype": f"same_as({input_name})"}},
+            "params": {p: {"type": "int"} for p in params},
+        }
+
+    def test_matching_shape_key_passes(self, validator):
+        errors = validator._check_single_input_workload_keys(
+            "op", self._sig(), [
+                {"input_shape": [8, 16], "dtypes": ["float16"],
+                 "label": "w", "dim": 0},
+            ],
+        )
+        assert errors == []
+
+    def test_wrong_shape_key_fails(self, validator):
+        errors = validator._check_single_input_workload_keys(
+            "op", self._sig(), [
+                {"x_shape": [8, 16], "dtypes": ["float16"]},
+            ],
+        )
+        assert any("input_shape" in e for e in errors), errors
+
+    def test_unknown_param_key_fails(self, validator):
+        errors = validator._check_single_input_workload_keys(
+            "op", self._sig(), [
+                {"input_shape": [8], "dtypes": ["float16"], "dmi": 0},
+            ],
+        )
+        assert any("dmi" in e and "unknown" in e for e in errors), errors
+
+    def test_multi_input_signature_out_of_scope(self, validator):
+        sig = {
+            "inputs": {"q": {"dtype": "float16"}, "k": {"dtype": "float16"}},
+            "params": {},
+        }
+        errors = validator._check_single_input_workload_keys(
+            "op", sig, [{"q_shape": [8], "kv_shape": [8], "dtypes": ["float16"]}],
+        )
+        assert errors == []
+
+    def test_shapeless_workloads_out_of_scope(self, validator):
+        errors = validator._check_single_input_workload_keys(
+            "op", self._sig(params=("num_tokens",)), [
+                {"num_tokens": 4096, "dtypes": ["float16"]},
+            ],
+        )
+        assert errors == []
+
+
 # ---------------------------------------------------------------------------
 # variant_of: cross-entry consistency (R16)
 # ---------------------------------------------------------------------------

--- a/tests/test_workloads_to_params.py
+++ b/tests/test_workloads_to_params.py
@@ -1,9 +1,11 @@
 """Contract tests for :func:`benchmarks.benchmark_base.workloads_to_params`.
 
-The helper is scoped to single-tensor-input ops whose input is named
-``x`` or (matching the PyTorch functional signature) ``input``. Multi-input
-ops (e.g. attention families declaring ``q_shape`` / ``kv_shape``) are out
-of scope and must surface a clear ``KeyError``.
+The helper serves single-tensor-input ops. The tensor input's name comes
+from the manifest ``signature.inputs`` (never a hardcoded list); the
+workload entry must declare ``{input}_shape`` and every other key must be a
+declared signature param. Multi-input ops (e.g. attention families
+declaring ``q_shape`` / ``kv_shape``) are out of scope and must surface a
+clear ``KeyError``.
 """
 
 from __future__ import annotations
@@ -13,6 +15,20 @@ import pytest
 from benchmarks.benchmark_base import _workload_extra_params, workloads_to_params
 
 pytestmark = pytest.mark.smoke
+
+
+def _patch_manifest(monkeypatch, op_name, input_name, params=(), workloads=()):
+    """Stub the manifest lookup and workload list for a synthetic op."""
+    import benchmarks.benchmark_base as bb
+
+    entry = {
+        "signature": {
+            "inputs": {input_name: {"dtype": "float16"}},
+            "params": {p: {"type": "int"} for p in params},
+        }
+    }
+    monkeypatch.setattr(bb, "load_manifest", lambda: {op_name: entry})
+    monkeypatch.setattr(bb, "load_workloads", lambda op: list(workloads))
 
 
 def test_single_input_ops_are_supported():
@@ -30,16 +46,15 @@ def test_single_input_with_extra_params():
         assert isinstance(extra, dict)
 
 
-def test_input_named_tensor_ops_are_supported(monkeypatch):
+def test_shape_key_is_derived_from_signature_input_name(monkeypatch):
     """Ops whose PyTorch signature names the tensor ``input`` (e.g.
-    ``F.dropout(input, ...)``) declare ``input_shape`` in the manifest and
-    must be accepted by the single-tensor-input harness."""
-    synthetic = [
-        {"input_shape": [1024, 4096], "p": 0.5, "dtypes": ["float16"], "label": "drp"},
-    ]
-    import benchmarks.benchmark_base as bb
-
-    monkeypatch.setattr(bb, "load_workloads", lambda op: synthetic)
+    ``F.dropout(input, ...)``) declare ``input_shape`` in the manifest; the
+    key is derived from ``signature.inputs``, not from an allowlist."""
+    _patch_manifest(
+        monkeypatch, "FakeInputOp", "input", params=("p",),
+        workloads=[{"input_shape": [1024, 4096], "p": 0.5,
+                    "dtypes": ["float16"], "label": "drp"}],
+    )
 
     params = workloads_to_params("FakeInputOp", include_extra=True)
     assert len(params) == 1
@@ -48,25 +63,36 @@ def test_input_named_tensor_ops_are_supported(monkeypatch):
     assert extra == {"p": 0.5}, "input_shape must be stripped from extras"
 
 
-def test_ambiguous_shape_keys_raise_keyerror(monkeypatch):
-    """A workload declaring both ``x_shape`` and ``input_shape`` is
-    ambiguous and must be rejected."""
-    synthetic = [
-        {"x_shape": [8], "input_shape": [8], "dtypes": ["float16"], "label": "amb"},
-    ]
-    import benchmarks.benchmark_base as bb
+def test_wrong_shape_key_raises_keyerror(monkeypatch):
+    """A workload keyed ``x_shape`` while the signature input is ``input``
+    is a manifest bug and must be rejected, not silently accepted."""
+    _patch_manifest(
+        monkeypatch, "FakeInputOp", "input",
+        workloads=[{"x_shape": [8], "dtypes": ["float16"], "label": "bad"}],
+    )
 
-    monkeypatch.setattr(bb, "load_workloads", lambda op: synthetic)
+    with pytest.raises(KeyError, match="input_shape"):
+        workloads_to_params("FakeInputOp")
 
-    with pytest.raises(KeyError, match="exactly one"):
-        workloads_to_params("FakeAmbiguousOp")
+
+def test_unknown_workload_key_raises_keyerror(monkeypatch):
+    """A workload key that is neither the shape key, a harness key, nor a
+    declared signature param (e.g. a typo) must fail at collection."""
+    _patch_manifest(
+        monkeypatch, "FakeOp", "x", params=("dim",),
+        workloads=[{"x_shape": [8], "dtypes": ["float16"],
+                    "label": "typo", "dmi": 0}],
+    )
+
+    with pytest.raises(KeyError, match="dmi"):
+        workloads_to_params("FakeOp")
 
 
 def test_multi_input_op_raises_keyerror():
-    """GroupedQueryAttentionFwdOp declares q_shape/kv_shape, not x_shape.
+    """GroupedQueryAttentionFwdOp declares three tensor inputs (q, k, v).
     The harness must surface a clear KeyError instead of silently binding
     the wrong tensor name."""
-    with pytest.raises(KeyError, match="x_shape"):
+    with pytest.raises(KeyError, match="exactly one tensor input"):
         workloads_to_params("GroupedQueryAttentionFwdOp")
 
 
@@ -78,19 +104,20 @@ def test_extra_params_strips_reserved_keys_only():
         "dim": 0,
         "keepdim": True,
     }
-    extra = _workload_extra_params(w)
+    extra = _workload_extra_params(w, "x_shape")
     assert extra == {"dim": 0, "keepdim": True}
 
 
-def test_extra_params_preserves_non_x_shape_keys():
-    """Any non-reserved key (even ``q_shape``) is surfaced as an op param;
-    the harness does not special-case other ``*_shape`` keys."""
+def test_extra_params_strips_only_the_signature_shape_key():
+    """Only the shape key derived from the signature is reserved; another
+    ``*_shape`` key is surfaced as an op param (and would be rejected by
+    ``workloads_to_params`` unless it is a declared signature param)."""
     w = {
         "x_shape": [2, 4],
         "dtypes": ["bfloat16"],
         "q_shape": [1, 2],
     }
-    extra = _workload_extra_params(w)
+    extra = _workload_extra_params(w, "x_shape")
     assert extra == {"q_shape": [1, 2]}
 
 
@@ -98,23 +125,23 @@ def test_keepdim_workload_is_surfaced_as_op_param(monkeypatch):
     """``keepdim`` on a workload entry must flow through as an op param so
     the benchmark baseline can see it.
 
-    Uses a synthetic workload list (patched in place of ``load_workloads``)
-    so the assertion describes the helper's contract, not the contents or
-    ordering of the ops manifest (`tileops/manifest/`).
+    Uses a synthetic manifest + workload list so the assertion describes
+    the helper's contract, not the contents or ordering of the ops
+    manifest (`tileops/manifest/`).
     """
-    synthetic = [
-        {"x_shape": [8, 16], "dtypes": ["bfloat16"], "label": "no-extras"},
-        {
-            "x_shape": [8, 16],
-            "dtypes": ["bfloat16"],
-            "label": "with-keepdim",
-            "dim": 0,
-            "keepdim": True,
-        },
-    ]
-    import benchmarks.benchmark_base as bb
-
-    monkeypatch.setattr(bb, "load_workloads", lambda op: synthetic)
+    _patch_manifest(
+        monkeypatch, "FakeOp", "x", params=("dim", "keepdim"),
+        workloads=[
+            {"x_shape": [8, 16], "dtypes": ["bfloat16"], "label": "no-extras"},
+            {
+                "x_shape": [8, 16],
+                "dtypes": ["bfloat16"],
+                "label": "with-keepdim",
+                "dim": 0,
+                "keepdim": True,
+            },
+        ],
+    )
 
     params = workloads_to_params("FakeOp", include_extra=True)
     extras_by_label = {p.id: p.values[2] for p in params}

--- a/tests/test_workloads_to_params.py
+++ b/tests/test_workloads_to_params.py
@@ -1,8 +1,9 @@
 """Contract tests for :func:`benchmarks.benchmark_base.workloads_to_params`.
 
-The helper is scoped to single-input ops whose tensor input is named
-``x``. Multi-input ops (e.g. attention families declaring ``q_shape`` /
-``kv_shape``) are out of scope and must surface a clear ``KeyError``.
+The helper is scoped to single-tensor-input ops whose input is named
+``x`` or (matching the PyTorch functional signature) ``input``. Multi-input
+ops (e.g. attention families declaring ``q_shape`` / ``kv_shape``) are out
+of scope and must surface a clear ``KeyError``.
 """
 
 from __future__ import annotations
@@ -27,6 +28,38 @@ def test_single_input_with_extra_params():
         assert len(p.values) == 3
         _, _, extra = p.values
         assert isinstance(extra, dict)
+
+
+def test_input_named_tensor_ops_are_supported(monkeypatch):
+    """Ops whose PyTorch signature names the tensor ``input`` (e.g.
+    ``F.dropout(input, ...)``) declare ``input_shape`` in the manifest and
+    must be accepted by the single-tensor-input harness."""
+    synthetic = [
+        {"input_shape": [1024, 4096], "p": 0.5, "dtypes": ["float16"], "label": "drp"},
+    ]
+    import benchmarks.benchmark_base as bb
+
+    monkeypatch.setattr(bb, "load_workloads", lambda op: synthetic)
+
+    params = workloads_to_params("FakeInputOp", include_extra=True)
+    assert len(params) == 1
+    shape, dtype, extra = params[0].values
+    assert shape == (1024, 4096)
+    assert extra == {"p": 0.5}, "input_shape must be stripped from extras"
+
+
+def test_ambiguous_shape_keys_raise_keyerror(monkeypatch):
+    """A workload declaring both ``x_shape`` and ``input_shape`` is
+    ambiguous and must be rejected."""
+    synthetic = [
+        {"x_shape": [8], "input_shape": [8], "dtypes": ["float16"], "label": "amb"},
+    ]
+    import benchmarks.benchmark_base as bb
+
+    monkeypatch.setattr(bb, "load_workloads", lambda op: synthetic)
+
+    with pytest.raises(KeyError, match="exactly one"):
+        workloads_to_params("FakeAmbiguousOp")
 
 
 def test_multi_input_op_raises_keyerror():

--- a/tileops/manifest/elementwise_unary_math.yaml
+++ b/tileops/manifest/elementwise_unary_math.yaml
@@ -23,8 +23,8 @@ ExpFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -55,8 +55,8 @@ LogFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -87,8 +87,8 @@ SqrtFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -119,8 +119,8 @@ RsqrtFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -151,8 +151,8 @@ AbsFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -183,8 +183,8 @@ NegFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -217,8 +217,8 @@ ReciprocalFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -249,8 +249,8 @@ SignFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -282,8 +282,8 @@ SinFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -314,8 +314,8 @@ CosFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -346,8 +346,8 @@ FloorFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -378,8 +378,8 @@ CeilFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -412,8 +412,8 @@ RoundFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -444,8 +444,8 @@ TruncFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -476,8 +476,8 @@ ErfFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -508,8 +508,8 @@ Log1pFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -541,8 +541,8 @@ Expm1FwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -574,8 +574,8 @@ SigmoidFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -608,8 +608,8 @@ TanhFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -642,8 +642,8 @@ LogicalNotFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [bool, float16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [bool], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [bool, float16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [bool], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -675,8 +675,8 @@ BitwiseNotFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [int32, int64], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [int32], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [int32, int64], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [int32], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -707,8 +707,8 @@ IsnanFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -740,8 +740,8 @@ IsinfFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:
@@ -773,8 +773,8 @@ IsfiniteFwdOp:
     - "output.shape == input.shape"
 
   workloads:
-  - {x_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
-  - {x_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
+  - {input_shape: [4096, 4096], dtypes: [float16, bfloat16, float32], label: "elementwise-16M"}
+  - {input_shape: [16384, 16384], dtypes: [float16, bfloat16], label: "elementwise-256M"}
 
   roofline:
     vars:

--- a/tileops/manifest/regularization.yaml
+++ b/tileops/manifest/regularization.yaml
@@ -7,15 +7,15 @@ DropoutOp:
 
   signature:
     inputs:
-      x: {dtype: "float16 | bfloat16 | float32"}
+      input: {dtype: "float16 | bfloat16 | float32"}
     outputs:
-      output: {dtype: "same_as(x)"}
+      output: {dtype: "same_as(input)"}
     params:
       p: {type: float, default: 0.5}
       seed: {type: int, default: 0}
       training: {type: bool, default: true}
     shape_rules:
-    - "x.numel() > 0"
+    - "input.numel() > 0"
     - "0.0 <= p <= 1.0"
 
   workloads:

--- a/tileops/manifest/sequence_modeling.yaml
+++ b/tileops/manifest/sequence_modeling.yaml
@@ -174,12 +174,12 @@ FFTC2COp:
 
   signature:
     inputs:
-      x: {dtype: "complex64 | complex128", shape: "[..., n]"}
+      input: {dtype: "complex64 | complex128", shape: "[..., n]"}
     outputs:
-      output: {dtype: "same_as(x)", shape: "same_as(x)"}
+      output: {dtype: "same_as(input)", shape: "same_as(input)"}
     shape_rules:
-    - "x.shape[-1] > 0"
-    - "x.shape[-1] & (x.shape[-1] - 1) == 0"
+    - "input.shape[-1] > 0"
+    - "input.shape[-1] & (input.shape[-1] - 1) == 0"
 
   workloads:
   - {input_shape: [4096], dtypes: [complex64], label: "fft-4k-c64-unbatched"}

--- a/tileops/ops/dropout.py
+++ b/tileops/ops/dropout.py
@@ -112,15 +112,17 @@ class DropoutOp(Op):
         y_flat = self.kernel(x_flat)
         return y_flat.reshape(orig_shape)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if not x.is_cuda:
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        if not input.is_cuda:
             raise ValueError("Input must be a CUDA tensor")
-        if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-            raise ValueError(f"x.dtype must be float16, bfloat16, or float32, got {x.dtype}")
+        if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+            raise ValueError(
+                f"input.dtype must be float16, bfloat16, or float32, got {input.dtype}"
+            )
         wrapped = type(self)._wrapped
         if wrapped is not None:
-            return wrapped(x, self._instance_key)
-        return self._eager_forward(x)
+            return wrapped(input, self._instance_key)
+        return self._eager_forward(input)
 
     _wrapped = None
 

--- a/tileops/ops/fft.py
+++ b/tileops/ops/fft.py
@@ -95,22 +95,22 @@ class FFTC2COp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"fft_c2c_kernel": FFTC2CKernel}
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Compute 1D FFT of complex input.
+    def forward(self, input: torch.Tensor) -> torch.Tensor:  # noqa: A002
+        """Compute 1D FFT of complex input.
 
         Args:
-            x: Input tensor of shape (..., n) with complex dtype
+            input: Input tensor of shape (..., n) with complex dtype
 
         Returns:
             Output tensor of same shape as input with FFT applied along last dimension
         """
+        x = input
         if not x.is_cuda:
-            raise ValueError("x must be a CUDA tensor")
+            raise ValueError("input must be a CUDA tensor")
         if x.dtype not in (torch.complex64, torch.complex128):
-            raise ValueError(f"x.dtype must be complex64 or complex128, got {x.dtype}")
+            raise ValueError(f"input.dtype must be complex64 or complex128, got {x.dtype}")
         if x.ndim == 0:
-            raise ValueError("x must be at least 1D")
+            raise ValueError("input must be at least 1D")
         n = x.shape[-1]
         if n <= 0 or n & (n - 1) != 0:
             raise ValueError(f"FFT size must be a positive power of 2, got {n}")


### PR DESCRIPTION
Closes #1746. Stacked on #1745 (first commit is that PR's; this PR's own change is the second commit — will rebase once #1745 merges).

## Summary

- Manifest: 24 `elementwise_unary_math` workloads rename `x_shape` → `input_shape` to match their declared signature input; `DropoutOp` / `FFTC2COp` rename signature input `x` → `input` (PyTorch mirror rule), with `same_as` / `shape_rules` references and `forward()` parameter names updated to match (caught by validator L1).
- `workloads_to_params` derives the shape key from `signature.inputs` and rejects workload keys that are not declared `signature.params` — the `_WORKLOAD_SHAPE_KEYS` allowlist is removed, so a misspelled workload key now fails at collection with the valid-key list instead of surfacing as an unexpected op kwarg.
- Validator: new R21 check enforces the same contract for single-tensor-input ops (multi-input family conventions like `q_shape`/`kv_shape` stay out of scope); documented in `docs/design/manifest.md` (rule list + workload entry schema).

Validator/manifest edits are human-authorized schema alignment (see #1746 Constraints).

## Test plan

- `python scripts/validate_manifest.py` passes on the aligned manifest (and was what caught the `forward()` naming drift)
- `pytest tests/test_validate_manifest.py` — 231 passed (5 new R21 tests)
- `pytest tests/test_workloads_to_params.py` — 9 passed (wrong-shape-key and unknown-key rejection covered)
- `pytest benchmarks/tests/test_roofline_workload_protocol.py` — 8 passed
- `pytest --collect-only benchmarks/ops` — 1638 collected, zero errors
- GPU (H200): `tests/ops/test_dropout.py` + `tests/ops/test_fft.py` — 37 passed; `bench_dropout.py` + `bench_fft.py` — 6 passed; `bench_unary_elementwise.py -k "exp or sigmoid or tanh"` — 10 passed

## Benchmark

Not applicable — no kernel or measurement-path change; harness parametrization and manifest schema only.

## Regression

- `grep -rn '_WORKLOAD_SHAPE_KEYS' benchmarks/` — no matches
- Existing bench files keep the `(shape, dtype[, extra])` parametrize contract unchanged