### PR TITLE
fix(bench): sample kernels from CUPTI collection window

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -90,57 +90,38 @@ _bench_results = threading.local()
 _bench_meta = threading.local()
 
 
-class _CuptiProjectionError(Exception):
-    """CUPTI trace lacked a projected annotation window for every repeat."""
-
-
-# Name of the ``record_function`` annotation wrapping the timed call. Kineto
-# projects this scope onto the device timeline. The L2-flush ``cache.zero_()``
-# is synchronized to completion before the window opens (see ``bench_kernel``),
-# so its device event cannot fall inside a window regardless of how the
-# projection behaves; kernels the timed call launches do.
-_KERNEL_REGION = "tileops_bench_kernel"
+class _CuptiSamplingError(Exception):
+    """CUPTI trace lacked CUDA kernel samples for the measured window."""
 
 
 def _sum_kernel_time_us(kineto_results):
-    """Sum device time of the kernels the timed call launched.
+    """Sum sampled business-kernel device time from a CUPTI collection window.
 
-    Sums only kernels inside a :data:`_KERNEL_REGION` annotation window, so the
-    L2-flush fill is excluded and the kernel under test is counted regardless of
-    its name. A call launching several kernels contributes all of them.
+    The measured CUPTI window is continuous across the repeat loop and includes
+    the L2 flush launches. Filter those fill kernels by name, then sum every
+    remaining CUDA kernel sample. A call launching several kernels contributes
+    all of them.
 
     Iterates the C++ Kineto events directly to bypass ``key_averages()``, which
     is ~16x slower (~130ms of Python parsing/tree-building) for large traces.
 
     Returns:
