### PR TITLE
[Feat][Manifest] add manifest entries for the mamba/SSD family

### DIFF
--- a/tests/perf/test_mamba_formulas.py
+++ b/tests/perf/test_mamba_formulas.py
@@ -1,0 +1,211 @@
+"""Unit tests for the Mamba-2 / State-Space Dual (SSD) roofline helpers.
+
+These exercise the (flops, bytes) accounting for the mamba family manifest
+entries, which use ``roofline.func``. Each helper is driven through a
+lightweight attribute stub (no CUDA build required), covering the
+flag-dependent cases (``has_dt_bias`` / ``dt_softplus`` / ``has_seq_idx`` /
+``has_initial_states``) and asserting exact FLOP and byte totals. The
+composite ``mamba2_fwd_roofline`` FLOP total is locked to the sum of the
+five standalone stage formulas.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tileops.perf import formulas
+
+pytestmark = pytest.mark.smoke
+
+# Small representative Mamba-2 geometry: S = NC * Q, G divides H.
+B, NC, Q, H, P, N, G = 2, 4, 128, 4, 16, 32, 1
+S = NC * Q
+TOKENS = B * S * H
+
+
+def _da_cumsum_op(has_dt_bias: bool, dt_softplus: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        batch=B,
+        seq_len=S,
+        n_heads=H,
+        has_dt_bias=has_dt_bias,
+        dt_softplus=dt_softplus,
+        dtype=torch.float16,
+    )
+
+
+@pytest.mark.parametrize(
+    "has_dt_bias, dt_softplus",
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+def test_da_cumsum_fwd_roofline_flag_cases(has_dt_bias: bool, dt_softplus: bool):
+    flops, nbytes = formulas.da_cumsum_fwd_roofline(
+        _da_cumsum_op(has_dt_bias, dt_softplus))
+    expected_flops = (3 + (1 if has_dt_bias else 0) +
+                      (4 if dt_softplus else 0)) * TOKENS
+    expected_nbytes = (
+        TOKENS * 4                              # dt read (fp32)
+        + H * 4                                 # A read
+        + (H * 4 if has_dt_bias else 0)         # dt_bias read
+        + TOKENS * 2                            # dt_out write (fp16)
+        + TOKENS * 4                            # dA_cumsum write
+    )
+    assert flops == expected_flops
+    assert nbytes == expected_nbytes
+
+
+def test_cb_producer_roofline():
+    op = SimpleNamespace(
+        batch=B, num_chunks=NC, n_groups=G, chunk_len=Q, d_state=N,
+        dtype=torch.float16)
+    flops, nbytes = formulas.cb_producer_roofline(op)
+    # Causal masking halves the 2*Q*Q*N GEMM work per (batch, chunk, group).
+    assert flops == B * NC * G * Q * Q * N
+    assert nbytes == (2 * B * S * G * N * 2 + B * NC * G * Q * Q * 2)
+
+
+def _chunk_state_op(has_seq_idx: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        batch=B, num_chunks=NC, chunk_len=Q, n_heads=H, d_head=P, d_state=N,
+        n_groups=G, has_seq_idx=has_seq_idx, dtype=torch.float16)
+
+
+@pytest.mark.parametrize("has_seq_idx", [False, True])
+def test_ssd_chunk_state_fwd_roofline(has_seq_idx: bool):
+    flops, nbytes = formulas.ssd_chunk_state_fwd_roofline(
+        _chunk_state_op(has_seq_idx))
+    assert flops == (2 * B * NC * H * P * N * Q + 4 * TOKENS + TOKENS * P)
+    expected_nbytes = (
+        TOKENS * P * 2                  # x
+        + B * S * G * N * 2             # Bmat
+        + TOKENS * 2                    # dt
+        + TOKENS * 4                    # dA_cumsum
+        + (B * S * 4 if has_seq_idx else 0)  # seq_idx
+        + B * NC * H * P * N * 4        # states out
+    )
+    assert nbytes == expected_nbytes
+
+
+def _state_passing_op(has_initial_states: bool, d_state: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        batch=B, num_chunks=NC, n_heads=H, d_state=d_state,
+        has_initial_states=has_initial_states, dtype=torch.float32)
+
+
+@pytest.mark.parametrize("has_initial_states", [False, True])
+def test_ssd_state_passing_fwd_roofline(has_initial_states: bool):
+    flops, nbytes = formulas.ssd_state_passing_fwd_roofline(
+        _state_passing_op(has_initial_states, N))
+    state_elems = B * NC * H * N
+    # One multiply-add per state element; the exp(dA_chunk_cumsum) decay
+    # scalar is shared across the state dim -> B*H*NC cardinality.
+    assert flops == 2 * state_elems + B * H * NC
+    expected_nbytes = (
+        state_elems * 4                 # states read (fp32 workload)
+        + B * H * NC * 4                # dA_chunk_cumsum
+        + (B * H * N * 4 if has_initial_states else 0)  # initial_states
+        + state_elems * 4               # out
+        + B * H * N * 4                 # final_states
+    )
+    assert nbytes == expected_nbytes
+
+
+def test_ssd_chunk_scan_fwd_roofline():
+    op = SimpleNamespace(
+        batch=B, num_chunks=NC, chunk_len=Q, n_heads=H, d_head=P, d_state=N,
+        n_groups=G, dtype=torch.float16)
+    flops, nbytes = formulas.ssd_chunk_scan_fwd_roofline(op)
+    assert flops == (2 * TOKENS * N * P + B * NC * H * Q * Q * P)
+    expected_nbytes = (
+        TOKENS * P * 2                  # x
+        + B * NC * G * Q * Q * 2        # cb
+        + TOKENS * 4                    # dA_cumsum
+        + B * S * G * N * 2             # C
+        + B * NC * H * P * N * 4        # prev_states
+        + TOKENS * 2                    # dt
+        + TOKENS * P * 4                # y out
+    )
+    assert nbytes == expected_nbytes
+
+
+def test_ssd_decode_roofline():
+    op = SimpleNamespace(
+        batch=B, n_heads=H, d_head=P, d_state=N, n_groups=G,
+        dtype=torch.float16)
+    flops, nbytes = formulas.ssd_decode_roofline(op)
+    state_elems = B * H * P * N
+    # dt*A, exp, two products for dt*x*B, decay multiply, state add, and
+    # the output multiply-add: eight ops per state element.
+    assert flops == 8 * state_elems
+    expected_nbytes = (
+        H * P * N * 4                   # A
+        + B * H * P * 4                 # dt
+        + B * H * P * 2                 # x
+        + 2 * B * G * N * 2             # B_in, C_in
+        + 2 * state_elems * 4           # state read + write
+        + B * H * P * 4                 # y_out
+    )
+    assert nbytes == expected_nbytes
+
+
+def _mamba2_op(has_dt_bias: bool, has_initial_states: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        batch=B, seqlen=S, num_chunks=NC, chunk_size=Q, n_heads=H, d_head=P,
+        d_state=N, n_groups=G, dtype=torch.float16, dt_softplus=True,
+        has_dt_bias=has_dt_bias, has_initial_states=has_initial_states)
+
+
+@pytest.mark.parametrize(
+    "has_dt_bias, has_initial_states",
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+def test_mamba2_fwd_roofline_flops_equal_stage_sum(has_dt_bias: bool,
+                                                   has_initial_states: bool):
+    """Composite FLOPs must equal the sum of the five standalone stages."""
+    composite_flops, _ = formulas.mamba2_fwd_roofline(
+        _mamba2_op(has_dt_bias, has_initial_states))
+
+    stage_flops = 0
+    stage_flops += formulas.da_cumsum_fwd_roofline(
+        _da_cumsum_op(has_dt_bias, dt_softplus=True))[0]
+    stage_flops += formulas.cb_producer_roofline(SimpleNamespace(
+        batch=B, num_chunks=NC, n_groups=G, chunk_len=Q, d_state=N,
+        dtype=torch.float16))[0]
+    stage_flops += formulas.ssd_chunk_state_fwd_roofline(
+        _chunk_state_op(has_seq_idx=False))[0]
+    # State passing runs over the flattened d_head * d_state dimension.
+    stage_flops += formulas.ssd_state_passing_fwd_roofline(
+        _state_passing_op(has_initial_states, P * N))[0]
+    stage_flops += formulas.ssd_chunk_scan_fwd_roofline(SimpleNamespace(
+        batch=B, num_chunks=NC, chunk_len=Q, n_heads=H, d_head=P, d_state=N,
+        n_groups=G, dtype=torch.float16))[0]
+
+    assert composite_flops == stage_flops
+
+
+@pytest.mark.parametrize(
+    "has_dt_bias, has_initial_states",
+    [(False, False), (True, True)],
+)
+def test_mamba2_fwd_roofline_nbytes(has_dt_bias: bool,
+                                    has_initial_states: bool):
+    _, nbytes = formulas.mamba2_fwd_roofline(
+        _mamba2_op(has_dt_bias, has_initial_states))
+    state_elems = B * NC * H * P * N
+    expected = (
+        TOKENS * P * 2                          # x
+        + TOKENS * 4                            # dt
+        + 2 * B * S * G * N * 2                 # B, C
+        + H * 4                                 # A
+        + (H * 4 if has_dt_bias else 0)         # dt_bias
+        + (B * H * P * N * 4 if has_initial_states else 0)  # initial_states
+        + B * NC * G * Q * Q * 2                # cb intermediate
+        + 2 * state_elems * 4                   # chunk states read + write
+        + TOKENS * 2                            # dt_out
+        + TOKENS * 4                            # dA_cumsum
+        + TOKENS * P * 4                        # y out
+    )
+    assert nbytes == expected

--- a/tests/perf/test_mamba_formulas.py
+++ b/tests/perf/test_mamba_formulas.py
@@ -2,11 +2,11 @@
 
 These exercise the (flops, bytes) accounting for the mamba family manifest
 entries, which use ``roofline.func``. Each helper is driven through a
-lightweight attribute stub (no CUDA build required), covering the
-flag-dependent cases (``has_dt_bias`` / ``dt_softplus`` / ``has_seq_idx`` /
-``has_initial_states``) and asserting exact FLOP and byte totals. The
-composite ``mamba2_fwd_roofline`` FLOP total is locked to the sum of the
-five standalone stage formulas.
+lightweight attribute stub (no CUDA build required). Conditional tensor
+presence (dt_bias / seq_idx / initial_states) is hard-wired per variant
+function, so every public variant helper is exercised explicitly and the
+composite ``mamba2_*_roofline`` FLOP totals are locked to the sum of the
+matching standalone stage helpers.
 """
 
 from __future__ import annotations
@@ -26,35 +26,34 @@ S = NC * Q
 TOKENS = B * S * H
 
 
