### PR TITLE
[Bench] Classify single-kernel CUPTI samples before timing

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import threading
 from abc import ABC, abstractmethod
+from collections import Counter
 from datetime import datetime
 from typing import (
     Any,
@@ -90,8 +91,8 @@ _bench_results = threading.local()
 _bench_meta = threading.local()
 
 
-class _CuptiProjectionError(Exception):
-    """CUPTI trace lacked a projected annotation window for every repeat."""
+class _CuptiSamplingError(Exception):
+    """CUPTI trace lacked a usable measured-window CUDA sample."""
 
 
 # Name of the ``record_function`` annotation wrapping the timed call. Kineto
@@ -102,25 +103,12 @@ class _CuptiProjectionError(Exception):
 _KERNEL_REGION = "tileops_bench_kernel"
 
 
-def _sum_kernel_time_us(kineto_results):
-    """Sum device time of the kernels the timed call launched.
-
-    Sums only kernels inside a :data:`_KERNEL_REGION` annotation window, so the
-    L2-flush fill is excluded and the kernel under test is counted regardless of
-    its name. A call launching several kernels contributes all of them.
-
-    Iterates the C++ Kineto events directly to bypass ``key_averages()``, which
-    is ~16x slower (~130ms of Python parsing/tree-building) for large traces.
-
-    Returns:
-        ``(total_us, n_regions)``: summed kernel time in microseconds and the
-        number of annotation windows. The caller checks ``n_regions ==
-        n_repeat`` to confirm the scope projected on every iteration.
-    """
+def _window_kernel_stats(kineto_results):
+    """Return per-annotation-window business CUDA kernel time and names."""
     import bisect
 
     windows: list[tuple[int, int]] = []
-    kernels: list[tuple[int, int]] = []  # (start_ns, duration_ns)
+    kernels: list[tuple[int, int, str]] = []  # (start_ns, duration_ns, name)
     for evt in kineto_results.events():
         if evt.device_type() != DeviceType.CUDA:
             continue
@@ -128,19 +116,81 @@ def _sum_kernel_time_us(kineto_results):
             if evt.name() == _KERNEL_REGION:
                 windows.append((evt.start_ns(), evt.end_ns()))
             continue
-        kernels.append((evt.start_ns(), evt.duration_ns()))
+        name = evt.name()
+        if "vectorized_elementwise" in name and "FillFunctor" in name:
+            continue
+        kernels.append((evt.start_ns(), evt.duration_ns(), name))
 
     windows.sort()
     starts = [w[0] for w in windows]
     ends = [w[1] for w in windows]
-    total_us = 0.0
-    for start_ns, dur_ns in kernels:
-        # Count only kernels that fall inside a timed-call window; everything
-        # outside (notably the L2-flush fill) is excluded.
+    window_us = [0.0] * len(windows)
+    window_kernel_counts: list[Counter[str]] = [Counter() for _ in windows]
+    for start_ns, dur_ns, name in kernels:
+        # Count only business kernels that fall inside a timed-call window.
         idx = bisect.bisect_right(starts, start_ns) - 1
         if idx >= 0 and start_ns < ends[idx]:
-            total_us += dur_ns / 1000.0
-    return total_us, len(windows)
+            window_us[idx] += dur_ns / 1000.0
+            window_kernel_counts[idx][name] += 1
+    return window_us, window_kernel_counts
+
+
+def _sum_kernel_time_us(kineto_results):
+    """Sum device time of the kernels the timed call launched.
+
+    Sums only kernels inside a :data:`_KERNEL_REGION` annotation window and
+    returns their names so the caller can distinguish single-kernel samples
+    from multi-kernel samples.
+
+    Iterates the C++ Kineto events directly to bypass ``key_averages()``, which
+    is ~16x slower (~130ms of Python parsing/tree-building) for large traces.
+
+    Returns:
+        ``(total_us, n_regions, kernel_counts)``: summed kernel time in
+        microseconds, number of annotation windows, and sampled business CUDA
+        kernel counts by kernel name.
+    """
+    window_us, window_kernel_counts = _window_kernel_stats(kineto_results)
+    kernel_counts: Counter[str] = Counter()
+    for counts in window_kernel_counts:
+        kernel_counts.update(counts)
+    return sum(window_us), len(window_kernel_counts), kernel_counts
+
+
+def _validate_single_kernel_classification(kineto_results, n_expected: int) -> None:
+    _, window_kernel_counts = _window_kernel_stats(kineto_results)
+    if len(window_kernel_counts) != n_expected:
+        raise _CuptiSamplingError(
+            f"{len(window_kernel_counts)}/{n_expected} classification windows projected"
+        )
+    kernel_names: Counter[str] = Counter()
+    for counts in window_kernel_counts:
+        n_kernels = sum(counts.values())
+        if n_kernels != 1:
+            raise _CuptiSamplingError(
+                f"classification window captured {n_kernels} business CUDA kernels"
+            )
+        kernel_names.update(counts)
+    if len(kernel_names) != 1:
+        raise _CuptiSamplingError(
+            f"classification captured {len(kernel_names)} kernel names"
+        )
+
+
+def _sampled_runs(kernel_counts: Counter[str], n_repeat: int) -> int:
+    n_kernels = sum(kernel_counts.values())
+    if n_kernels == 0:
+        raise _CuptiSamplingError("no business CUDA kernels captured")
+    if len(kernel_counts) != 1:
+        raise _CuptiSamplingError(
+            f"{n_kernels} business CUDA kernels across "
+            f"{len(kernel_counts)} kernel names captured for {n_repeat} repeats"
+        )
+    if n_kernels <= n_repeat:
+        return n_kernels
+    raise _CuptiSamplingError(
+        f"{n_kernels} business CUDA kernels captured for {n_repeat} repeats"
+    )
 
 
 # L2 cache flush buffer (sized to actual L2, allocated lazily)
@@ -266,13 +316,31 @@ def bench_kernel(
 
     # One plain profiler context per trial; torch.profiler.schedule is avoided
     # because queued launches leak across its warmup/active boundary.
-    # Kineto's window projection may include a flush merely enqueued before
-    # the window, so the flush is drained (sync) before the timed call and
-    # the call is drained before the next flush; the syncs add host-side
-    # latency only.
+    # Kineto may miss some per-repeat projected annotation windows, so the CUPTI
+    # path samples the business CUDA kernels that did project and validates that
+    # the sample is single-kernel before using it.
     trial_means: list[float] = []
     try:
         with _native_output_suppressor():
+            n_classify = min(2, n_repeat)
+            if n_classify <= 0:
+                raise _CuptiSamplingError(f"invalid repeat count: {n_repeat}")
+            with torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
+            ) as profiler:
+                for i in range(n_classify):
+                    cache.zero_()
+                    torch.cuda.synchronize()
+                    with torch.profiler.record_function(_KERNEL_REGION):
+                        _run(i)
+                    torch.cuda.synchronize()
+            _validate_single_kernel_classification(
+                profiler.profiler.kineto_results, n_classify
+            )
+
             for _ in range(n_trials):
                 with torch.profiler.profile(
                     # CPU activity is required for Kineto to project the
@@ -288,41 +356,28 @@ def bench_kernel(
                         with torch.profiler.record_function(_KERNEL_REGION):
                             _run(i)
                         torch.cuda.synchronize()
-                total_us, n_regions = _sum_kernel_time_us(profiler.profiler.kineto_results)
+                total_us, _, kernel_counts = _sum_kernel_time_us(
+                    profiler.profiler.kineto_results
+                )
                 # Untrustworthy trace → CUDA-events fallback; genuine CUDA
                 # errors and OOM propagate.
-                if n_regions != n_repeat:
-                    # Count actual CUDA kernels for diagnostics
-                    n_cuda_kernels = sum(
-                        1 for evt in profiler.profiler.kineto_results.events()
-                        if evt.device_type() == DeviceType.CUDA and not evt.is_user_annotation()
-                    )
-                    _logger.debug(
-                        "CUPTI projection mismatch: %d annotation windows vs %d repeats "
-                        "(%d CUDA kernels captured). This may indicate torch.profiler "
-                        "instability in the current environment. Falling back to CUDA events.",
-                        n_regions, n_repeat, n_cuda_kernels,
-                    )
-                    raise _CuptiProjectionError(
-                        f"{n_regions}/{n_repeat} annotation windows projected, "
-                        f"{n_cuda_kernels} CUDA kernels captured"
-                    )
-                trial_means.append((total_us / n_repeat) * 1e-3)
+                n_sampled_runs = _sampled_runs(kernel_counts, n_repeat)
+                trial_means.append((total_us / n_sampled_runs) * 1e-3)
         _bench_meta.timing = "cupti"
-    except _CuptiProjectionError as exc:
+    except _CuptiSamplingError as exc:
         # Check if cuda-events fallback is allowed
         allow_fallback = os.getenv("TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK", "1") == "1"
 
         if not allow_fallback:
             raise RuntimeError(
-                f"CUPTI profiling failed: {exc}. "
+                f"CUPTI sampling failed: {exc}. "
                 "CUDA-events fallback is disabled (TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=0). "
                 "This prevents generating inaccurate benchmark data with ~7x inflated latency. "
                 "To debug: run with TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1 and check logs."
             ) from exc
 
         _logger.warning(
-            "CUPTI projection failed (%s); falling back to CUDA-events "
+            "CUPTI sampling failed (%s); falling back to CUDA-events "
             "timing, which includes ~50-60us launch overhead per call. "
             "Latency will be inflated by ~6-7x for fast kernels (<10us). "
             "Set TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=0 to prevent fallback.", exc,


### PR DESCRIPTION
Closes #1796

- Classify profiled calls before CUPTI timing.
- Accept partial CUPTI samples only for verified single-kernel callables.
- Fall back to CUDA events for multi-kernel or ambiguous traces.

Validation: benchmark timing/fallback tests and representative CI benchmark runs pass.