### PR TITLE
[Refactor][Tooling] table-driven validator checks, shared emit/probe helpers, case-table tests

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -162,26 +162,12 @@ def _check_shape_rule_callables(
 ) -> list[str]:
     """Validate that bare-name calls in a shape_rule reference known helpers.
 
-    Parses ``rule_str`` as a Python expression and walks the AST. For each
-    ``ast.Call`` whose ``func`` is a bare ``ast.Name``, verify the name is
-    registered in ``_SHAPE_RULE_BUILTINS``. Method calls
-    (``x.foo(y)`` -> ``func`` is ``ast.Attribute``) and subscript calls
-    (``f[0](x)``) are skipped — only direct name lookups are validated.
-
-    A ``SyntaxError`` on parse surfaces as a single ``[schema]`` error so
-    typos and malformed rules are rejected at L0 without requiring the L2
-    eval context.
-
-    Args:
-        op_name: Op key being validated, used in error messages.
-        index: Index of the rule within ``signature.shape_rules`` for the
-            ``shape_rules[<i>]`` locator in error messages.
-        rule_str: The shape_rule expression source.
-
-    Returns:
-        A list of ``[schema]``-prefixed error strings. Empty when the rule
-        parses cleanly and every bare-name call resolves to a registered
-        builtin.
+    Walks the parsed rule AST; every ``ast.Call`` whose ``func`` is a
+    bare ``ast.Name`` must be registered in ``_SHAPE_RULE_BUILTINS``.
+    Method / subscript calls are skipped — only direct name lookups are
+    validated. A ``SyntaxError`` surfaces as a single ``[schema]`` error
+    so malformed rules are rejected at L0 without the L2 eval context.
+    Returns ``[schema]``-prefixed error strings (empty when clean).
     """
     errors: list[str] = []
     try:
@@ -720,14 +706,11 @@ def check_variant_of_consistency(
 ) -> list[str]:
     """Validate variant_of references across all entries.
 
-    Per R16:
-    - variant_of must reference an existing op in the manifest.
-    - Single-level: the primary (referenced) entry must NOT itself have
-      variant_of (no chaining).
-    - Variant and primary must share source.kernel and source.op.
-
-    When *scope* is given, only ops whose names are in *scope* are checked;
-    lookups into *ops* still use the full dict so reference resolution works.
+    Per R16: variant_of must reference an existing op; the primary must
+    not itself be a variant (no chaining); variant and primary must
+    share source.kernel and source.op. When *scope* is given, only ops
+    named in *scope* are checked; lookups still use the full dict so
+    reference resolution works.
     """
     errors: list[str] = []
 