-def _da_cumsum_op(has_dt_bias: bool, dt_softplus: bool) -> SimpleNamespace:
+def _da_cumsum_op(dt_softplus: bool) -> SimpleNamespace:
     return SimpleNamespace(
-        batch=B,
-        seq_len=S,
-        n_heads=H,
-        has_dt_bias=has_dt_bias,
-        dt_softplus=dt_softplus,
-        dtype=torch.float16,
-    )
+        batch=B, seq_len=S, n_heads=H, dt_softplus=dt_softplus,
+        dtype=torch.float16)
 
 
-@pytest.mark.parametrize(
-    "has_dt_bias, dt_softplus",
-    [(False, False), (True, False), (False, True), (True, True)],
-)
-def test_da_cumsum_fwd_roofline_flag_cases(has_dt_bias: bool, dt_softplus: bool):
-    flops, nbytes = formulas.da_cumsum_fwd_roofline(
-        _da_cumsum_op(has_dt_bias, dt_softplus))
-    expected_flops = (3 + (1 if has_dt_bias else 0) +
-                      (4 if dt_softplus else 0)) * TOKENS
-    expected_nbytes = (
+def _da_cumsum_expected(has_dt_bias: bool, dt_softplus: bool) -> tuple[int, int]:
+    flops = (3 + (1 if has_dt_bias else 0) + (4 if dt_softplus else 0)) * TOKENS
+    nbytes = (
         TOKENS * 4                              # dt read (fp32)
         + H * 4                                 # A read
         + (H * 4 if has_dt_bias else 0)         # dt_bias read
         + TOKENS * 2                            # dt_out write (fp16)
         + TOKENS * 4                            # dA_cumsum write
     )
-    assert flops == expected_flops
-    assert nbytes == expected_nbytes
+    return flops, nbytes
+
+
+@pytest.mark.parametrize("dt_softplus", [False, True])
+def test_da_cumsum_fwd_roofline(dt_softplus: bool):
+    assert formulas.da_cumsum_fwd_roofline(
+        _da_cumsum_op(dt_softplus)) == _da_cumsum_expected(False, dt_softplus)
+
+
+@pytest.mark.parametrize("dt_softplus", [False, True])
+def test_da_cumsum_bias_fwd_roofline(dt_softplus: bool):
+    assert formulas.da_cumsum_bias_fwd_roofline(
+        _da_cumsum_op(dt_softplus)) == _da_cumsum_expected(True, dt_softplus)
 
 
 def test_cb_producer_roofline():
@@ -67,18 +66,15 @@ def test_cb_producer_roofline():
     assert nbytes == (2 * B * S * G * N * 2 + B * NC * G * Q * Q * 2)
 
 
-def _chunk_state_op(has_seq_idx: bool) -> SimpleNamespace:
+def _chunk_state_op() -> SimpleNamespace:
     return SimpleNamespace(
         batch=B, num_chunks=NC, chunk_len=Q, n_heads=H, d_head=P, d_state=N,
-        n_groups=G, has_seq_idx=has_seq_idx, dtype=torch.float16)
+        n_groups=G, dtype=torch.float16)
 
 
-@pytest.mark.parametrize("has_seq_idx", [False, True])
-def test_ssd_chunk_state_fwd_roofline(has_seq_idx: bool):
-    flops, nbytes = formulas.ssd_chunk_state_fwd_roofline(
-        _chunk_state_op(has_seq_idx))
-    assert flops == (2 * B * NC * H * P * N * Q + 4 * TOKENS + TOKENS * P)
-    expected_nbytes = (
+def _chunk_state_expected(has_seq_idx: bool) -> tuple[int, int]:
+    flops = 2 * B * NC * H * P * N * Q + 4 * TOKENS + TOKENS * P
+    nbytes = (
         TOKENS * P * 2                  # x
         + B * S * G * N * 2             # Bmat
         + TOKENS * 2                    # dt
@@ -86,31 +82,49 @@ def test_ssd_chunk_state_fwd_roofline(has_seq_idx: bool):
         + (B * S * 4 if has_seq_idx else 0)  # seq_idx
         + B * NC * H * P * N * 4        # states out
     )
-    assert nbytes == expected_nbytes
+    return flops, nbytes
 
 
-def _state_passing_op(has_initial_states: bool, d_state: int) -> SimpleNamespace:
+def test_ssd_chunk_state_fwd_roofline():
+    assert formulas.ssd_chunk_state_fwd_roofline(
+        _chunk_state_op()) == _chunk_state_expected(False)
+
+
+def test_ssd_chunk_state_seq_idx_fwd_roofline():
+    assert formulas.ssd_chunk_state_seq_idx_fwd_roofline(
+        _chunk_state_op()) == _chunk_state_expected(True)
+
+
+def _state_passing_op(d_state: int) -> SimpleNamespace:
     return SimpleNamespace(
         batch=B, num_chunks=NC, n_heads=H, d_state=d_state,
-        has_initial_states=has_initial_states, dtype=torch.float32)
+        dtype=torch.float32)
 
 
-@pytest.mark.parametrize("has_initial_states", [False, True])
-def test_ssd_state_passing_fwd_roofline(has_initial_states: bool):
-    flops, nbytes = formulas.ssd_state_passing_fwd_roofline(
-        _state_passing_op(has_initial_states, N))
-    state_elems = B * NC * H * N
+def _state_passing_expected(has_initial_states: bool,
+                            d_state: int) -> tuple[int, int]:
+    state_elems = B * NC * H * d_state
     # One multiply-add per state element; the exp(dA_chunk_cumsum) decay
     # scalar is shared across the state dim -> B*H*NC cardinality.
