### PR TITLE
[Bench] Keep GQA paged decode benchmarks untuned

### DIFF
--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -132,6 +132,7 @@ def _flashinfer_gqa_decode_paged(test, q, k, v, real_seqlen_kv, block_table):
 _GQA_DECODE_PAGED_BENCH_PARAMS = manifest_params(
     load_workloads(_OP_NAME),
     gqa_decode_paged_args,
+    tune=False,
 )
 
 


### PR DESCRIPTION
## Summary
- Keep the manifest-driven GQA paged decode benchmark parameters explicitly untuned with `tune=False`.
- Narrow this PR to the benchmark stage boundary per review feedback: no `tests/` changes and no `tileops/manifest/` changes.
- The p16 workload manifest updates and deterministic p16 split-path correctness coverage should land in separately owned PRs before this benchmark consumes them.

## Test plan
Official runner image: `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`, using the preinstalled environment with source/cache mounts and no dependency installs/upgrades.

- `python3 -m pytest -q benchmarks/tests --tb=short`
  - `22 passed, 2 warnings`
- `python3 scripts/validate_manifest.py --check-op GroupedQueryAttentionDecodePagedWithKVCacheFwdOp --verbose`
  - `All manifest checks passed.`
  - Existing advisory warning: class does not override `_infer_output_shapes`; parity check skipped.