@@ -796,25 +779,16 @@ def check_l1_signature(
     appear in ``forward()`` in declaration order. Every ``static_dims`` key
     must appear as an ``__init__()`` parameter (per R20).
 
-    Args:
-        op_name: Manifest op name.
-        manifest_inputs: The signature.inputs dict from manifest.
-        manifest_params: The signature.params dict from manifest.
-        forward_params: List of parameter names from Op.forward() (excluding 'self').
-        init_params: List of parameter names from Op.__init__() (excluding 'self').
-            When None, treated as empty (only forward is checked).
-        manifest_static_dims: The signature.static_dims dict from manifest (may be None).
-
-    Returns:
-        List of error strings (empty if OK).
+    ``init_params=None`` is treated as empty (only forward is checked).
     """
     errors: list[str] = []
+    err = _emit_to(errors, "signature", op_name)
 
     # Guard: manifest_params must be a dict (schema should catch this, but be safe)
     if not isinstance(manifest_params, dict):
-        errors.append(
-            f"[signature] {op_name}: signature.params is not a mapping, "
-            f"cannot validate forward() consistency"
+        err(
+            "signature.params is not a mapping, cannot validate "
+            "forward() consistency"
         )
         return errors
 
@@ -828,33 +802,32 @@ def check_l1_signature(
         name for name in manifest_params.keys() if name in forward_params
     ]
     if forward_params != expected:
-        errors.append(
-            f"[signature] {op_name}: forward() params {forward_params} do not match "
+        err(
+            f"forward() params {forward_params} do not match "
             f"manifest order {expected}"
         )
 
-    # 2. Strict subset check: every manifest param must exist in init OR forward
+    # Strict subset check: every manifest param must exist in init OR forward
     code_params = set(forward_params) | set(init_params)
     for pname in manifest_params:
         if pname not in code_params:
-            errors.append(
-                f"[signature] {op_name}: manifest param {pname!r} not found in "
-                f"__init__() or forward() parameters"
+            err(
+                f"manifest param {pname!r} not found in __init__() or "
+                f"forward() parameters"
             )
 
-    # 3. static_dims check (R20): every static_dims key must be an __init__ param
+    # static_dims check (R20): every static_dims key must be an __init__ param
     if manifest_static_dims:
         if not isinstance(manifest_static_dims, dict):
-            errors.append(
-                f"[signature] {op_name}: signature.static_dims is not a mapping"
-            )
+            err("signature.static_dims is not a mapping")
         else:
             init_param_set = set(init_params)
             for dim_name in manifest_static_dims:
                 if dim_name not in init_param_set:
-                    errors.append(
-                        f"[signature] {op_name}: static_dims key {dim_name!r} not found in "
-                        f"__init__() parameters (R20: static_dims keys are required __init__ params)"
+                    err(
+                        f"static_dims key {dim_name!r} not found in "
+                        f"__init__() parameters (R20: static_dims keys "
+                        f"are required __init__ params)"
                     )
 
     return errors
@@ -874,13 +847,10 @@ class _ResolveResult:
 def _resolve_op_class(op_file: str, op_name: str) -> _ResolveResult:
     """Try to import the Op class from the source.op file.
 
-    Returns a _ResolveResult with:
-      - cls set if the Op class was found
-      - import_error=True if the module could not be imported due to
-        missing dependencies (ImportError / ModuleNotFoundError)
+    Returns a _ResolveResult: ``cls`` set when found; ``import_error``
+    True when the module could not be imported (missing dependencies).
     """
-    # Convert file path to module path
-    # e.g., "tileops/ops/norm/rms_norm.py" -> "tileops.ops.norm.rms_norm"
+    # "tileops/ops/norm/rms_norm.py" -> "tileops.ops.norm.rms_norm"
     mod_path = op_file.replace("/", ".").replace(".py", "")
     try:
         mod = importlib.import_module(mod_path)
@@ -889,8 +859,7 @@ def _resolve_op_class(op_file: str, op_name: str) -> _ResolveResult:
     except Exception:
         return _ResolveResult()
 
-    # Find Op subclass in the module. We look for classes defined in this module
-    # that have a forward() method.
+    # Candidates: classes defined in this module with a forward() method.
     seen_ids: set[int] = set()
     candidates = []
     for _name, obj in inspect.getmembers(mod, inspect.isclass):
@@ -1027,15 +996,7 @@ def check_l1(
     """Signature check: resolve Op class and compare forward() to manifest.
 
     Checks both ``__init__()`` and ``forward()`` parameter names against
-    the manifest signature.
-
-    Args:
-        op_name: Manifest op name.
-        entry: The manifest entry dict.
-        warnings: Optional list to append warning messages to.
-
-    Returns:
-        List of error strings (empty if OK).
+    the manifest signature. Returns error strings (empty if OK).
     """
     errors: list[str] = []
     sig = entry.get("signature", {})
@@ -1169,15 +1130,13 @@ def _validate_dtype_token(
 
 
 def _build_same_as_map(all_tensors: dict) -> dict[str, str]:
-    """Build a mapping from tensor name to its same_as reference target.
+    """Map tensor name → same_as reference target for pure same_as dtypes.
 
-    For each tensor whose dtype is ``same_as(ref)``, maps tensor → ref.
-    Only pure same_as dtypes are tracked (not ``float16 | same_as(x)``).
+    Mixed expressions (``float16 | same_as(x)``) are not tracked.
     """
     same_as_map: dict[str, str] = {}
     for tname, attrs in all_tensors.items():
-        dtype_str = attrs.get("dtype", "")
-        tokens = _parse_dtype_expr(dtype_str)
+        tokens = _parse_dtype_expr(attrs.get("dtype", ""))
         if len(tokens) == 1:
             m = _SAME_AS_RE.match(tokens[0])
             if m:
@@ -1188,12 +1147,13 @@ def _build_same_as_map(all_tensors: dict) -> dict[str, str]:
 def _check_dtype_combos_same_as_identity(
     op_name: str, dtype_combos: list, same_as_map: dict[str, str],
 ) -> list[str]:
-    """Enforce same_as identity constraint in dtype_combos entries.
+    """Enforce same_as identity in dtype_combos entries (R3).
 
-    For each dtype_combos entry, every tensor bound by same_as(ref) must
-    have the exact same dtype as its reference tensor (R3 identity constraint).
+    Every tensor bound by same_as(ref) must have the exact same dtype as
+    its reference tensor in every combo row.
     """
     errors: list[str] = []
+    err = _emit_to(errors, "dtype", op_name)
     for i, combo in enumerate(dtype_combos):
         if not isinstance(combo, dict):
             continue
@@ -1201,17 +1161,16 @@ def _check_dtype_combos_same_as_identity(
             t_in = tensor in combo
             r_in = ref in combo
             if t_in and r_in and combo[tensor] != combo[ref]:
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}] violates "
-                    f"same_as identity constraint — {tensor} "
-                    f"({combo[tensor]}) must match {ref} "
-                    f"({combo[ref]}) per R3"
+                err(
+                    f"dtype_combos[{i}] violates same_as identity "
+                    f"constraint — {tensor} ({combo[tensor]}) must match "
+                    f"{ref} ({combo[ref]}) per R3"
                 )
             elif t_in and not r_in:
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}] has "
-                    f"same_as-bound tensor '{tensor}' without its "
-                    f"reference '{ref}' — cannot verify identity"
+                err(
+                    f"dtype_combos[{i}] has same_as-bound tensor "
+                    f"'{tensor}' without its reference '{ref}' — cannot "
+                    f"verify identity"
                 )
     return errors
 
@@ -1223,6 +1182,7 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
     Also enforces same_as identity constraint in dtype_combos (R3).
     """
     errors: list[str] = []
+    err = _emit_to(errors, "dtype", op_name)
     sig = entry.get("signature", {})
     raw_inputs = sig.get("inputs")
     raw_outputs = sig.get("outputs")
@@ -1235,39 +1195,34 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
     tensor_names = set(all_tensors.keys())
     input_names = set(inputs.keys())
 
-    # Validate signature tensor dtypes. ``promote_int_to_float`` is an
-    # output-side-only construct (R3a) — reject it on input tensors.
+    # Signature tensor dtypes. ``promote_int_to_float`` is output-side
+    # only (R3a) — reject it on input tensors.
     for tname, attrs in all_tensors.items():
         if not isinstance(attrs, dict):
             continue
-        dtype_str = attrs.get("dtype", "")
-        tokens = _parse_dtype_expr(dtype_str)
-        is_input = tname in input_names
-        for token in tokens:
-            err = _validate_dtype_token(
+        for token in _parse_dtype_expr(attrs.get("dtype", "")):
+            token_err = _validate_dtype_token(
                 op_name, tname, token, tensor_names,
-                allow_promote_int_to_float=not is_input,
+                allow_promote_int_to_float=tname not in input_names,
                 input_tensor_names=input_names,
             )
-            if err:
-                errors.append(err)
+            if token_err:
+                errors.append(token_err)
 
-    # Validate same_as identity constraint in dtype_combos (R3)
+    # same_as identity constraint in dtype_combos (R3)
     dtype_combos = sig.get("dtype_combos", [])
     if isinstance(dtype_combos, list) and dtype_combos:
         same_as_map = _build_same_as_map(all_tensors)
         errors.extend(
             _check_dtype_combos_same_as_identity(op_name, dtype_combos, same_as_map)
         )
-        # Hard data-validation for combo values: every combo entry must
-        # resolve to a concrete torch dtype (or a ``same_as(ref)`` whose
-        # ref resolves to concrete torch dtypes). Runs unconditionally —
+        # Hard data-validation for combo values, run unconditionally —
         # independent of whether the op overrides ``_validate_dtypes`` —
         # so an un-migrated op carrying invalid combo data still surfaces
         # a hard L3 error rather than only a missing-override warning.
         errors.extend(check_l3_dtype_combos_data(op_name, sig))
 
-    # Validate workload dtypes
+    # Workload dtypes
     workloads = entry.get("workloads", [])
     if isinstance(workloads, list):
         for i, w in enumerate(workloads):
@@ -1278,20 +1233,16 @@ def check_l3(op_name: str, entry: dict) -> list[str]:
                 continue
             for j, dt in enumerate(dtypes):
                 if not isinstance(dt, str):
-                    errors.append(
-                        f"[dtype] {op_name}: workloads[{i}].dtypes[{j}] "
-                        f"is not a string"
-                    )
+                    err(f"workloads[{i}].dtypes[{j}] is not a string")
                     continue
-                tokens = _parse_dtype_expr(dt)
-                for token in tokens:
-                    err = _validate_dtype_token(
+                for token in _parse_dtype_expr(dt):
+                    token_err = _validate_dtype_token(
                         op_name, f"workloads[{i}].dtypes[{j}]",
                         token, tensor_names,
                         allow_promote_int_to_float=False,
                     )
-                    if err:
-                        errors.append(err)
+                    if token_err:
+                        errors.append(token_err)
 
     return errors
 
@@ -1310,6 +1261,7 @@ def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
         to nothing — generic fallback, so callers are never left guessing.
     """
     errors: list[str] = []
+    err = _emit_to(errors, "dtype", op_name)
     inputs = sig.get("inputs") or {}
     outputs = sig.get("outputs") or {}
     all_tensors: dict[str, dict] = {}
@@ -1318,9 +1270,9 @@ def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
     if isinstance(outputs, dict):
         all_tensors.update(outputs)
 
-    # Pure ``same_as(ref)`` edges only — mixed expressions (``float16 |
-    # same_as(x)``) are not part of the cycle graph; a cycle in pure edges
-    # is what makes fixpoint resolution stall.
+    # Pure ``same_as(ref)`` edges only — mixed expressions are not part
+    # of the cycle graph; a cycle in pure edges is what stalls fixpoint
+    # resolution.
     edges: dict[str, str] = {}
     for tname, attrs in all_tensors.items():
         if not isinstance(attrs, dict):
@@ -1335,17 +1287,16 @@ def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
     dangling: set[str] = set()
     for tname, ref in edges.items():
         if ref not in all_tensors:
-            errors.append(
-                f"[dtype] {op_name}: signature.inputs/outputs — tensor "
-                f"{tname!r} declares dtype same_as({ref}) but {ref!r} is "
-                f"not a declared tensor (dangling reference; combo "
-                f"validation cannot proceed)"
+            err(
+                f"signature.inputs/outputs — tensor {tname!r} declares "
+                f"dtype same_as({ref}) but {ref!r} is not a declared "
+                f"tensor (dangling reference; combo validation cannot "
+                f"proceed)"
             )
             dangling.add(tname)
 
-    # Cycle detection via DFS over pure same_as edges. Only tensors that
-    # have not already been reported as dangling are considered (a chain
-    # ending in a dangling ref is not a cycle).
+    # Cycle detection via DFS over pure same_as edges. A chain ending in
+    # a dangling ref is not a cycle.
     reported_cycles: set[frozenset[str]] = set()
     visited: set[str] = set()
     for start in edges:
@@ -1360,9 +1311,8 @@ def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
                 key = frozenset(cycle_nodes)
                 if key not in reported_cycles:
                     reported_cycles.add(key)
-                    errors.append(
-                        f"[dtype] {op_name}: same_as cycle detected "
-                        f"among tensors "
+                    err(
+                        f"same_as cycle detected among tensors "
                         f"{sorted(cycle_nodes)} — dtype options cannot "
                         f"be resolved (combo validation skipped)"
                     )
@@ -1380,15 +1330,15 @@ def _diagnose_unresolvable_signature(op_name: str, sig: dict) -> list[str]:
         visited.update(path)
 
     if not errors:
-        # Fixpoint failed but we cannot pinpoint a cycle or dangling edge
-        # (e.g. a mixed expression containing an unknown token that did
-        # not trip per-token validation). Emit a generic hard error so
-        # combo validation is never silently skipped.
-        errors.append(
-            f"[dtype] {op_name}: could not resolve signature.inputs/outputs "
-            f"dtype options — combo validation cannot proceed. Check "
-            f"signature.inputs/outputs dtype declarations for unresolved "
-            f"same_as references or malformed expressions."
+        # Fixpoint failed but no cycle or dangling edge was found (e.g. a
+        # mixed expression containing an unknown token that did not trip
+        # per-token validation). Emit a generic hard error so combo
+        # validation is never silently skipped.
+        err(
+            "could not resolve signature.inputs/outputs dtype options — "
+            "combo validation cannot proceed. Check "
+            "signature.inputs/outputs dtype declarations for unresolved "
+            "same_as references or malformed expressions."
         )
     return errors
 
@@ -1397,29 +1347,24 @@ def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
     """Validate ``dtype_combos`` entries resolve to concrete torch dtypes.
 
     Manifest-data check, independent of any op class / ``_validate_dtypes``
-    implementation. Every combo value must be either:
-      * a concrete dtype name in ``_TORCH_DTYPES``; or
-      * a ``same_as(ref)`` expression whose ref resolves transitively to
-        concrete dtype names.
-
-    Anything else (e.g. ``"not_a_real_dtype"``, ``same_as(unknown)``) is a
+    implementation. Every combo value must be either a concrete dtype
+    name in ``_TORCH_DTYPES`` or a ``same_as(ref)`` expression whose ref
+    resolves transitively to concrete dtype names. Anything else is a
     hard L3 error — callers must not silently proceed with invalid combo
     data.
     """
     errors: list[str] = []
+    err = _emit_to(errors, "dtype", op_name)
     dtype_combos = sig.get("dtype_combos")
     if not isinstance(dtype_combos, list) or not dtype_combos:
         return errors
     dtype_options = _resolve_tensor_dtype_options(sig)
     if dtype_options is None:
-        # Unresolvable signature. Previously this branch returned silently
-        # under the assumption that ``check_l3`` had already flagged the
-        # culprit, but a pure ``same_as`` cycle (e.g. ``x: same_as(y)`` and
-        # ``y: same_as(x)``) satisfies per-token validation *and* the R3
-        # identity check, so combo validation would be silently skipped and
-        # invalid combo data would pass. Emit a hard L3 error with a
-        # specific diagnosis when possible (cycle / dangling reference),
-        # falling back to a generic unresolved-signature error otherwise.
+        # Unresolvable signature. A pure ``same_as`` cycle satisfies
+        # per-token validation *and* the R3 identity check, so returning
+        # silently here would let invalid combo data pass. Emit a hard
+        # L3 error with a specific diagnosis (cycle / dangling
+        # reference) when possible.
         errors.extend(_diagnose_unresolvable_signature(op_name, sig))
         return errors
     inputs = sig.get("inputs") or {}
@@ -1430,63 +1375,53 @@ def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
         if not isinstance(combo, dict):
             continue
         # Combo-row completeness: every declared signature.inputs tensor
-        # must be assigned a dtype in every combo row. Otherwise a combo
-        # row that silently omits an input would pass L3 when no
-        # ``_validate_dtypes`` override exists, since ``_combo_accepted``
-        # is never exercised for omitted inputs.
+        # must be assigned a dtype in every combo row; otherwise a row
+        # omitting an input would pass L3 when no ``_validate_dtypes``
+        # override exists (``_combo_accepted`` never runs for it).
         for input_name in declared_input_names:
             if input_name not in combo:
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}] is missing "
-                    f"declared input {input_name!r} (every combo row "
-                    f"must cover every signature.inputs tensor)"
+                err(
+                    f"dtype_combos[{i}] is missing declared input "
+                    f"{input_name!r} (every combo row must cover every "
+                    f"signature.inputs tensor)"
                 )
         for key, val in combo.items():
             if not isinstance(val, str):
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                    f"{val!r} is not a string"
-                )
+                err(f"dtype_combos[{i}].{key} = {val!r} is not a string")
                 continue
-            # Per manifest.md R4, each combo value must be a single
-            # concrete dtype token (or a ``same_as(ref)`` naming one
-            # sibling in the same combo row). Reject union expressions
-            # like ``"float16 | bfloat16"`` outright — a union in a
-            # combo row would let an implementation silently widen the
-            # accepted-dtype set beyond what the manifest authored.
+            # Per manifest.md R4, each combo value pins a single concrete
+            # dtype token (or a ``same_as(ref)`` naming a sibling in the
+            # same row). A union would let an implementation silently
+            # widen the accepted-dtype set beyond what was authored.
             if "|" in val:
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                    f"{val!r} — combo values must be a single concrete "
-                    f"dtype, not a union"
+                err(
+                    f"dtype_combos[{i}].{key} = {val!r} — combo values "
+                    f"must be a single concrete dtype, not a union"
                 )
                 continue
-            # promote_int_to_float(ref) is an output-side construct that
-            # may expand to multiple concrete dtypes (e.g. {float32,
-            # float16, bfloat16}). Combo rows must pin a single concrete
-            # dtype per tensor, so reject this DSL form on the combo-value
-            # side. Authors should expand the rows manually or use
-            # same_as(ref) when the dtype is genuinely identity-bound.
+            # promote_int_to_float(ref) may expand to multiple concrete
+            # dtypes, so it cannot pin a combo row either; authors expand
+            # the rows manually or use same_as(ref).
             if _PROMOTE_INT_TO_FLOAT_RE.match(val):
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                    f"{val!r} — combo values must be a single concrete "
-                    f"dtype; promote_int_to_float(...) is allowed only on "
+                err(
+                    f"dtype_combos[{i}].{key} = {val!r} — combo values "
+                    f"must be a single concrete dtype; "
+                    f"promote_int_to_float(...) is allowed only on "
                     f"signature.outputs"
                 )
                 continue
             opts = _dtype_options_for_tensor(key, val, dtype_options)
             if opts is None:
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                    f"{val!r} is not a valid dtype (unresolved "
-                    f"same_as reference or not in torch dtype set)"
+                err(
+                    f"dtype_combos[{i}].{key} = {val!r} is not a valid "
+                    f"dtype (unresolved same_as reference or not in "
+                    f"torch dtype set)"
                 )
             elif not all(t in _TORCH_DTYPES for t in opts):
                 bad = [t for t in opts if t not in _TORCH_DTYPES]
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}].{key} = "
-                    f"{val!r} resolves to unknown dtype(s) {bad!r}"
+                err(
+                    f"dtype_combos[{i}].{key} = {val!r} resolves to "
+                    f"unknown dtype(s) {bad!r}"
                 )
     return errors
 
@@ -1495,30 +1430,23 @@ def check_l3_dtype_combos_data(op_name: str, sig: dict) -> list[str]:
 # shape parity: _infer_output_shapes vs shape_rules (L2 extension)
 # ---------------------------------------------------------------------------
 
-# Default mock sizes for symbolic shape dimensions. Chosen small to keep
-# evaluation cheap; 4 avoids degenerate cases (e.g. shape[0]==1 matching
-# scalar broadcasts) while staying small. Distinct symbolic dims get
-# ``_MOCK_DIM_SIZE + counter`` so cross-tensor equality checks remain
-# meaningful (see ``_mock_input_shapes``).
+# Default mock size for symbolic shape dims: small for cheap evaluation,
+# 4 avoids degenerate cases (e.g. shape[0]==1 matching scalar broadcasts).
+# Distinct symbolic dims get ``_MOCK_DIM_SIZE + counter`` so cross-tensor
+# equality checks remain meaningful (see ``_mock_input_shapes``).
 _MOCK_DIM_SIZE = 4
 
-# Safety bound for Cartesian-product enumeration in L3 dtype parity. A
-# pathological future op with many inputs × wide dtype unions could blow
-# CI budgets (each candidate allocates tiny tensors and invokes
-# _validate_dtypes). Current manifest maxes out at ~5 inputs × ~4 options
-# = 1024 combos, so this cap only fires on genuinely outsized specs; when
-# it does we skip the op deterministically with a warning rather than
-# sampling, so validation output stays reproducible.
+# Safety bound for Cartesian-product enumeration in L3 dtype parity: an op
+# with many inputs × wide dtype unions could blow CI budgets. Over-bound
+# ops are skipped deterministically with a warning (no sampling), so
+# validation output stays reproducible.
 _MAX_DTYPE_COMBOS = 4096
 
 # Sentinel pool used only by the same_as-identity negative probe, where
-# the goal is a dtype *different from the ref's baseline* (union membership
-# is irrelevant). The out-of-union probes in both branches of
-# ``check_l3_validate_dtypes_parity`` derive their candidate pool from
-# ``sorted(_TORCH_DTYPES - declared)`` instead — that guarantees a
-# non-empty probe whenever declared does not cover the entire torch dtype
-# universe, closing a prior engulfment gap where a fixed 8-dtype pool
-# could be fully absorbed by a wide union and leave the probe vacuous.
+# the goal is a dtype *different from the ref's baseline*. The
+# out-of-union probes derive their candidate pool from
+# ``sorted(_TORCH_DTYPES - declared)`` instead, guaranteeing a non-empty
+# probe whenever declared does not cover the entire torch dtype universe.
 _DTYPE_SENTINELS: tuple[str, ...] = (
     "float16", "bfloat16", "float32", "float64",
     "int8", "int16", "int32", "int64",
@@ -1526,12 +1454,11 @@ _DTYPE_SENTINELS: tuple[str, ...] = (
 
 
 def _out_of_union_candidates(declared: set[str]) -> list[str]:
-    """Return torch dtypes that are outside ``declared``.
+    """Return torch dtypes outside ``declared``, sorted for reproducibility.
 
-    Deterministic (sorted) so validator output is reproducible; bounded
-    because ``_TORCH_DTYPES`` is a fixed small set. Callers should still
-    cap the iteration length via ``_MAX_DTYPE_COMBOS`` when combining
-    with other enumeration.
+    Bounded because ``_TORCH_DTYPES`` is a fixed small set; callers still
+    cap iteration via ``_MAX_DTYPE_COMBOS`` when combining with other
+    enumeration.
     """
     return sorted(_TORCH_DTYPES - declared)
 
@@ -1553,27 +1480,40 @@ class _MockShape(tuple):
         return len(self)
 
 
-def _extract_shape_tuple_literals(rules: list) -> dict[str, int]:
-    """Parse ``<name>.shape == (<ids>...)`` rules for input-tensor rank hints.
+_SHAPE_EQ_RE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
+)
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-    Returns a mapping tensor-name → rank. Only handles the simple literal
-    form; other shape_rules patterns are skipped.
+
+def _shape_eq_literals(rules: list) -> list[tuple[str, list[str]]]:
+    """Extract ``<name>.shape == (<parts>...)`` literals from shape_rules.
+
+    Returns ``(tensor_name, parts)`` pairs in rule order; empty parts are
+    dropped. Only this simple literal form is recognized — consumers
+    decide whether the parts must be bare identifiers.
     """
-    ranks: dict[str, int] = {}
-    shape_eq_re = re.compile(
-        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
-    )
+    out: list[tuple[str, list[str]]] = []
     for rule in rules:
         if not isinstance(rule, str):
             continue
-        m = shape_eq_re.match(rule)
+        m = _SHAPE_EQ_RE.match(rule)
         if m is None:
             continue
-        name, body = m.group(1), m.group(2)
-        parts = [p.strip() for p in body.split(",") if p.strip()]
-        # Require all parts to be bare identifiers so we can assign mock
-        # sizes by name; skip otherwise.
-        if all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts):
+        parts = [p.strip() for p in m.group(2).split(",") if p.strip()]
+        out.append((m.group(1), parts))
+    return out
+
+
+def _extract_shape_tuple_literals(rules: list) -> dict[str, int]:
+    """Parse ``<name>.shape == (<ids>...)`` rules for input-tensor rank hints.
+
+    Only the all-bare-identifier form contributes a rank; other
+    shape_rules patterns are skipped.
+    """
+    ranks: dict[str, int] = {}
+    for name, parts in _shape_eq_literals(rules):
+        if all(_IDENT_RE.fullmatch(p) for p in parts):
             ranks[name] = len(parts)
     return ranks
 
@@ -1594,11 +1534,10 @@ def _parse_shape_decl(shape_str: str) -> list[str] | None:
     m = _SHAPE_DECL_RE.match(shape_str)
     if m is None:
         return None
-    body = m.group(1)
-    parts = [p.strip() for p in body.split(",") if p.strip()]
+    parts = [p.strip() for p in m.group(1).split(",") if p.strip()]
     if not parts:
         return None
-    if not all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts):
+    if not all(_IDENT_RE.fullmatch(p) for p in parts):
         return None
     return parts
 
@@ -1606,50 +1545,34 @@ def _parse_shape_decl(shape_str: str) -> list[str] | None:
 def _input_bound_symbols(sig: dict) -> set[str]:
     """Return symbolic dim names bound by INPUT shapes only.
 
-    A symbol is input-bound when it appears in either:
-      - a ``<input>.shape == (...)`` literal in ``signature.shape_rules``
-      - a ``signature.inputs[*].shape`` declaration like ``"[N, C, L]"``
-
-    Symbols that appear only in output shape declarations (e.g. ``L_out``
-    in ``signature.outputs.y.shape = "[N, C, L_out]"`` where ``L_out`` is
-    derived by a ``shape_rules`` entry such as ``L_out = L_in - kW + 1``)
-    are **not** included. The L2 parity check uses this set to decide
-    whether a declared output-shape symbol carries a concrete mock size
-    (input-bound) versus a value derived by ``_infer_output_shapes``
-    (output-only): comparing the inferred output against an arbitrary
-    mock size for output-only symbols would misreport a correct
-    implementation as a parity mismatch.
+    A symbol is input-bound when it appears in either a
+    ``<input>.shape == (...)`` literal in ``signature.shape_rules`` or a
+    ``signature.inputs[*].shape`` declaration like ``"[N, C, L]"``.
+    Symbols that appear only in output shape declarations (e.g. a conv
+    ``L_out`` derived by a shape_rules formula) are **not** included:
+    the L2 parity check compares input-bound symbols against concrete
+    mock sizes, while output-only symbols carry values derived by
+    ``_infer_output_shapes`` — comparing those against arbitrary mock
+    sizes would misreport a correct implementation.
     """
     bound: set[str] = set()
-    ident_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-    # shape_rules: <name>.shape == (<ids>...)
     rules = sig.get("shape_rules") or []
-    shape_eq_re = re.compile(
-        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
-    )
     inputs_raw = sig.get("inputs")
     inputs = inputs_raw if isinstance(inputs_raw, dict) else {}
     input_names = set(inputs.keys())
-    for rule in rules:
-        if not isinstance(rule, str):
-            continue
-        m = shape_eq_re.match(rule)
-        if m is None:
-            continue
-        tname, body = m.group(1), m.group(2)
+    for tname, parts in _shape_eq_literals(rules):
         if tname not in input_names:
             continue
-        for p in (q.strip() for q in body.split(",")):
-            if p and ident_re.fullmatch(p):
+        for p in parts:
+            if _IDENT_RE.fullmatch(p):
                 bound.add(p)
     # Per-tensor shape decl on inputs
-    if isinstance(inputs, dict):
-        for attrs in inputs.values():
-            if not isinstance(attrs, dict):
-                continue
-            parts = _parse_shape_decl(attrs.get("shape", ""))
-            if parts is not None:
-                bound.update(parts)
+    for attrs in inputs.values():
+        if not isinstance(attrs, dict):
+            continue
+        parts = _parse_shape_decl(attrs.get("shape", ""))
+        if parts is not None:
+            bound.update(parts)
     return bound
 
 
@@ -1659,19 +1582,18 @@ def _mock_input_shapes(
     """Derive concrete mock input shapes for every declared input.
 
     Uses rank hints from ``shape_rules`` (literal ``tensor.shape == (...)``
-    forms) and from ``signature.inputs[*].shape`` declarations (e.g.
-    ``"[N, C_in, L_in]"``). Falls back to a default 2D shape when the
-    rank is unknown. Returns (shapes, dim_sizes) where ``dim_sizes`` maps
-    each symbolic dimension name (e.g. ``B``, ``S``, ``H``, ``D``, or
-    ``N``, ``C_in``, ``L_in`` from shape declarations) to the integer
-    size used in the mock shapes, so callers can bind those names into a
-    shape_rules evaluation context. Returns None only if
-    ``signature.inputs`` is malformed.
+    forms) and from ``signature.inputs[*].shape`` declarations, falling
+    back to a default 2D shape when the rank is unknown. Returns
+    ``(shapes, dim_sizes)`` where ``dim_sizes`` maps each symbolic dim
+    name to the integer size used in the mock shapes, so callers can bind
+    those names into a shape_rules evaluation context. Returns None only
+    if ``signature.inputs`` is malformed.
     """
     inputs = sig.get("inputs")
     if not isinstance(inputs, dict) or not inputs:
         return None
     rules = sig.get("shape_rules") or []
+    rule_literals = _shape_eq_literals(rules)
     ranks = _extract_shape_tuple_literals(rules)
 
     # Extra rank hints from per-tensor shape declarations.
@@ -1685,41 +1607,22 @@ def _mock_input_shapes(
             ranks.setdefault(name, len(parts))
 
     shapes: dict[str, _MockShape] = {}
-    # Assign dim-name → size map shared across tensors for consistent rules.
-    # Use a global counter keyed on first-seen order so distinct symbolic
-    # dims get distinct sizes across rules (e.g. rule1 ``x.shape == (A, B)``
-    # and rule2 ``y.shape == (C, D)`` produce A=4, B=5, C=6, D=7 rather than
-    # colliding A==C and B==D, which would spuriously satisfy cross-tensor
-    # equality checks).
+    # Dim-name → size map shared across tensors. Distinct symbolic dims
+    # get distinct sizes (first-seen order) so cross-tensor equality
+    # rules do not spuriously pass on colliding mock sizes.
     dim_sizes: dict[str, int] = {}
-    shape_eq_re = re.compile(
-        r"^\s*([A-Za-z_][A-Za-z0-9_]*)\.shape\s*==\s*\(([^)]*)\)\s*$"
-    )
-    for rule in rules:
-        if not isinstance(rule, str):
-            continue
-        m = shape_eq_re.match(rule)
-        if m is None:
-            continue
-        body = m.group(2)
-        parts = [p.strip() for p in body.split(",") if p.strip()]
+    for _tname, parts in rule_literals:
         for p in parts:
-            if (
-                re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p)
-                and p not in dim_sizes
-            ):
+            if _IDENT_RE.fullmatch(p) and p not in dim_sizes:
                 dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
 
-    # Also bind symbolic dim names from per-tensor shape declarations so
-    # downstream rule/shape-decl checks resolve them against the same mock
-    # sizes used to build the input tensors.
+    # Also bind symbolic dims from input shape declarations, then from
+    # declared output shapes, so downstream rule / shape-decl checks
+    # resolve them against the same mock sizes.
     for parts in shape_decls.values():
         for p in parts:
             if p not in dim_sizes:
                 dim_sizes[p] = _MOCK_DIM_SIZE + len(dim_sizes)
-    # Also bind symbolic dim names from declared output shapes, so rules
-    # referencing output dim names (via signature.outputs[*].shape) can be
-    # evaluated when shape_rules are absent.
     outputs_map = sig.get("outputs") or {}
     if isinstance(outputs_map, dict):
         for attrs in outputs_map.values():
@@ -1734,19 +1637,13 @@ def _mock_input_shapes(
 
     for name in inputs:
         if name in ranks:
-            parts = None
-            for rule in rules:
-                if not isinstance(rule, str):
-                    continue
-                m = shape_eq_re.match(rule)
-                if m is None or m.group(1) != name:
-                    continue
-                parts = [
-                    p.strip() for p in m.group(2).split(",") if p.strip()
-                ]
-                break
+            # First matching rule literal for this tensor, if all parts
+            # are bare identifiers.
+            parts = next(
+                (ps for tn, ps in rule_literals if tn == name), None,
+            )
             if parts is not None and all(
-                re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", p) for p in parts
+                _IDENT_RE.fullmatch(p) for p in parts
             ):
                 shapes[name] = _MockShape(
                     dim_sizes.get(p, _MOCK_DIM_SIZE) for p in parts
@@ -1788,14 +1685,11 @@ def _static_dim_values(
 
     Each entry is declared as ``<name>: "<tensor>.shape[<axis>]"`` where
     ``<tensor>`` is an input and ``<axis>`` is either an integer literal
-    or a param name. Returns a mapping ``{static_dim_name: int}`` with
-    only successfully resolved entries (malformed / out-of-range entries
-    are silently skipped — validator's L0 schema check reports those).
-
-    Used by parity mock_self builders so methods that consult
-    ``self.<static_dim_name>`` attributes (e.g. ``_infer_output_shapes``
-    reading ``self.N``) see the concrete size carried by the synthetic
-    inputs, rather than raising ``AttributeError``.
+    or a param name. Returns only successfully resolved entries
+    (malformed / out-of-range entries are silently skipped — the L0
+    schema check reports those). Used by parity mock_self builders so
+    methods consulting ``self.<static_dim_name>`` see the concrete size
+    carried by the synthetic inputs instead of raising AttributeError.
     """
     out: dict = {}
     sdims = sig.get("static_dims")
@@ -1845,17 +1739,9 @@ def _class_overrides_method(cls: type, name: str) -> bool:
 def _broadcast_shapes(*shapes: object) -> tuple:
     """Pure-Python equivalent of ``torch.broadcast_shapes``.
 
-    Computes the broadcasted output shape from one or more input shapes
-    using NumPy/PyTorch broadcasting rules: shapes are right-aligned,
-    each dimension must be equal, or one of them must be 1 (or missing).
-
-    Args:
-        *shapes: Iterables of integers (typically tuples or lists)
-            representing tensor shapes. May be empty (scalar shape).
-
-    Returns:
-        The broadcasted shape as a tuple of ints. Returns ``()`` when
-        called with no arguments.
+    Shapes are right-aligned; each dimension must be equal, or one of
+    them must be 1 (or missing). Returns ``()`` when called with no
+    arguments.
 
     Raises:
         ValueError: If the shapes are not broadcast-compatible.
@@ -1889,18 +1775,10 @@ def _broadcast_shapes(*shapes: object) -> tuple:
 def _is_broadcastable_to(src: object, dst: object) -> bool:
     """Return True if ``src`` is broadcastable *to* ``dst`` (unidirectional).
 
-    Unlike ``broadcast_shapes`` which is symmetric, this predicate fixes
-    the destination shape and asks whether ``src`` can expand into it
-    without shrinking ``dst``: each ``src`` dim (right-aligned) must be
-    equal to the matching ``dst`` dim or be 1, and ``src`` may not have
-    more dimensions than ``dst``.
-
-    Args:
-        src: Source shape (iterable of ints).
-        dst: Destination shape (iterable of ints).
-
-    Returns:
-        True iff ``src`` broadcasts to ``dst``.
+    Unlike the symmetric ``broadcast_shapes``, this predicate fixes the
+    destination shape: each ``src`` dim (right-aligned) must equal the
+    matching ``dst`` dim or be 1, and ``src`` may not have more
+    dimensions than ``dst``.
     """
     src_t = tuple(int(d) for d in src)
     dst_t = tuple(int(d) for d in dst)
@@ -1916,29 +1794,23 @@ def _is_broadcastable_to(src: object, dst: object) -> bool:
 
 
 # Safe builtins allowed in shape_rules eval — matches the R11 / R11a
-# documented helper set (see docs/design/ops-design-reference.md). Keep this list
-# aligned with manifest spec; widening it changes the rule language.
+# documented helper set (see docs/design/ops-design-reference.md); keep
+# aligned with the manifest spec, since widening it changes the rule
+# language. Python primitives, the pure-Python broadcasting helpers
+# (validator stays torch-free), and the reduction-dim helpers from
+# ``tileops.manifest.shape_rules`` all share one flat eval namespace,
+# callable by bare name from any rule body.
 #
-# Three name groups live here together: Python primitives (``len`` etc.),
-# broadcasting helpers (``broadcast_shapes`` / ``is_broadcastable_to``,
-# pure-Python so the validator does not require ``torch``), and
-# reduction-dim helpers from ``tileops.manifest.shape_rules``. All three
-# share the same eval-scope contract — callable by bare name from any
-# rule body. Group membership is editorial; the eval scope sees one
-# flat namespace.
-#
-# The dict is built from an explicit (name, callable) list so a name
-# collision between groups raises at validator import time. Silent
-# dict-merge override would let a future helper shadow a Python primitive
-# (or an existing broadcasting helper) without surfacing the conflict.
+# Built from an explicit (name, callable) list so a name collision
+# raises at validator import time instead of silently shadowing a
+# primitive via dict merge.
 _SHAPE_RULE_BUILTIN_PAIRS = [
     ("len", len),
     ("isinstance", isinstance),
     ("int", int),
-    # ``float`` is part of the rule language so manifest rules can spell
-    # sentinel values like ``ord == float('inf')``. Adding new callables
-    # here widens the L2 eval scope; do so only when an existing manifest
-    # rule needs it and the addition has obvious bounded semantics.
+    # ``float`` lets manifest rules spell sentinels like
+    # ``ord == float('inf')``. Add new callables only when an existing
+    # manifest rule needs them and the semantics are obviously bounded.
     ("float", float),
     ("tuple", tuple),
     ("list", list),
@@ -1977,20 +1849,12 @@ def _eval_shape_rule(
     indicates the rule could not be evaluated (treated as skipped, not a
     parity error).
 
-    The eval globals expose the ``_SHAPE_RULE_BUILTINS`` helper set
-    (``len``, ``isinstance``, ``int``, ``float``, ``tuple``, ``list``,
-    ``type``, ``all``, ``any``, ``range``, ``set``, ``abs``, ``min``,
-    ``max``, ``broadcast_shapes``, ``is_broadcastable_to``,
-    ``dim_range_validity``, ``dim_uniqueness``, ``reduced_axes``) so
-    R11 / R11a-style rules that use these helpers can be evaluated
-    against the mock context instead of being silently skipped.
-
-    The context names (inputs / outputs / params) are injected into both
-    eval globals and locals. Comprehensions (generator / set / list /
-    dict) create their own enclosing scope at compile time that only
-    sees the eval globals, not the locals dict; passing ctx as globals
-    too lets rules like ``all(d % x.ndim in ... for d in dim)`` resolve
-    ``x`` and ``dim`` inside the generator expression.
+    The eval globals expose the ``_SHAPE_RULE_BUILTINS`` helper set so
+    R11 / R11a-style rules can be evaluated against the mock context
+    instead of being silently skipped. Context names (inputs / outputs /
+    params) are injected into both eval globals and locals: comprehension
+    scopes only see globals, so rules like
+    ``all(d % x.ndim in ... for d in dim)`` still resolve ``x`` / ``dim``.
     """
     # Defense-in-depth: even though manifest content is trusted (PR review
     # gates it), parse the rule first and reject any dunder attribute
@@ -2010,15 +1874,10 @@ def _eval_shape_rule(
             )
 
     eval_globals = {"__builtins__": _SHAPE_RULE_BUILTINS}
-    # Ctx names must be visible inside comprehensions, which only see
-    # globals. Merge ctx into globals while keeping locals=ctx so plain
-    # (non-comprehension) lookups behave identically.
     eval_globals.update(ctx)
-    # Defense-in-depth: a manifest identifier literally named
-    # ``__builtins__`` (via a rule context key) would otherwise overwrite
-    # the sandboxed builtins mapping installed above and re-expose the
-    # full unrestricted builtins set. Reinstate the sandbox after the
-    # update so ctx cannot escape it.
+    # A ctx key literally named ``__builtins__`` would overwrite the
+    # sandboxed mapping installed above and re-expose the unrestricted
+    # builtins; reinstate the sandbox after the update.
     eval_globals["__builtins__"] = _SHAPE_RULE_BUILTINS
     try:
         result = eval(
@@ -2039,29 +1898,16 @@ def _build_mock_self(
 ) -> object:
     """Build a mock ``self`` instance without running ``__init__``.
 
-    Uses ``cls.__new__(cls)`` so that methods bound to ``cls`` (and any
-    helpers defined on its MRO) remain accessible as ``self.method(...)``
-    calls — a plain :class:`types.SimpleNamespace` cannot satisfy methods
-    that read attributes defined on the class or reach for class helpers
-    during a parity probe.
-
-    ``param_defaults`` is the manifest-derived params map (from
-    ``signature.params``). Each default is installed as an instance
-    attribute so ``self.<param>`` lookups resolve without running any
-    initialization logic.
-
-    ``extra_attrs`` carries additional manifest-derived attributes to
-    install after the params — typically ``static_dims`` values resolved
-    from the synthetic mock inputs (so methods reading ``self.<N>``
-    where ``N`` is a static dim see a concrete size) and the dtype axis
-    (so ``self.dtype`` reflects the candidate combo instead of the
-    inherited ``Op.dtype = None`` base-class default). Entries in
-    ``extra_attrs`` override same-named entries in ``param_defaults``
-    because they are specific to the current parity probe context.
-
-    Falls back to :class:`types.SimpleNamespace` if ``cls.__new__``
-    raises (defensive; Python ``type`` subclasses can override ``__new__``
-    with required positional arguments).
+    Uses ``cls.__new__(cls)`` so methods and helpers on the MRO remain
+    reachable — a plain :class:`types.SimpleNamespace` cannot satisfy
+    methods that read class attributes during a parity probe. Each
+    ``param_defaults`` entry (from ``signature.params``) is installed as
+    an instance attribute so ``self.<param>`` lookups resolve.
+    ``extra_attrs`` carries probe-specific attributes installed last
+    (overriding same-named params): static_dims values resolved from the
+    synthetic mock inputs, and the dtype axis so ``self.dtype`` reflects
+    the candidate combo instead of the ``Op.dtype = None`` base default.
+    Falls back to SimpleNamespace if ``cls.__new__`` raises.
     """
     merged: dict = dict(param_defaults)
     if extra_attrs:
@@ -2092,19 +1938,11 @@ def check_l2_infer_parity(
     shapes (no tensor allocation, no kernel execution). Plugs the result
     into a shape_rules evaluation context and verifies every rule holds.
 
-    Behaviour:
-      - For implemented ops whose class does not override
-        ``_infer_output_shapes``, emits a warning reporting the missing
-        manifest-derived method. The parity check itself is skipped
-        because there is no concrete method to compare against, but the
-        gap is surfaced (no silent pass).
-      - An exception raised from the body of ``_infer_output_shapes``
-        (i.e. after argument binding succeeds) is a hard L2 error.
-        An introspection-level failure (signature binding mismatch)
-        is still reported separately as a signature error.
-      - Produces L2 errors for concrete disagreement: the method returns
-        shapes that fail one or more ``shape_rules`` or disagree with a
-        declared ``signature.outputs[*].shape``.
+    A missing override is surfaced as a warning (no silent pass); a
+    body-level exception after successful argument binding is a hard L2
+    error (binding mismatches report separately as signature errors);
+    concrete disagreement — rule violations or mismatches against a
+    declared ``signature.outputs[*].shape`` — produces L2 errors.
     """
     errors: list[str] = []
     if cls is None:
@@ -2218,17 +2056,14 @@ def check_l2_infer_parity(
     ctx.update(param_defaults)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
-    # Output-only symbols (appearing only in declared output shapes, not
-    # in any input shape) have their concrete sizes derived by
-    # ``_infer_output_shapes`` (possibly via a ``shape_rules`` formula
-    # such as ``L_out == L_in - kW + 1``). Rebind them from the inferred
-    # ``result`` so a rule defining them is checked against the actual
-    # computed value rather than a synthetic mock size — otherwise a
-    # wrong _infer_output_shapes would silently pass (the rule would
-    # fail in both ctx and input_only_ctx and be misclassified as an
-    # input-only precondition to skip). When the same symbol appears in
-    # multiple output positions with differing sizes, prefer the first
-    # and leave the consistency check below to flag the mismatch.
+    # Output-only symbols (appearing only in declared output shapes) get
+    # their concrete sizes from ``_infer_output_shapes`` (possibly via a
+    # ``shape_rules`` formula like ``L_out == L_in - kW + 1``). Rebind
+    # them from the inferred ``result`` so a rule defining them checks
+    # the computed value, not a synthetic mock size — otherwise a wrong
+    # implementation would be misclassified as an input-only
+    # precondition and skipped. On conflicting rebindings prefer the
+    # first; the consistency check below flags the mismatch.
     input_bound = _input_bound_symbols(sig)
     output_only_symbols: set[str] = set()
     output_only_rebindings: dict[str, int] = {}
@@ -2315,23 +2150,12 @@ def check_l2_infer_parity(
             )
 
     # Compare inferred outputs against per-tensor declared shapes in
-    # signature.outputs[*].shape, independently of shape_rules. This
-    # catches ops whose outputs are only specified via declared shape
-    # fields (no equivalent shape_rule).
-    #
-    # Only symbols **bound by input shapes** carry a concrete mock size
-    # that ``_infer_output_shapes`` is expected to echo back. Output-only
-    # symbols (e.g. a conv ``L_out`` derived by a shape_rules formula)
-    # cannot be compared against an arbitrary ``dim_sizes`` entry — that
-    # would flag a correct implementation. For those, enforce rank plus
-    # per-symbol consistency instead (same symbol -> same concrete size
-    # across every declared output position).
-    #
-    # Static-dim symbols (``signature.static_dims``) resolve to concrete
-    # integers against the mock inputs via ``_static_dim_values`` (stored
-    # in ``extra_attrs`` above) and pin expected sizes exactly — a bad
-    # ``_infer_output_shapes`` returning arbitrary integers for a
-    # static-dim position must be caught, not reclassified as output-only.
+    # signature.outputs[*].shape, independently of shape_rules (catches
+    # ops specified only via declared shape fields). Input-bound symbols
+    # carry a concrete mock size to echo back exactly; output-only
+    # symbols get rank + per-symbol consistency enforcement instead.
+    # Static-dim symbols resolve to concrete integers against the mock
+    # inputs (``extra_attrs`` above) and pin expected sizes exactly.
     static_expected: dict[str, int] = {
         name: int(val) for name, val in extra_attrs.items()
         if isinstance(val, int) and not isinstance(val, bool)
@@ -2435,28 +2259,13 @@ def _dtype_options_for_tensor(
     whether that is a temporary state inside the fixpoint loop or a
     permanent failure).
     """
-    tokens = _parse_dtype_expr(dtype_str)
-    # Pure same_as(ref): inherits ref's options.
-    if len(tokens) == 1:
-        m = _SAME_AS_RE.match(tokens[0])
-        if m:
-            ref = m.group(1)
-            if ref not in resolved:
-                # Unresolved reference — propagate failure per docstring
-                # contract. Returning [] here would silently disable parity.
-                return None
-            return list(resolved[ref])
-        m = _PROMOTE_INT_TO_FLOAT_RE.match(tokens[0])
-        if m:
-            ref = m.group(1)
-            if ref not in resolved:
-                return None
-            return _expand_promote_int_to_float(resolved[ref])
     out: list[str] = []
-    for tok in tokens:
+    for tok in _parse_dtype_expr(dtype_str):
         m = _SAME_AS_RE.match(tok)
         if m:
             ref = m.group(1)
+            # Unresolved reference — propagate failure per docstring
+            # contract. Returning [] here would silently disable parity.
             if ref not in resolved:
                 return None
             out.extend(resolved[ref])
@@ -2582,21 +2391,16 @@ def _combo_accepted(
     reason=None means the op raised during validation (rejected);
     reason!=None indicates the call could not be performed (skip).
 
-    ``sig`` (optional) is the manifest signature; when provided, the
-    mock-self is enriched with static_dims values resolved against
-    synthetic mock input shapes and with ``self.dtype`` bound to the
-    candidate's dtype axis (see below). Both attributes are commonly
-    consulted by generated ``_validate_dtypes`` implementations (e.g.
-    ``if x.dtype != self.dtype: raise``); without them the parity
-    probe would spuriously reject listed combos.
-
-    ``self_dtype_name`` (optional) pins the dtype installed on
-    ``mock_self.dtype``. Used by out-of-union probes to keep the op's
-    configured dtype at a valid baseline while mutating the input
-    tensor's dtype — otherwise ``self.dtype`` would follow the bad
-    candidate and a ``x.dtype != self.dtype`` check would spuriously
-    pass. When omitted, defaults to the combo entry for the first
-    non-same_as-bound input (the listed-combo convention).
+    When ``sig`` is provided, the mock-self is enriched with static_dims
+    values resolved against synthetic mock inputs and with ``self.dtype``
+    bound to the candidate's dtype axis — both commonly consulted by
+    generated ``_validate_dtypes`` implementations (``if x.dtype !=
+    self.dtype: raise``); without them the probe would spuriously reject
+    listed combos. ``self_dtype_name`` pins ``mock_self.dtype``
+    explicitly (out-of-union probes keep the op's configured dtype at a
+    valid baseline while mutating the input tensor's dtype); when
+    omitted it follows the combo entry for the first non-same_as-bound
+    input.
     """
     validate_fn = getattr(cls, "_validate_dtypes", None)
     if validate_fn is None:
@@ -2726,14 +2530,11 @@ def _probe_out_of_union(
 
     Starting from *baseline* (a combination known to be accepted),
     substitutes an out-of-union sentinel for each non-same_as-bound input
-    in turn; every resulting candidate must be rejected. ``self.dtype``
-    stays pinned to the baseline's primary dtype so only the input
-    tensor's dtype deviates from the op's configured dtype — otherwise a
-    generated ``x.dtype != self.dtype`` check would spuriously pass, since
-    both sides would track the bad dtype. same_as(ref)-bound tensors are
-    never mutated directly (their dtype follows ``ref``); the substitution
-    is propagated to them instead. Probing is bounded by
-    ``_MAX_DTYPE_COMBOS`` to preserve the Cartesian safety bound.
+    in turn; every candidate must be rejected. ``self.dtype`` stays
+    pinned to the baseline's primary dtype so only the input tensor's
+    dtype deviates (a generated ``x.dtype != self.dtype`` check would
+    otherwise spuriously pass). same_as-bound tensors follow their ref
+    via propagation. Bounded by ``_MAX_DTYPE_COMBOS``.
     """
     err = _emit_to(errors, "dtype", op_name)
     warn = _emit_to(warnings, "dtype", op_name)
@@ -3201,14 +3002,10 @@ def _ast_manifest_call_usage(
 ) -> dict[str, bool]:
     """Check whether target functions are imported and called with this op name.
 
-    Recognises three patterns:
-
-    1. **Direct** — ``from tileops.manifest import load_workloads`` called
-       with the op name and ``op.eval_roofline()`` called on an Op instance.
-    2. **Indirect via benchmarks.benchmark_base** — ``workloads_to_params``
-       (wraps ``load_workloads``) and ``ManifestBenchmark`` (wraps
-       op-local ``eval_roofline``) imported from ``benchmarks.benchmark_base``
-       and called with the op name as the first argument.
+    Recognises the direct pattern (``load_workloads`` from
+    ``tileops.manifest`` called with the op name + ``op.eval_roofline()``)
+    and the indirect one (``workloads_to_params`` / ``ManifestBenchmark``
+    from ``benchmarks.benchmark_base``, op name as first argument).
     """
     # Maps from the indirect helper name → the direct target it satisfies.
     _INDIRECT_EQUIV: dict[str, str] = {
@@ -3335,14 +3132,11 @@ def _init_calls_dispatch_kernel(cls: type) -> "bool | None":
     ``self.dispatch_kernel(...)`` directly or delegates via
     ``super().__init__(...)``.
 
-    ``None`` means we could not parse the source (built-in / dynamically
-    generated ``__init__``); the caller treats that as inconclusive.
-
-    Pure-AST inspection per the Slot S13 contract in
-    ``docs/design/ops-design-reference.md``: the body must call
-    ``self.dispatch_kernel(kernel_map)`` to honor the routing override.
-    ``super().__init__(...)`` satisfies S13 transitively — the parent's
-    body owns the dispatch call. No runtime construction; no GPU.
+    ``None`` means the source could not be parsed (built-in /
+    dynamically generated ``__init__``); callers treat that as
+    inconclusive. Pure-AST inspection per the Slot S13 contract in
+    ``docs/design/ops-design-reference.md``; ``super().__init__(...)``
+    satisfies S13 transitively. No runtime construction; no GPU.
     """
     try:
         lines, start_lineno = inspect.getsourcelines(cls.__init__)
@@ -3403,6 +3197,7 @@ def check_c3_ctor_signature_parity(
     errors: list[str] = []
     if cls is None:
         return errors
+    err = _emit_to(errors, "ctor", op_name)
 
     sig = entry.get("signature", {})
     manifest_params = sig.get("params") or {}
@@ -3454,8 +3249,8 @@ def check_c3_ctor_signature_parity(
         )
         code_has_default = code_p.default is not inspect.Parameter.empty
         if manifest_has_default and not code_has_default:
-            errors.append(
-                f"[ctor] {op_name}: param {pname!r} has manifest default "
+            err(
+                f"param {pname!r} has manifest default "
                 f"{manifest_default!r} but no default on __init__"
             )
         elif (not manifest_has_default) and code_has_default:
@@ -3463,8 +3258,8 @@ def check_c3_ctor_signature_parity(
                 not manifest_has_compat_default
                 or code_p.default != compat_default
             ):
-                errors.append(
-                    f"[ctor] {op_name}: param {pname!r} has __init__ default "
+                err(
+                    f"param {pname!r} has __init__ default "
                     f"{code_p.default!r} but no manifest default"
                 )
         elif (
@@ -3472,8 +3267,8 @@ def check_c3_ctor_signature_parity(
             and code_has_default
             and code_p.default != manifest_default
         ):
-            errors.append(
-                f"[ctor] {op_name}: param {pname!r} default mismatch — "
+            err(
+                f"param {pname!r} default mismatch — "
                 f"manifest={manifest_default!r}, code={code_p.default!r}"
             )
 
@@ -3481,20 +3276,15 @@ def check_c3_ctor_signature_parity(
         manifest_kw_only = bool(pattrs.get("kw_only", False))
         code_kw_only = code_p.kind is inspect.Parameter.KEYWORD_ONLY
         if manifest_kw_only != code_kw_only:
-            errors.append(
-                f"[ctor] {op_name}: param {pname!r} kw_only mismatch — "
+            err(
+                f"param {pname!r} kw_only mismatch — "
                 f"manifest={manifest_kw_only}, code={code_kw_only}"
             )
 
-    # Code-only extras detection deferred: a faithful "this kwarg is
-    # not declared anywhere in the manifest" rule needs to consult
-    # ``signature.params`` AND ``signature.static_dims`` AND shape /
-    # dtype variables exposed by the op protocol (e.g. ``N_total``,
-    # ``dtype`` in elementwise). Computing the protocol-derived
-    # allowed set requires interpretation of manifest
-    # ``signature.inputs`` shape strings + the op family's convention,
-    # which is out of scope for the C3 helper as written. Tracked as
-    # a strict-parity follow-up.
+    # Code-only extras detection deferred: a faithful "kwarg not declared
+    # anywhere in the manifest" rule needs the protocol-derived allowed
+    # set (params + static_dims + per-family shape/dtype variables),
+    # which is out of scope for the C3 helper. Strict-parity follow-up.
 
     return errors
 
@@ -3649,25 +3439,17 @@ def check_c7_eval_roofline_not_stub(
     return []
 
 
-# Tag prefixes that strict-parity checks (C1-C7) emit.
-#
-# Routing is structural, not tag-based: the orchestrator unconditionally
-# extends ``strict_errors`` with the return of each strict check. The
-# tags below are documentation / triage aids, not the routing key.
-#
-# ``[shape]`` and ``[dtype]`` are also emitted by the non-strict L2 / L3
-# checks (``check_l2`` / ``check_l3`` for shape_rules / dtype_combos
-# parsing); when those entries appear in ``errors`` it is not a strict
-# leak — they are non-strict errors that always stay in ``errors``
-# regardless of mode. Use ``STRICT_ONLY_TAGS`` for leakage assertions
-# (tags exclusive to C1-C7's parity / structural checks).
+# Tag prefixes that strict-parity checks (C1-C7) emit. Routing is
+# structural, not tag-based (the orchestrator extends ``strict_errors``
+# with each strict check's return); tags are triage aids only.
+# ``[shape]`` / ``[dtype]`` are also emitted by the non-strict L2 / L3
+# checks and may legitimately appear in ``errors`` regardless of mode —
+# use ``STRICT_ONLY_TAGS`` for leakage assertions.
 STRICT_TAGS: tuple[str, ...] = (
     "[shape]", "[dtype]", "[ctor]", "[forward]", "[dispatch]", "[stub]",
 )
 
-# Subset of ``STRICT_TAGS`` that only strict-parity checks emit. Used by
-# tests asserting that strict-parity failures are routed to ``warnings``
-# (advisory mode) instead of ``errors``.
+# Subset of ``STRICT_TAGS`` that only strict-parity checks emit.
 STRICT_ONLY_TAGS: tuple[str, ...] = (
     "[ctor]", "[forward]", "[dispatch]", "[stub]",
 )
@@ -3708,22 +3490,12 @@ def validate_manifest(
 ) -> tuple[list[str], list[str]]:
     """Run applicable validation levels on the manifest.
 
-    Args:
-        manifest_path: Optional path to a single manifest YAML file. When None,
-            the merged manifest is loaded from the ``tileops.manifest`` package
-            (one file per family). Tests pass a temp file to validate synthetic
-            single-file manifests.
-        repo_root: Repository root directory.
-        verbose: If True, print progress.
-        levels: Set of check names to run (e.g. {"schema", "shape", "dtype", "bench"}).
-                When None, all checks are enabled.
-        check_op: When set, force all validation levels (L0-L4) on this op and
-                  its variants, ignoring the ``status`` field. Only this variant
-                  family is validated; all other ops are skipped.
-
-    Returns:
-        A tuple of (errors, warnings). Errors are hard failures; warnings
-        are informational messages (e.g. signature skipped due to missing deps).
+    Returns ``(errors, warnings)``: errors are hard failures; warnings
+    are informational. ``manifest_path=None`` loads the merged manifest
+    from the ``tileops.manifest`` package (tests pass a temp file for
+    synthetic single-file manifests). ``levels=None`` enables all
+    checks. ``check_op`` forces all levels (L0-L4) on the named op and
+    its variants, ignoring ``status``; all other ops are skipped.
     """
     if repo_root is None:
         repo_root = REPO_ROOT
@@ -3747,9 +3519,8 @@ def validate_manifest(
     if check_op is not None and check_op not in ops:
         return [f"--check-op: op '{check_op}' not found in manifest"], []
 
-    # When --check-op is set, compute the "variant family" scope: the named
-    # op plus all ops where variant_of == check_op.  This ensures that
-    # modifications to a variant are caught when validating the primary.
+    # --check-op scope: the named op plus its immediate variants, so a
+    # variant edit is caught when validating the primary.
     variant_family: set[str] | None = None
     if check_op is not None:
         variant_family = {check_op} | {
@@ -3764,10 +3535,9 @@ def validate_manifest(
     # warnings (advisory mode) once all per-op checks have run.
     strict_errors: list[str] = []
 
-    # Cross-entry checks (must run before per-entry checks).
-    # When --check-op is set, scope cross-entry checks to the variant family
-    # so that unrelated ops with invalid variant_of references don't cause
-    # failures for the selected op.
+    # Cross-entry checks (must run before per-entry checks), scoped to
+    # the variant family under --check-op so unrelated ops with invalid
+    # variant_of references don't fail the selected op.
     if "schema" in levels:
         all_errors.extend(
             check_variant_of_consistency(ops, scope=variant_family)
@@ -3798,8 +3568,6 @@ def validate_manifest(
             continue
 
         # Resolve Op class once per entry so parity checks can reuse it.
-        # Resolution is lightweight (import + getattr); skipped silently
-        # when unnecessary.
         source = entry.get("source", {})
         op_file = source.get("op", "")
         resolve_result = _resolve_op_class(op_file, op_name) if op_file else None
@@ -3828,11 +3596,9 @@ def validate_manifest(
             )
 
         # C3-C7: strict parity gates for status: implemented ops, each
-        # gated by the level whose contract it enforces. ``--levels``
-        # therefore composes predictably: e.g. ``--levels schema``
-        # triggers no strict-parity work.
-        # Routed to strict_errors so advisory mode can downgrade them
-        # without losing visibility.
+        # gated by the level whose contract it enforces (``--levels
+        # schema`` triggers no strict-parity work). Routed to
+        # strict_errors so advisory mode can downgrade them.
         if "signature" in levels:
             strict_errors.extend(
                 check_c3_ctor_signature_parity(
@@ -3868,10 +3634,9 @@ def validate_manifest(
                 else:
                     all_warnings.extend(bench_errors)
 
-    # Deduplicate aggregate error/warning strings while preserving order.
-    # ``check_l3`` and ``check_l3_validate_dtypes_parity`` both surface
-    # ``dtype_combos`` data errors (each is a valid standalone entry
-    # point); deduping at the driver keeps user-visible reports crisp.
+    # Deduplicate while preserving order: ``check_l3`` and
+    # ``check_l3_validate_dtypes_parity`` both surface ``dtype_combos``
+    # data errors (each is a valid standalone entry point).
     def _dedup(items: list[str]) -> list[str]:
         seen: set[str] = set()
         out: list[str] = []

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -264,27 +264,23 @@ def _check_single_input_workload_keys(
     return errors
 
 
-def check_l0(
-    op_name: str, entry: dict, *, warnings: list[str] | None = None,
-    all_op_names: Collection[str] = (),
+def _l0_key_format(
+    op_name: str, all_op_names: Collection[str],
 ) -> list[str]:
-    """Validate structural schema of a manifest entry. Returns error strings."""
+    """Key format: variant words precede the direction suffix.
+
+    The direction suffix itself is required only when the manifest
+    carries a direction sibling of the same op.
+    """
     errors: list[str] = []
-
-    if not isinstance(entry, dict):
-        errors.append(f"[schema] {op_name}: entry must be a mapping, got {type(entry).__name__}")
-        return errors
-
-    # Key format: variant words precede the direction suffix; the direction
-    # suffix itself is required only when the manifest carries a direction
-    # sibling of the same op.
+    err = _emit_to(errors, "schema", op_name)
     key_match = re.match(r"^(.*)(Fwd|Bwd)Op(.+)$", op_name)
     if key_match:
         stem, direction, trailing = key_match.groups()
-        errors.append(
-            f"[schema] {op_name}: variant word '{trailing}' follows "
-            f"'{direction}Op'; variant words must precede the direction "
-            f"suffix (expected '{stem}{trailing}{direction}Op')"
+        err(
+            f"variant word '{trailing}' follows '{direction}Op'; variant "
+            f"words must precede the direction suffix "
+            f"(expected '{stem}{trailing}{direction}Op')"
         )
     elif op_name.endswith("Op") and not op_name.endswith(("FwdOp", "BwdOp")):
         stem = op_name[:-2]
@@ -292,424 +288,402 @@ def check_l0(
             s for s in (f"{stem}FwdOp", f"{stem}BwdOp") if s in all_op_names
         ]
         if siblings:
-            errors.append(
-                f"[schema] {op_name}: missing direction suffix; direction "
-                f"sibling '{siblings[0]}' exists in the manifest"
+            err(
+                f"missing direction suffix; direction sibling "
+                f"'{siblings[0]}' exists in the manifest"
+            )
+    return errors
+
+
+def _l0_signature(op_name: str, entry: dict, sig: dict) -> list[str]:
+    """Signature sub-schema: tensors, params, dtype_combos, shape_rules."""
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+
+    missing_sig = _REQUIRED_SIGNATURE - set(sig.keys())
+    if missing_sig:
+        err(f"signature missing: {missing_sig}")
+
+    # inputs/outputs/params names must be strings.
+    for field in ("inputs", "outputs", "params"):
+        names = sig.get(field)
+        if not isinstance(names, dict):
+            continue
+        non_str = sorted(repr(k) for k in names if not isinstance(k, str))
+        if non_str:
+            err(
+                f"signature.{field} has non-string names "
+                f"[{', '.join(non_str)}]"
             )
 
-    # Top-level required fields
-    missing_top = _REQUIRED_TOP - set(entry.keys())
-    if missing_top:
-        errors.append(f"[schema] {op_name}: missing top-level fields: {missing_top}")
-
-    # Signature structure
-    sig = entry.get("signature")
-    if isinstance(sig, dict):
-        missing_sig = _REQUIRED_SIGNATURE - set(sig.keys())
-        if missing_sig:
-            errors.append(f"[schema] {op_name}: signature missing: {missing_sig}")
-
-        # Check inputs/outputs/params are dicts with string names
-        for field in ("inputs", "outputs", "params"):
-            names = sig.get(field)
-            if not isinstance(names, dict):
+    # inputs/outputs are dicts of tensor-attr dicts carrying a dtype.
+    for direction in ("inputs", "outputs"):
+        tensors = sig.get(direction)
+        if not isinstance(tensors, dict):
+            if direction in sig:
+                err(f"signature.{direction} must be a dict")
+            continue
+        for tname, attrs in tensors.items():
+            if not isinstance(attrs, dict):
+                err(f"{direction}.{tname} must be a dict")
                 continue
-            non_str = sorted(repr(k) for k in names if not isinstance(k, str))
-            if non_str:
-                errors.append(
-                    f"[schema] {op_name}: signature.{field} has non-string "
-                    f"names [{', '.join(non_str)}]"
-                )
-
-        # Check inputs/outputs are dicts with dtype
-        for direction in ("inputs", "outputs"):
-            tensors = sig.get(direction)
-            if not isinstance(tensors, dict):
-                if direction in sig:
-                    errors.append(
-                        f"[schema] {op_name}: signature.{direction} must be a dict"
-                    )
-                continue
-            for tname, attrs in tensors.items():
-                if not isinstance(attrs, dict):
-                    errors.append(
-                        f"[schema] {op_name}: {direction}.{tname} must be a dict"
-                    )
-                    continue
-                if "dtype" not in attrs:
-                    errors.append(
-                        f"[schema] {op_name}: {direction}.{tname} missing 'dtype'"
-                    )
-                # constraints keys must name dims of the declared shape
-                if "constraints" in attrs:
-                    constraints = attrs["constraints"]
-                    if not isinstance(constraints, dict):
-                        errors.append(
-                            f"[schema] {op_name}: {direction}.{tname}."
-                            f"constraints must be a mapping"
-                        )
-                    elif not isinstance(attrs.get("shape"), str):
-                        errors.append(
-                            f"[schema] {op_name}: {direction}.{tname} has "
-                            f"constraints but no shape"
-                        )
-                    else:
-                        dims = {
-                            d.strip()
-                            for d in attrs["shape"].strip("[]").split(",")
-                            if d.strip()
-                        }
-                        for ckey in constraints:
-                            if ckey not in dims:
-                                errors.append(
-                                    f"[schema] {op_name}: {direction}.{tname} "
-                                    f"constraints key '{ckey}' is not in "
-                                    f"shape dims {sorted(dims)}"
-                                )
-                # layout validation (R19)
-                if "layout" in attrs:
-                    layout = attrs["layout"]
-                    if not isinstance(layout, str):
-                        errors.append(
-                            f"[schema] {op_name}: {direction}.{tname}.layout "
-                            f"must be a string"
-                        )
-                    elif layout not in _VALID_LAYOUTS:
-                        errors.append(
-                            f"[schema] {op_name}: {direction}.{tname}.layout "
-                            f"'{layout}' is not recognized "
-                            f"(valid: {', '.join(sorted(_VALID_LAYOUTS))})"
-                        )
-
-        # Params must be a mapping if present; each entry must have 'type' (R1)
-        if "params" in sig:
-            params = sig["params"]
-            if not isinstance(params, dict):
-                errors.append(
-                    f"[schema] {op_name}: signature.params must be a mapping"
-                )
-            else:
-                for pname, pattrs in params.items():
-                    if not isinstance(pattrs, dict):
-                        errors.append(
-                            f"[schema] {op_name}: params.{pname} must be a dict"
-                        )
-                        continue
-                    if "type" not in pattrs:
-                        errors.append(
-                            f"[schema] {op_name}: params.{pname} missing 'type'"
-                        )
-
-        # Surface invariant: every op produces at least one output, and every
-        # op has at least one construction handle — either a tensor input or
-        # a manifest-declared param. ``inputs: {}`` is permitted (generative
-        # ops synthesize the output from params alone); an op with neither
-        # inputs nor params has no surface the validator or codegen can act
-        # on.
-        raw_inputs = sig.get("inputs")
-        raw_outputs = sig.get("outputs")
-        raw_params = sig.get("params")
-        inputs_count = len(raw_inputs) if isinstance(raw_inputs, dict) else 0
-        outputs_count = len(raw_outputs) if isinstance(raw_outputs, dict) else 0
-        params_count = len(raw_params) if isinstance(raw_params, dict) else 0
-        if outputs_count < 1:
-            errors.append(
-                f"[schema] {op_name}: signature.outputs must declare at "
-                f"least one tensor"
-            )
-        if inputs_count < 1 and params_count < 1:
-            errors.append(
-                f"[schema] {op_name}: signature must declare at least one "
-                f"input tensor or one param (both are empty)"
-            )
-
-        # Every output must declare a shape, or the signature must carry
-        # shape_rules that pin the output shapes.
-        raw_rules = sig.get("shape_rules")
-        has_shape_rules = isinstance(raw_rules, list) and len(raw_rules) > 0
-        if isinstance(raw_outputs, dict) and not has_shape_rules:
-            for tname, attrs in raw_outputs.items():
-                if isinstance(attrs, dict) and "shape" not in attrs:
-                    errors.append(
-                        f"[schema] {op_name}: output '{tname}' must declare "
-                        f"'shape' or the signature must have shape_rules"
-                    )
-
-        # dtype_combos must be a list of dicts if present (R4)
-        if "dtype_combos" in sig:
-            combos = sig["dtype_combos"]
-            if not isinstance(combos, list):
-                errors.append(
-                    f"[schema] {op_name}: signature.dtype_combos must be a list"
-                )
-            else:
-                tensor_names = set()
-                for d in ("inputs", "outputs"):
-                    t = sig.get(d)
-                    if isinstance(t, dict):
-                        tensor_names.update(t.keys())
-                for i, combo in enumerate(combos):
-                    if not isinstance(combo, dict):
-                        errors.append(
-                            f"[schema] {op_name}: dtype_combos[{i}] must be a dict"
-                        )
-                        continue
-                    for key in combo:
-                        if key not in tensor_names:
-                            errors.append(
-                                f"[schema] {op_name}: dtype_combos[{i}] key "
-                                f"'{key}' is not a declared tensor name"
+            if "dtype" not in attrs:
+                err(f"{direction}.{tname} missing 'dtype'")
+            # constraints keys must name dims of the declared shape
+            if "constraints" in attrs:
+                constraints = attrs["constraints"]
+                if not isinstance(constraints, dict):
+                    err(f"{direction}.{tname}.constraints must be a mapping")
+                elif not isinstance(attrs.get("shape"), str):
+                    err(f"{direction}.{tname} has constraints but no shape")
+                else:
+                    dims = {
+                        d.strip()
+                        for d in attrs["shape"].strip("[]").split(",")
+                        if d.strip()
+                    }
+                    for ckey in constraints:
+                        if ckey not in dims:
+                            err(
+                                f"{direction}.{tname} constraints key "
+                                f"'{ckey}' is not in shape dims "
+                                f"{sorted(dims)}"
                             )
-
-        # shape_rules must be list of strings if present
-        if "shape_rules" in sig:
-            rules = sig["shape_rules"]
-            if not isinstance(rules, list):
-                errors.append(f"[schema] {op_name}: shape_rules must be a list")
-            else:
-                for i, rule in enumerate(rules):
-                    if not isinstance(rule, str):
-                        errors.append(
-                            f"[schema] {op_name}: shape_rules[{i}] must be a string"
-                        )
-                        continue
-                    errors.extend(
-                        _check_shape_rule_callables(op_name, i, rule)
+            # layout validation (R19)
+            if "layout" in attrs:
+                layout = attrs["layout"]
+                if not isinstance(layout, str):
+                    err(f"{direction}.{tname}.layout must be a string")
+                elif layout not in _VALID_LAYOUTS:
+                    err(
+                        f"{direction}.{tname}.layout '{layout}' is not "
+                        f"recognized "
+                        f"(valid: {', '.join(sorted(_VALID_LAYOUTS))})"
                     )
 
-        # Unknown signature keys are silently ignored by L1+, so reject
-        # anything outside the schema here.
-        unknown_sig = sorted(repr(k) for k in set(sig) - _VALID_SIGNATURE_KEYS)
-        if unknown_sig:
-            errors.append(
-                f"[schema] {op_name}: unknown signature keys "
-                f"[{', '.join(unknown_sig)}]; valid keys are "
-                f"{sorted(_VALID_SIGNATURE_KEYS)}"
-            )
+    # Params must be a mapping if present; each entry needs 'type' (R1).
+    if "params" in sig:
+        params = sig["params"]
+        if not isinstance(params, dict):
+            err("signature.params must be a mapping")
+        else:
+            for pname, pattrs in params.items():
+                if not isinstance(pattrs, dict):
+                    err(f"params.{pname} must be a dict")
+                    continue
+                if "type" not in pattrs:
+                    err(f"params.{pname} missing 'type'")
 
-        # static_dims must be a mapping of str -> str expression (R20)
-        if "static_dims" in sig:
-            errors.extend(
-                _check_static_dims(op_name, sig["static_dims"], sig)
-            )
-    elif "signature" in entry:
-        errors.append(f"[schema] {op_name}: signature must be a mapping")
+    # Surface invariant: every op produces at least one output, and has
+    # at least one construction handle — a tensor input or a declared
+    # param. ``inputs: {}`` is permitted (generative ops synthesize the
+    # output from params alone).
+    raw_inputs = sig.get("inputs")
+    raw_outputs = sig.get("outputs")
+    raw_params = sig.get("params")
+    inputs_count = len(raw_inputs) if isinstance(raw_inputs, dict) else 0
+    outputs_count = len(raw_outputs) if isinstance(raw_outputs, dict) else 0
+    params_count = len(raw_params) if isinstance(raw_params, dict) else 0
+    if outputs_count < 1:
+        err("signature.outputs must declare at least one tensor")
+    if inputs_count < 1 and params_count < 1:
+        err(
+            "signature must declare at least one input tensor or one "
+            "param (both are empty)"
+        )
 
-    # Workloads
-    workloads = entry.get("workloads")
-    if isinstance(workloads, list):
-        # Implemented ops need benchmarkable coverage: at least 2 workloads.
-        if entry.get("status") == "implemented" and len(workloads) < 2:
-            errors.append(
-                f"[schema] {op_name}: implemented op must have at least 2 "
-                f"workloads, got {len(workloads)}"
-            )
-        # Params without a default must be pinned by every workload.
-        sig_params = entry.get("signature", {})
-        sig_params = sig_params.get("params") if isinstance(sig_params, dict) else None
-        required_params = {
-            pname
-            for pname, pattrs in (sig_params or {}).items()
-            if isinstance(pname, str)
-            and isinstance(pattrs, dict)
-            and "default" not in pattrs
-        } if isinstance(sig_params, dict) else set()
-        for i, w in enumerate(workloads):
-            if not isinstance(w, dict):
-                errors.append(f"[schema] {op_name}: workloads[{i}] must be a dict")
-                continue
-            if "dtypes" not in w:
-                errors.append(
-                    f"[schema] {op_name}: workloads[{i}] missing 'dtypes'"
+    # Every output declares a shape, or shape_rules pin the output shapes.
+    raw_rules = sig.get("shape_rules")
+    has_shape_rules = isinstance(raw_rules, list) and len(raw_rules) > 0
+    if isinstance(raw_outputs, dict) and not has_shape_rules:
+        for tname, attrs in raw_outputs.items():
+            if isinstance(attrs, dict) and "shape" not in attrs:
+                err(
+                    f"output '{tname}' must declare 'shape' or the "
+                    f"signature must have shape_rules"
                 )
-            non_str = [k for k in w if not isinstance(k, str)]
-            if non_str:
-                errors.append(
-                    f"[schema] {op_name}: workloads[{i}] has non-string "
-                    f"keys {non_str}"
-                )
-            missing_params = required_params - set(w.keys())
-            if missing_params:
-                errors.append(
-                    f"[schema] {op_name}: workloads[{i}] missing required "
-                    f"param(s): {sorted(missing_params)}"
-                )
-        if isinstance(entry.get("signature"), dict):
-            errors.extend(
-                _check_single_input_workload_keys(
-                    op_name, entry["signature"], workloads
-                )
-            )
-    elif "workloads" in entry:
-        errors.append(f"[schema] {op_name}: workloads must be a list")
 
-    # Roofline (structural rules per docs/design/roofline.md §4.1)
-    roofline = entry.get("roofline")
-    if isinstance(roofline, dict):
-        has_inline = "flops" in roofline and "bytes" in roofline
-        has_func = "func" in roofline
-        if not has_inline and not has_func:
-            errors.append(
-                f"[schema] {op_name}: roofline must have (flops + bytes) or func"
-            )
-        if has_func and ({"flops", "bytes", "vars"} & set(roofline)):
-            errors.append(
-                f"[schema] {op_name}: roofline modes are exclusive — "
-                f"func must not coexist with flops/bytes/vars"
-            )
-        for field in ("flops", "bytes", "func"):
-            if field in roofline and not (
-                isinstance(roofline[field], str) and roofline[field].strip()
-            ):
-                errors.append(
-                    f"[schema] {op_name}: roofline.{field} must be a "
-                    f"non-empty string"
-                )
-        rl_vars = roofline.get("vars")
-        if rl_vars is not None:
-            if not isinstance(rl_vars, dict):
-                errors.append(
-                    f"[schema] {op_name}: roofline.vars must be a mapping"
-                )
-            else:
-                for k, v in rl_vars.items():
-                    if not isinstance(k, str):
-                        errors.append(
-                            f"[schema] {op_name}: roofline.vars key {k!r} "
-                            f"must be a string"
+    # dtype_combos must be a list of dicts if present (R4).
+    if "dtype_combos" in sig:
+        combos = sig["dtype_combos"]
+        if not isinstance(combos, list):
+            err("signature.dtype_combos must be a list")
+        else:
+            tensor_names = set()
+            for d in ("inputs", "outputs"):
+                t = sig.get(d)
+                if isinstance(t, dict):
+                    tensor_names.update(t.keys())
+            for i, combo in enumerate(combos):
+                if not isinstance(combo, dict):
+                    err(f"dtype_combos[{i}] must be a dict")
+                    continue
+                for key in combo:
+                    if key not in tensor_names:
+                        err(
+                            f"dtype_combos[{i}] key '{key}' is not a "
+                            f"declared tensor name"
                         )
-                    if not (isinstance(v, str) and v.strip()):
-                        errors.append(
-                            f"[schema] {op_name}: roofline.vars[{k!r}] must "
-                            f"be a non-empty string"
-                        )
-        if has_func and isinstance(roofline.get("func"), str):
-            mod, _, attr = roofline["func"].rpartition(".")
-            try:
-                target = importlib.import_module(mod) if mod else None
-            except ImportError:
-                target = None
-            if target is None or not callable(getattr(target, attr, None)):
-                errors.append(
-                    f"[schema] {op_name}: roofline.func "
-                    f"{roofline['func']!r} does not resolve to a callable"
-                )
-    elif "roofline" in entry:
-        errors.append(f"[schema] {op_name}: roofline must be a mapping")
 
-    # Source
-    source = entry.get("source")
-    if isinstance(source, dict):
-        missing_src = _REQUIRED_SOURCE - set(source.keys())
-        if missing_src:
-            errors.append(
-                f"[schema] {op_name}: source missing fields: {missing_src}"
+    # shape_rules must be a list of strings if present.
+    if "shape_rules" in sig:
+        rules = sig["shape_rules"]
+        if not isinstance(rules, list):
+            err("shape_rules must be a list")
+        else:
+            for i, rule in enumerate(rules):
+                if not isinstance(rule, str):
+                    err(f"shape_rules[{i}] must be a string")
+                    continue
+                errors.extend(_check_shape_rule_callables(op_name, i, rule))
+
+    # Unknown signature keys are silently ignored by L1+; reject here.
+    unknown_sig = sorted(repr(k) for k in set(sig) - _VALID_SIGNATURE_KEYS)
+    if unknown_sig:
+        err(
+            f"unknown signature keys [{', '.join(unknown_sig)}]; valid "
+            f"keys are {sorted(_VALID_SIGNATURE_KEYS)}"
+        )
+
+    # static_dims must be a mapping of str -> str expression (R20).
+    if "static_dims" in sig:
+        errors.extend(_check_static_dims(op_name, sig["static_dims"], sig))
+    return errors
+
+
+def _l0_workloads(op_name: str, entry: dict, workloads: list) -> list[str]:
+    """Workload policy: count, dtypes, required-param pinning, R21 keys."""
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+    # Implemented ops need benchmarkable coverage: at least 2 workloads.
+    if entry.get("status") == "implemented" and len(workloads) < 2:
+        err(
+            f"implemented op must have at least 2 workloads, "
+            f"got {len(workloads)}"
+        )
+    # Params without a default must be pinned by every workload.
+    sig_params = entry.get("signature", {})
+    sig_params = sig_params.get("params") if isinstance(sig_params, dict) else None
+    required_params = {
+        pname
+        for pname, pattrs in (sig_params or {}).items()
+        if isinstance(pname, str)
+        and isinstance(pattrs, dict)
+        and "default" not in pattrs
+    } if isinstance(sig_params, dict) else set()
+    for i, w in enumerate(workloads):
+        if not isinstance(w, dict):
+            err(f"workloads[{i}] must be a dict")
+            continue
+        if "dtypes" not in w:
+            err(f"workloads[{i}] missing 'dtypes'")
+        non_str = [k for k in w if not isinstance(k, str)]
+        if non_str:
+            err(f"workloads[{i}] has non-string keys {non_str}")
+        missing_params = required_params - set(w.keys())
+        if missing_params:
+            err(
+                f"workloads[{i}] missing required param(s): "
+                f"{sorted(missing_params)}"
             )
-        # source.kernel: string or list of strings
-        kernel = source.get("kernel")
-        if kernel is not None:
-            if isinstance(kernel, list):
-                for i, k in enumerate(kernel):
-                    if not isinstance(k, str):
-                        errors.append(
-                            f"[schema] {op_name}: source.kernel[{i}] "
-                            f"must be a string"
-                        )
-            elif not isinstance(kernel, str):
-                errors.append(
-                    f"[schema] {op_name}: source.kernel must be a string or list"
-                )
-        if "bench_manifest_driven" in source and not isinstance(
-            source["bench_manifest_driven"], bool,
+    if isinstance(entry.get("signature"), dict):
+        errors.extend(
+            _check_single_input_workload_keys(
+                op_name, entry["signature"], workloads
+            )
+        )
+    return errors
+
+
+def _l0_roofline(op_name: str, entry: dict, roofline: dict) -> list[str]:
+    """Roofline structural rules per docs/design/roofline.md §4.1."""
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+    has_inline = "flops" in roofline and "bytes" in roofline
+    has_func = "func" in roofline
+    if not has_inline and not has_func:
+        err("roofline must have (flops + bytes) or func")
+    if has_func and ({"flops", "bytes", "vars"} & set(roofline)):
+        err(
+            "roofline modes are exclusive — func must not coexist with "
+            "flops/bytes/vars"
+        )
+    for field in ("flops", "bytes", "func"):
+        if field in roofline and not (
+            isinstance(roofline[field], str) and roofline[field].strip()
         ):
-            errors.append(
-                f"[schema] {op_name}: source.bench_manifest_driven must be a bool"
+            err(f"roofline.{field} must be a non-empty string")
+    rl_vars = roofline.get("vars")
+    if rl_vars is not None:
+        if not isinstance(rl_vars, dict):
+            err("roofline.vars must be a mapping")
+        else:
+            for k, v in rl_vars.items():
+                if not isinstance(k, str):
+                    err(f"roofline.vars key {k!r} must be a string")
+                if not (isinstance(v, str) and v.strip()):
+                    err(f"roofline.vars[{k!r}] must be a non-empty string")
+    if has_func and isinstance(roofline.get("func"), str):
+        mod, _, attr = roofline["func"].rpartition(".")
+        try:
+            target = importlib.import_module(mod) if mod else None
+        except ImportError:
+            target = None
+        if target is None or not callable(getattr(target, attr, None)):
+            err(
+                f"roofline.func {roofline['func']!r} does not resolve "
+                f"to a callable"
             )
-    elif "source" in entry:
-        errors.append(f"[schema] {op_name}: source must be a mapping")
+    return errors
 
-    # Unknown top-level keys are ignored by every later level, so reject
-    # them here (covers removed fields like parity_opt_out).
-    unknown_top = sorted(repr(k) for k in set(entry) - _VALID_TOP_KEYS)
-    if unknown_top:
-        errors.append(
-            f"[schema] {op_name}: unknown entry keys [{', '.join(unknown_top)}]; "
-            f"valid keys are {sorted(_VALID_TOP_KEYS)}"
-        )
 
-    # variant_of: must be a string if present (R16); cross-entry checks in
-    # check_variant_of_consistency()
-    if "variant_of" in entry and not isinstance(entry["variant_of"], str):
-        errors.append(
-            f"[schema] {op_name}: variant_of must be a string"
-        )
+def _l0_source(op_name: str, entry: dict, source: dict) -> list[str]:
+    """Source block: required path fields; kernel string-or-list."""
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+    missing_src = _REQUIRED_SOURCE - set(source.keys())
+    if missing_src:
+        err(f"source missing fields: {missing_src}")
+    # source.kernel: string or list of strings
+    kernel = source.get("kernel")
+    if kernel is not None:
+        if isinstance(kernel, list):
+            for i, k in enumerate(kernel):
+                if not isinstance(k, str):
+                    err(f"source.kernel[{i}] must be a string")
+        elif not isinstance(kernel, str):
+            err("source.kernel must be a string or list")
+    if "bench_manifest_driven" in source and not isinstance(
+        source["bench_manifest_driven"], bool,
+    ):
+        err("source.bench_manifest_driven must be a bool")
+    return errors
 
-    # ref_api: required string — fully qualified PyTorch API equivalent or "none"
-    if "ref_api" not in entry:
-        errors.append(
-            f"[schema] {op_name}: missing required field 'ref_api'"
-        )
-    elif not isinstance(entry["ref_api"], str):
-        errors.append(
-            f"[schema] {op_name}: ref_api must be a string"
-        )
 
-    # status: must be "implemented" or "spec-only"
-    # (skip if already caught by missing top-level fields check)
-    status = entry.get("status")
-    if "status" in entry and not isinstance(status, str):
-        errors.append(
-            f"[schema] {op_name}: status must be a string, "
-            f"got {type(status).__name__}"
-        )
-    elif isinstance(status, str) and status not in ("implemented", "spec-only"):
-        errors.append(
-            f"[schema] {op_name}: status must be 'implemented' or 'spec-only', "
-            f"got '{status}'"
-        )
+def _l0_kernel_map(
+    op_name: str, entry: dict, warnings: list[str] | None,
+) -> list[str]:
+    """kernel_map (under source): mapping of str -> str.
 
-    # torch_compile_fullgraph: optional capability flag. Declares that
-    # torch.compile(op, fullgraph=True) succeeds cold-call. Only literal
-    # `true` is accepted; absence is the only spelling of "no promise"
-    # (`false` is rejected). Invalid on `status: spec-only` entries — a
-    # spec without an implementation cannot promise graph capture.
-    if "torch_compile_fullgraph" in entry:
-        tcf = entry["torch_compile_fullgraph"]
-        if tcf is not True:
-            errors.append(
-                f"[schema] {op_name}: torch_compile_fullgraph must be "
-                f"literal true when present (omit the field to make no "
-                f"promise), got {tcf!r}"
-            )
-        elif status == "spec-only":
-            errors.append(
-                f"[schema] {op_name}: torch_compile_fullgraph is invalid "
-                f"on 'status: spec-only' entries — the promise requires "
-                f"an implementation"
-            )
-
-    # kernel_map: lives under source (source.kernel_map per manifest spec)
+    Missing kernel_map on an implemented op is advisory (warning), not
+    an error.
+    """
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
     source = entry.get("source", {})
     kernel_map = source.get("kernel_map") if isinstance(source, dict) else None
     if kernel_map is not None:
         if not isinstance(kernel_map, dict):
-            errors.append(
-                f"[schema] {op_name}: kernel_map must be a mapping, "
+            err(
+                f"kernel_map must be a mapping, "
                 f"got {type(kernel_map).__name__}"
             )
         else:
             for k, v in kernel_map.items():
                 if not isinstance(k, str) or not isinstance(v, str):
-                    errors.append(
-                        f"[schema] {op_name}: kernel_map entries must be "
-                        f"str -> str, got {k!r}: {v!r}"
+                    err(
+                        f"kernel_map entries must be str -> str, "
+                        f"got {k!r}: {v!r}"
                     )
-    elif status == "implemented" and warnings is not None:
+    elif entry.get("status") == "implemented" and warnings is not None:
         warnings.append(
             f"[schema] {op_name}: status is 'implemented' but "
             f"kernel_map is missing (should be a mapping of str -> str)"
         )
+    return errors
 
+
+# Table-driven L0 sections, in emission order. Each row: (field, expected
+# container type, type-error phrase, section validator run on type match).
+# Genuinely custom rules (key format, scalar fields, kernel_map) stay as
+# dedicated small validators around the table loop in ``check_l0``.
+_L0_SECTIONS = (
+    ("signature", dict, "a mapping", _l0_signature),
+    ("workloads", list, "a list", _l0_workloads),
+    ("roofline", dict, "a mapping", _l0_roofline),
+    ("source", dict, "a mapping", _l0_source),
+)
+
+
+def check_l0(
+    op_name: str, entry: dict, *, warnings: list[str] | None = None,
+    all_op_names: Collection[str] = (),
+) -> list[str]:
+    """Validate structural schema of a manifest entry. Returns error strings."""
+    if not isinstance(entry, dict):
+        return [
+            f"[schema] {op_name}: entry must be a mapping, "
+            f"got {type(entry).__name__}"
+        ]
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+
+    errors.extend(_l0_key_format(op_name, all_op_names))
+
+    # Top-level required fields
+    missing_top = _REQUIRED_TOP - set(entry.keys())
+    if missing_top:
+        err(f"missing top-level fields: {missing_top}")
+
+    for field, container, desc, section in _L0_SECTIONS:
+        value = entry.get(field)
+        if isinstance(value, container):
+            errors.extend(section(op_name, entry, value))
+        elif field in entry:
+            err(f"{field} must be {desc}")
+
+    # Unknown top-level keys are ignored by every later level, so reject
+    # them here (covers removed fields like parity_opt_out).
+    unknown_top = sorted(repr(k) for k in set(entry) - _VALID_TOP_KEYS)
+    if unknown_top:
+        err(
+            f"unknown entry keys [{', '.join(unknown_top)}]; "
+            f"valid keys are {sorted(_VALID_TOP_KEYS)}"
+        )
+
+    # variant_of: must be a string if present (R16); cross-entry checks
+    # in check_variant_of_consistency().
+    if "variant_of" in entry and not isinstance(entry["variant_of"], str):
+        err("variant_of must be a string")
+
+    # ref_api: required string — fully qualified PyTorch API equivalent
+    # or "none".
+    if "ref_api" not in entry:
+        err("missing required field 'ref_api'")
+    elif not isinstance(entry["ref_api"], str):
+        err("ref_api must be a string")
+
+    # status: must be "implemented" or "spec-only"
+    # (missing status is already caught by the required-fields check).
+    status = entry.get("status")
+    if "status" in entry and not isinstance(status, str):
+        err(f"status must be a string, got {type(status).__name__}")
+    elif isinstance(status, str) and status not in ("implemented", "spec-only"):
+        err(
+            f"status must be 'implemented' or 'spec-only', "
+            f"got '{status}'"
+        )
+
+    # torch_compile_fullgraph: optional capability flag declaring that
+    # torch.compile(op, fullgraph=True) succeeds cold-call. Only literal
+    # `true` is accepted; absence is the only spelling of "no promise".
+    # Invalid on `status: spec-only` entries — a spec without an
+    # implementation cannot promise graph capture.
+    if "torch_compile_fullgraph" in entry:
+        tcf = entry["torch_compile_fullgraph"]
+        if tcf is not True:
+            err(
+                f"torch_compile_fullgraph must be literal true when "
+                f"present (omit the field to make no promise), got {tcf!r}"
+            )
+        elif status == "spec-only":
+            err(
+                "torch_compile_fullgraph is invalid on 'status: "
+                "spec-only' entries — the promise requires an "
+                "implementation"
+            )
+
+    errors.extend(_l0_kernel_map(op_name, entry, warnings))
     return errors
 
 
@@ -2135,6 +2109,8 @@ def check_l2_infer_parity(
     errors: list[str] = []
     if cls is None:
         return errors
+    err = _emit_to(errors, "shape", op_name)
+    warn = _emit_to(warnings, "shape", op_name)
 
     sig = entry.get("signature", {})
     rules = sig.get("shape_rules") or []
@@ -2154,14 +2130,12 @@ def check_l2_infer_parity(
         return errors
 
     if not _class_overrides_method(cls, "_infer_output_shapes"):
-        if warnings is not None:
-            warnings.append(
-                f"[shape] {op_name}: class does not override "
-                f"_infer_output_shapes — manifest-derived method not yet "
-                f"generated; parity check skipped. Demote the op to "
-                f"'status: spec-only' if the method genuinely cannot be "
-                f"exercised from the CPU validator."
-            )
+        warn(
+            "class does not override _infer_output_shapes — "
+            "manifest-derived method not yet generated; parity check "
+            "skipped. Demote the op to 'status: spec-only' if the method "
+            "genuinely cannot be exercised from the CPU validator."
+        )
         return errors
 
     infer_fn = getattr(cls, "_infer_output_shapes", None)
@@ -2176,17 +2150,12 @@ def check_l2_infer_parity(
     params = sig.get("params") or {}
     param_defaults = _param_defaults(params)
 
-    # Build a mock ``self`` via ``cls.__new__(cls)`` so class-defined
-    # helpers and attribute descriptors remain reachable, then install
-    # manifest-derived params as instance attributes without running
-    # __init__. A plain SimpleNamespace would raise AttributeError when
-    # _infer_output_shapes consults an unrelated ``self.<attr>`` helper.
-    #
-    # Generated ``_infer_output_shapes`` implementations commonly consult
-    # static_dims via ``self.<dim>`` (e.g. ``self.N`` for
-    # ``static_dims: {N: x.shape[-1]}``). Resolve them against the
-    # synthetic mock inputs so the parity call does not raise a spurious
-    # ``AttributeError`` and skip the check.
+    # Build a mock ``self`` via ``cls.__new__(cls)`` (see
+    # ``_build_mock_self``) enriched with static_dims values resolved
+    # against the synthetic mock inputs, so generated implementations
+    # consulting ``self.<dim>`` (e.g. ``self.N`` for
+    # ``static_dims: {N: x.shape[-1]}``) do not raise a spurious
+    # AttributeError and skip the check.
     extra_attrs = _static_dim_values(sig, mock_shapes, param_defaults)
     mock_self = _build_mock_self(cls, param_defaults, extra_attrs)
 
@@ -2199,19 +2168,18 @@ def check_l2_infer_parity(
     try:
         inspect.signature(infer_fn).bind(mock_self, **shape_kwargs)
     except TypeError as exc:
-        errors.append(
-            f"[shape] {op_name}: _infer_output_shapes signature does not match "
-            f"manifest inputs (expected kwargs {sorted(shape_kwargs)}): {exc}"
+        err(
+            f"_infer_output_shapes signature does not match manifest "
+            f"inputs (expected kwargs {sorted(shape_kwargs)}): {exc}"
         )
         return errors
     except Exception as exc:
         # signature() itself failed (e.g. builtin without introspection) —
         # skip parity rather than fabricating a signature error.
-        if warnings is not None:
-            warnings.append(
-                f"[shape] {op_name}: _infer_output_shapes parity skipped — "
-                f"inspect.signature raised {exc.__class__.__name__}: {exc}"
-            )
+        warn(
+            f"_infer_output_shapes parity skipped — inspect.signature "
+            f"raised {exc.__class__.__name__}: {exc}"
+        )
         return errors
 
     try:
@@ -2221,16 +2189,15 @@ def check_l2_infer_parity(
         # derived ``_infer_output_shapes`` must succeed on manifest-
         # compatible mock inputs; treat any body-level exception as a
         # hard L2 parity error.
-        errors.append(
-            f"[shape] {op_name}: _infer_output_shapes raised "
-            f"{exc.__class__.__name__} under mock inputs "
-            f"{shape_kwargs}: {exc}"
+        err(
+            f"_infer_output_shapes raised {exc.__class__.__name__} "
+            f"under mock inputs {shape_kwargs}: {exc}"
         )
         return errors
 
     if not isinstance(result, dict):
-        errors.append(
-            f"[shape] {op_name}: _infer_output_shapes must return a dict "
+        err(
+            f"_infer_output_shapes must return a dict "
             f"(output_name -> shape), got {type(result).__name__}"
         )
         return errors
@@ -2238,38 +2205,32 @@ def check_l2_infer_parity(
     outputs = sig.get("outputs") or {}
     for out_name in outputs:
         if out_name not in result:
-            errors.append(
-                f"[shape] {op_name}: _infer_output_shapes missing output "
-                f"{out_name!r} (declared in manifest)"
+            err(
+                f"_infer_output_shapes missing output {out_name!r} "
+                f"(declared in manifest)"
             )
 
     # Assemble evaluation context: symbolic dims + inputs + outputs +
-    # params. Symbolic dim names (e.g. B, S, H, D extracted from literal
-    # shape_rules like ``q.shape == (B, S, H, D)``) are bound first so
-    # param / tensor names later in the dict take precedence on any
-    # accidental collision.
+    # params. Symbolic dim names are bound first so param / tensor names
+    # later in the dict take precedence on any accidental collision.
     ctx: dict = {}
     ctx.update(dim_sizes)
     ctx.update(param_defaults)
     for name, shape in mock_shapes.items():
         ctx[name] = _MockShape(shape)
-    # Identify output-only symbols (symbols that appear only in declared
-    # output shapes, not in any input shape). Their concrete sizes are
-    # derived by ``_infer_output_shapes`` (possibly via a ``shape_rules``
-    # formula such as ``L_out == L_in - kW + 1``). For classification
-    # and rule evaluation, rebind these from the inferred ``result`` so
-    # a rule defining them is checked against the actual computed value
-    # rather than a synthetic mock size — otherwise a wrong
-    # _infer_output_shapes would silently pass, because the synthetic
-    # size pre-bound in ``dim_sizes`` would make the rule fail in both
-    # ctx and input_only_ctx and be misclassified as an input-only
-    # precondition to skip.
+    # Output-only symbols (appearing only in declared output shapes, not
+    # in any input shape) have their concrete sizes derived by
+    # ``_infer_output_shapes`` (possibly via a ``shape_rules`` formula
+    # such as ``L_out == L_in - kW + 1``). Rebind them from the inferred
+    # ``result`` so a rule defining them is checked against the actual
+    # computed value rather than a synthetic mock size — otherwise a
+    # wrong _infer_output_shapes would silently pass (the rule would
+    # fail in both ctx and input_only_ctx and be misclassified as an
+    # input-only precondition to skip). When the same symbol appears in
+    # multiple output positions with differing sizes, prefer the first
+    # and leave the consistency check below to flag the mismatch.
     input_bound = _input_bound_symbols(sig)
     output_only_symbols: set[str] = set()
-    # Rebind output-only symbols from the inferred ``result`` tuple
-    # positions. When the same symbol appears in multiple output
-    # positions that yield differing sizes, prefer the first and leave
-    # the consistency check below to flag the mismatch.
     output_only_rebindings: dict[str, int] = {}
     for out_name, decl_parts in declared_output_shapes.items():
         for p in decl_parts:
@@ -2290,19 +2251,15 @@ def check_l2_infer_parity(
                 continue
             if p not in output_only_rebindings:
                 output_only_rebindings[p] = got
-    # Apply output-only rebindings before rule evaluation. These replace
-    # the synthetic sizes that ``_mock_input_shapes`` seeded via the
-    # declared-output-shape pass in ``dim_sizes``.
     for p, v in output_only_rebindings.items():
         ctx[p] = v
     # Input-only context (no inferred outputs, no output-only symbols)
-    # is used to detect rules that already fail on the mock inputs
-    # themselves — such rules encode input-only preconditions (e.g.
-    # ``weight.shape == (x.shape[dim],)``) that mock inputs may violate.
-    # A correct ``_infer_output_shapes`` must not be blamed in that
-    # case. Strip output-only symbols so a rule like
-    # ``L_out == L_in - kW + 1`` is never reachable via this path (it is
-    # output-dependent by construction).
+    # detects rules that already fail on the mock inputs themselves —
+    # such rules encode input-only preconditions (e.g.
+    # ``weight.shape == (x.shape[dim],)``) that mock inputs may violate;
+    # a correct ``_infer_output_shapes`` must not be blamed for those.
+    # Output-only symbols are stripped so an output-dependent rule like
+    # ``L_out == L_in - kW + 1`` is never reachable via this path.
     input_only_ctx: dict = {
         k: v for k, v in ctx.items() if k not in output_only_symbols
     }
@@ -2310,9 +2267,9 @@ def check_l2_infer_parity(
         try:
             ctx[out_name] = _MockShape(tuple(out_shape))
         except TypeError:
-            errors.append(
-                f"[shape] {op_name}: _infer_output_shapes returned "
-                f"non-iterable shape for {out_name!r}: {out_shape!r}"
+            err(
+                f"_infer_output_shapes returned non-iterable shape "
+                f"for {out_name!r}: {out_shape!r}"
             )
 
     output_names = set(result.keys()) | set(outputs.keys())
@@ -2323,11 +2280,10 @@ def check_l2_infer_parity(
         if reason is not None:
             # Could not evaluate this rule under the mock context; do not
             # flag as parity mismatch.
-            if warnings is not None:
-                warnings.append(
-                    f"[shape] {op_name}: shape_rules[{i}] could not be "
-                    f"evaluated against mock inputs ({reason}); rule: {rule!r}"
-                )
+            warn(
+                f"shape_rules[{i}] could not be evaluated against mock "
+                f"inputs ({reason}); rule: {rule!r}"
+            )
             continue
         if not ok:
             # Distinguish a genuine parity mismatch from a mock-input
@@ -2347,18 +2303,15 @@ def check_l2_infer_parity(
                     rule, input_only_ctx,
                 )
                 if reason_inputs is None and not ok_inputs:
-                    if warnings is not None:
-                        warnings.append(
-                            f"[shape] {op_name}: shape_rules[{i}] "
-                            f"{rule!r} not satisfied by synthetic mock "
-                            f"inputs {shape_kwargs}; parity check "
-                            f"skipped (input-only precondition)"
-                        )
+                    warn(
+                        f"shape_rules[{i}] {rule!r} not satisfied by "
+                        f"synthetic mock inputs {shape_kwargs}; parity "
+                        f"check skipped (input-only precondition)"
+                    )
                     continue
-            errors.append(
-                f"[shape] {op_name}: _infer_output_shapes output violates "
-                f"shape_rules[{i}] {rule!r} under mock inputs "
-                f"{shape_kwargs} -> {result}"
+            err(
+                f"_infer_output_shapes output violates shape_rules[{i}] "
+                f"{rule!r} under mock inputs {shape_kwargs} -> {result}"
             )
 
     # Compare inferred outputs against per-tensor declared shapes in
@@ -2366,44 +2319,28 @@ def check_l2_infer_parity(
     # catches ops whose outputs are only specified via declared shape
     # fields (no equivalent shape_rule).
     #
-    # Only symbols **bound by input shapes** (input shape_rules literals
-    # or signature.inputs[*].shape declarations) carry a concrete mock
-    # size that ``_infer_output_shapes`` is expected to echo back.
-    # Output-only symbols (e.g. ``L_out`` in a conv output shape that is
-    # derived by a ``shape_rules`` entry such as ``L_out = L_in - kW + 1``)
-    # cannot be meaningfully compared against an arbitrary
-    # ``dim_sizes`` entry — doing so would flag a correct
-    # implementation, since ``_infer_output_shapes`` computes the real
-    # post-conv length, not the synthetic size assigned to ``L_out``.
-    # For such symbols we enforce rank + per-symbol consistency instead
-    # (same symbol must map to the same concrete size across every
-    # position it appears in any declared output shape).
-    # ``input_bound`` is already computed above (reused for the
-    # output-only rebinding pass before rule evaluation).
+    # Only symbols **bound by input shapes** carry a concrete mock size
+    # that ``_infer_output_shapes`` is expected to echo back. Output-only
+    # symbols (e.g. a conv ``L_out`` derived by a shape_rules formula)
+    # cannot be compared against an arbitrary ``dim_sizes`` entry — that
+    # would flag a correct implementation. For those, enforce rank plus
+    # per-symbol consistency instead (same symbol -> same concrete size
+    # across every declared output position).
     #
-    # Static-dim resolution: symbols declared in ``signature.static_dims``
-    # (e.g. ``static_dims: {N: "x.shape[-1]"}``) are resolved to concrete
-    # integer sizes against the mock inputs via ``_static_dim_values``
-    # (already stored in ``extra_attrs`` above). Treat those as pinned
-    # expected sizes for the declared-output-shape comparison — a bad
+    # Static-dim symbols (``signature.static_dims``) resolve to concrete
+    # integers against the mock inputs via ``_static_dim_values`` (stored
+    # in ``extra_attrs`` above) and pin expected sizes exactly — a bad
     # ``_infer_output_shapes`` returning arbitrary integers for a
-    # static-dim position must be caught, not mistakenly reclassified as
-    # an output-only symbol with only rank/consistency enforcement.
+    # static-dim position must be caught, not reclassified as output-only.
     static_expected: dict[str, int] = {
         name: int(val) for name, val in extra_attrs.items()
         if isinstance(val, int) and not isinstance(val, bool)
     }
     # Params with a concrete integer ``default`` are also compile-time
-    # known and should pin declared-output-shape dims with the same
-    # authority as ``static_dims``. Without this, a declared output
-    # ``shape: "[k]"`` where ``k`` is a param default would be
-    # classified as an output-only symbol, and a bad
-    # ``_infer_output_shapes`` returning an arbitrary integer for that
-    # position would only trip rank/consistency checks rather than exact
-    # value comparison. Edge cases: params without a default (supplied
-    # at op construction, unknown to the validator) are skipped; params
-    # whose default is not a single ``int`` (e.g. ``list[int]``) are
-    # skipped so they cannot pin a scalar dim position.
+    # known and pin declared-output-shape dims with the same authority as
+    # ``static_dims``. Params without a default (supplied at op
+    # construction, unknown to the validator) are skipped; non-int
+    # defaults (e.g. ``list[int]``) cannot pin a scalar dim position.
     for pname, pdefault in param_defaults.items():
         if pname in static_expected:
             continue  # static_dims wins — it is the declared source of truth.
@@ -2420,11 +2357,11 @@ def check_l2_infer_parity(
         except TypeError:
             continue  # already reported above
         if len(inferred) != len(decl_parts):
-            errors.append(
-                f"[shape] {op_name}: _infer_output_shapes output "
-                f"{out_name!r} rank {len(inferred)} disagrees with "
-                f"declared shape {decl_parts} (rank {len(decl_parts)}) "
-                f"under mock inputs {shape_kwargs} -> {inferred}"
+            err(
+                f"_infer_output_shapes output {out_name!r} rank "
+                f"{len(inferred)} disagrees with declared shape "
+                f"{decl_parts} (rank {len(decl_parts)}) under mock "
+                f"inputs {shape_kwargs} -> {inferred}"
             )
             continue
         for idx, (p, got) in enumerate(zip(decl_parts, inferred, strict=True)):
@@ -2437,10 +2374,10 @@ def check_l2_infer_parity(
                     p, dim_sizes.get(p, _MOCK_DIM_SIZE)
                 )
                 if got != expected:
-                    errors.append(
-                        f"[shape] {op_name}: _infer_output_shapes output "
-                        f"{out_name!r} dim[{idx}]={got} disagrees with "
-                        f"declared {p}={expected} under mock inputs "
+                    err(
+                        f"_infer_output_shapes output {out_name!r} "
+                        f"dim[{idx}]={got} disagrees with declared "
+                        f"{p}={expected} under mock inputs "
                         f"{shape_kwargs} -> {inferred}"
                     )
             else:
@@ -2453,11 +2390,11 @@ def check_l2_infer_parity(
                 if prev is None:
                     output_only_seen[p] = got
                 elif prev != got:
-                    errors.append(
-                        f"[shape] {op_name}: _infer_output_shapes output "
-                        f"{out_name!r} binds output-only symbol {p!r} to "
-                        f"{got} but earlier output bound it to {prev} "
-                        f"(inconsistent under mock inputs {shape_kwargs})"
+                    err(
+                        f"_infer_output_shapes output {out_name!r} binds "
+                        f"output-only symbol {p!r} to {got} but earlier "
+                        f"output bound it to {prev} (inconsistent under "
+                        f"mock inputs {shape_kwargs})"
                     )
     return errors
 
@@ -2736,6 +2673,121 @@ def _combo_accepted(
     return True, None
 
 
+def _emit_to(sink, tag: str, op_name: str):
+    """Return an emitter appending ``[tag] op_name: msg`` strings to *sink*.
+
+    A ``None`` sink yields a no-op emitter so callers can bind a warning
+    emitter without guarding every call site.
+    """
+    if sink is None:
+        return lambda msg: None
+    prefix = f"[{tag}] {op_name}: "
+    return lambda msg: sink.append(prefix + msg)
+
+
+# ``_combo_accepted`` reason prefixes → dispatch kinds. Callers branch on
+# the kind instead of re-matching prefixes at every probe site.
+_REASON_KINDS = (
+    ("TypeError", "signature"),
+    ("introspect-failed", "introspect"),
+    ("unexpected", "unexpected"),
+    ("cannot build mock tensor", "no-mock"),
+    ("combo missing input", "missing-input"),
+)
+
+
+def _probe_reason_kind(reason: str | None) -> str | None:
+    """Classify a ``_combo_accepted`` reason string by its prefix.
+
+    Returns None for a clean probe (reason is None); ``"other"`` for an
+    unrecognized reason (no caller acts on it, matching the previous
+    per-site prefix cascades).
+    """
+    if reason is None:
+        return None
+    for prefix, kind in _REASON_KINDS:
+        if reason.startswith(prefix):
+            return kind
+    return "other"
+
+
+def _probe_out_of_union(
+    op_name: str,
+    cls: type,
+    sig: dict,
+    forward_inputs: list[str],
+    baseline: dict[str, str],
+    dtype_options: dict[str, list[str]],
+    param_defaults: dict,
+    errors: list[str],
+    warnings: list[str] | None,
+) -> None:
+    """Out-of-union negative probe (rejection side), shared by both branches.
+
+    Starting from *baseline* (a combination known to be accepted),
+    substitutes an out-of-union sentinel for each non-same_as-bound input
+    in turn; every resulting candidate must be rejected. ``self.dtype``
+    stays pinned to the baseline's primary dtype so only the input
+    tensor's dtype deviates from the op's configured dtype — otherwise a
+    generated ``x.dtype != self.dtype`` check would spuriously pass, since
+    both sides would track the bad dtype. same_as(ref)-bound tensors are
+    never mutated directly (their dtype follows ``ref``); the substitution
+    is propagated to them instead. Probing is bounded by
+    ``_MAX_DTYPE_COMBOS`` to preserve the Cartesian safety bound.
+    """
+    err = _emit_to(errors, "dtype", op_name)
+    warn = _emit_to(warnings, "dtype", op_name)
+    same_as_refs = _same_as_refs(sig)
+    baseline_primary = _primary_dtype_input(sig, forward_inputs)
+    baseline_self_dtype = (
+        baseline.get(baseline_primary)
+        if baseline_primary is not None else None
+    )
+    probed = 0
+    for target in forward_inputs:
+        if target in same_as_refs:
+            continue
+        declared = set(dtype_options.get(target, []))
+        out_of_union = _out_of_union_candidates(declared)
+        if not out_of_union:
+            # Declared union covers the entire torch dtype set (wildly
+            # permissive spec) — no rejection candidate exists. Warn
+            # instead of vacuously passing.
+            warn(
+                f"out-of-union probe skipped for input {target!r} — "
+                f"declared dtype union covers the entire torch dtype "
+                f"set; rejection side cannot be exercised"
+            )
+            continue
+        for bad_dtype in out_of_union:
+            if probed >= _MAX_DTYPE_COMBOS:
+                break
+            probed += 1
+            candidate = dict(baseline)
+            candidate[target] = bad_dtype
+            for tname, ref in same_as_refs.items():
+                if ref == target and tname in candidate:
+                    candidate[tname] = bad_dtype
+            accepted, reason = _combo_accepted(
+                cls, forward_inputs, candidate, param_defaults,
+                sig=sig, self_dtype_name=baseline_self_dtype,
+            )
+            if _probe_reason_kind(reason) == "unexpected":
+                err(
+                    f"_validate_dtypes raised unexpected exception on "
+                    f"out-of-union probe {candidate!r} — {reason}"
+                )
+                continue
+            if accepted:
+                err(
+                    f"_validate_dtypes accepts out-of-union dtype "
+                    f"{candidate!r} (input {target!r} declared "
+                    f"{sorted(declared)})"
+                )
+        if probed >= _MAX_DTYPE_COMBOS:
+            break
+
+
 def check_l3_validate_dtypes_parity(
     op_name: str,
     entry: dict,
@@ -2759,16 +2811,16 @@ def check_l3_validate_dtypes_parity(
     errors: list[str] = []
     if cls is None:
         return errors
+    err = _emit_to(errors, "dtype", op_name)
+    warn = _emit_to(warnings, "dtype", op_name)
 
     if not _class_overrides_method(cls, "_validate_dtypes"):
-        if warnings is not None:
-            warnings.append(
-                f"[dtype] {op_name}: class does not override "
-                f"_validate_dtypes — manifest-derived method not yet "
-                f"generated; parity check skipped. Demote the op to "
-                f"'status: spec-only' if the method genuinely cannot be "
-                f"exercised from the CPU validator."
-            )
+        warn(
+            "class does not override _validate_dtypes — manifest-derived "
+            "method not yet generated; parity check skipped. Demote the "
+            "op to 'status: spec-only' if the method genuinely cannot be "
+            "exercised from the CPU validator."
+        )
         return errors
 
     sig = entry.get("signature", {})
@@ -2789,24 +2841,19 @@ def check_l3_validate_dtypes_parity(
     dtype_combos = sig.get("dtype_combos")
     if isinstance(dtype_combos, list) and dtype_combos:
         # Combo-data validity: surface invalid entries as hard L3 errors
-        # so downstream parity probing does not run on junk data (which
-        # would otherwise produce a cascade of misleading "rejects" /
-        # "skipped" diagnostics). The same check also runs
-        # unconditionally in ``check_l3`` — the driver dedupes error
-        # strings so users see each message once even when both entry
-        # points are invoked in the same run.
+        # so downstream parity probing does not run on junk data. The
+        # same check also runs unconditionally in ``check_l3`` — the
+        # driver dedupes error strings so users see each message once.
         combo_validation_errors = check_l3_dtype_combos_data(op_name, sig)
         if combo_validation_errors:
             errors.extend(combo_validation_errors)
             return errors
 
         # Expand ``same_as(ref)`` in combo values to a concrete dtype
-        # before parity probing: ``_combo_accepted`` / ``_make_mock_tensor``
-        # expect literal torch dtype names and would otherwise try to look
-        # up ``same_as(x)`` as a torch attribute. Per R3 + R4 we already
-        # enforce identity (``_check_dtype_combos_same_as_identity``), so
-        # each ``same_as(ref)`` value resolves to the same concrete dtype
-        # the ref carries in the same combo row.
+        # before parity probing: ``_combo_accepted`` expects literal
+        # torch dtype names. Per R3 + R4 identity is already enforced
+        # (``_check_dtype_combos_same_as_identity``), so each
+        # ``same_as(ref)`` resolves to the ref's dtype in the same row.
         expanded_combos: list[dict[str, str]] = []
         for combo in dtype_combos:
             if not isinstance(combo, dict):
@@ -2832,53 +2879,40 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, combo, param_defaults, sig=sig,
             )
-            if reason and reason.startswith("TypeError"):
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes signature does "
-                    f"not match manifest inputs (expected kwargs "
-                    f"{sorted(forward_inputs)}): {reason}"
-                )
-                return errors
-            if reason and reason.startswith("introspect-failed"):
-                # Validator-side introspection failure (inspect.signature
-                # could not parse the method). Not an op-side bug —
-                # skip with warning.
-                if warnings is not None:
-                    warnings.append(
-                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
-                        f"for dtype_combos[{i}] — {reason}"
-                    )
-                continue
-            if reason and reason.startswith("unexpected"):
-                # Body-level exception that is not ValueError / TypeError
-                # — a real implementation bug. Hard L3 parity error.
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes raised "
-                    f"unexpected exception on dtype_combos[{i}] "
-                    f"{combo!r} — {reason}"
-                )
-                continue
-            if reason and reason.startswith("cannot build mock tensor"):
-                # Validator limitation (no torch dtype for this name) — emit
-                # a parity-skip warning rather than reporting a rejection.
-                if warnings is not None:
-                    warnings.append(
-                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
-                        f"for dtype_combos[{i}] — {reason}"
-                    )
-                continue
-            if reason and reason.startswith("combo missing input"):
-                # Manifest error: combo doesn't specify a dtype for every
-                # declared input. Surface as parity error but not a reject.
-                errors.append(
-                    f"[dtype] {op_name}: dtype_combos[{i}] {combo!r} "
+            kind = _probe_reason_kind(reason)
+            if kind == "signature":
+                err(
+                    f"_validate_dtypes signature does not match manifest "
+                    f"inputs (expected kwargs {sorted(forward_inputs)}): "
                     f"{reason}"
                 )
+                return errors
+            if kind in ("introspect", "no-mock"):
+                # Validator-side limitation (inspect.signature failed or
+                # the local torch build lacks the dtype) — skip with a
+                # parity-skip warning, not an op-side error.
+                warn(
+                    f"_validate_dtypes parity skipped for "
+                    f"dtype_combos[{i}] — {reason}"
+                )
+                continue
+            if kind == "unexpected":
+                # Body-level exception that is not ValueError / TypeError
+                # — a real implementation bug. Hard L3 parity error.
+                err(
+                    f"_validate_dtypes raised unexpected exception on "
+                    f"dtype_combos[{i}] {combo!r} — {reason}"
+                )
+                continue
+            if kind == "missing-input":
+                # Manifest error: combo doesn't specify a dtype for every
+                # declared input. Parity error, not a rejection.
+                err(f"dtype_combos[{i}] {combo!r} {reason}")
                 continue
             if not accepted:
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes rejects "
-                    f"dtype_combos[{i}] {combo!r} listed in manifest"
+                err(
+                    f"_validate_dtypes rejects dtype_combos[{i}] "
+                    f"{combo!r} listed in manifest"
                 )
 
         # Every non-listed combo drawn from the inputs' union must be
@@ -2892,15 +2926,13 @@ def check_l3_validate_dtypes_parity(
         for opts in input_options:
             product_size *= max(len(opts), 1)
         if product_size > _MAX_DTYPE_COMBOS:
-            if warnings is not None:
-                warnings.append(
-                    f"[dtype] {op_name}: Cartesian product of dtype "
-                    f"options ({product_size}) exceeds "
-                    f"_MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; non-listed "
-                    f"rejection check skipped "
-                    f"({len(forward_inputs)} inputs × options "
-                    f"{[len(o) for o in input_options]})"
-                )
+            warn(
+                f"Cartesian product of dtype options ({product_size}) "
+                f"exceeds _MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; "
+                f"non-listed rejection check skipped "
+                f"({len(forward_inputs)} inputs × options "
+                f"{[len(o) for o in input_options]})"
+            )
             return errors
         listed_combo_keys = {
             tuple(combo.get(n) for n in forward_inputs)
@@ -2916,16 +2948,13 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, candidate, param_defaults, sig=sig,
             )
-            if reason and reason.startswith(
-                ("introspect-failed", "TypeError")
-            ):
+            kind = _probe_reason_kind(reason)
+            if kind in ("introspect", "signature"):
                 continue
-            if reason and reason.startswith("unexpected"):
-                # Body-level unexpected exception — hard error.
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes raised "
-                    f"unexpected exception on non-listed combo "
-                    f"{candidate!r} — {reason}"
+            if kind == "unexpected":
+                err(
+                    f"_validate_dtypes raised unexpected exception on "
+                    f"non-listed combo {candidate!r} — {reason}"
                 )
                 continue
             if not accepted:
@@ -2933,17 +2962,13 @@ def check_l3_validate_dtypes_parity(
                 continue
             # Accepted non-listed combo — parity violation. Keep scanning
             # so multiple such combos are all surfaced in a single run.
-            errors.append(
-                f"[dtype] {op_name}: _validate_dtypes accepts non-listed "
-                f"combo {candidate!r} (not in dtype_combos)"
+            err(
+                f"_validate_dtypes accepts non-listed combo "
+                f"{candidate!r} (not in dtype_combos)"
             )
 
-        # --- Out-of-union negative probe (rejection side) -------------
-        # Mirrors the probe in the no-dtype_combos branch. Picks a listed
-        # combo as a baseline (known to be accepted) and substitutes an
-        # out-of-union sentinel for each non-same_as-bound input in turn.
-        # Each resulting candidate must be rejected. Bounded by
-        # _MAX_DTYPE_COMBOS to preserve the Cartesian safety bound.
+        # Out-of-union negative probe: baseline is the first listed combo
+        # covering every input (known to be accepted).
         baseline_combo: dict[str, str] | None = None
         for c in dtype_combos:
             if isinstance(c, dict) and all(
@@ -2952,94 +2977,26 @@ def check_l3_validate_dtypes_parity(
                 baseline_combo = dict(c)
                 break
         if baseline_combo is not None:
-            same_as_refs = _same_as_refs(sig)
-            # Baseline's primary dtype pins ``self.dtype`` during the
-            # probe so only the input tensor's dtype deviates from the
-            # op's configured dtype (otherwise the ``x.dtype !=
-            # self.dtype`` check in a generated _validate_dtypes would
-            # spuriously pass, since both sides track the bad dtype).
-            baseline_primary = _primary_dtype_input(sig, forward_inputs)
-            baseline_self_dtype = (
-                baseline_combo.get(baseline_primary)
-                if baseline_primary is not None else None
+            _probe_out_of_union(
+                op_name, cls, sig, forward_inputs, baseline_combo,
+                dtype_options, param_defaults, errors, warnings,
             )
-            probe_budget = _MAX_DTYPE_COMBOS
-            probed = 0
-            for target in forward_inputs:
-                # Skip same_as(ref)-bound tensors: their dtype is
-                # controlled by ``ref``. Mutate the ref instead and let
-                # same_as propagation carry the out-of-union dtype.
-                if target in same_as_refs:
-                    continue
-                declared = set(dtype_options.get(target, []))
-                out_of_union = _out_of_union_candidates(declared)
-                if not out_of_union:
-                    # Declared union covers the entire torch dtype
-                    # universe for this input — no candidate exists to
-                    # probe rejection. Emit a parity-skip warning naming
-                    # the op/input so the gap is visible rather than a
-                    # vacuous pass. Only possible when declared ==
-                    # _TORCH_DTYPES (wildly permissive spec).
-                    if warnings is not None:
-                        warnings.append(
-                            f"[dtype] {op_name}: out-of-union probe "
-                            f"skipped for input {target!r} — declared "
-                            f"dtype union covers the entire torch dtype "
-                            f"set; rejection side cannot be exercised"
-                        )
-                    continue
-                for bad_dtype in out_of_union:
-                    if probed >= probe_budget:
-                        break
-                    probed += 1
-                    candidate = dict(baseline_combo)
-                    candidate[target] = bad_dtype
-                    for tname, ref in same_as_refs.items():
-                        if ref == target and tname in candidate:
-                            candidate[tname] = bad_dtype
-                    accepted, reason = _combo_accepted(
-                        cls, forward_inputs, candidate, param_defaults,
-                        sig=sig, self_dtype_name=baseline_self_dtype,
-                    )
-                    if reason and reason.startswith(
-                        ("introspect-failed", "TypeError",
-                         "cannot build", "combo missing")
-                    ):
-                        continue
-                    if reason and reason.startswith("unexpected"):
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes raised "
-                            f"unexpected exception on out-of-union probe "
-                            f"{candidate!r} — {reason}"
-                        )
-                        continue
-                    if accepted:
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes "
-                            f"accepts out-of-union dtype "
-                            f"{candidate!r} (input {target!r} declared "
-                            f"{sorted(declared)})"
-                        )
-                if probed >= probe_budget:
-                    break
 
-        if not errors and warnings is not None:
+        if not errors:
             if not checked_any:
                 # No non-listed combo exists in the Cartesian product —
                 # dtype_combos already enumerates every reachable tuple.
-                warnings.append(
-                    f"[dtype] {op_name}: could not find a non-listed combo "
-                    f"to exercise rejection (dtype_combos exhausts the "
-                    f"union)"
+                warn(
+                    "could not find a non-listed combo to exercise "
+                    "rejection (dtype_combos exhausts the union)"
                 )
             elif not rejected_at_least_one:
                 # Non-listed combos were tried but none were rejected —
                 # either _validate_dtypes is too lax or every non-listed
                 # candidate was skipped (unexpected/TypeError).
-                warnings.append(
-                    f"[dtype] {op_name}: no non-listed dtype combo was "
-                    f"rejected by _validate_dtypes; parity coverage may be "
-                    f"incomplete"
+                warn(
+                    "no non-listed dtype combo was rejected by "
+                    "_validate_dtypes; parity coverage may be incomplete"
                 )
     else:
         # No dtype_combos — verify every Cartesian combination is accepted.
@@ -3052,14 +3009,12 @@ def check_l3_validate_dtypes_parity(
         for opts in input_options:
             product_size *= len(opts)
         if product_size > _MAX_DTYPE_COMBOS:
-            if warnings is not None:
-                warnings.append(
-                    f"[dtype] {op_name}: Cartesian product of dtype "
-                    f"options ({product_size}) exceeds "
-                    f"_MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; parity check "
-                    f"skipped ({len(forward_inputs)} inputs × options "
-                    f"{[len(o) for o in input_options]})"
-                )
+            warn(
+                f"Cartesian product of dtype options ({product_size}) "
+                f"exceeds _MAX_DTYPE_COMBOS={_MAX_DTYPE_COMBOS}; parity "
+                f"check skipped ({len(forward_inputs)} inputs × options "
+                f"{[len(o) for o in input_options]})"
+            )
             return errors
         for tup in itertools.product(*input_options):
             # Only keep combos that honour same_as identity constraints:
@@ -3070,43 +3025,39 @@ def check_l3_validate_dtypes_parity(
             accepted, reason = _combo_accepted(
                 cls, forward_inputs, candidate, param_defaults, sig=sig,
             )
-            if reason and reason.startswith("TypeError"):
+            kind = _probe_reason_kind(reason)
+            if kind == "signature":
                 # Signature mismatch between manifest inputs and the op's
                 # _validate_dtypes — surface as a parity error (analogous
                 # to the L2 _infer_output_shapes signature check).
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes signature does "
-                    f"not match manifest inputs (expected kwargs "
-                    f"{sorted(forward_inputs)}): {reason}"
+                err(
+                    f"_validate_dtypes signature does not match manifest "
+                    f"inputs (expected kwargs {sorted(forward_inputs)}): "
+                    f"{reason}"
                 )
                 return errors
-            if reason and reason.startswith("introspect-failed"):
-                if warnings is not None:
-                    warnings.append(
-                        f"[dtype] {op_name}: _validate_dtypes parity skipped "
-                        f"for combo {candidate!r} — {reason}"
-                    )
+            if kind == "introspect":
+                warn(
+                    f"_validate_dtypes parity skipped for combo "
+                    f"{candidate!r} — {reason}"
+                )
                 continue
-            if reason and reason.startswith("unexpected"):
+            if kind == "unexpected":
                 # Body-level unexpected exception — hard error.
                 # See ``_combo_accepted`` docstring.
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes raised "
-                    f"unexpected exception on combo {candidate!r} — "
-                    f"{reason}"
+                err(
+                    f"_validate_dtypes raised unexpected exception on "
+                    f"combo {candidate!r} — {reason}"
                 )
                 continue
             if not accepted:
-                errors.append(
-                    f"[dtype] {op_name}: _validate_dtypes rejects valid "
-                    f"combo {candidate!r} drawn from manifest dtype unions"
+                err(
+                    f"_validate_dtypes rejects valid combo {candidate!r} "
+                    f"drawn from manifest dtype unions"
                 )
 
-        # --- Out-of-union negative probe (rejection side) -------------
-        # For each input, substitute one dtype outside its declared union
-        # and assert _validate_dtypes rejects it. Candidates are built on
-        # a same_as-honouring baseline so the only deviation is the
-        # out-of-union dtype. Bounded by _MAX_DTYPE_COMBOS.
+        # Out-of-union negative probe: baseline is the first
+        # same_as-honouring candidate from the union.
         baseline: dict[str, str] | None = None
         for tup in itertools.product(*input_options):
             cand = dict(zip(forward_inputs, tup, strict=True))
@@ -3114,73 +3065,10 @@ def check_l3_validate_dtypes_parity(
                 baseline = cand
                 break
         if baseline is not None:
-            same_as_refs = _same_as_refs(sig)
-            # Keep ``self.dtype`` pinned to the baseline's primary valid
-            # dtype during out-of-union probes — see the dtype_combos
-            # branch above for rationale.
-            baseline_primary = _primary_dtype_input(sig, forward_inputs)
-            baseline_self_dtype = (
-                baseline.get(baseline_primary)
-                if baseline_primary is not None else None
+            _probe_out_of_union(
+                op_name, cls, sig, forward_inputs, baseline,
+                dtype_options, param_defaults, errors, warnings,
             )
-            probe_budget = _MAX_DTYPE_COMBOS
-            probed = 0
-            for target in forward_inputs:
-                # Don't directly mutate tensors that are bound by
-                # same_as(ref) — their dtype is controlled by ``ref``.
-                # Instead mutate the ref (or a free tensor) and let
-                # same_as propagation carry the out-of-union dtype.
-                if target in same_as_refs:
-                    continue
-                declared = set(dtype_options.get(target, []))
-                out_of_union = _out_of_union_candidates(declared)
-                if not out_of_union:
-                    # Declared union covers every torch dtype — cannot
-                    # produce a rejection candidate. Skip with a warning
-                    # rather than vacuously pass.
-                    if warnings is not None:
-                        warnings.append(
-                            f"[dtype] {op_name}: out-of-union probe "
-                            f"skipped for input {target!r} — declared "
-                            f"dtype union covers the entire torch dtype "
-                            f"set; rejection side cannot be exercised"
-                        )
-                    continue
-                for bad_dtype in out_of_union:
-                    if probed >= probe_budget:
-                        break
-                    probed += 1
-                    candidate = dict(baseline)
-                    candidate[target] = bad_dtype
-                    # Propagate to all same_as(target) tensors so the
-                    # only manifest violation is the out-of-union dtype.
-                    for tname, ref in same_as_refs.items():
-                        if ref == target and tname in candidate:
-                            candidate[tname] = bad_dtype
-                    accepted, reason = _combo_accepted(
-                        cls, forward_inputs, candidate, param_defaults,
-                        sig=sig, self_dtype_name=baseline_self_dtype,
-                    )
-                    if reason and reason.startswith(
-                        ("introspect-failed", "TypeError")
-                    ):
-                        continue
-                    if reason and reason.startswith("unexpected"):
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes raised "
-                            f"unexpected exception on out-of-union probe "
-                            f"{candidate!r} — {reason}"
-                        )
-                        continue
-                    if accepted:
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes "
-                            f"accepts out-of-union dtype "
-                            f"{candidate!r} (input {target!r} declared "
-                            f"{sorted(declared)})"
-                        )
-                if probed >= probe_budget:
-                    break
 
         # --- same_as identity negative probe (R3 rejection side) -------
         # For each same_as(ref) input, build a candidate where that
@@ -3212,22 +3100,21 @@ def check_l3_validate_dtypes_parity(
                     accepted, reason = _combo_accepted(
                         cls, forward_inputs, candidate, param_defaults, sig=sig,
                     )
-                    if reason and reason.startswith(
-                        ("introspect-failed", "TypeError")
-                    ):
+                    kind = _probe_reason_kind(reason)
+                    if kind in ("introspect", "signature"):
                         continue
-                    if reason and reason.startswith("unexpected"):
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes raised "
-                            f"unexpected exception on same_as probe "
-                            f"{candidate!r} — {reason}"
+                    if kind == "unexpected":
+                        err(
+                            f"_validate_dtypes raised unexpected "
+                            f"exception on same_as probe {candidate!r} "
+                            f"— {reason}"
                         )
                         continue
                     if accepted:
-                        errors.append(
-                            f"[dtype] {op_name}: _validate_dtypes "
-                            f"accepts same_as violation {candidate!r} "
-                            f"(input {tname!r} declared same_as({ref}))"
+                        err(
+                            f"_validate_dtypes accepts same_as violation "
+                            f"{candidate!r} (input {tname!r} declared "
+                            f"same_as({ref}))"
                         )
     return errors
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -95,6 +95,16 @@ def _sig(inputs, outputs=None, **extra):
     return sig
 
 
+def _conv_sig():
+    """Conv-style signature with an output-only ``L_out`` symbol."""
+    return _sig(
+        {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+         "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
+        {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
+        shape_rules=["L_out == L_in - kW + 1"],
+    )
+
+
 def _make_op_cls_with_infer(infer_fn, *, name="FakeOp"):
     """Build a minimal Op subclass whose ``_infer_output_shapes`` is *infer_fn*.
 
@@ -408,37 +418,28 @@ class TestSchema:
     def test_shape_rule_expressions_rejected_at_l0(self, validator):
         """Unknown callables and syntax errors fail with [schema] errors;
         repeated misspellings in one rule are reported once per name."""
-        entry = _make_entry()
-        entry["signature"]["shape_rules"] = ["totally_unknown_helper(x.shape) == 0"]
-        errors = validator.check_l0("test_op", entry)
-        assert any(
-            "[schema]" in e and "shape_rules[0]" in e
-            and "totally_unknown_helper" in e
-            for e in errors
-        ), errors
-
-        entry = _make_entry()
-        entry["signature"]["shape_rules"] = ["x.shape == ("]
-        errors = validator.check_l0("test_op", entry)
-        assert any(
-            "[schema]" in e and "shape_rules[0]" in e and "syntax" in e.lower()
-            for e in errors
-        ), errors
-
-        entry = _make_entry()
-        entry["signature"]["shape_rules"] = [
-            "totally_unknown_helper(x.shape) and totally_unknown_helper(x.shape)"
+        cases = [
+            # (rule, substring expected alongside shape_rules[0], count)
+            ("totally_unknown_helper(x.shape) == 0",
+             "totally_unknown_helper", None),
+            ("x.shape == (", "syntax", None),
+            ("totally_unknown_helper(x.shape) and "
+             "totally_unknown_helper(x.shape)",
+             "totally_unknown_helper", 1),
         ]
-        errors = validator.check_l0("test_op", entry)
-        matching = [
-            e for e in errors
-            if "[schema]" in e and "shape_rules[0]" in e
-            and "totally_unknown_helper" in e
-        ]
-        assert len(matching) == 1, (
-            f"Expected one schema error for the duplicated unknown callable, "
-            f"got {len(matching)}: {matching}"
-        )
+        for rule, substring, count in cases:
+            entry = _make_entry()
+            entry["signature"]["shape_rules"] = [rule]
+            errors = validator.check_l0("test_op", entry)
+            matching = [
+                e for e in errors
+                if "[schema]" in e and "shape_rules[0]" in e
+                and substring in e.lower()
+            ]
+            if count is None:
+                assert matching, (rule, errors)
+            else:
+                assert len(matching) == count, (rule, matching)
 
 
 class TestWorkloadPolicy:
@@ -478,7 +479,8 @@ class TestWorkloadPolicy:
 class TestOutputShapeDeclaration:
     """Every output declares a shape, or the signature has shape_rules."""
 
-    def test_output_without_shape_or_rules_fails(self, validator):
+    def test_output_shape_presence(self, validator):
+        """Case table: no shape and no rules fails; declared shape passes."""
         entry = _make_entry()
         del entry["signature"]["shape_rules"]
         errors = validator.check_l0("test_op", entry)
@@ -486,7 +488,6 @@ class TestOutputShapeDeclaration:
             "output" in e and "'y'" in e and "shape" in e for e in errors
         ), errors
 
-    def test_output_with_declared_shape_passes(self, validator):
         entry = _make_entry(
             outputs={"y": {"dtype": "same_as(x)", "shape": "[M, N]"}},
         )
@@ -497,28 +498,29 @@ class TestOutputShapeDeclaration:
 class TestTensorConstraints:
     """Tensor ``constraints`` keys must name dims of the declared shape."""
 
-    def test_constraint_key_outside_shape_dims_fails(self, validator):
-        entry = _make_entry(
-            inputs={"x": {"dtype": "float16", "shape": "[M, N]",
-                          "constraints": {"K": "K % 2 == 0"}}},
-        )
-        errors = validator.check_l0("test_op", entry)
-        assert any("constraints" in e and "'K'" in e for e in errors), errors
-
-    def test_constraints_without_shape_fails(self, validator):
-        entry = _make_entry(
-            inputs={"x": {"dtype": "float16",
-                          "constraints": {"N": "N % 2 == 0"}}},
-        )
-        errors = validator.check_l0("test_op", entry)
-        assert any("constraints" in e and "shape" in e for e in errors), errors
-
-    def test_constraint_keys_matching_shape_dims_pass(self, validator):
-        entry = _make_entry(
-            inputs={"x": {"dtype": "float16", "shape": "[M, N]",
-                          "constraints": {"N": "N % 2 == 0"}}},
-        )
-        assert validator.check_l0("test_op", entry) == []
+    def test_constraint_key_shape_dim_matching(self, validator):
+        """Case table: key outside dims / constraints without shape fail;
+        keys matching the declared dims pass."""
+        cases = [
+            # (description, input tensor attrs, substrings or None=pass)
+            ("constraint key outside shape dims",
+             {"dtype": "float16", "shape": "[M, N]",
+              "constraints": {"K": "K % 2 == 0"}}, ["constraints", "'K'"]),
+            ("constraints without shape",
+             {"dtype": "float16", "constraints": {"N": "N % 2 == 0"}},
+             ["constraints", "shape"]),
+            ("constraint keys matching shape dims",
+             {"dtype": "float16", "shape": "[M, N]",
+              "constraints": {"N": "N % 2 == 0"}}, None),
+        ]
+        for desc, attrs, substrings in cases:
+            errors = validator.check_l0("test_op", _make_entry(inputs={"x": attrs}))
+            if substrings is None:
+                assert errors == [], (desc, errors)
+            else:
+                assert any(
+                    all(s in e for s in substrings) for e in errors
+                ), f"{desc}: expected error with {substrings}, got: {errors}"
 
 
 class TestSourcePathExistence:
@@ -1035,12 +1037,8 @@ class TestDtype:
         assert errors == [], errors
 
     def test_check_l3_with_non_dict_signature_does_not_crash(self, validator):
-        """check_l3 must tolerate malformed signature.inputs/outputs.
-
-        A list or string in place of the expected dict triggered an
-        unguarded ``.update()`` / ``.keys()`` crash; treat as empty so
-        the schema layer's own diagnostics surface unmasked.
-        """
+        """check_l3 treats malformed signature.inputs/outputs as empty
+        (schema layer owns the diagnostics) instead of crashing."""
         for inputs_val in ([{"x": {}}], "not a mapping", None):
             for outputs_val in ([{"y": {}}], "nope", None):
                 entry = {
@@ -1087,12 +1085,9 @@ class TestInferShapeParity:
         ), warnings
 
     def test_symbolic_dim_rule_detects_wrong_output(self, validator):
-        """Rules like ``o.shape == (B, S, H, D)`` must evaluate, not warn-skip.
-
-        Symbolic dim names declared only via literal rules must be bound
-        into the eval context; an unbound name raises NameError, downgrades
-        the rule to a warning, and lets a wrong impl pass parity.
-        """
+        """Rules like ``o.shape == (B, S, H, D)`` must evaluate, not
+        warn-skip: an unbound symbolic dim would NameError into a warning
+        and let a wrong impl pass parity."""
         def infer(self, q_shape, k_shape, v_shape):
             # Wrong: returns a 1-D shape instead of a 4-D shape.
             return {"o": (999,)}
@@ -1165,10 +1160,9 @@ class TestInferShapeParity:
         assert seen_rank == [4], seen_rank
 
     def test_r11_style_rule_uses_len_helper(self, validator):
-        """R11 / R11a rules calling ``len`` or using comprehensions must be
-        evaluable: the restricted builtins expose the helpers, and ctx
-        names resolve inside comprehension scopes. Breaking either turns
-        the rule into a NameError warning-skip and hides mismatches."""
+        """R11-style rules using ``len`` / comprehensions stay evaluable
+        (restricted builtins + ctx visibility in comprehension scopes);
+        breaking either hides mismatches behind NameError skips."""
         # Wrong: reduction op declares dim, keepdim=False so y should drop
         # rank(s), but _infer_output_shapes returns x_shape verbatim.
         def infer(self, x_shape):
@@ -1206,12 +1200,8 @@ class TestInferShapeParity:
         ), errors
 
     def test_input_only_precondition_not_blamed_on_infer(self, validator):
-        """Mock-input precondition violations must not become parity errors.
-
-        When ``shape_rules`` encode an input-only precondition that the
-        synthesized mock inputs violate, a correct ``_infer_output_shapes``
-        is not blamed; the rule is reported as skipped via warning.
-        """
+        """Input-only preconditions violated by mock inputs are reported
+        as skip warnings, never blamed on a correct impl."""
         def infer(self, x_shape, weight_shape):
             # Correct: y has the same shape as x.
             return {"y": x_shape}
@@ -1233,11 +1223,8 @@ class TestInferShapeParity:
         assert any("input-only precondition" in w for w in warnings), warnings
 
     def test_mock_input_shapes_cross_tensor_dims_distinct(self, validator):
-        """Distinct symbolic dims across rules must get distinct mock sizes.
-
-        Colliding sizes would make a cross-tensor rule like
-        ``x.shape[0] == y.shape[0]`` evaluate to a spurious True / False.
-        """
+        """Distinct symbolic dims across rules get distinct mock sizes;
+        collisions would make cross-tensor rules spuriously True/False."""
         sig = {
             "inputs": {"x": {}, "y": {}},
             "shape_rules": [
@@ -1254,12 +1241,8 @@ class TestInferShapeParity:
         assert tuple(shapes["x"])[0] != tuple(shapes["y"])[0]
 
     def test_eval_shape_rule_rejects_dunder_attr(self, validator):
-        """Shape-rule evaluator must reject dunder attribute access.
-
-        Defense-in-depth: a classic sandbox-escape expression such as
-        ``().__class__.__mro__[1].__subclasses__()`` would bypass the
-        restricted builtins; the AST filter rejects dunder attributes.
-        """
+        """Evaluator rejects dunder attribute access (sandbox-escape
+        defense against the restricted builtins)."""
         ok, reason = validator._eval_shape_rule(
             "().__class__ is None", {},
         )
@@ -1268,13 +1251,9 @@ class TestInferShapeParity:
         assert "dunder attribute access not permitted" in reason
 
     def test_body_exception_is_hard_error_not_signature_mismatch(self, validator):
-        """Exceptions raised inside the _infer_output_shapes body surface as
-        hard L2 parity errors, never as signature mismatches or warnings.
-
-        The signature is pre-bound via ``inspect.signature().bind`` so a
-        body TypeError is distinguished from a signature mismatch;
-        RuntimeError placeholders follow the same hard-error policy.
-        """
+        """Body exceptions are hard L2 errors, never signature mismatches:
+        the signature is pre-bound, so body TypeError / RuntimeError
+        cannot masquerade as a binding failure."""
         sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
                    shape_rules=["y.shape == x.shape"])
         for exc_cls, message in (
@@ -1294,12 +1273,8 @@ class TestInferShapeParity:
             ), (exc_cls, errors, warnings)
 
     def test_declared_output_shape_catches_wrong_infer(self, validator):
-        """Declared output shapes alone (no shape_rules) must drive parity.
-
-        Inferred outputs are compared against ``signature.outputs[*].shape``
-        even when ``shape_rules`` is empty (e.g. conv ops declaring
-        ``"[N, C_out, L_out]"`` per output).
-        """
+        """Declared output shapes alone (no shape_rules) must drive
+        parity against ``signature.outputs[*].shape``."""
         def infer(self, x_shape, w_shape):
             # Wrong: returns x_shape verbatim instead of [N, C_out, L_out].
             return {"y": tuple(x_shape)}
@@ -1313,12 +1288,8 @@ class TestInferShapeParity:
         assert any("disagrees with declared" in e for e in errors), errors
 
     def test_infer_reads_self_attr_uses_cls_new(self, validator):
-        """Reading a non-manifest-param ``self`` attribute must not falsely skip parity.
-
-        The mock ``self`` is built via ``cls.__new__(cls)`` so
-        class-defined attributes stay reachable; a plain namespace mock
-        raises AttributeError and silently skips the check.
-        """
+        """Reading a class-defined ``self`` attribute must not skip parity:
+        the mock self is built via ``cls.__new__(cls)``."""
         from tileops.ops.op_base import Op
 
         class SelfAttrOp(Op):
@@ -1352,12 +1323,8 @@ class TestInferShapeParity:
         ), warnings
 
     def test_infer_reads_static_dim_attr_populated(self, validator):
-        """Reading ``self.<static_dim>`` must exercise parity, not AttributeError-skip.
-
-        ``_build_mock_self`` installs ``static_dims`` values resolved
-        against the mock inputs in addition to ``signature.params``
-        defaults.
-        """
+        """Reading ``self.<static_dim>`` must exercise parity:
+        ``_build_mock_self`` installs resolved static_dims values."""
         from tileops.ops.op_base import Op
 
         class StaticDimOp(Op):
@@ -1386,45 +1353,28 @@ class TestInferShapeParity:
         assert not any("AttributeError" in w for w in warnings), warnings
 
     def test_conv_like_output_only_symbol_not_blamed(self, validator):
-        """Correct infer with an output-only ``L_out`` symbol passes parity.
-
-        Output-only symbols have no input-derived concrete size; they are
-        checked only for rank and per-symbol consistency across outputs,
-        never against an arbitrary ``dim_sizes`` entry.
-        """
+        """Correct infer with an output-only ``L_out`` symbol passes:
+        output-only symbols get rank/consistency checks only, never a
+        comparison against arbitrary mock sizes."""
         def infer(self, x_shape, w_shape):
             # x: [N, C_in, L_in]; w: [C_out, C_in, kW]
             return {"y": (x_shape[0], w_shape[0], x_shape[2] - w_shape[2] + 1)}
 
-        sig = _sig(
-            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
-            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
-            shape_rules=["L_out == L_in - kW + 1"],
+        errors, _ = _infer_parity(
+            validator, infer, _conv_sig(), name="ConvLikeOp",
         )
-        errors, _ = _infer_parity(validator, infer, sig, name="ConvLikeOp")
         assert errors == [], errors
 
     def test_conv_like_wrong_output_only_value_reported(self, validator):
-        """Wrong output-only symbol value is flagged via the shape_rules defining it.
-
-        ``L_out == L_in - kW + 1`` mentions no output tensor name but
-        ``L_out`` appears in a declared output shape, so it must classify
-        as output-mentioning and be rebound from the inferred result;
-        treated as an input-only precondition it would be skipped.
-        """
+        """Wrong output-only value is flagged via the defining rule:
+        ``L_out`` classifies as output-mentioning (rebound from the
+        inferred result), not as an input-only precondition."""
         def infer(self, x_shape, w_shape):
             # Deliberately wrong output-only L_out value (999).
             return {"y": (x_shape[0], w_shape[0], 999)}
 
-        sig = _sig(
-            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
-            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
-            shape_rules=["L_out == L_in - kW + 1"],
-        )
         errors, _ = _infer_parity(
-            validator, infer, sig, name="ConvLikeWrongOutOnlyOp",
+            validator, infer, _conv_sig(), name="ConvLikeWrongOutOnlyOp",
         )
         assert any(
             "L_out == L_in - kW + 1" in e and "violates shape_rules" in e
@@ -1440,14 +1390,8 @@ class TestInferShapeParity:
             # Wrong rank: drops the spatial dim entirely.
             return {"y": (x_shape[0], w_shape[0])}
 
-        sig = _sig(
-            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
-            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
-            shape_rules=["L_out == L_in - kW + 1"],
-        )
         errors, _ = _infer_parity(
-            validator, bad_rank_infer, sig, name="ConvLikeBadOp",
+            validator, bad_rank_infer, _conv_sig(), name="ConvLikeBadOp",
         )
         assert any("rank" in e and "disagrees" in e for e in errors), errors
 
@@ -1477,12 +1421,8 @@ class TestDtypeOptionsHelper:
     """Unit tests for ``_dtype_options_for_tensor`` unresolved-ref contract."""
 
     def test_pure_same_as_unresolved_returns_none(self, validator):
-        """same_as(ref) with ref missing from ``resolved`` returns None.
-
-        Returning ``[]`` instead would silently disable downstream dtype
-        parity: ``_resolve_tensor_dtype_options`` bails only on None, and
-        an empty list yields an empty Cartesian product.
-        """
+        """same_as(unresolved ref) returns None — an empty list would
+        silently disable dtype parity via an empty Cartesian product."""
         out = validator._dtype_options_for_tensor(
             "y", "same_as(x)", resolved={},
         )
@@ -1573,31 +1513,24 @@ class TestValidateDtypesParity:
             "does not override _validate_dtypes" in w for w in warnings
         ), warnings
 
-    def test_union_accept_all_passes(self, validator):
+    def test_union_accept_reject_matrix(self, validator):
+        """Accepting the whole union passes; rejecting a declared dtype
+        is a parity error."""
         import torch
 
-        def validate(self, x):
+        def accept_union(self, x):
             if x.dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError(f"bad dtype {x.dtype}")
 
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
-        )
-        assert errors == []
-
-    def test_union_reject_declared_fails(self, validator):
-        """Rejects a dtype in the declared union -> parity error."""
-        import torch
-
-        def validate(self, x):
+        def fp16_only(self, x):
             if x.dtype != torch.float16:
                 raise ValueError("only fp16")
 
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
-        )
+        sig = _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"})
+        errors, _ = _dtype_parity(validator, accept_union, sig)
+        assert errors == []
+
+        errors, _ = _dtype_parity(validator, fp16_only, sig)
         assert any("rejects valid combo" in e for e in errors), errors
 
     def test_dtype_combos_accept_listed_pass(self, validator):
@@ -1648,11 +1581,8 @@ class TestValidateDtypesParity:
         assert any("accepts non-listed combo" in e for e in errors), errors
 
     def test_dtype_combos_first_rejected_later_accepted_fails(self, validator):
-        """Non-listed combos must all be checked, not just the first.
-
-        Stopping at the first rejection would let a later accepted
-        non-listed combo escape detection.
-        """
+        """Non-listed combos are all checked: stopping at the first
+        rejection would let a later accepted combo escape."""
         import torch
 
         def validate(self, x, w):
@@ -1719,11 +1649,8 @@ class TestValidateDtypesParity:
             ), (branch, errors, warnings)
 
     def test_wide_union_probe_pool_derived_from_torch_dtypes(self, validator):
-        """The out-of-union probe pool is ``sorted(_TORCH_DTYPES - declared)``.
-
-        A wide 8-dtype union still leaves ``uint8`` as a probe candidate,
-        so an over-permissive ``_validate_dtypes`` surfaces a hard error.
-        """
+        """Probe pool is ``sorted(_TORCH_DTYPES - declared)``: a wide
+        8-dtype union still leaves uint8 to catch permissive impls."""
         def accept_all(self, x):
             return True  # over-permissive: accepts any dtype
 
@@ -1739,12 +1666,8 @@ class TestValidateDtypesParity:
         ), (errors, warnings)
 
     def test_full_torch_coverage_emits_skip_warning(self, validator):
-        """Declared union == full torch dtype set → warning, no vacuous pass.
-
-        The probe cannot produce a candidate so it skips with a warning
-        naming the op/input; no hard error because the impl is free to
-        accept anything under this (wildly permissive) spec.
-        """
+        """Full-coverage union skips the probe with a warning naming the
+        input — no vacuous pass, no hard error."""
         full_union = " | ".join(sorted(validator._TORCH_DTYPES))
 
         def accept_all(self, x):
@@ -1783,12 +1706,8 @@ class TestValidateDtypesParity:
         assert any("exceeds _MAX_DTYPE_COMBOS" in w for w in warnings), warnings
 
     def test_body_typeerror_is_rejection_not_signature_mismatch(self, validator):
-        """Body TypeError is a legitimate rejection, not a signature mismatch.
-
-        The signature is pre-bound before invocation; a bare
-        ``except (ValueError, TypeError)`` around the call could not tell
-        a kwarg-name mismatch from a TypeError raised inside the body.
-        """
+        """Body TypeError is a rejection, not a signature mismatch
+        (the signature is pre-bound before invocation)."""
         def validate(self, x):
             raise TypeError("dtype comparison not supported")
 
@@ -1804,12 +1723,8 @@ class TestValidateDtypesParity:
         assert any("rejects valid combo" in e for e in errors), errors
 
     def test_dtype_combos_exhausts_union_emits_warning(self, validator):
-        """Exhaustive dtype_combos still emit the 'exhausts the union' warning.
-
-        When every Cartesian tuple is listed, no non-listed combo is ever
-        checked, so the warning must not be conditioned on a non-listed
-        probe having run.
-        """
+        """Exhaustive dtype_combos still emit the 'exhausts the union'
+        warning even though no non-listed combo ever runs."""
         import torch
 
         allowed = {torch.float16, torch.bfloat16}
@@ -1835,45 +1750,32 @@ class TestValidateDtypesParity:
         assert errors == [], errors
         assert any("exhausts the union" in w for w in warnings), warnings
 
-    def test_no_combos_accepts_out_of_union_fails(self, validator):
-        """Accepting an out-of-union dtype is a parity error on the no-combos branch.
-
-        Iterating only the union's Cartesian product cannot detect an
-        overly-permissive ``_validate_dtypes``; the branch needs its own
-        out-of-union probe.
-        """
-        def validate(self, x):
-            return None  # overly permissive: accepts any dtype
-
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
-        )
-        assert any("out-of-union" in e for e in errors), errors
-
-    def test_no_combos_rejects_out_of_union_pass(self, validator):
-        """Op that rejects out-of-union dtypes produces no parity error."""
+    def test_no_combos_out_of_union_probe_matrix(self, validator):
+        """No-combos branch fires its own out-of-union probe: a permissive
+        op accepting any dtype fails (union iteration alone cannot catch
+        it); an op rejecting out-of-union dtypes passes."""
         import torch
 
-        def validate(self, x):
+        def accept_all(self, x):
+            return None
+
+        def reject_out_of_union(self, x):
             if x.dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError(f"unsupported dtype {x.dtype}")
 
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
-        )
+        sig = _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"})
+        errors, _ = _dtype_parity(validator, accept_all, sig)
+        assert any("out-of-union" in e for e in errors), errors
+
+        errors, _ = _dtype_parity(validator, reject_out_of_union, sig)
         assert errors == [], errors
 
     def test_no_combos_out_of_union_probe_respects_max(
         self, validator, monkeypatch,
     ):
-        """Out-of-union probe must stay within ``_MAX_DTYPE_COMBOS``.
-
-        With the cap tightened to 2, at most 2 probes fire even though
-        the pool has 6 out-of-union dtypes for a {float16, bfloat16}
-        union. (Product size 2 keeps the Cartesian enumeration alive.)
-        """
+        """Out-of-union probe is bounded by ``_MAX_DTYPE_COMBOS``: cap 2
+        fires at most 2 probes from a 6-dtype pool (product size 2 keeps
+        the Cartesian enumeration alive)."""
         monkeypatch.setattr(validator, "_MAX_DTYPE_COMBOS", 2)
 
         def validate(self, x):
@@ -1886,30 +1788,19 @@ class TestValidateDtypesParity:
         out_of_union_errs = [e for e in errors if "out-of-union" in e]
         assert len(out_of_union_errs) == 2, out_of_union_errs
 
-    def test_no_combos_accepts_same_as_violation_fails(self, validator):
-        """Accepting a same_as identity violation is a parity error.
-
-        The union-iteration loop skips every same_as-violating candidate
-        via ``_honours_same_as``, so a permissive op that fails to enforce
-        same_as would go unflagged without a dedicated probe.
-        """
-        def validate(self, x, w):
-            return None  # does not check x.dtype == w.dtype
-
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
-                 {"y": "same_as(x)"}),
-        )
-        assert any("same_as violation" in e for e in errors), errors
-
-    def test_no_combos_rejects_same_as_violation_pass(self, validator):
-        """Op that enforces same_as passes the same_as probe."""
+    def test_no_combos_same_as_probe_matrix(self, validator):
+        """same_as identity has a dedicated negative probe: the union
+        iteration skips same_as-violating candidates via
+        ``_honours_same_as``, so a permissive op not enforcing same_as
+        fails only through the probe; an enforcing op passes."""
         import torch
 
         allowed = (torch.float16, torch.bfloat16)
 