-    assert flops == 2 * state_elems + B * H * NC
-    expected_nbytes = (
+    flops = 2 * state_elems + B * H * NC
+    nbytes = (
         state_elems * 4                 # states read (fp32 workload)
         + B * H * NC * 4                # dA_chunk_cumsum
-        + (B * H * N * 4 if has_initial_states else 0)  # initial_states
+        + (B * H * d_state * 4 if has_initial_states else 0)  # initial_states
         + state_elems * 4               # out
-        + B * H * N * 4                 # final_states
+        + B * H * d_state * 4           # final_states
     )
-    assert nbytes == expected_nbytes
+    return flops, nbytes
+
+
+def test_ssd_state_passing_fwd_roofline():
+    assert formulas.ssd_state_passing_fwd_roofline(
+        _state_passing_op(N)) == _state_passing_expected(False, N)
+
+
+def test_ssd_state_passing_init_states_fwd_roofline():
+    assert formulas.ssd_state_passing_init_states_fwd_roofline(
+        _state_passing_op(N)) == _state_passing_expected(True, N)
 
 
 def test_ssd_chunk_scan_fwd_roofline():
@@ -151,34 +165,43 @@ def test_ssd_decode_roofline():
     assert nbytes == expected_nbytes
 
 
-def _mamba2_op(has_dt_bias: bool, has_initial_states: bool) -> SimpleNamespace:
+def _mamba2_op() -> SimpleNamespace:
     return SimpleNamespace(
         batch=B, seqlen=S, num_chunks=NC, chunk_size=Q, n_heads=H, d_head=P,
-        d_state=N, n_groups=G, dtype=torch.float16, dt_softplus=True,
-        has_dt_bias=has_dt_bias, has_initial_states=has_initial_states)
+        d_state=N, n_groups=G, dtype=torch.float16, dt_softplus=True)
 
 
-@pytest.mark.parametrize(
-    "has_dt_bias, has_initial_states",
-    [(False, False), (True, False), (False, True), (True, True)],
-)
-def test_mamba2_fwd_roofline_flops_equal_stage_sum(has_dt_bias: bool,
+# (composite helper, has_dt_bias, has_initial_states) — one public roofline
+# function per Mamba2 manifest variant.
+_MAMBA2_VARIANTS = [
+    (formulas.mamba2_fwd_roofline, False, False),
+    (formulas.mamba2_bias_fwd_roofline, True, False),
+    (formulas.mamba2_init_states_fwd_roofline, False, True),
+    (formulas.mamba2_bias_init_states_fwd_roofline, True, True),
+]
+
+
+@pytest.mark.parametrize(("helper", "has_dt_bias", "has_initial_states"),
+                         _MAMBA2_VARIANTS)
+def test_mamba2_fwd_roofline_flops_equal_stage_sum(helper, has_dt_bias: bool,
                                                    has_initial_states: bool):
     """Composite FLOPs must equal the sum of the five standalone stages."""
-    composite_flops, _ = formulas.mamba2_fwd_roofline(
-        _mamba2_op(has_dt_bias, has_initial_states))
+    composite_flops, _ = helper(_mamba2_op())
+
+    da_cumsum = (formulas.da_cumsum_bias_fwd_roofline if has_dt_bias
+                 else formulas.da_cumsum_fwd_roofline)
+    state_passing = (formulas.ssd_state_passing_init_states_fwd_roofline
+                     if has_initial_states
+                     else formulas.ssd_state_passing_fwd_roofline)
 
     stage_flops = 0
-    stage_flops += formulas.da_cumsum_fwd_roofline(
-        _da_cumsum_op(has_dt_bias, dt_softplus=True))[0]
+    stage_flops += da_cumsum(_da_cumsum_op(dt_softplus=True))[0]
     stage_flops += formulas.cb_producer_roofline(SimpleNamespace(
         batch=B, num_chunks=NC, n_groups=G, chunk_len=Q, d_state=N,
         dtype=torch.float16))[0]
-    stage_flops += formulas.ssd_chunk_state_fwd_roofline(
-        _chunk_state_op(has_seq_idx=False))[0]
+    stage_flops += formulas.ssd_chunk_state_fwd_roofline(_chunk_state_op())[0]
     # State passing runs over the flattened d_head * d_state dimension.
-    stage_flops += formulas.ssd_state_passing_fwd_roofline(
-        _state_passing_op(has_initial_states, P * N))[0]
+    stage_flops += state_passing(_state_passing_op(P * N))[0]
     stage_flops += formulas.ssd_chunk_scan_fwd_roofline(SimpleNamespace(
         batch=B, num_chunks=NC, chunk_len=Q, n_heads=H, d_head=P, d_state=N,
         n_groups=G, dtype=torch.float16))[0]
@@ -186,14 +209,11 @@ def test_mamba2_fwd_roofline_flops_equal_stage_sum(has_dt_bias: bool,
     assert composite_flops == stage_flops
 
 
-@pytest.mark.parametrize(
-    "has_dt_bias, has_initial_states",
-    [(False, False), (True, True)],
-)
-def test_mamba2_fwd_roofline_nbytes(has_dt_bias: bool,
+@pytest.mark.parametrize(("helper", "has_dt_bias", "has_initial_states"),
+                         _MAMBA2_VARIANTS)
+def test_mamba2_fwd_roofline_nbytes(helper, has_dt_bias: bool,
                                     has_initial_states: bool):
-    _, nbytes = formulas.mamba2_fwd_roofline(
-        _mamba2_op(has_dt_bias, has_initial_states))
+    _, nbytes = helper(_mamba2_op())
     state_elems = B * NC * H * P * N
     expected = (
         TOKENS * P * 2                          # x

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -265,8 +265,8 @@ Mamba2FwdOp:
   # spec-only: the composite class does not yet conform to the Op protocol
   # (not an Op subclass; no kernel_map ctor param / dispatch_kernel slot),
   # so it cannot pass the implemented-status validator gates. The runtime,
-  # tests, and benchmark exist; conforming the class is code-side work for
-  # a follow-up implementation PR.
+  # tests, and benchmark exist; the status flips once the class conforms to
+  # the Op protocol.
   #
   # dt_bias and initial_states are optional at the code level (zeros are
   # substituted when omitted; initial_states additionally requires

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -6,9 +6,10 @@
 #
 # Reference: Dao & Gu, "Transformers are SSMs: Generalized Models and
 # Efficient Algorithms Through Structured State Space Duality" (Mamba-2),
-# arXiv:2405.21060. Signatures mirror the staged decomposition of
+# arXiv:2405.21060. Signatures derive from the staged decomposition of
 # mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined; no single
-# torch.* public API covers these stages, hence ref_api "none".
+# torch.* public API covers these stages, hence ref_api "none" and any
+# deviation from the upstream form is declared on the owning entry.
 #
 # Dim-name conventions shared across this family:
 #   B  batch          S  seq_len (= NC * Q)   H  n_heads
@@ -390,8 +391,12 @@ SSDDecodeOp:
 
 Mamba2FwdOp:
   # End-to-end Mamba-2 SSD forward: DaCumsum -> CBProducer -> SSDChunkState ->
-  # SSDStatePassing -> SSDChunkScan. Interface mirrors
-  # mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined.
+  # SSDStatePassing -> SSDChunkScan. Interface derives from
+  # mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined with one
+  # declared deviation: final_states is always returned (fixed output
+  # arity; the Op protocol has no conditional-output mechanism, and
+  # chunked prefill consumes the carried state), so the upstream
+  # return_final_states switch does not exist here.
   # Primary entry: no dt_bias, no initial_states. The optional tensors land
   # as the Bias / InitStates / BiasInitStates variants below.
   #

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -46,9 +46,6 @@ DaCumsumFwdOp:
       chunk_len: {type: int}
       dtype: {type: torch.dtype}
       dt_softplus: {type: bool, default: false}
-      # has_dt_bias stays false for this entry; the true form is the
-      # DaCumsumBiasFwdOp variant.
-      has_dt_bias: {type: bool, default: false}
       dt_min: {type: float, default: 0.0}
       dt_max: {type: float, default: .inf}
     shape_rules:
@@ -91,8 +88,6 @@ DaCumsumBiasFwdOp:
       chunk_len: {type: int}
       dtype: {type: torch.dtype}
       dt_softplus: {type: bool, default: false}
-      # has_dt_bias is true for this entry by construction.
-      has_dt_bias: {type: bool, default: false}
       dt_min: {type: float, default: 0.0}
       dt_max: {type: float, default: .inf}
     shape_rules:
@@ -100,12 +95,12 @@ DaCumsumBiasFwdOp:
     - "NC == S // chunk_len"
 
   workloads:
-  - {dt_shape: [1, 4096, 48], A_shape: [48], dt_bias_shape: [48], chunk_len: 256, dtype: float16, dt_softplus: true, has_dt_bias: true, dtypes: [float16], label: "mamba2-780m-b1-s4k"}
-  - {dt_shape: [8, 2048, 64], A_shape: [64], dt_bias_shape: [64], chunk_len: 256, dtype: bfloat16, dt_softplus: true, has_dt_bias: true, dtypes: [bfloat16], label: "mamba2-1p3b-b8-s2k"}
-  - {dt_shape: [2, 32768, 80], A_shape: [80], dt_bias_shape: [80], chunk_len: 256, dtype: float16, dt_softplus: true, has_dt_bias: true, dtypes: [float16], label: "mamba2-2p7b-b2-s32k"}
+  - {dt_shape: [1, 4096, 48], A_shape: [48], dt_bias_shape: [48], chunk_len: 256, dtype: float16, dt_softplus: true, dtypes: [float16], label: "mamba2-780m-b1-s4k"}
+  - {dt_shape: [8, 2048, 64], A_shape: [64], dt_bias_shape: [64], chunk_len: 256, dtype: bfloat16, dt_softplus: true, dtypes: [bfloat16], label: "mamba2-1p3b-b8-s2k"}
+  - {dt_shape: [2, 32768, 80], A_shape: [80], dt_bias_shape: [80], chunk_len: 256, dtype: float16, dt_softplus: true, dtypes: [float16], label: "mamba2-2p7b-b2-s32k"}
 
   roofline:
-    func: "tileops.perf.formulas.da_cumsum_fwd_roofline"
+    func: "tileops.perf.formulas.da_cumsum_bias_fwd_roofline"
 
   source:
     kernel: tileops/kernels/mamba/da_cumsum.py
@@ -182,10 +177,7 @@ SSDChunkStateFwdOp:
       dA_cumsum: {dtype: "float32", shape: "[B, H, NC, Q]"}
     outputs:
       states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
-    params:
-      # has_seq_idx stays false for this entry; the true form is the
-      # SSDChunkStateSeqIdxFwdOp variant.
-      has_seq_idx: {type: bool, default: false}
+    params: {}
     shape_rules:
     - "S == NC * Q"
     - "H % G == 0"
@@ -223,19 +215,17 @@ SSDChunkStateSeqIdxFwdOp:
       seq_idx: {dtype: "int32", shape: "[B, S]"}
     outputs:
       states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
-    params:
-      # has_seq_idx is true for this entry by construction.
-      has_seq_idx: {type: bool, default: false}
+    params: {}
     shape_rules:
     - "S == NC * Q"
     - "H % G == 0"
 
   workloads:
-  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], seq_idx_shape: [1, 4096], has_seq_idx: true, dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
-  - {x_shape: [2, 32768, 64, 64], Bmat_shape: [2, 32768, 1, 128], dt_shape: [2, 64, 128, 256], dA_cumsum_shape: [2, 64, 128, 256], seq_idx_shape: [2, 32768], has_seq_idx: true, dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
+  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], seq_idx_shape: [1, 4096], dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
+  - {x_shape: [2, 32768, 64, 64], Bmat_shape: [2, 32768, 1, 128], dt_shape: [2, 64, 128, 256], dA_cumsum_shape: [2, 64, 128, 256], seq_idx_shape: [2, 32768], dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
 
   roofline:
-    func: "tileops.perf.formulas.ssd_chunk_state_fwd_roofline"
+    func: "tileops.perf.formulas.ssd_chunk_state_seq_idx_fwd_roofline"
 
   source:
     kernel: tileops/kernels/mamba/ssd_chunk_state.py
@@ -267,14 +257,11 @@ SSDStatePassingFwdOp:
     outputs:
       out: {dtype: "float32", shape: "[B, NC, H, N]"}
       final_states: {dtype: "float32", shape: "[B, H, N]"}
-    params:
-      # has_initial_states stays false for this entry; the true form is the
-      # SSDStatePassingInitStatesFwdOp variant.
-      has_initial_states: {type: bool, default: true}
+    params: {}
 
   workloads:
-  - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], has_initial_states: false, dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
-  - {states_shape: [2, 128, 80, 128], dA_chunk_cumsum_shape: [2, 80, 128], has_initial_states: false, dtypes: [float16], label: "mamba2-2p7b-b2-s32k-dstate"}
+  - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
+  - {states_shape: [2, 128, 80, 128], dA_chunk_cumsum_shape: [2, 80, 128], dtypes: [float16], label: "mamba2-2p7b-b2-s32k-dstate"}
 
   roofline:
     func: "tileops.perf.formulas.ssd_state_passing_fwd_roofline"
@@ -304,9 +291,7 @@ SSDStatePassingInitStatesFwdOp:
     outputs:
       out: {dtype: "float32", shape: "[B, NC, H, N]"}
       final_states: {dtype: "float32", shape: "[B, H, N]"}
-    params:
-      # has_initial_states is true for this entry by construction.
-      has_initial_states: {type: bool, default: true}
+    params: {}
 
   workloads:
   - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 128], dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
@@ -314,7 +299,7 @@ SSDStatePassingInitStatesFwdOp:
   - {states_shape: [1, 16, 64, 8192], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 8192], dtypes: [float32], label: "mamba2-1p3b-b1-s4k-flat"}
 
   roofline:
-    func: "tileops.perf.formulas.ssd_state_passing_fwd_roofline"
+    func: "tileops.perf.formulas.ssd_state_passing_init_states_fwd_roofline"
 
   source:
     kernel: tileops/kernels/mamba/ssd_state_passing.py
@@ -431,8 +416,6 @@ Mamba2FwdOp:
     params:
       chunk_size: {type: int, default: 256}
       dt_softplus: {type: bool, default: true}
-      has_initial_states: {type: bool, default: false}
-      return_final_states: {type: bool, default: false}
     shape_rules:
     - "S % chunk_size == 0"
     - "H % G == 0"
@@ -473,8 +456,6 @@ Mamba2BiasFwdOp:
     params:
       chunk_size: {type: int, default: 256}
       dt_softplus: {type: bool, default: true}
-      has_initial_states: {type: bool, default: false}
-      return_final_states: {type: bool, default: false}
     shape_rules:
     - "S % chunk_size == 0"
     - "H % G == 0"
@@ -484,7 +465,7 @@ Mamba2BiasFwdOp:
   - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
 
   roofline:
-    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+    func: "tileops.perf.formulas.mamba2_bias_fwd_roofline"
 
   source:
     kernel: tileops/ops/mamba2_fwd.py
@@ -515,19 +496,16 @@ Mamba2InitStatesFwdOp:
     params:
       chunk_size: {type: int, default: 256}
       dt_softplus: {type: bool, default: true}
-      # has_initial_states is true for this entry by construction.
-      has_initial_states: {type: bool, default: false}
-      return_final_states: {type: bool, default: false}
     shape_rules:
     - "S % chunk_size == 0"
     - "H % G == 0"
 
   workloads:
-  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], initial_states_shape: [1, 80, 64, 128], has_initial_states: true, dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
-  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], initial_states_shape: [1, 64, 64, 128], has_initial_states: true, dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], initial_states_shape: [1, 80, 64, 128], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], initial_states_shape: [1, 64, 64, 128], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
 
   roofline:
-    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+    func: "tileops.perf.formulas.mamba2_init_states_fwd_roofline"
 
   source:
     kernel: tileops/ops/mamba2_fwd.py
@@ -560,19 +538,16 @@ Mamba2BiasInitStatesFwdOp:
     params:
       chunk_size: {type: int, default: 256}
       dt_softplus: {type: bool, default: true}
-      # has_initial_states is true for this entry by construction.
-      has_initial_states: {type: bool, default: false}
-      return_final_states: {type: bool, default: false}
     shape_rules:
     - "S % chunk_size == 0"
     - "H % G == 0"
 
   workloads:
-  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], initial_states_shape: [1, 80, 64, 128], has_initial_states: true, dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
-  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], initial_states_shape: [1, 64, 64, 128], has_initial_states: true, dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], initial_states_shape: [1, 80, 64, 128], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], initial_states_shape: [1, 64, 64, 128], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
 
   roofline:
-    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+    func: "tileops.perf.formulas.mamba2_bias_init_states_fwd_roofline"
 
   source:
     kernel: tileops/ops/mamba2_fwd.py

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -15,9 +15,14 @@ DaCumsumFwdOp:
   # Mamba-2 dt preprocessing + chunk-local inclusive prefix sum of dA = dt * A.
   # dt_bias is consumed only when has_dt_bias=true; the tensor is still part
   # of the forward tuple, so it is declared as a regular input here.
+  #
+  # spec-only: the constructor carries a legacy `dtype` default
+  # (torch.float32) that the spec does not advertise, failing strict ctor
+  # parity. The status flips once the code-side default is removed
+  # (dtype is spec-required, matching the repo-wide ctor-dtype removal).
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -59,9 +64,14 @@ DaCumsumFwdOp:
 CBProducerOp:
   # Causal C@B coupling-matrix producer:
   #   cb[b, c, g, l, s] = sum_n C[b, c*Q+l, g, n] * B[b, c*Q+s, g, n], s <= l.
+  #
+  # spec-only: the constructor carries a legacy `dtype` default
+  # (torch.float16) that the spec does not advertise, failing strict ctor
+  # parity. The status flips once the code-side default is removed
+  # (dtype is spec-required, matching the repo-wide ctor-dtype removal).
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -4,22 +4,32 @@
 # other family files by tileops.manifest at runtime. See docs/design/manifest.md
 # for the full schema.
 #
+# Reference: Dao & Gu, "Transformers are SSMs: Generalized Models and
+# Efficient Algorithms Through Structured State Space Duality" (Mamba-2),
+# arXiv:2405.21060. Signatures mirror the staged decomposition of
+# mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined; no single
+# torch.* public API covers these stages, hence ref_api "none".
+#
 # Dim-name conventions shared across this family:
 #   B  batch          S  seq_len (= NC * Q)   H  n_heads
 #   P  d_head         N  d_state              G  n_groups (H % G == 0)
 #   NC num_chunks     Q  chunk_len
 # Workload shapes follow the public Mamba-2 model family sizes
 # (780M: H=48, 1.3B: H=64, 2.7B: H=80; P=64, N=128, Q=256, G=1).
+#
+# All entries land spec-only; promotion to implemented is a separate
+# status-flip change after conformance review. Conditional tensor inputs
+# (dt_bias, seq_idx, initial_states) are modeled as variant_of entries per
+# the "No Optional[Tensor]" manifest rule.
 
 DaCumsumFwdOp:
   # Mamba-2 dt preprocessing + chunk-local inclusive prefix sum of dA = dt * A.
