### PR TITLE
[Feat][Manifest] declare torch_compile_fullgraph on evidence-backed ops

### DIFF
--- a/.claude/domain-rules/manifest-spec.md
+++ b/.claude/domain-rules/manifest-spec.md
@@ -39,6 +39,8 @@ ______________________________________________________________________
 
 - `status` is required: `implemented` or `spec-only`.
 
+- `torch_compile_fullgraph`: literal `true` only; omit for no promise; invalid on `spec-only`. Declare only ops with a registered cold `fullgraph=True` compile test. Semantics: [manifest.md](../../docs/design/manifest.md#torch_compile_fullgraph).
+
 - No `Optional[Tensor]` in manifest. Conditional inputs split into variant entries linked by `variant_of` (single-level, no chaining). Variants share `source.kernel` and `source.op`; each carries its own `signature`, `workloads`, `roofline`.
 
 - Tensor layout defaults to contiguous row-major. Non-default needs an explicit `layout` field; `shape` dim names reflect memory order.

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -237,19 +237,28 @@ Validator enforces `cls.__name__ == manifest_key` exactly — no heuristic resol
 
 ## Entry Structure
 
-| Field       | Required | Description                                                   |
-| ----------- | -------- | ------------------------------------------------------------- |
-| `family`    | yes      | Op family. See [below](#family).                              |
-| `ref_api`   | yes      | External API reference, or `"none"` if no direct counterpart. |
-| `status`    | yes      | `spec-only` or `implemented`.                                 |
-| `signature` | yes      | Op interface. See [Signature](#signature).                    |
-| `workloads` | yes      | Benchmark shapes/dtypes.                                      |
-| `roofline`  | yes      | Performance model.                                            |
-| `source`    | yes      | Implementation paths.                                         |
+| Field                     | Required | Description                                                   |
+| ------------------------- | -------- | ------------------------------------------------------------- |
+| `family`                  | yes      | Op family. See [below](#family).                              |
+| `ref_api`                 | yes      | External API reference, or `"none"` if no direct counterpart. |
+| `status`                  | yes      | `spec-only` or `implemented`.                                 |
+| `torch_compile_fullgraph` | no       | Literal `true` only. See [below](#torch_compile_fullgraph).   |
+| `signature`               | yes      | Op interface. See [Signature](#signature).                    |
+| `workloads`               | yes      | Benchmark shapes/dtypes.                                      |
+| `roofline`                | yes      | Performance model.                                            |
+| `source`                  | yes      | Implementation paths.                                         |
 
 ### `family`
 
 Closed set: `elementwise`, `reduction`, `normalization`, `convolution`, `gemm`, `quantize`, `sampling`, `attention`, `moe`, `linear_attention`, `ssm`, `scan`.
+
+### `torch_compile_fullgraph`
+
+Optional; literal `true` only. Omit for "no promise" — `false` is invalid. Invalid on `status: spec-only`.
+
+`true` declares: for each manifest-supported configuration, the first call through `torch.compile(op, fullgraph=True)` succeeds with no prior eager call and is correct under the op's tolerance policy. Not promised: dynamic shapes, `dynamic=True`, absence of recompilation. Warm-up-dependent capture does not qualify.
+
+Every declared op MUST have a compile test registered in `tests/compile_contract.py`; CI holds declarations and registered evidence in exact set equality.
 
 ### `ref_api`
 

--- a/docs/design/trust-model.md
+++ b/docs/design/trust-model.md
@@ -20,12 +20,12 @@ Reads are not policed; the trust model controls writes and import-level coupling
 
 Source of truth for op interfaces. Human-reviewed, separate PR.
 
-- **OWNS**: op signatures, dtypes, workload shapes, roofline formulas, status, kernel_map (dispatch registration table)
+- **OWNS**: op signatures, dtypes, workload shapes, roofline formulas, status, kernel_map (dispatch registration table), user-visible capability declarations (`torch_compile_fullgraph`)
 - **MUST NOT WRITE**: kernel internals, dispatch strategy, or test logic
 
 ### Status flip carve-out
 
-An implementation PR may edit only `status`, `source.kernel_map`, `source.test`, `source.bench`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field needs a separate manifest-only PR.
+An implementation PR may edit only `status`, `source.kernel_map`, `source.test`, `source.bench`, and (only when promoting `spec-only → implemented`) `workloads` on the aligned op; every other contractual field — including `torch_compile_fullgraph` — needs a separate manifest-only PR.
 
 Full enumeration: [.claude/rules/manifest-trust-model.md](../../.claude/rules/manifest-trust-model.md) §Status flip carve-out.
 

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -8,6 +8,7 @@ MultiHeadAttentionFwdOp:
   ref_api: "torch.nn.functional.scaled_dot_product_attention"
   family: attention
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/tileops/manifest/elementwise_binary.yaml
+++ b/tileops/manifest/elementwise_binary.yaml
@@ -62,6 +62,7 @@ MaskedFillFwdOp:
   # "No Optional[Tensor]" manifest rule for variant splits.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -99,6 +100,7 @@ MaskedFillScalarFwdOp:
   # 0-dim-Tensor-value primary entry above.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: MaskedFillFwdOp
 
   signature:
@@ -138,6 +140,7 @@ AddFwdOp:
   ref_api: "torch.add"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -168,6 +171,7 @@ SubFwdOp:
   ref_api: "torch.sub"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -197,6 +201,7 @@ MulFwdOp:
   ref_api: "torch.mul"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -224,6 +229,7 @@ DivFwdOp:
   ref_api: "torch.div"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -254,6 +260,7 @@ RemainderFwdOp:
   ref_api: "torch.remainder"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -281,6 +288,7 @@ PowFwdOp:
   ref_api: "torch.pow"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -308,6 +316,7 @@ FloorDivideFwdOp:
   ref_api: "torch.floor_divide"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -338,6 +347,7 @@ LerpFwdOp:
   # slice that the existing kernel implements.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -367,6 +377,7 @@ MaximumFwdOp:
   ref_api: "torch.maximum"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -394,6 +405,7 @@ MinimumFwdOp:
   ref_api: "torch.minimum"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -425,6 +437,7 @@ EqFwdOp:
   ref_api: "torch.eq"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -452,6 +465,7 @@ NeFwdOp:
   ref_api: "torch.ne"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -479,6 +493,7 @@ GtFwdOp:
   ref_api: "torch.gt"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -506,6 +521,7 @@ LtFwdOp:
   ref_api: "torch.lt"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -533,6 +549,7 @@ GeFwdOp:
   ref_api: "torch.ge"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -560,6 +577,7 @@ LeFwdOp:
   ref_api: "torch.le"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -591,6 +609,7 @@ LogicalAndFwdOp:
   ref_api: "torch.logical_and"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -618,6 +637,7 @@ LogicalOrFwdOp:
   ref_api: "torch.logical_or"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -649,6 +669,7 @@ BitwiseAndFwdOp:
   ref_api: "torch.bitwise_and"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -676,6 +697,7 @@ BitwiseOrFwdOp:
   ref_api: "torch.bitwise_or"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -703,6 +725,7 @@ BitwiseXorFwdOp:
   ref_api: "torch.bitwise_xor"
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/tileops/manifest/elementwise_fused_gated.yaml
+++ b/tileops/manifest/elementwise_fused_gated.yaml
@@ -16,6 +16,7 @@ SiluAndMulFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       x: {dtype: "float16 | bfloat16 | float32", shape: "[M, two_N]"}
@@ -58,6 +59,7 @@ GeluAndMulFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       x: {dtype: "float16 | bfloat16 | float32", shape: "[M, two_N]"}
@@ -98,6 +100,7 @@ GeluTanhAndMulFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       x: {dtype: "float16 | bfloat16 | float32", shape: "[M, two_N]"}

--- a/tileops/manifest/elementwise_multi_input.yaml
+++ b/tileops/manifest/elementwise_multi_input.yaml
@@ -10,6 +10,7 @@ WhereFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       condition: {dtype: "bool"}
@@ -51,6 +52,7 @@ LerpTensorFwdOp:
   # dispatch.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: LerpFwdOp
 
   signature:

--- a/tileops/manifest/elementwise_unary_activation.yaml
+++ b/tileops/manifest/elementwise_unary_activation.yaml
@@ -12,6 +12,7 @@ ReluFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -49,6 +50,7 @@ GeluFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -85,6 +87,7 @@ SiluFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -120,6 +123,7 @@ HardswishFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -155,6 +159,7 @@ HardsigmoidFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -190,6 +195,7 @@ MishFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -225,6 +231,7 @@ SeluFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -414,6 +421,7 @@ ClampFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -451,6 +459,7 @@ ClampScalarFwdOp:
   # rule, this is split from the Tensor-bound primary entry above.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: ClampFwdOp
 
   signature:
@@ -492,6 +501,7 @@ ClampMinFwdOp:
   # equivalent to torch.clamp with only the lower bound provided.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: ClampFwdOp
 
   signature:
@@ -527,6 +537,7 @@ ClampMaxFwdOp:
   # equivalent to torch.clamp with only the upper bound provided.
   family: elementwise
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: ClampFwdOp
 
   signature:

--- a/tileops/manifest/elementwise_unary_math.yaml
+++ b/tileops/manifest/elementwise_unary_math.yaml
@@ -14,6 +14,7 @@ ExpFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -46,6 +47,7 @@ LogFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -78,6 +80,7 @@ SqrtFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -110,6 +113,7 @@ RsqrtFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -142,6 +146,7 @@ AbsFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32 | int8 | int16 | int32 | int64 | uint8"}
@@ -174,6 +179,7 @@ NegFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32 | int8 | int16 | int32 | int64 | uint8"}
@@ -206,6 +212,7 @@ ReciprocalFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32 | int8 | int16 | int32 | int64 | uint8"}
@@ -240,6 +247,7 @@ SignFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32 | int8 | int16 | int32 | int64 | uint8"}
@@ -273,6 +281,7 @@ SinFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -305,6 +314,7 @@ CosFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -337,6 +347,7 @@ FloorFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -369,6 +380,7 @@ CeilFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -401,6 +413,7 @@ RoundFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -435,6 +448,7 @@ TruncFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -467,6 +481,7 @@ ErfFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -499,6 +514,7 @@ Log1pFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -532,6 +548,7 @@ Expm1FwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -565,6 +582,7 @@ SigmoidFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -599,6 +617,7 @@ TanhFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "float16 | bfloat16 | float32"}
@@ -633,6 +652,7 @@ LogicalNotFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -666,6 +686,7 @@ BitwiseNotFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64"}
@@ -698,6 +719,7 @@ IsnanFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -731,6 +753,7 @@ IsinfFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}
@@ -764,6 +787,7 @@ IsfiniteFwdOp:
   family: elementwise
   status: implemented
 
+  torch_compile_fullgraph: true
   signature:
     inputs:
       input: {dtype: "bool | uint8 | int8 | int16 | int32 | int64 | float16 | bfloat16 | float32"}


### PR DESCRIPTION
Part of #1748 (step 2 of 3).

## Summary

- Declare `torch_compile_fullgraph: true` on the 64 ops backed by registered cold fullgraph tests.
- Document the field semantics and Manifest-stage ownership.
- Leave the equality gate and CI enforcement to step 3; ops without qualifying evidence remain undeclared.

## Test plan

- [x] Declared set equals registry: 64 == 64
- [x] Validator and 193 validator tests passed
- [x] Pre-commit passed

## Test node delta

No test files changed.