-        ``(total_us, n_regions)``: summed kernel time in microseconds and the
-        number of annotation windows. The caller checks ``n_regions ==
-        n_repeat`` to confirm the scope projected on every iteration.
+        ``(total_us, n_kernels)``: summed kernel time in microseconds and the
+        number of sampled business CUDA kernels.
     """
-    import bisect
-
-    windows: list[tuple[int, int]] = []
-    kernels: list[tuple[int, int]] = []  # (start_ns, duration_ns)
+    total_us = 0.0
+    n_kernels = 0
     for evt in kineto_results.events():
         if evt.device_type() != DeviceType.CUDA:
             continue
         if evt.is_user_annotation():
-            if evt.name() == _KERNEL_REGION:
-                windows.append((evt.start_ns(), evt.end_ns()))
             continue
-        kernels.append((evt.start_ns(), evt.duration_ns()))
-
-    windows.sort()
-    starts = [w[0] for w in windows]
-    ends = [w[1] for w in windows]
-    total_us = 0.0
-    for start_ns, dur_ns in kernels:
-        # Count only kernels that fall inside a timed-call window; everything
-        # outside (notably the L2-flush fill) is excluded.
-        idx = bisect.bisect_right(starts, start_ns) - 1
-        if idx >= 0 and start_ns < ends[idx]:
-            total_us += dur_ns / 1000.0
-    return total_us, len(windows)
+        name = evt.name()
+        if "vectorized_elementwise" in name and "FillFunctor" in name:
+            continue
+        total_us += evt.duration_ns() / 1000.0
+        n_kernels += 1
+    return total_us, n_kernels
 
 
 # L2 cache flush buffer (sized to actual L2, allocated lazily)
@@ -264,52 +245,41 @@ def bench_kernel(
         _run(i)
     torch.cuda.synchronize()
 
-    # One plain profiler context per trial; torch.profiler.schedule is avoided
-    # because queued launches leak across its warmup/active boundary.
-    # Kineto's window projection may include a flush merely enqueued before
-    # the window, so the flush is drained (sync) before the timed call and
-    # the call is drained before the next flush; the syncs add host-side
-    # latency only.
+    # One continuous CUPTI collection window per trial. torch.profiler.schedule
+    # is avoided because queued launches leak across its warmup/active boundary,
+    # and per-repeat dynamic collection toggling introduces extra CUPTI enable
+    # boundaries. The syncs drain the L2 flush before the sampled call and drain
+    # the call before the next flush; they add host-side latency only.
     trial_means: list[float] = []
     try:
         with _native_output_suppressor():
             for _ in range(n_trials):
                 with torch.profiler.profile(
-                    # CPU activity is required for Kineto to project the
-                    # annotation window; it never adds device time.
-                    activities=[
-                        torch.profiler.ProfilerActivity.CPU,
-                        torch.profiler.ProfilerActivity.CUDA,
-                    ],
+                    activities=[torch.profiler.ProfilerActivity.CUDA],
                 ) as profiler:
                     for i in range(n_repeat):
                         cache.zero_()
                         torch.cuda.synchronize()
-                        with torch.profiler.record_function(_KERNEL_REGION):
-                            _run(i)
+                        _run(i)
                         torch.cuda.synchronize()
-                total_us, n_regions = _sum_kernel_time_us(profiler.profiler.kineto_results)
-                # Untrustworthy trace → CUDA-events fallback; genuine CUDA
-                # errors and OOM propagate.
-                if n_regions != n_repeat:
-                    # Count actual CUDA kernels for diagnostics
-                    n_cuda_kernels = sum(
-                        1 for evt in profiler.profiler.kineto_results.events()
-                        if evt.device_type() == DeviceType.CUDA and not evt.is_user_annotation()
-                    )
+                total_us, n_kernels = _sum_kernel_time_us(
+                    profiler.profiler.kineto_results
+                )
+                if n_kernels == 0:
                     _logger.debug(
-                        "CUPTI projection mismatch: %d annotation windows vs %d repeats "
-                        "(%d CUDA kernels captured). This may indicate torch.profiler "
-                        "instability in the current environment. Falling back to CUDA events.",
-                        n_regions, n_repeat, n_cuda_kernels,
+                        "CUPTI captured no business CUDA kernels in the measured "
+                        "window; falling back to CUDA events."
                     )
-                    raise _CuptiProjectionError(
-                        f"{n_regions}/{n_repeat} annotation windows projected, "
-                        f"{n_cuda_kernels} CUDA kernels captured"
+                    raise _CuptiSamplingError(
+                        "no business CUDA kernels captured in CUPTI window"
                     )
-                trial_means.append((total_us / n_repeat) * 1e-3)
+                # Single-kernel ops may occasionally produce fewer samples than
+                # repeats in a valid CUPTI collection window. Average over the
+                # sampled business runs; multi-kernel calls still use n_repeat.
+                n_sampled_runs = min(n_kernels, n_repeat)
+                trial_means.append((total_us / n_sampled_runs) * 1e-3)
         _bench_meta.timing = "cupti"
-    except _CuptiProjectionError as exc:
+    except _CuptiSamplingError as exc:
         # Check if cuda-events fallback is allowed
         allow_fallback = os.getenv("TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK", "1") == "1"
 
@@ -322,7 +292,7 @@ def bench_kernel(
             ) from exc
 
         _logger.warning(
-            "CUPTI projection failed (%s); falling back to CUDA-events "
+            "CUPTI sampling failed (%s); falling back to CUDA-events "
             "timing, which includes ~50-60us launch overhead per call. "
             "Latency will be inflated by ~6-7x for fast kernels (<10us). "
             "Set TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=0 to prevent fallback.", exc,

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -222,8 +222,8 @@ def test_multi_input_op_raises_keyerror():
 
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_projection_failure_falls_back_to_cuda_events():
-    """A callable launching no CUDA kernel projects no annotation windows;
+def test_empty_cupti_sample_falls_back_to_cuda_events():
+    """A callable launching no CUDA kernel has no CUPTI business-kernel sample;
     bench_kernel must fall back and mark the deviating timing method."""
     latency = bench_kernel(lambda: sum(range(64)), n_warmup=1, n_repeat=2, n_trials=1)
     assert latency >= 0.0


### PR DESCRIPTION
## Summary

- stop using Kineto projected annotation windows as the CUPTI benchmark timing/counting boundary
- sample business CUDA kernels directly from one continuous CUPTI CUDA activity window per trial
- filter the benchmark L2 flush fill kernel from CUDA activity summation
- keep CUDA-events fallback only for empty CUPTI business-kernel samples

## Previous Timing Model

Before this patch, `bench_kernel()` used two different concepts of a window:

- **CPU window**: every repeat wrapped `_run(i)` in `torch.profiler.record_function(_KERNEL_REGION)`. This created one CPU-side annotation scope per repeat.
- **GPU timing/counting window**: Kineto was expected to project those CPU annotation scopes onto the CUDA timeline. `_sum_kernel_time_us()` then summed CUDA kernels whose start timestamp fell inside a projected CUDA annotation window, and required the number of projected windows to equal `n_repeat`.

So the benchmark was not only asking CUPTI for CUDA kernel activity. It was also requiring Kineto projection to produce exactly one CUDA-side annotation window per repeat.

The L2 flush was intended to stay outside the timed call by doing:

```text
cache.zero_()
torch.cuda.synchronize()
record_function(_KERNEL_REGION):
    _run(i)
torch.cuda.synchronize()
```

That part drains CUDA work, but it does not provide a synchronization primitive for Kineto projection itself.

## What Went Wrong

The failure mode is a CPU/GPU window mismatch:

- CPU issued `n_repeat` annotation scopes.
- CUDA kernels were often present in the CUPTI activity trace.
- Kineto sometimes produced fewer CUDA-side projected annotation windows than repeats, e.g. `49/50`, `48/50`, `47/50`, or `0/50`.
- The benchmark treated this as an untrustworthy CUPTI trace and fell back to CUDA events.

The missing piece is a projection-ready synchronization signal. `torch.cuda.synchronize()` only waits for GPU work to finish. It does not guarantee that Kineto has materialized one projected CUDA annotation window for every CPU `record_function` scope. PyTorch/Kineto does not expose a public GPU-side semaphore for "projection is ready for this repeat".

Because of that, the previous implementation tied benchmark correctness to Kineto projection stability instead of CUPTI CUDA activity sampling itself.

## Observed Incidence

This was not a rare single-case issue.

From the previous nightly artifact we inspected, [run 30170991562](https://github.com/tile-ai/TileOPs/actions/runs/30170991562):

- all benchmark rows: `88/2923` used CUPTI, `2835/2923` used CUDA events (`96.99%` fallback)
- TileOps rows only: `26/1280` used CUPTI, `1254/1280` used CUDA events (`97.97%` fallback)

In local official-runner reproduction on clean `main`, the fallback rate was lower but still material:

- all rows: `208/2178` CUDA-events fallback (`9.55%`)
- TileOps-like rows: `90/1068` CUDA-events fallback (`8.43%`)

Focused reruns also showed repeated projection mismatches such as `49/50`, `48/50`, `47/50`, and `0/50`. Immediate retry did not reliably recover the same case, so simply retrying after fallback is not a principled fix.

GLA `0/50` projection behavior is intentionally left out of this patch; it appears to be a separate Kineto projection issue and should be handled independently.

## Fix

This patch removes projected annotations from the main timing/counting path.

The new CUPTI path uses:

- CUDA-only profiler activity collection
- one continuous CUPTI collection window per trial
- repeated `cache.zero_ -> synchronize -> run -> synchronize` inside that collection window
- direct summation of CUDA business-kernel activity samples
- name-based filtering of the benchmark L2 flush fill kernel (`vectorized_elementwise` + `FillFunctor`)

The benchmark now uses the CUPTI collection window itself as the sampling window. CPU annotations and Kineto projected CUDA annotations are no longer part of the primary timing/counting path.

If CUPTI captures no business CUDA kernel samples, we still fall back to CUDA events using the existing fallback policy. If CUPTI captures samples, we compute latency from the sampled CUDA kernel durations.

## Validation

Ran in `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10` without installing/upgrading tilelang, torch, or dependencies:

```text
python py_compile benchmarks/benchmark_base.py benchmarks/tests/test_benchmark_base.py
pytest -q benchmarks/tests/test_benchmark_base.py::test_empty_cupti_sample_falls_back_to_cuda_events benchmarks/tests/test_benchmark_base.py::test_kernel_runtime_error_propagates
pytest -q -s benchmarks/ops/bench_gemm.py::test_gemm_fp8_bench[ds-v3-decode-gate-up-block128-float8_e4m3fn]
pytest -q -s benchmarks/ops/attention/bench_gqa_sliding_window.py::test_gqa_sliding_window_fwd_bench[llama-3.1-8b-short-w256-float16]
```