### PR TITLE
[Perf][Attention] Add page-aligned Hopper bs1 paged GQA dispatch

### DIFF
--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -238,7 +238,7 @@ def test_gqa_decode_paged_bs1_dispatch() -> None:
         pytest.param(1, torch.bfloat16, 128, 256, None, id="bf16"),
         pytest.param(1, torch.float16, 64, 256, None, id="head-dim"),
         pytest.param(1, torch.float16, 128, 16, None, id="small-page"),
-        pytest.param(1, torch.float16, 128, 96, None, id="unsupported-wgmma-tile"),
+        pytest.param(1, torch.float16, 128, 192, None, id="generic-page-tile"),
         pytest.param(1, torch.float16, 128, 256, 2.0, id="softcap"),
     ],
 )
@@ -250,20 +250,11 @@ def test_gqa_decode_paged_bs1_dispatch_fallbacks(
     softcap: float | None,
 ) -> None:
     """Unsupported shapes and features stay on the generic paged kernel."""
-    seqlen_kv = 8064 if page_size == 96 else 8192
+    seqlen_kv = 8064 if page_size == 192 else 8192
     op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
         batch, 32, 4, seqlen_kv, dim, page_size, dtype, softcap=softcap)
     assert not op._uses_bs1_fast_path()
     assert op.kernel.__class__.__name__ == "GQADecodePagedKernel"
-
-
-@pytest.mark.smoke
-def test_gqa_decode_paged_rejects_non_divisible_page() -> None:
-    """Reject page layouts that neither current paged kernel can address correctly."""
-    with pytest.raises(ValueError, match="page_size must be divisible"):
-        GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
-            1, 32, 4, 8256, 128, 192, torch.float16)
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import GroupedQueryAttentionDecodePagedWithKVCacheFwdOp
+from tileops.utils import is_hopper
 from workloads.attention.gqa import (
     GroupedQueryAttentionDecodePagedTest as _GroupedQueryAttentionDecodePagedTestWorkload,
 )
@@ -73,6 +74,7 @@ class GroupedQueryAttentionDecodePagedFixture(FixtureBase):
             pytest.param(1, 8, 4, 1024, 64, 256, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16, 8, 512, 128, 128, torch.float16, False, marks=pytest.mark.full),
             pytest.param(1, 16, 4, 2048, 128, 512, torch.float16, False, marks=pytest.mark.full),
+            pytest.param(1, 32, 4, 4096, 128, 256, torch.float16, False, marks=pytest.mark.full),
             pytest.param(1, 32, 16, 512, 64, 128, torch.float16, False, marks=pytest.mark.full),
         ]),
     ]
@@ -166,6 +168,47 @@ def test_gqa_decode_paged_op_softmax_controls(
         softcap=softcap,
     )
     test.check(op, *test.gen_inputs(), compare=test._maxdiff_cosine_compare)
+
+
+@pytest.mark.smoke
+def test_gqa_decode_paged_bs1_dispatch() -> None:
+    """Eligible Hopper requests select the paged TMA/WGMMA kernel."""
+    if not is_hopper():
+        pytest.skip("batch=1 warp-specialized paged decode requires Hopper")
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+        1, 32, 4, 8192, 128, 256, torch.float16)
+    assert op._uses_bs1_fast_path()
+    assert op.kernel.__class__.__name__ == "GQADecodePagedBs1Kernel"
+    assert op.kernel._select_tier(1024) == "ctx"
+    assert op.kernel._select_tier(512) == "no_split"
+    assert op.kernel._ctx_splits_for(8192) == 32
+    assert op.kernel._ctx_splits_for(2048) == 16
+    assert op.kernel._ctx_splits_for(3072) == 8
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "batch, dtype, dim, page_size, softcap",
+    [
+        pytest.param(2, torch.float16, 128, 256, None, id="batched"),
+        pytest.param(1, torch.bfloat16, 128, 256, None, id="bf16"),
+        pytest.param(1, torch.float16, 64, 256, None, id="head-dim"),
+        pytest.param(1, torch.float16, 128, 16, None, id="small-page"),
+        pytest.param(1, torch.float16, 128, 256, 2.0, id="softcap"),
+    ],
+)
+def test_gqa_decode_paged_bs1_dispatch_fallbacks(
+    batch: int,
+    dtype: torch.dtype,
+    dim: int,
+    page_size: int,
+    softcap: float | None,
+) -> None:
+    """Unsupported shapes and features stay on the generic paged kernel."""
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+        batch, 32, 4, 8192, dim, page_size, dtype, softcap=softcap)
+    assert not op._uses_bs1_fast_path()
+    assert op.kernel.__class__.__name__ == "GQADecodePagedKernel"
 
 
 if __name__ == "__main__":

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -74,7 +74,6 @@ class GroupedQueryAttentionDecodePagedFixture(FixtureBase):
             pytest.param(1, 8, 4, 1024, 64, 256, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16, 8, 512, 128, 128, torch.float16, False, marks=pytest.mark.full),
             pytest.param(1, 16, 4, 2048, 128, 512, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(1, 32, 4, 4096, 128, 256, torch.float16, False, marks=pytest.mark.full),
             pytest.param(1, 32, 16, 512, 64, 128, torch.float16, False, marks=pytest.mark.full),
         ]),
     ]
@@ -171,6 +170,51 @@ def test_gqa_decode_paged_op_softmax_controls(
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("real_seqlen_kv_value", "reverse_pages"),
+    [
+        pytest.param(512, False, id="no-split"),
+        pytest.param(4096, True, id="ctx-reversed-pages"),
+    ],
+)
+def test_gqa_decode_paged_bs1_fixed_tier_correctness(
+    real_seqlen_kv_value: int,
+    reverse_pages: bool,
+) -> None:
+    """Check both runtime tiers, including output-distinguishing page translation."""
+    if not is_hopper():
+        pytest.skip("batch=1 warp-specialized paged decode requires Hopper")
+
+    torch.manual_seed(0)
+    batch, heads, heads_kv, seqlen_kv, dim, page_size = 1, 32, 4, 4096, 128, 256
+    dtype = torch.float16
+    test = GroupedQueryAttentionDecodePagedTest(
+        batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype
+    )
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+        batch, heads, heads_kv, seqlen_kv, dim, page_size, dtype
+    )
+    q, k, v, real_seqlen_kv, block_table = test.gen_inputs()
+    real_seqlen_kv.fill_(real_seqlen_kv_value)
+    if reverse_pages:
+        block_table = block_table.flip(-1).contiguous()
+
+    assert op.kernel.__class__.__name__ == "GQADecodePagedBs1Kernel"
+    assert op.kernel._select_tier(real_seqlen_kv_value) == (
+        "ctx" if real_seqlen_kv_value >= 1024 else "no_split"
+    )
+    test.check(
+        op,
+        q,
+        k,
+        v,
+        real_seqlen_kv,
+        block_table,
+        compare=test._maxdiff_cosine_compare,
+    )
+
+
+@pytest.mark.smoke
 def test_gqa_decode_paged_bs1_dispatch() -> None:
     """Eligible Hopper requests select the paged TMA/WGMMA kernel."""
     if not is_hopper():
@@ -194,6 +238,7 @@ def test_gqa_decode_paged_bs1_dispatch() -> None:
         pytest.param(1, torch.bfloat16, 128, 256, None, id="bf16"),
         pytest.param(1, torch.float16, 64, 256, None, id="head-dim"),
         pytest.param(1, torch.float16, 128, 16, None, id="small-page"),
+        pytest.param(1, torch.float16, 128, 96, None, id="unsupported-wgmma-tile"),
         pytest.param(1, torch.float16, 128, 256, 2.0, id="softcap"),
     ],
 )
@@ -205,8 +250,9 @@ def test_gqa_decode_paged_bs1_dispatch_fallbacks(
     softcap: float | None,
 ) -> None:
     """Unsupported shapes and features stay on the generic paged kernel."""
+    seqlen_kv = 8064 if page_size == 96 else 8192
     op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
-        batch, 32, 4, 8192, dim, page_size, dtype, softcap=softcap)
+        batch, 32, 4, seqlen_kv, dim, page_size, dtype, softcap=softcap)
     assert not op._uses_bs1_fast_path()
     assert op.kernel.__class__.__name__ == "GQADecodePagedKernel"
 

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -194,6 +194,7 @@ def test_gqa_decode_paged_bs1_dispatch() -> None:
         pytest.param(1, torch.bfloat16, 128, 256, None, id="bf16"),
         pytest.param(1, torch.float16, 64, 256, None, id="head-dim"),
         pytest.param(1, torch.float16, 128, 16, None, id="small-page"),
+        pytest.param(1, torch.float16, 128, 192, None, id="non-divisible-page"),
         pytest.param(1, torch.float16, 128, 256, 2.0, id="softcap"),
     ],
 )

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -194,7 +194,6 @@ def test_gqa_decode_paged_bs1_dispatch() -> None:
         pytest.param(1, torch.bfloat16, 128, 256, None, id="bf16"),
         pytest.param(1, torch.float16, 64, 256, None, id="head-dim"),
         pytest.param(1, torch.float16, 128, 16, None, id="small-page"),
-        pytest.param(1, torch.float16, 128, 192, None, id="non-divisible-page"),
         pytest.param(1, torch.float16, 128, 256, 2.0, id="softcap"),
     ],
 )
@@ -210,6 +209,14 @@ def test_gqa_decode_paged_bs1_dispatch_fallbacks(
         batch, 32, 4, 8192, dim, page_size, dtype, softcap=softcap)
     assert not op._uses_bs1_fast_path()
     assert op.kernel.__class__.__name__ == "GQADecodePagedKernel"
+
+
+@pytest.mark.smoke
+def test_gqa_decode_paged_rejects_non_divisible_page() -> None:
+    """Reject page layouts that neither current paged kernel can address correctly."""
+    with pytest.raises(ValueError, match="page_size must be divisible"):
+        GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+            1, 32, 4, 8256, 128, 192, torch.float16)
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/attention/__init__.py
+++ b/tileops/kernels/attention/__init__.py
@@ -13,6 +13,7 @@ from .gqa_bwd import (
 )
 from .gqa_decode import GQADecodeKernel
 from .gqa_decode_bs1 import GQADecodeBs1Kernel
