### PR TITLE
[Fix][Bench] Vectorize DeltaNet WY reference programs

### DIFF
--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -115,23 +115,15 @@ def prepare_wy_repr_deltanet_torch(k, beta, chunk_size):
     B, H, S, DK = k.shape
     assert S % chunk_size == 0
     BC = chunk_size
-    Aw = torch.empty(B, H, S, BC, dtype=torch.float32, device=k.device)
-    Au = torch.empty(B, H, S, BC, dtype=torch.float32, device=k.device)
-
-    for b in range(B):
-        for h in range(H):
-            for c in range(S // BC):
-                i0, i1 = c * BC, (c + 1) * BC
-                kc = k[b, h, i0:i1, :].float()
-                bc = beta[b, h, i0:i1].float()
-                Gram = kc @ kc.T
-                M = bc.unsqueeze(-1) * Gram
-                A = torch.eye(BC, device=k.device) + torch.tril(M, diagonal=-1)
-                A_inv = torch.linalg.inv(A)
-                Aw[b, h, i0:i1, :] = A_inv
-                Au[b, h, i0:i1, :] = A_inv
-
-    return Aw, Au
+    NC = S // BC
+    kc = k.float().reshape(B, H, NC, BC, DK)
+    bc = beta.float().reshape(B, H, NC, BC)
+    gram = kc @ kc.transpose(-2, -1)
+    m = bc.unsqueeze(-1) * gram
+    eye = torch.eye(BC, dtype=torch.float32, device=k.device)
+    a = eye + torch.tril(m, diagonal=-1)
+    a_inv = torch.linalg.inv(a).reshape(B, H, S, BC)
+    return a_inv, a_inv.clone()
 
 
 class _DeltaNetFwdTestBaseline(DeltaNetFwdTest):

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -130,25 +130,17 @@ def prepare_wy_repr_gated_torch(k, g_cum, beta, chunk_size):
     B, H, S, DK = k.shape
     assert S % chunk_size == 0
     BC = chunk_size
-    Aw = torch.empty(B, H, S, BC, dtype=torch.float32, device=k.device)
-    Au = torch.empty(B, H, S, BC, dtype=torch.float32, device=k.device)
-
-    for b in range(B):
-        for h in range(H):
-            for c in range(S // BC):
-                i0, i1 = c * BC, (c + 1) * BC
-                kc = k[b, h, i0:i1, :].float()
-                gc = g_cum[b, h, i0:i1].float()
-                bc = beta[b, h, i0:i1].float()
-                Gram = kc @ kc.T
-                Gamma = torch.exp(gc.unsqueeze(1) - gc.unsqueeze(0))
-                M = bc.unsqueeze(-1) * (Gamma * Gram)
-                A_g = torch.eye(BC, device=k.device) + torch.tril(M, diagonal=-1)
-                A_g_inv = torch.linalg.inv(A_g)
-                Aw[b, h, i0:i1, :] = A_g_inv
-                Au[b, h, i0:i1, :] = A_g_inv
-
-    return Aw, Au
+    NC = S // BC
+    kc = k.float().reshape(B, H, NC, BC, DK)
+    gc = g_cum.float().reshape(B, H, NC, BC)
+    bc = beta.float().reshape(B, H, NC, BC)
+    gram = kc @ kc.transpose(-2, -1)
+    gamma = torch.exp(gc.unsqueeze(-1) - gc.unsqueeze(-2))
+    m = bc.unsqueeze(-1) * (gamma * gram)
+    eye = torch.eye(BC, dtype=torch.float32, device=k.device)
+    a_g = eye + torch.tril(m, diagonal=-1)
+    a_g_inv = torch.linalg.inv(a_g).reshape(B, H, S, BC)
+    return a_g_inv, a_g_inv.clone()
 
 
 class _GatedDeltaNetFwdTestBaseline(GatedDeltaNetFwdTest):


### PR DESCRIPTION
## Summary

- batch the DeltaNet WY-representation reference over batch, head, and chunk: the Python `(batch, head, chunk)` loop becomes batched Gram products + batched matrix inversion
- same vectorization for gated DeltaNet, preserving its gate-difference orientation and independent `Aw` / `Au` outputs

The profiler now sees a constant-size op sequence instead of millions of tiny `slice` / `as_strided` ops as sequence length grows.

## Numerical validation

Vectorized helpers vs. the original loop, on the benchmark workload distribution:

| Reference | WY max diff | Final output max diff |
|---|---:|---:|
| DeltaNet | 3.73e-8 | 2.98e-8 |
| Gated DeltaNet | 1.86e-8 | 1.86e-9 |

## H200 wall time

Image `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`, standard cache mounts, no dependency changes.

| Benchmark file | Result | Pytest time | Container wall time |
|---|---:|---:|---:|
| `bench_deltanet.py` | 19 passed | 17.36 s | 23.98 s |
| `bench_gated_deltanet.py` | 19 passed | 21.13 s | 31.02 s |
| both, final code | 38 passed | 32.45 s | 41.28 s |

Well under the 300 s threshold; profiler methodology unchanged.

Fixes #1786
