### PR TITLE
[Bench] Detach op benchmarks from tests package

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -543,14 +543,16 @@ def workload_field_params(workloads: list, keys: tuple) -> list:
         )
     return params
 
-class ManifestBenchmark(BenchmarkBase[ShapeDtypeWorkload]):
+class ManifestBenchmark(BenchmarkBase[Any]):
     """Generic benchmark that reads FLOP/memory counts from an Op instance.
 
-    Accepts an op name, an instantiated Op, and any workload satisfying
-    :class:`ShapeDtypeWorkload`.  The op must implement ``eval_roofline()``.
-    Dynamic-shape ops may bind roofline variables during ``forward()``, so
-    this helper calls ``op.eval_roofline()`` only while building a result
-    after profiling has executed the op.
+    Accepts an op name, an instantiated Op, and the workload that produced
+    the inputs.  Roofline numbers come from ``op.eval_roofline()``, so the
+    workload needs no ``shape`` / ``dtype`` metadata — it is retained only
+    for subclasses that read their own fields off it.  Dynamic-shape ops may
+    bind roofline variables during ``forward()``, so this helper calls
+    ``op.eval_roofline()`` only while building a result after profiling has
+    executed the op.
 
     Usage::
 
@@ -563,7 +565,7 @@ class ManifestBenchmark(BenchmarkBase[ShapeDtypeWorkload]):
         self,
         op_name: str,
         op: Any,
-        workload: ShapeDtypeWorkload,
+        workload: Any,
     ):
         super().__init__(workload)
         self._op_name = op_name

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -17,20 +17,7 @@ _DTYPE_MAP = {
 }
 
 
-class _BmmBenchmarkWorkload(BmmWorkload):
-    @property
-    def shape(self) -> tuple[int, int, int, int]:
-        return self.batch, self.m, self.n, self.k
-
-    def torch_bmm(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        return torch.bmm(a, b)
-
-
 class _BmmFp8BenchmarkWorkload(BmmFp8Workload):
-    @property
-    def shape(self) -> tuple[int, int, int, int]:
-        return self.batch, self.m, self.n, self.k
-
     def torch_fp32_bmm_ref(self, *inputs: torch.Tensor) -> torch.Tensor:
         a, b, scale_a, scale_b = inputs
         if scale_a.dim() != 0 or scale_b.dim() != 0:
@@ -95,7 +82,7 @@ def _manifest_fp8_params() -> list:
 @pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_params())
 def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     dtype = _DTYPE_MAP[dtype_str]
-    workload = _BmmBenchmarkWorkload(batch, m, n, k, dtype)
+    workload = BmmWorkload(batch, m, n, k, dtype)
     a, b = workload.gen_inputs()
 
     op = BmmFwdOp(tune=True)
@@ -106,7 +93,7 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     result = bm.profile(op, a, b)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(workload.torch_bmm, a, b)
+    result_bl = bm.profile(torch.bmm, a, b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
 
 

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -2,9 +2,9 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
-from tests.ops.test_bmm import BmmFp8Test, BmmTest
 from tileops.manifest import load_workloads
 from tileops.ops import BmmFp8Op, BmmFwdOp
+from workloads.bmm import BmmFp8Workload, BmmWorkload
 
 _OP_NAME = "BmmFwdOp"
 _FP8_OP_NAME = "BmmFp8Op"
@@ -17,8 +17,34 @@ _DTYPE_MAP = {
 }
 
 
+class _BmmBenchmarkWorkload(BmmWorkload):
+    @property
+    def shape(self) -> tuple[int, int, int, int]:
+        return self.batch, self.m, self.n, self.k
+
+    def torch_bmm(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.bmm(a, b)
+
+
+class _BmmFp8BenchmarkWorkload(BmmFp8Workload):
+    @property
+    def shape(self) -> tuple[int, int, int, int]:
+        return self.batch, self.m, self.n, self.k
+
+    def torch_fp32_bmm_ref(self, *inputs: torch.Tensor) -> torch.Tensor:
+        a, b, scale_a, scale_b = inputs
+        if scale_a.dim() != 0 or scale_b.dim() != 0:
+            raise ValueError(
+                "BmmFp8 benchmark baseline requires per-tensor 0-D scales, "
+                f"got {tuple(scale_a.shape)} / {tuple(scale_b.shape)}"
+            )
+        a_f = a.float() * scale_a
+        b_f = b.float() * scale_b
+        return torch.bmm(a_f, b_f).to(self.out_dtype)
+
+
 def _flashinfer_bmm_fp8_per_tensor_ref(
-    test: BmmFp8Test, a: torch.Tensor, b_kmajor: torch.Tensor,
+    workload: _BmmFp8BenchmarkWorkload, a: torch.Tensor, b_kmajor: torch.Tensor,
     scale_a: torch.Tensor, scale_b: torch.Tensor,
 ) -> torch.Tensor:
 
@@ -27,7 +53,7 @@ def _flashinfer_bmm_fp8_per_tensor_ref(
     if a.dtype != torch.float8_e4m3fn or b_kmajor.dtype != torch.float8_e4m3fn:
         raise ValueError(
             "FlashInfer bmm_fp8 baseline requires float8_e4m3fn.")
-    if test.out_dtype not in (torch.bfloat16, torch.float16):
+    if workload.out_dtype not in (torch.bfloat16, torch.float16):
         raise ValueError(
             "FlashInfer bmm_fp8 baseline requires bfloat16 / float16 output.")
     if scale_a.dim() != 0 or scale_b.dim() != 0:
@@ -37,7 +63,7 @@ def _flashinfer_bmm_fp8_per_tensor_ref(
         )
     return flashinfer.bmm_fp8(
         a, b_kmajor, scale_a, scale_b,
-        dtype=test.out_dtype, backend="cudnn",
+        dtype=workload.out_dtype, backend="cudnn",
     )
 
 
@@ -69,18 +95,18 @@ def _manifest_fp8_params() -> list:
 @pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_params())
 def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
     dtype = _DTYPE_MAP[dtype_str]
-    test = BmmTest(batch, m, n, k, dtype)
-    a, b = test.gen_inputs()
+    workload = _BmmBenchmarkWorkload(batch, m, n, k, dtype)
+    a, b = workload.gen_inputs()
 
     op = BmmFwdOp(tune=True)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(_OP_NAME, op, workload)
 
     # eval_roofline() is read lazily after profiling, by which point
     # forward() has bound the dims.
     result = bm.profile(op, a, b)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, a, b)
+    result_bl = bm.profile(workload.torch_bmm, a, b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
 
 
@@ -90,25 +116,25 @@ def test_bmm_fp8_bench(
 ) -> None:
     dtype = _DTYPE_MAP[dtype_str]
     out_dtype = torch.bfloat16
-    test = BmmFp8Test(batch, m, n, k, dtype, out_dtype=out_dtype)
-    a, b_kn, scale_a, scale_b = test.gen_inputs()
+    workload = _BmmFp8BenchmarkWorkload(batch, m, n, k, dtype, out_dtype=out_dtype)
+    a, b_kn, scale_a, scale_b = workload.gen_inputs()
     b_nk = b_kn.transpose(-2, -1).contiguous()      # [B, N, K], K-innermost
     b_kmajor = b_nk.transpose(-2, -1)               # [B, K, N] view, zero-copy
 
     # Fast path: feed [B, N, K] (K-innermost) via explicit b_layout='nk'.
     op = BmmFp8Op(out_dtype=out_dtype, tune=True, b_layout="nk")
-    bm = ManifestBenchmark(_FP8_OP_NAME, op, test)
+    bm = ManifestBenchmark(_FP8_OP_NAME, op, workload)
     result = bm.profile(op, a, b_nk, scale_a, scale_b)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, a, b_kn, scale_a, scale_b)
+    result_bl = bm.profile(workload.torch_fp32_bmm_ref, a, b_kn, scale_a, scale_b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-fp32-ref")
 
     flashinfer = pytest.importorskip("flashinfer")
     try:
         result_flashinfer = bm.profile(
             lambda a_, b_, sa_, sb_: _flashinfer_bmm_fp8_per_tensor_ref(
-                test, a_, b_, sa_, sb_),
+                workload, a_, b_, sa_, sb_),
             a, b_kmajor, scale_a, scale_b,
         )
     except RuntimeError as exc:

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -22,10 +22,6 @@ _DTYPE_MAP = {
 
 
 class _GemmBenchmarkWorkload(GemmWorkload):
-    @property
-    def shape(self) -> tuple[int, int, int]:
-        return self.m, self.n, self.k
-
     def torch_matmul(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         if self.trans_a:
             a = a.T
@@ -35,10 +31,6 @@ class _GemmBenchmarkWorkload(GemmWorkload):
 
 
 class _GemmFp8BenchmarkWorkload(GemmFp8Workload):
-    @property
-    def shape(self) -> tuple[int, int, int]:
-        return self.m, self.n, self.k
-
     def _expand_scale(self, scale: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
         if tuple(scale.shape) == (1, 1):
             return scale.expand(rows, cols)
@@ -60,10 +52,6 @@ class _GemmFp8BenchmarkWorkload(GemmFp8Workload):
 
 
 class _GemmW4A16BenchmarkWorkload(GemmW4A16Workload):
-    @property
-    def shape(self) -> tuple[int, int, int]:
-        return self.m, self.n, self.k
-
     def torch_dequantized_matmul(
         self,
         activation: torch.Tensor,

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -4,10 +4,9 @@ import pytest
 import torch
 
 from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
-from tests.ops.test_gemm import GemmFp8Test, GemmTest
 from tileops.manifest import load_workloads
 from tileops.ops import GemmFp8Op, GemmOp, GemmW4A16Op
-from workloads.gemm import GemmW4A16Workload
+from workloads.gemm import GemmFp8Workload, GemmW4A16Workload, GemmWorkload
 
 _OP_NAME = "GemmOp"
 _FP8_OP_NAME = "GemmFp8Op"
@@ -20,6 +19,44 @@ _DTYPE_MAP = {
     "float8_e4m3fn": torch.float8_e4m3fn,
     "float8_e5m2": torch.float8_e5m2,
 }
+
+
+class _GemmBenchmarkWorkload(GemmWorkload):
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return self.m, self.n, self.k
+
+    def torch_matmul(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        if self.trans_a:
+            a = a.T
+        if self.trans_b:
+            b = b.T
+        return torch.matmul(a, b)
+
+
+class _GemmFp8BenchmarkWorkload(GemmFp8Workload):
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return self.m, self.n, self.k
+
+    def _expand_scale(self, scale: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+        if tuple(scale.shape) == (1, 1):
+            return scale.expand(rows, cols)
+        scale_cols = (cols + 127) // 128
+        if tuple(scale.shape) != (rows, scale_cols):
+            raise ValueError(
+                f"unsupported FP8 scale shape {tuple(scale.shape)} for {(rows, cols)}")
+        return scale.repeat_interleave(128, dim=1)[:, :cols]
+
+    def torch_scaled_matmul(self, *inputs: torch.Tensor) -> torch.Tensor:
+        a, b, scale_a, scale_b = inputs[:4]
+        bias = inputs[4] if len(inputs) == 5 else None
+        a_f = a.float() * self._expand_scale(scale_a, self.m, self.k)
+        b_f = b.float() * self._expand_scale(scale_b, self.n, self.k)
+        out = torch.matmul(a_f, b_f.T)
+        if bias is not None:
+            out = out + bias.float()
+        return out.to(self.out_dtype)
 
 
 class _GemmW4A16BenchmarkWorkload(GemmW4A16Workload):
@@ -38,7 +75,9 @@ class _GemmW4A16BenchmarkWorkload(GemmW4A16Workload):
         return torch.matmul(activation, self.dequantized_weight.T)
 
 
-def _flashinfer_fp8_blockscale_ref(test: GemmFp8Test, *inputs: torch.Tensor) -> torch.Tensor:
+def _flashinfer_fp8_blockscale_ref(
+    workload: _GemmFp8BenchmarkWorkload, *inputs: torch.Tensor
+) -> torch.Tensor:
     from flashinfer.gemm import fp8_blockscale_gemm_sm90
 
     a, b, scale_a, scale_b = inputs[:4]
@@ -46,21 +85,24 @@ def _flashinfer_fp8_blockscale_ref(test: GemmFp8Test, *inputs: torch.Tensor) -> 
         raise ValueError("FlashInfer FP8 blockscale GEMM baseline does not support bias.")
     if a.dtype != torch.float8_e4m3fn or b.dtype != torch.float8_e4m3fn:
         raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires float8_e4m3fn.")
-    if test.out_dtype != torch.bfloat16:
+    if workload.out_dtype != torch.bfloat16:
         raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires bfloat16 output.")
-    if test.k % 128 != 0:
+    if workload.k % 128 != 0:
         raise ValueError("FlashInfer FP8 blockscale GEMM baseline requires k divisible by 128.")
-    if scale_a.shape != (test.m, test.k // 128) or scale_b.shape != (test.n, test.k // 128):
+    if scale_a.shape != (workload.m, workload.k // 128) or scale_b.shape != (
+        workload.n, workload.k // 128
+    ):
         raise ValueError(
             "FlashInfer FP8 blockscale GEMM baseline requires exact "
-            f"scale shapes {(test.m, test.k // 128)} and {(test.n, test.k // 128)}, "
+            f"scale shapes {(workload.m, workload.k // 128)} "
+            f"and {(workload.n, workload.k // 128)}, "
             f"got {tuple(scale_a.shape)} and {tuple(scale_b.shape)}"
         )
-    return fp8_blockscale_gemm_sm90(a, b, scale_a, scale_b, out_dtype=test.out_dtype)
+    return fp8_blockscale_gemm_sm90(a, b, scale_a, scale_b, out_dtype=workload.out_dtype)
 
 
 def _prepare_flashinfer_fp8_per_tensor(
-    test: GemmFp8Test, *inputs: torch.Tensor
+    workload: _GemmFp8BenchmarkWorkload, *inputs: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
     import flashinfer
 
@@ -69,7 +111,7 @@ def _prepare_flashinfer_fp8_per_tensor(
         raise ValueError("FlashInfer FP8 per-tensor GEMM baseline does not support bias.")
     if a.dtype != torch.float8_e4m3fn or b.dtype != torch.float8_e4m3fn:
         raise ValueError("FlashInfer FP8 per-tensor GEMM baseline requires float8_e4m3fn.")
-    if test.out_dtype != torch.bfloat16:
+    if workload.out_dtype != torch.bfloat16:
         raise ValueError("FlashInfer FP8 per-tensor GEMM baseline requires bfloat16 output.")
     if scale_a.shape != (1, 1) or scale_b.shape != (1, 1):
         raise ValueError(
@@ -226,18 +268,18 @@ def test_gemm_bench(
     dtype_str: str,
 ) -> None:
     dtype = _DTYPE_MAP[dtype_str]
-    test = GemmTest(m, n, k, dtype, trans_a, trans_b)
-    a, b = test.gen_inputs()
+    workload = _GemmBenchmarkWorkload(m, n, k, dtype, trans_a, trans_b)
+    a, b = workload.gen_inputs()
 
     op = GemmOp(trans_a=trans_a, trans_b=trans_b)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    bm = ManifestBenchmark(_OP_NAME, op, workload)
 
     # The benchmark framework warms up internally; eval_roofline() is read
     # lazily after profiling, by which point forward() has bound the dims.
     result = bm.profile(op, a, b)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, a, b)
+    result_bl = bm.profile(workload.torch_matmul, a, b)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
 
 
@@ -251,16 +293,16 @@ def test_gemm_fp8_bench(
 ) -> None:
     dtype = _DTYPE_MAP[dtype_str]
     out_dtype = torch.bfloat16
-    test = GemmFp8Test(m, n, k, dtype, scale_mode, out_dtype=out_dtype)
-    inputs = test.gen_inputs()
+    workload = _GemmFp8BenchmarkWorkload(m, n, k, dtype, scale_mode, out_dtype=out_dtype)
+    inputs = workload.gen_inputs()
 
     op = GemmFp8Op(out_dtype=out_dtype)
-    bm = ManifestBenchmark(_FP8_OP_NAME, op, test)
+    bm = ManifestBenchmark(_FP8_OP_NAME, op, workload)
 
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
+    result_bl = bm.profile(workload.torch_scaled_matmul, *inputs)
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-scaled-mm")
 
     if scale_mode == "per_tensor":
@@ -269,7 +311,7 @@ def test_gemm_fp8_bench(
             print(f"  [skip] flashinfer-mm-fp8: {unsupported_reason}")
             return
         flashinfer = pytest.importorskip("flashinfer")
-        prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(test, *inputs)
+        prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(workload, *inputs)
         try:
             result_flashinfer = bm.profile(
                 lambda a: flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=out_dtype),
@@ -285,7 +327,7 @@ def test_gemm_fp8_bench(
     if scale_mode == "block128":
         pytest.importorskip("flashinfer")
         result_flashinfer = bm.profile(
-            lambda *args: _flashinfer_fp8_blockscale_ref(test, *args), *inputs
+            lambda *args: _flashinfer_fp8_blockscale_ref(workload, *args), *inputs
         )
         BenchmarkReport.record(
             op, locals(), result_flashinfer, tag="flashinfer-fp8-blockscale-sm90"

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -14,9 +14,8 @@ from typing import Optional
 import pytest
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
-from tests.ops.test_mamba import mamba2_fwd_ref as _mamba2_fwd_ref
 from tileops.ops.mamba2_fwd import Mamba2FwdOp
-from workloads.mamba2_e2e import Mamba2FwdFixture, Mamba2FwdTest
+from workloads.mamba2_e2e import Mamba2FwdFixture, Mamba2FwdTest, mamba2_fwd_ref
 
 # Optional mamba_ssm Triton baseline
 try:
@@ -115,7 +114,7 @@ def test_mamba2_fwd_bench(batch, seqlen, n_heads, d_head, d_state, n_groups,
         BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
     else:
         def _torch_wrapper(x, dt, A, B, C):
-            return _mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus)
+            return mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus)
 
         result_torch = bm.profile(_torch_wrapper, x, dt, A, B, C)
         BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -15,7 +15,8 @@ import pytest
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops.mamba2_fwd import Mamba2FwdOp
-from workloads.mamba2_e2e import Mamba2FwdFixture, Mamba2FwdTest, mamba2_fwd_ref
+from tileops.testing.mamba2_reference import mamba2_fwd_ref
+from workloads.mamba2_e2e import Mamba2FwdFixture, Mamba2FwdTest
 
 # Optional mamba_ssm Triton baseline
 try:

--- a/benchmarks/tests/test_benchmark_import_boundaries.py
+++ b/benchmarks/tests/test_benchmark_import_boundaries.py
@@ -1,0 +1,46 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_DIRS = (
+    REPO_ROOT / "benchmarks" / "ops",
+    REPO_ROOT / "benchmarks" / "kernels",
+)
+
+
+def _production_benchmark_files() -> list[Path]:
+    files: list[Path] = []
+    for bench_dir in BENCHMARK_DIRS:
+        files.extend(
+            path for path in bench_dir.rglob("*.py")
+            if path.name != "__init__.py"
+        )
+    return sorted(files)
+
+
+def _test_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "tests" or (node.module or "").startswith("tests."):
+                imports.append(f"from {node.module} import ...")
+        elif isinstance(node, ast.Import):
+            imports.extend(
+                f"import {alias.name}" for alias in node.names
+                if alias.name == "tests" or alias.name.startswith("tests.")
+            )
+    return imports
+
+
+@pytest.mark.smoke
+def test_production_benchmarks_do_not_import_tests_package() -> None:
+    offenders = {
+        str(path.relative_to(REPO_ROOT)): imports
+        for path in _production_benchmark_files()
+        if (imports := _test_imports(path))
+    }
+
+    assert offenders == {}

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -22,6 +22,7 @@ from workloads.mamba import (
     SSDStatePassingFwdFixture,
     SSDStatePassingFwdWorkload,
 )
+from workloads.mamba2_e2e import mamba2_fwd_ref
 
 
 def da_cumsum_fwd_ref(
@@ -468,102 +469,6 @@ def test_ssd_decode(batch, n_heads, d_head, d_state, n_groups, dtype, tune):
     rtol = 1e-3
     allclose_compare(y_op, y_ref, atol=atol, rtol=rtol)
     allclose_compare(state, state_ref, atol=atol, rtol=rtol)
-
-
-def mamba2_fwd_ref(
-    x: torch.Tensor,
-    dt: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    dt_bias: torch.Tensor | None,
-    chunk_size: int,
-    dt_softplus: bool,
-) -> torch.Tensor:
-    """Pure-PyTorch reference for the Mamba-2 SSD forward pass.
-
-    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
-      out[l,p] = exp(dA[l]) * C[l] @ prev_state
-               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
-
-    Inputs:
-        x:           (B, S, H, P)     dtype
-        dt:          (B, S, H)        float32
-        A:           (H,)             float32  (log-space, <= 0)
-        B:           (B, S, G, N)     dtype
-        C:           (B, S, G, N)     dtype
-        dt_bias:     (H,)             float32, optional
-        chunk_size:  int
-        dt_softplus: bool
-
-    Returns:
-        y: (B, S, H, P)  float32
-    """
-    b, S, h, p = x.shape
-    n = B.shape[-1]
-    g = B.shape[2]
-    hpg = h // g
-    Q = chunk_size
-    num_chunks = S // Q
-
-    # Step 1: DaCumsum
-    dt_val = dt.float()
-    if dt_bias is not None:
-        dt_val = dt_val + dt_bias.float()
-    if dt_softplus:
-        dt_val = F.softplus(dt_val)
-    dt_val = torch.clamp(dt_val, min=0.0)
-    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)  # (B, H, C, Q)
-    dA = dt_chunked * A.float().view(1, h, 1, 1)
-    dA_cumsum = dA.cumsum(dim=-1)  # (B, H, C, Q)
-
-    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned
-    B_c = B.float().reshape(b, num_chunks, Q, g, n)  # (B, C, Q, G, N)
-    C_c = C.float().reshape(b, num_chunks, Q, g, n)  # (B, C, Q, G, N)
-    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)  # (B, C, G, Q, Q)
-    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
-    cb = cb * mask.view(1, 1, 1, Q, Q)
-
-    # Step 3: SSDChunkState
-    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)   # (B, H, C, Q)
-    decay_c = decay.permute(0, 2, 3, 1)                       # (B, C, Q, H)
-    dt_c = dt_chunked.permute(0, 2, 3, 1)                     # (B, C, Q, H)
-    x_c = x.float().reshape(b, num_chunks, Q, h, p)           # (B, C, Q, H, P)
-    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-    wx = x_c * (decay_c * dt_c).unsqueeze(-1)                 # (B, C, Q, H, P)
-    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)  # (B, C, H, P, N)
-
-    # Step 4: SSDStatePassing
-    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])  # (B, H, C)
-    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
-    prev_states_list = []
-    for ci in range(num_chunks):
-        prev_states_list.append(s.unsqueeze(1))
-        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
-        s = scale * s + chunk_states[:, ci]
-    prev_states = torch.cat(prev_states_list, dim=1)  # (B, C, H, P, N)  kept in float32 (accum_dtype)
-
-    # Step 5: SSDChunkScan
-    dA_c = dA_cumsum.permute(0, 2, 3, 1)  # (B, C, Q, H)
-    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-
-    # History: exp(dA[l]) * C[l] @ prev_state  -> (B, C, Q, H, P)
-    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
-    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
-
-    # Intra: sum_s cb[l,s] * exp(dA[l]-dA[s]) * dt[s] * x[s]  -> (B, C, Q, H, P)
-    dA_l = dA_cumsum.unsqueeze(-1)   # (B, H, C, Q, 1)
-    dA_s = dA_cumsum.unsqueeze(-2)   # (B, H, C, 1, Q)
-    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
-        ~mask.view(1, 1, 1, Q, Q), 0.0
-    ).permute(0, 2, 1, 3, 4)  # (B, C, H, Q, Q)
-    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]  # (B, C, H, Q, Q)
-    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)   # (B, C, H, Q, Q)
-    wx_t = x_c.permute(0, 1, 3, 2, 4)   # (B, C, H, Q, P)
-    # y_intra result is (B, C, H, Q, P); permute to (B, C, Q, H, P)
-    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
-
-    return (y_hist + y_intra).reshape(b, S, h, p)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -10,6 +10,7 @@ from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
 from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
 from tileops.ops.ssd_decode import SSDDecodeOp
 from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
+from tileops.testing.mamba2_reference import mamba2_fwd_ref
 from workloads.mamba import (
     DaCumsumFwdFixture,
     DaCumsumFwdWorkload,
@@ -22,7 +23,6 @@ from workloads.mamba import (
     SSDStatePassingFwdFixture,
     SSDStatePassingFwdWorkload,
 )
-from workloads.mamba2_e2e import mamba2_fwd_ref
 
 
 def da_cumsum_fwd_ref(

--- a/tileops/testing/mamba2_reference.py
+++ b/tileops/testing/mamba2_reference.py
@@ -1,0 +1,95 @@
+import torch
+import torch.nn.functional as F
+
+
+def mamba2_fwd_ref(
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    chunk_size: int,
+    dt_softplus: bool,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for the Mamba-2 SSD forward pass.
+
+    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
+      out[l,p] = exp(dA[l]) * C[l] @ prev_state
+               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
+
+    Inputs:
+        x:           (B, S, H, P)     dtype
+        dt:          (B, S, H)        float32
+        A:           (H,)             float32  (log-space, <= 0)
+        B:           (B, S, G, N)     dtype
+        C:           (B, S, G, N)     dtype
+        dt_bias:     (H,)             float32, optional
+        chunk_size:  int
+        dt_softplus: bool
+
+    Returns:
+        y: (B, S, H, P)  float32
+    """
+    b, S, h, p = x.shape
+    n = B.shape[-1]
+    g = B.shape[2]
+    hpg = h // g
+    Q = chunk_size
+    num_chunks = S // Q
+
+    # Step 1: DaCumsum
+    dt_val = dt.float()
+    if dt_bias is not None:
+        dt_val = dt_val + dt_bias.float()
+    if dt_softplus:
+        dt_val = F.softplus(dt_val)
+    dt_val = torch.clamp(dt_val, min=0.0)
+    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)
+    dA = dt_chunked * A.float().view(1, h, 1, 1)
+    dA_cumsum = dA.cumsum(dim=-1)
+
+    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned.
+    B_c = B.float().reshape(b, num_chunks, Q, g, n)
+    C_c = C.float().reshape(b, num_chunks, Q, g, n)
+    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)
+    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
+    cb = cb * mask.view(1, 1, 1, Q, Q)
+
+    # Step 3: SSDChunkState
+    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)
+    decay_c = decay.permute(0, 2, 3, 1)
+    dt_c = dt_chunked.permute(0, 2, 3, 1)
+    x_c = x.float().reshape(b, num_chunks, Q, h, p)
+    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
+    wx = x_c * (decay_c * dt_c).unsqueeze(-1)
+    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)
+
+    # Step 4: SSDStatePassing
+    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])
+    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
+    prev_states_list = []
+    for ci in range(num_chunks):
+        prev_states_list.append(s.unsqueeze(1))
+        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
+        s = scale * s + chunk_states[:, ci]
+    prev_states = torch.cat(prev_states_list, dim=1)
+
+    # Step 5: SSDChunkScan
+    dA_c = dA_cumsum.permute(0, 2, 3, 1)
+    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
+
+    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
+    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
+
+    dA_l = dA_cumsum.unsqueeze(-1)
+    dA_s = dA_cumsum.unsqueeze(-2)
+    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
+        ~mask.view(1, 1, 1, Q, Q), 0.0
+    ).permute(0, 2, 1, 3, 4)
+    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]
+    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)
+    wx_t = x_c.permute(0, 1, 3, 2, 4)
+    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
+
+    return (y_hist + y_intra).reshape(b, S, h, p)