+from .gqa_decode_bs1_paged import GQADecodePagedBs1Kernel
 from .gqa_decode_paged import GQADecodePagedKernel
 from .gqa_fwd import (
     GQAFwdKernel,
@@ -50,6 +51,7 @@ __all__ = [
     "GQABwdWgmmaPipelinedKernel",
     "GQADecodeBs1Kernel",
     "GQADecodeKernel",
+    "GQADecodePagedBs1Kernel",
     "GQADecodePagedKernel",
     "GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel",
     "GQAFwdKernel",

--- a/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/tileops/kernels/attention/gqa_decode_bs1.py
@@ -17,22 +17,14 @@ from tileops.kernels.attention.gqa_decode import _gqa_decode_no_split_op
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.online_softmax import LOG2E
 
+from .gqa_decode_bs1_common import (
+    COMPILE_FLAGS,
+    RING_DEPTH,
+    make_gqa_decode_bs1_combine,
+    make_gqa_decode_bs1_consumer,
+)
+
 __all__ = ["GQADecodeBs1Kernel"]
-
-_RING = 2  # K/V shared-ring depth (double-buffered).
-
-_COMPILE_FLAGS = [
-    "-O3",
-    "--use_fast_math",
-    "-Wno-deprecated-declarations",
-    "-U__CUDA_NO_HALF_OPERATORS__",
-    "-U__CUDA_NO_HALF_CONVERSIONS__",
-    "-U__CUDA_NO_HALF2_OPERATORS__",
-    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
-    "--expt-relaxed-constexpr",
-    "--expt-extended-lambda",
-    "-DNDEBUG",
-]
 
 
 @functools.lru_cache(maxsize=32)
@@ -41,21 +33,37 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
     scale = score_scale * LOG2E
     accum_dtype = "float"
     kv_group_num = heads // groups
-    ns = _RING
+    ns = RING_DEPTH
 
     @tilelang.jit(
         out_idx=[-1],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
         },
-        compile_flags=_COMPILE_FLAGS)
+        compile_flags=COMPILE_FLAGS)
     def _func(block_M, block_N, ctx_splits, threads):
         shape_q = [batch, heads, dim]
         shape_k = [batch, seqlen_kv, groups, dim]
         shape_o = [batch, heads, dim]
         part_shape = [batch, heads, ctx_splits, dim]
         lse_shape = [batch, heads, ctx_splits]
-        policy = T.GemmWarpPolicy.FullRow
+        consumer = make_gqa_decode_bs1_consumer(
+            block_M,
+            block_N,
+            dim,
+            scale,
+            kv_group_num,
+            ns,
+            accum_dtype,
+        )
+        combine = make_gqa_decode_bs1_combine(
+            batch,
+            heads,
+            ctx_splits,
+            dim,
+            dtype,
+            accum_dtype,
+        )
 
         @T.macro
         def _split(
@@ -104,70 +112,29 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
                                    Vs[k % ns, :, :], barrier=ready[k % ns])
                         T.mbarrier_arrive(ready[k % ns])
                 else:   # consumer
