### PR TITLE
[Fix][Manifest] normalize six placeholder rooflines to the string form

### DIFF
--- a/tileops/manifest/linear_attention.yaml
+++ b/tileops/manifest/linear_attention.yaml
@@ -243,7 +243,7 @@ GatedDeltaNetFwdOp:
       - "S % chunk_size == 0"
       - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
     op: tileops/ops/gated_deltanet.py
@@ -276,7 +276,7 @@ GatedDeltaNetBwdOp:
       - "S % chunk_size == 0"
       - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/gated_deltanet/gated_deltanet_bwd.py
     op: tileops/ops/gated_deltanet.py
@@ -307,7 +307,7 @@ DeltaNetFwdOp:
       - "S % chunk_size == 0"
       - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/deltanet/deltanet_fwd.py
     op: tileops/ops/deltanet.py
@@ -342,7 +342,7 @@ DeltaNetBwdOp:
       - "S % chunk_size == 0"
       - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/deltanet/deltanet_bwd.py
     op: tileops/ops/deltanet.py
@@ -370,7 +370,7 @@ GLAFwdOp:
     shape_rules:
       - "S % chunk_size == 0"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/gla/gla_fwd.py
     op: tileops/ops/gla.py
@@ -404,7 +404,7 @@ GLABwdOp:
       - "S % chunk_size == 0"
       - "NC == S // chunk_size"
   workloads: []
-  roofline: {flops: 0, bytes: 0}
+  roofline: {flops: "0", bytes: "0"}
   source:
     kernel: tileops/kernels/gla/gla_bwd.py
     op: tileops/ops/gla.py


### PR DESCRIPTION
## Summary

Manifest-only. `GLA*/DeltaNet*/GatedDeltaNet*` fwd/bwd carry `roofline: {flops: 0, bytes: 0}`; the spec requires formula strings. `"0"` evaluates identically — consumer behavior unchanged. Real formulas: #1760. Prerequisite for the stricter roofline type checks in #1757.

## Test plan

- [x] `validate_manifest.py` passes (with #1757's checks applied locally)
- [x] Six-line diff, values semantically identical