-  # dt_bias is consumed only when has_dt_bias=true; the tensor is still part
-  # of the forward tuple, so it is declared as a regular input here.
+  # Primary entry: no per-head dt bias (has_dt_bias=false construction).
+  # The bias-consuming form is the DaCumsumBiasFwdOp variant below.
   #
-  # spec-only: the constructor carries a legacy `dtype` default
-  # (torch.float32) that the spec does not advertise, failing strict ctor
-  # parity. The status flips once the code-side default is removed
-  # (dtype is spec-required, matching the repo-wide ctor-dtype removal).
+  # Code drift blocking promotion: the constructor carries a legacy `dtype`
+  # default (torch.float32) that the spec does not advertise, failing strict
+  # ctor parity; dtype is spec-required.
   ref_api: "none"
   family: mamba
   status: spec-only
@@ -28,7 +38,6 @@ DaCumsumFwdOp:
     inputs:
       dt: {dtype: "float32", shape: "[B, S, H]"}
       A: {dtype: "float32", shape: "[H]"}
-      dt_bias: {dtype: "float32", shape: "[H]"}
     outputs:
       # dt_out is stored in the construction dtype; dA_cumsum stays float32.
       dt_out: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, NC, chunk_len]"}
@@ -37,6 +46,52 @@ DaCumsumFwdOp:
       chunk_len: {type: int}
       dtype: {type: torch.dtype}
       dt_softplus: {type: bool, default: false}
+      # has_dt_bias stays false for this entry; the true form is the
+      # DaCumsumBiasFwdOp variant.
+      has_dt_bias: {type: bool, default: false}
+      dt_min: {type: float, default: 0.0}
+      dt_max: {type: float, default: .inf}
+    shape_rules:
+    - "S % chunk_len == 0"
+    - "NC == S // chunk_len"
+
+  workloads:
+  - {dt_shape: [1, 4096, 48], A_shape: [48], chunk_len: 256, dtype: float16, dt_softplus: true, dtypes: [float16], label: "mamba2-780m-b1-s4k"}
+  - {dt_shape: [8, 2048, 64], A_shape: [64], chunk_len: 256, dtype: bfloat16, dt_softplus: true, dtypes: [bfloat16], label: "mamba2-1p3b-b8-s2k"}
+
+  roofline:
+    func: "tileops.perf.formulas.da_cumsum_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/da_cumsum.py
+    kernel_map:
+      da_cumsum_fwd: DaCumsumFwdKernel
+    op: tileops/ops/da_cumsum.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+DaCumsumBiasFwdOp:
+  # dt_bias-consuming variant: per-head bias added to dt before
+  # softplus/clamp (has_dt_bias=true construction).
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: DaCumsumFwdOp
+
+  signature:
+    inputs:
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      dt_bias: {dtype: "float32", shape: "[H]"}
+    outputs:
+      dt_out: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, NC, chunk_len]"}
+      dA_cumsum: {dtype: "float32", shape: "[B, H, NC, chunk_len]"}
+    params:
+      chunk_len: {type: int}
+      dtype: {type: torch.dtype}
+      dt_softplus: {type: bool, default: false}
+      # has_dt_bias is true for this entry by construction.
       has_dt_bias: {type: bool, default: false}
       dt_min: {type: float, default: 0.0}
       dt_max: {type: float, default: .inf}
@@ -65,10 +120,9 @@ CBProducerOp:
   # Causal C@B coupling-matrix producer:
   #   cb[b, c, g, l, s] = sum_n C[b, c*Q+l, g, n] * B[b, c*Q+s, g, n], s <= l.
   #
-  # spec-only: the constructor carries a legacy `dtype` default
-  # (torch.float16) that the spec does not advertise, failing strict ctor
-  # parity. The status flips once the code-side default is removed
-  # (dtype is spec-required, matching the repo-wide ctor-dtype removal).
+  # Code drift blocking promotion: the constructor carries a legacy `dtype`
+  # default (torch.float16) that the spec does not advertise, failing strict
+  # ctor parity; dtype is spec-required.
   ref_api: "none"
   family: mamba
   status: spec-only
@@ -114,11 +168,51 @@ CBProducerOp:
 
 SSDChunkStateFwdOp:
   # Per-chunk SSM state: decay-weighted (P x Q) @ (Q x N) per (batch, chunk,
-  # head). seq_idx is consumed only when has_seq_idx=true; the kernel still
-  # receives the tensor (zeros otherwise), so it is declared as an input.
+  # head). Primary entry: no sequence-boundary index (has_seq_idx=false).
+  # The seq_idx-consuming form is the SSDChunkStateSeqIdxFwdOp variant.
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      Bmat: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      dt: {dtype: "same_as(x)", shape: "[B, H, NC, Q]"}
+      dA_cumsum: {dtype: "float32", shape: "[B, H, NC, Q]"}
+    outputs:
+      states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
+    params:
+      # has_seq_idx stays false for this entry; the true form is the
+      # SSDChunkStateSeqIdxFwdOp variant.
+      has_seq_idx: {type: bool, default: false}
+    shape_rules:
+    - "S == NC * Q"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
+  - {x_shape: [4, 2048, 80, 64], Bmat_shape: [4, 2048, 1, 128], dt_shape: [4, 80, 8, 256], dA_cumsum_shape: [4, 80, 8, 256], dtypes: [bfloat16], label: "mamba2-2p7b-b4-s2k"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_chunk_state_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_chunk_state.py
+    kernel_map:
+      ssd_chunk_state_fwd: SSDChunkStateFwdKernel
+    op: tileops/ops/ssd_chunk_state.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+SSDChunkStateSeqIdxFwdOp:
+  # seq_idx-consuming variant: per-token sequence-boundary index masks
+  # cross-sequence state contributions (has_seq_idx=true construction).
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: SSDChunkStateFwdOp
 
   signature:
     inputs:
@@ -130,15 +224,15 @@ SSDChunkStateFwdOp:
     outputs:
       states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
     params:
+      # has_seq_idx is true for this entry by construction.
       has_seq_idx: {type: bool, default: false}
     shape_rules:
     - "S == NC * Q"
     - "H % G == 0"
 
   workloads:
-  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], seq_idx_shape: [1, 4096], dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
-  - {x_shape: [4, 2048, 80, 64], Bmat_shape: [4, 2048, 1, 128], dt_shape: [4, 80, 8, 256], dA_cumsum_shape: [4, 80, 8, 256], seq_idx_shape: [4, 2048], dtypes: [bfloat16], label: "mamba2-2p7b-b4-s2k"}
-  - {x_shape: [2, 32768, 64, 64], Bmat_shape: [2, 32768, 1, 128], dt_shape: [2, 64, 128, 256], dA_cumsum_shape: [2, 64, 128, 256], seq_idx_shape: [2, 32768], dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
+  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], seq_idx_shape: [1, 4096], has_seq_idx: true, dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
+  - {x_shape: [2, 32768, 64, 64], Bmat_shape: [2, 32768, 1, 128], dt_shape: [2, 64, 128, 256], dA_cumsum_shape: [2, 64, 128, 256], seq_idx_shape: [2, 32768], has_seq_idx: true, dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
 
   roofline:
     func: "tileops.perf.formulas.ssd_chunk_state_fwd_roofline"
@@ -156,9 +250,51 @@ SSDStatePassingFwdOp:
   # Inter-chunk recurrent scan over a flattened state dimension:
   #   s_c = exp(dA_chunk_cumsum[b, h, c]) * s_{c-1} + states[b, c, h, :].
   # In the Mamba-2 pipeline N here is the flattened d_head * d_state.
+  # Primary entry: scan starts from a zero state (has_initial_states=false).
+  # The seeded form is the SSDStatePassingInitStatesFwdOp variant.
+  #
+  # Code drift blocking promotion: forward() currently requires the
+  # initial_states argument unconditionally; the spec models absence as
+  # this entry, so the argument must become variant-selected in code.
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
+
+  signature:
+    inputs:
+      states: {dtype: "float16 | bfloat16 | float32", shape: "[B, NC, H, N]"}
+      dA_chunk_cumsum: {dtype: "float32", shape: "[B, H, NC]"}
+    outputs:
+      out: {dtype: "float32", shape: "[B, NC, H, N]"}
+      final_states: {dtype: "float32", shape: "[B, H, N]"}
+    params:
+      # has_initial_states stays false for this entry; the true form is the
+      # SSDStatePassingInitStatesFwdOp variant.
+      has_initial_states: {type: bool, default: true}
+
+  workloads:
+  - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], has_initial_states: false, dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
+  - {states_shape: [2, 128, 80, 128], dA_chunk_cumsum_shape: [2, 80, 128], has_initial_states: false, dtypes: [float16], label: "mamba2-2p7b-b2-s32k-dstate"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_state_passing_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_state_passing.py
+    kernel_map:
+      ssd_state_passing_fwd: SSDStatePassingFwdKernel
+    op: tileops/ops/ssd_state_passing.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+SSDStatePassingInitStatesFwdOp:
+  # initial_states-consuming variant: the scan is seeded with a caller-
+  # provided (B, H, N) state (has_initial_states=true construction).
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: SSDStatePassingFwdOp
 
   signature:
     inputs:
@@ -169,13 +305,13 @@ SSDStatePassingFwdOp:
       out: {dtype: "float32", shape: "[B, NC, H, N]"}
       final_states: {dtype: "float32", shape: "[B, H, N]"}
     params:
+      # has_initial_states is true for this entry by construction.
       has_initial_states: {type: bool, default: true}
 
   workloads:
   - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 128], dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
     # Flattened d_head * d_state = 8192 as produced inside Mamba2FwdOp.
   - {states_shape: [1, 16, 64, 8192], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 8192], dtypes: [float32], label: "mamba2-1p3b-b1-s4k-flat"}
-  - {states_shape: [2, 128, 80, 128], dA_chunk_cumsum_shape: [2, 80, 128], initial_states_shape: [2, 80, 128], dtypes: [float16], label: "mamba2-2p7b-b2-s32k-dstate"}
 
   roofline:
     func: "tileops.perf.formulas.ssd_state_passing_fwd_roofline"
@@ -194,7 +330,7 @@ SSDChunkScanFwdOp:
   # prev_states) plus the causal intra-chunk path over cb.
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -234,7 +370,7 @@ SSDDecodeOp:
   # z-gate are not fused here.
   ref_api: "none"
   family: mamba
-  status: implemented
+  status: spec-only
 
   signature:
     inputs:
@@ -271,20 +407,143 @@ Mamba2FwdOp:
   # End-to-end Mamba-2 SSD forward: DaCumsum -> CBProducer -> SSDChunkState ->
   # SSDStatePassing -> SSDChunkScan. Interface mirrors
   # mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined.
+  # Primary entry: no dt_bias, no initial_states. The optional tensors land
+  # as the Bias / InitStates / BiasInitStates variants below.
   #
-  # spec-only: the composite class does not yet conform to the Op protocol
-  # (not an Op subclass; no kernel_map ctor param / dispatch_kernel slot),
-  # so it cannot pass the implemented-status validator gates. The runtime,
-  # tests, and benchmark exist; the status flips once the class conforms to
-  # the Op protocol.
-  #
-  # dt_bias and initial_states are optional at the code level (zeros are
-  # substituted when omitted; initial_states additionally requires
-  # has_initial_states=true). They are declared as regular inputs because
-  # they are part of the forward tuple.
+  # Code drift blocking promotion: the composite class does not conform to
+  # the Op protocol (not an Op subclass; no kernel_map ctor param /
+  # dispatch_kernel slot), so it cannot pass the implemented-status
+  # validator gates.
   ref_api: "none"
   family: mamba
   status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      B: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      C: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+    outputs:
+      y: {dtype: "float32", shape: "[B, S, H, P]"}
+      final_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    params:
+      chunk_size: {type: int, default: 256}
+      dt_softplus: {type: bool, default: true}
+      has_initial_states: {type: bool, default: false}
+      return_final_states: {type: bool, default: false}
+    shape_rules:
+    - "S % chunk_size == 0"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+
+  roofline:
+    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+
+  source:
+    kernel: tileops/ops/mamba2_fwd.py
+    op: tileops/ops/mamba2_fwd.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba2_e2e.py
+    bench_manifest_driven: false
+
+Mamba2BiasFwdOp:
+  # dt_bias-consuming variant: per-head bias added to dt in the DaCumsum
+  # stage; scan still starts from a zero state.
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: Mamba2FwdOp
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      B: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      C: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      dt_bias: {dtype: "float32", shape: "[H]"}
+    outputs:
+      y: {dtype: "float32", shape: "[B, S, H, P]"}
+      final_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    params:
+      chunk_size: {type: int, default: 256}
+      dt_softplus: {type: bool, default: true}
+      has_initial_states: {type: bool, default: false}
+      return_final_states: {type: bool, default: false}
+    shape_rules:
+    - "S % chunk_size == 0"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+
+  roofline:
+    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+
+  source:
+    kernel: tileops/ops/mamba2_fwd.py
+    op: tileops/ops/mamba2_fwd.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba2_e2e.py
+    bench_manifest_driven: false
+
+Mamba2InitStatesFwdOp:
+  # initial_states-consuming variant: the inter-chunk scan is seeded with a
+  # caller-provided (B, H, P, N) state (has_initial_states=true); no dt_bias.
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: Mamba2FwdOp
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      B: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      C: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      initial_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    outputs:
+      y: {dtype: "float32", shape: "[B, S, H, P]"}
+      final_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    params:
+      chunk_size: {type: int, default: 256}
+      dt_softplus: {type: bool, default: true}
+      # has_initial_states is true for this entry by construction.
+      has_initial_states: {type: bool, default: false}
+      return_final_states: {type: bool, default: false}
+    shape_rules:
+    - "S % chunk_size == 0"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], initial_states_shape: [1, 80, 64, 128], has_initial_states: true, dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], initial_states_shape: [1, 64, 64, 128], has_initial_states: true, dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+
+  roofline:
+    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+
+  source:
+    kernel: tileops/ops/mamba2_fwd.py
+    op: tileops/ops/mamba2_fwd.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba2_e2e.py
+    bench_manifest_driven: false
+
+Mamba2BiasInitStatesFwdOp:
+  # Combined variant: dt_bias and initial_states both present. This is the
+  # configuration used by full Mamba-2 model inference (bias-trained dt,
+  # chunked prefill with carried state).
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+  variant_of: Mamba2FwdOp
 
   signature:
     inputs:
@@ -301,6 +560,7 @@ Mamba2FwdOp:
     params:
       chunk_size: {type: int, default: 256}
       dt_softplus: {type: bool, default: true}
+      # has_initial_states is true for this entry by construction.
       has_initial_states: {type: bool, default: false}
       return_final_states: {type: bool, default: false}
     shape_rules:
@@ -308,8 +568,8 @@ Mamba2FwdOp:
     - "H % G == 0"
 
   workloads:
-  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], initial_states_shape: [1, 80, 64, 128], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
-  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], initial_states_shape: [1, 64, 64, 128], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], initial_states_shape: [1, 80, 64, 128], has_initial_states: true, dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], initial_states_shape: [1, 64, 64, 128], has_initial_states: true, dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
 
   roofline:
     func: "tileops.perf.formulas.mamba2_fwd_roofline"