-        def validate(self, x, w):
+        def accept_all(self, x, w):
+            return None  # does not check x.dtype == w.dtype
+
+        def enforce_same_as(self, x, w):
             if x.dtype not in allowed or w.dtype not in allowed:
                 raise ValueError(
                     f"unsupported dtype: x.dtype={x.dtype} "
@@ -1921,19 +1812,17 @@ class TestValidateDtypesParity:
                     f"w.dtype={w.dtype}"
                 )
 
-        errors, _ = _dtype_parity(
-            validator, validate,
-            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
-                 {"y": "same_as(x)"}),
-        )
+        sig = _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                   {"y": "same_as(x)"})
+        errors, _ = _dtype_parity(validator, accept_all, sig)
+        assert any("same_as violation" in e for e in errors), errors
+
+        errors, _ = _dtype_parity(validator, enforce_same_as, sig)
         assert errors == [], errors
 
     def test_combos_branch_out_of_union_probe(self, validator):
-        """Dtype_combos branch must fire the out-of-union probe.
-
-        Without it, a permissive ``_validate_dtypes`` that accepts every
-        dtype passes parity as long as every listed combo is accepted.
-        """
+        """Dtype_combos branch fires the out-of-union probe; otherwise a
+        permissive impl passes once listed combos are accepted."""
         def validate(self, x):
             return None  # overly permissive
 
