### PR TITLE
[Feat][POOL] cold-call torch.compile support for max_pool ops

### DIFF
--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -17,6 +17,7 @@ import importlib
 # gains contract-backing compile tests.
 _EVIDENCE_MODULES = (
     "tests.ops.test_elementwise_compile",
+    "tests.ops.test_pool",
     "tests.test_compile",
 )
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+from tests.compile_contract import register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
@@ -1384,15 +1385,20 @@ def test_max_pool1d_dynamic_shape_kernel_cache_and_roofline(
     assert len(op._kernel_cache) == 2
 
 
+_MAX_POOL1D_COMPILE_CASES = [
+    pytest.param(MaxPool1dFwdOp, False, id="max-pool1d"),
+    pytest.param(MaxPool1dIndicesFwdOp, True, id="max-pool1d-indices"),
+]
+for _case in _MAX_POOL1D_COMPILE_CASES:
+    register_compile_contract(_case.values[0])
+
+
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.usefixtures("isolated_dynamo")
 @pytest.mark.parametrize(
     ("op_cls", "return_indices"),
-    [
-        pytest.param(MaxPool1dFwdOp, False, id="max-pool1d"),
-        pytest.param(MaxPool1dIndicesFwdOp, True, id="max-pool1d-indices"),
-    ],
+    _MAX_POOL1D_COMPILE_CASES,
 )
 def test_max_pool1d_compile_fullgraph(
     op_cls: type,
@@ -1400,8 +1406,6 @@ def test_max_pool1d_compile_fullgraph(
 ) -> None:
     op = op_cls(kernel_size=3, stride=2, padding=1)
     x = torch.randn(2, 8, 32, device="cuda", dtype=torch.float16)
-    # Warm up the kernel cache so torch.compile traces only the custom-op call.
-    op(x)
     compiled = torch.compile(op, fullgraph=True)
     out = compiled(x)
     ref = F.max_pool1d(
@@ -1961,15 +1965,20 @@ def test_max_pool3d_dynamic_shape_kernel_cache_and_roofline(
     assert len(op._kernel_cache) == 2
 
 
+_MAX_POOL3D_COMPILE_CASES = [
+    pytest.param(MaxPool3dFwdOp, False, id="max-pool3d"),
+    pytest.param(MaxPool3dIndicesFwdOp, True, id="max-pool3d-indices"),
+]
+for _case in _MAX_POOL3D_COMPILE_CASES:
+    register_compile_contract(_case.values[0])
+
+
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.usefixtures("isolated_dynamo")
 @pytest.mark.parametrize(
     ("op_cls", "return_indices"),
-    [
-        pytest.param(MaxPool3dFwdOp, False, id="max-pool3d"),
-        pytest.param(MaxPool3dIndicesFwdOp, True, id="max-pool3d-indices"),
-    ],
+    _MAX_POOL3D_COMPILE_CASES,
 )
 def test_max_pool3d_compile_fullgraph(
     op_cls: type,
@@ -1977,8 +1986,6 @@ def test_max_pool3d_compile_fullgraph(
 ) -> None:
     op = op_cls(kernel_size=3, stride=2, padding=1)
     x = torch.randn(1, 4, 8, 16, 16, device="cuda", dtype=torch.float16)
-    # Warm up the kernel cache so torch.compile traces only the custom-op call.
-    op(x)
     compiled = torch.compile(op, fullgraph=True)
     out = compiled(x)
     ref = F.max_pool3d(
@@ -2559,15 +2566,20 @@ def test_max_pool2d_dynamic_shape_kernel_cache_and_roofline(
     assert len(op._kernel_cache) == 2
 
 
+_MAX_POOL2D_COMPILE_CASES = [
+    pytest.param(MaxPool2dFwdOp, False, id="max-pool2d"),
+    pytest.param(MaxPool2dIndicesFwdOp, True, id="max-pool2d-indices"),
+]
+for _case in _MAX_POOL2D_COMPILE_CASES:
+    register_compile_contract(_case.values[0])
+
+
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 @pytest.mark.usefixtures("isolated_dynamo")
 @pytest.mark.parametrize(
     ("op_cls", "return_indices"),
-    [
-        pytest.param(MaxPool2dFwdOp, False, id="max-pool2d"),
-        pytest.param(MaxPool2dIndicesFwdOp, True, id="max-pool2d-indices"),
-    ],
+    _MAX_POOL2D_COMPILE_CASES,
 )
 def test_max_pool2d_compile_fullgraph(
     op_cls: type,
@@ -2575,8 +2587,6 @@ def test_max_pool2d_compile_fullgraph(
 ) -> None:
     op = op_cls(kernel_size=(3, 3), stride=(2, 2), padding=(1, 1))
     x = torch.randn(2, 8, 16, 16, device="cuda", dtype=torch.float16)
-    # Warm up the kernel cache so torch.compile traces only the custom-op call.
-    op(x)
     compiled = torch.compile(op, fullgraph=True)
     out = compiled(x)
     ref = F.max_pool2d(

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -43,7 +43,10 @@ class Kernel(ABC):
             else:
                 self.config = self.default_config
 
-        print(f"{self.__class__.__name__} initialized with config: {self.config}")
+        # Guarded so dynamo can trace kernel construction inside a compiled
+        # forward: print() is a graph break under fullgraph=True.
+        if not torch.compiler.is_compiling():
+            print(f"{self.__class__.__name__} initialized with config: {self.config}")
 
     @property
     def dtype_str(self) -> str:

--- a/tileops/kernels/pool/max_pool1d.py
+++ b/tileops/kernels/pool/max_pool1d.py
@@ -150,6 +150,9 @@ class MaxPool1dKernel(Kernel):
         self.ceil_mode = ceil_mode
         self.dtype = dtype
         self.out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool1d_kernel(
             n,
             c_in,
@@ -160,7 +163,7 @@ class MaxPool1dKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property
@@ -358,6 +361,9 @@ class MaxPool1dWithIndicesKernel(Kernel):
         self.ceil_mode = ceil_mode
         self.dtype = dtype
         self.out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool1d_with_indices_kernel(
             n,
             c_in,
@@ -368,7 +374,7 @@ class MaxPool1dWithIndicesKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property

--- a/tileops/kernels/pool/max_pool2d.py
+++ b/tileops/kernels/pool/max_pool2d.py
@@ -186,6 +186,9 @@ class MaxPool2dKernel(Kernel):
         self.dtype = dtype
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool2d_kernel(
             n,
             c_in,
@@ -201,7 +204,7 @@ class MaxPool2dKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property
@@ -441,6 +444,9 @@ class MaxPool2dWithIndicesKernel(Kernel):
         self.dtype = dtype
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool2d_with_indices_kernel(
             n,
             c_in,
@@ -456,7 +462,7 @@ class MaxPool2dWithIndicesKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property

--- a/tileops/kernels/pool/max_pool3d.py
+++ b/tileops/kernels/pool/max_pool3d.py
@@ -231,6 +231,9 @@ class MaxPool3dKernel(Kernel):
         self.out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool3d_kernel(
             n,
             c_in,
@@ -251,7 +254,7 @@ class MaxPool3dKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property
@@ -540,6 +543,9 @@ class MaxPool3dWithIndicesKernel(Kernel):
         self.out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
+        # Built only for autotuning: eager launch goes through the
+        # custom op (which rebuilds via the lru_cached builder), and a
+        # traced forward must not touch the tilelang JIT machinery.
         self.kernel = _max_pool3d_with_indices_kernel(
             n,
             c_in,
@@ -560,7 +566,7 @@ class MaxPool3dWithIndicesKernel(Kernel):
             dilation_w,
             ceil_mode,
             self.dtype_str,
-        )
+        ) if tune else None
         self.init_config(config, tune)
 
     @property

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -191,6 +191,7 @@ MaxPool1dFwdOp:
   # Equivalent to torch.nn.functional.max_pool1d (return_indices=False)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -249,6 +250,7 @@ MaxPool1dIndicesFwdOp:
   # Equivalent to torch.nn.functional.max_pool1d (return_indices=True)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: MaxPool1dFwdOp
 
   signature:
@@ -307,6 +309,7 @@ MaxPool2dFwdOp:
   # Equivalent to torch.nn.functional.max_pool2d (return_indices=False)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -376,6 +379,7 @@ MaxPool2dIndicesFwdOp:
   # Equivalent to torch.nn.functional.max_pool2d (return_indices=True)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: MaxPool2dFwdOp
 
   signature:
@@ -446,6 +450,7 @@ MaxPool3dFwdOp:
   # Equivalent to torch.nn.functional.max_pool3d (return_indices=False)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -527,6 +532,7 @@ MaxPool3dIndicesFwdOp:
   # Equivalent to torch.nn.functional.max_pool3d (return_indices=True)
   family: pool
   status: implemented
+  torch_compile_fullgraph: true
   variant_of: MaxPool3dFwdOp
 
   signature:


### PR DESCRIPTION
## Summary

Follow-up deferred from #1748: upgrade max_pool to the cold-call contract and declare the 6 ops.

- Root cause of the old eager warm-up: `forward` constructs the Kernel object outside the custom-op boundary on cache miss, and dynamo cannot trace the eager tilelang build (`inspect`/`id()`) nor `init_config`'s `print`. The eager build only feeds autotuning — now built only when `tune=True`; the print is skipped under `torch.compiler.is_compiling()`.
- Compile tests drop the warm-up (verified cold on H200 for all six ops, exact match vs `F.max_pool*`), register their case tables as contract evidence, and `pool.yaml` declares `torch_compile_fullgraph: true` on the 6 max_pool ops.
- Declarations + evidence in one PR by design: the always-on equality gate rejects either half alone.

## Test plan

- [x] 6 cold `compile_fullgraph` cases pass on GPU
- [x] Equality gate: 70 declared == 70 registered; `validate_manifest.py` passes
- [x] `tests/ops/test_pool.py -m smoke` — 83 passed; autotune (`tune=True`) still builds the kernel
- [x] Test node delta: 0 (`tests/ops/test_pool.py` 205 → 205)