--- a/workloads/mamba2_e2e.py
+++ b/workloads/mamba2_e2e.py
@@ -5,6 +5,7 @@ Covers model-scale configurations (130M–2.7B) and workload types
 """
 
 import torch
+import torch.nn.functional as F
 
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -138,3 +139,96 @@ class Mamba2FwdTest(WorkloadBase):
         dt_bias = torch.randn(h,           dtype=torch.float32, device=dev) * 0.1
 
         return x, dt_raw, A, B, C, dt_bias
+
+
+def mamba2_fwd_ref(
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    chunk_size: int,
+    dt_softplus: bool,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for the Mamba-2 SSD forward pass.
+
+    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
+      out[l,p] = exp(dA[l]) * C[l] @ prev_state
+               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
+
+    Inputs:
+        x:           (B, S, H, P)     dtype
+        dt:          (B, S, H)        float32
+        A:           (H,)             float32  (log-space, <= 0)
+        B:           (B, S, G, N)     dtype
+        C:           (B, S, G, N)     dtype
+        dt_bias:     (H,)             float32, optional
+        chunk_size:  int
+        dt_softplus: bool
+
+    Returns:
+        y: (B, S, H, P)  float32
+    """
+    b, S, h, p = x.shape
+    n = B.shape[-1]
+    g = B.shape[2]
+    hpg = h // g
+    Q = chunk_size
+    num_chunks = S // Q
+
+    # Step 1: DaCumsum
+    dt_val = dt.float()
+    if dt_bias is not None:
+        dt_val = dt_val + dt_bias.float()
+    if dt_softplus:
+        dt_val = F.softplus(dt_val)
+    dt_val = torch.clamp(dt_val, min=0.0)
+    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)
+    dA = dt_chunked * A.float().view(1, h, 1, 1)
+    dA_cumsum = dA.cumsum(dim=-1)
+
+    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned.
+    B_c = B.float().reshape(b, num_chunks, Q, g, n)
+    C_c = C.float().reshape(b, num_chunks, Q, g, n)
+    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)
+    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
+    cb = cb * mask.view(1, 1, 1, Q, Q)
+
+    # Step 3: SSDChunkState
+    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)
+    decay_c = decay.permute(0, 2, 3, 1)
+    dt_c = dt_chunked.permute(0, 2, 3, 1)
+    x_c = x.float().reshape(b, num_chunks, Q, h, p)
+    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
+    wx = x_c * (decay_c * dt_c).unsqueeze(-1)
+    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)
+
+    # Step 4: SSDStatePassing
+    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])
+    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
+    prev_states_list = []
+    for ci in range(num_chunks):
+        prev_states_list.append(s.unsqueeze(1))
+        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
+        s = scale * s + chunk_states[:, ci]
+    prev_states = torch.cat(prev_states_list, dim=1)
+
+    # Step 5: SSDChunkScan
+    dA_c = dA_cumsum.permute(0, 2, 3, 1)
+    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
+
+    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
+    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
+
+    dA_l = dA_cumsum.unsqueeze(-1)
+    dA_s = dA_cumsum.unsqueeze(-2)
+    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
+        ~mask.view(1, 1, 1, Q, Q), 0.0
+    ).permute(0, 2, 1, 3, 4)
+    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]
+    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)
+    wx_t = x_c.permute(0, 1, 3, 2, 4)
+    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
+
+    return (y_hist + y_intra).reshape(b, S, h, p)