@@ -1945,13 +1834,8 @@ class TestValidateDtypesParity:
         assert any("out-of-union" in e for e in errors), errors
 
     def test_invalid_dtype_combo_value_is_hard_error(self, validator):
-        """A non-existent dtype in dtype_combos is a hard L3 error, not a skip warning.
-
-        The upfront validation pass rejects entries that are neither in
-        ``_TORCH_DTYPES`` nor a resolvable ``same_as`` ref; letting them
-        reach the ``cannot build mock tensor`` branch would silently
-        disable the check and hide a manifest data bug.
-        """
+        """A non-existent dtype in dtype_combos is a hard L3 error, not a
+        'cannot build mock tensor' skip that would hide the data bug."""
         def validate(self, x, w):
             return None
 
@@ -1974,12 +1858,8 @@ class TestValidateDtypesParity:
     def test_valid_dtype_combo_reaches_build_mock_tensor(
         self, validator, monkeypatch,
     ):
-        """The 'cannot build mock tensor' warning stays reserved for valid dtype names.
-
-        Simulates a torch build lacking support for a declared dtype by
-        monkeypatching ``_make_mock_tensor`` to return None for
-        ``float8_e4m3fn`` while the combo itself is valid.
-        """
+        """'cannot build mock tensor' stays reserved for valid dtype
+        names on torch builds lacking them (simulated via monkeypatch)."""
         def validate(self, x):
             return None
 