--- a/tileops/manifest/mamba.yaml
+++ b/tileops/manifest/mamba.yaml
@@ -1,0 +1,312 @@
+# mamba.yaml -- manifest entries for the 'mamba' (Mamba-2 / SSD) family.
+#
+# Source of truth for op interfaces in this family. Loaded and merged with
+# other family files by tileops.manifest at runtime. See docs/design/manifest.md
+# for the full schema.
+#
+# Dim-name conventions shared across this family:
+#   B  batch          S  seq_len (= NC * Q)   H  n_heads
+#   P  d_head         N  d_state              G  n_groups (H % G == 0)
+#   NC num_chunks     Q  chunk_len
+# Workload shapes follow the public Mamba-2 model family sizes
+# (780M: H=48, 1.3B: H=64, 2.7B: H=80; P=64, N=128, Q=256, G=1).
+
+DaCumsumFwdOp:
+  # Mamba-2 dt preprocessing + chunk-local inclusive prefix sum of dA = dt * A.
+  # dt_bias is consumed only when has_dt_bias=true; the tensor is still part
+  # of the forward tuple, so it is declared as a regular input here.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      dt_bias: {dtype: "float32", shape: "[H]"}
+    outputs:
+      # dt_out is stored in the construction dtype; dA_cumsum stays float32.
+      dt_out: {dtype: "float16 | bfloat16 | float32", shape: "[B, H, NC, chunk_len]"}
+      dA_cumsum: {dtype: "float32", shape: "[B, H, NC, chunk_len]"}
+    params:
+      chunk_len: {type: int}
+      dtype: {type: torch.dtype}
+      dt_softplus: {type: bool, default: false}
+      has_dt_bias: {type: bool, default: false}
+      dt_min: {type: float, default: 0.0}
+      dt_max: {type: float, default: .inf}
+    shape_rules:
+    - "S % chunk_len == 0"
+    - "NC == S // chunk_len"
+
+  workloads:
+  - {dt_shape: [1, 4096, 48], A_shape: [48], dt_bias_shape: [48], chunk_len: 256, dtype: float16, dt_softplus: true, has_dt_bias: true, dtypes: [float16], label: "mamba2-780m-b1-s4k"}
+  - {dt_shape: [8, 2048, 64], A_shape: [64], dt_bias_shape: [64], chunk_len: 256, dtype: bfloat16, dt_softplus: true, has_dt_bias: true, dtypes: [bfloat16], label: "mamba2-1p3b-b8-s2k"}
+  - {dt_shape: [2, 32768, 80], A_shape: [80], dt_bias_shape: [80], chunk_len: 256, dtype: float16, dt_softplus: true, has_dt_bias: true, dtypes: [float16], label: "mamba2-2p7b-b2-s32k"}
+
+  roofline:
+    func: "tileops.perf.formulas.da_cumsum_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/da_cumsum.py
+    kernel_map:
+      da_cumsum_fwd: DaCumsumFwdKernel
+    op: tileops/ops/da_cumsum.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+CBProducerOp:
+  # Causal C@B coupling-matrix producer:
+  #   cb[b, c, g, l, s] = sum_n C[b, c*Q+l, g, n] * B[b, c*Q+s, g, n], s <= l.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      C_mat: {dtype: "float16 | bfloat16", shape: "[B, S, G, N]"}
+      B_mat: {dtype: "same_as(C_mat)", shape: "[B, S, G, N]"}
+    outputs:
+      cb: {dtype: "same_as(C_mat)", shape: "[B, NC, G, Q, Q]"}
+    params:
+      batch: {type: int}
+      num_chunks: {type: int}
+      n_groups: {type: int}
+      chunk_len: {type: int}
+      d_state: {type: int}
+      dtype: {type: torch.dtype}
+    shape_rules:
+    - "B == batch"
+    - "S == num_chunks * chunk_len"
+    - "G == n_groups"
+    - "N == d_state"
+    - "NC == num_chunks"
+    - "Q == chunk_len"
+
+  workloads:
+  - {C_mat_shape: [1, 4096, 1, 128], B_mat_shape: [1, 4096, 1, 128], batch: 1, num_chunks: 16, n_groups: 1, chunk_len: 256, d_state: 128, dtype: float16, dtypes: [float16], label: "mamba2-780m-b1-s4k"}
+  - {C_mat_shape: [4, 2048, 1, 128], B_mat_shape: [4, 2048, 1, 128], batch: 4, num_chunks: 8, n_groups: 1, chunk_len: 256, d_state: 128, dtype: bfloat16, dtypes: [bfloat16], label: "mamba2-2p7b-b4-s2k"}
+
+  roofline:
+    func: "tileops.perf.formulas.cb_producer_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/cb_producer.py
+    kernel_map:
+      cb_producer: CBProducerKernel
+    op: tileops/ops/cb_producer.py
+    test: tests/ops/test_mamba.py
+    # Exercised through the Mamba-2 end-to-end benchmark (CB stage of
+    # Mamba2FwdOp); no standalone bench file exists yet.
+    bench: benchmarks/ops/bench_mamba2_e2e.py
+    bench_manifest_driven: false
+
+SSDChunkStateFwdOp:
+  # Per-chunk SSM state: decay-weighted (P x Q) @ (Q x N) per (batch, chunk,
+  # head). seq_idx is consumed only when has_seq_idx=true; the kernel still
+  # receives the tensor (zeros otherwise), so it is declared as an input.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      Bmat: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      dt: {dtype: "same_as(x)", shape: "[B, H, NC, Q]"}
+      dA_cumsum: {dtype: "float32", shape: "[B, H, NC, Q]"}
+      seq_idx: {dtype: "int32", shape: "[B, S]"}
+    outputs:
+      states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
+    params:
+      has_seq_idx: {type: bool, default: false}
+    shape_rules:
+    - "S == NC * Q"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 4096, 48, 64], Bmat_shape: [1, 4096, 1, 128], dt_shape: [1, 48, 16, 256], dA_cumsum_shape: [1, 48, 16, 256], seq_idx_shape: [1, 4096], dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
+  - {x_shape: [4, 2048, 80, 64], Bmat_shape: [4, 2048, 1, 128], dt_shape: [4, 80, 8, 256], dA_cumsum_shape: [4, 80, 8, 256], seq_idx_shape: [4, 2048], dtypes: [bfloat16], label: "mamba2-2p7b-b4-s2k"}
+  - {x_shape: [2, 32768, 64, 64], Bmat_shape: [2, 32768, 1, 128], dt_shape: [2, 64, 128, 256], dA_cumsum_shape: [2, 64, 128, 256], seq_idx_shape: [2, 32768], dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_chunk_state_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_chunk_state.py
+    kernel_map:
+      ssd_chunk_state_fwd: SSDChunkStateFwdKernel
+    op: tileops/ops/ssd_chunk_state.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+SSDStatePassingFwdOp:
+  # Inter-chunk recurrent scan over a flattened state dimension:
+  #   s_c = exp(dA_chunk_cumsum[b, h, c]) * s_{c-1} + states[b, c, h, :].
+  # In the Mamba-2 pipeline N here is the flattened d_head * d_state.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      states: {dtype: "float16 | bfloat16 | float32", shape: "[B, NC, H, N]"}
+      dA_chunk_cumsum: {dtype: "float32", shape: "[B, H, NC]"}
+      initial_states: {dtype: "float32", shape: "[B, H, N]"}
+    outputs:
+      out: {dtype: "float32", shape: "[B, NC, H, N]"}
+      final_states: {dtype: "float32", shape: "[B, H, N]"}
+    params:
+      has_initial_states: {type: bool, default: true}
+
+  workloads:
+  - {states_shape: [1, 16, 64, 128], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 128], dtypes: [float16, bfloat16], label: "mamba2-1p3b-b1-s4k-dstate"}
+    # Flattened d_head * d_state = 8192 as produced inside Mamba2FwdOp.
+  - {states_shape: [1, 16, 64, 8192], dA_chunk_cumsum_shape: [1, 64, 16], initial_states_shape: [1, 64, 8192], dtypes: [float32], label: "mamba2-1p3b-b1-s4k-flat"}
+  - {states_shape: [2, 128, 80, 128], dA_chunk_cumsum_shape: [2, 80, 128], initial_states_shape: [2, 80, 128], dtypes: [float16], label: "mamba2-2p7b-b2-s32k-dstate"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_state_passing_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_state_passing.py
+    kernel_map:
+      ssd_state_passing_fwd: SSDStatePassingFwdKernel
+    op: tileops/ops/ssd_state_passing.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+SSDChunkScanFwdOp:
+  # Fused SSD chunk output: history contribution exp(dA[l]) * (C[l] @
+  # prev_states) plus the causal intra-chunk path over cb.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      cb: {dtype: "same_as(x)", shape: "[B, NC, G, Q, Q]"}
+      dA_cumsum: {dtype: "float32", shape: "[B, H, NC, Q]"}
+      C: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      prev_states: {dtype: "float32", shape: "[B, NC, H, P, N]"}
+      dt: {dtype: "same_as(x)", shape: "[B, H, NC, Q]"}
+    outputs:
+      y: {dtype: "float32", shape: "[B, S, H, P]"}
+    params: {}
+    shape_rules:
+    - "S == NC * Q"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 4096, 48, 64], cb_shape: [1, 16, 1, 256, 256], dA_cumsum_shape: [1, 48, 16, 256], C_shape: [1, 4096, 1, 128], prev_states_shape: [1, 16, 48, 64, 128], dt_shape: [1, 48, 16, 256], dtypes: [float16, bfloat16], label: "mamba2-780m-b1-s4k"}
+  - {x_shape: [4, 2048, 80, 64], cb_shape: [4, 8, 1, 256, 256], dA_cumsum_shape: [4, 80, 8, 256], C_shape: [4, 2048, 1, 128], prev_states_shape: [4, 8, 80, 64, 128], dt_shape: [4, 80, 8, 256], dtypes: [bfloat16], label: "mamba2-2p7b-b4-s2k"}
+  - {x_shape: [2, 32768, 64, 64], cb_shape: [2, 128, 1, 256, 256], dA_cumsum_shape: [2, 64, 128, 256], C_shape: [2, 32768, 1, 128], prev_states_shape: [2, 128, 64, 64, 128], dt_shape: [2, 64, 128, 256], dtypes: [float16], label: "mamba2-1p3b-b2-s32k"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_chunk_scan_fwd_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_chunk_scan.py
+    kernel_map:
+      ssd_chunk_scan_fwd: SSDChunkScanFwdKernel
+    op: tileops/ops/ssd_chunk_scan.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+SSDDecodeOp:
+  # Single-token Mamba-2 SSD decode step. state is updated in place (read +
+  # write); y_out is the only returned tensor. The D * x skip connection and
+  # z-gate are not fused here.
+  ref_api: "none"
+  family: mamba
+  status: implemented
+
+  signature:
+    inputs:
+      A: {dtype: "float32", shape: "[H, P, N]"}
+      dt: {dtype: "float32", shape: "[B, H, P]"}
+      x: {dtype: "float16 | bfloat16", shape: "[B, H, P]"}
+      B_in: {dtype: "same_as(x)", shape: "[B, G, N]"}
+      C_in: {dtype: "same_as(x)", shape: "[B, G, N]"}
+      state: {dtype: "float32", shape: "[B, H, P, N]"}
+    outputs:
+      y_out: {dtype: "float32", shape: "[B, H, P]"}
+    params: {}
+    shape_rules:
+    - "H % G == 0"
+
+  workloads:
+  - {A_shape: [64, 64, 128], dt_shape: [1, 64, 64], x_shape: [1, 64, 64], B_in_shape: [1, 1, 128], C_in_shape: [1, 1, 128], state_shape: [1, 64, 64, 128], dtypes: [float16, bfloat16], label: "mamba2-1p3b-decode-b1"}
+  - {A_shape: [80, 64, 128], dt_shape: [8, 80, 64], x_shape: [8, 80, 64], B_in_shape: [8, 1, 128], C_in_shape: [8, 1, 128], state_shape: [8, 80, 64, 128], dtypes: [float16], label: "mamba2-2p7b-decode-b8"}
+  - {A_shape: [48, 64, 128], dt_shape: [32, 48, 64], x_shape: [32, 48, 64], B_in_shape: [32, 1, 128], C_in_shape: [32, 1, 128], state_shape: [32, 48, 64, 128], dtypes: [float16], label: "mamba2-780m-decode-b32"}
+
+  roofline:
+    func: "tileops.perf.formulas.ssd_decode_roofline"
+
+  source:
+    kernel: tileops/kernels/mamba/ssd_decode.py
+    kernel_map:
+      ssd_decode: SSDDecodeKernel
+    op: tileops/ops/ssd_decode.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba.py
+    bench_manifest_driven: false
+
+Mamba2FwdOp:
+  # End-to-end Mamba-2 SSD forward: DaCumsum -> CBProducer -> SSDChunkState ->
+  # SSDStatePassing -> SSDChunkScan. Interface mirrors
+  # mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined.
+  #
+  # spec-only: the composite class does not yet conform to the Op protocol
+  # (not an Op subclass; no kernel_map ctor param / dispatch_kernel slot),
+  # so it cannot pass the implemented-status validator gates. The runtime,
+  # tests, and benchmark exist; conforming the class is code-side work for
+  # a follow-up implementation PR.
+  #
+  # dt_bias and initial_states are optional at the code level (zeros are
+  # substituted when omitted; initial_states additionally requires
+  # has_initial_states=true). They are declared as regular inputs because
+  # they are part of the forward tuple.
+  ref_api: "none"
+  family: mamba
+  status: spec-only
+
+  signature:
+    inputs:
+      x: {dtype: "float16 | bfloat16", shape: "[B, S, H, P]"}
+      dt: {dtype: "float32", shape: "[B, S, H]"}
+      A: {dtype: "float32", shape: "[H]"}
+      B: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      C: {dtype: "same_as(x)", shape: "[B, S, G, N]"}
+      dt_bias: {dtype: "float32", shape: "[H]"}
+      initial_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    outputs:
+      y: {dtype: "float32", shape: "[B, S, H, P]"}
+      final_states: {dtype: "float32", shape: "[B, H, P, N]"}
+    params:
+      chunk_size: {type: int, default: 256}
+      dt_softplus: {type: bool, default: true}
+      has_initial_states: {type: bool, default: false}
+      return_final_states: {type: bool, default: false}
+    shape_rules:
+    - "S % chunk_size == 0"
+    - "H % G == 0"
+
+  workloads:
+  - {x_shape: [1, 2048, 80, 64], dt_shape: [1, 2048, 80], A_shape: [80], B_shape: [1, 2048, 1, 128], C_shape: [1, 2048, 1, 128], dt_bias_shape: [80], initial_states_shape: [1, 80, 64, 128], dtypes: [bfloat16], label: "mamba2-2p7b-b1-s2k"}
+  - {x_shape: [1, 8192, 64, 64], dt_shape: [1, 8192, 64], A_shape: [64], B_shape: [1, 8192, 1, 128], C_shape: [1, 8192, 1, 128], dt_bias_shape: [64], initial_states_shape: [1, 64, 64, 128], dtypes: [float16], label: "mamba2-1p3b-b1-s8k"}
+
+  roofline:
+    func: "tileops.perf.formulas.mamba2_fwd_roofline"
+
+  source:
+    kernel: tileops/ops/mamba2_fwd.py
+    op: tileops/ops/mamba2_fwd.py
+    test: tests/ops/test_mamba.py
+    bench: benchmarks/ops/bench_mamba2_e2e.py
+    bench_manifest_driven: false

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -1285,14 +1285,18 @@ def da_cumsum_fwd_roofline(op: "Op") -> tuple[int, int]:
     batch = int(op.batch)
     seq_len = int(op.seq_len)
     n_heads = int(op.n_heads)
+    has_dt_bias = bool(getattr(op, "has_dt_bias", False))
+    dt_softplus = bool(getattr(op, "dt_softplus", False))
     elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
 
     tokens = batch * seq_len * n_heads
-    # bias add + softplus (~4 flops) + clamp + dt * A + cumsum add
-    flops = 8 * tokens
+    # Unconditional: clamp + dt * A + cumsum add; bias add (+1) and
+    # softplus (~4 flops) only when the op is configured with them.
+    flops = (3 + (1 if has_dt_bias else 0) + (4 if dt_softplus else 0)) * tokens
     nbytes = (
         tokens * 4                 # dt (float32, read)
-        + 2 * n_heads * 4          # A + dt_bias (float32, read)
+        + n_heads * 4              # A (float32, read)
+        + (n_heads * 4 if has_dt_bias else 0)  # dt_bias (float32, read)
         + tokens * elem_bytes      # dt_out (target dtype, write)
         + tokens * 4               # dA_cumsum (float32, write)
     )
@@ -1343,7 +1347,7 @@ def ssd_chunk_state_fwd_roofline(op: "Op") -> tuple[int, int]:
         + batch * seq_len * n_groups * d_state * elem_bytes     # Bmat
         + tokens * elem_bytes                                   # dt
         + tokens * 4                                            # dA_cumsum
-        + batch * seq_len * 4                                   # seq_idx
+        + (batch * seq_len * 4 if bool(getattr(op, "has_seq_idx", False)) else 0)  # seq_idx
         + batch * num_chunks * n_heads * d_head * d_state * 4   # states out
     )
     return int(flops), int(nbytes)
@@ -1358,12 +1362,15 @@ def ssd_state_passing_fwd_roofline(op: "Op") -> tuple[int, int]:
     elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
 
     state_elems = batch * num_chunks * n_heads * d_state
-    # exp-scaled multiply-add per state element along the chunk scan.
-    flops = 3 * state_elems
+    # Multiply-add per state element along the chunk scan; the decay scalar
+    # exp(dA_chunk_cumsum[b, h, c]) is computed once per (batch, head, chunk)
+    # and shared across the state dimension.
+    flops = 2 * state_elems + batch * n_heads * num_chunks
     nbytes = (
         state_elems * elem_bytes                 # states (read)
         + batch * n_heads * num_chunks * 4       # dA_chunk_cumsum
-        + batch * n_heads * d_state * 4          # initial_states
+        + (batch * n_heads * d_state * 4         # initial_states
+           if bool(getattr(op, "has_initial_states", True)) else 0)
         + state_elems * 4                        # out (float32)
         + batch * n_heads * d_state * 4          # final_states
     )
@@ -1411,9 +1418,10 @@ def ssd_decode_roofline(op: "Op") -> tuple[int, int]:
     elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
 
     state_elems = batch * n_heads * d_head * d_state
