### PR TITLE
[Refactor][Tooling] revert the retired-ctor-params validator mechanism

### DIFF
--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -3121,15 +3121,6 @@ def check_l4_benchmark(
 # Op interface contract.
 _CTOR_INFRA_PARAMS = frozenset({"self", "kernel_map", "tune"})
 
-# Ctor parameter names whose mechanism has been removed from the codebase
-# (e.g. elementwise ``strategy``, folded into the kernel config dict). A
-# retired name appearing as a code-only ``__init__`` parameter is an error
-# regardless of family: unlike the general code-only-extras rule (deferred
-# in ``check_c3_ctor_signature_parity``), retired names need no
-# protocol-derived allowed set — they are illegal by construction unless
-# the manifest explicitly reintroduces them under ``signature.params``.
-_CTOR_RETIRED_PARAMS = frozenset({"strategy"})
-
 # Sentinel for "manifest did not declare this attribute" — distinct from
 # any legitimate manifest value (including the string "REQUIRED" used to
 # explicitly mark a parameter as required).
@@ -3233,16 +3224,6 @@ def check_c3_ctor_signature_parity(
         ):
             continue
         code_params[pname] = p
-
-    # Retired-name check: code-only occurrences of a retired ctor param
-    # fail outright (see _CTOR_RETIRED_PARAMS).
-    for pname in sorted(_CTOR_RETIRED_PARAMS & set(code_params)):
-        if pname not in manifest_params:
-            errors.append(
-                f"[ctor] {op_name}: param {pname!r} is retired — its "
-                f"dispatch mechanism lives in the kernel config dict; "
-                f"remove it from __init__"
-            )
 
     for pname, pattrs in manifest_params.items():
         if pname not in code_params:

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2595,34 +2595,6 @@ class TestCtorSignatureParity:
             )
             assert any(substring in e for e in errs), (desc, errs)
 
-    def test_retired_ctor_param_fails(self, validator):
-        """A code-only retired ctor param (e.g. `strategy`) is rejected."""
-        from tileops.ops.op_base import Op
-
-        class OpRetired(Op):
-            def __init__(self, dim=-1, strategy=None, kernel_map=None): pass
-            def forward(self, x): return None
-            @property
-            def default_kernel_map(self): return {}
-
-        entry = {"signature": {"params": {"dim": {"type": "int", "default": -1}}}}
-        errs = validator.check_c3_ctor_signature_parity("OpRetired", entry, OpRetired)
-        assert any("'strategy' is retired" in e for e in errs), errs
-
-        # Explicit manifest declaration reintroduces the name legally.
-        entry_declared = {"signature": {"params": {
-            "dim": {"type": "int", "default": -1},
-            "strategy": {"type": "str", "compat_default": None},
-        }}}
-        errs = validator.check_c3_ctor_signature_parity(
-            "OpRetired", entry_declared, OpRetired,
-        )
-        assert not any("retired" in e for e in errs), errs
-
-
-class TestForwardSignatureParity:
-    """C4: forward positional names match manifest inputs order."""
-
     def test_forward_order_matrix(self, validator):
         """Matching order passes; swapped positional names fail."""
         entry = {"signature": {


### PR DESCRIPTION
Dedicated validator-infrastructure PR (per the manifest-validator domain rule) reverting a mechanism that #1778 smuggled in:

- `_CTOR_RETIRED_PARAMS` frozenset + its check loop in `check_c3_ctor_signature_parity`, and `test_retired_ctor_param_fails`.

Why revert: (1) PR-scoping violation — validator infrastructure inside an elementwise refactor; (2) speculative enforcement generalized from exactly one name; (3) triple redundancy — the no-`strategy`-kwarg guarantee is already pinned by the inspect-based signature guards `test_..._ops_do_not_expose_strategy_kwarg` / `..._kernels_...` shipped in the same PR. The legitimate 1-line `_CTOR_INFRA_PARAMS` cleanup from #1778 is kept.

Verification: validator output unchanged on the full manifest; `tests/test_validate_manifest.py` 120 passed.