### PR TITLE
[Refactor][ELEMENTWISE] move strategy into kernel config; drop ctor kwarg

### DIFF
--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -12,6 +12,11 @@ import torch
 import torch.nn.functional as F
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from tileops.kernels.elementwise import (
+    GeluAndMulFwdKernel,
+    GeluTanhAndMulFwdKernel,
+    SiluAndMulFwdKernel,
+)
 from tileops.ops.elementwise import (
     BitwiseAndFwdOp,
     BitwiseOrFwdOp,
@@ -370,28 +375,30 @@ def test_fused_gated_bench(
 
 _STRATEGY_SHAPES = [(1024, 4096), (1024, 11008), (4096, 4096)]
 _STRATEGY_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
-_STRATEGY_OPS = [
-    ("silu_and_mul", SiluAndMulFwdOp),
-    ("gelu_and_mul", GeluAndMulFwdOp),
-    ("gelu_tanh_and_mul", GeluTanhAndMulFwdOp),
+_STRATEGY_KERNELS = [
+    ("silu_and_mul", SiluAndMulFwdKernel),
+    ("gelu_and_mul", GeluAndMulFwdKernel),
+    ("gelu_tanh_and_mul", GeluTanhAndMulFwdKernel),
 ]
 
 
 def _strategy_params():
     """3 ops × 3 shapes × 3 dtypes × 2 strategies = 54 rows."""
     params = []
-    for op_name, op_cls in _STRATEGY_OPS:
+    for op_name, kernel_cls in _STRATEGY_KERNELS:
         for M, N in _STRATEGY_SHAPES:
             for dtype in _STRATEGY_DTYPES:
                 for strategy in ("direct", "explicit_parallel"):
                     is_smoke = _STRATEGY_SHAPES[0] == (M, N) and dtype == torch.float16
                     mark = pytest.mark.smoke if is_smoke else pytest.mark.full
-                    params.append(pytest.param(op_name, M, N, dtype, op_cls, strategy, marks=mark))
+                    params.append(
+                        pytest.param(op_name, M, N, dtype, kernel_cls, strategy, marks=mark)
+                    )
     return params
 
 
 class FusedGatedStrategyBenchFixture(FixtureBase):
-    PARAMS = [("op_name, M, N, dtype, op_cls, strategy", _strategy_params())]
+    PARAMS = [("op_name, M, N, dtype, kernel_cls, strategy", _strategy_params())]
 
 
 @FusedGatedStrategyBenchFixture
@@ -400,7 +407,7 @@ def test_fused_gated_strategy_bench(
     M: int,
     N: int,
     dtype: torch.dtype,
-    op_cls,
+    kernel_cls,
     strategy: str,
 ) -> None:
     """Benchmark each fused gated strategy to validate DEFAULT_STRATEGY choice."""
@@ -409,8 +416,8 @@ def test_fused_gated_strategy_bench(
     inputs = test.gen_inputs()
 
     shape = (M, N)
-    op = op_cls(M=M, N=N, dtype=dtype, strategy=strategy)
-    result = bm.profile(op, *inputs)
+    kernel = kernel_cls(M=M, N=N, dtype=dtype, config={"strategy": strategy})
+    result = bm.profile(kernel, *inputs)
     BenchmarkReport.record(
         f"{op_name}_strategy", locals(), result, tag=f"tileops-{strategy}",
     )

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -330,6 +330,11 @@ class FusedGatedBenchFixture(FixtureBase):
     ]
 
 
+def _silu_and_mul_baseline(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return F.silu(x[..., :half]) * x[..., half:]
+
+
 def _gelu_and_mul_baseline(x: torch.Tensor) -> torch.Tensor:
     half = x.shape[-1] // 2
     return F.gelu(x[..., :half]) * x[..., half:]
@@ -341,6 +346,7 @@ def _gelu_tanh_and_mul_baseline(x: torch.Tensor) -> torch.Tensor:
 
 
 _FUSED_BASELINES = {
+    "silu_and_mul": _silu_and_mul_baseline,
     "gelu_and_mul": _gelu_and_mul_baseline,
     "gelu_tanh_and_mul": _gelu_tanh_and_mul_baseline,
 }
@@ -418,9 +424,11 @@ def test_fused_gated_strategy_bench(
     shape = (M, N)
     kernel = kernel_cls(M=M, N=N, dtype=dtype, config={"strategy": strategy})
     result = bm.profile(kernel, *inputs)
-    BenchmarkReport.record(
-        f"{op_name}_strategy", locals(), result, tag=f"tileops-{strategy}",
-    )
+    BenchmarkReport.record(kernel, locals(), result, tag=f"tileops-{strategy}")
+
+    baseline_fn = _FUSED_BASELINES[op_name]
+    result_bl = bm.profile(baseline_fn, *inputs)
+    BenchmarkReport.record(kernel, locals(), result_bl, tag="torch")
 
 
 # Broadcast benchmark (bias-add pattern)

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3437,6 +3437,15 @@ def check_l4_benchmark(
 # Op interface contract.
 _CTOR_INFRA_PARAMS = frozenset({"self", "kernel_map", "tune"})
 
+# Ctor parameter names whose mechanism has been removed from the codebase
+# (e.g. elementwise ``strategy``, folded into the kernel config dict). A
+# retired name appearing as a code-only ``__init__`` parameter is an error
+# regardless of family: unlike the general code-only-extras rule (deferred
+# in ``check_c3_ctor_signature_parity``), retired names need no
+# protocol-derived allowed set — they are illegal by construction unless
+# the manifest explicitly reintroduces them under ``signature.params``.
+_CTOR_RETIRED_PARAMS = frozenset({"strategy"})
+
 # Sentinel for "manifest did not declare this attribute" — distinct from
 # any legitimate manifest value (including the string "REQUIRED" used to
 # explicitly mark a parameter as required).
@@ -3542,6 +3551,16 @@ def check_c3_ctor_signature_parity(
         ):
             continue
         code_params[pname] = p
+
+    # Retired-name check: code-only occurrences of a retired ctor param
+    # fail outright (see _CTOR_RETIRED_PARAMS).
+    for pname in sorted(_CTOR_RETIRED_PARAMS & set(code_params)):
+        if pname not in manifest_params:
+            errors.append(
+                f"[ctor] {op_name}: param {pname!r} is retired — its "
+                f"dispatch mechanism lives in the kernel config dict; "
+                f"remove it from __init__"
+            )
 
     for pname, pattrs in manifest_params.items():
         if pname not in code_params:

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3435,7 +3435,7 @@ def check_l4_benchmark(
 # Infrastructure params that the validator filters out of ctor parity:
 # they never appear in manifest ``signature.params`` but are part of the
 # Op interface contract.
-_CTOR_INFRA_PARAMS = frozenset({"self", "kernel_map", "tune", "strategy"})
+_CTOR_INFRA_PARAMS = frozenset({"self", "kernel_map", "tune"})
 
 # Sentinel for "manifest did not declare this attribute" — distinct from
 # any legitimate manifest value (including the string "REQUIRED" used to

--- a/tests/ops/test_activation.py
+++ b/tests/ops/test_activation.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.elementwise import ReluFwdKernel
 from tileops.ops.elementwise import ReluFwdOp
 from workloads.elementwise import ReluTest as _ReluTestWorkload
 
@@ -60,11 +61,13 @@ class ReluStrategyFixture(FixtureBase):
 
 @ReluStrategyFixture
 def test_relu_strategies(n_total: int, dtype: torch.dtype, strategy: str) -> None:
-    """Verify all 3 unary strategies produce correct results."""
+    """All 3 unary strategies selected via the config dict produce correct results."""
     test = ReluTest(n_total, dtype)
-    op = ReluFwdOp(N_total=n_total, dtype=dtype, strategy=strategy)
+    kernel = ReluFwdKernel(n_total, dtype, config={"strategy": strategy})
+    assert kernel.strategy == strategy
+    assert kernel.config["strategy"] == strategy
     atol, rtol = _get_tolerances(dtype)
-    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    test.check(kernel, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
 # Template-based activation ops

--- a/tests/ops/test_binary_arith.py
+++ b/tests/ops/test_binary_arith.py
@@ -5,11 +5,18 @@ floor_divide, lerp, maximum, minimum (plus existing add).
 Also includes L4 edge case tests for div, remainder, floor_divide, pow.
 """
 
+import math
+
 import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.elementwise import DivTruncFwdKernel, FloorDivideFwdKernel
+from tileops.kernels.elementwise import (
+    AddFwdKernel,
+    DivTruncFwdKernel,
+    FloorDivideFwdKernel,
+    MaximumFwdKernel,
+)
 from tileops.ops.elementwise import (
     AddFwdOp,
     DivFwdOp,
@@ -243,12 +250,16 @@ class AddStrategyFixture(FixtureBase):
 
 @AddStrategyFixture
 def test_add_strategies(n_total: int, dtype: torch.dtype, strategy: str) -> None:
-    """Verify both binary strategies produce correct results."""
+    """Binary strategies selected via the config dict produce correct results."""
     test = AddSameShapeTest(n_total, dtype)
-    shape = (n_total,)
-    op = AddFwdOp(a_shape=shape, b_shape=shape, dtype=dtype, strategy=strategy)
+    kernel = AddFwdKernel(
+        n_total, dtype, (n_total,), (1,), (1,), n_total, n_total,
+        config={"strategy": strategy},
+    )
+    assert kernel.strategy == strategy
+    assert kernel.config["strategy"] == strategy
     atol, rtol = _get_tolerances(dtype)
-    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    test.check(kernel, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
 # Generic binary test helper
@@ -785,33 +796,41 @@ def test_max_min_optimized_large(op_cls, torch_ref, n_total: int, dtype: torch.d
 
 @pytest.mark.smoke
 def test_register_copy_downgrades_on_broadcast() -> None:
-    """Explicitly requesting register_copy on broadcast shapes must not crash.
+    """Requesting register_copy via config on broadcast shapes must not crash.
 
     register_copy only works for same-shape contiguous inputs. When the
-    caller passes strategy='register_copy' with broadcast shapes, the kernel
-    must silently downgrade to explicit_parallel and produce correct results.
+    caller passes config={"strategy": "register_copy"} with broadcast
+    strides, the kernel must silently downgrade to explicit_parallel and
+    produce correct results.
     """
     a_shape = (2, 64, 128)
     b_shape = (1, 1, 128)
     dtype = torch.float16
+    out_shape, coalesced_shape, a_strides, b_strides = coalesce_broadcast_dims(
+        a_shape, b_shape,
+    )
+    n_total = math.prod(out_shape)
 
-    for op_cls, ref_fn in [
-        (AddFwdOp, lambda a, b: a + b),
-        (MaximumFwdOp, lambda a, b: torch.maximum(a, b)),
+    for kernel_cls, ref_fn in [
+        (AddFwdKernel, lambda a, b: a + b),
+        (MaximumFwdKernel, lambda a, b: torch.maximum(a, b)),
     ]:
-        op = op_cls(
-            a_shape=a_shape, b_shape=b_shape, dtype=dtype,
-            strategy="register_copy",
+        kernel = kernel_cls(
+            n_total, dtype, coalesced_shape, a_strides, b_strides,
+            math.prod(a_shape), math.prod(b_shape),
+            config={"strategy": "register_copy"},
         )
-        # Strategy must have been downgraded
-        assert op.kernel.strategy == "explicit_parallel", (
-            f"{op_cls.__name__} did not downgrade register_copy for broadcast inputs"
+        # Strategy must have been downgraded, and the resolved config must
+        # reflect the downgrade (config is the single source of truth).
+        assert kernel.strategy == "explicit_parallel", (
+            f"{kernel_cls.__name__} did not downgrade register_copy for broadcast inputs"
         )
+        assert kernel.config["strategy"] == "explicit_parallel"
         a = torch.randn(*a_shape, device="cuda", dtype=dtype)
         b = torch.randn(*b_shape, device="cuda", dtype=dtype)
         ref = ref_fn(a, b)
         with torch.no_grad():
-            out = op(a, b)
+            out = kernel(a.view(-1), b.view(-1)).reshape(out_shape)
         torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
 
 

--- a/tests/ops/test_elementwise_caching_autotune.py
+++ b/tests/ops/test_elementwise_caching_autotune.py
@@ -68,7 +68,7 @@ class TestUnaryCaching:
     @pytest.mark.full
     def test_unary_direct_strategy_caching(self):
         """Direct strategy kernels should also cache _compiled_fn."""
-        k = ReluFwdKernel(N, torch.float16, strategy="direct")
+        k = ReluFwdKernel(N, torch.float16, config={"strategy": "direct"})
         assert hasattr(k, "_compiled_fn")
         assert k._compiled_fn is not None
 

--- a/tests/ops/test_elementwise_config_dtype.py
+++ b/tests/ops/test_elementwise_config_dtype.py
@@ -1,5 +1,6 @@
 """Regression tests for elementwise dtype/config consistency."""
 
+import inspect
 from unittest.mock import patch
 
 import pytest
@@ -134,8 +135,12 @@ def test_unary_default_config_preserves_strategy_npt_split():
         patch.object(ReluFwdKernel, "_build_kernel", return_value=None),
         patch.object(ReluFwdKernel, "init_config"),
     ):
-        explicit = ReluFwdKernel(N_total=1024, dtype=torch.float16, strategy="explicit_parallel")
-        register = ReluFwdKernel(N_total=1024, dtype=torch.float16, strategy="register_copy")
+        explicit = ReluFwdKernel(
+            N_total=1024, dtype=torch.float16, config={"strategy": "explicit_parallel"},
+        )
+        register = ReluFwdKernel(
+            N_total=1024, dtype=torch.float16, config={"strategy": "register_copy"},
+        )
     assert explicit.default_config["num_per_thread"] == 4
     assert register.default_config["num_per_thread"] == 8
 
@@ -156,8 +161,8 @@ def test_binary_default_config_preserves_strategy_npt_split():
         patch.object(AddFwdKernel, "_build_kernel", return_value=None),
         patch.object(AddFwdKernel, "init_config"),
     ):
-        explicit = AddFwdKernel(strategy="explicit_parallel", **common_kwargs)
-        register = AddFwdKernel(strategy="register_copy", **common_kwargs)
+        explicit = AddFwdKernel(config={"strategy": "explicit_parallel"}, **common_kwargs)
+        register = AddFwdKernel(config={"strategy": "register_copy"}, **common_kwargs)
     assert explicit.default_config["num_per_thread"] == 4
     assert register.default_config["num_per_thread"] == 8
 
@@ -175,11 +180,61 @@ def test_fused_gated_explicit_uses_occupancy_config():
         patch.object(SiluAndMulFwdKernel, "_build_kernel", return_value=None),
         patch.object(SiluAndMulFwdKernel, "init_config"),
     ):
-        direct = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="direct")
-        explicit_fp16 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float16, strategy="explicit_parallel")
-        explicit_bf16 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.bfloat16, strategy="explicit_parallel")
-        explicit_fp32 = SiluAndMulFwdKernel(M=32, N=1024, dtype=torch.float32, strategy="explicit_parallel")
+        direct = SiluAndMulFwdKernel(
+            M=32, N=1024, dtype=torch.float16, config={"strategy": "direct"},
+        )
+        explicit_fp16 = SiluAndMulFwdKernel(
+            M=32, N=1024, dtype=torch.float16, config={"strategy": "explicit_parallel"},
+        )
+        explicit_bf16 = SiluAndMulFwdKernel(
+            M=32, N=1024, dtype=torch.bfloat16, config={"strategy": "explicit_parallel"},
+        )
+        explicit_fp32 = SiluAndMulFwdKernel(
+            M=32, N=1024, dtype=torch.float32, config={"strategy": "explicit_parallel"},
+        )
     assert direct.default_config["num_per_thread"] == 8
-    assert explicit_fp16.default_config == {"threads": 128, "num_per_thread": 8}
-    assert explicit_bf16.default_config == {"threads": 128, "num_per_thread": 8}
-    assert explicit_fp32.default_config == {"threads": 256, "num_per_thread": 4}
+    assert explicit_fp16.default_config == {
+        "strategy": "explicit_parallel", "threads": 128, "num_per_thread": 8,
+    }
+    assert explicit_bf16.default_config == {
+        "strategy": "explicit_parallel", "threads": 128, "num_per_thread": 8,
+    }
+    assert explicit_fp32.default_config == {
+        "strategy": "explicit_parallel", "threads": 256, "num_per_thread": 4,
+    }
+
+
+# Strategy lives in the kernel config dict, not in op/kernel ctor kwargs
+
+
+@pytest.mark.smoke
+def test_elementwise_ops_do_not_expose_strategy_kwarg():
+    """No elementwise Op constructor exposes a ``strategy`` parameter.
+
+    Strategy selection is a kernel-config concern (``config={"strategy": ...}``
+    on the kernel); the op layer must not re-expose it as ctor plumbing.
+    """
+    import tileops.ops.elementwise as ew
+    from tileops.ops.op_base import Op
+
+    checked = 0
+    for name in dir(ew):
+        obj = getattr(ew, name)
+        if not (isinstance(obj, type) and issubclass(obj, Op)):
+            continue
+        params = inspect.signature(obj.__init__).parameters
+        assert "strategy" not in params, (
+            f"{name}.__init__ still exposes a strategy kwarg"
+        )
+        checked += 1
+    assert checked > 0, "Test bug: no Op classes discovered"
+
+
+@pytest.mark.smoke
+def test_elementwise_kernels_do_not_expose_strategy_kwarg():
+    """Kernel ctors take strategy via config, not as a dedicated kwarg."""
+    for kernel_cls in (ReluFwdKernel, AddFwdKernel, SiluAndMulFwdKernel):
+        params = inspect.signature(kernel_cls.__init__).parameters
+        assert "strategy" not in params, (
+            f"{kernel_cls.__name__}.__init__ still exposes a strategy kwarg"
+        )

--- a/tests/ops/test_elementwise_unary_activation_alignment.py
+++ b/tests/ops/test_elementwise_unary_activation_alignment.py
@@ -193,37 +193,31 @@ def test_gelu_approximate_runs_through_forward(approximate: str) -> None:
 _FROZEN_UNARY_ACTIVATION_SIGNATURES = {
     "ReluFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),
     "SiluFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),
     "HardswishFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),
     "HardsigmoidFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),
     "MishFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),
     "SeluFwdOp": (
         "(self, N_total: int, dtype: torch.dtype, inplace: bool = False, *, "
-        "strategy: Optional[str] = None, "
         "kernel_map: Optional[Dict[str, tileops.kernels.kernel_base.Kernel]] = None, "
         "tune: bool = False)"
     ),

--- a/tests/ops/test_fused_gated.py
+++ b/tests/ops/test_fused_gated.py
@@ -10,6 +10,8 @@ import torch.nn.functional as F
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.elementwise import (
     FusedGatedKernel,
+    GeluAndMulFwdKernel,
+    GeluTanhAndMulFwdKernel,
     SiluAndMulFwdKernel,
 )
 from tileops.ops.elementwise import GeluAndMulFwdOp, GeluTanhAndMulFwdOp, SiluAndMulFwdOp
@@ -199,7 +201,9 @@ def test_fused_gated_kernel_has_strategies() -> None:
 def test_fused_gated_kernel_rejects_unknown_strategy() -> None:
     """FusedGatedKernel must reject unknown strategy names."""
     with pytest.raises(ValueError, match="Unknown strategy"):
-        SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16, strategy="nonexistent")
+        SiluAndMulFwdKernel(
+            M=16, N=16, dtype=torch.float16, config={"strategy": "nonexistent"},
+        )
 
 
 class FusedGatedDirectStrategyFixture(FixtureBase):
@@ -214,29 +218,31 @@ class FusedGatedDirectStrategyFixture(FixtureBase):
 
 @FusedGatedDirectStrategyFixture
 def test_silu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
-    """SiluAndMul with strategy='direct' produces correct results."""
+    """SiluAndMul with config strategy='direct' produces correct results."""
     test = SiluAndMulTest(m, n, dtype)
-    op = SiluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
+    kernel = SiluAndMulFwdKernel(M=m, N=n, dtype=dtype, config={"strategy": "direct"})
     atol, rtol = _get_tolerances(dtype)
-    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    test.check(kernel, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
 @FusedGatedDirectStrategyFixture
 def test_gelu_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
-    """GeluAndMul with strategy='direct' produces correct results."""
+    """GeluAndMul with config strategy='direct' produces correct results."""
     test = GeluAndMulTest(m, n, dtype)
-    op = GeluAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
+    kernel = GeluAndMulFwdKernel(M=m, N=n, dtype=dtype, config={"strategy": "direct"})
     atol, rtol = _get_tolerances(dtype)
-    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    test.check(kernel, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
 @FusedGatedDirectStrategyFixture
 def test_gelu_tanh_and_mul_direct_strategy(m: int, n: int, dtype: torch.dtype) -> None:
-    """GeluTanhAndMul with strategy='direct' produces correct results."""
+    """GeluTanhAndMul with config strategy='direct' produces correct results."""
     test = GeluTanhAndMulTest(m, n, dtype)
-    op = GeluTanhAndMulFwdOp(M=m, N=n, dtype=dtype, strategy="direct")
+    kernel = GeluTanhAndMulFwdKernel(
+        M=m, N=n, dtype=dtype, config={"strategy": "direct"},
+    )
     atol, rtol = _get_tolerances(dtype)
-    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+    test.check(kernel, *test.gen_inputs(), atol=atol, rtol=rtol)
 
 
 @pytest.mark.smoke
@@ -247,11 +253,13 @@ def test_fused_gated_default_strategy_is_explicit_parallel() -> None:
 
 @pytest.mark.smoke
 def test_fused_gated_kernel_stores_strategy() -> None:
-    """FusedGatedKernel.strategy should record the chosen strategy."""
-    k = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16, strategy="direct")
+    """FusedGatedKernel records the config-selected strategy on kernel and config."""
+    k = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16, config={"strategy": "direct"})
     assert k.strategy == "direct"
+    assert k.config["strategy"] == "direct"
     k2 = SiluAndMulFwdKernel(M=16, N=16, dtype=torch.float16)
     assert k2.strategy == FusedGatedKernel.DEFAULT_STRATEGY
+    assert k2.config["strategy"] == FusedGatedKernel.DEFAULT_STRATEGY
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -3515,6 +3515,30 @@ class TestCtorSignatureParity:
             )
             assert any(substring in e for e in errs), (desc, errs)
 
+    def test_retired_ctor_param_fails(self, validator):
+        """A code-only retired ctor param (e.g. `strategy`) is rejected."""
+        from tileops.ops.op_base import Op
+
+        class OpRetired(Op):
+            def __init__(self, dim=-1, strategy=None, kernel_map=None): pass
+            def forward(self, x): return None
+            @property
+            def default_kernel_map(self): return {}
+
+        entry = {"signature": {"params": {"dim": {"type": "int", "default": -1}}}}
+        errs = validator.check_c3_ctor_signature_parity("OpRetired", entry, OpRetired)
+        assert any("'strategy' is retired" in e for e in errs), errs
+
+        # Explicit manifest declaration reintroduces the name legally.
+        entry_declared = {"signature": {"params": {
+            "dim": {"type": "int", "default": -1},
+            "strategy": {"type": "str", "compat_default": None},
+        }}}
+        errs = validator.check_c3_ctor_signature_parity(
+            "OpRetired", entry_declared, OpRetired,
+        )
+        assert not any("retired" in e for e in errs), errs
+
 
 class TestForwardSignatureParity:
     """C4: forward positional names match manifest inputs order."""

--- a/tileops/kernels/elementwise.py
+++ b/tileops/kernels/elementwise.py
@@ -646,9 +646,11 @@ class UnaryKernel(Kernel):
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype for input.
-        strategy: One of "direct", "explicit_parallel", "register_copy".
-        config: Optional dict with "threads" and "num_per_thread".
-        tune: Whether to autotune.
+        config: Optional dict with "strategy", "threads" and "num_per_thread".
+            "strategy" is one of "direct", "explicit_parallel",
+            "register_copy"; it selects the kernel body at build time.
+        tune: Whether to autotune (sweeps "threads" / "num_per_thread"
+            within the resolved strategy).
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -664,7 +666,7 @@ class UnaryKernel(Kernel):
         """Pointwise operation. Must be overridden by subclass."""
         raise NotImplementedError
 
-    def __init__(self, N_total, dtype, strategy=None, config=None, tune=False):
+    def __init__(self, N_total, dtype, config=None, tune=False):
         super().__init__()
         if self.SUPPORTED_DTYPES is not None and dtype not in self.SUPPORTED_DTYPES:
             supported = ", ".join(str(dt) for dt in self.SUPPORTED_DTYPES)
@@ -683,6 +685,14 @@ class UnaryKernel(Kernel):
             self.output_dtype = torch.float16
         else:
             self.output_dtype = self.OUTPUT_DTYPE or dtype
+        # Validate a config-requested strategy up front so typos raise the
+        # same ValueError regardless of dtype (the bool coercion below would
+        # otherwise silently accept an unknown strategy for bool inputs).
+        requested = (config or {}).get("strategy")
+        if requested is not None and requested not in self.STRATEGIES:
+            raise ValueError(
+                f"Unknown strategy '{requested}', expected one of {self.STRATEGIES}"
+            )
         # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads, which
         # the CUDA codegen cannot lower. Keep bool inputs on the scalar path.
         bool_output = torch.bool == self.OUTPUT_DTYPE
@@ -690,32 +700,32 @@ class UnaryKernel(Kernel):
             torch.uint8, torch.int8, torch.int16,
         )
         if dtype == torch.bool:
-            if strategy is not None and strategy != "direct":
+            if requested is not None and requested != "direct":
                 warnings.warn(
                     f"UnaryKernel: dtype=torch.bool requires strategy="
                     f"'direct' (TileLang cannot lower vectorised boolx<N> "
-                    f"loads); overriding requested strategy={strategy!r}.",
+                    f"loads); overriding requested strategy={requested!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
             self.strategy = "direct"
         elif bool_output_needs_scalar:
-            if strategy is not None and strategy != "direct":
+            if requested is not None and requested != "direct":
                 warnings.warn(
                     f"UnaryKernel: dtype={dtype} with torch.bool output "
                     f"requires strategy='direct' (TileLang cannot lower "
                     f"vectorised boolx<N> stores for sub-32-bit integer "
-                    f"inputs); overriding requested strategy={strategy!r}.",
+                    f"inputs); overriding requested strategy={requested!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
             self.strategy = "direct"
         # fp8: register_copy may not reliably handle 8-bit fragments;
         # default to explicit_parallel for fp8 dtypes
-        elif strategy is None and _is_fp8(dtype):
+        elif requested is None and _is_fp8(dtype):
             self.strategy = "explicit_parallel"
         else:
-            self.strategy = strategy or self.DEFAULT_STRATEGY
+            self.strategy = requested or self.DEFAULT_STRATEGY
         if self.strategy not in self.STRATEGIES:
             raise ValueError(
                 f"Unknown strategy '{self.strategy}', expected one of {self.STRATEGIES}"
@@ -765,16 +775,18 @@ class UnaryKernel(Kernel):
     def default_config(self) -> dict:
         if _is_fp8(self.dtype):
             # fp8: 1 byte per element, 16 elements = 128-bit alignment
-            return {"threads": 256, "num_per_thread": 16}
+            return {"strategy": self.strategy, "threads": 256, "num_per_thread": 16}
         npt = _strategy_npt(self.strategy, self.dtype)
-        return {"threads": 256, "num_per_thread": npt}
+        return {"strategy": self.strategy, "threads": 256, "num_per_thread": npt}
 
     @property
     def autotune_configs(self) -> list[dict]:
         """Search space: threads in {128, 256, 512} x num_per_thread in {2, 4, 8}.
 
         Covers a range of occupancy/register-pressure tradeoffs for
-        bandwidth-bound unary elementwise kernels.
+        bandwidth-bound unary elementwise kernels. "strategy" is a
+        build-time config key (it selects the kernel body, not a JIT
+        parameter), so it is excluded from the sweep.
         """
         if _is_fp8(self.dtype):
             # fp8 needs 128-bit alignment: npt >= 16 for 1-byte elements
@@ -816,6 +828,10 @@ class UnaryKernel(Kernel):
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
         super().init_config(config, tune)
+        # Record the resolved strategy so ``self.config`` is the single
+        # source of truth (a coerced/downgraded request or an autotune
+        # result would otherwise leave the key stale or missing).
+        self.config["strategy"] = self.strategy
         # Pre-compile and cache the kernel function for the chosen config
         # to avoid JIT lookup overhead on every forward() call.
         cfg = self.config
@@ -845,11 +861,12 @@ class BinaryKernel(Kernel):
         b_strides: Strides for input b (0 means broadcast).
         a_numel: Number of elements in a.
         b_numel: Number of elements in b.
-        strategy: One of "direct", "explicit_parallel", "register_copy".
-            If "register_copy" is requested but inputs require broadcast,
-            silently downgrades to "explicit_parallel".
-        config: Optional dict with "threads" and "num_per_thread".
-        tune: Whether to autotune.
+        config: Optional dict with "strategy", "threads" and "num_per_thread".
+            "strategy" is one of "direct", "explicit_parallel",
+            "register_copy". If "register_copy" is requested but inputs
+            require broadcast, silently downgrades to "explicit_parallel".
+        tune: Whether to autotune (sweeps "threads" / "num_per_thread"
+            within the resolved strategy).
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -865,7 +882,7 @@ class BinaryKernel(Kernel):
 
     def __init__(
         self, N_total, dtype, coalesced_shape, a_strides, b_strides,
-        a_numel, b_numel, strategy=None, config=None, tune=False,
+        a_numel, b_numel, config=None, tune=False,
     ):
         super().__init__()
         if self.SUPPORTED_DTYPES is not None and dtype not in self.SUPPORTED_DTYPES:
@@ -889,12 +906,13 @@ class BinaryKernel(Kernel):
         self._same_shape = _is_contiguous_same_shape(
             coalesced_shape, a_strides, b_strides,
         )
-        # Validate a caller-provided strategy up front so typos raise the
+        # Validate a config-requested strategy up front so typos raise the
         # same ValueError regardless of dtype (the bool override below
         # otherwise silently accepts an unknown strategy for bool inputs).
-        if strategy is not None and strategy not in self.STRATEGIES:
+        requested = (config or {}).get("strategy")
+        if requested is not None and requested not in self.STRATEGIES:
             raise ValueError(
-                f"Unknown strategy '{strategy}', expected one of {self.STRATEGIES}"
+                f"Unknown strategy '{requested}', expected one of {self.STRATEGIES}"
             )
         # torch.bool maps to TileLang ``boolx<N>`` for vectorised loads /
         # stores, which the CUDA codegen cannot lower. Force the scalar
@@ -905,34 +923,34 @@ class BinaryKernel(Kernel):
             torch.uint8, torch.int8, torch.int16,
         )
         if bool_input:
-            if strategy is not None and strategy != "direct":
+            if requested is not None and requested != "direct":
                 warnings.warn(
                     f"BinaryKernel: dtype=torch.bool requires strategy="
                     f"'direct' (TileLang cannot lower vectorised boolx<N> "
-                    f"loads); overriding requested strategy={strategy!r}.",
+                    f"loads); overriding requested strategy={requested!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
             self.strategy = "direct"
         elif bool_output_needs_scalar:
-            if strategy is not None and strategy != "direct":
+            if requested is not None and requested != "direct":
                 warnings.warn(
                     f"BinaryKernel: dtype={dtype} with torch.bool output "
                     f"requires strategy='direct' (TileLang cannot lower "
                     f"vectorised boolx<N> stores for sub-32-bit integer "
-                    f"inputs); overriding requested strategy={strategy!r}.",
+                    f"inputs); overriding requested strategy={requested!r}.",
                     RuntimeWarning,
                     stacklevel=2,
                 )
             self.strategy = "direct"
-        elif strategy is not None:
+        elif requested is not None:
             # register_copy requires same-shape contiguous inputs (no
             # broadcast); silently downgrade to explicit_parallel when
             # the caller requests register_copy on broadcast shapes.
-            if strategy == "register_copy" and (not self._same_shape or bool_output):
+            if requested == "register_copy" and (not self._same_shape or bool_output):
                 self.strategy = "explicit_parallel"
             else:
-                self.strategy = strategy
+                self.strategy = requested
         elif self._same_shape and not bool_output:
             # register_copy gives vectorized 128-bit loads, ~2-3x faster
             # for complex op_funcs that block TVM's auto-vectorizer.
@@ -993,16 +1011,18 @@ class BinaryKernel(Kernel):
     @property
     def default_config(self) -> dict:
         if _is_fp8(self.dtype):
-            return {"threads": 256, "num_per_thread": 16}
+            return {"strategy": self.strategy, "threads": 256, "num_per_thread": 16}
         npt = _strategy_npt(self.strategy, self.dtype)
-        return {"threads": 256, "num_per_thread": npt}
+        return {"strategy": self.strategy, "threads": 256, "num_per_thread": npt}
 
     @property
     def autotune_configs(self) -> list[dict]:
         """Search space: threads in {128, 256, 512} x num_per_thread in {2, 4, 8}.
 
         Covers a range of occupancy/register-pressure tradeoffs for
-        bandwidth-bound binary elementwise kernels.
+        bandwidth-bound binary elementwise kernels. "strategy" is a
+        build-time config key (it selects the kernel body, not a JIT
+        parameter), so it is excluded from the sweep.
         """
         if _is_fp8(self.dtype):
             # fp8 needs 128-bit alignment: npt >= 16 for 1-byte elements
@@ -1047,6 +1067,10 @@ class BinaryKernel(Kernel):
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
         super().init_config(config, tune)
+        # Record the resolved strategy so ``self.config`` is the single
+        # source of truth (a coerced/downgraded request or an autotune
+        # result would otherwise leave the key stale or missing).
+        self.config["strategy"] = self.strategy
         # Pre-compile and cache the kernel function for the chosen config
         # to avoid JIT lookup overhead on every forward() call.
         cfg = self.config
@@ -1074,9 +1098,11 @@ class FusedGatedKernel(Kernel):
         M: Number of rows.
         N: Half the column dimension (output width).
         dtype: Torch dtype.
-        strategy: One of "direct", "explicit_parallel".
-        config: Optional dict with "threads" and "num_per_thread".
-        tune: Whether to autotune.
+        config: Optional dict with "strategy", "threads" and "num_per_thread".
+            "strategy" is one of "direct", "explicit_parallel"; it selects
+            the kernel body at build time.
+        tune: Whether to autotune (sweeps "threads" / "num_per_thread"
+            within the resolved strategy).
     """
 
     supported_archs: list[int] = [80, 86, 89, 90]
@@ -1093,7 +1119,7 @@ class FusedGatedKernel(Kernel):
         """Activation function. Must be overridden by subclass."""
         raise NotImplementedError
 
-    def __init__(self, M, N, dtype, strategy=None, config=None, tune=False):
+    def __init__(self, M, N, dtype, config=None, tune=False):
         super().__init__()
         if self.SUPPORTED_DTYPES is not None and dtype not in self.SUPPORTED_DTYPES:
             supported = ", ".join(str(dt) for dt in self.SUPPORTED_DTYPES)
@@ -1111,7 +1137,7 @@ class FusedGatedKernel(Kernel):
             self.output_dtype = torch.float16
         else:
             self.output_dtype = dtype
-        self.strategy = strategy or self.DEFAULT_STRATEGY
+        self.strategy = (config or {}).get("strategy") or self.DEFAULT_STRATEGY
         if self.strategy not in self.STRATEGIES:
             raise ValueError(
                 f"Unknown strategy '{self.strategy}', expected one of {self.STRATEGIES}"
@@ -1153,20 +1179,22 @@ class FusedGatedKernel(Kernel):
     @property
     def default_config(self) -> dict:
         if _is_fp8(self.dtype):
-            return {"threads": 256, "num_per_thread": 16}
+            return {"strategy": self.strategy, "threads": 256, "num_per_thread": 16}
         if self.strategy == "explicit_parallel" and self.dtype in (torch.float16, torch.bfloat16):
             # 128x8 keeps block_N=1024 but widens loads to 128-bit and lifts occupancy.
             # Only fp16/bf16 gain the width: fp32 npt=4 already saturates LDG.128.
-            return {"threads": 128, "num_per_thread": 8}
+            return {"strategy": self.strategy, "threads": 128, "num_per_thread": 8}
         npt = _strategy_npt(self.strategy, self.dtype)
-        return {"threads": 256, "num_per_thread": npt}
+        return {"strategy": self.strategy, "threads": 256, "num_per_thread": npt}
 
     @property
     def autotune_configs(self) -> list[dict]:
         """Search space: threads in {128, 256, 512} x num_per_thread in {2, 4, 8}.
 
         Covers a range of occupancy/register-pressure tradeoffs for
-        bandwidth-bound fused gated elementwise kernels.
+        bandwidth-bound fused gated elementwise kernels. "strategy" is a
+        build-time config key (it selects the kernel body, not a JIT
+        parameter), so it is excluded from the sweep.
         """
         if _is_fp8(self.dtype):
             # fp8 needs 128-bit alignment: npt >= 16 for 1-byte elements
@@ -1208,6 +1236,9 @@ class FusedGatedKernel(Kernel):
     def init_config(self, config=None, tune=False):
         """Override to cache the compiled kernel function after config is set."""
         super().init_config(config, tune)
+        # Record the resolved strategy so ``self.config`` is the single
+        # source of truth (an autotune result would otherwise drop the key).
+        self.config["strategy"] = self.strategy
         # Pre-compile and cache the kernel function for the chosen config
         # to avoid JIT lookup overhead on every forward() call.
         cfg = self.config
@@ -1255,7 +1286,7 @@ class _Uint8StorageUnaryKernel(UnaryKernel):
 
     @property
     def default_config(self) -> dict:
-        return {"threads": 256, "num_per_thread": 16}
+        return {"strategy": self.strategy, "threads": 256, "num_per_thread": 16}
 
 
 class _Uint8StorageBinaryKernel(BinaryKernel):
@@ -1266,7 +1297,7 @@ class _Uint8StorageBinaryKernel(BinaryKernel):
 
     @property
     def default_config(self) -> dict:
-        return {"threads": 256, "num_per_thread": 16}
+        return {"strategy": self.strategy, "threads": 256, "num_per_thread": 16}
 
 
 class ReluFwdKernel(FloatUnaryKernel):
@@ -1299,7 +1330,7 @@ class _AlphaScaledBinaryKernel(BinaryKernel):
 
     def __init__(
         self, N_total, dtype, coalesced_shape, a_strides, b_strides,
-        a_numel, b_numel, strategy=None, config=None, tune=False, alpha=1,
+        a_numel, b_numel, config=None, tune=False, alpha=1,
     ):
         # PyTorch's torch.add / torch.sub reject a floating alpha when the
         # input tensor is integral (or bool). Mirror that contract here so
@@ -1315,7 +1346,7 @@ class _AlphaScaledBinaryKernel(BinaryKernel):
         self._alpha = alpha
         super().__init__(
             N_total, dtype, coalesced_shape, a_strides, b_strides,
-            a_numel, b_numel, strategy=strategy, config=config, tune=tune,
+            a_numel, b_numel, config=config, tune=tune,
         )
 
     def _alpha_op_func(self):
@@ -1508,12 +1539,12 @@ class LerpFwdKernel(BinaryKernel):
 
     def __init__(
         self, N_total, dtype, coalesced_shape, a_strides, b_strides,
-        a_numel, b_numel, strategy=None, config=None, tune=False, weight=0.5,
+        a_numel, b_numel, config=None, tune=False, weight=0.5,
     ):
         self._weight = weight
         super().__init__(
             N_total, dtype, coalesced_shape, a_strides, b_strides,
-            a_numel, b_numel, strategy=strategy, config=config, tune=tune,
+            a_numel, b_numel, config=config, tune=tune,
         )
 
     def _build_kernel(self, strategy):

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -598,7 +598,6 @@ class UnaryOp(Op):
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
-        strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
     """
@@ -616,16 +615,14 @@ class UnaryOp(Op):
         self,
         N_total: int,
         dtype: torch.dtype,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         self.N_total = N_total
         self.dtype = dtype
-        self.strategy = strategy
         self.dispatch_kernel(kernel_map)
         self.kernel = self._build_kernel_instance(
-            N_total=N_total, dtype=dtype, strategy=strategy, tune=tune,
+            N_total=N_total, dtype=dtype, tune=tune,
         )
         self.output_dtype = self._resolve_output_dtype()
         # Register in global registry for torch.compile dispatch
@@ -637,13 +634,10 @@ class UnaryOp(Op):
         *,
         N_total: int,
         dtype: torch.dtype,
-        strategy: Optional[str],
         tune: bool,
     ):
         """Construct the kernel. Subclasses override to specialize construction."""
-        return self.kernel_map[self._op_name](
-            N_total, dtype, strategy=strategy, tune=tune,
-        )
+        return self.kernel_map[self._op_name](N_total, dtype, tune=tune)
 
     def _resolve_output_dtype(self) -> torch.dtype:
         # Use _fp8_output_dtype (the final dtype after Op-layer post-cast)
@@ -718,7 +712,6 @@ class BinaryOp(Op):
         a_shape: Shape of input a.
         b_shape: Shape of input b.
         dtype: Torch dtype.
-        strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
     """
@@ -763,7 +756,6 @@ class BinaryOp(Op):
         a_shape: tuple,
         b_shape: tuple,
         dtype: torch.dtype,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -777,7 +769,6 @@ class BinaryOp(Op):
         self.dtype = dtype
         self.a_shape = tuple(a_shape)
         self.b_shape = tuple(b_shape)
-        self.strategy = strategy
         out_shape, coalesced_shape, a_strides, b_strides = coalesce_broadcast_dims(
             a_shape, b_shape,
         )
@@ -788,19 +779,19 @@ class BinaryOp(Op):
         self.b_numel = prod(b_shape)
         self.dispatch_kernel(kernel_map)
         self.kernel = self._build_kernel_instance(
-            coalesced_shape, a_strides, b_strides, strategy, tune,
+            coalesced_shape, a_strides, b_strides, tune,
         )
         # Register in global registry for torch.compile dispatch
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 
     def _build_kernel_instance(
-        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+        self, coalesced_shape, a_strides, b_strides, tune,
     ):
         """Construct the kernel. Subclasses override to inject extra kwargs."""
         return self.kernel_map[self._op_name](
             self.N_total, self.dtype, coalesced_shape, a_strides, b_strides,
-            self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            self.a_numel, self.b_numel, tune=tune,
         )
 
     @property
@@ -868,7 +859,6 @@ class FusedGatedOp(Op):
         N: Optional half column dim (output width). Inferred from ``x`` when
             omitted.
         dtype: Optional torch dtype. Inferred from ``x`` when omitted.
-        strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
     """
@@ -883,7 +873,6 @@ class FusedGatedOp(Op):
         M: Optional[int] = None,
         N: Optional[int] = None,
         dtype: Optional[torch.dtype] = None,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -896,7 +885,6 @@ class FusedGatedOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
-        self.strategy = strategy
         self.tune = tune
         self.dispatch_kernel(kernel_map)
         self.kernel = None
@@ -952,9 +940,7 @@ class FusedGatedOp(Op):
         self.M = M
         self.N = N
         self.dtype = dtype
-        self.kernel = self.kernel_map[self._op_name](
-            M, N, dtype, strategy=self.strategy, tune=self.tune,
-        )
+        self.kernel = self.kernel_map[self._op_name](M, N, dtype, tune=self.tune)
         self._kernel_key = key
 
     def _validate_runtime_input(self, x: torch.Tensor) -> tuple[int, int]:
@@ -1057,13 +1043,10 @@ class _ParamFreeActivationOp(_UnaryActivationMixin, UnaryOp):
         dtype: torch.dtype,
         inplace: bool = False,
         *,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
+        super().__init__(N_total, dtype, kernel_map=kernel_map, tune=tune)
         self.inplace = inplace
 
 
@@ -1123,9 +1106,9 @@ class _AlphaScaledBinaryOp(BinaryOp):
     through the same fast kernel as the default.
 
     The leading ``*`` makes ``alpha`` and the existing
-    ``strategy`` / ``kernel_map`` / ``tune`` parameters keyword-only;
-    only the positional triplet ``(a_shape, b_shape, dtype)`` is shared
-    with ``BinaryOp``.
+    ``kernel_map`` / ``tune`` parameters keyword-only; only the
+    positional triplet ``(a_shape, b_shape, dtype)`` is shared with
+    ``BinaryOp``.
     """
 
     def __init__(
@@ -1135,22 +1118,20 @@ class _AlphaScaledBinaryOp(BinaryOp):
         dtype: torch.dtype,
         *,
         alpha: int | float = 1,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         self.alpha = alpha
         super().__init__(
-            a_shape, b_shape, dtype,
-            strategy=strategy, kernel_map=kernel_map, tune=tune,
+            a_shape, b_shape, dtype, kernel_map=kernel_map, tune=tune,
         )
 
     def _build_kernel_instance(
-        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+        self, coalesced_shape, a_strides, b_strides, tune,
     ):
         return self.kernel_map[self._op_name](
             self.N_total, self.dtype, coalesced_shape, a_strides, b_strides,
-            self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            self.a_numel, self.b_numel, tune=tune,
             alpha=self.alpha,
         )
 
@@ -1168,7 +1149,7 @@ class _BoolOutputBinaryOp(BinaryOp):
         return kernel_map
 
     def _build_kernel_instance(
-        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+        self, coalesced_shape, a_strides, b_strides, tune,
     ):
         self._bool_storage = (
             self.dtype == torch.bool and self.bool_storage_kernel_cls is not None
@@ -1176,10 +1157,10 @@ class _BoolOutputBinaryOp(BinaryOp):
         if self._bool_storage:
             return self.kernel_map[f"{self._op_name}_bool_storage"](
                 self.N_total, torch.uint8, coalesced_shape, a_strides, b_strides,
-                self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+                self.a_numel, self.b_numel, tune=tune,
             )
         return super()._build_kernel_instance(
-            coalesced_shape, a_strides, b_strides, strategy, tune,
+            coalesced_shape, a_strides, b_strides, tune,
         )
 
     def _eager_forward(
@@ -1253,14 +1234,12 @@ class _IntIdentityUnaryOp(UnaryOp):
         self,
         N_total: int,
         dtype: torch.dtype,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
         if dtype in type(self)._fallback_dtypes:
             self.N_total = N_total
             self.dtype = dtype
-            self.strategy = strategy
             # The float-only kernel cannot be instantiated for an integer
             # dtype, so the kernel itself stays unconstructed. The kernel_map
             # is still installed through the shared validate-and-install path
@@ -1276,9 +1255,7 @@ class _IntIdentityUnaryOp(UnaryOp):
             self._instance_key = id(self)
             _OP_REGISTRY[self._instance_key] = self
             return
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
+        super().__init__(N_total, dtype, kernel_map=kernel_map, tune=tune)
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:
         if self.kernel is None:
@@ -1302,7 +1279,6 @@ class _GeluApproximateBase(UnaryOp):
         dtype: torch.dtype,
         *,
         approximate: str = "none",
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -1312,9 +1288,7 @@ class _GeluApproximateBase(UnaryOp):
                 f"'tanh', got {approximate!r}"
             )
         self.approximate = approximate
-        super().__init__(
-            N_total, dtype, strategy=strategy, kernel_map=kernel_map, tune=tune,
-        )
+        super().__init__(N_total, dtype, kernel_map=kernel_map, tune=tune)
 
 
 class _ClampTensorBase(Op):

--- a/tileops/ops/elementwise/activations.py
+++ b/tileops/ops/elementwise/activations.py
@@ -55,7 +55,6 @@ class GeluFwdOp(_GeluApproximateBase):
             the erf-based ``GeluFwdKernel``. ``'tanh'`` routes to
             ``GeluTanhFwdKernel`` (the fused tanh approximation
             ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))``).
-        strategy: Optional kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune the kernel.
     """

--- a/tileops/ops/elementwise/arithmetic.py
+++ b/tileops/ops/elementwise/arithmetic.py
@@ -75,10 +75,9 @@ class DivFwdOp(BinaryOp):
     ``rounding_mode`` accepts ``None`` (true division), ``"trunc"``
     (truncation toward zero), or ``"floor"`` (floor division); each
     value selects a dedicated kernel specialization. The leading ``*``
-    makes ``rounding_mode`` and the existing ``strategy`` /
-    ``kernel_map`` / ``tune`` parameters keyword-only; only the
-    positional triplet ``(a_shape, b_shape, dtype)`` is shared with
-    ``BinaryOp``.
+    makes ``rounding_mode`` and the existing ``kernel_map`` / ``tune``
+    parameters keyword-only; only the positional triplet
+    ``(a_shape, b_shape, dtype)`` is shared with ``BinaryOp``.
     """
 
     _op_name = "div"
@@ -91,7 +90,6 @@ class DivFwdOp(BinaryOp):
         dtype: torch.dtype,
         *,
         rounding_mode: Optional[str] = None,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -107,8 +105,7 @@ class DivFwdOp(BinaryOp):
         # matching ``rounding_mode``.
         self.kernel_cls = _DIV_KERNEL_BY_ROUNDING_MODE[rounding_mode]
         super().__init__(
-            a_shape, b_shape, dtype, strategy=strategy,
-            kernel_map=kernel_map, tune=tune,
+            a_shape, b_shape, dtype, kernel_map=kernel_map, tune=tune,
         )
 
 
@@ -152,7 +149,6 @@ class LerpFwdOp(BinaryOp):
         b_shape: Shape of input b.
         dtype: Torch dtype.
         weight: Scalar interpolation weight, fixed at construction (default 0.5).
-        strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
     """
@@ -167,7 +163,6 @@ class LerpFwdOp(BinaryOp):
         b_shape: tuple,
         dtype: torch.dtype,
         weight: float = 0.5,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -181,7 +176,6 @@ class LerpFwdOp(BinaryOp):
         self.dtype = dtype
         self.a_shape = tuple(a_shape)
         self.b_shape = tuple(b_shape)
-        self.strategy = strategy
         self._weight = weight
         out_shape, coalesced_shape, a_strides, b_strides = coalesce_broadcast_dims(
             a_shape, b_shape,
@@ -194,7 +188,7 @@ class LerpFwdOp(BinaryOp):
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map[self._op_name](
             self.N_total, dtype, coalesced_shape, a_strides, b_strides,
-            self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+            self.a_numel, self.b_numel, tune=tune,
             weight=weight,
         )
         # Register in global registry for torch.compile dispatch
@@ -249,7 +243,6 @@ class LerpTensorFwdOp(Op):
         end: tuple,
         weight: tuple,
         dtype: torch.dtype,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -263,7 +256,6 @@ class LerpTensorFwdOp(Op):
         self.end_shape = tuple(end)
         self.weight_shape = tuple(weight)
         self.dtype = dtype
-        self.strategy = strategy
         self.out_shape = tuple(
             torch.broadcast_shapes(
                 self.input_shape, self.end_shape, self.weight_shape,

--- a/tileops/ops/elementwise/bitwise.py
+++ b/tileops/ops/elementwise/bitwise.py
@@ -29,7 +29,7 @@ class _BoolStorageBitwiseBinaryOp(BinaryOp):
         return kernel_map
 
     def _build_kernel_instance(
-        self, coalesced_shape, a_strides, b_strides, strategy, tune,
+        self, coalesced_shape, a_strides, b_strides, tune,
     ):
         self._bool_storage = (
             self.dtype == torch.bool and self.bool_storage_kernel_cls is not None
@@ -37,10 +37,10 @@ class _BoolStorageBitwiseBinaryOp(BinaryOp):
         if self._bool_storage:
             return self.kernel_map[f"{self._op_name}_bool_storage"](
                 self.N_total, torch.uint8, coalesced_shape, a_strides, b_strides,
-                self.a_numel, self.b_numel, strategy=strategy, tune=tune,
+                self.a_numel, self.b_numel, tune=tune,
             )
         return super()._build_kernel_instance(
-            coalesced_shape, a_strides, b_strides, strategy, tune,
+            coalesced_shape, a_strides, b_strides, tune,
         )
 
     def _eager_forward(

--- a/tileops/ops/elementwise/logical.py
+++ b/tileops/ops/elementwise/logical.py
@@ -49,16 +49,15 @@ class LogicalNotFwdOp(UnaryOp):
         *,
         N_total: int,
         dtype: torch.dtype,
-        strategy,
         tune: bool = False,
     ):
         self._bool_storage = dtype == torch.bool
         if self._bool_storage:
             return self.kernel_map[f"{self._op_name}_bool_storage"](
-                N_total, torch.uint8, strategy=strategy, tune=tune,
+                N_total, torch.uint8, tune=tune,
             )
         return super()._build_kernel_instance(
-            N_total=N_total, dtype=dtype, strategy=strategy, tune=tune,
+            N_total=N_total, dtype=dtype, tune=tune,
         )
 
     def _resolve_output_dtype(self):

--- a/tileops/ops/elementwise/math_unary.py
+++ b/tileops/ops/elementwise/math_unary.py
@@ -89,7 +89,6 @@ class ReciprocalFwdOp(UnaryOp):
         self,
         N_total: int,
         dtype: torch.dtype,
-        strategy: Optional[str] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ):
@@ -102,15 +101,11 @@ class ReciprocalFwdOp(UnaryOp):
             # stays float32 (set by the kernel) per the manifest's
             # ``promote_int_to_float`` contract.
             super().__init__(
-                N_total, torch.float32, strategy=strategy,
-                kernel_map=kernel_map, tune=tune,
+                N_total, torch.float32, kernel_map=kernel_map, tune=tune,
             )
             self.dtype = dtype
         else:
-            super().__init__(
-                N_total, dtype, strategy=strategy,
-                kernel_map=kernel_map, tune=tune,
-            )
+            super().__init__(N_total, dtype, kernel_map=kernel_map, tune=tune)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if self.dtype in _MANIFEST_INT_DTYPES:
@@ -172,7 +167,6 @@ class RoundFwdOp(_IntIdentityUnaryOp):
     Args:
         N_total: Total number of elements (flattened).
         dtype: Torch dtype.
-        strategy: Kernel strategy override.
         kernel_map: Optional kernel dispatch override.
         tune: Whether to autotune.
     """


### PR DESCRIPTION
Closes #1768

## Summary

- Move elementwise `strategy` selection into the kernel `config` dict; delete the ctor kwarg and its pass-through plumbing from all elementwise kernels and Ops.
- fp8/bool coercions and the `register_copy` broadcast downgrade stay inside the kernel; same kernel body selected for every (op, dtype, shape) as before.
- Migrate strategy tests to config-based construction; add guards asserting no elementwise Op/kernel exposes a `strategy` kwarg.
- Fused-gated strategy bench now records a torch baseline and the measured kernel object.
- Validator: `"strategy"` removed from `_CTOR_INFRA_PARAMS` — reintroducing the kwarg on any op now fails validation (validator suite 142 passed).

## Test plan

- [x] pre-commit passed; 335 passed across the six modified test files
- [x] AC-1: no elementwise Op/kernel exposes `strategy` (signature guards, +2 test nodes)
- [x] AC-2: register_copy broadcast-downgrade regression preserved under config form
- [x] AC-3: elementwise GPU smoke tier green (219 passed, H200)

## Benchmark

NVIDIA H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.11. Fused-gated explicit_parallel (4096, 4096) fp16:

| Op | TileOPs (ms) | torch (ms) | Speedup | BW (TB/s) |
| --- | ---: | ---: | ---: | ---: |
| SiluAndMul | 0.0292 | 0.1130 | 3.87× | 3.45 |
| GeluAndMul | 0.0332 | 0.1213 | 3.65× | 3.03 |
| GeluTanhAndMul | 0.0294 | 0.1147 | 3.90× | 3.43 |

All rows meet or exceed the documented bandwidth basis (3.04/2.72/3.38 TB/s) — perf-neutral or better.

## Regression

`test_register_copy_downgrades_on_broadcast` PASSED — config-form downgrade matches PyTorch under broadcast strides.
