### PR TITLE
[Perf][Attention] Pipeline KV loads and fix page tiling in generic paged GQA decode

### DIFF
--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -104,6 +104,24 @@ def test_gqa_decode_paged_op(
 
 
 @pytest.mark.smoke
+def test_gqa_decode_paged_non_divisible_128_page_split() -> None:
+    """page_size=192 uses 64-token tiles without skipping page tails."""
+    batch, heads, heads_kv, seqlen_kv, dim, page_size = 1, 16, 4, 3072, 128, 192
+    test = GroupedQueryAttentionDecodePagedTest(
+        batch, heads, heads_kv, seqlen_kv, dim, page_size, torch.float16)
+    q, k, v, real_seqlen_kv, block_table = test.gen_inputs()
+    real_seqlen_kv.fill_(seqlen_kv)
+    block_table.copy_(torch.arange(
+        seqlen_kv // page_size, device="cuda", dtype=torch.int32).flip(0).unsqueeze(0))
+    op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+        batch, heads, heads_kv, seqlen_kv, dim, page_size, torch.float16)
+    assert op.kernel.config["block_N"] == 64
+    test.check(
+        op, q, k, v, real_seqlen_kv, block_table,
+        compare=test._maxdiff_cosine_compare)
+
+
+@pytest.mark.smoke
 @pytest.mark.parametrize("sm_scale, softcap", [
     pytest.param(0.25, None, id="custom-sm-scale"),
     pytest.param(None, 2.0, id="softcap"),

--- a/tests/ops/attention/test_gqa_decode_paged.py
+++ b/tests/ops/attention/test_gqa_decode_paged.py
@@ -115,10 +115,21 @@ def test_gqa_decode_paged_non_divisible_128_page_split() -> None:
         seqlen_kv // page_size, device="cuda", dtype=torch.int32).flip(0).unsqueeze(0))
     op = GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, heads_kv, seqlen_kv, dim, page_size, torch.float16)
-    assert op.kernel.config["block_N"] == 64
+    assert page_size % op.kernel.config["block_N"] == 0
+    assert {config["block_N"] for config in op.kernel.autotune_configs} == {64}
     test.check(
         op, q, k, v, real_seqlen_kv, block_table,
         compare=test._maxdiff_cosine_compare)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("page_size", [96, 160, 224])
+def test_gqa_decode_paged_rejects_unsupported_page_tile(page_size: int) -> None:
+    """Reject page layouts that no supported generic N tile can cover exactly."""
+    seqlen_kv = page_size * 16
+    with pytest.raises(ValueError, match="matches no supported block_N"):
+        GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(
+            1, 16, 4, seqlen_kv, 128, page_size, torch.float16)
 
 
 @pytest.mark.smoke

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -16,6 +16,29 @@ from tileops.kernels.online_softmax import (
 
 __all__ = ["GQADecodePagedKernel"]
 
+
+def gqa_decode_paged_block_ns(page_size: int) -> tuple[int, ...]:
+    """Return page-contained N tiles supported by generic paged decode."""
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+
+    block_ns = tuple(
+        block_n
+        for block_n in (128, 64)
+        if block_n <= page_size and page_size % block_n == 0
+    )
+    if block_ns:
+        return block_ns
+    if page_size < 64:
+        return (page_size,)
+    raise ValueError(f"page_size={page_size} matches no supported block_N")
+
+
+def gqa_decode_paged_block_n(page_size: int) -> int:
+    """Return the widest page-contained N tile supported by generic paged decode."""
+    return gqa_decode_paged_block_ns(page_size)[0]
+
+
 # JIT kernel: no-split variant (paged)
 
 
@@ -93,8 +116,7 @@ def _gqa_decode_no_split_paged_kernel(
                     T.copy(
                         K[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], K_shared)
-                    # Match prefill's pipeline: issue both KV loads before QK
-                    # so the next iteration's copies can overlap the GEMMs.
+                    # Issue both K/V loads before QK so copies can overlap the GEMMs.
                     T.copy(
                         V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], V_shared)
@@ -233,7 +255,7 @@ def _gqa_decode_split_paged_kernel(
                     T.copy(
                         K[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], K_shared)
-                    # Keep K/V in one producer stage, as in the prefill kernel.
+                    # Issue both K/V loads before QK so copies can overlap the GEMMs.
                     T.copy(
                         V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], V_shared)
@@ -402,6 +424,13 @@ class GQADecodePagedKernel(Kernel):
         self.dtype = dtype
         self.sm_scale = dim**-0.5 if sm_scale is None else sm_scale
         self.softcap = softcap
+        self._supported_block_ns = gqa_decode_paged_block_ns(page_size)
+        if config is not None:
+            block_n = config.get("block_N")
+            if block_n is not None and block_n not in self._supported_block_ns:
+                raise ValueError(
+                    f"block_N={block_n} is not supported for page_size={page_size}"
+                )
 
         self.no_split_jit = _gqa_decode_no_split_paged_kernel(
             self.batch, self.heads, self.groups, self.seqlen_kv, self.dim, self.page_size,
@@ -462,16 +491,12 @@ class GQADecodePagedKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # Each KV tile must stay within one physical page. Prefer the widest
-        # supported tile that divides the page exactly.
-        block_N = min(128, self.page_size)
-        if self.page_size >= 64 and self.page_size % block_N != 0:
-            block_N = 64
+        block_N = gqa_decode_paged_block_n(self.page_size)
         return {"block_H": 64, "block_N": block_N, "num_split": 16, "num_stages": 2, "threads": 128}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_N = [64, 128]
+        block_N = self._supported_block_ns
         block_H = [64]
         num_split = [2, 4, 8]
         num_stages = [1, 2, 3]
@@ -484,8 +509,7 @@ class GQADecodePagedKernel(Kernel):
             'num_split': c[2],
             'num_stages': c[3],
             'threads': c[4]
-        } for c in _configs
-                   if c[0] <= self.page_size and self.page_size % c[0] == 0]
+        } for c in _configs]
         return configs
 
     def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor,

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -93,6 +93,11 @@ def _gqa_decode_no_split_paged_kernel(
                     T.copy(
                         K[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], K_shared)
+                    # Match prefill's pipeline: issue both KV loads before QK
+                    # so the next iteration's copies can overlap the GEMMs.
+                    T.copy(
+                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
+                          cur_kv_head, :], V_shared)
                     T.clear(acc_s)
                     T.gemm(
                         Q_shared,
@@ -108,9 +113,6 @@ def _gqa_decode_no_split_paged_kernel(
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale, scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
-                    T.copy(
-                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
-                          cur_kv_head, :], V_shared)
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     acc_o[i, j] = T.if_then_else(logsum[i] == 0, 0, acc_o[i, j] / logsum[i])
@@ -231,6 +233,10 @@ def _gqa_decode_split_paged_kernel(
                     T.copy(
                         K[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
                           cur_kv_head, :], K_shared)
+                    # Keep K/V in one producer stage, as in the prefill kernel.
+                    T.copy(
+                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
+                          cur_kv_head, :], V_shared)
                     T.clear(acc_s)
                     T.gemm(
                         Q_shared,
@@ -248,9 +254,6 @@ def _gqa_decode_split_paged_kernel(
                     online_softmax(acc_s, scores_max, scores_max_prev, scores_scale, scores_sum, logsum)
                     T.copy(acc_s, acc_s_cast)
                     rescale(acc_o, scores_scale)
-                    T.copy(
-                        V[blockn_num_offset * block_N:(blockn_num_offset + 1) * block_N,
-                          cur_kv_head, :], V_shared)
                     T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
                 for i, j in T.Parallel(block_H, dim):
                     # When loop_range was 0 (split entirely beyond real_seqlen_kv), logsum=0 -> avoid 0/0

--- a/tileops/kernels/attention/gqa_decode_paged.py
+++ b/tileops/kernels/attention/gqa_decode_paged.py
@@ -462,8 +462,11 @@ class GQADecodePagedKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # block_N must be <= page_size so num_blockn_in_page = page_size // block_N >= 1 (no div by zero)
+        # Each KV tile must stay within one physical page. Prefer the widest
+        # supported tile that divides the page exactly.
         block_N = min(128, self.page_size)
+        if self.page_size >= 64 and self.page_size % block_N != 0:
+            block_N = 64
         return {"block_H": 64, "block_N": block_N, "num_split": 16, "num_stages": 2, "threads": 128}
 
     @property
@@ -481,7 +484,8 @@ class GQADecodePagedKernel(Kernel):
             'num_split': c[2],
             'num_stages': c[3],
             'threads': c[4]
-        } for c in _configs if c[0] <= self.page_size]
+        } for c in _configs
+                   if c[0] <= self.page_size and self.page_size % c[0] == 0]
         return configs
 
     def forward(self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor,


### PR DESCRIPTION
## Summary

- issue both K and V shared-memory loads before the QK GEMM in generic paged GQA decode, for both no-split and split paths
- derive default, autotune, and custom-config `block_N` legality from one page-coverage helper
- add output-correctness coverage for a 3072-token split request with a reversed page table, plus construction-time rejection coverage for unsupported page layouts

## Correctness

The old address translation used `num_blockn_in_page = page_size // block_N`, so `page_size=192` with `block_N=128` skipped the last 64 tokens of every physical page. The generic default now selects the widest supported tile that divides the page exactly: `block_N=64` for `page_size=192`.

Layouts such as page sizes 96, 160, and 224 match neither supported tile width and now fail explicitly before JIT instead of silently dropping page tails. The same supported-tile set drives default config, autotune candidates, and custom-config validation.

This is the generic-path prerequisite for #1783. Landing order should be #1787 first, then rebase #1783 and remove its temporary `FIXME(staged-rollout)` constructor rejection in the same update.

## H200 benchmark

Image: `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`; 300 warmup iterations, 13 samples × 500 iterations, median latency.

| Shape / path | Before | After | Improvement |
|---|---:|---:|---:|
| B=8, page=256, real KV=512 (no-split) | 68.07 us | 63.27 us | 7.1% |
| B=8, page=256, real KV=4096 (split) | 192.76 us | 180.14 us | 6.5% |
| B=32, page=64, real KV=4096 (split) | 276.93 us | 266.77 us | 3.7% |

## Testing

Official runner image, GPU4/H200, repository source plus CI caches only; no dependency installation or upgrade:

```bash
python -m pytest -q tests/ops/attention/test_gqa_decode_paged.py
```

Result: `13 passed`.

The reversed `page_size=192` case checks the split path numerically. Separate smoke nodes assert that page sizes 96, 160, and 224 fail construction because no supported N tile covers each page exactly. `pre-commit` passes on both touched files.