@@ -2021,13 +1901,8 @@ class TestValidateDtypesParity:
         assert not any("rejects dtype_combos[0]" in e for e in errors), errors
 
     def test_validate_dtypes_reads_self_dtype_attr(self, validator):
-        """Comparing ``x.dtype != self.dtype`` must work with a populated mock self.
-
-        ``_build_mock_self`` populates the dtype axis from the candidate
-        combo; if ``self.dtype`` fell through to the base-class
-        ``Op.dtype = None``, the comparison would raise and every listed
-        combo would be marked rejected.
-        """
+        """``x.dtype != self.dtype`` works on the mock self: the dtype
+        axis is populated from the candidate combo, not Op's None."""
         def validate(self, x):
             # The generated pattern under test: compare the input dtype
             # against ``self.dtype`` (set in __init__ via a dtype param).
@@ -2051,13 +1926,9 @@ class TestDtypeCombosData:
     """
 
     def test_malformed_combo_rows_are_hard_errors(self, validator):
-        """Case table: incomplete rows and multi-dtype combo values fail.
-
-        Per manifest.md R4, every combo row covers every declared input and
-        each value is a single concrete dtype token (or a ``same_as(ref)``
-        resolving to one); unions and ``promote_int_to_float(ref)`` expand
-        to multiple dtypes and cannot pin a combo row.
-        """
+        """Case table (manifest.md R4): rows must cover every declared
+        input; unions and promote_int_to_float expand to multiple dtypes
+        and cannot pin a combo row."""
         cases = [
             # (description, sig, substrings expected in one error)
             ("combo row missing a declared input",
@@ -2084,12 +1955,8 @@ class TestDtypeCombosData:
             ), f"{desc}: expected error with {substrings}, got: {errors}"
 
     def test_unresolvable_same_as_graph_is_hard_error(self, validator):
-        """Pure ``same_as`` cycles and dangling refs must surface hard L3
-        errors instead of silently skipping combo validation.
-
-        A pure cycle satisfies per-token validation and the R3 identity
-        check, so it needs a dedicated diagnosis.
-        """
+        """Pure same_as cycles and dangling refs surface hard L3 errors
+        (they satisfy per-token + R3 checks, so need a dedicated diagnosis)."""
         cycle_sig = _sig(
             {"x": "same_as(y)", "y": "same_as(x)"}, {"z": "same_as(x)"},
             dtype_combos=[{"x": "float16", "y": "float16"}],
@@ -2115,12 +1982,8 @@ class TestStaticDimShapeParity:
     """static_dims values must pin expected output sizes in L2 parity."""
 
     def test_static_dim_output_shape_catches_bad_infer(self, validator):
-        """Arbitrary integers at a static-dim-bound output position must fail parity.
-
-        ``static_dims`` keys in declared output shapes are checked by
-        exact value (resolved against mock inputs), not only by
-        rank/consistency.
-        """
+        """Static-dim-bound output positions are checked by exact value
+        (resolved against mock inputs), not only rank/consistency."""
         def bad_infer(self, x_shape):
             # static_dims pins N = x.shape[-1] (=4 under mock); a correct
             # impl returns (4, 4).
@@ -2173,68 +2036,60 @@ class TestParamDefaultOutputShapePin:
 
 # Bench checks
 class TestBench:
-    """bench checks that bench files use manifest workloads and op roofline."""
+    """bench checks that bench files use manifest workloads and op roofline.
 
-    @staticmethod
-    def _bench_errors(validator, tmp_path, text):
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(text)
-        return validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+    Case table: direct (``load_workloads`` + ``op.eval_roofline()``) and
+    indirect (``benchmarks.benchmark_base`` helpers) usage passes; missing
+    helpers, wrong op names, and syntax errors fail with the named
+    diagnostics. Rows with ``None`` expect a clean pass.
+    """
 
-    def test_bench_with_load_workloads_passes(self, validator, tmp_path):
-        errors = self._bench_errors(validator, tmp_path, (
-            "from tileops.manifest import load_workloads\n"
-            "workloads = load_workloads('test_op')\n"
-            "op.eval_roofline()\n"
-        ))
-        assert errors == []
-
-    def test_bench_with_load_workloads_only_fails(self, validator, tmp_path):
-        """Bench using load_workloads but not op eval_roofline fails bench validation."""
-        errors = self._bench_errors(validator, tmp_path, (
-            "from tileops.manifest import load_workloads\n"
-            "workloads = load_workloads('test_op')\n"
-        ))
-        assert any("eval_roofline" in e for e in errors), errors
-
-    def test_bench_without_load_workloads_fails(self, validator, tmp_path):
-        errors = self._bench_errors(validator, tmp_path, (
-            "import pytest\n"
-            "shapes = [(1024, 4096)]\n"
-        ))
-        assert any("load_workloads" in e for e in errors)
-
-    def test_wrong_op_name_fails_l4(self, validator, tmp_path):
-        """Manifest helpers called with a different op name must fail, on
-        both the direct and the indirect (benchmarks.benchmark_base) path."""
-        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
-            from tileops.manifest import load_workloads
-            workloads = load_workloads('wrong_op')
-            op.eval_roofline()
-        """))
-        assert any("load_workloads" in e for e in errors)
-
-        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
-            from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-            params = workloads_to_params('wrong_op')
-            ManifestBenchmark('wrong_op', op, params[0])
-        """))
-        assert any("load_workloads" in e for e in errors)
-        assert any("eval_roofline" in e for e in errors)
-
-    def test_syntax_error_in_bench_file_fails_l4(self, validator, tmp_path):
-        """A bench file with syntax errors produces an bench error."""
-        errors = self._bench_errors(validator, tmp_path, "def broken(\n")
-        assert any("syntax error" in e for e in errors)
-
-    def test_bench_indirect_helpers_pass(self, validator, tmp_path):
-        """Importing workloads_to_params/ManifestBenchmark from benchmarks.benchmark_base passes."""
-        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
-            from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
-            params = workloads_to_params('test_op')
-            ManifestBenchmark('test_op', op, params[0])
-        """))
-        assert errors == []
+    def test_bench_file_usage_matrix(self, validator, tmp_path):
+        cases = [
+            # (description, bench file text, expected substrings or None)
+            ("direct load_workloads + eval_roofline passes", """\
+                from tileops.manifest import load_workloads
+                workloads = load_workloads('test_op')
+                op.eval_roofline()
+            """, None),
+            ("indirect benchmark_base helpers pass", """\
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                params = workloads_to_params('test_op')
+                ManifestBenchmark('test_op', op, params[0])
+            """, None),
+            ("load_workloads without eval_roofline fails", """\
+                from tileops.manifest import load_workloads
+                workloads = load_workloads('test_op')
+            """, ["eval_roofline"]),
+            ("no load_workloads fails", """\
+                import pytest
+                shapes = [(1024, 4096)]
+            """, ["load_workloads"]),
+            ("wrong op name fails (direct path)", """\
+                from tileops.manifest import load_workloads
+                workloads = load_workloads('wrong_op')
+                op.eval_roofline()
+            """, ["load_workloads"]),
+            ("wrong op name fails (indirect path)", """\
+                from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
+                params = workloads_to_params('wrong_op')
+                ManifestBenchmark('wrong_op', op, params[0])
+            """, ["load_workloads", "eval_roofline"]),
+            ("syntax error fails", "def broken(\n", ["syntax error"]),
+        ]
+        for desc, text, expected in cases:
+            bench_file = tmp_path / "bench_test.py"
+            bench_file.write_text(textwrap.dedent(text))
+            errors = validator.check_l4_benchmark(
+                "test_op", str(bench_file), REPO_ROOT,
+            )
+            if expected is None:
+                assert errors == [], (desc, errors)
+            else:
+                for substring in expected:
+                    assert any(substring in e for e in errors), (
+                        f"{desc}: expected {substring!r} in errors, got: {errors}"
+                    )
 
 
 # --check-op: force all levels on a specific op, ignoring status
@@ -2338,12 +2193,8 @@ class TestCheckOp:
         )
 
     def test_check_op_ignores_unrelated_variant_of_errors(self, validator, tmp_path):
-        """--check-op must not report variant_of errors from unrelated ops.
-
-        check_variant_of_consistency must scope to the variant family;
-        run across the full manifest it fails --check-op on unrelated ops
-        with invalid variant_of references.
-        """
+        """--check-op scopes variant_of checks to the variant family;
+        unrelated ops with bad references must not fail the run."""
         other_entry = _make_entry()
         other_entry["variant_of"] = "nonexistent_primary"
         manifest_file = _write_manifest(
@@ -2369,11 +2220,8 @@ class TestCheckOp:
         )
 
     def test_check_op_validates_variant_family(self, validator, tmp_path):
-        """--check-op on a primary also validates its immediate variants.
-
-        Excluding variants from the scope would let a variant edit that
-        breaks R16 pass --check-op <primary>.
-        """
+        """--check-op on a primary also validates its immediate variants,
+        so a variant edit breaking R16 cannot slip through."""
         primary = _make_entry(source_kernel="shared_kernel.py")
         valid_variant = _make_entry(source_kernel="shared_kernel.py")
         valid_variant["variant_of"] = "primary_op"
@@ -2428,14 +2276,12 @@ class TestCheckOp:
         assert len(schema_errors) > 0, errors
 
     def test_check_op_cli_parsing(self, validator):
-        """_parse_check_op extracts the op name from argv."""
+        """_parse_check_op extracts the op name from argv; a missing
+        value exits with status 2."""
         assert validator._parse_check_op(["--check-op", "SoftmaxFwdOp"]) == "SoftmaxFwdOp"
         assert validator._parse_check_op(["--check-op=SoftmaxFwdOp"]) == "SoftmaxFwdOp"
         assert validator._parse_check_op(["--verbose"]) is None
         assert validator._parse_check_op([]) is None
-
-    def test_check_op_rejects_missing_value(self, validator):
-        """_parse_check_op exits with status 2 when no op name is given."""
         with pytest.raises(SystemExit, match="2"):
             validator._parse_check_op(["--check-op"])
 
@@ -2511,11 +2357,8 @@ class TestResolveOpClass:
         assert any("could not resolve" in e for e in errors)
 
     def test_direct_match_resolves_exact_class_name(self, validator):
-        """Direct match resolves when cls.__name__ == manifest key.
-
-        For op_name='SumFwdOp' with both _SumHelper and SumFwdOp in the
-        module, the exact match finds SumFwdOp. No heuristic fallback.
-        """
+        """Direct match resolves cls.__name__ == manifest key even next
+        to sibling candidates. No heuristic fallback."""
         fake_mod = _fake_op_module(
             "tileops.ops.fake_priority", ["_SumHelper", "SumFwdOp"],
         )
@@ -2566,14 +2409,9 @@ class TestShapeRuleHelpers:
     """Unit tests for :mod:`tileops.manifest.shape_rules` predicates."""
 
     def test_helper_rule_validator_warns_on_malformed_dim(self, validator):
-        """Validator integration: helper rules surface malformed dims as warnings.
-
-        A malformed dim default (``dim=["2"]``) raises TypeError from the
-        helper, which the validator classifies as an eval-error warning
-        ("could not be evaluated"): parity is skipped with a warning, not
-        turned into a hard shape error — bit-identical to the equivalent
-        inline form.
-        """
+        """A malformed dim default (``dim=["2"]``) raises TypeError from
+        the helper; the validator classifies it as an eval-error warning
+        (parity skip), bit-identical to the equivalent inline form."""
         def infer(self, x_shape, *, dim=None, keepdim=False):
             return {"y": x_shape}
 
@@ -2619,14 +2457,9 @@ class TestValidatorHelperResolution:
     """Validator integration of the shape_rules helper builtins."""
 
     def test_l2_parity_helper_detects_out_of_range_default(self, validator):
-        """Out-of-range default ``dim`` surfaces as an input-only precondition.
-
-        The helper predicate evaluates to False under mock inputs, but the
-        validator classifies that as an *input* problem (mock default
-        ``dim`` out of range for the mock ``x.ndim``), not a parity
-        failure of ``_infer_output_shapes``: ``errors == []`` plus exactly
-        one "input-only precondition" warning citing the helper rule.
-        """
+        """Out-of-range default ``dim`` classifies as an input problem:
+        ``errors == []`` plus exactly one input-only-precondition warning
+        citing the helper rule — never parity blame on the impl."""
         def infer(self, x_shape):
             return {"y": x_shape}
 
@@ -2658,12 +2491,8 @@ class TestValidatorHelperResolution:
         assert len(precondition_hits) == 1, warnings
 
     def test_input_bound_symbols_tolerates_non_dict_inputs(self, validator):