--- a/workloads/mamba2_e2e.py
+++ b/workloads/mamba2_e2e.py
@@ -5,7 +5,6 @@ Covers model-scale configurations (130M–2.7B) and workload types
 """
 
 import torch
-import torch.nn.functional as F
 
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -139,96 +138,3 @@ class Mamba2FwdTest(WorkloadBase):
         dt_bias = torch.randn(h,           dtype=torch.float32, device=dev) * 0.1
 
         return x, dt_raw, A, B, C, dt_bias
-
-
-def mamba2_fwd_ref(
-    x: torch.Tensor,
-    dt: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    dt_bias: torch.Tensor | None,
-    chunk_size: int,
-    dt_softplus: bool,
-) -> torch.Tensor:
-    """Pure-PyTorch reference for the Mamba-2 SSD forward pass.
-
-    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
-      out[l,p] = exp(dA[l]) * C[l] @ prev_state
-               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
-
-    Inputs:
-        x:           (B, S, H, P)     dtype
-        dt:          (B, S, H)        float32
-        A:           (H,)             float32  (log-space, <= 0)
-        B:           (B, S, G, N)     dtype
-        C:           (B, S, G, N)     dtype
-        dt_bias:     (H,)             float32, optional
-        chunk_size:  int
-        dt_softplus: bool
-
-    Returns:
-        y: (B, S, H, P)  float32
-    """
-    b, S, h, p = x.shape
-    n = B.shape[-1]
-    g = B.shape[2]
-    hpg = h // g
-    Q = chunk_size
-    num_chunks = S // Q
-
-    # Step 1: DaCumsum
-    dt_val = dt.float()
-    if dt_bias is not None:
-        dt_val = dt_val + dt_bias.float()
-    if dt_softplus:
-        dt_val = F.softplus(dt_val)
-    dt_val = torch.clamp(dt_val, min=0.0)
-    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)
-    dA = dt_chunked * A.float().view(1, h, 1, 1)
-    dA_cumsum = dA.cumsum(dim=-1)
-
-    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned.
-    B_c = B.float().reshape(b, num_chunks, Q, g, n)
-    C_c = C.float().reshape(b, num_chunks, Q, g, n)
-    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)
-    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
-    cb = cb * mask.view(1, 1, 1, Q, Q)
-
-    # Step 3: SSDChunkState
-    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)
-    decay_c = decay.permute(0, 2, 3, 1)
-    dt_c = dt_chunked.permute(0, 2, 3, 1)
-    x_c = x.float().reshape(b, num_chunks, Q, h, p)
-    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-    wx = x_c * (decay_c * dt_c).unsqueeze(-1)
-    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)
-
-    # Step 4: SSDStatePassing
-    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])
-    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
-    prev_states_list = []
-    for ci in range(num_chunks):
-        prev_states_list.append(s.unsqueeze(1))
-        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
-        s = scale * s + chunk_states[:, ci]
-    prev_states = torch.cat(prev_states_list, dim=1)
-
-    # Step 5: SSDChunkScan
-    dA_c = dA_cumsum.permute(0, 2, 3, 1)
-    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-
-    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
-    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
-
-    dA_l = dA_cumsum.unsqueeze(-1)
-    dA_s = dA_cumsum.unsqueeze(-2)
-    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
-        ~mask.view(1, 1, 1, Q, Q), 0.0
-    ).permute(0, 2, 1, 3, 4)
-    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]
-    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)
-    wx_t = x_c.permute(0, 1, 3, 2, 4)
-    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
-
-    return (y_hist + y_intra).reshape(b, S, h, p)


### PR DESCRIPTION
## Summary

Fixes #1803.

- Remove remaining production benchmark imports from `tests.*` in GEMM, BMM, and Mamba2 E2E benchmarks.
- Move shared Mamba2 PyTorch reference code to `tileops.testing.mamba2_reference` for test/benchmark reuse without importing `tests.*`.
- Add an AST boundary test preventing production benchmarks from importing the `tests` package.

## Validation

- `rg` confirms no `tests.*` imports under `benchmarks/ops` or `benchmarks/kernels`.
- `ruff check` on changed files.
- `pytest -q benchmarks/tests/test_benchmark_base.py benchmarks/tests/test_benchmark_import_boundaries.py`.
- `compileall` and `git diff --check`.

Closes #1803.