-                    T.fill(acc_o, 0)
-                    T.fill(logsum, 0)
-                    T.fill(sm, -T.infinity(accum_dtype))
-                    T.copy(Q[bid, hid * kv_group_num:hid * kv_group_num + kv_group_num, :],
-                           Qs[0:kv_group_num, :])
-                    for k in T.serial(loop_range):
-                        T.mbarrier_wait_parity(ready[k % ns], (k // ns) % ns)
-                        T.wgmma_gemm(Qs, Ks[k % ns, :, :], acc_s, transpose_B=True, policy=policy,
-                                     clear_accum=True)
-                        T.wait_wgmma(0)
-                        for i, j in T.Parallel(block_M, block_N):
-                            acc_s[i, j] = T.if_then_else(k * block_N + j < this_len, acc_s[i, j],
-                                                         -T.infinity(accum_dtype))
-                        T.copy(sm, smp)
-                        T.reduce_max(acc_s, sm, dim=1, clear=False)
-                        for i in T.Parallel(block_M):
-                            alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
-                        for i, j in T.Parallel(block_M, block_N):
-                            acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
-                        T.reduce_sum(acc_s, ss, dim=1)
-                        for i in T.Parallel(block_M):
-                            logsum[i] = logsum[i] * alpha[i] + ss[i]
-                        for i, j in T.Parallel(block_M, dim):
-                            acc_o[i, j] *= alpha[i]
-                        T.copy(acc_s, Ps)
-                        T.wgmma_gemm(Ps, Vs[k % ns, :, :], acc_o, policy=policy, clear_accum=False)
-                        T.wait_wgmma(0)
-                        T.mbarrier_arrive(free[k % ns])
-                    for i, j in T.Parallel(block_M, dim):
-                        acc_o[i, j] /= logsum[i]
-                    for i in T.Parallel(block_M):
-                        if i < kv_group_num:
-                            glse[bid, hid * kv_group_num + i, sid] = T.log2(logsum[i]) + sm[i] * scale
-                    for i, j in T.Parallel(block_M, dim):
-                        if i < kv_group_num:
-                            Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
-
-        @T.macro
-        def _combine(
-                glse: T.Tensor(lse_shape, accum_dtype),
-                Output_partial: T.Tensor(part_shape, accum_dtype),
-                Output: T.Tensor(shape_o, dtype),
-        ):
-            with T.Kernel(heads, batch, threads=128) as (hq, bid):
-                lse_vec = T.alloc_fragment([ctx_splits], accum_dtype)
-                lse_max = T.alloc_fragment([1], accum_dtype)
-                lse_logsum = T.alloc_local([1], accum_dtype)
-                o_accum = T.alloc_fragment([dim], accum_dtype)
-
-                for s in T.Parallel(ctx_splits):
-                    lse_vec[s] = glse[bid, hq, s]
-                T.fill(lse_max, -T.infinity(accum_dtype))
-                T.reduce_max(lse_vec, lse_max, dim=0, clear=False)
-                lse_logsum[0] = 0
-                for s in T.serial(ctx_splits):
-                    lse_logsum[0] += T.exp2(glse[bid, hq, s] - lse_max[0])
-                lse_logsum[0] = T.log2(lse_logsum[0]) + lse_max[0]
-                T.clear(o_accum)
-                for s in T.serial(ctx_splits):
-                    w = T.exp2(glse[bid, hq, s] - lse_logsum[0])
-                    for j in T.Parallel(dim):
-                        o_accum[j] += Output_partial[bid, hq, s, j] * w
-                for j in T.Parallel(dim):
-                    Output[bid, hq, j] = T.cast(o_accum[j], dtype)
+                    consumer(
+                        Q,
+                        bid,
+                        hid,
+                        sid,
+                        this_len,
+                        loop_range,
+                        Qs,
+                        Ks,
+                        Vs,
+                        Ps,
+                        ready,
+                        free,
+                        acc_s,
+                        acc_o,
+                        sm,
+                        smp,
+                        alpha,
+                        ss,
+                        logsum,
+                        glse,
+                        Output_partial,
+                    )
 
         @T.prim_func
         def gqa_decode_bs1_ctx(
@@ -180,7 +147,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
                 Output: T.Tensor(shape_o, dtype),
         ):
             _split(Q, K, V, real_seqlen_kv, glse, Output_partial)
-            _combine(glse, Output_partial, Output)
+            combine(glse, Output_partial, Output)
 
         return gqa_decode_bs1_ctx
 

--- a/tileops/kernels/attention/gqa_decode_bs1.py
+++ b/tileops/kernels/attention/gqa_decode_bs1.py
@@ -20,8 +20,9 @@ from tileops.kernels.online_softmax import LOG2E
 from .gqa_decode_bs1_common import (
     COMPILE_FLAGS,
     RING_DEPTH,
+    GQADecodeBs1KernelMixin,
     make_gqa_decode_bs1_combine,
-    make_gqa_decode_bs1_consumer,
+    make_gqa_decode_bs1_split,
 )
 
 __all__ = ["GQADecodeBs1Kernel"]
@@ -33,7 +34,6 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
     scale = score_scale * LOG2E
     accum_dtype = "float"
     kv_group_num = heads // groups
-    ns = RING_DEPTH
 
     @tilelang.jit(
         out_idx=[-1],
@@ -47,14 +47,34 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
         shape_o = [batch, heads, dim]
         part_shape = [batch, heads, ctx_splits, dim]
         lse_shape = [batch, heads, ctx_splits]
-        consumer = make_gqa_decode_bs1_consumer(
+
+        @T.macro
+        def load_kv(K, V, unused_layout, bid, hid, base, k, Ks, Vs, ready):
+            T.tma_copy(
+                K[bid, base + k * block_N : base + (k + 1) * block_N, hid, :],
+                Ks[k % RING_DEPTH, :, :],
+                barrier=ready[k % RING_DEPTH],
+            )
+            T.tma_copy(
+                V[bid, base + k * block_N : base + (k + 1) * block_N, hid, :],
+                Vs[k % RING_DEPTH, :, :],
+                barrier=ready[k % RING_DEPTH],
+            )
+
+        split = make_gqa_decode_bs1_split(
+            batch,
+            groups,
             block_M,
             block_N,
             dim,
+            dtype,
             scale,
             kv_group_num,
-            ns,
+            ctx_splits,
+            threads,
             accum_dtype,
+            False,
+            load_kv,
         )
         combine = make_gqa_decode_bs1_combine(
             batch,
@@ -64,77 +84,6 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
             dtype,
             accum_dtype,
         )
-
-        @T.macro
-        def _split(
-                Q: T.Tensor(shape_q, dtype),
-                K: T.Tensor(shape_k, dtype),
-                V: T.Tensor(shape_k, dtype),
-                real_seqlen_kv: T.int32,
-                glse: T.Tensor(lse_shape, accum_dtype),
-                Output_partial: T.Tensor(part_shape, accum_dtype),
-        ):
-            with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
-                Qs = T.alloc_shared([block_M, dim], dtype)
-                Ks = T.alloc_shared([ns, block_N, dim], dtype)
-                Vs = T.alloc_shared([ns, block_N, dim], dtype)
-                Ps = T.alloc_shared([block_M, block_N], dtype)
-                T.annotate_layout({
-                    Qs: tilelang.layout.make_swizzled_layout(Qs),
-                    Ks: tilelang.layout.make_swizzled_layout(Ks),
-                    Vs: tilelang.layout.make_swizzled_layout(Vs),
-                    Ps: tilelang.layout.make_swizzled_layout(Ps),
-                })
-                ready = T.alloc_barrier([32] * ns)   # producer -> consumer
-                free = T.alloc_barrier([128] * ns)   # consumer -> producer
-                acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
-                acc_o = T.alloc_fragment([block_M, dim], accum_dtype)
-                sm = T.alloc_fragment([block_M], accum_dtype)
-                smp = T.alloc_fragment([block_M], accum_dtype)
-                alpha = T.alloc_fragment([block_M], accum_dtype)
-                ss = T.alloc_fragment([block_M], accum_dtype)
-                logsum = T.alloc_fragment([block_M], accum_dtype)
-
-                # Redistribute over the real length so every split holds a full tile.
-                base_len = real_seqlen_kv // (ctx_splits * block_N) * block_N
-                this_len = T.if_then_else(sid == ctx_splits - 1,
-                                          real_seqlen_kv - (ctx_splits - 1) * base_len, base_len)
-                base = base_len * sid
-                loop_range = T.ceildiv(this_len, block_N)
-                tx = T.get_thread_binding()
-
-                if tx >= 128:   # producer
-                    for k in T.serial(loop_range):
-                        T.mbarrier_wait_parity(free[k % ns], ((k // ns) % ns) ^ 1)
-                        T.tma_copy(K[bid, base + k * block_N:base + (k + 1) * block_N, hid, :],
-                                   Ks[k % ns, :, :], barrier=ready[k % ns])
-                        T.tma_copy(V[bid, base + k * block_N:base + (k + 1) * block_N, hid, :],
-                                   Vs[k % ns, :, :], barrier=ready[k % ns])
-                        T.mbarrier_arrive(ready[k % ns])
-                else:   # consumer
-                    consumer(
-                        Q,
-                        bid,
-                        hid,
-                        sid,
-                        this_len,
-                        loop_range,
-                        Qs,
-                        Ks,
-                        Vs,
-                        Ps,
-                        ready,
-                        free,
-                        acc_s,
-                        acc_o,
-                        sm,
-                        smp,
-                        alpha,
-                        ss,
-                        logsum,
-                        glse,
-                        Output_partial,
-                    )
 
         @T.prim_func
         def gqa_decode_bs1_ctx(
@@ -146,7 +95,7 @@ def _gqa_decode_bs1_ctx_kernel(batch, heads, groups, seqlen_kv, dim, sm_scale, s
                 Output_partial: T.Tensor(part_shape, accum_dtype),
                 Output: T.Tensor(shape_o, dtype),
         ):
-            _split(Q, K, V, real_seqlen_kv, glse, Output_partial)
+            split(Q, K, V, K, real_seqlen_kv, glse, Output_partial)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_bs1_ctx
@@ -173,7 +122,7 @@ def _(batch: int, heads: int, groups: int, seqlen_kv: int, real_seqlen_kv: int, 
     return torch.empty_like(Q)
 
 
-class GQADecodeBs1Kernel(Kernel):
+class GQADecodeBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
     """Hopper warp-specialized batch=1 GQA decode kernel with a context-length switch.
 
     ``forward`` dispatches on the runtime ``real_seqlen_kv``: >= 1024 runs the context-only
@@ -181,10 +130,6 @@ class GQADecodeBs1Kernel(Kernel):
     """
 
     supported_archs: list[int] = [90]
-
-    _MIN_CTX = 1024
-    # Powers of two TileLang lowers cleanly; the largest dividing the KV length balances slices.
-    _CTX_SPLIT_CANDIDATES = (32, 16, 8)
 
     def __init__(self,
                  batch,
@@ -218,16 +163,6 @@ class GQADecodeBs1Kernel(Kernel):
     def default_config(self) -> dict:
         return {"block_M": 64, "block_N": 128, "threads": 160}
 
-    def _select_tier(self, real_seqlen_kv: int) -> str:
-        return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
-
-    def _ctx_splits_for(self, real_seqlen_kv: int) -> int:
-        block_N = self.config["block_N"]
-        for cs in self._CTX_SPLIT_CANDIDATES:
-            if real_seqlen_kv % (cs * block_N) == 0:
-                return cs
-        return self._CTX_SPLIT_CANDIDATES[-1]
-
     def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor, real_seqlen_kv: int):
         c = self.config
         if real_seqlen_kv < self._MIN_CTX:
@@ -236,12 +171,7 @@ class GQADecodeBs1Kernel(Kernel):
                                            self.dtype_str, 64, 128, 2, 128, Q, K, V)
 
         ctx_splits = self._ctx_splits_for(real_seqlen_kv)
-        glse = torch.empty((self.batch, self.heads, ctx_splits),
-                           dtype=torch.float32,
-                           device=Q.device)
-        Output_partial = torch.empty((self.batch, self.heads, ctx_splits, self.dim),
-                                     dtype=torch.float32,
-                                     device=Q.device)
+        glse, Output_partial = self._allocate_partials(Q, ctx_splits)
         return _gqa_decode_bs1_ctx_op(self.batch, self.heads, self.groups, self.seqlen_kv,
                                       real_seqlen_kv, self.dim, self.sm_scale, self.softcap,
                                       self.dtype_str, c["block_M"], c["block_N"], ctx_splits,

--- a/tileops/kernels/attention/gqa_decode_bs1_common.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_common.py
@@ -1,0 +1,147 @@
+"""Shared macros for Hopper batch=1 GQA decode kernels."""
+
+import tilelang.language as T
+
+RING_DEPTH = 2
+
+COMPILE_FLAGS = [
+    "-O3",
+    "--use_fast_math",
+    "-Wno-deprecated-declarations",
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-DNDEBUG",
+]
+
+
+def make_gqa_decode_bs1_consumer(
+    block_m: int,
+    block_n: int,
+    dim: int,
+    scale: float,
+    kv_group_num: int,
+    ring_depth: int,
+    accum_dtype: str,
+):
+    """Create the paging-independent WGMMA consumer macro."""
+
+    @T.macro
+    def consumer(
+        Q,
+        bid,
+        hid,
+        sid,
+        this_len,
+        loop_range,
+        Qs,
+        Ks,
+        Vs,
+        Ps,
+        ready,
+        free,
+        acc_s,
+        acc_o,
+        sm,
+        smp,
+        alpha,
+        ss,
+        logsum,
+        glse,
+        Output_partial,
+    ):
+        T.fill(acc_o, 0)
+        T.fill(logsum, 0)
+        T.fill(sm, -T.infinity(accum_dtype))
+        T.copy(
+            Q[bid, hid * kv_group_num : hid * kv_group_num + kv_group_num, :],
+            Qs[0:kv_group_num, :],
+        )
+        for k in T.serial(loop_range):
+            T.mbarrier_wait_parity(ready[k % ring_depth], (k // ring_depth) % ring_depth)
+            T.wgmma_gemm(
+                Qs,
+                Ks[k % ring_depth, :, :],
+                acc_s,
+                transpose_B=True,
+                policy=T.GemmWarpPolicy.FullRow,
+                clear_accum=True,
+            )
+            T.wait_wgmma(0)
+            for i, j in T.Parallel(block_m, block_n):
+                acc_s[i, j] = T.if_then_else(
+                    k * block_n + j < this_len,
+                    acc_s[i, j],
+                    -T.infinity(accum_dtype),
+                )
+            T.copy(sm, smp)
+            T.reduce_max(acc_s, sm, dim=1, clear=False)
+            for i in T.Parallel(block_m):
+                alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
+            for i, j in T.Parallel(block_m, block_n):
+                acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
+            T.reduce_sum(acc_s, ss, dim=1)
+            for i in T.Parallel(block_m):
+                logsum[i] = logsum[i] * alpha[i] + ss[i]
+            for i, j in T.Parallel(block_m, dim):
+                acc_o[i, j] *= alpha[i]
+            T.copy(acc_s, Ps)
+            T.wgmma_gemm(
+                Ps,
+                Vs[k % ring_depth, :, :],
+                acc_o,
+                policy=T.GemmWarpPolicy.FullRow,
+                clear_accum=False,
+            )
+            T.wait_wgmma(0)
+            T.mbarrier_arrive(free[k % ring_depth])
+        for i, j in T.Parallel(block_m, dim):
+            acc_o[i, j] /= logsum[i]
+        for i in T.Parallel(block_m):
+            if i < kv_group_num:
+                glse[bid, hid * kv_group_num + i, sid] = T.log2(logsum[i]) + sm[i] * scale
+        for i, j in T.Parallel(block_m, dim):
+            if i < kv_group_num:
+                Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
+
+    return consumer
+
+
+def make_gqa_decode_bs1_combine(
+    batch: int,
+    heads: int,
+    ctx_splits: int,
+    dim: int,
+    dtype: str,
+    accum_dtype: str,
+):
+    """Create the paging-independent split-output combine macro."""
+
+    @T.macro
+    def combine(glse, Output_partial, Output):
+        with T.Kernel(heads, batch, threads=128) as (hq, bid):
+            lse_vec = T.alloc_fragment([ctx_splits], accum_dtype)
+            lse_max = T.alloc_fragment([1], accum_dtype)
+            lse_logsum = T.alloc_local([1], accum_dtype)
+            o_accum = T.alloc_fragment([dim], accum_dtype)
+
+            for s in T.Parallel(ctx_splits):
+                lse_vec[s] = glse[bid, hq, s]
+            T.fill(lse_max, -T.infinity(accum_dtype))
+            T.reduce_max(lse_vec, lse_max, dim=0, clear=False)
+            lse_logsum[0] = 0
+            for s in T.serial(ctx_splits):
+                lse_logsum[0] += T.exp2(glse[bid, hq, s] - lse_max[0])
+            lse_logsum[0] = T.log2(lse_logsum[0]) + lse_max[0]
+            T.clear(o_accum)
+            for s in T.serial(ctx_splits):
+                weight = T.exp2(glse[bid, hq, s] - lse_logsum[0])
+                for j in T.Parallel(dim):
+                    o_accum[j] += Output_partial[bid, hq, s, j] * weight
+            for j in T.Parallel(dim):
+                Output[bid, hq, j] = T.cast(o_accum[j], dtype)
+
+    return combine

--- a/tileops/kernels/attention/gqa_decode_bs1_common.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_common.py
@@ -1,6 +1,8 @@
 """Shared macros for Hopper batch=1 GQA decode kernels."""
 
+import tilelang
 import tilelang.language as T
+import torch
 
 RING_DEPTH = 2
 
@@ -16,6 +18,40 @@ COMPILE_FLAGS = [
     "--expt-extended-lambda",
     "-DNDEBUG",
 ]
+
+
+class GQADecodeBs1KernelMixin:
+    """Shared runtime policy for contiguous and paged Hopper batch=1 decode."""
+
+    _MIN_CTX = 1024
+    _CTX_SPLIT_CANDIDATES = (32, 16, 8)
+
+    def _select_tier(self, real_seqlen_kv: int) -> str:
+        return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
+
+    def _ctx_splits_for(self, real_seqlen_kv: int) -> int:
+        block_n = self.config["block_N"]
+        for ctx_splits in self._CTX_SPLIT_CANDIDATES:
+            if real_seqlen_kv % (ctx_splits * block_n) == 0:
+                return ctx_splits
+        return self._CTX_SPLIT_CANDIDATES[-1]
+
+    def _allocate_partials(
+        self,
+        q: torch.Tensor,
+        ctx_splits: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        glse = torch.empty(
+            (self.batch, self.heads, ctx_splits),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        output_partial = torch.empty(
+            (self.batch, self.heads, ctx_splits, self.dim),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        return glse, output_partial
 
 
 def make_gqa_decode_bs1_consumer(
@@ -108,6 +144,117 @@ def make_gqa_decode_bs1_consumer(
                 Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
 
     return consumer
+
+
+def make_gqa_decode_bs1_split(
+    batch: int,
+    groups: int,
+    block_m: int,
+    block_n: int,
+    dim: int,
+    dtype: str,
+    scale: float,
+    kv_group_num: int,
+    ctx_splits: int,
+    threads: int,
+    accum_dtype: str,
+    real_seqlen_is_buffer: bool,
+    load_kv,
+):
+    """Create the shared context-split schedule around a layout-specific KV loader."""
+    consumer = make_gqa_decode_bs1_consumer(
+        block_m,
+        block_n,
+        dim,
+        scale,
+        kv_group_num,
+        RING_DEPTH,
+        accum_dtype,
+    )
+
+    @T.macro
+    def split(Q, K, V, kv_layout, real_seqlen_kv, glse, output_partial):
+        with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
+            qs = T.alloc_shared([block_m, dim], dtype)
+            ks = T.alloc_shared([RING_DEPTH, block_n, dim], dtype)
+            vs = T.alloc_shared([RING_DEPTH, block_n, dim], dtype)
+            ps = T.alloc_shared([block_m, block_n], dtype)
+            T.annotate_layout(
+                {
+                    qs: tilelang.layout.make_swizzled_layout(qs),
+                    ks: tilelang.layout.make_swizzled_layout(ks),
+                    vs: tilelang.layout.make_swizzled_layout(vs),
+                    ps: tilelang.layout.make_swizzled_layout(ps),
+                }
+            )
+            ready = T.alloc_barrier([32] * RING_DEPTH)
+            free = T.alloc_barrier([128] * RING_DEPTH)
+            acc_s = T.alloc_fragment([block_m, block_n], accum_dtype)
+            acc_o = T.alloc_fragment([block_m, dim], accum_dtype)
+            sm = T.alloc_fragment([block_m], accum_dtype)
+            smp = T.alloc_fragment([block_m], accum_dtype)
+            alpha = T.alloc_fragment([block_m], accum_dtype)
+            ss = T.alloc_fragment([block_m], accum_dtype)
+            logsum = T.alloc_fragment([block_m], accum_dtype)
+
+            seqlen_kv_b = (
+                real_seqlen_kv[bid] if real_seqlen_is_buffer else real_seqlen_kv
+            )
+            base_len = seqlen_kv_b // (ctx_splits * block_n) * block_n
+            this_len = T.if_then_else(
+                sid == ctx_splits - 1,
+                seqlen_kv_b - (ctx_splits - 1) * base_len,
+                base_len,
+            )
+            base = base_len * sid
+            loop_range = T.ceildiv(this_len, block_n)
+            tx = T.get_thread_binding()
+
+            if tx >= 128:
+                for k in T.serial(loop_range):
+                    T.mbarrier_wait_parity(
+                        free[k % RING_DEPTH],
+                        ((k // RING_DEPTH) % RING_DEPTH) ^ 1,
+                    )
+                    load_kv(
+                        K,
+                        V,
+                        kv_layout,
+                        bid,
+                        hid,
+                        base,
+                        k,
+                        ks,
+                        vs,
+                        ready,
+                    )
+                    T.mbarrier_arrive(ready[k % RING_DEPTH])
+            else:
+                consumer(
+                    Q,
+                    bid,
+                    hid,
+                    sid,
+                    this_len,
+                    loop_range,
+                    qs,
+                    ks,
+                    vs,
+                    ps,
+                    ready,
+                    free,
+                    acc_s,
+                    acc_o,
+                    sm,
+                    smp,
+                    alpha,
+                    ss,
+                    logsum,
+                    glse,
+                    output_partial,
+                )
+
+    return split
 
 
 def make_gqa_decode_bs1_combine(

--- a/tileops/kernels/attention/gqa_decode_bs1_paged.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_paged.py
@@ -15,7 +15,10 @@ import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.attention.gqa_decode_paged import _gqa_decode_paged_no_split_op
+from tileops.kernels.attention.gqa_decode_paged import (
+    _gqa_decode_paged_no_split_op,
+    gqa_decode_paged_block_n,
+)
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.online_softmax import LOG2E
 
@@ -250,11 +253,8 @@ class GQADecodePagedBs1Kernel(Kernel):
     @staticmethod
     def block_n_for_page_size(page_size: int) -> Optional[int]:
         """Return a page-contained WGMMA N tile, or None when the fast path is unsafe."""
-        if page_size == 64:
-            return 64
-        if page_size >= 128 and page_size % 128 == 0:
-            return 128
-        return None
+        block_n = gqa_decode_paged_block_n(page_size)
+        return block_n if block_n in (64, 128) and page_size % block_n == 0 else None
 
     def __init__(
         self,

--- a/tileops/kernels/attention/gqa_decode_bs1_paged.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_paged.py
@@ -1,0 +1,403 @@
+"""Warp-specialized batch=1 paged GQA decode kernel (Hopper), context-split.
+
+``GQADecodePagedBs1Kernel`` dispatches on the runtime ``real_seqlen_kv``: lengths >= 1024
+run a context-only warp-specialized split (one TMA producer warp feeding a four-warp
+wgmma consumer warpgroup, exp2-domain online softmax, fp32 partial reduce via a combine
+kernel); shorter lengths fall back to the generic paged non-split decode kernel.
+Logical KV tiles are translated through the page table before TMA. Hopper-only, low-level
+``tma_copy`` / ``mbarrier`` / ``wgmma_gemm``.
+"""
+
+import functools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.attention.gqa_decode_paged import _gqa_decode_paged_no_split_op
+from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.online_softmax import LOG2E
+
+__all__ = ["GQADecodePagedBs1Kernel"]
+
+_RING = 2  # K/V shared-ring depth (double-buffered).
+
+_COMPILE_FLAGS = [
+    "-O3",
+    "--use_fast_math",
+    "-Wno-deprecated-declarations",
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+    "--expt-relaxed-constexpr",
+    "--expt-extended-lambda",
+    "-DNDEBUG",
+]
+
+
+@functools.lru_cache(maxsize=32)
+def _gqa_decode_paged_bs1_ctx_kernel(
+    batch, heads, groups, seqlen_kv, dim, page_size, sm_scale, softcap, dtype
+):
+    score_scale = dim**-0.5 if sm_scale is None else sm_scale
+    scale = score_scale * LOG2E
+    accum_dtype = "float"
+    kv_group_num = heads // groups
+    ns = _RING
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={
+            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        },
+        compile_flags=_COMPILE_FLAGS,
+    )
+    def _func(block_M, block_N, ctx_splits, threads):
+        shape_q = [batch, heads, dim]
+        shape_k = [seqlen_kv, groups, dim]
+        shape_o = [batch, heads, dim]
+        part_shape = [batch, heads, ctx_splits, dim]
+        lse_shape = [batch, heads, ctx_splits]
+        policy = T.GemmWarpPolicy.FullRow
+
+        @T.macro
+        def _split(
+            Q: T.Tensor(shape_q, dtype),
+            K: T.Tensor(shape_k, dtype),
+            V: T.Tensor(shape_k, dtype),
+            real_seqlen_kv: T.Tensor([batch], T.int32),
+            block_table: T.Tensor([batch, seqlen_kv // page_size], T.int32),
+            glse: T.Tensor(lse_shape, accum_dtype),
+            Output_partial: T.Tensor(part_shape, accum_dtype),
+        ):
+            with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
+                Qs = T.alloc_shared([block_M, dim], dtype)
+                Ks = T.alloc_shared([ns, block_N, dim], dtype)
+                Vs = T.alloc_shared([ns, block_N, dim], dtype)
+                Ps = T.alloc_shared([block_M, block_N], dtype)
+                T.annotate_layout(
+                    {
+                        Qs: tilelang.layout.make_swizzled_layout(Qs),
+                        Ks: tilelang.layout.make_swizzled_layout(Ks),
+                        Vs: tilelang.layout.make_swizzled_layout(Vs),
+                        Ps: tilelang.layout.make_swizzled_layout(Ps),
+                    }
+                )
+                ready = T.alloc_barrier([32] * ns)  # producer -> consumer
+                free = T.alloc_barrier([128] * ns)  # consumer -> producer
+                acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
+                acc_o = T.alloc_fragment([block_M, dim], accum_dtype)
+                sm = T.alloc_fragment([block_M], accum_dtype)
+                smp = T.alloc_fragment([block_M], accum_dtype)
+                alpha = T.alloc_fragment([block_M], accum_dtype)
+                ss = T.alloc_fragment([block_M], accum_dtype)
+                logsum = T.alloc_fragment([block_M], accum_dtype)
+
+                # Redistribute over the real length so every split holds a full tile.
+                seqlen_kv_b = real_seqlen_kv[bid]
+                base_len = seqlen_kv_b // (ctx_splits * block_N) * block_N
+                this_len = T.if_then_else(
+                    sid == ctx_splits - 1, seqlen_kv_b - (ctx_splits - 1) * base_len, base_len
+                )
+                base = base_len * sid
+                loop_range = T.ceildiv(this_len, block_N)
+                tx = T.get_thread_binding()
+
+                if tx >= 128:  # producer
+                    for k in T.serial(loop_range):
+                        T.mbarrier_wait_parity(free[k % ns], ((k // ns) % ns) ^ 1)
+                        logical_block = base // block_N + k
+                        blocks_per_page = page_size // block_N
+                        page_idx = logical_block // blocks_per_page
+                        block_in_page = logical_block % blocks_per_page
+                        physical_block = (
+                            block_table[bid, page_idx] * blocks_per_page + block_in_page
+                        )
+                        T.tma_copy(
+                            K[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
+                            Ks[k % ns, :, :],
+                            barrier=ready[k % ns],
+                        )
+                        T.tma_copy(
+                            V[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
+                            Vs[k % ns, :, :],
+                            barrier=ready[k % ns],
+                        )
+                        T.mbarrier_arrive(ready[k % ns])
+                else:  # consumer
+                    T.fill(acc_o, 0)
+                    T.fill(logsum, 0)
+                    T.fill(sm, -T.infinity(accum_dtype))
+                    T.copy(
+                        Q[bid, hid * kv_group_num : hid * kv_group_num + kv_group_num, :],
+                        Qs[0:kv_group_num, :],
+                    )
+                    for k in T.serial(loop_range):
+                        T.mbarrier_wait_parity(ready[k % ns], (k // ns) % ns)
+                        T.wgmma_gemm(
+                            Qs,
+                            Ks[k % ns, :, :],
+                            acc_s,
+                            transpose_B=True,
+                            policy=policy,
+                            clear_accum=True,
+                        )
+                        T.wait_wgmma(0)
+                        for i, j in T.Parallel(block_M, block_N):
+                            acc_s[i, j] = T.if_then_else(
+                                k * block_N + j < this_len, acc_s[i, j], -T.infinity(accum_dtype)
+                            )
+                        T.copy(sm, smp)
+                        T.reduce_max(acc_s, sm, dim=1, clear=False)
+                        for i in T.Parallel(block_M):
+                            alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
+                        for i, j in T.Parallel(block_M, block_N):
+                            acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
+                        T.reduce_sum(acc_s, ss, dim=1)
+                        for i in T.Parallel(block_M):
+                            logsum[i] = logsum[i] * alpha[i] + ss[i]
+                        for i, j in T.Parallel(block_M, dim):
+                            acc_o[i, j] *= alpha[i]
+                        T.copy(acc_s, Ps)
+                        T.wgmma_gemm(Ps, Vs[k % ns, :, :], acc_o, policy=policy, clear_accum=False)
+                        T.wait_wgmma(0)
+                        T.mbarrier_arrive(free[k % ns])
+                    for i, j in T.Parallel(block_M, dim):
+                        acc_o[i, j] /= logsum[i]
+                    for i in T.Parallel(block_M):
+                        if i < kv_group_num:
+                            glse[bid, hid * kv_group_num + i, sid] = (
+                                T.log2(logsum[i]) + sm[i] * scale
+                            )
+                    for i, j in T.Parallel(block_M, dim):
+                        if i < kv_group_num:
+                            Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
+
+        @T.macro
+        def _combine(
+            glse: T.Tensor(lse_shape, accum_dtype),
+            Output_partial: T.Tensor(part_shape, accum_dtype),
+            Output: T.Tensor(shape_o, dtype),
+        ):
+            with T.Kernel(heads, batch, threads=128) as (hq, bid):
+                lse_vec = T.alloc_fragment([ctx_splits], accum_dtype)
+                lse_max = T.alloc_fragment([1], accum_dtype)
+                lse_logsum = T.alloc_local([1], accum_dtype)
+                o_accum = T.alloc_fragment([dim], accum_dtype)
+
+                for s in T.Parallel(ctx_splits):
+                    lse_vec[s] = glse[bid, hq, s]
+                T.fill(lse_max, -T.infinity(accum_dtype))
+                T.reduce_max(lse_vec, lse_max, dim=0, clear=False)
+                lse_logsum[0] = 0
+                for s in T.serial(ctx_splits):
+                    lse_logsum[0] += T.exp2(glse[bid, hq, s] - lse_max[0])
+                lse_logsum[0] = T.log2(lse_logsum[0]) + lse_max[0]
+                T.clear(o_accum)
+                for s in T.serial(ctx_splits):
+                    w = T.exp2(glse[bid, hq, s] - lse_logsum[0])
+                    for j in T.Parallel(dim):
+                        o_accum[j] += Output_partial[bid, hq, s, j] * w
+                for j in T.Parallel(dim):
+                    Output[bid, hq, j] = T.cast(o_accum[j], dtype)
+
+        @T.prim_func
+        def gqa_decode_paged_bs1_ctx(
+            Q: T.Tensor(shape_q, dtype),
+            K: T.Tensor(shape_k, dtype),
+            V: T.Tensor(shape_k, dtype),
+            real_seqlen_kv: T.Tensor([batch], T.int32),
+            block_table: T.Tensor([batch, seqlen_kv // page_size], T.int32),
+            glse: T.Tensor(lse_shape, accum_dtype),
+            Output_partial: T.Tensor(part_shape, accum_dtype),
+            Output: T.Tensor(shape_o, dtype),
+        ):
+            _split(Q, K, V, real_seqlen_kv, block_table, glse, Output_partial)
+            _combine(glse, Output_partial, Output)
+
+        return gqa_decode_paged_bs1_ctx
+
+    return _func
+
+
+@torch.library.custom_op("top::gqa_decode_paged_bs1_ctx_op", mutates_args=())
+def _gqa_decode_paged_bs1_ctx_op(
+    batch: int,
+    heads: int,
+    groups: int,
+    seqlen_kv: int,
+    dim: int,
+    page_size: int,
+    sm_scale: float,
+    softcap: float,
+    dtype: str,
+    block_M: int,
+    block_N: int,
+    ctx_splits: int,
+    threads: int,
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    real_seqlen_kv: torch.Tensor,
+    block_table: torch.Tensor,
+    glse: torch.Tensor,
+    Output_partial: torch.Tensor,
+) -> torch.Tensor:
+    return _gqa_decode_paged_bs1_ctx_kernel(
+        batch, heads, groups, seqlen_kv, dim, page_size, sm_scale, softcap, dtype
+    )(block_M, block_N, ctx_splits, threads)(
+        Q, K, V, real_seqlen_kv, block_table, glse, Output_partial
+    )
+
+
+@_gqa_decode_paged_bs1_ctx_op.register_fake
+def _(
+    batch: int,
+    heads: int,
+    groups: int,
+    seqlen_kv: int,
+    dim: int,
+    page_size: int,
+    sm_scale: float,
+    softcap: float,
+    dtype: str,
+    block_M: int,
+    block_N: int,
+    ctx_splits: int,
+    threads: int,
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    real_seqlen_kv: torch.Tensor,
+    block_table: torch.Tensor,
+    glse: torch.Tensor,
+    Output_partial: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty_like(Q)
+
+
+class GQADecodePagedBs1Kernel(Kernel):
+    """Hopper warp-specialized batch=1 paged GQA decode kernel.
+
+    ``forward`` dispatches on the runtime ``real_seqlen_kv``: >= 1024 runs the context-only
+    split, shorter lengths run the generic non-split paged GQA decode kernel.
+    """
+
+    supported_archs: list[int] = [90]
+
+    _MIN_CTX = 1024
+    # Powers of two TileLang lowers cleanly; the largest dividing the KV length balances slices.
+    _CTX_SPLIT_CANDIDATES = (32, 16, 8)
+
+    def __init__(
+        self,
+        batch,
+        heads,
+        groups,
+        seqlen_kv,
+        dim,
+        page_size,
+        dtype="float16",
+        sm_scale: Optional[float] = None,
+        softcap: float = 0.0,
+        config: Optional[dict] = None,
+        tune=False,
+    ):
+        super().__init__()
+        self.batch = batch
+        self.heads = heads
+        self.groups = groups
+        self.seqlen_kv = seqlen_kv
+        self.dim = dim
+        self.page_size = page_size
+        self.dtype = dtype
+        self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
+        self.softcap = softcap
+        if self.groups <= 0:
+            raise ValueError("groups must be positive")
+        if self.heads % self.groups != 0:
+            raise ValueError("heads must be divisible by groups")
+        if self.seqlen_kv <= 0:
+            raise ValueError("seqlen_kv must be positive")
+        if self.page_size <= 0 or self.seqlen_kv % self.page_size != 0:
+            raise ValueError("page_size must be positive and divide seqlen_kv")
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {"block_M": 64, "block_N": min(128, self.page_size), "threads": 160}
+
+    def _select_tier(self, real_seqlen_kv: int) -> str:
+        return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
+
+    def _ctx_splits_for(self, real_seqlen_kv: int) -> int:
+        block_N = self.config["block_N"]
+        for cs in self._CTX_SPLIT_CANDIDATES:
+            if real_seqlen_kv % (cs * block_N) == 0:
+                return cs
+        return self._CTX_SPLIT_CANDIDATES[-1]
+
+    def forward(
+        self,
+        Q: torch.Tensor,
+        K: torch.Tensor,
+        V: torch.Tensor,
+        real_seqlen_kv: torch.Tensor,
+        block_table: torch.Tensor,
+    ):
+        c = self.config
+        real_max = int(real_seqlen_kv.max().item())
+        if real_max < self._MIN_CTX:
+            block_N = min(128, self.page_size)
+            return _gqa_decode_paged_no_split_op(
+                self.batch,
+                self.heads,
+                self.groups,
+                self.seqlen_kv,
+                self.dim,
+                self.page_size,
+                self.sm_scale,
+                self.softcap,
+                self.dtype_str,
+                64,
+                block_N,
+                2,
+                128,
+                Q,
+                K,
+                V,
+                real_seqlen_kv,
+                block_table,
+            )
+
+        ctx_splits = self._ctx_splits_for(real_max)
+        glse = torch.empty(
+            (self.batch, self.heads, ctx_splits), dtype=torch.float32, device=Q.device
+        )
+        Output_partial = torch.empty(
+            (self.batch, self.heads, ctx_splits, self.dim), dtype=torch.float32, device=Q.device
+        )
+        return _gqa_decode_paged_bs1_ctx_op(
+            self.batch,
+            self.heads,
+            self.groups,
+            self.seqlen_kv,
+            self.dim,
+            self.page_size,
+            self.sm_scale,
+            self.softcap,
+            self.dtype_str,
+            c["block_M"],
+            c["block_N"],
+            ctx_splits,
+            c["threads"],
+            Q,
+            K,
+            V,
+            real_seqlen_kv,
+            block_table,
+            glse,
+            Output_partial,
+        )

--- a/tileops/kernels/attention/gqa_decode_bs1_paged.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_paged.py
@@ -19,22 +19,14 @@ from tileops.kernels.attention.gqa_decode_paged import _gqa_decode_paged_no_spli
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.online_softmax import LOG2E
 
+from .gqa_decode_bs1_common import (
+    COMPILE_FLAGS,
+    RING_DEPTH,
+    make_gqa_decode_bs1_combine,
+    make_gqa_decode_bs1_consumer,
+)
+
 __all__ = ["GQADecodePagedBs1Kernel"]
-
-_RING = 2  # K/V shared-ring depth (double-buffered).
-
-_COMPILE_FLAGS = [
-    "-O3",
-    "--use_fast_math",
-    "-Wno-deprecated-declarations",
-    "-U__CUDA_NO_HALF_OPERATORS__",
-    "-U__CUDA_NO_HALF_CONVERSIONS__",
-    "-U__CUDA_NO_HALF2_OPERATORS__",
-    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
-    "--expt-relaxed-constexpr",
-    "--expt-extended-lambda",
-    "-DNDEBUG",
-]
 
 
 @functools.lru_cache(maxsize=32)
@@ -45,14 +37,14 @@ def _gqa_decode_paged_bs1_ctx_kernel(
     scale = score_scale * LOG2E
     accum_dtype = "float"
     kv_group_num = heads // groups
-    ns = _RING
+    ns = RING_DEPTH
 
     @tilelang.jit(
         out_idx=[-1],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
         },
-        compile_flags=_COMPILE_FLAGS,
+        compile_flags=COMPILE_FLAGS,
     )
     def _func(block_M, block_N, ctx_splits, threads):
         shape_q = [batch, heads, dim]
@@ -60,7 +52,23 @@ def _gqa_decode_paged_bs1_ctx_kernel(
         shape_o = [batch, heads, dim]
         part_shape = [batch, heads, ctx_splits, dim]
         lse_shape = [batch, heads, ctx_splits]
-        policy = T.GemmWarpPolicy.FullRow
+        consumer = make_gqa_decode_bs1_consumer(
+            block_M,
+            block_N,
+            dim,
+            scale,
+            kv_group_num,
+            ns,
+            accum_dtype,
+        )
+        combine = make_gqa_decode_bs1_combine(
+            batch,
+            heads,
+            ctx_splits,
+            dim,
+            dtype,
+            accum_dtype,
+        )
 
         @T.macro
         def _split(
@@ -127,81 +135,29 @@ def _gqa_decode_paged_bs1_ctx_kernel(
                         )
                         T.mbarrier_arrive(ready[k % ns])
                 else:  # consumer
-                    T.fill(acc_o, 0)
-                    T.fill(logsum, 0)
-                    T.fill(sm, -T.infinity(accum_dtype))
-                    T.copy(
-                        Q[bid, hid * kv_group_num : hid * kv_group_num + kv_group_num, :],
-                        Qs[0:kv_group_num, :],
+                    consumer(
+                        Q,
+                        bid,
+                        hid,
+                        sid,
+                        this_len,
+                        loop_range,
+                        Qs,
+                        Ks,
+                        Vs,
+                        Ps,
+                        ready,
+                        free,
+                        acc_s,
+                        acc_o,
+                        sm,
+                        smp,
+                        alpha,
+                        ss,
+                        logsum,
+                        glse,
+                        Output_partial,
                     )
-                    for k in T.serial(loop_range):
-                        T.mbarrier_wait_parity(ready[k % ns], (k // ns) % ns)
-                        T.wgmma_gemm(
-                            Qs,
-                            Ks[k % ns, :, :],
-                            acc_s,
-                            transpose_B=True,
-                            policy=policy,
-                            clear_accum=True,
-                        )
-                        T.wait_wgmma(0)
-                        for i, j in T.Parallel(block_M, block_N):
-                            acc_s[i, j] = T.if_then_else(
-                                k * block_N + j < this_len, acc_s[i, j], -T.infinity(accum_dtype)
-                            )
-                        T.copy(sm, smp)
-                        T.reduce_max(acc_s, sm, dim=1, clear=False)
-                        for i in T.Parallel(block_M):
-                            alpha[i] = T.exp2(smp[i] * scale - sm[i] * scale)
-                        for i, j in T.Parallel(block_M, block_N):
-                            acc_s[i, j] = T.exp2(acc_s[i, j] * scale - sm[i] * scale)
-                        T.reduce_sum(acc_s, ss, dim=1)
-                        for i in T.Parallel(block_M):
-                            logsum[i] = logsum[i] * alpha[i] + ss[i]
-                        for i, j in T.Parallel(block_M, dim):
-                            acc_o[i, j] *= alpha[i]
-                        T.copy(acc_s, Ps)
-                        T.wgmma_gemm(Ps, Vs[k % ns, :, :], acc_o, policy=policy, clear_accum=False)
-                        T.wait_wgmma(0)
-                        T.mbarrier_arrive(free[k % ns])
-                    for i, j in T.Parallel(block_M, dim):
-                        acc_o[i, j] /= logsum[i]
-                    for i in T.Parallel(block_M):
-                        if i < kv_group_num:
-                            glse[bid, hid * kv_group_num + i, sid] = (
-                                T.log2(logsum[i]) + sm[i] * scale
-                            )
-                    for i, j in T.Parallel(block_M, dim):
-                        if i < kv_group_num:
-                            Output_partial[bid, hid * kv_group_num + i, sid, j] = acc_o[i, j]
-
-        @T.macro
-        def _combine(
-            glse: T.Tensor(lse_shape, accum_dtype),
-            Output_partial: T.Tensor(part_shape, accum_dtype),
-            Output: T.Tensor(shape_o, dtype),
-        ):
-            with T.Kernel(heads, batch, threads=128) as (hq, bid):
-                lse_vec = T.alloc_fragment([ctx_splits], accum_dtype)
-                lse_max = T.alloc_fragment([1], accum_dtype)
-                lse_logsum = T.alloc_local([1], accum_dtype)
-                o_accum = T.alloc_fragment([dim], accum_dtype)
-
-                for s in T.Parallel(ctx_splits):
-                    lse_vec[s] = glse[bid, hq, s]
-                T.fill(lse_max, -T.infinity(accum_dtype))
-                T.reduce_max(lse_vec, lse_max, dim=0, clear=False)
-                lse_logsum[0] = 0
-                for s in T.serial(ctx_splits):
-                    lse_logsum[0] += T.exp2(glse[bid, hq, s] - lse_max[0])
-                lse_logsum[0] = T.log2(lse_logsum[0]) + lse_max[0]
-                T.clear(o_accum)
-                for s in T.serial(ctx_splits):
-                    w = T.exp2(glse[bid, hq, s] - lse_logsum[0])
-                    for j in T.Parallel(dim):
-                        o_accum[j] += Output_partial[bid, hq, s, j] * w
-                for j in T.Parallel(dim):
-                    Output[bid, hq, j] = T.cast(o_accum[j], dtype)
 
         @T.prim_func
         def gqa_decode_paged_bs1_ctx(
@@ -215,7 +171,7 @@ def _gqa_decode_paged_bs1_ctx_kernel(
             Output: T.Tensor(shape_o, dtype),
         ):
             _split(Q, K, V, real_seqlen_kv, block_table, glse, Output_partial)
-            _combine(glse, Output_partial, Output)
+            combine(glse, Output_partial, Output)
 
         return gqa_decode_paged_bs1_ctx
 
@@ -291,6 +247,15 @@ class GQADecodePagedBs1Kernel(Kernel):
     # Powers of two TileLang lowers cleanly; the largest dividing the KV length balances slices.
     _CTX_SPLIT_CANDIDATES = (32, 16, 8)
 
+    @staticmethod
+    def block_n_for_page_size(page_size: int) -> Optional[int]:
+        """Return a page-contained WGMMA N tile, or None when the fast path is unsafe."""
+        if page_size == 64:
+            return 64
+        if page_size >= 128 and page_size % 128 == 0:
+            return 128
+        return None
+
     def __init__(
         self,
         batch,
@@ -327,7 +292,12 @@ class GQADecodePagedBs1Kernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        return {"block_M": 64, "block_N": min(128, self.page_size), "threads": 160}
+        block_n = self.block_n_for_page_size(self.page_size)
+        if block_n is None:
+            raise ValueError(
+                "batch=1 paged decode requires page_size=64 or a multiple of 128"
+            )
+        return {"block_M": 64, "block_N": block_n, "threads": 160}
 
     def _select_tier(self, real_seqlen_kv: int) -> str:
         return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
@@ -350,7 +320,6 @@ class GQADecodePagedBs1Kernel(Kernel):
         c = self.config
         real_max = int(real_seqlen_kv.max().item())
         if real_max < self._MIN_CTX:
-            block_N = min(128, self.page_size)
             return _gqa_decode_paged_no_split_op(
                 self.batch,
                 self.heads,
@@ -362,7 +331,7 @@ class GQADecodePagedBs1Kernel(Kernel):
                 self.softcap,
                 self.dtype_str,
                 64,
-                block_N,
+                c["block_N"],
                 2,
                 128,
                 Q,

--- a/tileops/kernels/attention/gqa_decode_bs1_paged.py
+++ b/tileops/kernels/attention/gqa_decode_bs1_paged.py
@@ -25,8 +25,9 @@ from tileops.kernels.online_softmax import LOG2E
 from .gqa_decode_bs1_common import (
     COMPILE_FLAGS,
     RING_DEPTH,
+    GQADecodeBs1KernelMixin,
     make_gqa_decode_bs1_combine,
-    make_gqa_decode_bs1_consumer,
+    make_gqa_decode_bs1_split,
 )
 
 __all__ = ["GQADecodePagedBs1Kernel"]
@@ -40,7 +41,6 @@ def _gqa_decode_paged_bs1_ctx_kernel(
     scale = score_scale * LOG2E
     accum_dtype = "float"
     kv_group_num = heads // groups
-    ns = RING_DEPTH
 
     @tilelang.jit(
         out_idx=[-1],
@@ -55,14 +55,39 @@ def _gqa_decode_paged_bs1_ctx_kernel(
         shape_o = [batch, heads, dim]
         part_shape = [batch, heads, ctx_splits, dim]
         lse_shape = [batch, heads, ctx_splits]
-        consumer = make_gqa_decode_bs1_consumer(
+
+        @T.macro
+        def load_kv(K, V, block_table, bid, hid, base, k, Ks, Vs, ready):
+            logical_block = base // block_N + k
+            blocks_per_page = page_size // block_N
+            page_idx = logical_block // blocks_per_page
+            block_in_page = logical_block % blocks_per_page
+            physical_block = block_table[bid, page_idx] * blocks_per_page + block_in_page
+            T.tma_copy(
+                K[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
+                Ks[k % RING_DEPTH, :, :],
+                barrier=ready[k % RING_DEPTH],
+            )
+            T.tma_copy(
+                V[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
+                Vs[k % RING_DEPTH, :, :],
+                barrier=ready[k % RING_DEPTH],
+            )
+
+        split = make_gqa_decode_bs1_split(
+            batch,
+            groups,
             block_M,
             block_N,
             dim,
+            dtype,
             scale,
             kv_group_num,
-            ns,
+            ctx_splits,
+            threads,
             accum_dtype,
+            True,
+            load_kv,
         )
         combine = make_gqa_decode_bs1_combine(
             batch,
@@ -72,95 +97,6 @@ def _gqa_decode_paged_bs1_ctx_kernel(
             dtype,
             accum_dtype,
         )
-
-        @T.macro
-        def _split(
-            Q: T.Tensor(shape_q, dtype),
-            K: T.Tensor(shape_k, dtype),
-            V: T.Tensor(shape_k, dtype),
-            real_seqlen_kv: T.Tensor([batch], T.int32),
-            block_table: T.Tensor([batch, seqlen_kv // page_size], T.int32),
-            glse: T.Tensor(lse_shape, accum_dtype),
-            Output_partial: T.Tensor(part_shape, accum_dtype),
-        ):
-            with T.Kernel(batch, groups, ctx_splits, threads=threads) as (bid, hid, sid):
-                Qs = T.alloc_shared([block_M, dim], dtype)
-                Ks = T.alloc_shared([ns, block_N, dim], dtype)
-                Vs = T.alloc_shared([ns, block_N, dim], dtype)
-                Ps = T.alloc_shared([block_M, block_N], dtype)
-                T.annotate_layout(
-                    {
-                        Qs: tilelang.layout.make_swizzled_layout(Qs),
-                        Ks: tilelang.layout.make_swizzled_layout(Ks),
-                        Vs: tilelang.layout.make_swizzled_layout(Vs),
-                        Ps: tilelang.layout.make_swizzled_layout(Ps),
-                    }
-                )
-                ready = T.alloc_barrier([32] * ns)  # producer -> consumer
-                free = T.alloc_barrier([128] * ns)  # consumer -> producer
-                acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
-                acc_o = T.alloc_fragment([block_M, dim], accum_dtype)
-                sm = T.alloc_fragment([block_M], accum_dtype)
-                smp = T.alloc_fragment([block_M], accum_dtype)
-                alpha = T.alloc_fragment([block_M], accum_dtype)
-                ss = T.alloc_fragment([block_M], accum_dtype)
-                logsum = T.alloc_fragment([block_M], accum_dtype)
-
-                # Redistribute over the real length so every split holds a full tile.
-                seqlen_kv_b = real_seqlen_kv[bid]
-                base_len = seqlen_kv_b // (ctx_splits * block_N) * block_N
-                this_len = T.if_then_else(
-                    sid == ctx_splits - 1, seqlen_kv_b - (ctx_splits - 1) * base_len, base_len
-                )
-                base = base_len * sid
-                loop_range = T.ceildiv(this_len, block_N)
-                tx = T.get_thread_binding()
-
-                if tx >= 128:  # producer
-                    for k in T.serial(loop_range):
-                        T.mbarrier_wait_parity(free[k % ns], ((k // ns) % ns) ^ 1)
-                        logical_block = base // block_N + k
-                        blocks_per_page = page_size // block_N
-                        page_idx = logical_block // blocks_per_page
-                        block_in_page = logical_block % blocks_per_page
-                        physical_block = (
-                            block_table[bid, page_idx] * blocks_per_page + block_in_page
-                        )
-                        T.tma_copy(
-                            K[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
-                            Ks[k % ns, :, :],
-                            barrier=ready[k % ns],
-                        )
-                        T.tma_copy(
-                            V[physical_block * block_N : (physical_block + 1) * block_N, hid, :],
-                            Vs[k % ns, :, :],
-                            barrier=ready[k % ns],
-                        )
-                        T.mbarrier_arrive(ready[k % ns])
-                else:  # consumer
-                    consumer(
-                        Q,
-                        bid,
-                        hid,
-                        sid,
-                        this_len,
-                        loop_range,
-                        Qs,
-                        Ks,
-                        Vs,
-                        Ps,
-                        ready,
-                        free,
-                        acc_s,
-                        acc_o,
-                        sm,
-                        smp,
-                        alpha,
-                        ss,
-                        logsum,
-                        glse,
-                        Output_partial,
-                    )
 
         @T.prim_func
         def gqa_decode_paged_bs1_ctx(
@@ -173,7 +109,7 @@ def _gqa_decode_paged_bs1_ctx_kernel(
             Output_partial: T.Tensor(part_shape, accum_dtype),
             Output: T.Tensor(shape_o, dtype),
         ):
-            _split(Q, K, V, real_seqlen_kv, block_table, glse, Output_partial)
+            split(Q, K, V, block_table, real_seqlen_kv, glse, Output_partial)
             combine(glse, Output_partial, Output)
 
         return gqa_decode_paged_bs1_ctx
@@ -237,7 +173,7 @@ def _(
     return torch.empty_like(Q)
 
 
-class GQADecodePagedBs1Kernel(Kernel):
+class GQADecodePagedBs1Kernel(GQADecodeBs1KernelMixin, Kernel):
     """Hopper warp-specialized batch=1 paged GQA decode kernel.
 
     ``forward`` dispatches on the runtime ``real_seqlen_kv``: >= 1024 runs the context-only
@@ -246,15 +182,16 @@ class GQADecodePagedBs1Kernel(Kernel):
 
     supported_archs: list[int] = [90]
 
-    _MIN_CTX = 1024
-    # Powers of two TileLang lowers cleanly; the largest dividing the KV length balances slices.
-    _CTX_SPLIT_CANDIDATES = (32, 16, 8)
-
     @staticmethod
     def block_n_for_page_size(page_size: int) -> Optional[int]:
         """Return a page-contained WGMMA N tile, or None when the fast path is unsafe."""
-        block_n = gqa_decode_paged_block_n(page_size)
-        return block_n if block_n in (64, 128) and page_size % block_n == 0 else None
+        try:
+            block_n = gqa_decode_paged_block_n(page_size)
+        except ValueError:
+            return None
+        if page_size == 64 or block_n == 128:
+            return block_n
+        return None
 
     def __init__(
         self,
@@ -299,16 +236,6 @@ class GQADecodePagedBs1Kernel(Kernel):
             )
         return {"block_M": 64, "block_N": block_n, "threads": 160}
 
-    def _select_tier(self, real_seqlen_kv: int) -> str:
-        return "ctx" if real_seqlen_kv >= self._MIN_CTX else "no_split"
-
-    def _ctx_splits_for(self, real_seqlen_kv: int) -> int:
-        block_N = self.config["block_N"]
-        for cs in self._CTX_SPLIT_CANDIDATES:
-            if real_seqlen_kv % (cs * block_N) == 0:
-                return cs
-        return self._CTX_SPLIT_CANDIDATES[-1]
-
     def forward(
         self,
         Q: torch.Tensor,
@@ -342,12 +269,7 @@ class GQADecodePagedBs1Kernel(Kernel):
             )
 
         ctx_splits = self._ctx_splits_for(real_max)
-        glse = torch.empty(
-            (self.batch, self.heads, ctx_splits), dtype=torch.float32, device=Q.device
-        )
-        Output_partial = torch.empty(
-            (self.batch, self.heads, ctx_splits, self.dim), dtype=torch.float32, device=Q.device
-        )
+        glse, Output_partial = self._allocate_partials(Q, ctx_splits)
         return _gqa_decode_paged_bs1_ctx_op(
             self.batch,
             self.heads,

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -38,7 +38,6 @@ def gqa_decode_paged_block_n(page_size: int) -> int:
     """Return the widest page-contained N tile supported by generic paged decode."""
     return gqa_decode_paged_block_ns(page_size)[0]
 
-
 # JIT kernel: no-split variant (paged)
 
 

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -135,6 +135,9 @@ def _gqa_decode_no_split_paged_kernel(
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale, scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
+                    T.copy(
+                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
+                          cur_kv_head, :], V_shared)
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     acc_o[i, j] = T.if_then_else(logsum[i] == 0, 0, acc_o[i, j] / logsum[i])
@@ -276,6 +279,9 @@ def _gqa_decode_split_paged_kernel(
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale, scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
+                    T.copy(
+                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
+                          cur_kv_head, :], V_shared)
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     # When loop_range was 0 (split entirely beyond real_seqlen_kv), logsum=0 -> avoid 0/0

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -431,6 +431,16 @@ class GQADecodePagedKernel(Kernel):
                 raise ValueError(
                     f"block_N={block_n} is not supported for page_size={page_size}"
                 )
+        if self.groups <= 0:
+            raise ValueError("groups must be positive")
+        if self.heads % self.groups != 0:
+            raise ValueError("heads must be divisible by groups")
+        if self.seqlen_kv <= 0:
+            raise ValueError("seqlen_kv must be positive")
+        if self.page_size <= 0:
+            raise ValueError("page_size must be positive")
+        if self.seqlen_kv % self.page_size != 0:
+            raise ValueError("seqlen_kv must be divisible by page_size")
 
         self.no_split_jit = _gqa_decode_no_split_paged_kernel(
             self.batch, self.heads, self.groups, self.seqlen_kv, self.dim, self.page_size,

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -518,6 +518,9 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
       - "H % H_kv == 0"
 
   workloads:
+    # Qwen3-30B-A3B batch=1 Hopper fast path.
+    - {q_shape: [1, 32, 128], kv_shape: [4096, 4, 128], page_size: 256, dtypes: [float16], label: "qwen3-30b-a3b-bs1-4k-p256"}
+    - {q_shape: [1, 32, 128], kv_shape: [32768, 4, 128], page_size: 256, dtypes: [float16], label: "qwen3-30b-a3b-bs1-32k-p256"}
     - {q_shape: [32, 32, 128], kv_shape: [4096, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-p64"}
     - {q_shape: [8, 32, 128], kv_shape: [32768, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-long-p64"}
     - {q_shape: [64, 32, 128], kv_shape: [2048, 8, 128], page_size: 64, dtypes: [float16], label: "throughput-8b-p64"}
@@ -537,6 +540,7 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
     kernel: tileops/kernels/attention/gqa_decode_paged.py
     kernel_map:
       gqa_decode_paged_kernel: GQADecodePagedKernel
+      gqa_decode_paged_bs1_kernel: GQADecodePagedBs1Kernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_decode_paged.py
     bench: benchmarks/ops/attention/bench_gqa_decode_paged.py

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -518,9 +518,6 @@ GroupedQueryAttentionDecodePagedWithKVCacheFwdOp:
       - "H % H_kv == 0"
 
   workloads:
-    # Qwen3-30B-A3B batch=1 Hopper fast path.
-    - {q_shape: [1, 32, 128], kv_shape: [4096, 4, 128], page_size: 256, dtypes: [float16], label: "qwen3-30b-a3b-bs1-4k-p256"}
-    - {q_shape: [1, 32, 128], kv_shape: [32768, 4, 128], page_size: 256, dtypes: [float16], label: "qwen3-30b-a3b-bs1-32k-p256"}
     - {q_shape: [32, 32, 128], kv_shape: [4096, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-p64"}
     - {q_shape: [8, 32, 128], kv_shape: [32768, 8, 128], page_size: 64, dtypes: [float16], label: "serving-8b-long-p64"}
     - {q_shape: [64, 32, 128], kv_shape: [2048, 8, 128], page_size: 64, dtypes: [float16], label: "throughput-8b-p64"}

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -1498,7 +1498,8 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
             return False
         # The TMA producer must load a complete WGMMA N tile without crossing
         # a potentially non-contiguous page boundary.
-        if self.page_size < 64 or self.page_size % 64 != 0:
+        block_n = min(128, self.page_size)
+        if self.page_size < 64 or self.page_size % block_n != 0:
             return False
         return 1 <= self.heads // self.heads_kv <= 64
 

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -69,6 +69,28 @@ def _validate_attention_dtype(dtype: torch.dtype) -> None:
         raise ValueError(f"Expected dtype torch.float16 or torch.bfloat16, got {dtype}")
 
 
+def _supports_gqa_decode_bs1(
+    batch: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    dtype: torch.dtype,
+    softcap: float,
+) -> bool:
+    """Return whether the common Hopper batch=1 GQA decode contract is satisfied."""
+    if not (
+        batch == 1
+        and is_hopper()
+        and dtype == torch.float16
+        and dim == 128
+        and softcap == 0.0
+    ):
+        return False
+    if heads_kv <= 0 or heads % heads_kv != 0:
+        return False
+    return 1 <= heads // heads_kv <= 64
+
+
 def _supports_gqa_ws_noncausal(
     batch: int,
     heads: int,
@@ -1417,12 +1439,14 @@ class GroupedQueryAttentionDecodeWithKVCacheFwdOp(Op):
         one wgmma tile routes to GQADecodeBs1Kernel, which then switches on the runtime KV
         length in forward().
         """
-        if not (self.batch == 1 and is_hopper() and self.dtype == torch.float16
-                and self.dim == 128 and self.softcap == 0.0):
-            return False
-        if self.heads % self.heads_kv != 0:
-            return False
-        return 1 <= self.heads // self.heads_kv <= 64
+        return _supports_gqa_decode_bs1(
+            self.batch,
+            self.heads,
+            self.heads_kv,
+            self.dim,
+            self.dtype,
+            self.softcap,
+        )
 
     def _select_decode_kernel_key(self) -> str:
         if self._uses_bs1_fast_path():
@@ -1468,6 +1492,11 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         if page_size <= 0:
             raise ValueError("page_size must be positive")
         block_n = min(128, page_size)
+        # FIXME(staged-rollout): reject page layouts unsupported by the generic fallback.
+        #
+        # Broken invariant: unsupported batch=1 page layouts should fall back to generic decode.
+        # Why: generic paged address translation currently requires page_size to divide block_N.
+        # Cleanup: remove this guard once generic paged decode supports page-aligned ragged tiling.
         if page_size % block_n != 0:
             raise ValueError("page_size must be divisible by the paged decode block_N")
         self.dtype = dtype
@@ -1496,17 +1525,14 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         return kernel_map
 
     def _uses_bs1_fast_path(self) -> bool:
-        if not (self.batch == 1 and is_hopper() and self.dtype == torch.float16
-                and self.dim == 128 and self.softcap == 0.0):
-            return False
-        if self.heads % self.heads_kv != 0:
-            return False
-        # The TMA producer must load a complete WGMMA N tile without crossing
-        # a potentially non-contiguous page boundary.
-        block_n = min(128, self.page_size)
-        if self.page_size < 64 or self.page_size % block_n != 0:
-            return False
-        return 1 <= self.heads // self.heads_kv <= 64
+        return _supports_gqa_decode_bs1(
+            self.batch,
+            self.heads,
+            self.heads_kv,
+            self.dim,
+            self.dtype,
+            self.softcap,
+        ) and GQADecodePagedBs1Kernel.block_n_for_page_size(self.page_size) is not None
 
     def _select_decode_kernel_key(self) -> str:
         if self._uses_bs1_fast_path():

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -30,6 +30,7 @@ from tileops.kernels.attention import (
     GQASlidingWindowVarlenFwdKernel,
     GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
 )
+from tileops.kernels.attention.gqa_decode_paged import gqa_decode_paged_block_n
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import is_h200, is_hopper
 
@@ -1491,7 +1492,7 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.page_size = page_size
         if page_size <= 0:
             raise ValueError("page_size must be positive")
-        block_n = min(128, page_size)
+        block_n = gqa_decode_paged_block_n(page_size)
         # FIXME(staged-rollout): reject page layouts unsupported by the generic fallback.
         #
         # Broken invariant: unsupported batch=1 page layouts should fall back to generic decode.
@@ -1525,6 +1526,7 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         return kernel_map
 
     def _uses_bs1_fast_path(self) -> bool:
+        """Use the paged Hopper fast path only when its TMA tile stays within one page."""
         return _supports_gqa_decode_bs1(
             self.batch,
             self.heads,

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -1465,6 +1465,11 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.seqlen_kv = seqlen_kv
         self.dim = dim
         self.page_size = page_size
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+        block_n = min(128, page_size)
+        if page_size % block_n != 0:
+            raise ValueError("page_size must be divisible by the paged decode block_N")
         self.dtype = dtype
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -11,6 +11,7 @@ from tileops.kernels.attention import (
     GQABwdWgmmaPipelinedKernel,
     GQADecodeBs1Kernel,
     GQADecodeKernel,
+    GQADecodePagedBs1Kernel,
     GQADecodePagedKernel,
     GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
     GQAFwdKernel,
@@ -1469,7 +1470,7 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.softcap = _score_softcap(softcap)
 
         self.dispatch_kernel(kernel_map)
-        self.kernel = self.kernel_map["gqa_decode_paged_kernel"](
+        self.kernel = self.kernel_map[self._select_decode_kernel_key()](
             batch,
             heads,
             heads_kv,
@@ -1484,7 +1485,27 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"gqa_decode_paged_kernel": GQADecodePagedKernel}
+        kernel_map: Dict[str, Kernel] = {"gqa_decode_paged_kernel": GQADecodePagedKernel}
+        if is_hopper():
+            kernel_map["gqa_decode_paged_bs1_kernel"] = GQADecodePagedBs1Kernel
+        return kernel_map
+
+    def _uses_bs1_fast_path(self) -> bool:
+        if not (self.batch == 1 and is_hopper() and self.dtype == torch.float16
+                and self.dim == 128 and self.softcap == 0.0):
+            return False
+        if self.heads % self.heads_kv != 0:
+            return False
+        # The TMA producer must load a complete WGMMA N tile without crossing
+        # a potentially non-contiguous page boundary.
+        if self.page_size < 64 or self.page_size % 64 != 0:
+            return False
+        return 1 <= self.heads // self.heads_kv <= 64
+
+    def _select_decode_kernel_key(self) -> str:
+        if self._uses_bs1_fast_path():
+            return "gqa_decode_paged_bs1_kernel"
+        return "gqa_decode_paged_kernel"
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
                 real_seqlen_kv: torch.Tensor, block_table: torch.Tensor) -> torch.Tensor:

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -30,7 +30,6 @@ from tileops.kernels.attention import (
     GQASlidingWindowVarlenFwdKernel,
     GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
 )
-from tileops.kernels.attention.gqa_decode_paged import gqa_decode_paged_block_n
 from tileops.kernels.kernel_base import Kernel
 from tileops.utils import is_h200, is_hopper
 
@@ -1492,14 +1491,6 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.page_size = page_size
         if page_size <= 0:
             raise ValueError("page_size must be positive")
-        block_n = gqa_decode_paged_block_n(page_size)
-        # FIXME(staged-rollout): reject page layouts unsupported by the generic fallback.
-        #
-        # Broken invariant: unsupported batch=1 page layouts should fall back to generic decode.
-        # Why: generic paged address translation currently requires page_size to divide block_N.
-        # Cleanup: remove this guard once generic paged decode supports page-aligned ragged tiling.
-        if page_size % block_n != 0:
-            raise ValueError("page_size must be divisible by the paged decode block_N")
         self.dtype = dtype
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)


### PR DESCRIPTION
## Summary

- Add a Hopper batch-1 TMA/WGMMA fast path for paged GQA decode.
- Resolve logical KV tiles through `block_table` while keeping fast-path TMA tiles page-contained.
- Share the context-split schedule, buffers/barriers, consumer/combine math, tier policy, and partial allocation with contiguous batch-1 decode.
- Add dispatch and numerical coverage for both runtime tiers, including reversed page tables.

## Validation

Official runner image: `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`.

- `pytest -q tests/ops/attention/test_gqa_decode_paged.py tests/ops/attention/test_gqa_decode.py` -> 36 passed.
- Coverage includes no-split, context-split, reversed pages, paged dispatch/fallback contracts, and contiguous decode regression coverage.
- H200 smoke: 4K KV TileOps 16.8 us vs FlashInfer 26.4 us; 32K KV TileOps 63.4 us vs FlashInfer 58.6 us.