-        """``_input_bound_symbols`` must treat malformed inputs as empty.
-
-        Schema-independent shape-rule extraction must not crash when
-        ``signature.inputs`` is missing or non-mapping; the schema layer
-        owns the structural error message.
-        """
+        """``_input_bound_symbols`` treats malformed inputs as empty
+        instead of crashing (schema layer owns the diagnostics)."""
         result = validator._input_bound_symbols({
             "inputs": [{"x": {"shape": "[N]"}}],
             "shape_rules": ["x.shape == (N)"],
@@ -2675,14 +2504,9 @@ class TestValidatorHelperResolution:
         assert isinstance(result, set)
 
     def test_shape_rules_helpers_callable_by_bare_name(self, validator):
-        """Reduction-dim helpers from shape_rules.py are in the eval scope.
-
-        Each function in ``tileops.manifest.shape_rules.__all__`` must be
-        callable from a shape_rule body by bare name. Adding a new helper
-        requires updating both ``__all__`` and the validator's
-        ``_SHAPE_RULE_BUILTIN_PAIRS`` — this test fails loudly when one
-        side moves without the other.
-        """
+        """Every ``tileops.manifest.shape_rules.__all__`` helper is
+        callable by bare name from rule bodies; fails loudly when
+        ``__all__`` and ``_SHAPE_RULE_BUILTIN_PAIRS`` drift apart."""
         import types
 
         from tileops.manifest import shape_rules
@@ -2698,72 +2522,69 @@ class TestValidatorHelperResolution:
 # C1-C7 strict parity gates
 
 
+def _strict_op(name, init=None, forward=None, **methods):
+    """Op subclass with lambda-supplied ``__init__`` / ``forward``.
+
+    C3 / C4 / C6 / C7 checks read signatures and method identity only,
+    so lambdas suffice. (C5 parses ``__init__`` source and needs real
+    ``def`` statements — see TestDispatchKernelInvariant.)
+    """
+    from tileops.ops.op_base import Op
+
+    ns = {
+        "forward": forward if forward is not None else (lambda self, x: None),
+        "default_kernel_map": property(lambda self: {}),
+    }
+    if init is not None:
+        ns["__init__"] = init
+    ns.update(methods)
+    return type(name, (Op,), ns)
+
+
 class TestCtorSignatureParity:
     """C3: ctor signature parity (defaults + kw-only)."""
 
     def test_matching_defaults_pass(self, validator):
-        from tileops.ops.op_base import Op
-
-        class Op1(Op):
-            def __init__(self, dim=-1, eps=1e-6, kernel_map=None): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
+        cls = _strict_op(
+            "Op1", init=lambda self, dim=-1, eps=1e-6, kernel_map=None: None,
+        )
         entry = {"signature": {
             "params": {
                 "dim": {"type": "int", "default": -1},
                 "eps": {"type": "float", "default": 1e-6},
             },
         }}
-        assert validator.check_c3_ctor_signature_parity("Op1", entry, Op1) == []
+        assert validator.check_c3_ctor_signature_parity("Op1", entry, cls) == []
 
         # compat_default: required manifest param with a ctor-only default.
-        class OpCompat(Op):
-            def __init__(self, num_experts=None, kernel_map=None): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
+        cls = _strict_op(
+            "OpCompat", init=lambda self, num_experts=None, kernel_map=None: None,
+        )
         entry = {"signature": {
             "params": {
                 "num_experts": {"type": "int", "compat_default": None},
             },
         }}
         assert validator.check_c3_ctor_signature_parity(
-            "OpCompat", entry, OpCompat
+            "OpCompat", entry, cls
         ) == []
 
     def test_ctor_mismatches_fail(self, validator):
         """Case table: missing default, compat_default mismatch, kw-only."""
-        from tileops.ops.op_base import Op
-
-        class OpNoDefault(Op):
-            def __init__(self, dim, kernel_map=None): pass  # no default
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
-        class OpCompatMismatch(Op):
-            def __init__(self, num_experts=0, kernel_map=None): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
-        class OpKwOnly(Op):
-            def __init__(self, *, dim=-1, kernel_map=None): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
         cases = [
-            ("param default missing on __init__", OpNoDefault,
+            ("param default missing on __init__",
+             _strict_op("OpNoDefault",
+                        init=lambda self, dim, kernel_map=None: None),
              {"dim": {"type": "int", "default": -1}},
              "no default on __init__"),
-            ("compat_default value mismatch", OpCompatMismatch,
+            ("compat_default value mismatch",
+             _strict_op("OpCompatMismatch",
+                        init=lambda self, num_experts=0, kernel_map=None: None),
              {"num_experts": {"type": "int", "compat_default": None}},
              "no manifest default"),
-            ("kw_only mismatch", OpKwOnly,
+            ("kw_only mismatch",
+             _strict_op("OpKwOnly",
+                        init=lambda self, *, dim=-1, kernel_map=None: None),
              {"dim": {"type": "int", "default": -1, "kw_only": False}},
              "kw_only mismatch"),
         ]
@@ -2778,35 +2599,18 @@ class TestCtorSignatureParity:
 class TestForwardSignatureParity:
     """C4: forward positional names match manifest inputs order."""
 
-    def test_matching_passes(self, validator):
-        from tileops.ops.op_base import Op
-
-        class Op1(Op):
-            def __init__(self): pass
-            def forward(self, x, weight): return None
-            @property
-            def default_kernel_map(self): return {}
-
+    def test_forward_order_matrix(self, validator):
+        """Matching order passes; swapped positional names fail."""
         entry = {"signature": {
             "inputs": {"x": {"dtype": "float16"}, "weight": {"dtype": "float16"}},
         }}
+        cls = _strict_op("Op1", forward=lambda self, x, weight: None)
         assert validator.check_c4_forward_signature_parity(
-            "Op1", entry, Op1,
+            "Op1", entry, cls,
         ) == []
 
-    def test_wrong_order_fails(self, validator):
-        from tileops.ops.op_base import Op
-
-        class Op2(Op):
-            def __init__(self): pass
-            def forward(self, weight, x): return None  # swapped
-            @property
-            def default_kernel_map(self): return {}
-
-        entry = {"signature": {
-            "inputs": {"x": {"dtype": "float16"}, "weight": {"dtype": "float16"}},
-        }}
-        errs = validator.check_c4_forward_signature_parity("Op2", entry, Op2)
+        cls = _strict_op("Op2", forward=lambda self, weight, x: None)  # swapped
+        errs = validator.check_c4_forward_signature_parity("Op2", entry, cls)
         assert any("do not start with" in e for e in errs), errs
 
 
@@ -2817,34 +2621,24 @@ class TestDispatchKernelInvariant:
 
     def test_compliant_ctor_forms_pass(self, validator):
         """Case table: explicit kwarg, **kwargs absorption, and a
-        dispatch_kernel call nested in a branch all satisfy S12+S13."""
-        from tileops.ops.op_base import Op
-
-        class GoodOp(Op):
+        branch-nested dispatch_kernel call all satisfy S12+S13. Pure
+        static inspection of ``__init__`` — plain classes suffice."""
+        class GoodOp:
             def __init__(self, kernel_map=None):
                 self.dispatch_kernel(kernel_map)
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
-        class VarKwOp(Op):
+        class VarKwOp:
             # ``**kwargs`` absorbs ``kernel_map`` and satisfies S12.
             def __init__(self, **kwargs):
                 self.dispatch_kernel(kwargs.get("kernel_map"))
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
-        class BranchOp(Op):
+        class BranchOp:
             # The S13 walker is AST-recursive; a call inside a branch counts.
             def __init__(self, kernel_map=None, fast=False):
                 if fast:
                     self.dispatch_kernel(kernel_map)
                 else:
                     self.dispatch_kernel(kernel_map)
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
         for cls in (GoodOp, VarKwOp, BranchOp):
             assert validator.check_c5_dispatch_kernel_invariant(
@@ -2854,33 +2648,22 @@ class TestDispatchKernelInvariant:
     def test_non_compliant_ctor_forms_fail(self, validator):
         """Case table: dropped override, missing kwarg, and helper-only
         dispatch each violate the invariant."""
-        from tileops.ops.op_base import Op
-
-        class SilentDropOp(Op):
+        class SilentDropOp:
             # S13 violation: kwarg accepted but the body never calls
             # ``self.dispatch_kernel`` — the override is silently dropped.
             def __init__(self, kernel_map=None):
                 pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
-        class NoKwargOp(Op):
+        class NoKwargOp:
             # S12 violation: ``__init__`` does not accept ``kernel_map``.
             def __init__(self): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
-        class HelperOp(Op):
+        class HelperOp:
             # S13 requires dispatch_kernel in __init__ or super().__init__.
             def __init__(self, kernel_map=None):
                 self._prepare(kernel_map)
             def _prepare(self, kernel_map=None):
                 self.dispatch_kernel(kernel_map)
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
 
         cases = [
             (SilentDropOp, "Slot S13"),
@@ -2898,55 +2681,37 @@ class TestStubOverrideGates:
     """C6 / C7: _validate_dtypes / eval_roofline must not be base stubs."""
 
     def test_base_stubs_detected(self, validator):
-        from tileops.ops.op_base import Op
-
-        class StubOp(Op):
-            def __init__(self): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
-        errs = validator.check_c6_validate_dtypes_not_stub("StubOp", {}, StubOp)
+        cls = _strict_op("StubOp", init=lambda self: None)
+        errs = validator.check_c6_validate_dtypes_not_stub("StubOp", {}, cls)
         assert any("is the Op base stub" in e for e in errs), errs
-        errs = validator.check_c7_eval_roofline_not_stub("StubOp", {}, StubOp)
+        errs = validator.check_c7_eval_roofline_not_stub("StubOp", {}, cls)
         assert any("is the Op base stub" in e for e in errs), errs
 
     def test_overrides_pass(self, validator):
-        from tileops.ops.op_base import Op
-
-        class OverriddenOp(Op):
-            def __init__(self): pass
-            def forward(self, x): return None
-            def _validate_dtypes(self, *args): pass
-            def eval_roofline(self): return (0, 0)
-            @property
-            def default_kernel_map(self): return {}
-
+        cls = _strict_op(
+            "OverriddenOp", init=lambda self: None,
+            _validate_dtypes=lambda self, *args: None,
+            eval_roofline=lambda self: (0, 0),
+        )
         assert validator.check_c6_validate_dtypes_not_stub(
-            "OverriddenOp", {}, OverriddenOp,
+            "OverriddenOp", {}, cls,
         ) == []
         assert validator.check_c7_eval_roofline_not_stub(
-            "OverriddenOp", {}, OverriddenOp,
+            "OverriddenOp", {}, cls,
         ) == []
 
 
 class TestStrictAdvisoryMode:
-    """Advisory vs strict routing of C1-C7 failures through ``validate_manifest()``.
-
-    Drives a synthetic single-file manifest pointing at a stub-only Op
-    fixture: tests the routing itself, not the bare helpers, so the
-    outcome is independent of the checked-in manifest's strict-parity
-    backlog.
+    """Advisory vs strict routing of C1-C7 failures through
+    ``validate_manifest()``, driven by a stub-only synthetic manifest so
+    the outcome is independent of the checked-in strict-parity backlog.
     """
 
     @pytest.fixture
     def stub_setup(self, tmp_path, monkeypatch, validator):
-        """Synthetic single-file manifest wired to an in-process Op fixture failing C6/C7.
-
-        Monkeypatches the validator's op-class resolver so the test does
-        not depend on the synthetic op file being importable from
-        sys.path.
-        """
+        """Synthetic single-file manifest wired to an in-process Op
+        fixture failing C6/C7; the op-class resolver is monkeypatched so
+        no importable module is needed."""
         from tileops.ops.op_base import Op
 
         class StubOp(Op):
@@ -2962,34 +2727,27 @@ class TestStrictAdvisoryMode:
         # Schema-valid synthetic manifest entry: all required top-level
         # fields present so the test would still parse if schema checks
         # were enabled.
-        manifest_yaml = tmp_path / "stub.yaml"
-        manifest_yaml.write_text(
-            "StubOp:\n"
-            "  family: synth\n"
-            "  status: implemented\n"
-            "  ref_api: https://example.invalid/stub\n"
-            "  signature:\n"
-            "    params:\n"
-            "      N: {type: int}\n"
-            "      dtype: {type: torch.dtype}\n"
-            "    inputs:\n"
-            "      x: {dtype: float16}\n"
-            "    outputs:\n"
-            "      y: {dtype: 'same_as(x)'}\n"
-            "    shape_rules:\n"
-            "      - 'y.shape == x.shape'\n"
-            "  workloads: []\n"
-            "  roofline:\n"
-            "    flops: 'N'\n"
-            "    bytes: '2 * N'\n"
-            "  source:\n"
-            "    op: tests/__strict_parity_stub__.py\n"
-            "    kernel: tileops/kernels/__strict_parity_stub__.py\n"
-            "    bench: benchmarks/ops/__strict_parity_stub__.py\n"
-            "    test: tests/__strict_parity_stub_test__.py\n"
-            "    kernel_map:\n"
-            "      stub: tileops.kernels.StubKernel\n"
-        )
+        entry = {
+            "family": "synth",
+            "status": "implemented",
+            "ref_api": "https://example.invalid/stub",
+            "signature": _sig(
+                {"x": "float16"}, {"y": "same_as(x)"},
+                params={"N": {"type": "int"},
+                        "dtype": {"type": "torch.dtype"}},
+                shape_rules=["y.shape == x.shape"],
+            ),
+            "workloads": [],
+            "roofline": {"flops": "N", "bytes": "2 * N"},
+            "source": {
+                "op": "tests/__strict_parity_stub__.py",
+                "kernel": "tileops/kernels/__strict_parity_stub__.py",
+                "bench": "benchmarks/ops/__strict_parity_stub__.py",
+                "test": "tests/__strict_parity_stub_test__.py",
+                "kernel_map": {"stub": "tileops.kernels.StubKernel"},
+            },
+        }
+        manifest_yaml = _write_manifest(tmp_path, {"StubOp": entry})
 
         def _fake_resolve(op_file, op_name):
             if op_name == "StubOp":
@@ -3045,11 +2803,8 @@ class TestCompileContractRegistry:
     """
 
     def test_declarations_match_registered_evidence(self):
-        """Manifest declarations == registered compile-test evidence, exactly.
-
-        A broken registration helper, a missing evidence module, or a
-        typo'd op name all surface as a set difference here.
-        """
+        """Manifest declarations == registered compile-test evidence;
+        broken registration or typo'd op names surface as a set diff."""
         from tests.compile_contract import compile_contract_ops
         from tileops.manifest import load_manifest
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -5,6 +5,7 @@ Uses synthetic manifest data to test individual check functions,
 plus an integration test against the real ops manifest (tileops/manifest/).
 """
 
+import contextlib
 import subprocess
 import sys
 import textwrap
@@ -31,7 +32,7 @@ def validator():
     return mod
 
 
-# schema: YAML structure validation
+# Shared builders and drivers for the synthetic-op test scaffolding.
 
 def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
                  source_kernel="k.py", status="spec-only", kernel_map=None,
@@ -73,6 +74,130 @@ def _make_entry(*, inputs=None, outputs=None, params=None, dtype_combos=None,
     entry.update(extra)
     return entry
 
+
+def _sig(inputs, outputs=None, **extra):
+    """Build a signature dict from dtype-string shorthand.
+
+    ``inputs`` / ``outputs`` map tensor name -> dtype string, or a full
+    attr dict when the test needs ``shape`` / ``constraints`` fields.
+    Extra keyword args (``params``, ``shape_rules``, ``dtype_combos``,
+    ``static_dims``) are copied verbatim.
+    """
+    def _tensors(d):
+        return {
+            k: ({"dtype": v} if isinstance(v, str) else v)
+            for k, v in d.items()
+        }
+    sig = {"inputs": _tensors(inputs)}
+    if outputs is not None:
+        sig["outputs"] = _tensors(outputs)
+    sig.update(extra)
+    return sig
+
+
+def _make_op_cls_with_infer(infer_fn, *, name="FakeOp"):
+    """Build a minimal Op subclass whose ``_infer_output_shapes`` is *infer_fn*.
+
+    Uses the real :class:`tileops.ops.op_base.Op` so ``_class_overrides_method``
+    correctly treats the method as an override.
+    """
+    from tileops.ops.op_base import Op
+
+    attrs = {
+        "_infer_output_shapes": infer_fn,
+        "forward": lambda self, *a, **kw: None,
+        "default_kernel_map": property(lambda self: {}),
+    }
+    return type(name, (Op,), attrs)
+
+
+def _make_op_cls_with_validate(validate_fn, *, name="FakeDtypeOp"):
+    from tileops.ops.op_base import Op
+
+    attrs = {
+        "_validate_dtypes": validate_fn,
+        "forward": lambda self, *a, **kw: None,
+        "default_kernel_map": property(lambda self: {}),
+    }
+    return type(name, (Op,), attrs)
+
+
+def _make_bare_op(name="BareOp"):
+    """Op subclass overriding neither parity method."""
+    from tileops.ops.op_base import Op
+
+    return type(name, (Op,), {
+        "forward": lambda self, *a, **kw: None,
+        "default_kernel_map": property(lambda self: {}),
+    })
+
+
+def _infer_parity(validator, infer_fn, sig, *, name="FakeOp"):
+    """Drive ``check_l2_infer_parity`` with a synthetic op class.
+
+    Returns ``(errors, warnings)``.
+    """
+    cls = _make_op_cls_with_infer(infer_fn, name=name)
+    warnings: list[str] = []
+    errors = validator.check_l2_infer_parity(
+        name, {"signature": sig}, cls, warnings=warnings,
+    )
+    return errors, warnings
+
+
+def _dtype_parity(validator, validate_fn, sig, *, name="FakeDtypeOp"):
+    """Drive ``check_l3_validate_dtypes_parity`` with a synthetic op class.
+
+    Returns ``(errors, warnings)``.
+    """
+    cls = _make_op_cls_with_validate(validate_fn, name=name)
+    warnings: list[str] = []
+    errors = validator.check_l3_validate_dtypes_parity(
+        name, {"signature": sig}, cls, warnings=warnings,
+    )
+    return errors, warnings
+
+
+def _write_manifest(tmp_path, ops):
+    """Serialize *ops* to a single-file synthetic manifest; return its path."""
+    import yaml
+
+    manifest_file = tmp_path / "ops_manifest.yaml"
+    manifest_file.write_text(yaml.safe_dump(ops))
+    return manifest_file
+
+
+def _fake_op_module(mod_name, class_names):
+    """Fake module holding forward()-bearing classes named *class_names*."""
+    import types as _types
+
+    mod = _types.ModuleType(mod_name)
+    mod.__name__ = mod_name
+    for cname in class_names:
+        cls = type(cname, (), {"forward": staticmethod(lambda: None)})
+        cls.__module__ = mod_name
+        setattr(mod, cname, cls)
+    return mod
+
+
+@contextlib.contextmanager
+def _patched_import(fake_mod):
+    """Patch ``importlib.import_module`` to serve *fake_mod* by name."""
+    import importlib
+    import unittest.mock as mock
+
+    original = importlib.import_module
+
+    def patched(name):
+        if name == fake_mod.__name__:
+            return fake_mod
+        return original(name)
+
+    with mock.patch.object(importlib, "import_module", side_effect=patched):
+        yield
+
+
+# schema: YAML structure validation
 
 class TestSchema:
     """schema checks that required fields exist and have correct types."""
@@ -171,9 +296,8 @@ class TestSchema:
         assert validator.check_l0("test_op", entry) == []
 
         # signature.inputs == {} with non-empty params: generative ops
-        # (ALiBi / sinusoidal positional encodings) synthesize the output
-        # entirely from construction-time parameters. The schema gate is
-        # ``len(outputs) >= 1 AND (len(inputs) >= 1 OR len(params) >= 1)``.
+        # synthesize the output entirely from construction-time params.
+        # The schema gate is ``outputs >= 1 AND (inputs >= 1 OR params >= 1)``.
         entry = _make_entry(
             inputs={},
             outputs={"output": {"dtype": "float16 | bfloat16 | float32"}},
@@ -325,9 +449,7 @@ class TestWorkloadPolicy:
         entry = _make_entry(status="implemented", kernel_map={})
         entry["workloads"] = entry["workloads"][:1]
         errors = validator.check_l0("test_op", entry)
-        assert any(
-            "at least 2 workloads" in e for e in errors
-        ), f"Expected workload-count error, got: {errors}"
+        assert any("at least 2 workloads" in e for e in errors), errors
 
         entry = _make_entry(status="spec-only")
         entry["workloads"] = entry["workloads"][:1]
@@ -345,13 +467,12 @@ class TestWorkloadPolicy:
         assert any(
             "workloads[1]" in e and "required param" in e and "dim" in e
             for e in errors
-        ), f"Expected required-param error, got: {errors}"
+        ), errors
 
     def test_workload_defaulted_param_may_be_omitted(self, validator):
         """Params with a default are not required in workloads."""
         entry = _make_entry(params={"dim": {"type": "int", "default": -1}})
-        errors = validator.check_l0("test_op", entry)
-        assert errors == [], f"Unexpected schema errors: {errors}"
+        assert validator.check_l0("test_op", entry) == []
 
 
 class TestOutputShapeDeclaration:
@@ -363,15 +484,14 @@ class TestOutputShapeDeclaration:
         errors = validator.check_l0("test_op", entry)
         assert any(
             "output" in e and "'y'" in e and "shape" in e for e in errors
-        ), f"Expected output-shape error, got: {errors}"
+        ), errors
 
     def test_output_with_declared_shape_passes(self, validator):
         entry = _make_entry(
             outputs={"y": {"dtype": "same_as(x)", "shape": "[M, N]"}},
         )
         del entry["signature"]["shape_rules"]
-        errors = validator.check_l0("test_op", entry)
-        assert errors == [], f"Unexpected schema errors: {errors}"
+        assert validator.check_l0("test_op", entry) == []
 
 
 class TestTensorConstraints:
@@ -383,9 +503,7 @@ class TestTensorConstraints:
                           "constraints": {"K": "K % 2 == 0"}}},
         )
         errors = validator.check_l0("test_op", entry)
-        assert any(
-            "constraints" in e and "'K'" in e for e in errors
-        ), f"Expected constraint-key error, got: {errors}"
+        assert any("constraints" in e and "'K'" in e for e in errors), errors
 
     def test_constraints_without_shape_fails(self, validator):
         entry = _make_entry(
@@ -393,29 +511,23 @@ class TestTensorConstraints:
                           "constraints": {"N": "N % 2 == 0"}}},
         )
         errors = validator.check_l0("test_op", entry)
-        assert any(
-            "constraints" in e and "shape" in e for e in errors
-        ), f"Expected constraints-without-shape error, got: {errors}"
+        assert any("constraints" in e and "shape" in e for e in errors), errors
 
     def test_constraint_keys_matching_shape_dims_pass(self, validator):
         entry = _make_entry(
             inputs={"x": {"dtype": "float16", "shape": "[M, N]",
                           "constraints": {"N": "N % 2 == 0"}}},
         )
-        errors = validator.check_l0("test_op", entry)
-        assert errors == [], f"Unexpected schema errors: {errors}"
+        assert validator.check_l0("test_op", entry) == []
 
 
 class TestSourcePathExistence:
     """source path values of non-spec-only ops must point at real files."""
 
     def test_missing_source_file_fails_for_implemented(self, validator, tmp_path):
-        import yaml
-
-        entry = _make_entry(status="implemented", kernel_map={})
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
-
+        manifest_file = _write_manifest(
+            tmp_path, {"my_op": _make_entry(status="implemented", kernel_map={})},
+        )
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
@@ -423,15 +535,12 @@ class TestSourcePathExistence:
         )
         assert any(
             "source." in e and "not a file" in e for e in errors
-        ), f"Expected source-path error, got: {errors}"
+        ), errors
 
     def test_spec_only_source_paths_are_placeholders(self, validator, tmp_path):
-        import yaml
-
-        entry = _make_entry(status="spec-only")
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
-
+        manifest_file = _write_manifest(
+            tmp_path, {"my_op": _make_entry(status="spec-only")},
+        )
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
@@ -440,20 +549,17 @@ class TestSourcePathExistence:
         assert not any("not a file" in e for e in errors), errors
 
     def test_existing_source_files_pass(self, validator, tmp_path):
-        import yaml
-
         for name in ("k.py", "o.py", "t.py", "b.py"):
             (tmp_path / name).write_text("# placeholder\n")
-        entry = _make_entry(status="implemented", kernel_map={})
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
-
+        manifest_file = _write_manifest(
+            tmp_path, {"my_op": _make_entry(status="implemented", kernel_map={})},
+        )
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
             levels=frozenset({"schema"}),
         )
-        assert errors == [], f"Unexpected errors: {errors}"
+        assert errors == [], errors
 
 
 class TestSingleInputWorkloadKeys:
@@ -521,53 +627,44 @@ class TestSingleInputWorkloadKeys:
         assert any("unknown entry keys" in e for e in errors), errors
 
 
-# torch_compile_fullgraph: capability flag schema
-
 class TestRooflineStructuralRules:
-    """L0 roofline reject branches, one guard each.
+    """L0 roofline reject branches, one guard per row.
 
     Accept paths are owned by TestIntegration: the shipped manifest
     exercises inline and func modes through the same checks.
     """
 
-    def _entry(self, validator, roofline):
-        entry = _make_entry()
-        entry["roofline"] = roofline
-        return validator.check_l0("my_op", entry)
-
-    def test_mixed_modes_fail(self, validator):
-        errors = self._entry(
-            validator, {"flops": "2*M*N", "bytes": "M*N", "func": "tileops.perf.formulas.gemm"})
-        assert any("exclusive" in e for e in errors)
-
-    def test_non_string_field_fails(self, validator):
-        """Integer placeholders were the shipped violation shape."""
-        errors = self._entry(validator, {"flops": 0, "bytes": "M*N"})
-        assert any("non-empty string" in e for e in errors)
-
-    def test_vars_non_mapping_fails(self, validator):
-        errors = self._entry(
-            validator, {"flops": "2*M*N", "bytes": "M*N", "vars": ["M"]})
-        assert any("vars must be a mapping" in e for e in errors)
-
-    def test_vars_non_string_value_fails(self, validator):
-        errors = self._entry(
-            validator, {"flops": "2*M*N", "bytes": "M*N", "vars": {"M": 4}})
-        assert any("vars" in e and "non-empty string" in e for e in errors)
-
-    def test_vars_non_string_key_fails(self, validator):
-        errors = self._entry(
-            validator, {"flops": "2*M*N", "bytes": "M*N", "vars": {4: "M"}})
-        assert any("key" in e and "must be a string" in e for e in errors)
-
-    def test_unresolvable_func_fails(self, validator):
-        errors = self._entry(validator, {"func": "tileops.perf.formulas.no_such_formula"})
-        assert any("does not resolve" in e for e in errors)
-
-    def test_non_callable_func_fails(self, validator):
-        """Distinguishes the callable() predicate from a hasattr regression."""
-        errors = self._entry(validator, {"func": "tileops.perf.formulas.__doc__"})
-        assert any("does not resolve" in e for e in errors)
+    def test_reject_branches(self, validator):
+        cases = [
+            # (description, roofline value, substrings expected in one error)
+            ("mixed inline+func modes",
+             {"flops": "2*M*N", "bytes": "M*N",
+              "func": "tileops.perf.formulas.gemm"}, ["exclusive"]),
+            ("non-string field (shipped violation shape)",
+             {"flops": 0, "bytes": "M*N"}, ["non-empty string"]),
+            ("vars non-mapping",
+             {"flops": "2*M*N", "bytes": "M*N", "vars": ["M"]},
+             ["vars must be a mapping"]),
+            ("vars non-string value",
+             {"flops": "2*M*N", "bytes": "M*N", "vars": {"M": 4}},
+             ["vars", "non-empty string"]),
+            ("vars non-string key",
+             {"flops": "2*M*N", "bytes": "M*N", "vars": {4: "M"}},
+             ["key", "must be a string"]),
+            ("unresolvable func",
+             {"func": "tileops.perf.formulas.no_such_formula"},
+             ["does not resolve"]),
+            ("non-callable func (callable() predicate, not hasattr)",
+             {"func": "tileops.perf.formulas.__doc__"},
+             ["does not resolve"]),
+        ]
+        for desc, roofline, substrings in cases:
+            entry = _make_entry()
+            entry["roofline"] = roofline
+            errors = validator.check_l0("my_op", entry)
+            assert any(
+                all(s in e for s in substrings) for e in errors
+            ), f"{desc}: expected error with {substrings}, got: {errors}"
 
 
 class TestTorchCompileFullgraph:
@@ -585,7 +682,6 @@ class TestTorchCompileFullgraph:
 
     def test_invalid_spellings_rejected(self, validator):
         """false, non-bool values, and spec-only placement are all rejected."""
-        # Non-true values: absence is the only spelling of "no promise".
         for value in (False, "true", 1, None):
             entry = _make_entry(
                 status="implemented", kernel_map={},
@@ -596,12 +692,11 @@ class TestTorchCompileFullgraph:
                 "torch_compile_fullgraph" in e and "true" in e for e in errors
             ), f"Expected literal-true error for {value!r}, got: {errors}"
 
-        # The field is invalid on status: spec-only entries.
         entry = _make_entry(status="spec-only", torch_compile_fullgraph=True)
         errors = validator.check_l0("test_op", entry)
         assert any(
             "torch_compile_fullgraph" in e and "spec-only" in e for e in errors
-        ), f"Expected spec-only rejection, got: {errors}"
+        ), errors
 
 
 # variant_of: cross-entry consistency (R16)
@@ -618,58 +713,42 @@ class TestVariantOf:
                 "variant_of": "moe_fused_moe",
             },
         }
-        errors = validator.check_variant_of_consistency(ops)
-        assert errors == [], f"Unexpected errors: {errors}"
-
-    def test_variant_target_missing_fails(self, validator):
-        """variant_of pointing to nonexistent entry fails (R16)."""
-        ops = {
-            "moe_fused_moe_cb": {
-                **_make_entry(),
-                "variant_of": "nonexistent",
-            },
-        }
-        errors = validator.check_variant_of_consistency(ops)
-        assert any("nonexistent" in e and "does not exist" in e for e in errors)
-
+        assert validator.check_variant_of_consistency(ops) == []
 
     def test_malformed_entry_does_not_crash(self, validator):
         """Non-dict entry must not crash variant_of check."""
         ops = {"bad": 123, "ok": _make_entry()}
-        errors = validator.check_variant_of_consistency(ops)
-        assert errors == []
+        assert validator.check_variant_of_consistency(ops) == []
 
-    def test_variant_chaining_fails(self, validator):
-        """Chained variant_of fails (R16 single-level)."""
-        ops = {
-            "primary": _make_entry(),
-            "variant_a": {**_make_entry(), "variant_of": "primary"},
-            "variant_b": {**_make_entry(), "variant_of": "variant_a"},
-        }
-        errors = validator.check_variant_of_consistency(ops)
-        assert any("chaining" in e.lower() for e in errors)
-
-    def test_variant_mismatched_kernel_fails(self, validator):
-        """Variant with different source.kernel fails (R16)."""
-        ops = {
-            "primary": _make_entry(source_kernel="shared.py"),
-            "variant": {
-                **_make_entry(source_kernel="different.py"),
-                "variant_of": "primary",
-            },
-        }
-        errors = validator.check_variant_of_consistency(ops)
-        assert any("source.kernel" in e and "R16" in e for e in errors)
-
-    def test_variant_mismatched_op_fails(self, validator):
-        """Variant with different source.op fails (R16)."""
-        primary = _make_entry()
-        variant = _make_entry()
-        variant["source"]["op"] = "different_op.py"
-        variant["variant_of"] = "primary"
-        ops = {"primary": primary, "variant": variant}
-        errors = validator.check_variant_of_consistency(ops)
-        assert any("source.op" in e and "R16" in e for e in errors)
+    def test_violations_rejected(self, validator):
+        """Case table: missing target, chaining, and shared-source
+        mismatches all fail (R16)."""
+        mismatched_op = _make_entry()
+        mismatched_op["source"]["op"] = "different_op.py"
+        mismatched_op["variant_of"] = "primary"
+        cases = [
+            ("variant target missing",
+             {"v": {**_make_entry(), "variant_of": "nonexistent"}},
+             ["nonexistent", "does not exist"]),
+            ("variant chaining (single-level rule)",
+             {"primary": _make_entry(),
+              "variant_a": {**_make_entry(), "variant_of": "primary"},
+              "variant_b": {**_make_entry(), "variant_of": "variant_a"}},
+             ["chaining"]),
+            ("mismatched source.kernel",
+             {"primary": _make_entry(source_kernel="shared.py"),
+              "variant": {**_make_entry(source_kernel="different.py"),
+                          "variant_of": "primary"}},
+             ["source.kernel", "R16"]),
+            ("mismatched source.op",
+             {"primary": _make_entry(), "variant": mismatched_op},
+             ["source.op", "R16"]),
+        ]
+        for desc, ops, substrings in cases:
+            errors = validator.check_variant_of_consistency(ops)
+            assert any(
+                all(s in e for s in substrings) for e in errors
+            ), f"{desc}: expected error with {substrings}, got: {errors}"
 
 
 # signature: Op.forward() consistency
@@ -830,16 +909,10 @@ class TestDtype:
     """dtype checks that dtype strings are valid torch dtype names."""
 
     def test_invalid_dtype_tokens_are_hard_l3_errors(self, validator):
-        """Unrecognized dtype names in workloads or dtype_combos fail hard.
-
-        The dtype_combos case must not depend on a ``_validate_dtypes``
-        override — the data-level check alone reports it.
-        """
+        """Unrecognized dtype names in workloads or dtype_combos fail hard,
+        independent of any ``_validate_dtypes`` override."""
         entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
+            "signature": _sig({"x": "float16"}, {"y": "same_as(x)"}),
             "workloads": [{"dtypes": ["not_a_dtype"]}],
         }
         errors = validator.check_l3("test_op", entry)
@@ -847,31 +920,27 @@ class TestDtype:
 
         entry = {
             "status": "implemented",
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [{"x": "not_a_real_dtype"}],
-            },
+            "signature": _sig(
+                {"x": "float16 | bfloat16"}, {"y": "same_as(x)"},
+                dtype_combos=[{"x": "not_a_real_dtype"}],
+            ),
             "workloads": [{"dtypes": ["float16"]}],
         }
         errors = validator.check_l3("test_op", entry)
         assert any(
             "not_a_real_dtype" in e and "dtype_combos" in e for e in errors
-        ), f"Expected hard L3 error for invalid combo value, got: {errors}"
+        ), errors
 
     def test_dtype_combos_same_as_identity(self, validator):
         """R3 identity: same_as-bound tensors must match in every combo;
         a combo omitting the reference cannot be verified and fails."""
         def entry_with_combos(combos):
             return {
-                "signature": {
-                    "inputs": {
-                        "x": {"dtype": "float16 | bfloat16"},
-                        "w": {"dtype": "same_as(x)"},
-                    },
-                    "outputs": {"y": {"dtype": "same_as(x)"}},
-                    "dtype_combos": combos,
-                },
+                "signature": _sig(
+                    {"x": "float16 | bfloat16", "w": "same_as(x)"},
+                    {"y": "same_as(x)"},
+                    dtype_combos=combos,
+                ),
                 "workloads": [{"dtypes": ["float16"]}],
             }
 
@@ -898,30 +967,21 @@ class TestDtype:
         """``_resolve_tensor_dtype_options`` resolves forward same_as refs
         (R3 is an identity constraint, not an ordering rule) and expands
         ``promote_int_to_float`` per R3a."""
-        sig = {
-            "inputs": {
-                "x": {"dtype": "same_as(y)"},
-                "y": {"dtype": "float16 | bfloat16"},
-            },
-            "outputs": {"z": {"dtype": "same_as(y)"}},
-        }
+        sig = _sig(
+            {"x": "same_as(y)", "y": "float16 | bfloat16"},
+            {"z": "same_as(y)"},
+        )
         resolved = validator._resolve_tensor_dtype_options(sig)
         assert resolved is not None, "Forward same_as reference must resolve"
         assert resolved["x"] == ["float16", "bfloat16"]
         assert resolved["y"] == ["float16", "bfloat16"]
         assert resolved["z"] == ["float16", "bfloat16"]
 
-        sig = {
-            "inputs": {
-                "input": {
-                    "dtype": (
-                        "float16 | bfloat16 | float32 | "
-                        "int8 | int16 | int32 | int64 | uint8"
-                    ),
-                },
-            },
-            "outputs": {"output": {"dtype": "promote_int_to_float(input)"}},
-        }
+        sig = _sig(
+            {"input": ("float16 | bfloat16 | float32 | "
+                       "int8 | int16 | int32 | int64 | uint8")},
+            {"output": "promote_int_to_float(input)"},
+        )
         resolved = validator._resolve_tensor_dtype_options(sig)
         assert resolved is not None
         # All integral options collapse to a single float32 entry; float
@@ -933,29 +993,24 @@ class TestDtype:
         and malformed args are rejected wherever they appear."""
         cases = [
             # (description, sig, workloads, substrings expected in one error)
-            ("unknown tensor reference", {
-                "inputs": {"x": {"dtype": "float16 | int32"}},
-                "outputs": {"y": {"dtype": "promote_int_to_float(z)"}},
-            }, [{"dtypes": ["float16"]}],
+            ("unknown tensor reference",
+             _sig({"x": "float16 | int32"}, {"y": "promote_int_to_float(z)"}),
+             [{"dtypes": ["float16"]}],
              ["promote_int_to_float(z)",
               "must reference a signature input tensor"]),
-            ("malformed empty arg", {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "promote_int_to_float()"}},
-            }, [{"dtypes": ["float16"]}],
+            ("malformed empty arg",
+             _sig({"x": "float16"}, {"y": "promote_int_to_float()"}),
+             [{"dtypes": ["float16"]}],
              ["unrecognized dtype", "promote_int_to_float()"]),
-            ("input-side use", {
-                "inputs": {
-                    "x": {"dtype": "int8 | int32 | float32"},
-                    "y": {"dtype": "promote_int_to_float(x)"},
-                },
-                "outputs": {"out": {"dtype": "float32"}},
-            }, [{"dtypes": ["float32"]}],
+            ("input-side use",
+             _sig({"x": "int8 | int32 | float32",
+                   "y": "promote_int_to_float(x)"}, {"out": "float32"}),
+             [{"dtypes": ["float32"]}],
              ["promote_int_to_float", " y ", "output-side only"]),
-            ("workload-dtype use", {
-                "inputs": {"x": {"dtype": "int8 | int32 | float32"}},
-                "outputs": {"y": {"dtype": "promote_int_to_float(x)"}},
-            }, [{"dtypes": ["promote_int_to_float(x)"]}],
+            ("workload-dtype use",
+             _sig({"x": "int8 | int32 | float32"},
+                  {"y": "promote_int_to_float(x)"}),
+             [{"dtypes": ["promote_int_to_float(x)"]}],
              ["promote_int_to_float", "workloads[0].dtypes[0]",
               "output-side only"]),
         ]
@@ -969,26 +1024,15 @@ class TestDtype:
     def test_promote_int_to_float_signature_accepts(self, validator):
         """``promote_int_to_float(ref)`` is a recognized output dtype token."""
         entry = {
-            "signature": {
-                "inputs": {
-                    "input": {
-                        "dtype": (
-                            "float16 | bfloat16 | float32 | "
-                            "int8 | int16 | int32 | int64 | uint8"
-                        ),
-                    },
-                },
-                "outputs": {
-                    "output": {"dtype": "promote_int_to_float(input)"},
-                },
-            },
+            "signature": _sig(
+                {"input": ("float16 | bfloat16 | float32 | "
+                           "int8 | int16 | int32 | int64 | uint8")},
+                {"output": "promote_int_to_float(input)"},
+            ),
             "workloads": [{"dtypes": ["float16"]}],
         }
         errors = validator.check_l3("PromoteOp", entry)
-        assert errors == [], (
-            f"promote_int_to_float on declared input must validate, got: {errors}"
-        )
-
+        assert errors == [], errors
 
     def test_check_l3_with_non_dict_signature_does_not_crash(self, validator):
         """check_l3 must tolerate malformed signature.inputs/outputs.
@@ -1023,115 +1067,58 @@ class TestDtype:
 # L2 extension: _infer_output_shapes parity with shape_rules
 
 
-def _make_op_cls_with_infer(infer_fn, *, name="FakeOp"):
-    """Build a minimal Op subclass whose ``_infer_output_shapes`` is *infer_fn*.
-
-    Uses the real :class:`tileops.ops.op_base.Op` so ``_class_overrides_method``
-    correctly treats the method as an override.
-    """
-    from tileops.ops.op_base import Op
-
-    attrs = {
-        "_infer_output_shapes": infer_fn,
-        "forward": lambda self, *a, **kw: None,
-        "default_kernel_map": property(lambda self: {}),
-    }
-    return type(name, (Op,), attrs)
-
-
 class TestInferShapeParity:
     """L2 extension: ``_infer_output_shapes`` output must satisfy shape_rules."""
 
-
     def test_no_override_emits_missing_method_warning(self, validator):
-        """Missing override must not pass silently.
-
-        Implemented ops whose class does not define
-        ``_infer_output_shapes`` must surface a warning naming the gap;
-        silently skipping such ops would leave the parity check with no
-        visible coverage signal.
-        """
-        from tileops.ops.op_base import Op
-
-        class BareOp(Op):
-            def forward(self):
-                return None
-
-            @property
-            def default_kernel_map(self):
-                return {}
-
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
+        """Implemented op lacking the codegen-derived method warns; the gap
+        must not pass silently."""
+        entry = {"signature": _sig(
+            {"x": "float16"}, {"y": "same_as(x)"},
+            shape_rules=["y.shape == x.shape"],
+        )}
         warnings: list[str] = []
         errors = validator.check_l2_infer_parity(
-            "BareOp", entry, BareOp, warnings=warnings,
+            "BareOp", entry, _make_bare_op(), warnings=warnings,
         )
         assert errors == []
         assert any(
             "does not override _infer_output_shapes" in w for w in warnings
-        ), (
-            f"Expected missing-method warning when implemented op lacks "
-            f"the codegen-derived method, got: {warnings}"
-        )
-
+        ), warnings
 
     def test_symbolic_dim_rule_detects_wrong_output(self, validator):
         """Rules like ``o.shape == (B, S, H, D)`` must evaluate, not warn-skip.
 
-        Symbolic dimension names declared only via literal
-        ``tensor.shape == (...)`` rules must be bound into the evaluation
-        context; an unbound name raises NameError, downgrades the rule to
-        a warning, and lets a wrong ``_infer_output_shapes`` pass parity.
+        Symbolic dim names declared only via literal rules must be bound
+        into the eval context; an unbound name raises NameError, downgrades
+        the rule to a warning, and lets a wrong impl pass parity.
         """
         def infer(self, q_shape, k_shape, v_shape):
             # Wrong: returns a 1-D shape instead of a 4-D shape.
             return {"o": (999,)}
 
-        cls = _make_op_cls_with_infer(infer, name="BadMHA")
-        entry = {
-            "signature": {
-                "inputs": {
-                    "q": {"dtype": "float16"},
-                    "k": {"dtype": "float16"},
-                    "v": {"dtype": "float16"},
-                },
-                "outputs": {"o": {"dtype": "float16"}},
-                "shape_rules": [
-                    "q.shape == (B, S, H, D)",
-                    "k.shape == (B, S, H, D)",
-                    "v.shape == (B, S, H, D)",
-                    "o.shape == (B, S, H, D)",
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "BadMHA", entry, cls, warnings=warnings,
+        sig = _sig(
+            {"q": "float16", "k": "float16", "v": "float16"},
+            {"o": "float16"},
+            shape_rules=[
+                "q.shape == (B, S, H, D)",
+                "k.shape == (B, S, H, D)",
+                "v.shape == (B, S, H, D)",
+                "o.shape == (B, S, H, D)",
+            ],
         )
+        errors, warnings = _infer_parity(validator, infer, sig, name="BadMHA")
         assert any(
             "_infer_output_shapes output violates" in e and "o.shape" in e
             for e in errors
-        ), (
-            f"Expected symbolic-dim rule to evaluate and flag mismatch, "
-            f"got errors={errors} warnings={warnings}"
-        )
+        ), (errors, warnings)
         assert not any(
             "could not be evaluated" in w for w in warnings
-        ), (
-            f"Symbolic dim names must be bound into ctx, not reported as "
-            f"NameError: {warnings}"
-        )
+        ), warnings
 
     def test_no_cls_skipped(self, validator):
         entry = {"signature": {"shape_rules": ["y.shape == x.shape"]}}
         assert validator.check_l2_infer_parity("Foo", entry, None) == []
-
 
     def test_incorrect_infer_fails(self, validator):
         """Parity error when _infer_output_shapes disagrees with shape_rules."""
@@ -1139,47 +1126,27 @@ class TestInferShapeParity:
             # Wrong: drops a dim.
             return {"y": x_shape[:-1]}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
-        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
-        assert any("_infer_output_shapes output violates" in e for e in errors), (
-            f"Expected parity error, got: {errors}"
-        )
+        sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
+                   shape_rules=["y.shape == x.shape"])
+        errors, _ = _infer_parity(validator, infer, sig)
+        assert any("_infer_output_shapes output violates" in e for e in errors), errors
 
     def test_missing_output_fails(self, validator):
         def infer(self, x_shape):
             return {}  # missing y
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
-        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
+                   shape_rules=["y.shape == x.shape"])
+        errors, _ = _infer_parity(validator, infer, sig)
         assert any("missing output" in e for e in errors), errors
 
     def test_signature_mismatch_reports(self, validator):
         def infer(self, a_shape):
             return {"y": a_shape}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
-        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
+        sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
+                   shape_rules=["y.shape == x.shape"])
+        errors, _ = _infer_parity(validator, infer, sig)
         assert any("signature does not match" in e for e in errors), errors
 
     def test_tuple_literal_rule_rank(self, validator):
@@ -1190,141 +1157,86 @@ class TestInferShapeParity:
             seen_rank.append(len(x_shape))
             return {"y": x_shape}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": [
-                    "x.shape == (B, S, H, D)",
-                    "y.shape == x.shape",
-                ],
-            },
-        }
-        assert validator.check_l2_infer_parity("FakeOp", entry, cls) == []
+        sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
+                   shape_rules=["x.shape == (B, S, H, D)",
+                                "y.shape == x.shape"])
+        errors, _ = _infer_parity(validator, infer, sig)
+        assert errors == []
         assert seen_rank == [4], seen_rank
 
     def test_r11_style_rule_uses_len_helper(self, validator):
-        """R11 / R11a rules that call ``len`` or use comprehensions must be
-        evaluable.
-
-        Two eval-context invariants: the restricted builtins expose
-        ``len`` / ``isinstance`` / ``set``, and ctx names are visible
-        inside comprehension scopes (``eval`` resolves those against
-        globals). Breaking either turns the rule into a NameError
-        warning-skip and hides parity mismatches.
-        """
+        """R11 / R11a rules calling ``len`` or using comprehensions must be
+        evaluable: the restricted builtins expose the helpers, and ctx
+        names resolve inside comprehension scopes. Breaking either turns
+        the rule into a NameError warning-skip and hides mismatches."""
         # Wrong: reduction op declares dim, keepdim=False so y should drop
         # rank(s), but _infer_output_shapes returns x_shape verbatim.
         def infer(self, x_shape):
             return {"y": x_shape}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "params": {
-                    "dim": {"default": -1},
-                    "keepdim": {"default": False},
-                },
-                "shape_rules": [
-                    "y.ndim == x.ndim - len({dim % x.ndim})",
-                ],
-            },
-        }
-        errors = validator.check_l2_infer_parity("FakeOp", entry, cls)
-        assert any("_infer_output_shapes output violates" in e for e in errors), (
-            f"Expected R11-style rule to evaluate and flag mismatch, got: {errors}"
+        sig = _sig(
+            {"x": "float16"}, {"y": "same_as(x)"},
+            params={"dim": {"default": -1}, "keepdim": {"default": False}},
+            shape_rules=["y.ndim == x.ndim - len({dim % x.ndim})"],
         )
+        errors, _ = _infer_parity(validator, infer, sig)
+        assert any("_infer_output_shapes output violates" in e for e in errors), errors
 
         # Comprehension scoping: generator / set comprehensions in the rule
         # body must not be skipped via a NameError warning.
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "params": {
-                    "dim": {"default": [-1]},
-                    "keepdim": {"default": False},
-                },
-                "shape_rules": [
-                    # Generator expression inside all(...): comprehension scope.
-                    "all(d % x.ndim in range(x.ndim) for d in dim)",
-                    # Set comprehension: also its own scope.
-                    "len({d % x.ndim for d in dim}) == len(dim)",
-                    # Actual parity rule expected to catch the mismatch.
-                    "y.ndim == x.ndim - len(dim)",
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "FakeOp", entry, cls, warnings=warnings,
+        sig = _sig(
+            {"x": "float16"}, {"y": "same_as(x)"},
+            params={"dim": {"default": [-1]}, "keepdim": {"default": False}},
+            shape_rules=[
+                # Generator expression inside all(...): comprehension scope.
+                "all(d % x.ndim in range(x.ndim) for d in dim)",
+                # Set comprehension: also its own scope.
+                "len({d % x.ndim for d in dim}) == len(dim)",
+                # Actual parity rule expected to catch the mismatch.
+                "y.ndim == x.ndim - len(dim)",
+            ],
         )
+        errors, warnings = _infer_parity(validator, infer, sig)
         assert not any(
             "could not be evaluated" in w for w in warnings
-        ), f"Comprehension rule skipped via warning: {warnings}"
+        ), warnings
         assert any(
             "_infer_output_shapes output violates" in e and "y.ndim" in e
             for e in errors
-        ), f"Expected ndim parity mismatch, got: {errors}"
-
+        ), errors
 
     def test_input_only_precondition_not_blamed_on_infer(self, validator):
         """Mock-input precondition violations must not become parity errors.
 
-        When ``shape_rules`` encode an input-only precondition (e.g.
-        ``weight.shape == (x.shape[dim],)``) that the synthesised mock
-        inputs happen to violate, a correct ``_infer_output_shapes`` must
-        not be blamed. The rule must be reported as skipped via warning
-        rather than an error.
+        When ``shape_rules`` encode an input-only precondition that the
+        synthesized mock inputs violate, a correct ``_infer_output_shapes``
+        is not blamed; the rule is reported as skipped via warning.
         """
         def infer(self, x_shape, weight_shape):
             # Correct: y has the same shape as x.
             return {"y": x_shape}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16"},
