### PR TITLE
[Refactor][OPS] narrow manifest key-format rule; move variant words before direction suffix

### DIFF
--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -8,12 +8,12 @@ from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import load_workloads
 from tileops.ops.norm.group_norm import (
     GroupNormFwdOp,
-    GroupNormFwdOpNoAffine,
+    GroupNormNoAffineFwdOp,
 )
 from workloads.group_norm import GroupNormTest
 
 _OP_NAME = "GroupNormFwdOp"
-_OP_NAME_NO_AFFINE = "GroupNormFwdOpNoAffine"
+_OP_NAME_NO_AFFINE = "GroupNormNoAffineFwdOp"
 
 
 class GroupNormBenchmark(BenchmarkBase[GroupNormTest]):
@@ -86,7 +86,7 @@ def test_group_norm_no_affine_bench(n: int, c: int, spatial: tuple,
     test = GroupNormTest(n, c, spatial, num_groups, dtype)
     x, _, _ = test.gen_inputs()
 
-    op = GroupNormFwdOpNoAffine(num_groups=num_groups, tune=tune)
+    op = GroupNormNoAffineFwdOp(num_groups=num_groups, tune=tune)
     bm = GroupNormBenchmark(test, op)
     result = bm.profile(op, x)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -8,12 +8,12 @@ from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.manifest import load_workloads
 from tileops.ops.norm.instance_norm import (
     InstanceNormFwdOp,
-    InstanceNormFwdOpNoAffine,
+    InstanceNormNoAffineFwdOp,
 )
 from workloads.instance_norm import InstanceNormTest
 
 _OP_NAME = "InstanceNormFwdOp"
-_OP_NAME_NO_AFFINE = "InstanceNormFwdOpNoAffine"
+_OP_NAME_NO_AFFINE = "InstanceNormNoAffineFwdOp"
 
 
 class InstanceNormBenchmark(BenchmarkBase[InstanceNormTest]):
@@ -78,7 +78,7 @@ def test_instance_norm_no_affine_bench(n: int, c: int, spatial: tuple,
     test = InstanceNormTest(n, c, spatial, dtype)
     x, _, _ = test.gen_inputs()
 
-    op = InstanceNormFwdOpNoAffine(tune=tune)
+    op = InstanceNormNoAffineFwdOp(tune=tune)
     bm = InstanceNormBenchmark(test, op)
     # Running stats are required positional args (R16) but ignored on the
     # use_input_stats=True path; pass placeholders.

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -221,17 +221,17 @@ The base class emits a once-per-type runtime warning when the default `_cache_ke
 
 ## Manifest Key Format
 
-Each top-level entry is keyed by the **Python class name** of the Op — PascalCase with a mandatory direction suffix and `Op` suffix:
+Each top-level entry is keyed by the **Python class name** of the Op — PascalCase with an `Op` suffix and an optional direction suffix:
 
 ```
-{PascalCaseName}{Direction}Op
+{PascalCaseName}[{Direction}]Op
 ```
 
-- **PascalCaseName** — descriptive name in PascalCase (`RMSNorm`, `BatchNorm`, `Softmax`). Author chooses; no abbreviation rules.
-- **Direction** — mandatory: `Fwd` or `Bwd`.
+- **PascalCaseName** — descriptive name in PascalCase (`RMSNorm`, `BatchNorm`, `Softmax`). Author chooses; no abbreviation rules. Variant words are part of this name and always precede `{Direction}Op` (`GroupNormNoAffineFwdOp`, never `GroupNormFwdOpNoAffine`).
+- **Direction** — `Fwd` or `Bwd`. REQUIRED when the manifest carries both directions of the same op (a direction sibling exists); single-direction ops MAY omit it.
 - **Op** — literal suffix.
 
-Examples: `RMSNormFwdOp`, `BatchNormFwdOp`, `SoftmaxFwdOp`, `LinearFwdOp`.
+Examples: `RMSNormFwdOp`, `BatchNormFwdOp`, `SoftmaxFwdOp`, `DropoutOp`.
 
 Validator enforces `cls.__name__ == manifest_key` exactly — no heuristic resolution or case conversion.
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -30,6 +30,7 @@ import sys
 import textwrap
 import types
 import warnings as _warnings
+from collections.abc import Collection
 from pathlib import Path
 
 import yaml
@@ -265,6 +266,7 @@ def _check_single_input_workload_keys(
 
 def check_l0(
     op_name: str, entry: dict, *, warnings: list[str] | None = None,
+    all_op_names: Collection[str] = (),
 ) -> list[str]:
     """Validate structural schema of a manifest entry. Returns error strings."""
     errors: list[str] = []
@@ -272,6 +274,28 @@ def check_l0(
     if not isinstance(entry, dict):
         errors.append(f"[schema] {op_name}: entry must be a mapping, got {type(entry).__name__}")
         return errors
+
+    # Key format: variant words precede the direction suffix; the direction
+    # suffix itself is required only when the manifest carries a direction
+    # sibling of the same op.
+    key_match = re.match(r"^(.*)(Fwd|Bwd)Op(.+)$", op_name)
+    if key_match:
+        stem, direction, trailing = key_match.groups()
+        errors.append(
+            f"[schema] {op_name}: variant word '{trailing}' follows "
+            f"'{direction}Op'; variant words must precede the direction "
+            f"suffix (expected '{stem}{trailing}{direction}Op')"
+        )
+    elif op_name.endswith("Op") and not op_name.endswith(("FwdOp", "BwdOp")):
+        stem = op_name[:-2]
+        siblings = [
+            s for s in (f"{stem}FwdOp", f"{stem}BwdOp") if s in all_op_names
+        ]
+        if siblings:
+            errors.append(
+                f"[schema] {op_name}: missing direction suffix; direction "
+                f"sibling '{siblings[0]}' exists in the manifest"
+            )
 
     # Top-level required fields
     missing_top = _REQUIRED_TOP - set(entry.keys())
@@ -3872,7 +3896,9 @@ def validate_manifest(
 
         # schema: YAML structure validation
         if "schema" in levels:
-            schema_errors = check_l0(op_name, entry, warnings=all_warnings)
+            schema_errors = check_l0(
+                op_name, entry, warnings=all_warnings, all_op_names=ops.keys(),
+            )
             schema_errors.extend(check_source_paths(op_name, entry, repo_root))
             all_errors.extend(schema_errors)
             if schema_errors:

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormFwdOpNoAffine
+from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormNoAffineFwdOp
 from workloads.group_norm import GroupNormTest as _GroupNormTestWorkload
 
 
@@ -231,7 +231,7 @@ class GroupNormNoAffineFixture(FixtureBase):
 def test_group_norm_no_affine_op(n: int, c: int, spatial: tuple, g: int,
                                  dtype: torch.dtype) -> None:
     """No-affine GroupNorm op matches torch.nn.functional.group_norm with weight=bias=None."""
-    op = GroupNormFwdOpNoAffine(num_groups=g)
+    op = GroupNormNoAffineFwdOp(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     y = op(x)
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None, eps=1e-5).to(dtype)
@@ -244,7 +244,7 @@ def test_group_norm_no_affine_op(n: int, c: int, spatial: tuple, g: int,
 def test_group_norm_no_affine_forward_signature() -> None:
     """No-affine forward accepts only x — no weight/bias parameters."""
     import inspect
-    sig = inspect.signature(GroupNormFwdOpNoAffine.forward)
+    sig = inspect.signature(GroupNormNoAffineFwdOp.forward)
     params = [p for p in sig.parameters if p != "self"]
     assert params == ["x"], f"expected ['x'], got {params}"
 
@@ -256,7 +256,7 @@ def test_group_norm_no_affine_lazily_specializes_per_device() -> None:
         pytest.skip("multi-device test requires >= 2 CUDA devices")
 
     n, c, spatial, g, dtype = 2, 32, (8, 8), 8, torch.float16
-    op = GroupNormFwdOpNoAffine(num_groups=g)
+    op = GroupNormNoAffineFwdOp(num_groups=g)
     x_other = torch.randn(
         (n, c, *spatial), dtype=dtype, device=torch.device("cuda", 1),
     )
@@ -277,7 +277,7 @@ def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
                                          g: int) -> None:
     """No-affine GroupNorm handles M not divisible by the kernel's block_m."""
     dtype = torch.float16
-    op = GroupNormFwdOpNoAffine(num_groups=g)
+    op = GroupNormNoAffineFwdOp(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     y = op(x)
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None,

--- a/tests/ops/test_instance_norm.py
+++ b/tests/ops/test_instance_norm.py
@@ -8,7 +8,7 @@ import yaml
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.norm.instance_norm import (
     InstanceNormFwdOp,
-    InstanceNormFwdOpNoAffine,
+    InstanceNormNoAffineFwdOp,
 )
 from workloads.instance_norm import InstanceNormTest as _InstanceNormTestWorkload
 
@@ -117,8 +117,8 @@ class InstanceNormNoAffineFixture(FixtureBase):
 @InstanceNormNoAffineFixture
 def test_instance_norm_no_affine_op(n: int, c: int, spatial: tuple,
                                     dtype: torch.dtype, tune: bool) -> None:
-    """Forward correctness for InstanceNormFwdOpNoAffine vs F.instance_norm(weight=None, bias=None)."""
-    op = InstanceNormFwdOpNoAffine()
+    """Forward correctness for InstanceNormNoAffineFwdOp vs F.instance_norm(weight=None, bias=None)."""
+    op = InstanceNormNoAffineFwdOp()
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     # Running stats are required positional args (R16) but ignored on the
     # use_input_stats=True path; pass placeholders.
@@ -138,7 +138,7 @@ def test_instance_norm_no_affine_running_stats(
     n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool,
 ) -> None:
     """use_input_stats=False uses running_mean/running_var; matches torch reference."""
-    op = InstanceNormFwdOpNoAffine(use_input_stats=False)
+    op = InstanceNormNoAffineFwdOp(use_input_stats=False)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     running_mean = torch.randn(c, dtype=torch.float32, device="cuda")
     running_var = torch.rand(c, dtype=torch.float32, device="cuda") + 0.1
@@ -302,9 +302,9 @@ def test_instance_norm_rejects_affine_device_mismatch() -> None:
 _OP_CLASSES = [
     pytest.param(InstanceNormFwdOp, "InstanceNormFwdOp", id="InstanceNormFwdOp"),
     pytest.param(
-        InstanceNormFwdOpNoAffine,
-        "InstanceNormFwdOpNoAffine",
-        id="InstanceNormFwdOpNoAffine",
+        InstanceNormNoAffineFwdOp,
+        "InstanceNormNoAffineFwdOp",
+        id="InstanceNormNoAffineFwdOp",
     ),
 ]
 
@@ -362,7 +362,7 @@ def test_instance_norm_affine_rejects_running_stats_path() -> None:
 def test_instance_norm_no_affine_accepts_running_stats_path() -> None:
     """No-affine variant supports `use_input_stats=False` end-to-end."""
     n, c, spatial, dtype = 2, 16, (8, 8), torch.float16
-    op = InstanceNormFwdOpNoAffine(use_input_stats=False)
+    op = InstanceNormNoAffineFwdOp(use_input_stats=False)
     assert op.use_input_stats is False
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
     running_mean = torch.randn(c, dtype=torch.float32, device="cuda")

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -144,6 +144,23 @@ class TestSchema:
                 all(s in e for s in substrings) for e in errors
             ), f"{desc}: expected error with {substrings}, got: {errors}"
 
+    def test_key_variant_word_after_direction_op_rejected(self, validator):
+        """Key format: variant words must precede the direction suffix."""
+        errors = validator.check_l0("GroupNormFwdOpNoAffine", _make_entry())
+        assert any(
+            "NoAffine" in e and "precede" in e for e in errors
+        ), errors
+
+    def test_key_missing_direction_suffix_with_sibling_rejected(self, validator):
+        """Key format: direction suffix is required when a direction sibling exists."""
+        errors = validator.check_l0(
+            "SoftmaxOp", _make_entry(),
+            all_op_names={"SoftmaxOp", "SoftmaxFwdOp"},
+        )
+        assert any(
+            "direction suffix" in e and "SoftmaxFwdOp" in e for e in errors
+        ), errors
+
     def test_valid_forms_pass(self, validator):
         """Case table: entry variations the schema explicitly permits."""
         # Tensor with valid layout field (R19).

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -448,7 +448,7 @@ GroupNormFwdOp:
     bench: benchmarks/ops/bench_group_norm.py
     bench_manifest_driven: true
 
-GroupNormFwdOpNoAffine:
+GroupNormNoAffineFwdOp:
   ref_api: "torch.nn.functional.group_norm"
   # No-affine variant: torch.nn.functional.group_norm(x, num_groups, weight=None,
   # bias=None, eps), matching torch.nn.GroupNorm(affine=False). Split from
@@ -544,7 +544,7 @@ InstanceNormFwdOp:
     bench: benchmarks/ops/bench_instance_norm.py
     bench_manifest_driven: true
 
-InstanceNormFwdOpNoAffine:
+InstanceNormNoAffineFwdOp:
   ref_api: "torch.nn.functional.instance_norm"
   # No-affine variant: torch.nn.functional.instance_norm(x, weight=None,
   # bias=None, ...), matching torch.nn.InstanceNorm*(affine=False) — the

--- a/tileops/ops/norm/__init__.py
+++ b/tileops/ops/norm/__init__.py
@@ -3,8 +3,8 @@ from .ada_layer_norm_zero import AdaLayerNormZeroFwdOp
 from .batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from .fused_add_layer_norm import FusedAddLayerNormFwdOp
 from .fused_add_rms_norm import FusedAddRMSNormFwdOp
-from .group_norm import GroupNormFwdOp, GroupNormFwdOpNoAffine
-from .instance_norm import InstanceNormFwdOp, InstanceNormFwdOpNoAffine
+from .group_norm import GroupNormFwdOp, GroupNormNoAffineFwdOp
+from .instance_norm import InstanceNormFwdOp, InstanceNormNoAffineFwdOp
 from .layer_norm import LayerNormFwdOp
 from .rms_norm import RMSNormFwdOp
 
@@ -16,9 +16,9 @@ __all__: list[str] = [
     "FusedAddLayerNormFwdOp",
     "FusedAddRMSNormFwdOp",
     "GroupNormFwdOp",
-    "GroupNormFwdOpNoAffine",
+    "GroupNormNoAffineFwdOp",
     "InstanceNormFwdOp",
-    "InstanceNormFwdOpNoAffine",
+    "InstanceNormNoAffineFwdOp",
     "LayerNormFwdOp",
     "RMSNormFwdOp",
 ]

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -24,7 +24,7 @@ from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 from ..op_base import Op
 from .norm_base import ALIGNMENT, align_up
 
-__all__ = ["GroupNormFwdOp", "GroupNormFwdOpNoAffine"]
+__all__ = ["GroupNormFwdOp", "GroupNormNoAffineFwdOp"]
 
 # Largest candidate block_m in GroupNormNoAffineKernel.autotune_configs.
 # The op pads M to a multiple of this value so the kernel's full-tile
@@ -183,9 +183,9 @@ class GroupNormFwdOp(Op):
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
             weight: Affine scale of shape ``(C,)`` on CUDA. Required; the
-                affine-free path is :class:`GroupNormFwdOpNoAffine`.
+                affine-free path is :class:`GroupNormNoAffineFwdOp`.
             bias: Affine shift of shape ``(C,)`` on CUDA. Required; the
-                affine-free path is :class:`GroupNormFwdOpNoAffine`.
+                affine-free path is :class:`GroupNormNoAffineFwdOp`.
 
         Returns:
             Normalized tensor of the same shape as *x*.
@@ -207,12 +207,12 @@ class GroupNormFwdOp(Op):
         ) = self._resolve_spec(x)
         if not isinstance(weight, torch.Tensor):
             raise ValueError(
-                "weight is required; use GroupNormFwdOpNoAffine for the "
+                "weight is required; use GroupNormNoAffineFwdOp for the "
                 "affine-free path"
             )
         if not isinstance(bias, torch.Tensor):
             raise ValueError(
-                "bias is required; use GroupNormFwdOpNoAffine for the "
+                "bias is required; use GroupNormNoAffineFwdOp for the "
                 "affine-free path"
             )
         if not weight.is_cuda:
@@ -274,7 +274,7 @@ class GroupNormFwdOp(Op):
         return y
 
 
-class GroupNormFwdOpNoAffine(Op):
+class GroupNormNoAffineFwdOp(Op):
     """Group Normalization forward without affine scale/shift.
 
     Computes group normalization without the trailing weight/bias affine:
@@ -331,7 +331,7 @@ class GroupNormFwdOpNoAffine(Op):
     def eval_roofline(self) -> tuple[int, int]:
         if self._last_roofline_spec is None:
             raise RuntimeError(
-                "GroupNormFwdOpNoAffine.eval_roofline() requires a prior forward() call"
+                "GroupNormNoAffineFwdOp.eval_roofline() requires a prior forward() call"
             )
         N, C, spatial_size, dtype = self._last_roofline_spec
         elem_bytes = dtype.itemsize

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -27,7 +27,7 @@ from tileops.kernels.norm import (
 from ..op_base import Op
 from .norm_base import ALIGNMENT, align_up
 
-__all__ = ["InstanceNormFwdOp", "InstanceNormFwdOpNoAffine"]
+__all__ = ["InstanceNormFwdOp", "InstanceNormNoAffineFwdOp"]
 
 # Largest candidate block_m in InstanceNormNoAffineKernel.autotune_configs.
 # The op pads M to a multiple of this value so the kernel's full-tile
@@ -220,9 +220,9 @@ class InstanceNormFwdOp(Op):
         Args:
             x: Input tensor of shape ``(N, C, *spatial)`` on CUDA.
             weight: Affine scale of shape ``(C,)`` on CUDA. Required; the
-                affine-free path is :class:`InstanceNormFwdOpNoAffine`.
+                affine-free path is :class:`InstanceNormNoAffineFwdOp`.
             bias: Affine shift of shape ``(C,)`` on CUDA. Required; the
-                affine-free path is :class:`InstanceNormFwdOpNoAffine`.
+                affine-free path is :class:`InstanceNormNoAffineFwdOp`.
 
         Returns:
             Normalized tensor of the same shape as *x*.
@@ -233,12 +233,12 @@ class InstanceNormFwdOp(Op):
         """
         if not isinstance(weight, torch.Tensor):
             raise ValueError(
-                "weight is required; use InstanceNormFwdOpNoAffine for the "
+                "weight is required; use InstanceNormNoAffineFwdOp for the "
                 "affine-free path"
             )
         if not isinstance(bias, torch.Tensor):
             raise ValueError(
-                "bias is required; use InstanceNormFwdOpNoAffine for the "
+                "bias is required; use InstanceNormNoAffineFwdOp for the "
                 "affine-free path"
             )
         self._validate_dtypes(x, weight, bias)
@@ -291,7 +291,7 @@ class InstanceNormFwdOp(Op):
         return y
 
 
-class InstanceNormFwdOpNoAffine(Op):
+class InstanceNormNoAffineFwdOp(Op):
     """Instance Normalization forward without affine scale/shift.
 
     Computes instance normalization without the trailing weight/bias affine:
@@ -357,7 +357,7 @@ class InstanceNormFwdOpNoAffine(Op):
     def eval_roofline(self) -> tuple[int, int]:
         if self._last_roofline_spec is None:
             raise RuntimeError(
-                "InstanceNormFwdOpNoAffine.eval_roofline() requires a prior forward() call"
+                "InstanceNormNoAffineFwdOp.eval_roofline() requires a prior forward() call"
             )
         N, C, spatial_size, dtype = self._last_roofline_spec
         elem_bytes = dtype.itemsize


### PR DESCRIPTION
Closes #1758

## Summary

- Narrow the key-format rule in `docs/design/manifest.md`: direction suffix is required only where a direction pair (or bwd sibling) exists; variant words always precede `FwdOp`/`BwdOp`.
- Rename `GroupNormFwdOpNoAffine` → `GroupNormNoAffineFwdOp` and `InstanceNormFwdOpNoAffine` → `InstanceNormNoAffineFwdOp` (class + manifest key + exports + call sites).
- Add the narrowed format check to `check_l0` with one guard per reject branch; the shipped manifest passes.

The 21 single-direction keys without a direction suffix are legitimized by the narrowed rule, not an omission. Manifest+code rename atomicity is human-driven, enforced by the `cls.__name__ == key` validator check.

## Test plan

- [x] `pytest tests/test_validate_manifest.py` — 142 passed, including one test per new reject branch
- [x] `pytest tests/ops/test_group_norm.py tests/ops/test_instance_norm.py` — 73 passed (GPU)
- [x] `python scripts/validate_manifest.py --levels schema,signature,shape,dtype,bench --strict` — shipped manifest passes

## Test node delta

```
File                               Base    HEAD    Delta
--------------------------------------------------------
tests/test_validate_manifest.py     140     142       +2
--------------------------------------------------------
```

**Justification:** one test per new `check_l0` reject branch (variant word after direction suffix; missing direction suffix with a bwd sibling). The norm test files are pure renames with no node growth (base-side collection fails against the renamed package, so the script reports them as new).