-    # Per state element: exp(dt * A), decay multiply, dt*B*x fused
-    # multiply-add, and the output dot against C.
-    flops = 6 * state_elems
+    # Per state element under the multiply/add convention: dt * A, exp,
+    # two products for dt * x * B, the decay multiply, the state add, and
+    # the output multiply-add against C — eight ops total.
+    flops = 8 * state_elems
     nbytes = (
         n_heads * d_head * d_state * 4          # A
         + batch * n_heads * d_head * 4          # dt
@@ -1442,13 +1450,21 @@ def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
     n_groups = int(op.n_groups)
     elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
 
+    has_dt_bias = bool(getattr(op, "has_dt_bias", False))
+    dt_softplus = bool(getattr(op, "dt_softplus", False))
+    has_initial_states = bool(getattr(op, "has_initial_states", False))
+
     tokens = batch * seq_len * n_heads
     state_elems = batch * num_chunks * n_heads * d_head * d_state
+    # FLOPs are the exact sum of the five standalone stage formulas, with the
+    # state-passing stage running over the flattened d_head * d_state dim.
     flops = (
-        8 * tokens                                                       # da_cumsum
+        # da_cumsum: clamp + dt*A + cumsum, plus configured bias/softplus
+        (3 + (1 if has_dt_bias else 0) + (4 if dt_softplus else 0)) * tokens
         + batch * num_chunks * n_groups * chunk_len**2 * d_state         # cb (causal)
-        + 2 * batch * num_chunks * n_heads * d_head * d_state * chunk_len  # chunk_state
-        + 3 * state_elems                                                # state_passing
+        + 2 * batch * num_chunks * n_heads * d_head * d_state * chunk_len  # chunk_state GEMM
+        + 4 * tokens + tokens * d_head                                   # chunk_state decay + x scaling
+        + 2 * state_elems + batch * n_heads * num_chunks                 # state_passing
         + 2 * tokens * d_state * d_head                                  # scan history
         + batch * num_chunks * n_heads * chunk_len**2 * d_head           # scan intra (causal)
     )
@@ -1456,7 +1472,10 @@ def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
         tokens * d_head * elem_bytes                                 # x
         + tokens * 4                                                 # dt
         + 2 * batch * seq_len * n_groups * d_state * elem_bytes      # B, C
-        + 2 * n_heads * 4                                            # A, dt_bias
+        + n_heads * 4                                                # A
+        + (n_heads * 4 if has_dt_bias else 0)                        # dt_bias
+        + (batch * n_heads * d_head * d_state * 4                    # initial_states
+           if has_initial_states else 0)
         # dominant intermediates: cb, chunk states (read + write), dt_out,
         # dA_cumsum
         + batch * num_chunks * n_groups * chunk_len**2 * elem_bytes

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -23,9 +23,11 @@ __all__ = [
     "bitwise_and_fwd_roofline",
     "bitwise_or_fwd_roofline",
     "bitwise_xor_fwd_roofline",
+    "cb_producer_roofline",
     "clamp_fwd_roofline",
     "clamp_max_fwd_roofline",
     "clamp_min_fwd_roofline",
+    "da_cumsum_fwd_roofline",
     "deepseek_dsa_decode_roofline",
     "deepseek_mla_decode_roofline",
     "deltanet_decode_roofline",
@@ -61,6 +63,7 @@ __all__ = [
     "logical_and_fwd_roofline",
     "logical_or_fwd_roofline",
     "lt_fwd_roofline",
+    "mamba2_fwd_roofline",
     "masked_fill_fwd_roofline",
     "maximum_fwd_roofline",
     "mha_bwd_roofline",
@@ -76,6 +79,10 @@ __all__ = [
     "remainder_fwd_roofline",
     "rope_position_ids_roofline",
     "rope_roofline",
+    "ssd_chunk_scan_fwd_roofline",
+    "ssd_chunk_state_fwd_roofline",
+    "ssd_decode_roofline",
+    "ssd_state_passing_fwd_roofline",
     "sub_fwd_roofline",
     "topk_selector_roofline",
     "where_fwd_roofline",
@@ -1262,4 +1269,200 @@ def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
     out_bytes = op.out_dtype.itemsize
     flops = 2 * batch * m * n * k
     nbytes = batch * ((m * k + n * k) * input_bytes + m * n * out_bytes) + 8
+    return int(flops), int(nbytes)
+
+
+# Mamba-2 / State-Space Dual (SSD) family
+
+
+def da_cumsum_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the Mamba-2 dA_cumsum forward stage.
+
+    Elementwise dt preprocessing (bias add, softplus, clamp, dt * A) plus a
+    chunk-local inclusive prefix sum. Valid only after the first ``forward()``
+    (batch / seq_len / n_heads are inferred from the inputs then).
+    """
+    batch = int(op.batch)
+    seq_len = int(op.seq_len)
+    n_heads = int(op.n_heads)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
+
+    tokens = batch * seq_len * n_heads
+    # bias add + softplus (~4 flops) + clamp + dt * A + cumsum add
+    flops = 8 * tokens
+    nbytes = (
+        tokens * 4                 # dt (float32, read)
+        + 2 * n_heads * 4          # A + dt_bias (float32, read)
+        + tokens * elem_bytes      # dt_out (target dtype, write)
+        + tokens * 4               # dA_cumsum (float32, write)
+    )
+    return int(flops), int(nbytes)
+
+
+def cb_producer_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the causal C@B coupling-matrix producer."""
+    batch = int(op.batch)
+    num_chunks = int(op.num_chunks)
+    n_groups = int(op.n_groups)
+    chunk_len = int(op.chunk_len)
+    d_state = int(op.d_state)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
+
+    seq_len = num_chunks * chunk_len
+    # Causal masking halves the 2*Q*Q*N GEMM work per (batch, chunk, group).
+    flops = batch * num_chunks * n_groups * chunk_len * chunk_len * d_state
+    nbytes = (
+        2 * batch * seq_len * n_groups * d_state * elem_bytes         # C, B
+        + batch * num_chunks * n_groups * chunk_len**2 * elem_bytes   # cb
+    )
+    return int(flops), int(nbytes)
+
+
+def ssd_chunk_state_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the SSD per-chunk state computation."""
+    batch = int(op.batch)
+    num_chunks = int(op.num_chunks)
+    chunk_len = int(op.chunk_len)
+    n_heads = int(op.n_heads)
+    d_head = int(op.d_head)
+    d_state = int(op.d_state)
+    n_groups = int(op.n_groups)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
+
+    seq_len = num_chunks * chunk_len
+    tokens = batch * seq_len * n_heads
+    # Per (batch, chunk, head): (P x Q) @ (Q x N) GEMM; plus per-token decay
+    # weights (exp + mul) and x row scaling.
+    flops = (
+        2 * batch * num_chunks * n_heads * d_head * d_state * chunk_len
+        + 4 * tokens
+        + tokens * d_head
+    )
+    nbytes = (
+        tokens * d_head * elem_bytes                            # x
+        + batch * seq_len * n_groups * d_state * elem_bytes     # Bmat
+        + tokens * elem_bytes                                   # dt
+        + tokens * 4                                            # dA_cumsum
+        + batch * seq_len * 4                                   # seq_idx
+        + batch * num_chunks * n_heads * d_head * d_state * 4   # states out
+    )
+    return int(flops), int(nbytes)
+
+
+def ssd_state_passing_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the SSD inter-chunk recurrent state scan."""
+    batch = int(op.batch)
+    num_chunks = int(op.num_chunks)
+    n_heads = int(op.n_heads)
+    d_state = int(op.d_state)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
+
+    state_elems = batch * num_chunks * n_heads * d_state
+    # exp-scaled multiply-add per state element along the chunk scan.
+    flops = 3 * state_elems
+    nbytes = (
+        state_elems * elem_bytes                 # states (read)
+        + batch * n_heads * num_chunks * 4       # dA_chunk_cumsum
+        + batch * n_heads * d_state * 4          # initial_states
+        + state_elems * 4                        # out (float32)
+        + batch * n_heads * d_state * 4          # final_states
+    )
+    return int(flops), int(nbytes)
+
+
+def ssd_chunk_scan_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the fused SSD chunk output scan."""
+    batch = int(op.batch)
+    num_chunks = int(op.num_chunks)
+    chunk_len = int(op.chunk_len)
+    n_heads = int(op.n_heads)
+    d_head = int(op.d_head)
+    d_state = int(op.d_state)
+    n_groups = int(op.n_groups)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
+
+    seq_len = num_chunks * chunk_len
+    tokens = batch * seq_len * n_heads
+    # History path: per-token (1 x N) @ (N x P); intra-chunk path: causal
+    # (Q x Q) @ (Q x P) per (batch, chunk, head) — causal masking halves it.
+    flops = (
+        2 * tokens * d_state * d_head
+        + batch * num_chunks * n_heads * chunk_len**2 * d_head
+    )
+    nbytes = (
+        tokens * d_head * elem_bytes                                 # x
+        + batch * num_chunks * n_groups * chunk_len**2 * elem_bytes  # cb
+        + tokens * 4                                                 # dA_cumsum
+        + batch * seq_len * n_groups * d_state * elem_bytes          # C
+        + batch * num_chunks * n_heads * d_head * d_state * 4        # prev_states
+        + tokens * elem_bytes                                        # dt
+        + tokens * d_head * 4                                        # y out
+    )
+    return int(flops), int(nbytes)
+
+
+def ssd_decode_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the single-token Mamba-2 SSD decode step."""
+    batch = int(op.batch)
+    n_heads = int(op.n_heads)
+    d_head = int(op.d_head)
+    d_state = int(op.d_state)
+    n_groups = int(op.n_groups)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
+
+    state_elems = batch * n_heads * d_head * d_state
+    # Per state element: exp(dt * A), decay multiply, dt*B*x fused
+    # multiply-add, and the output dot against C.
+    flops = 6 * state_elems
+    nbytes = (
+        n_heads * d_head * d_state * 4          # A
+        + batch * n_heads * d_head * 4          # dt
+        + batch * n_heads * d_head * elem_bytes  # x
+        + 2 * batch * n_groups * d_state * elem_bytes  # B_in, C_in
+        + 2 * state_elems * 4                   # state (read + write)
+        + batch * n_heads * d_head * 4          # y_out
+    )
+    return int(flops), int(nbytes)
+
+
+def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
+    """Roofline for the end-to-end Mamba-2 SSD forward pass.
+
+    Sums the DaCumsum, CB-producer, chunk-state, state-passing (over the
+    flattened ``d_head * d_state`` dimension), and chunk-scan stage costs.
+    Valid only after the first ``forward()``.
+    """
+    batch = int(op.batch)
+    seq_len = int(op.seqlen)
+    num_chunks = int(op.num_chunks)
+    chunk_len = int(op.chunk_size)
+    n_heads = int(op.n_heads)
+    d_head = int(op.d_head)
+    d_state = int(op.d_state)
+    n_groups = int(op.n_groups)
+    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
+
+    tokens = batch * seq_len * n_heads
+    state_elems = batch * num_chunks * n_heads * d_head * d_state
+    flops = (
+        8 * tokens                                                       # da_cumsum
+        + batch * num_chunks * n_groups * chunk_len**2 * d_state         # cb (causal)
+        + 2 * batch * num_chunks * n_heads * d_head * d_state * chunk_len  # chunk_state
+        + 3 * state_elems                                                # state_passing
+        + 2 * tokens * d_state * d_head                                  # scan history
+        + batch * num_chunks * n_heads * chunk_len**2 * d_head           # scan intra (causal)
+    )
+    nbytes = (
+        tokens * d_head * elem_bytes                                 # x
+        + tokens * 4                                                 # dt
+        + 2 * batch * seq_len * n_groups * d_state * elem_bytes      # B, C
+        + 2 * n_heads * 4                                            # A, dt_bias
+        # dominant intermediates: cb, chunk states (read + write), dt_out,
+        # dA_cumsum
+        + batch * num_chunks * n_groups * chunk_len**2 * elem_bytes
+        + 2 * state_elems * 4
+        + tokens * elem_bytes
+        + tokens * 4
+        + tokens * d_head * 4                                        # y out
+    )
     return int(flops), int(nbytes)

--- a/tileops/perf/formulas.py
+++ b/tileops/perf/formulas.py
@@ -1272,26 +1272,22 @@ def bmm_fp8_fwd_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
+
+
 # Mamba-2 / State-Space Dual (SSD) family
+#
+# Conditional tensor presence (dt_bias / seq_idx / initial_states) is modeled
+# as variant_of manifest entries, so each variant binds its own public
+# roofline function with the presence hard-wired; the shared arithmetic lives
+# in private per-stage cost helpers.
 
 
-def da_cumsum_fwd_roofline(op: "Op") -> tuple[int, int]:
-    """Roofline for the Mamba-2 dA_cumsum forward stage.
-
-    Elementwise dt preprocessing (bias add, softplus, clamp, dt * A) plus a
-    chunk-local inclusive prefix sum. Valid only after the first ``forward()``
-    (batch / seq_len / n_heads are inferred from the inputs then).
-    """
-    batch = int(op.batch)
-    seq_len = int(op.seq_len)
-    n_heads = int(op.n_heads)
-    has_dt_bias = bool(getattr(op, "has_dt_bias", False))
-    dt_softplus = bool(getattr(op, "dt_softplus", False))
-    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
-
+def _da_cumsum_fwd_cost(batch: int, seq_len: int, n_heads: int,
+                        elem_bytes: int, *, has_dt_bias: bool,
+                        dt_softplus: bool) -> tuple[int, int]:
     tokens = batch * seq_len * n_heads
     # Unconditional: clamp + dt * A + cumsum add; bias add (+1) and
-    # softplus (~4 flops) only when the op is configured with them.
+    # softplus (~4 flops) only when configured.
     flops = (3 + (1 if has_dt_bias else 0) + (4 if dt_softplus else 0)) * tokens
     nbytes = (
         tokens * 4                 # dt (float32, read)
@@ -1301,6 +1297,29 @@ def da_cumsum_fwd_roofline(op: "Op") -> tuple[int, int]:
         + tokens * 4               # dA_cumsum (float32, write)
     )
     return int(flops), int(nbytes)
+
+
+def da_cumsum_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the Mamba-2 dA_cumsum forward stage (no dt bias).
+
+    Elementwise dt preprocessing (softplus, clamp, dt * A) plus a chunk-local
+    inclusive prefix sum. Valid only after the first ``forward()`` (batch /
+    seq_len / n_heads are inferred from the inputs then).
+    """
+    return _da_cumsum_fwd_cost(
+        int(op.batch), int(op.seq_len), int(op.n_heads),
+        _dtype_itemsize(getattr(op, "dtype", "float32")),
+        has_dt_bias=False,
+        dt_softplus=bool(getattr(op, "dt_softplus", False)))
+
+
+def da_cumsum_bias_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the dt_bias-consuming dA_cumsum variant."""
+    return _da_cumsum_fwd_cost(
+        int(op.batch), int(op.seq_len), int(op.n_heads),
+        _dtype_itemsize(getattr(op, "dtype", "float32")),
+        has_dt_bias=True,
+        dt_softplus=bool(getattr(op, "dt_softplus", False)))
 
 
 def cb_producer_roofline(op: "Op") -> tuple[int, int]:
@@ -1322,17 +1341,10 @@ def cb_producer_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
-def ssd_chunk_state_fwd_roofline(op: "Op") -> tuple[int, int]:
-    """Roofline for the SSD per-chunk state computation."""
-    batch = int(op.batch)
-    num_chunks = int(op.num_chunks)
-    chunk_len = int(op.chunk_len)
-    n_heads = int(op.n_heads)
-    d_head = int(op.d_head)
-    d_state = int(op.d_state)
-    n_groups = int(op.n_groups)
-    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
-
+def _ssd_chunk_state_fwd_cost(batch: int, num_chunks: int, chunk_len: int,
+                              n_heads: int, d_head: int, d_state: int,
+                              n_groups: int, elem_bytes: int, *,
+                              has_seq_idx: bool) -> tuple[int, int]:
     seq_len = num_chunks * chunk_len
     tokens = batch * seq_len * n_heads
     # Per (batch, chunk, head): (P x Q) @ (Q x N) GEMM; plus per-token decay
@@ -1347,20 +1359,33 @@ def ssd_chunk_state_fwd_roofline(op: "Op") -> tuple[int, int]:
         + batch * seq_len * n_groups * d_state * elem_bytes     # Bmat
         + tokens * elem_bytes                                   # dt
         + tokens * 4                                            # dA_cumsum
-        + (batch * seq_len * 4 if bool(getattr(op, "has_seq_idx", False)) else 0)  # seq_idx
+        + (batch * seq_len * 4 if has_seq_idx else 0)           # seq_idx
         + batch * num_chunks * n_heads * d_head * d_state * 4   # states out
     )
     return int(flops), int(nbytes)
 
 
-def ssd_state_passing_fwd_roofline(op: "Op") -> tuple[int, int]:
-    """Roofline for the SSD inter-chunk recurrent state scan."""
-    batch = int(op.batch)
-    num_chunks = int(op.num_chunks)
-    n_heads = int(op.n_heads)
-    d_state = int(op.d_state)
-    elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float32"))
+def ssd_chunk_state_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the SSD per-chunk state computation (no seq_idx)."""
+    return _ssd_chunk_state_fwd_cost(
+        int(op.batch), int(op.num_chunks), int(op.chunk_len),
+        int(op.n_heads), int(op.d_head), int(op.d_state), int(op.n_groups),
+        _dtype_itemsize(getattr(op, "dtype", "float16")),
+        has_seq_idx=False)
 
+
+def ssd_chunk_state_seq_idx_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the seq_idx-consuming SSD chunk-state variant."""
+    return _ssd_chunk_state_fwd_cost(
+        int(op.batch), int(op.num_chunks), int(op.chunk_len),
+        int(op.n_heads), int(op.d_head), int(op.d_state), int(op.n_groups),
+        _dtype_itemsize(getattr(op, "dtype", "float16")),
+        has_seq_idx=True)
+
+
+def _ssd_state_passing_fwd_cost(batch: int, num_chunks: int, n_heads: int,
+                                d_state: int, elem_bytes: int, *,
+                                has_initial_states: bool) -> tuple[int, int]:
     state_elems = batch * num_chunks * n_heads * d_state
     # Multiply-add per state element along the chunk scan; the decay scalar
     # exp(dA_chunk_cumsum[b, h, c]) is computed once per (batch, head, chunk)
@@ -1370,11 +1395,27 @@ def ssd_state_passing_fwd_roofline(op: "Op") -> tuple[int, int]:
         state_elems * elem_bytes                 # states (read)
         + batch * n_heads * num_chunks * 4       # dA_chunk_cumsum
         + (batch * n_heads * d_state * 4         # initial_states
-           if bool(getattr(op, "has_initial_states", True)) else 0)
+           if has_initial_states else 0)
         + state_elems * 4                        # out (float32)
         + batch * n_heads * d_state * 4          # final_states
     )
     return int(flops), int(nbytes)
+
+
+def ssd_state_passing_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the SSD inter-chunk state scan (zero initial state)."""
+    return _ssd_state_passing_fwd_cost(
+        int(op.batch), int(op.num_chunks), int(op.n_heads), int(op.d_state),
+        _dtype_itemsize(getattr(op, "dtype", "float32")),
+        has_initial_states=False)
+
+
+def ssd_state_passing_init_states_fwd_roofline(op: "Op") -> tuple[int, int]:
+    """Roofline for the initial_states-seeded SSD state-scan variant."""
+    return _ssd_state_passing_fwd_cost(
+        int(op.batch), int(op.num_chunks), int(op.n_heads), int(op.d_state),
+        _dtype_itemsize(getattr(op, "dtype", "float32")),
+        has_initial_states=True)
 
 
 def ssd_chunk_scan_fwd_roofline(op: "Op") -> tuple[int, int]:
@@ -1433,13 +1474,8 @@ def ssd_decode_roofline(op: "Op") -> tuple[int, int]:
     return int(flops), int(nbytes)
 
 
-def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
-    """Roofline for the end-to-end Mamba-2 SSD forward pass.
-
-    Sums the DaCumsum, CB-producer, chunk-state, state-passing (over the
-    flattened ``d_head * d_state`` dimension), and chunk-scan stage costs.
-    Valid only after the first ``forward()``.
-    """
+def _mamba2_fwd_cost(op: Any, *, has_dt_bias: bool,
+                     has_initial_states: bool) -> tuple[int, int]:
     batch = int(op.batch)
     seq_len = int(op.seqlen)
     num_chunks = int(op.num_chunks)
@@ -1449,22 +1485,23 @@ def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
     d_state = int(op.d_state)
     n_groups = int(op.n_groups)
     elem_bytes = _dtype_itemsize(getattr(op, "dtype", "float16"))
-
-    has_dt_bias = bool(getattr(op, "has_dt_bias", False))
     dt_softplus = bool(getattr(op, "dt_softplus", False))
-    has_initial_states = bool(getattr(op, "has_initial_states", False))
 
     tokens = batch * seq_len * n_heads
     state_elems = batch * num_chunks * n_heads * d_head * d_state
-    # FLOPs are the exact sum of the five standalone stage formulas, with the
-    # state-passing stage running over the flattened d_head * d_state dim.
+    # FLOPs are the exact sum of the five standalone stage cost helpers, with
+    # the state-passing stage running over the flattened d_head * d_state dim.
     flops = (
-        # da_cumsum: clamp + dt*A + cumsum, plus configured bias/softplus
-        (3 + (1 if has_dt_bias else 0) + (4 if dt_softplus else 0)) * tokens
+        _da_cumsum_fwd_cost(batch, seq_len, n_heads, elem_bytes,
+                            has_dt_bias=has_dt_bias,
+                            dt_softplus=dt_softplus)[0]
         + batch * num_chunks * n_groups * chunk_len**2 * d_state         # cb (causal)
-        + 2 * batch * num_chunks * n_heads * d_head * d_state * chunk_len  # chunk_state GEMM
-        + 4 * tokens + tokens * d_head                                   # chunk_state decay + x scaling
-        + 2 * state_elems + batch * n_heads * num_chunks                 # state_passing
+        + _ssd_chunk_state_fwd_cost(batch, num_chunks, chunk_len, n_heads,
+                                    d_head, d_state, n_groups, elem_bytes,
+                                    has_seq_idx=False)[0]
+        + _ssd_state_passing_fwd_cost(batch, num_chunks, n_heads,
+                                      d_head * d_state, elem_bytes,
+                                      has_initial_states=has_initial_states)[0]
         + 2 * tokens * d_state * d_head                                  # scan history
         + batch * num_chunks * n_heads * chunk_len**2 * d_head           # scan intra (causal)
     )
@@ -1485,3 +1522,30 @@ def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
         + tokens * d_head * 4                                        # y out
     )
     return int(flops), int(nbytes)
+
+
+def mamba2_fwd_roofline(op: Any) -> tuple[int, int]:
+    """Roofline for the end-to-end Mamba-2 SSD forward (no dt_bias, zero
+    initial state).
+
+    Sums the DaCumsum, CB-producer, chunk-state, state-passing (over the
+    flattened ``d_head * d_state`` dimension), and chunk-scan stage costs.
+    Valid only after the first ``forward()``.
+    """
+    return _mamba2_fwd_cost(op, has_dt_bias=False, has_initial_states=False)
+
+
+def mamba2_bias_fwd_roofline(op: Any) -> tuple[int, int]:
+    """Roofline for the dt_bias-consuming Mamba-2 forward variant."""
+    return _mamba2_fwd_cost(op, has_dt_bias=True, has_initial_states=False)
+
+
+def mamba2_init_states_fwd_roofline(op: Any) -> tuple[int, int]:
+    """Roofline for the initial_states-seeded Mamba-2 forward variant."""
+    return _mamba2_fwd_cost(op, has_dt_bias=False, has_initial_states=True)
+
+
+def mamba2_bias_init_states_fwd_roofline(op: Any) -> tuple[int, int]:
+    """Roofline for the Mamba-2 forward variant with dt_bias and
+    initial_states both present."""
+    return _mamba2_fwd_cost(op, has_dt_bias=True, has_initial_states=True)


### PR DESCRIPTION
Closes #1771

## Summary

- Add `tileops/manifest/mamba.yaml`: manifest entries for all 7 mamba/SSD ops (signature, params, shape_rules, >=2 curated Mamba-2 workloads, func-mode roofline, `source` pointers).
- Add the family's func-mode roofline formulas in `tileops/perf/formulas.py`; manifest codegen installs `eval_roofline` / `_validate_dtypes` on the implemented ops.
- 4 ops ship `status: implemented` (SSDChunkStateFwdOp, SSDStatePassingFwdOp, SSDChunkScanFwdOp, SSDDecodeOp); 3 ship `spec-only` per the trust-model status-flip rule (DaCumsumFwdOp, CBProducerOp: strict ctor-parity drift; Mamba2FwdOp: not an Op-protocol class). Code-side conformance and promotion tracked in #1774.

## Test plan

- [x] Modified files pass unit tests
- [x] AC-1: every mamba/SSD op resolves through load_manifest with validator passing
- [x] AC-2: each entry has >=2 workloads and a roofline consumed by eval_roofline

AC-1/AC-2 read per the issue Plan's "fix code-side drift via status flips" rule: implemented entries pass strict per-op validation and numeric `eval_roofline` checks; the 3 spec-only entries keep full signatures, workloads, and resolvable `roofline.func`, consumed on promotion (#1774).