-                    "weight": {"dtype": "float16"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "params": {"dim": {"default": -1}},
-                "shape_rules": [
-                    # Input-only precondition the mock (4,4) vs (4,4)
-                    # arrangement would naively satisfy; use a form that
-                    # the mock synthesis will not satisfy to trigger the
-                    # precondition-violation path.
-                    "weight.shape == (x.shape[dim] + 1,)",
-                    "y.shape == x.shape",
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "FakeOp", entry, cls, warnings=warnings,
+        sig = _sig(
+            {"x": "float16", "weight": "float16"}, {"y": "same_as(x)"},
+            params={"dim": {"default": -1}},
+            shape_rules=[
+                # Form the mock synthesis will not satisfy, triggering the
+                # precondition-violation path.
+                "weight.shape == (x.shape[dim] + 1,)",
+                "y.shape == x.shape",
+            ],
         )
+        errors, warnings = _infer_parity(validator, infer, sig)
         assert not any(
             "_infer_output_shapes output violates" in e for e in errors
-        ), (
-            "Correct _infer_output_shapes should not be blamed for an "
-            f"input-only precondition violation on mock inputs: {errors}"
-        )
-        assert any(
-            "input-only precondition" in w for w in warnings
-        ), f"Expected precondition-skip warning, got: {warnings}"
+        ), errors
+        assert any("input-only precondition" in w for w in warnings), warnings
 
     def test_mock_input_shapes_cross_tensor_dims_distinct(self, validator):
         """Distinct symbolic dims across rules must get distinct mock sizes.
 
-        If dims from different rules collide (e.g. ``A`` in
-        ``x.shape == (A, B)`` and ``C`` in ``y.shape == (C, D)`` mapping
-        to the same mock size), a downstream rule comparing
-        ``x.shape[0]`` to ``y.shape[0]`` evaluates to a spurious
-        True / False.
+        Colliding sizes would make a cross-tensor rule like
+        ``x.shape[0] == y.shape[0]`` evaluate to a spurious True / False.
         """
         sig = {
             "inputs": {"x": {}, "y": {}},
@@ -1338,19 +1250,15 @@ class TestInferShapeParity:
         shapes, dim_sizes = result
         # Four distinct symbolic dims → four distinct mock sizes.
         assert len({dim_sizes[k] for k in ("A", "B", "C", "D")}) == 4
-        # Corollary: the mock shapes of x and y disagree on the first
-        # dim, so a ``x.shape[0] == y.shape[0]`` rule would correctly
-        # evaluate False on mock inputs.
+        # Corollary: x and y disagree on the first dim.
         assert tuple(shapes["x"])[0] != tuple(shapes["y"])[0]
 
     def test_eval_shape_rule_rejects_dunder_attr(self, validator):
         """Shape-rule evaluator must reject dunder attribute access.
 
-        Defense-in-depth: manifest content is trusted (PR-gated), but
-        a classic sandbox-escape expression such as
+        Defense-in-depth: a classic sandbox-escape expression such as
         ``().__class__.__mro__[1].__subclasses__()`` would bypass the
-        restricted builtins. The evaluator runs an AST filter that
-        rejects any attribute whose name starts or ends with ``__``.
+        restricted builtins; the AST filter rejects dunder attributes.
         """
         ok, reason = validator._eval_shape_rule(
             "().__class__ is None", {},
@@ -1364,17 +1272,11 @@ class TestInferShapeParity:
         hard L2 parity errors, never as signature mismatches or warnings.
 
         The signature is pre-bound via ``inspect.signature().bind`` so a
-        TypeError from the body is distinguished from a signature
-        mismatch; RuntimeError (e.g. ``'not ready'`` placeholders) follows
-        the same hard-error policy so genuine bugs cannot silently pass.
+        body TypeError is distinguished from a signature mismatch;
+        RuntimeError placeholders follow the same hard-error policy.
         """
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
+        sig = _sig({"x": "float16"}, {"y": "same_as(x)"},
+                   shape_rules=["y.shape == x.shape"])
         for exc_cls, message in (
             (TypeError, "simulated implementation bug"),
             (RuntimeError, "not ready"),
@@ -1383,68 +1285,32 @@ class TestInferShapeParity:
                 # Signature matches; the body itself raises.
                 raise _exc(_msg)
 
-            cls = _make_op_cls_with_infer(infer)
-            warnings: list[str] = []
-            errors = validator.check_l2_infer_parity(
-                "FakeOp", entry, cls, warnings=warnings,
-            )
+            errors, warnings = _infer_parity(validator, infer, sig)
             assert not any(
                 "signature does not match manifest inputs" in e for e in errors
-            ), (
-                f"Body {exc_cls.__name__} must not be misreported as "
-                f"signature mismatch; errors={errors}"
-            )
+            ), (exc_cls, errors)
             assert any(
                 f"raised {exc_cls.__name__}" in e for e in errors
-            ), (
-                f"Body {exc_cls.__name__} must surface as a hard L2 parity "
-                f"error; errors={errors} warnings={warnings}"
-            )
-
+            ), (exc_cls, errors, warnings)
 
     def test_declared_output_shape_catches_wrong_infer(self, validator):
         """Declared output shapes alone (no shape_rules) must drive parity.
 
         Inferred outputs are compared against ``signature.outputs[*].shape``
-        even when ``shape_rules`` is empty; a manifest that declares
-        shapes only per-output (e.g. conv ops' ``"[N, C_out, L_out]"``)
-        must still catch a broken ``_infer_output_shapes``.
+        even when ``shape_rules`` is empty (e.g. conv ops declaring
+        ``"[N, C_out, L_out]"`` per output).
         """
         def infer(self, x_shape, w_shape):
-            # Wrong: returns x_shape verbatim instead of
-            # ``[N, C_out, L_out]`` implied by the declared output shape.
+            # Wrong: returns x_shape verbatim instead of [N, C_out, L_out].
             return {"y": tuple(x_shape)}
 
-        cls = _make_op_cls_with_infer(infer)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-                    "w": {
-                        "dtype": "float16",
-                        "shape": "[C_out, C_in, kW]",
-                    },
-                },
-                "outputs": {
-                    "y": {
-                        "dtype": "float16",
-                        "shape": "[N, C_out, L_out]",
-                    },
-                },
-                # No shape_rules; declared shape fields alone must drive
-                # the parity check.
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "FakeOp", entry, cls, warnings=warnings,
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
+            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
         )
-        assert any(
-            "disagrees with declared" in e for e in errors
-        ), (
-            "Wrong _infer_output_shapes against declared output shape "
-            f"must surface as a parity error; errors={errors}"
-        )
+        errors, _ = _infer_parity(validator, infer, sig)
+        assert any("disagrees with declared" in e for e in errors), errors
 
     def test_infer_reads_self_attr_uses_cls_new(self, validator):
         """Reading a non-manifest-param ``self`` attribute must not falsely skip parity.
@@ -1468,37 +1334,29 @@ class TestInferShapeParity:
                 return {}
 
             def _infer_output_shapes(self, x_shape):
-                # Read an attribute that must be reachable through self.
                 _ = self.some_attr
                 return {"y": tuple(x_shape)}
 
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "shape_rules": ["y.shape == x.shape"],
-            },
-        }
+        entry = {"signature": _sig(
+            {"x": "float16"}, {"y": "same_as(x)"},
+            shape_rules=["y.shape == x.shape"],
+        )}
         warnings: list[str] = []
         errors = validator.check_l2_infer_parity(
             "SelfAttrOp", entry, SelfAttrOp, warnings=warnings,
         )
-        assert errors == [], f"Expected no errors, got: {errors}"
+        assert errors == [], errors
         assert not any(
             "parity skipped" in w and "AttributeError" in w
             for w in warnings
-        ), (
-            "self.<class_attr> lookup must not cause a parity skip; "
-            f"warnings={warnings}"
-        )
+        ), warnings
 
     def test_infer_reads_static_dim_attr_populated(self, validator):
         """Reading ``self.<static_dim>`` must exercise parity, not AttributeError-skip.
 
         ``_build_mock_self`` installs ``static_dims`` values resolved
         against the mock inputs in addition to ``signature.params``
-        defaults, so a generated ``_infer_output_shapes`` that consults
-        ``self.N`` runs end-to-end instead of AttributeError-skipping.
+        defaults.
         """
         from tileops.ops.op_base import Op
 
@@ -1515,22 +1373,17 @@ class TestInferShapeParity:
                 # Reads a static_dims attribute: N = x.shape[-1]
                 return {"y": (self.N, self.N)}
 
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16", "shape": "[B, N]"}},
-                "outputs": {"y": {"dtype": "float16", "shape": "[N, N]"}},
-                "static_dims": {"N": "x.shape[-1]"},
-            },
-        }
+        entry = {"signature": _sig(
+            {"x": {"dtype": "float16", "shape": "[B, N]"}},
+            {"y": {"dtype": "float16", "shape": "[N, N]"}},
+            static_dims={"N": "x.shape[-1]"},
+        )}
         warnings: list[str] = []
         errors = validator.check_l2_infer_parity(
             "StaticDimOp", entry, StaticDimOp, warnings=warnings,
         )
-        assert errors == [], f"Expected no errors, got: {errors}"
-        assert not any(
-            "AttributeError" in w for w in warnings
-        ), f"static_dims lookup must not AttributeError-skip; warnings={warnings}"
-
+        assert errors == [], errors
+        assert not any("AttributeError" in w for w in warnings), warnings
 
     def test_conv_like_output_only_symbol_not_blamed(self, validator):
         """Correct infer with an output-only ``L_out`` symbol passes parity.
@@ -1541,67 +1394,42 @@ class TestInferShapeParity:
         """
         def infer(self, x_shape, w_shape):
             # x: [N, C_in, L_in]; w: [C_out, C_in, kW]
-            # y: [N, C_out, L_in - kW + 1]
             return {"y": (x_shape[0], w_shape[0], x_shape[2] - w_shape[2] + 1)}
 
-        cls = _make_op_cls_with_infer(infer, name="ConvLikeOp")
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
-                },
-                "outputs": {
-                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
-                },
-                "shape_rules": ["L_out == L_in - kW + 1"],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "ConvLikeOp", entry, cls, warnings=warnings,
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
+            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
+            shape_rules=["L_out == L_in - kW + 1"],
         )
-        assert errors == [], (
-            f"Correct conv-like infer must not be flagged for output-only "
-            f"symbol L_out; errors={errors}"
-        )
+        errors, _ = _infer_parity(validator, infer, sig, name="ConvLikeOp")
+        assert errors == [], errors
 
     def test_conv_like_wrong_output_only_value_reported(self, validator):
         """Wrong output-only symbol value is flagged via the shape_rules defining it.
 
-        A rule like ``L_out == L_in - kW + 1`` mentions no output tensor
-        name, but ``L_out`` appears in a declared output shape, so it
-        must classify as output-mentioning and be rebound from the
-        inferred result before evaluation; treated as an input-only
-        precondition it would fail in both contexts and be skipped.
+        ``L_out == L_in - kW + 1`` mentions no output tensor name but
+        ``L_out`` appears in a declared output shape, so it must classify
+        as output-mentioning and be rebound from the inferred result;
+        treated as an input-only precondition it would be skipped.
         """
         def infer(self, x_shape, w_shape):
             # Deliberately wrong output-only L_out value (999).
             return {"y": (x_shape[0], w_shape[0], 999)}
 
-        cls = _make_op_cls_with_infer(infer, name="ConvLikeWrongOutOnlyOp")
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
-                },
-                "outputs": {
-                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
-                },
-                "shape_rules": ["L_out == L_in - kW + 1"],
-            },
-        }
-        errors = validator.check_l2_infer_parity(
-            "ConvLikeWrongOutOnlyOp", entry, cls,
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
+            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
+            shape_rules=["L_out == L_in - kW + 1"],
+        )
+        errors, _ = _infer_parity(
+            validator, infer, sig, name="ConvLikeWrongOutOnlyOp",
         )
         assert any(
             "L_out == L_in - kW + 1" in e and "violates shape_rules" in e
             for e in errors
-        ), (
-            "Wrong L_out value must produce a shape_rules parity error; "
-            f"errors={errors}"
-        )
+        ), errors
 
     def test_conv_like_rank_and_consistency_still_caught(self, validator):
         """Loosening the output-only value check must not weaken the rank
@@ -1612,23 +1440,16 @@ class TestInferShapeParity:
             # Wrong rank: drops the spatial dim entirely.
             return {"y": (x_shape[0], w_shape[0])}
 
-        cls = _make_op_cls_with_infer(bad_rank_infer, name="ConvLikeBadOp")
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
-                    "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"},
-                },
-                "outputs": {
-                    "y": {"dtype": "float16", "shape": "[N, C_out, L_out]"},
-                },
-                "shape_rules": ["L_out == L_in - kW + 1"],
-            },
-        }
-        errors = validator.check_l2_infer_parity("ConvLikeBadOp", entry, cls)
-        assert any(
-            "rank" in e and "disagrees" in e for e in errors
-        ), f"Expected rank error; got: {errors}"
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[N, C_in, L_in]"},
+             "w": {"dtype": "float16", "shape": "[C_out, C_in, kW]"}},
+            {"y": {"dtype": "float16", "shape": "[N, C_out, L_out]"}},
+            shape_rules=["L_out == L_in - kW + 1"],
+        )
+        errors, _ = _infer_parity(
+            validator, bad_rank_infer, sig, name="ConvLikeBadOp",
+        )
+        assert any("rank" in e and "disagrees" in e for e in errors), errors
 
         # Two outputs claiming ``L_out`` with different concrete sizes is
         # an internal inconsistency even though L_out is output-only.
@@ -1638,25 +1459,18 @@ class TestInferShapeParity:
                 "y2": (x_shape[0], x_shape[1] - 2),
             }
 
-        cls = _make_op_cls_with_infer(
-            inconsistent_infer, name="InconsistentOutOnlyOp",
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[N, L_in]"}},
+            {"y1": {"dtype": "float16", "shape": "[N, L_out]"},
+             "y2": {"dtype": "float16", "shape": "[N, L_out]"}},
+            shape_rules=["L_out == L_in - 1"],
         )
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16", "shape": "[N, L_in]"}},
-                "outputs": {
-                    "y1": {"dtype": "float16", "shape": "[N, L_out]"},
-                    "y2": {"dtype": "float16", "shape": "[N, L_out]"},
-                },
-                "shape_rules": ["L_out == L_in - 1"],
-            },
-        }
-        errors = validator.check_l2_infer_parity(
-            "InconsistentOutOnlyOp", entry, cls,
+        errors, _ = _infer_parity(
+            validator, inconsistent_infer, sig, name="InconsistentOutOnlyOp",
         )
         assert any(
             "output-only symbol" in e and "L_out" in e for e in errors
-        ), f"Expected output-only consistency error; got: {errors}"
+        ), errors
 
 
 class TestDtypeOptionsHelper:
@@ -1672,9 +1486,7 @@ class TestDtypeOptionsHelper:
         out = validator._dtype_options_for_tensor(
             "y", "same_as(x)", resolved={},
         )
-        assert out is None, (
-            f"Pure same_as(unresolved) must return None, got {out!r}"
-        )
+        assert out is None, out
 
 
 # shape_rules broadcasting helpers (broadcast_shapes / is_broadcastable_to)
@@ -1687,9 +1499,8 @@ class TestShapeRuleBroadcastBuiltins:
         """``broadcast_shapes`` produces the expected output across cases.
 
         Covers identical / scalar / size-1-expand / rank-promotion /
-        variadic (0, 1, 3+ args) / list-input forms in one matrix. Hand-
-        coded expectations (no torch dependency) so the test stays
-        consistent with the validator's pure-Python implementation.
+        variadic (0, 1, 3+ args) / list-input forms. Hand-coded
+        expectations (no torch dependency).
         """
         fn = validator._SHAPE_RULE_BUILTINS["broadcast_shapes"]
         cases: list[tuple[tuple, tuple]] = [
@@ -1713,12 +1524,8 @@ class TestShapeRuleBroadcastBuiltins:
             fn((2, 3), (3, 3))
 
     def test_is_broadcastable_to_value_matrix(self, validator):
-        """``is_broadcastable_to(src, dst)`` returns True/False per cases.
-
-        Pins the asymmetric semantics (src may grow into dst; dst is
-        fixed) including the equal-shape, size-1-expand, dst-smaller,
-        dst-shrink, dim-mismatch, and extra-leading-dim branches.
-        """
+        """``is_broadcastable_to(src, dst)`` pins the asymmetric semantics
+        (src may grow into dst; dst is fixed)."""
         fn = validator._SHAPE_RULE_BUILTINS["is_broadcastable_to"]
         cases: list[tuple[tuple, tuple, bool]] = [
             ((2, 3), (2, 3), True),     # equal
@@ -1735,16 +1542,8 @@ class TestShapeRuleBroadcastBuiltins:
             assert fn(src, dst) is expected, (src, dst, fn(src, dst), expected)
 
     def test_broadcast_helpers_callable_from_shape_rule_eval(self, validator):
-        """Both helpers resolve from inside ``_eval_shape_rule`` rule bodies.
-
-        Pins the validator-integration contract: the helpers in
-        ``_SHAPE_RULE_BUILTINS`` are reachable as bare names from rule
-        text, returning the same value as direct calls. Drives one true
-        and one false case for ``is_broadcastable_to`` (its bool return
-        flows through the ok/reason pair) plus one ``broadcast_shapes``
-        equality rule (its tuple return must support ``==`` comparison
-        in the rule body).
-        """
+        """Both helpers resolve as bare names from inside ``_eval_shape_rule``
+        rule bodies, returning the same value as direct calls."""
         cases: list[tuple[str, bool]] = [
             ("broadcast_shapes((1, 3), (2, 1)) == (2, 3)", True),
             ("is_broadcastable_to((1, 3), (2, 3))", True),
@@ -1759,48 +1558,20 @@ class TestShapeRuleBroadcastBuiltins:
 # L3 extension: _validate_dtypes parity with dtype_combos / unions
 
 
-def _make_op_cls_with_validate(validate_fn, *, name="FakeDtypeOp"):
-    from tileops.ops.op_base import Op
-
-    attrs = {
-        "_validate_dtypes": validate_fn,
-        "forward": lambda self, *a, **kw: None,
-        "default_kernel_map": property(lambda self: {}),
-    }
-    return type(name, (Op,), attrs)
-
-
 class TestValidateDtypesParity:
     """L3 extension: ``_validate_dtypes`` matches manifest dtype_combos/unions."""
 
-
     def test_no_override_emits_missing_method_warning(self, validator):
         """Missing ``_validate_dtypes`` override must not pass silently on L3."""
-        from tileops.ops.op_base import Op
-
-        class BareOp(Op):
-            def forward(self):
-                return None
-
-            @property
-            def default_kernel_map(self):
-                return {}
-
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
+        entry = {"signature": _sig({"x": "float16"}, {"y": "same_as(x)"})}
         warnings: list[str] = []
         errors = validator.check_l3_validate_dtypes_parity(
-            "BareOp", entry, BareOp, warnings=warnings,
+            "BareOp", entry, _make_bare_op(), warnings=warnings,
         )
         assert errors == []
         assert any(
             "does not override _validate_dtypes" in w for w in warnings
         ), warnings
-
 
     def test_union_accept_all_passes(self, validator):
         import torch
@@ -1809,14 +1580,11 @@ class TestValidateDtypesParity:
             if x.dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError(f"bad dtype {x.dtype}")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        assert validator.check_l3_validate_dtypes_parity("FakeDtypeOp", entry, cls) == []
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
+        )
+        assert errors == []
 
     def test_union_reject_declared_fails(self, validator):
         """Rejects a dtype in the declared union -> parity error."""
@@ -1826,14 +1594,10 @@ class TestValidateDtypesParity:
             if x.dtype != torch.float16:
                 raise ValueError("only fp16")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        errors = validator.check_l3_validate_dtypes_parity("FakeDtypeOp", entry, cls)
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
+        )
         assert any("rejects valid combo" in e for e in errors), errors
 
     def test_dtype_combos_accept_listed_pass(self, validator):
@@ -1844,23 +1608,14 @@ class TestValidateDtypesParity:
             if (x.dtype, w.dtype) not in allowed:
                 raise ValueError("unlisted")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                    {"x": "bfloat16", "w": "bfloat16"},
-                ],
-            },
-        }
-        assert validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls,
-        ) == []
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16", "w": "float16"},
+                               {"x": "bfloat16", "w": "bfloat16"}]),
+        )
+        assert errors == []
 
     def test_dtype_combos_rejects_listed_fails(self, validator):
         import torch
@@ -1870,22 +1625,12 @@ class TestValidateDtypesParity:
             if x.dtype != torch.float16:
                 raise ValueError("unlisted")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                    {"x": "bfloat16", "w": "bfloat16"},
-                ],
-            },
-        }
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16", "w": "float16"},
+                               {"x": "bfloat16", "w": "bfloat16"}]),
         )
         assert any("rejects dtype_combos" in e for e in errors), errors
 
@@ -1894,21 +1639,11 @@ class TestValidateDtypesParity:
         def validate(self, x, w):
             return None  # accepts everything
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "float16 | bfloat16"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                ],
-            },
-        }
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "float16 | bfloat16"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16", "w": "float16"}]),
         )
         assert any("accepts non-listed combo" in e for e in errors), errors
 
@@ -1916,92 +1651,49 @@ class TestValidateDtypesParity:
         """Non-listed combos must all be checked, not just the first.
 
         Stopping at the first rejection would let a later accepted
-        non-listed combo escape detection; every non-listed combination
-        is probed and each acceptance reported.
+        non-listed combo escape detection.
         """
         import torch
 
         def validate(self, x, w):
             # Reject the first non-listed combo (fp16, bf16) but accept a
-            # later non-listed combo (bf16, fp16). Listed (fp16, fp16) is
-            # also accepted.
+            # later non-listed combo (bf16, fp16).
             if x.dtype == torch.float16 and w.dtype == torch.bfloat16:
                 raise ValueError("rejected early non-listed combo")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "float16 | bfloat16"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                ],
-            },
-        }
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "float16 | bfloat16"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16", "w": "float16"}]),
         )
-        # Must flag the later accepted non-listed combo (bf16, fp16) and
-        # may also flag (bf16, bf16). At minimum one 'accepts non-listed'
-        # error must be present.
-        assert any("accepts non-listed combo" in e for e in errors), (
-            f"Expected later non-listed acceptance to be flagged, got: {errors}"
-        )
-        # Stronger check: the (bfloat16, float16) combo specifically is
-        # surfaced — proves the loop did not stop at the first rejection.
+        assert any("accepts non-listed combo" in e for e in errors), errors
+        # The (bfloat16, float16) combo specifically is surfaced — proves
+        # the loop did not stop at the first rejection.
         assert any(
             "'x': 'bfloat16'" in e and "'w': 'float16'" in e
             for e in errors
-        ), (
-            f"Expected (bfloat16, float16) combo in errors, got: {errors}"
-        )
+        ), errors
 
     def test_signature_mismatch_union_fails(self, validator):
         """_validate_dtypes with a wrong kwarg name must fail on both the
-        union and the dtype_combos branch.
-
-        A signature-mismatch TypeError is a hard parity error; downgraded
-        to a warning it would let an uncallable ``_validate_dtypes``
-        satisfy parity.
-        """
+        union and the dtype_combos branch; downgraded to a warning it
+        would let an uncallable ``_validate_dtypes`` satisfy parity."""
         def validate(self, wrong_name, other_wrong=None):
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        union_entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        combos_entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                    {"x": "bfloat16", "w": "bfloat16"},
-                ],
-            },
-        }
-        for branch, entry in (("union", union_entry), ("combos", combos_entry)):
-            warnings: list[str] = []
-            errors = validator.check_l3_validate_dtypes_parity(
-                "FakeDtypeOp", entry, cls, warnings=warnings,
-            )
+        union_sig = _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"})
+        combos_sig = _sig(
+            {"x": "float16 | bfloat16", "w": "same_as(x)"},
+            {"y": "same_as(x)"},
+            dtype_combos=[{"x": "float16", "w": "float16"},
+                          {"x": "bfloat16", "w": "bfloat16"}],
+        )
+        for branch, sig in (("union", union_sig), ("combos", combos_sig)):
+            errors, warnings = _dtype_parity(validator, validate, sig)
             assert any(
                 "signature does not match manifest inputs" in e for e in errors
-            ), (
-                f"Signature mismatch in _validate_dtypes must surface as a "
-                f"parity error on the {branch} branch, got errors={errors} "
-                f"warnings={warnings}"
-            )
+            ), (branch, errors, warnings)
 
     def test_body_unexpected_exception_is_hard_error(self, validator):
         """_validate_dtypes raising RuntimeError for every valid combo must
@@ -2010,144 +1702,85 @@ class TestValidateDtypesParity:
         def bad_validate(self, x):
             raise RuntimeError("simulated bug")
 
-        cls = _make_op_cls_with_validate(bad_validate, name="BadValidateOp")
-        combos_entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16"},
-                    {"x": "bfloat16"},
-                ],
-            },
-        }
-        no_combos_entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        for branch, entry in (
-            ("combos", combos_entry), ("no-combos", no_combos_entry),
+        combos_sig = _sig(
+            {"x": "float16 | bfloat16"}, {"y": "same_as(x)"},
+            dtype_combos=[{"x": "float16"}, {"x": "bfloat16"}],
+        )
+        no_combos_sig = _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"})
+        for branch, sig in (
+            ("combos", combos_sig), ("no-combos", no_combos_sig),
         ):
-            warnings: list[str] = []
-            errors = validator.check_l3_validate_dtypes_parity(
-                "BadValidateOp", entry, cls, warnings=warnings,
+            errors, warnings = _dtype_parity(
+                validator, bad_validate, sig, name="BadValidateOp",
             )
             assert any(
                 "raised unexpected exception" in e and "RuntimeError" in e
                 for e in errors
-            ), (
-                f"expected hard L3 error on the {branch} branch, got "
-                f"errors={errors} warnings={warnings}"
-            )
+            ), (branch, errors, warnings)
 
     def test_wide_union_probe_pool_derived_from_torch_dtypes(self, validator):
         """The out-of-union probe pool is ``sorted(_TORCH_DTYPES - declared)``.
 
-        The pool must stay non-empty for every union that does not cover
-        the entire torch dtype universe: an op declaring a wide 8-dtype
-        union still leaves ``uint8`` as a probe candidate, so an
-        over-permissive ``_validate_dtypes`` that accepts it surfaces a
-        hard L3 error.
+        A wide 8-dtype union still leaves ``uint8`` as a probe candidate,
+        so an over-permissive ``_validate_dtypes`` surfaces a hard error.
         """
         def accept_all(self, x):
             return True  # over-permissive: accepts any dtype
 
-        cls = _make_op_cls_with_validate(accept_all, name="WideEightDtypeOp")
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": (
-                    "float16 | bfloat16 | float32 | float64 | "
-                    "int8 | int16 | int32 | int64"
-                )}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "WideEightDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, accept_all,
+            _sig({"x": ("float16 | bfloat16 | float32 | float64 | "
+                        "int8 | int16 | int32 | int64")},
+                 {"y": "same_as(x)"}),
+            name="WideEightDtypeOp",
         )
         assert any(
             "accepts out-of-union dtype" in e for e in errors
-        ), (
-            f"expected out-of-union rejection error despite 8-dtype "
-            f"union; errors={errors} warnings={warnings}"
-        )
+        ), (errors, warnings)
 
     def test_full_torch_coverage_emits_skip_warning(self, validator):
         """Declared union == full torch dtype set → warning, no vacuous pass.
 
         The probe cannot produce a candidate so it skips with a warning
-        naming the op/input. No hard error is emitted because the
-        ``_validate_dtypes`` impl is free to accept anything in this
-        (wildly permissive) spec.
+        naming the op/input; no hard error because the impl is free to
+        accept anything under this (wildly permissive) spec.
         """
         full_union = " | ".join(sorted(validator._TORCH_DTYPES))
 
         def accept_all(self, x):
             return True
 
-        cls = _make_op_cls_with_validate(
-            accept_all, name="FullCoverageOp",
+        errors, warnings = _dtype_parity(
+            validator, accept_all,
+            _sig({"x": full_union}, {"y": "same_as(x)"}),
+            name="FullCoverageOp",
         )
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": full_union}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FullCoverageOp", entry, cls, warnings=warnings,
-        )
-        assert not any("accepts out-of-union dtype" in e for e in errors), (
-            f"full-coverage spec must not produce a probe error; "
-            f"errors={errors}"
-        )
+        assert not any("accepts out-of-union dtype" in e for e in errors), errors
         assert any(
             "out-of-union probe skipped" in w and "'x'" in w
             for w in warnings
-        ), (
-            f"expected skip warning naming input 'x'; warnings={warnings}"
-        )
-
+        ), warnings
 
     def test_cartesian_product_over_bound_skipped_with_warning(
         self, validator, monkeypatch,
     ):
-        """Enumerating every combo must stay within a configurable bound.
-
-        Guards against future ops that declare many inputs × wide dtype
-        unions from exploding CI wall-time. When the product exceeds
-        ``_MAX_DTYPE_COMBOS`` the op is skipped deterministically with
-        a warning naming input count × option sizes.
-        """
+        """Enumeration must stay within ``_MAX_DTYPE_COMBOS``: over-bound
+        ops skip deterministically with a warning naming input count ×
+        option sizes (guards CI wall-time on many-input wide-union ops)."""
         monkeypatch.setattr(validator, "_MAX_DTYPE_COMBOS", 4)
 
         def _accept_all(self, **kwargs):
             return None
 
-        cls = _make_op_cls_with_validate(_accept_all, name="WideDtypeOp")
-        entry = {
-            "signature": {
-                "inputs": {
-                    "a": {"dtype": "float16 | bfloat16 | float32"},
-                    "b": {"dtype": "float16 | bfloat16 | float32"},
-                },
-                "outputs": {"y": {"dtype": "same_as(a)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "WideDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, _accept_all,
+            _sig({"a": "float16 | bfloat16 | float32",
+                  "b": "float16 | bfloat16 | float32"},
+                 {"y": "same_as(a)"}),
+            name="WideDtypeOp",
         )
-        assert errors == [], (
-            f"Over-bound enumeration should skip, not error: {errors}"
-        )
-        assert any(
-            "exceeds _MAX_DTYPE_COMBOS" in w for w in warnings
-        ), f"Expected over-bound skip warning, got: {warnings}"
+        assert errors == [], errors
+        assert any("exceeds _MAX_DTYPE_COMBOS" in w for w in warnings), warnings
 
     def test_body_typeerror_is_rejection_not_signature_mismatch(self, validator):
         """Body TypeError is a legitimate rejection, not a signature mismatch.
@@ -2156,38 +1789,19 @@ class TestValidateDtypesParity:
         ``except (ValueError, TypeError)`` around the call could not tell
         a kwarg-name mismatch from a TypeError raised inside the body.
         """
-        # Signature matches (``x`` kwarg), but the body raises TypeError
-        # on every call. This should be treated as a rejection of every
-        # combo drawn from the union, not a signature mismatch — which in
-        # turn means each Cartesian combo is reported as rejected.
         def validate(self, x):
             raise TypeError("dtype comparison not supported")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
         )
         assert not any(
             "signature does not match manifest inputs" in e for e in errors
-        ), (
-            "Body-level TypeError must not be misreported as signature "
-            f"mismatch; errors={errors}"
-        )
+        ), errors
         # The body rejects every combo drawn from the union, so the
         # no-dtype_combos branch reports each as a parity violation.
-        assert any(
-            "rejects valid combo" in e for e in errors
-        ), (
-            "Body TypeError should surface as a rejection of declared "
-            f"union combos; errors={errors}"
-        )
+        assert any("rejects valid combo" in e for e in errors), errors
 
     def test_dtype_combos_exhausts_union_emits_warning(self, validator):
         """Exhaustive dtype_combos still emit the 'exhausts the union' warning.
@@ -2207,33 +1821,19 @@ class TestValidateDtypesParity:
                 raise ValueError("dtype out of union")
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                    {"x": "float16", "w": "bfloat16"},
-                    {"x": "bfloat16", "w": "float16"},
-                    {"x": "bfloat16", "w": "bfloat16"},
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[
+                     {"x": "float16", "w": "float16"},
+                     {"x": "float16", "w": "bfloat16"},
+                     {"x": "bfloat16", "w": "float16"},
+                     {"x": "bfloat16", "w": "bfloat16"},
+                 ]),
         )
-        assert errors == [], f"Expected no errors, got: {errors}"
-        assert any(
-            "exhausts the union" in w for w in warnings
-        ), (
-            "Validator must warn when dtype_combos covers every "
-            f"Cartesian combo; warnings={warnings}"
-        )
+        assert errors == [], errors
+        assert any("exhausts the union" in w for w in warnings), warnings
 
     def test_no_combos_accepts_out_of_union_fails(self, validator):
         """Accepting an out-of-union dtype is a parity error on the no-combos branch.
@@ -2242,27 +1842,14 @@ class TestValidateDtypesParity:
         overly-permissive ``_validate_dtypes``; the branch needs its own
         out-of-union probe.
         """
-        # Overly-permissive implementation: accepts any dtype.
         def validate(self, x):
-            return None
+            return None  # overly permissive: accepts any dtype
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
         )
-        assert any(
-            "out-of-union" in e for e in errors
-        ), (
-            "Out-of-union dtype must surface as parity error when "
-            f"_validate_dtypes accepts it; errors={errors}"
-        )
+        assert any("out-of-union" in e for e in errors), errors
 
     def test_no_combos_rejects_out_of_union_pass(self, validator):
         """Op that rejects out-of-union dtypes produces no parity error."""
@@ -2272,55 +1859,32 @@ class TestValidateDtypesParity:
             if x.dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError(f"unsupported dtype {x.dtype}")
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
         )
-        assert errors == [], (
-            "Conforming op must not emit a parity error; "
-            f"errors={errors}"
-        )
+        assert errors == [], errors
 
     def test_no_combos_out_of_union_probe_respects_max(
         self, validator, monkeypatch,
     ):
         """Out-of-union probe must stay within ``_MAX_DTYPE_COMBOS``.
 
-        With the cap tightened to 2, at most 2 out-of-union probes fire
-        even though the sentinel pool contains 6 out-of-union dtypes
-        for a {float16, bfloat16} union.
+        With the cap tightened to 2, at most 2 probes fire even though
+        the pool has 6 out-of-union dtypes for a {float16, bfloat16}
+        union. (Product size 2 keeps the Cartesian enumeration alive.)
         """
-        # Product size for a single-input {float16, bfloat16} union is 2,
-        # so _MAX_DTYPE_COMBOS=2 keeps the Cartesian enumeration alive.
         monkeypatch.setattr(validator, "_MAX_DTYPE_COMBOS", 2)
 
         def validate(self, x):
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
         )
         out_of_union_errs = [e for e in errors if "out-of-union" in e]
-        # Sentinel pool has 6 out-of-union entries but probe budget is 2.
-        assert len(out_of_union_errs) == 2, (
-            "Out-of-union probe must be bounded by _MAX_DTYPE_COMBOS; "
-            f"got {len(out_of_union_errs)} errors: {out_of_union_errs}"
-        )
+        assert len(out_of_union_errs) == 2, out_of_union_errs
 
     def test_no_combos_accepts_same_as_violation_fails(self, validator):
         """Accepting a same_as identity violation is a parity error.
@@ -2329,30 +1893,15 @@ class TestValidateDtypesParity:
         via ``_honours_same_as``, so a permissive op that fails to enforce
         same_as would go unflagged without a dedicated probe.
         """
-        # Overly-permissive: does not check x.dtype == w.dtype.
         def validate(self, x, w):
-            return None
+            return None  # does not check x.dtype == w.dtype
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"}),
         )
-        assert any(
-            "same_as violation" in e for e in errors
-        ), (
-            "same_as identity violation must surface as parity error "
-            f"when _validate_dtypes accepts it; errors={errors}"
-        )
+        assert any("same_as violation" in e for e in errors), errors
 
     def test_no_combos_rejects_same_as_violation_pass(self, validator):
         """Op that enforces same_as passes the same_as probe."""
@@ -2372,24 +1921,12 @@ class TestValidateDtypesParity:
                     f"w.dtype={w.dtype}"
                 )
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"}),
         )
-        assert errors == [], (
-            "Conforming op must not emit a parity error; "
-            f"errors={errors}"
-        )
+        assert errors == [], errors
 
     def test_combos_branch_out_of_union_probe(self, validator):
         """Dtype_combos branch must fire the out-of-union probe.
@@ -2397,31 +1934,15 @@ class TestValidateDtypesParity:
         Without it, a permissive ``_validate_dtypes`` that accepts every
         dtype passes parity as long as every listed combo is accepted.
         """
-        # Overly-permissive implementation: accepts any dtype combo.
         def validate(self, x):
-            return None
+            return None  # overly permissive
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16"},
-                    {"x": "bfloat16"},
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16"}, {"x": "bfloat16"}]),
         )
-        assert any(
-            "out-of-union" in e for e in errors
-        ), (
-            "Out-of-union probe must fire in the dtype_combos branch; "
-            f"errors={errors}"
-        )
+        assert any("out-of-union" in e for e in errors), errors
 
     def test_invalid_dtype_combo_value_is_hard_error(self, validator):
         """A non-existent dtype in dtype_combos is a hard L3 error, not a skip warning.
@@ -2434,37 +1955,21 @@ class TestValidateDtypesParity:
         def validate(self, x, w):
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "not_a_real_dtype", "w": "not_a_real_dtype"},
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[
+                     {"x": "not_a_real_dtype", "w": "not_a_real_dtype"},
+                 ]),
         )
         assert any(
             "not a valid dtype" in e and "not_a_real_dtype" in e
             for e in errors
-        ), (
-            "Invalid dtype in dtype_combos must produce a hard error "
-            f"mentioning the invalid dtype name; errors={errors}"
-        )
+        ), errors
         assert not any(
             "cannot build mock tensor" in w for w in warnings
-        ), (
-            "Invalid dtype name must not be downgraded to "
-            f"'cannot build mock tensor' warning; warnings={warnings}"
-        )
-
+        ), warnings
 
     def test_valid_dtype_combo_reaches_build_mock_tensor(
         self, validator, monkeypatch,
@@ -2478,18 +1983,6 @@ class TestValidateDtypesParity:
         def validate(self, x):
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | float8_e4m3fn"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float8_e4m3fn"},
-                ],
-            },
-        }
         original = validator._make_mock_tensor
 
         def fake(name):
@@ -2498,59 +1991,34 @@ class TestValidateDtypesParity:
             return original(name)
 
         monkeypatch.setattr(validator, "_make_mock_tensor", fake)
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | float8_e4m3fn"}, {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float8_e4m3fn"}]),
         )
         # Valid dtype that the local build can't materialize: no hard
         # error, but the parity-skip warning path still fires.
-        assert not any(
-            "not a valid dtype" in e for e in errors
-        ), (
-            "Valid dtype name must not be flagged as invalid by the "
-            f"upfront validation pass; errors={errors}"
-        )
+        assert not any("not a valid dtype" in e for e in errors), errors
         assert any(
             "cannot build mock tensor" in w for w in warnings
-        ), (
-            "Valid-name-but-unmaterializable dtype must still reach the "
-            f"'cannot build mock tensor' warning path; warnings={warnings}"
-        )
+        ), warnings
 
     def test_combo_missing_input_is_manifest_error(self, validator):
         """A combo omitting an input is a manifest error, never a rejection or silent skip."""
         def validate(self, x, w):
             return None
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "same_as(x)"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16"},  # missing 'w'
-                ],
-            },
-        }
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls,
+        errors, _ = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16", "w": "same_as(x)"},
+                 {"y": "same_as(x)"},
+                 dtype_combos=[{"x": "float16"}]),  # missing 'w'
         )
         assert any(
             "is missing declared input" in e or "combo missing input" in e
             for e in errors
-        ), (
-            "Combo missing an input entry must be reported as a "
-            f"manifest error; errors={errors}"
-        )
-        assert not any(
-            "rejects dtype_combos[0]" in e for e in errors
-        ), (
-            "missing-input skip must not be reported as rejection; "
-            f"errors={errors}"
-        )
+        ), errors
+        assert not any("rejects dtype_combos[0]" in e for e in errors), errors
 
     def test_validate_dtypes_reads_self_dtype_attr(self, validator):
         """Comparing ``x.dtype != self.dtype`` must work with a populated mock self.
@@ -2568,21 +2036,11 @@ class TestValidateDtypesParity:
                     f"x.dtype {x.dtype} does not match self.dtype {self.dtype}"
                 )
 
-        cls = _make_op_cls_with_validate(validate)
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l3_validate_dtypes_parity(
-            "FakeDtypeOp", entry, cls, warnings=warnings,
+        errors, warnings = _dtype_parity(
+            validator, validate,
+            _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"}),
         )
-        assert errors == [], (
-            "With self.dtype populated from the combo, listed combos "
-            f"must be accepted; errors={errors} warnings={warnings}"
-        )
+        assert errors == [], (errors, warnings)
 
 
 class TestDtypeCombosData:
@@ -2602,29 +2060,22 @@ class TestDtypeCombosData:
         """
         cases = [
             # (description, sig, substrings expected in one error)
-            ("combo row missing a declared input", {
-                "inputs": {
-                    "x": {"dtype": "float16 | bfloat16"},
-                    "w": {"dtype": "float16 | bfloat16"},
-                },
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "w": "float16"},
-                    {"x": "bfloat16"},  # missing 'w'
-                ],
-            }, ["dtype_combos[1]", "missing declared input 'w'"]),
-            ("union expression as combo value", {
-                "inputs": {"x": {"dtype": "float16 | bfloat16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "dtype_combos": [{"x": "float16 | bfloat16"}],
-            }, ["combo values must be a single concrete dtype"]),
-            ("promote_int_to_float as combo value", {
-                "inputs": {"x": {"dtype": "float16 | int8"}},
-                "outputs": {"y": {"dtype": "promote_int_to_float(x)"}},
-                "dtype_combos": [
-                    {"x": "float16", "y": "promote_int_to_float(x)"},
-                ],
-            }, ["promote_int_to_float(...) is allowed only on signature.outputs"]),
+            ("combo row missing a declared input",
+             _sig({"x": "float16 | bfloat16", "w": "float16 | bfloat16"},
+                  {"y": "same_as(x)"},
+                  dtype_combos=[{"x": "float16", "w": "float16"},
+                                {"x": "bfloat16"}]),  # missing 'w'
+             ["dtype_combos[1]", "missing declared input 'w'"]),
+            ("union expression as combo value",
+             _sig({"x": "float16 | bfloat16"}, {"y": "same_as(x)"},
+                  dtype_combos=[{"x": "float16 | bfloat16"}]),
+             ["combo values must be a single concrete dtype"]),
+            ("promote_int_to_float as combo value",
+             _sig({"x": "float16 | int8"}, {"y": "promote_int_to_float(x)"},
+                  dtype_combos=[
+                      {"x": "float16", "y": "promote_int_to_float(x)"},
+                  ]),
+             ["promote_int_to_float(...) is allowed only on signature.outputs"]),
         ]
         for desc, sig, substrings in cases:
             errors = validator.check_l3_dtype_combos_data("FakeOp", sig)
@@ -2636,34 +2087,28 @@ class TestDtypeCombosData:
         """Pure ``same_as`` cycles and dangling refs must surface hard L3
         errors instead of silently skipping combo validation.
 
-        A pure cycle like ``x: same_as(y)`` / ``y: same_as(x)`` satisfies
-        per-token validation and the R3 identity check, so it needs a
-        dedicated diagnosis to keep invalid combo data from passing.
+        A pure cycle satisfies per-token validation and the R3 identity
+        check, so it needs a dedicated diagnosis.
         """
-        cycle_sig = {
-            "inputs": {
-                "x": {"dtype": "same_as(y)"},
-                "y": {"dtype": "same_as(x)"},
-            },
-            "outputs": {"z": {"dtype": "same_as(x)"}},
-            "dtype_combos": [{"x": "float16", "y": "float16"}],
-        }
+        cycle_sig = _sig(
+            {"x": "same_as(y)", "y": "same_as(x)"}, {"z": "same_as(x)"},
+            dtype_combos=[{"x": "float16", "y": "float16"}],
+        )
         errors = validator.check_l3_dtype_combos_data("CycleOp", cycle_sig)
         assert any(
             "same_as cycle" in e and "'x'" in e and "'y'" in e
             for e in errors
-        ), f"expected cycle diagnosis naming x and y, got {errors}"
+        ), errors
 
-        dangling_sig = {
-            "inputs": {"x": {"dtype": "same_as(nope)"}},
-            "outputs": {"z": {"dtype": "same_as(x)"}},
-            "dtype_combos": [{"x": "float16"}],
-        }
+        dangling_sig = _sig(
+            {"x": "same_as(nope)"}, {"z": "same_as(x)"},
+            dtype_combos=[{"x": "float16"}],
+        )
         errors = validator.check_l3_dtype_combos_data("DanglingOp", dangling_sig)
         assert any(
             "dangling reference" in e and "same_as(nope)" in e
             for e in errors
-        ), f"expected dangling diagnosis, got {errors}"
+        ), errors
 
 
 class TestStaticDimShapeParity:
@@ -2674,31 +2119,24 @@ class TestStaticDimShapeParity:
 
         ``static_dims`` keys in declared output shapes are checked by
         exact value (resolved against mock inputs), not only by
-        rank/consistency; a bad impl returning ``(999, 999)`` for a
-        declared ``[N, N]`` with ``static_dims: {N: "x.shape[-1]"}``
-        must be caught.
+        rank/consistency.
         """
         def bad_infer(self, x_shape):
             # static_dims pins N = x.shape[-1] (=4 under mock); a correct
             # impl returns (4, 4).
             return {"y": (999, 999)}
 
-        cls = _make_op_cls_with_infer(bad_infer, name="StaticDimBadOp")
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16", "shape": "[M, N]"}},
-                "outputs": {
-                    "y": {"dtype": "same_as(x)", "shape": "[N, N]"},
-                },
-                "static_dims": {"N": "x.shape[-1]"},
-            },
-        }
-        errors = validator.check_l2_infer_parity(
-            "StaticDimBadOp", entry, cls,
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[M, N]"}},
+            {"y": {"dtype": "same_as(x)", "shape": "[N, N]"}},
+            static_dims={"N": "x.shape[-1]"},
+        )
+        errors, _ = _infer_parity(
+            validator, bad_infer, sig, name="StaticDimBadOp",
         )
         assert any(
             "dim[0]=999" in e or "dim[1]=999" in e for e in errors
-        ), f"expected static-dim parity error, got {errors}"
+        ), errors
 
 
 class TestParamDefaultOutputShapePin:
@@ -2708,111 +2146,94 @@ class TestParamDefaultOutputShapePin:
         """Bad infer returning ``(999,)`` for declared ``[k]`` with
         ``params.k.default = 4`` must produce a hard L2 error; a correct
         infer returning ``(4,)`` passes parity."""
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16", "shape": "[M]"}},
-                "outputs": {
-                    "y": {"dtype": "same_as(x)", "shape": "[k]"},
-                },
-                "params": {"k": {"type": "int", "default": 4}},
-            },
-        }
+        sig = _sig(
+            {"x": {"dtype": "float16", "shape": "[M]"}},
+            {"y": {"dtype": "same_as(x)", "shape": "[k]"}},
+            params={"k": {"type": "int", "default": 4}},
+        )
 
         def bad_infer(self, x_shape):
             return {"y": (999,)}
 
-        cls = _make_op_cls_with_infer(bad_infer, name="ParamDefaultBadOp")
-        errors = validator.check_l2_infer_parity(
-            "ParamDefaultBadOp", entry, cls,
+        errors, _ = _infer_parity(
+            validator, bad_infer, sig, name="ParamDefaultBadOp",
         )
         assert any(
             "dim[0]=999" in e and "k=4" in e for e in errors
-        ), f"expected param-default parity error, got {errors}"
+        ), errors
 
         def good_infer(self, x_shape):
             return {"y": (4,)}
 
-        cls = _make_op_cls_with_infer(good_infer, name="ParamDefaultGoodOp")
-        errors = validator.check_l2_infer_parity(
-            "ParamDefaultGoodOp", entry, cls,
+        errors, _ = _infer_parity(
+            validator, good_infer, sig, name="ParamDefaultGoodOp",
         )
-        assert errors == [], (
-            f"expected no parity errors on correct impl, got {errors}"
-        )
+        assert errors == [], errors
 
 
 # Bench checks
 class TestBench:
     """bench checks that bench files use manifest workloads and op roofline."""
 
-    def test_bench_with_load_workloads_passes(self, validator, tmp_path):
+    @staticmethod
+    def _bench_errors(validator, tmp_path, text):
         bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(
+        bench_file.write_text(text)
+        return validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+
+    def test_bench_with_load_workloads_passes(self, validator, tmp_path):
+        errors = self._bench_errors(validator, tmp_path, (
             "from tileops.manifest import load_workloads\n"
             "workloads = load_workloads('test_op')\n"
             "op.eval_roofline()\n"
-        )
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        ))
         assert errors == []
 
     def test_bench_with_load_workloads_only_fails(self, validator, tmp_path):
         """Bench using load_workloads but not op eval_roofline fails bench validation."""
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(
+        errors = self._bench_errors(validator, tmp_path, (
             "from tileops.manifest import load_workloads\n"
             "workloads = load_workloads('test_op')\n"
-        )
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
-        assert any("eval_roofline" in e for e in errors), (
-            f"Expected bench error about missing eval_roofline, got: {errors}"
-        )
+        ))
+        assert any("eval_roofline" in e for e in errors), errors
 
     def test_bench_without_load_workloads_fails(self, validator, tmp_path):
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(
+        errors = self._bench_errors(validator, tmp_path, (
             "import pytest\n"
             "shapes = [(1024, 4096)]\n"
-        )
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        ))
         assert any("load_workloads" in e for e in errors)
 
     def test_wrong_op_name_fails_l4(self, validator, tmp_path):
         """Manifest helpers called with a different op name must fail, on
         both the direct and the indirect (benchmarks.benchmark_base) path."""
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(textwrap.dedent("""\
+        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
             from tileops.manifest import load_workloads
             workloads = load_workloads('wrong_op')
             op.eval_roofline()
         """))
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert any("load_workloads" in e for e in errors)
 
-        bench_file.write_text(textwrap.dedent("""\
+        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
             from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
             params = workloads_to_params('wrong_op')
             ManifestBenchmark('wrong_op', op, params[0])
         """))
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert any("load_workloads" in e for e in errors)
         assert any("eval_roofline" in e for e in errors)
 
     def test_syntax_error_in_bench_file_fails_l4(self, validator, tmp_path):
         """A bench file with syntax errors produces an bench error."""
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text("def broken(\n")
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
+        errors = self._bench_errors(validator, tmp_path, "def broken(\n")
         assert any("syntax error" in e for e in errors)
 
     def test_bench_indirect_helpers_pass(self, validator, tmp_path):
         """Importing workloads_to_params/ManifestBenchmark from benchmarks.benchmark_base passes."""
-        bench_file = tmp_path / "bench_test.py"
-        bench_file.write_text(textwrap.dedent("""\
+        errors = self._bench_errors(validator, tmp_path, textwrap.dedent("""\
             from benchmarks.benchmark_base import workloads_to_params, ManifestBenchmark
             params = workloads_to_params('test_op')
             ManifestBenchmark('test_op', op, params[0])
         """))
-        errors = validator.check_l4_benchmark("test_op", str(bench_file), REPO_ROOT)
         assert errors == []
 
 
@@ -2831,23 +2252,18 @@ class TestCheckOp:
         entry = _make_entry(status="spec-only")
         entry["source"]["bench"] = str(bench_file)
         entry["source"]["bench_manifest_driven"] = True
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        import yaml
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
+        manifest_file = _write_manifest(tmp_path, {"my_op": entry})
 
         # Without check_op: spec-only op skips L1-L4.
-        errors_no_flag, warnings_no_flag = validator.validate_manifest(
+        errors_no_flag, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
         )
         bench_errors_no_flag = [e for e in errors_no_flag if "[bench]" in e]
-        assert bench_errors_no_flag == [], (
-            f"Spec-only op should skip bench check without --check-op: {bench_errors_no_flag}"
-        )
+        assert bench_errors_no_flag == [], bench_errors_no_flag
 
         # With check_op="my_op": all levels forced despite spec-only.
-        errors_flag, warnings_flag = validator.validate_manifest(
+        errors_flag, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
             check_op="my_op",
@@ -2859,38 +2275,25 @@ class TestCheckOp:
 
     def test_spec_only_op_without_check_op_still_skipped(self, validator, tmp_path):
         """Default behavior unchanged: spec-only ops skip L1-L4."""
-        entry = _make_entry(status="spec-only")
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        import yaml
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
-
-        errors, warnings = validator.validate_manifest(
+        manifest_file = _write_manifest(
+            tmp_path, {"my_op": _make_entry(status="spec-only")},
+        )
+        errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
         )
         non_schema = [e for e in errors if "[schema]" not in e]
-        assert non_schema == [], (
-            f"Spec-only op should only have schema errors (if any), got: {non_schema}"
-        )
-
+        assert non_schema == [], non_schema
 
     def test_check_op_nonexistent_op_reports_error(self, validator, tmp_path):
         """--check-op with a name not in manifest reports an error."""
-        entry = _make_entry()
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        import yaml
-        manifest_file.write_text(yaml.safe_dump({"my_op": entry}))
-
-        errors, warnings = validator.validate_manifest(
+        manifest_file = _write_manifest(tmp_path, {"my_op": _make_entry()})
+        errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
             check_op="nonexistent_op",
         )
-        assert any("nonexistent_op" in e and "not found" in e for e in errors), (
-            f"Expected error about 'nonexistent_op' not found in manifest, got: {errors}"
-        )
+        assert any("nonexistent_op" in e and "not found" in e for e in errors), errors
 
     def test_manifest_path_non_mapping_root_reports_error(self, validator, tmp_path):
         """A non-mapping manifest root yields a schema error, not an AttributeError."""
@@ -2904,41 +2307,31 @@ class TestCheckOp:
             manifest_path=manifest_file,
             repo_root=tmp_path,
         )
-        assert any("top-level mapping" in e for e in errors), (
-            f"Expected a top-level-mapping error, got: {errors}"
-        )
+        assert any("top-level mapping" in e for e in errors), errors
 
     def test_check_op_scopes_to_single_op(self, validator, tmp_path):
         """--check-op validates only the named op; unrelated ops are not processed."""
-        import yaml
-
-        # target_op: spec-only, has a real bench file -> L4 will run and find errors
+        # target_op: spec-only with a real bench file -> L4 runs and fails.
         bench_file = tmp_path / "bench_target.py"
         bench_file.write_text("import pytest\n")
         target_entry = _make_entry(status="spec-only")
         target_entry["source"]["bench"] = str(bench_file)
         target_entry["source"]["bench_manifest_driven"] = True
 
-        # other_op: implemented (not spec-only), points to a nonexistent kernel
-        # If validated, L1 would fail trying to import a missing module.
+        # other_op: implemented, points at a nonexistent kernel — if
+        # validated, L1 would fail importing the missing module.
         other_entry = _make_entry(source_kernel="nonexistent_impl.py")
+        manifest_file = _write_manifest(
+            tmp_path, {"target_op": target_entry, "other_op": other_entry},
+        )
 
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump(
-            {"target_op": target_entry, "other_op": other_entry},
-        ))
-
-        # other_op must be completely skipped — no import errors from its
-        # missing kernel.
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
             repo_root=tmp_path,
             check_op="target_op",
         )
         other_errors = [e for e in errors if "other_op" in e]
-        assert other_errors == [], (
-            f"--check-op should not validate unrelated ops, but got: {other_errors}"
-        )
+        assert other_errors == [], other_errors
         target_errors = [e for e in errors if "target_op" in e]
         assert len(target_errors) > 0, (
             "target_op should have validation errors from forced L4 check"
@@ -2951,16 +2344,11 @@ class TestCheckOp:
         run across the full manifest it fails --check-op on unrelated ops
         with invalid variant_of references.
         """
-        import yaml
-
-        target_entry = _make_entry()
         other_entry = _make_entry()
         other_entry["variant_of"] = "nonexistent_primary"
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump(
-            {"target_op": target_entry, "other_op": other_entry},
-        ))
+        manifest_file = _write_manifest(
+            tmp_path, {"target_op": _make_entry(), "other_op": other_entry},
+        )
 
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -2968,10 +2356,7 @@ class TestCheckOp:
             check_op="target_op",
         )
         variant_errors = [e for e in errors if "variant_of" in e]
-        assert variant_errors == [], (
-            f"--check-op should not report variant_of errors from unrelated ops: "
-            f"{variant_errors}"
-        )
+        assert variant_errors == [], variant_errors
 
         errors_all, _ = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -2989,23 +2374,17 @@ class TestCheckOp:
         Excluding variants from the scope would let a variant edit that
         breaks R16 pass --check-op <primary>.
         """
-        import yaml
-
         primary = _make_entry(source_kernel="shared_kernel.py")
-        # Valid variant: shares source with primary.
         valid_variant = _make_entry(source_kernel="shared_kernel.py")
         valid_variant["variant_of"] = "primary_op"
-
         # Broken variant: different source.kernel violates R16.
         broken_variant = _make_entry(source_kernel="different_kernel.py")
         broken_variant["variant_of"] = "primary_op"
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({
+        manifest_file = _write_manifest(tmp_path, {
             "primary_op": primary,
             "good_variant": valid_variant,
             "bad_variant": broken_variant,
-        }))
+        })
 
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -3013,21 +2392,13 @@ class TestCheckOp:
             check_op="primary_op",
         )
         r16_errors = [e for e in errors if "bad_variant" in e and "R16" in e]
-        assert len(r16_errors) > 0, (
-            f"--check-op on primary must catch R16 violation in variant, "
-            f"got errors: {errors}"
-        )
+        assert len(r16_errors) > 0, errors
 
         good_r16 = [e for e in errors if "good_variant" in e and "R16" in e]
-        assert good_r16 == [], (
-            f"good_variant should pass R16, got: {good_r16}"
-        )
-
+        assert good_r16 == [], good_r16
 
     def test_check_op_variant_family_runs_schema_on_variants(self, validator, tmp_path):
         """--check-op on primary runs per-op schema checks on variants too."""
-        import yaml
-
         primary = _make_entry(source_kernel="shared.py")
         broken_variant = {
             "family": "test",
@@ -3043,12 +2414,10 @@ class TestCheckOp:
             },
             "variant_of": "primary_op",
         }
-
-        manifest_file = tmp_path / "ops_manifest.yaml"
-        manifest_file.write_text(yaml.safe_dump({
+        manifest_file = _write_manifest(tmp_path, {
             "primary_op": primary,
             "broken_var": broken_variant,
-        }))
+        })
 
         errors, _ = validator.validate_manifest(
             manifest_path=manifest_file,
@@ -3056,10 +2425,7 @@ class TestCheckOp:
             check_op="primary_op",
         )
         schema_errors = [e for e in errors if "broken_var" in e and "source" in e]
-        assert len(schema_errors) > 0, (
-            f"--check-op on primary must run schema checks on variants, "
-            f"got errors: {errors}"
-        )
+        assert len(schema_errors) > 0, errors
 
     def test_check_op_cli_parsing(self, validator):
         """_parse_check_op extracts the op name from argv."""
@@ -3095,7 +2461,6 @@ class TestResolveOpClass:
         assert result.cls is None
         assert result.warning is not None
 
-
     def test_nonexistent_module_returns_import_error(self, validator):
         """Module that cannot be imported returns import_error=True."""
         result = validator._resolve_op_class(
@@ -3112,40 +2477,11 @@ class TestResolveOpClass:
 
     def test_ambiguous_fallback_returns_none_with_warning(self, validator):
         """When multiple candidates exist but none matches the manifest key, return cls=None."""
-        import importlib
-        import types
-
-        # Create a fake module with two candidate classes, neither named
-        # after the given op_name.
-        fake_mod = types.ModuleType("tileops.ops.fake_ambiguous")
-        fake_mod.__name__ = "tileops.ops.fake_ambiguous"
-
-        class AlphaKernel:
-            @staticmethod
-            def forward():
-                pass
-
-        class BetaKernel:
-            @staticmethod
-            def forward():
-                pass
-
-        AlphaKernel.__module__ = fake_mod.__name__
-        BetaKernel.__module__ = fake_mod.__name__
-        fake_mod.AlphaKernel = AlphaKernel
-        fake_mod.BetaKernel = BetaKernel
-
-        original_import = importlib.import_module
-
-        def patched_import(name):
-            if name == "tileops.ops.fake_ambiguous":
-                return fake_mod
-            return original_import(name)
-
-        import unittest.mock as mock
-
+        fake_mod = _fake_op_module(
+            "tileops.ops.fake_ambiguous", ["AlphaKernel", "BetaKernel"],
+        )
         with (
-            mock.patch.object(importlib, "import_module", side_effect=patched_import),
+            _patched_import(fake_mod),
             pytest.warns(UserWarning, match="No class named"),
         ):
             result = validator._resolve_op_class(
@@ -3157,43 +2493,16 @@ class TestResolveOpClass:
 
     def test_ambiguous_warning_plumbed_through_check_l1(self, validator):
         """Ambiguity warning surfaces in check_l1's structured warnings list."""
-        import importlib
-        import types
-        import unittest.mock as mock
-
-        fake_mod = types.ModuleType("tileops.ops.fake_ambiguous")
-        fake_mod.__name__ = "tileops.ops.fake_ambiguous"
-
-        class AlphaKernel:
-            @staticmethod
-            def forward():
-                pass
-
-        class BetaKernel:
-            @staticmethod
-            def forward():
-                pass
-
-        AlphaKernel.__module__ = fake_mod.__name__
-        BetaKernel.__module__ = fake_mod.__name__
-        fake_mod.AlphaKernel = AlphaKernel
-        fake_mod.BetaKernel = BetaKernel
-
-        original_import = importlib.import_module
-
-        def patched_import(name):
-            if name == "tileops.ops.fake_ambiguous":
-                return fake_mod
-            return original_import(name)
-
+        fake_mod = _fake_op_module(
+            "tileops.ops.fake_ambiguous", ["AlphaKernel", "BetaKernel"],
+        )
         entry = {
             "source": {"op": "tileops/ops/fake_ambiguous.py"},
             "signature": {"inputs": {}, "params": {}},
         }
         warn_list: list[str] = []
-
         with (
-            mock.patch.object(importlib, "import_module", side_effect=patched_import),
+            _patched_import(fake_mod),
             pytest.warns(UserWarning, match="No class named"),
         ):
             errors = validator.check_l1("mystery_fwd", entry, warnings=warn_list)
@@ -3201,49 +2510,20 @@ class TestResolveOpClass:
         assert any("No class named" in w for w in warn_list)
         assert any("could not resolve" in e for e in errors)
 
-
     def test_direct_match_resolves_exact_class_name(self, validator):
         """Direct match resolves when cls.__name__ == manifest key.
 
-        For op_name='SumFwdOp' with both _SumHelper and SumFwdOp in the module,
-        the exact match finds SumFwdOp. No heuristic fallback.
+        For op_name='SumFwdOp' with both _SumHelper and SumFwdOp in the
+        module, the exact match finds SumFwdOp. No heuristic fallback.
         """
-        import importlib
-        import types
-        import unittest.mock as mock
-
-        fake_mod = types.ModuleType("tileops.ops.fake_priority")
-        fake_mod.__name__ = "tileops.ops.fake_priority"
-
-        class _SumHelper:
-            @staticmethod
-            def forward():
-                pass
-
-        class SumFwdOp:
-            @staticmethod
-            def forward():
-                pass
-
-        _SumHelper.__module__ = fake_mod.__name__
-        SumFwdOp.__module__ = fake_mod.__name__
-        fake_mod._SumHelper = _SumHelper
-        fake_mod.SumFwdOp = SumFwdOp
-
-        original_import = importlib.import_module
-
-        def patched_import(name):
-            if name == "tileops.ops.fake_priority":
-                return fake_mod
-            return original_import(name)
-
-        with mock.patch.object(importlib, "import_module", side_effect=patched_import):
+        fake_mod = _fake_op_module(
+            "tileops.ops.fake_priority", ["_SumHelper", "SumFwdOp"],
+        )
+        with _patched_import(fake_mod):
             result = validator._resolve_op_class(
                 "tileops/ops/fake_priority.py", "SumFwdOp",
             )
-        assert result.cls is SumFwdOp, (
-            f"Expected SumFwdOp (direct match) but got {result.cls.__name__}"
-        )
+        assert result.cls is fake_mod.SumFwdOp, result.cls
 
 
 # Integration: validate_manifest.py passes on the real codebase
@@ -3285,58 +2565,46 @@ class TestIntegration:
 class TestShapeRuleHelpers:
     """Unit tests for :mod:`tileops.manifest.shape_rules` predicates."""
 
-
     def test_helper_rule_validator_warns_on_malformed_dim(self, validator):
         """Validator integration: helper rules surface malformed dims as warnings.
 
-        A malformed dim default (``dim=["2"]``) raises TypeError from
-        the helper, which the validator classifies as an eval-error
-        warning ("could not be evaluated"). The contract: the parity
-        check is skipped with a warning, not turned into a hard shape
-        error — bit-identical to the equivalent inline form.
+        A malformed dim default (``dim=["2"]``) raises TypeError from the
+        helper, which the validator classifies as an eval-error warning
+        ("could not be evaluated"): parity is skipped with a warning, not
+        turned into a hard shape error — bit-identical to the equivalent
+        inline form.
         """
         def infer(self, x_shape, *, dim=None, keepdim=False):
             return {"y": x_shape}
 
-        cls = _make_op_cls_with_infer(infer, name="HelperMalformedDimOp")
-        sig_common = {
-            "inputs": {"x": {"dtype": "float16"}},
-            "outputs": {"y": {"dtype": "same_as(x)"}},
-            "params": {
-                "dim": {
-                    "type": "int | list[int] | tuple[int, ...] | None",
-                    "default": ["2"],
-                },
-                "keepdim": {"type": "bool", "default": False},
+        params = {
+            "dim": {
+                "type": "int | list[int] | tuple[int, ...] | None",
+                "default": ["2"],
             },
+            "keepdim": {"type": "bool", "default": False},
         }
-        entry_inline = {
-            "signature": {
-                **sig_common,
-                "shape_rules": [
-                    "dim is None or all(-x.ndim <= d < x.ndim for d in "
-                    "([dim] if isinstance(dim, int) else dim))",
-                    "isinstance(dim, (int, type(None))) or "
-                    "len({d % x.ndim for d in dim}) == len(dim)",
-                ],
-            },
-        }
-        entry_helper = {
-            "signature": {
-                **sig_common,
-                "shape_rules": [
-                    "dim_range_validity(x, dim)",
-                    "dim_uniqueness(x, dim)",
-                ],
-            },
-        }
-        warn_inline: list[str] = []
-        warn_helper: list[str] = []
-        errs_inline = validator.check_l2_infer_parity(
-            "HelperMalformedDimOp", entry_inline, cls, warnings=warn_inline,
+        sig_inline = _sig(
+            {"x": "float16"}, {"y": "same_as(x)"}, params=params,
+            shape_rules=[
+                "dim is None or all(-x.ndim <= d < x.ndim for d in "
+                "([dim] if isinstance(dim, int) else dim))",
+                "isinstance(dim, (int, type(None))) or "
+                "len({d % x.ndim for d in dim}) == len(dim)",
+            ],
         )
-        errs_helper = validator.check_l2_infer_parity(
-            "HelperMalformedDimOp", entry_helper, cls, warnings=warn_helper,
+        sig_helper = _sig(
+            {"x": "float16"}, {"y": "same_as(x)"}, params=params,
+            shape_rules=[
+                "dim_range_validity(x, dim)",
+                "dim_uniqueness(x, dim)",
+            ],
+        )
+        errs_inline, warn_inline = _infer_parity(
+            validator, infer, sig_inline, name="HelperMalformedDimOp",
+        )
+        errs_helper, warn_helper = _infer_parity(
+            validator, infer, sig_helper, name="HelperMalformedDimOp",
         )
         assert errs_inline == [] == errs_helper, (errs_inline, errs_helper)
         assert any("could not be evaluated" in w for w in warn_inline), (
@@ -3353,36 +2621,28 @@ class TestValidatorHelperResolution:
     def test_l2_parity_helper_detects_out_of_range_default(self, validator):
         """Out-of-range default ``dim`` surfaces as an input-only precondition.
 
-        Mirrors what the inline expression would do: the predicate
-        evaluates to False under mock inputs, but the validator
-        classifies that as an *input* problem (the manifest's mock
-        default ``dim`` is out of range for the mock ``x.ndim``), not
-        as a parity failure of ``_infer_output_shapes``. The contract
-        pinned here: ``errors == []`` (no parity blame on infer) plus
-        exactly one ``"input-only precondition"`` warning citing the
-        helper rule itself.
+        The helper predicate evaluates to False under mock inputs, but the
+        validator classifies that as an *input* problem (mock default
+        ``dim`` out of range for the mock ``x.ndim``), not a parity
+        failure of ``_infer_output_shapes``: ``errors == []`` plus exactly
+        one "input-only precondition" warning citing the helper rule.
         """
         def infer(self, x_shape):
             return {"y": x_shape}
 
-        cls = _make_op_cls_with_infer(infer, name="HelperBadDimOp")
-        # Mock inputs for a single-rank-2 tensor; default dim=9 is out of
-        # range. The helper rule must fail under mock evaluation.
-        entry = {
-            "signature": {
-                "inputs": {"x": {"dtype": "float16"}},
-                "outputs": {"y": {"dtype": "same_as(x)"}},
-                "params": {"dim": {"type": "int", "default": 9}},
-                "shape_rules": [
-                    "x.shape == (B, S)",
-                    "dim_range_validity(x, dim)",
-                    "y.shape == x.shape",
-                ],
-            },
-        }
-        warnings: list[str] = []
-        errors = validator.check_l2_infer_parity(
-            "HelperBadDimOp", entry, cls, warnings=warnings,
+        # Rank-2 mock input; default dim=9 is out of range, so the helper
+        # rule must fail under mock evaluation.
+        sig = _sig(
+            {"x": "float16"}, {"y": "same_as(x)"},
+            params={"dim": {"type": "int", "default": 9}},
+            shape_rules=[
+                "x.shape == (B, S)",
+                "dim_range_validity(x, dim)",
+                "y.shape == x.shape",
+            ],
+        )
+        errors, warnings = _infer_parity(
+            validator, infer, sig, name="HelperBadDimOp",
         )
         # No "could not be evaluated" warning: the helper resolved and ran;
         # the failure was a real predicate result, not an eval skip.
@@ -3417,10 +2677,9 @@ class TestValidatorHelperResolution:
     def test_shape_rules_helpers_callable_by_bare_name(self, validator):
         """Reduction-dim helpers from shape_rules.py are in the eval scope.
 
-        Pin the public surface of ``tileops.manifest.shape_rules`` as
-        seen by manifest YAML: each function listed in :data:`__all__`
-        must be callable from a shape_rule body by bare name. Adding a
-        new helper requires updating both ``__all__`` and the validator's
+        Each function in ``tileops.manifest.shape_rules.__all__`` must be
+        callable from a shape_rule body by bare name. Adding a new helper
+        requires updating both ``__all__`` and the validator's
         ``_SHAPE_RULE_BUILTIN_PAIRS`` — this test fails loudly when one
         side moves without the other.
         """
@@ -3700,11 +2959,9 @@ class TestStrictAdvisoryMode:
             def default_kernel_map(self):
                 return {}
 
-        # Schema-valid synthetic manifest entry. ``shape_rules`` is a
-        # list of expression strings under ``signature``; all required
-        # top-level fields (``ref_api``, ``roofline``, ``source.{op,
-        # kernel, bench, test, kernel_map}``) are present so the test
-        # would still parse if schema checks were enabled.
+        # Schema-valid synthetic manifest entry: all required top-level
+        # fields present so the test would still parse if schema checks
+        # were enabled.
         manifest_yaml = tmp_path / "stub.yaml"
         manifest_yaml.write_text(
             "StubOp:\n"
@@ -3747,30 +3004,23 @@ class TestStrictAdvisoryMode:
     ):
         """Advisory mode routes strict-parity failures to warnings, not errors."""
         # Skip schema/L1 to keep the synthetic manifest minimal; the
-        # checks we exercise here are the strict-parity ones (C5-C7),
-        # gated by signature/dtype/bench.
+        # checks exercised here are the strict-parity ones (C5-C7).
         levels = frozenset({"signature", "shape", "dtype", "bench"})
         errors, warnings = validator.validate_manifest(
             manifest_path=stub_setup, strict_parity=False, levels=levels,
         )
-        # No strict-parity-only tag should appear in errors. Use
+        # No strict-parity-only tag may appear in errors. Use
         # STRICT_ONLY_TAGS, not STRICT_TAGS: ``[shape]`` / ``[dtype]``
         # are also emitted by non-strict L2 / L3 checks and may
         # legitimately reach errors regardless of advisory mode.
         leaked = [e for e in errors if any(t in e for t in validator.STRICT_ONLY_TAGS)]
-        assert not leaked, (
-            f"strict failures must not appear in errors in advisory mode; "
-            f"leaked={leaked}"
-        )
+        assert not leaked, leaked
         # At least one strict-parity warning was raised (C6/C7 fixture
         # is guaranteed to fail both).
         strict_warnings = [
             w for w in warnings if "STRICT-PARITY (advisory)" in w
         ]
-        assert strict_warnings, (
-            f"advisory mode must surface strict-parity warnings; "
-            f"warnings={warnings}"
-        )
+        assert strict_warnings, warnings
 
     def test_strict_routes_failures_to_errors(
         self, validator, stub_setup,
@@ -3781,13 +3031,10 @@ class TestStrictAdvisoryMode:
             manifest_path=stub_setup, strict_parity=True, levels=levels,
         )
         strict_errors = [e for e in errors if "[stub]" in e]
-        assert strict_errors, (
-            f"strict mode must surface strict-parity errors; "
-            f"errors={errors}"
-        )
+        assert strict_errors, errors
         assert not any(
             "STRICT-PARITY (advisory)" in w for w in warnings
-        ), f"strict mode must not demote to advisory; warnings={warnings}"
+        ), warnings
 
 
 class TestCompileContractRegistry:


### PR DESCRIPTION
Closes #1767

## Summary

- Table-drive `check_l0`: per-field validators registered in an `_L0_SECTIONS` table; genuinely custom rules stay as small validators.
- Extract L3-parity helpers `_probe_out_of_union` / reason-kind dispatch, shared by the combos and no-combos branches.
- Add a shared per-op error emitter (`_emit_to`) used across L0/L1/L2/L3/C3 checks; consolidate shape-literal parsing into `_SHAPE_EQ_RE`/`_shape_eq_literals`.
- Convert sibling pass/fail test pairs to case tables with shared scaffolding (`_sig`, `_infer_parity`, `_dtype_parity`, `_write_manifest`, `_fake_op_module`, `_strict_op`).
- Combined pair shrinks 7917 -> 6571 lines (-1346); test nodes 142 -> 120 (31 removed named tests consolidated into 9 case-table tests, all intents preserved).

## Test plan

- [x] Modified files pass unit tests (`pytest -q tests/test_validate_manifest.py`: 120 passed)
- [x] Golden-file diff of validator output over the full manifest is empty (default / `--verbose` / `--strict`: exit codes, stdout, stderr byte-identical to main)
- [x] Combined pair shrinks by >=1300 lines; all baseline test intents preserved
- [x] `TestCompileContractRegistry` remains collected by the compile-contract-gate invocation
- [x] pre-commit passed

## Regression

Default, `--verbose`, and `--strict` full-manifest validator output and exit codes are byte-identical to main; 5000 randomized `check_l0` inputs show zero old-vs-new mismatches.
