### PR TITLE
[Feat][Pool] Implement adaptive 2D pooling ops

### DIFF
--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -16,6 +16,9 @@ from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
 from tileops.kernels.pool.common import pool_output_dim
 from tileops.manifest import load_workloads
 from tileops.ops import (
+    AdaptiveAvgPool2dFwdOp,
+    AdaptiveMaxPool2dFwdOp,
+    AdaptiveMaxPool2dIndicesFwdOp,
     AvgPool1dFwdOp,
     AvgPool2dFwdOp,
     AvgPool3dFwdOp,
@@ -35,6 +38,9 @@ from workloads.pool import (
     MaxPool3dBenchCase,
 )
 
+_ADAPTIVE_AVG_POOL2D_OP_NAME = "AdaptiveAvgPool2dFwdOp"
+_ADAPTIVE_MAX_POOL2D_OP_NAME = "AdaptiveMaxPool2dFwdOp"
+_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME = "AdaptiveMaxPool2dIndicesFwdOp"
 _AVG_POOL1D_OP_NAME = "AvgPool1dFwdOp"
 _AVG_POOL2D_OP_NAME = "AvgPool2dFwdOp"
 _AVG_POOL3D_OP_NAME = "AvgPool3dFwdOp"
@@ -782,6 +788,164 @@ def test_max_pool3d_indices_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL3D_INDICES_OP_NAME, op, test)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+
+
+class AdaptiveAvgPool2dBenchCase:
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        output_size: tuple[int, int],
+        dtype: torch.dtype,
+    ) -> None:
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.output_size = output_size
+        self.dtype = dtype
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(
+            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
+        ).contiguous()
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor:
+        return F.adaptive_avg_pool2d(x, self.output_size)
+
+
+class AdaptiveMaxPool2dBenchCase:
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        output_size: tuple[int, int],
+        dtype: torch.dtype,
+        return_indices: bool = False,
+    ) -> None:
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.output_size = output_size
+        self.dtype = dtype
+        self.return_indices = return_indices
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(
+            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
+        ).contiguous()
+        return (x,)
+
+    def ref_program(self, x: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        return F.adaptive_max_pool2d(
+            x, self.output_size, return_indices=self.return_indices
+        )
+
+
+def _adaptive_pool2d_bench_params(op_name: str) -> list:
+    params = []
+    for workload in load_workloads(op_name):
+        n, c_in, h_in, w_in = workload["input_shape"]
+        output_size = tuple(workload["output_size"])
+        label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
+        for dtype_str in workload["dtypes"]:
+            dtype = getattr(torch, dtype_str)
+            params.append(
+                pytest.param(
+                    n,
+                    c_in,
+                    h_in,
+                    w_in,
+                    output_size,
+                    dtype,
+                    True,
+                    id=f"{label}-{dtype_str}",
+                )
+            )
+    return params
+
+
+@pytest.mark.parametrize(
+    "n, c_in, h_in, w_in, output_size, dtype, tune",
+    _adaptive_pool2d_bench_params(_ADAPTIVE_AVG_POOL2D_OP_NAME),
+)
+def test_adaptive_avg_pool2d_bench(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    output_size: tuple[int, int],
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    test = AdaptiveAvgPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
+    inputs = test.gen_inputs()
+
+    op = AdaptiveAvgPool2dFwdOp(output_size=output_size, tune=tune)
+    bm = ManifestBenchmark(_ADAPTIVE_AVG_POOL2D_OP_NAME, op, test)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+
+
+@pytest.mark.parametrize(
+    "n, c_in, h_in, w_in, output_size, dtype, tune",
+    _adaptive_pool2d_bench_params(_ADAPTIVE_MAX_POOL2D_OP_NAME),
+)
+def test_adaptive_max_pool2d_bench(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    output_size: tuple[int, int],
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    test = AdaptiveMaxPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
+    inputs = test.gen_inputs()
+
+    op = AdaptiveMaxPool2dFwdOp(output_size=output_size, tune=tune)
+    bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_OP_NAME, op, test)
+    result = bm.profile(op, *inputs)
+    BenchmarkReport.record(op, locals(), result, tag="tileops")
+
+    result_bl = bm.profile(test.ref_program, *inputs)
+    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+
+
+@pytest.mark.parametrize(
+    "n, c_in, h_in, w_in, output_size, dtype, tune",
+    _adaptive_pool2d_bench_params(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME),
+)
+def test_adaptive_max_pool2d_indices_bench(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    output_size: tuple[int, int],
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    test = AdaptiveMaxPool2dBenchCase(
+        n, c_in, h_in, w_in, output_size, dtype, return_indices=True
+    )
+    inputs = test.gen_inputs()
+
+    op = AdaptiveMaxPool2dIndicesFwdOp(output_size=output_size, tune=tune)
+    bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -853,9 +853,9 @@ class AdaptiveMaxPool2dBenchCase:
         )
 
 
-def _adaptive_pool2d_bench_params(op_name: str) -> list:
+def _adaptive_pool2d_bench_params_from_workloads(workloads) -> list:
     params = []
-    for workload in load_workloads(op_name):
+    for workload in workloads:
         n, c_in, h_in, w_in = workload["input_shape"]
         output_size = tuple(workload["output_size"])
         label = workload.get("label", f"{n}x{c_in}x{h_in}x{w_in}")
@@ -878,7 +878,7 @@ def _adaptive_pool2d_bench_params(op_name: str) -> list:
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params(_ADAPTIVE_AVG_POOL2D_OP_NAME),
+    _adaptive_pool2d_bench_params_from_workloads(load_workloads(_ADAPTIVE_AVG_POOL2D_OP_NAME)),
 )
 def test_adaptive_avg_pool2d_bench(
     n: int,
@@ -903,7 +903,7 @@ def test_adaptive_avg_pool2d_bench(
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params(_ADAPTIVE_MAX_POOL2D_OP_NAME),
+    _adaptive_pool2d_bench_params_from_workloads(load_workloads(_ADAPTIVE_MAX_POOL2D_OP_NAME)),
 )
 def test_adaptive_max_pool2d_bench(
     n: int,
@@ -928,7 +928,7 @@ def test_adaptive_max_pool2d_bench(
 
 @pytest.mark.parametrize(
     "n, c_in, h_in, w_in, output_size, dtype, tune",
-    _adaptive_pool2d_bench_params(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME),
+    _adaptive_pool2d_bench_params_from_workloads(load_workloads(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME)),
 )
 def test_adaptive_max_pool2d_indices_bench(
     n: int,

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -798,7 +798,9 @@ def test_max_pool3d_indices_bench(
 
 class _AdaptiveAvgPool2dBenchCase(AdaptivePool2dWorkload):
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        return F.adaptive_avg_pool2d(x, self.torch_output_size)
+        # torch rejects a scalar None here; (None, None) means the same.
+        size = (None, None) if self.output_size is None else self.output_size
+        return F.adaptive_avg_pool2d(x, size)
 
 
 class _AdaptiveMaxPool2dBenchCase(AdaptivePool2dWorkload):
@@ -807,8 +809,10 @@ class _AdaptiveMaxPool2dBenchCase(AdaptivePool2dWorkload):
         self.return_indices = return_indices
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # torch rejects a scalar None here; (None, None) means the same.
+        size = (None, None) if self.output_size is None else self.output_size
         return F.adaptive_max_pool2d(
-            x, self.torch_output_size, return_indices=self.return_indices
+            x, size, return_indices=self.return_indices
         )
 
 

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -30,6 +30,7 @@ from tileops.ops import (
     MaxPool3dIndicesFwdOp,
 )
 from workloads.pool import (
+    AdaptivePool2dWorkload,
     AvgPool1dBenchCase,
     AvgPool2dBenchCase,
     AvgPool3dBenchCase,
@@ -795,61 +796,19 @@ def test_max_pool3d_indices_bench(
     BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-class AdaptiveAvgPool2dBenchCase:
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        output_size: tuple[int, int],
-        dtype: torch.dtype,
-    ) -> None:
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.output_size = output_size
-        self.dtype = dtype
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(
-            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
-        ).contiguous()
-        return (x,)
-
+class _AdaptiveAvgPool2dBenchCase(AdaptivePool2dWorkload):
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:
-        return F.adaptive_avg_pool2d(x, self.output_size)
+        return F.adaptive_avg_pool2d(x, self.torch_output_size)
 
 
-class AdaptiveMaxPool2dBenchCase:
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        output_size: tuple[int, int],
-        dtype: torch.dtype,
-        return_indices: bool = False,
-    ) -> None:
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.output_size = output_size
-        self.dtype = dtype
+class _AdaptiveMaxPool2dBenchCase(AdaptivePool2dWorkload):
+    def __init__(self, *args, return_indices: bool = False, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self.return_indices = return_indices
-
-    def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(
-            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
-        ).contiguous()
-        return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return F.adaptive_max_pool2d(
-            x, self.output_size, return_indices=self.return_indices
+            x, self.torch_output_size, return_indices=self.return_indices
         )
 
 
@@ -889,7 +848,7 @@ def test_adaptive_avg_pool2d_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = AdaptiveAvgPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
+    test = _AdaptiveAvgPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
     inputs = test.gen_inputs()
 
     op = AdaptiveAvgPool2dFwdOp(output_size=output_size, tune=tune)
@@ -914,7 +873,7 @@ def test_adaptive_max_pool2d_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = AdaptiveMaxPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
+    test = _AdaptiveMaxPool2dBenchCase(n, c_in, h_in, w_in, output_size, dtype)
     inputs = test.gen_inputs()
 
     op = AdaptiveMaxPool2dFwdOp(output_size=output_size, tune=tune)
@@ -939,7 +898,7 @@ def test_adaptive_max_pool2d_indices_bench(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = AdaptiveMaxPool2dBenchCase(
+    test = _AdaptiveMaxPool2dBenchCase(
         n, c_in, h_in, w_in, output_size, dtype, return_indices=True
     )
     inputs = test.gen_inputs()

--- a/docs/design/ops-design.md
+++ b/docs/design/ops-design.md
@@ -312,6 +312,26 @@ satisfy the cold-call contract.
 
 The scaffold emits T2 (L1-direct) ops only; once a family accumulates 2-3 ops sharing an identical `forward()` flow, a separate family-specific refactoring (not scaffold-op) extracts an L2 base and rewrites the concrete ops as T1 thin wrappers — see [Development Path](ops-design-reference.md#development-path) for when to extract and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the process. Family bases MUST NOT normalize genuine per-op behavior differences.
 
+### Adaptive 2D pool protocol
+
+`_AdaptivePool2dFwdOpBase` owns the common adaptive-pooling flow for the
+average, max-value, and max-with-indices variants. It normalizes CHW input to
+NCHW for the kernel, resolves `None` output dimensions, caches kernels by the
+resolved shape/dtype/device/tuning tuple, and restores the original rank on
+return.
+
+Concrete adaptive-pool Ops provide two class variables:
+
+- `_kernel_slot` selects the manifest-declared `kernel_map` entry.
+- `_returns_indices` selects the value-only or `(output, indices)` shape and
+  post-processing path; it defaults to `False` and is enabled only by the
+  indices variant.
+
+Each concrete class still declares its own `default_kernel_map`,
+`_validate_dtypes`, and `eval_roofline`. Keeping those slots class-local lets
+manifest code generation resolve each public Op independently rather than
+silently inheriting another variant's contract.
+
 ## Further Reference
 
 - [Slot Rules](ops-design-reference.md#slot-rules) — full Rule / Derivation / Example / Common mistakes per slot

--- a/docs/design/ops-design.md
+++ b/docs/design/ops-design.md
@@ -312,26 +312,6 @@ satisfy the cold-call contract.
 
 The scaffold emits T2 (L1-direct) ops only; once a family accumulates 2-3 ops sharing an identical `forward()` flow, a separate family-specific refactoring (not scaffold-op) extracts an L2 base and rewrites the concrete ops as T1 thin wrappers — see [Development Path](ops-design-reference.md#development-path) for when to extract and [Adding a New Family Base](ops-design-reference.md#adding-a-new-family-base) for the process. Family bases MUST NOT normalize genuine per-op behavior differences.
 
-### Adaptive 2D pool protocol
-
-`_AdaptivePool2dFwdOpBase` owns the common adaptive-pooling flow for the
-average, max-value, and max-with-indices variants. It normalizes CHW input to
-NCHW for the kernel, resolves `None` output dimensions, caches kernels by the
-resolved shape/dtype/device/tuning tuple, and restores the original rank on
-return.
-
-Concrete adaptive-pool Ops provide two class variables:
-
-- `_kernel_slot` selects the manifest-declared `kernel_map` entry.
-- `_returns_indices` selects the value-only or `(output, indices)` shape and
-  post-processing path; it defaults to `False` and is enabled only by the
-  indices variant.
-
-Each concrete class still declares its own `default_kernel_map`,
-`_validate_dtypes`, and `eval_roofline`. Keeping those slots class-local lets
-manifest code generation resolve each public Op independently rather than
-silently inheriting another variant's contract.
-
 ## Further Reference
 
 - [Slot Rules](ops-design-reference.md#slot-rules) — full Rule / Derivation / Example / Common mistakes per slot

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1770,6 +1770,9 @@ class AdaptiveAvgPool2dFixture(FixtureBase):
                 pytest.param(
                     1, 8, 9, 11, (None, None), torch.float16, False,
                     marks=pytest.mark.full, id="full-all-none-identity-fp16"),
+                pytest.param(
+                    1, 8, 9, 11, None, torch.float16, False,
+                    marks=pytest.mark.full, id="full-scalar-none-identity-fp16"),
             ],
         ),
     ]
@@ -1808,6 +1811,9 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
                 pytest.param(
                     1, 16, 10, 10, [6, 6], torch.float16, False,
                     marks=pytest.mark.full, id="full-list-output-size-fp16"),
+                pytest.param(
+                    1, 8, 9, 11, None, torch.float16, False,
+                    marks=pytest.mark.full, id="full-scalar-none-identity-fp16"),
             ],
         ),
     ]
@@ -1816,7 +1822,7 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
 class AdaptiveAvgPool2dTest(TestBase):
     def __init__(
         self,
-        output_size: int | tuple[int | None, int | None],
+        output_size: int | None | tuple[int | None, int | None],
         dtype: torch.dtype,
     ) -> None:
         self.output_size = output_size
@@ -1827,13 +1833,15 @@ class AdaptiveAvgPool2dTest(TestBase):
         return (x,)
 
     def ref_program(self, input: torch.Tensor) -> torch.Tensor:
-        return F.adaptive_avg_pool2d(input, self.output_size)
+        # torch 2.10 rejects scalar None; (None, None) is the same semantics.
+        output_size = (None, None) if self.output_size is None else self.output_size
+        return F.adaptive_avg_pool2d(input, output_size)
 
 
 class AdaptiveMaxPool2dTest(TestBase):
     def __init__(
         self,
-        output_size: int | tuple[int | None, int | None],
+        output_size: int | None | tuple[int | None, int | None],
         dtype: torch.dtype,
         return_indices: bool,
     ) -> None:
@@ -1846,8 +1854,10 @@ class AdaptiveMaxPool2dTest(TestBase):
         return (x,)
 
     def ref_program(self, input: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # torch 2.10 rejects scalar None; (None, None) is the same semantics.
+        output_size = (None, None) if self.output_size is None else self.output_size
         return F.adaptive_max_pool2d(
-            input, self.output_size, return_indices=self.return_indices
+            input, output_size, return_indices=self.return_indices
         )
 
 
@@ -1857,7 +1867,7 @@ def test_adaptive_avg_pool2d(
     c_in: int,
     h_in: int,
     w_in: int,
-    output_size: int | tuple[int | None, int | None],
+    output_size: int | None | tuple[int | None, int | None],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
@@ -1874,7 +1884,7 @@ def test_adaptive_max_pool2d(
     c_in: int,
     h_in: int,
     w_in: int,
-    output_size: int | tuple[int | None, int | None],
+    output_size: int | None | tuple[int | None, int | None],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
@@ -1943,19 +1953,19 @@ def test_adaptive_max_pool2d_tied_maxima_indices() -> None:
             id="zero-entry"),
         pytest.param(
             (2, 2, 2), TypeError,
-            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
             id="len-3-tuple"),
         pytest.param(
             "3", TypeError,
-            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
             id="string"),
         pytest.param(
             True, TypeError,
-            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
             id="bool"),
         pytest.param(
             (3.0, 3), TypeError,
-            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
             id="float-entry"),
     ],
 )

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1834,7 +1834,7 @@ def test_adaptive_max_pool2d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    # 同一配置同时覆盖 return_indices=False / True 两个 Op。
+    # Exercise both the plain and the return_indices op on the same config.
     for return_indices in (False, True):
         test = AdaptiveMaxPool2dTest(output_size, dtype, return_indices)
         op_cls = (
@@ -1876,7 +1876,8 @@ def test_adaptive_max_pool2d_indices_unbatched_and_batched(with_batch: bool) -> 
 @pytest.mark.smoke
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_adaptive_max_pool2d_tied_maxima_indices() -> None:
-    # bin 内并列最大值：索引必须与 PyTorch 完全一致（行主序首个）。
+    # Tied maxima inside a bin: indices must match PyTorch exactly (first in
+    # row-major order).
     x = torch.tensor(
         [[[[1.0, 3.0, 0.0], [3.0, 2.0, 1.0], [0.0, 1.0, 2.0]]]],
         device="cuda", dtype=torch.float16,

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1730,7 +1730,7 @@ class AdaptiveAvgPool2dFixture(FixtureBase):
                     1, 16, 10, 10, 4, torch.bfloat16, False,
                     marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
                 pytest.param(
-                    1, 8, 9, 11, (None, None), torch.float16, False,
+                    1, 8, 9, 11, None, torch.float16, False,
                     marks=pytest.mark.full, id="full-all-none-identity-fp16"),
             ],
         ),
@@ -1763,7 +1763,9 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
 
 class AdaptiveAvgPool2dTest(AdaptivePool2dWorkload, TestBase):
     def ref_program(self, input: torch.Tensor) -> torch.Tensor:
-        return F.adaptive_avg_pool2d(input, self.torch_output_size)
+        # torch rejects a scalar None here; (None, None) means the same.
+        size = (None, None) if self.output_size is None else self.output_size
+        return F.adaptive_avg_pool2d(input, size)
 
 
 class AdaptiveMaxPool2dTest(AdaptivePool2dWorkload, TestBase):
@@ -1772,8 +1774,10 @@ class AdaptiveMaxPool2dTest(AdaptivePool2dWorkload, TestBase):
         self.return_indices = return_indices
 
     def ref_program(self, input: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # torch rejects a scalar None here; (None, None) means the same.
+        size = (None, None) if self.output_size is None else self.output_size
         return F.adaptive_max_pool2d(
-            input, self.torch_output_size, return_indices=self.return_indices
+            input, size, return_indices=self.return_indices
         )
 
 
@@ -1858,6 +1862,36 @@ def test_adaptive_pool_compile_fullgraph(
     else:
         ref = F.adaptive_max_pool2d(x, (4, 4))
         torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+def test_adaptive_pool2d_accepts_chw() -> None:
+    """A 3-D input keeps its rank on the way out; NCHW cases never exercise that."""
+    x = torch.randn(16, 11, 13, device="cuda", dtype=torch.float16)
+    avg = AdaptiveAvgPool2dFwdOp(output_size=(5, 4))(x)
+    assert avg.shape == (16, 5, 4)
+    torch.testing.assert_close(
+        avg.float(), F.adaptive_avg_pool2d(x.float(), (5, 4)), atol=2e-3, rtol=2e-3
+    )
+
+    val, idx = AdaptiveMaxPool2dIndicesFwdOp(output_size=(5, 4))(x)
+    ref_val, ref_idx = F.adaptive_max_pool2d(x.float(), (5, 4), return_indices=True)
+    assert val.shape == (16, 5, 4) and idx.shape == (16, 5, 4)
+    torch.testing.assert_close(val.float(), ref_val, atol=0, rtol=0)
+    torch.testing.assert_close(idx, ref_idx, atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+def test_adaptive_max_pool2d_indices_nan_window() -> None:
+    """A NaN in the window wins, and the recorded index is the last one seen."""
+    x = torch.randn(1, 1, 4, 4, device="cuda", dtype=torch.float16)
+    x[0, 0, 1, 1] = float("nan")
+    x[0, 0, 3, 3] = float("nan")
+
+    val, idx = AdaptiveMaxPool2dIndicesFwdOp(output_size=(1, 1))(x)
+    ref_val, ref_idx = F.adaptive_max_pool2d(x.float(), (1, 1), return_indices=True)
+    assert torch.isnan(val.float()).all()
+    torch.testing.assert_close(idx, ref_idx, atol=0, rtol=0)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -9,6 +9,9 @@ from tests.compile_contract import register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
+    AdaptiveAvgPool2dKernel,
+    AdaptiveMaxPool2dKernel,
+    AdaptiveMaxPool2dWithIndicesKernel,
     AvgPool1dKernel,
     AvgPool1dSpatialKernel,
     AvgPool2dSpatialKernel,
@@ -22,6 +25,9 @@ from tileops.kernels.pool import (
     MaxPool3dWithIndicesKernel,
 )
 from tileops.ops import (
+    AdaptiveAvgPool2dFwdOp,
+    AdaptiveMaxPool2dFwdOp,
+    AdaptiveMaxPool2dIndicesFwdOp,
     AvgPool1dFwdOp,
     AvgPool2dFwdOp,
     AvgPool3dFwdOp,
@@ -1695,6 +1701,219 @@ def test_avg_pool2d_kernel_cache_separates_dtypes() -> None:
     op(torch.randn(*shape, dtype=torch.float16, device="cuda"))
     op(torch.randn(*shape, dtype=torch.float32, device="cuda"))
     assert len(op._kernel_cache) == 2
+
+
+# ---------------------------------------------------------------------------
+# Adaptive pool family
+# ---------------------------------------------------------------------------
+
+
+class AdaptiveAvgPool2dFixture(FixtureBase):
+    PARAMS = [
+        (
+            "n, c_in, h_in, w_in, output_size, dtype, tune",
+            [
+                pytest.param(
+                    2, 64, 56, 56, (6, 6), torch.float16, False,
+                    marks=[pytest.mark.smoke, pytest.mark.packaging],
+                    id="smoke-spp-6x6-fp16"),
+                pytest.param(
+                    2, 64, 56, 56, (6, 6), torch.bfloat16, False,
+                    marks=pytest.mark.smoke, id="smoke-spp-6x6-bf16"),
+                pytest.param(
+                    1, 32, 7, 7, (1, 1), torch.float16, False,
+                    marks=pytest.mark.smoke, id="smoke-global-fp16"),
+                pytest.param(
+                    1, 128, 55, 57, (7, 7), torch.float16, False,
+                    marks=pytest.mark.full, id="full-nondiv-fp16"),
+                pytest.param(
+                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
+                    marks=pytest.mark.full, id="full-asymmetric-bf16"),
+                pytest.param(
+                    1, 8, 8, 8, (12, 12), torch.float16, False,
+                    marks=pytest.mark.full, id="full-expand-fp16"),
+                pytest.param(
+                    1, 16, 11, 13, (None, 5), torch.float16, False,
+                    marks=pytest.mark.full, id="full-partial-none-fp16"),
+                pytest.param(
+                    1, 16, 10, 10, 4, torch.bfloat16, False,
+                    marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
+            ],
+        ),
+    ]
+
+
+class AdaptiveMaxPool2dFixture(FixtureBase):
+    PARAMS = [
+        (
+            "n, c_in, h_in, w_in, output_size, dtype, tune",
+            [
+                pytest.param(
+                    2, 64, 56, 56, (6, 6), torch.float16, False,
+                    marks=[pytest.mark.smoke, pytest.mark.packaging],
+                    id="smoke-spp-6x6-fp16"),
+                pytest.param(
+                    2, 64, 56, 56, (6, 6), torch.bfloat16, False,
+                    marks=pytest.mark.smoke, id="smoke-spp-6x6-bf16"),
+                pytest.param(
+                    1, 32, 7, 7, (1, 1), torch.float16, False,
+                    marks=pytest.mark.smoke, id="smoke-global-fp16"),
+                pytest.param(
+                    1, 128, 55, 57, (7, 7), torch.float16, False,
+                    marks=pytest.mark.full, id="full-nondiv-fp16"),
+                pytest.param(
+                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
+                    marks=pytest.mark.full, id="full-asymmetric-bf16"),
+                pytest.param(
+                    1, 8, 8, 8, (12, 12), torch.float16, False,
+                    marks=pytest.mark.full, id="full-expand-fp16"),
+                pytest.param(
+                    1, 16, 11, 13, (5, None), torch.float16, False,
+                    marks=pytest.mark.full, id="full-partial-none-fp16"),
+                pytest.param(
+                    1, 16, 10, 10, 4, torch.bfloat16, False,
+                    marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
+            ],
+        ),
+    ]
+
+
+class AdaptiveAvgPool2dTest(TestBase):
+    def __init__(self, output_size, dtype: torch.dtype) -> None:
+        self.output_size = output_size
+        self.dtype = dtype
+
+    def gen_inputs(self, *shape: int) -> tuple[torch.Tensor]:
+        x = torch.randn(*shape, device="cuda", dtype=self.dtype).contiguous()
+        return (x,)
+
+    def ref_program(self, input: torch.Tensor) -> torch.Tensor:
+        return F.adaptive_avg_pool2d(input, self.output_size)
+
+
+class AdaptiveMaxPool2dTest(TestBase):
+    def __init__(self, output_size, dtype: torch.dtype, return_indices: bool) -> None:
+        self.output_size = output_size
+        self.dtype = dtype
+        self.return_indices = return_indices
+
+    def gen_inputs(self, *shape: int) -> tuple[torch.Tensor]:
+        x = torch.randn(*shape, device="cuda", dtype=self.dtype).contiguous()
+        return (x,)
+
+    def ref_program(self, input: torch.Tensor):
+        return F.adaptive_max_pool2d(
+            input, self.output_size, return_indices=self.return_indices
+        )
+
+
+@AdaptiveAvgPool2dFixture
+def test_adaptive_avg_pool2d(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    output_size,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    test = AdaptiveAvgPool2dTest(output_size, dtype)
+    op = AdaptiveAvgPool2dFwdOp(output_size, tune=tune)
+    atol, rtol = (1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2)
+    test.check(op, *test.gen_inputs(n, c_in, h_in, w_in), atol=atol, rtol=rtol)
+    assert isinstance(op.kernel, AdaptiveAvgPool2dKernel)
+
+
+@AdaptiveMaxPool2dFixture
+def test_adaptive_max_pool2d(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    output_size,
+    dtype: torch.dtype,
+    tune: bool,
+) -> None:
+    # 同一配置同时覆盖 return_indices=False / True 两个 Op。
+    for return_indices in (False, True):
+        test = AdaptiveMaxPool2dTest(output_size, dtype, return_indices)
+        op_cls = (
+            AdaptiveMaxPool2dIndicesFwdOp if return_indices else AdaptiveMaxPool2dFwdOp
+        )
+        op = op_cls(output_size, tune=tune)
+        test.check(op, *test.gen_inputs(n, c_in, h_in, w_in), atol=0, rtol=0)
+        expected_kernel = (
+            AdaptiveMaxPool2dWithIndicesKernel if return_indices else AdaptiveMaxPool2dKernel
+        )
+        assert isinstance(op.kernel, expected_kernel)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("with_batch", [False, True], ids=["chw", "nchw"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+def test_adaptive_avg_pool2d_unbatched_and_batched(with_batch: bool, dtype: torch.dtype) -> None:
+    shape = (2, 8, 55, 57) if with_batch else (8, 55, 57)
+    x = torch.randn(*shape, device="cuda", dtype=dtype)
+    op = AdaptiveAvgPool2dFwdOp((7, 7))
+    ref = F.adaptive_avg_pool2d(x, (7, 7))
+    atol, rtol = (1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2)
+    torch.testing.assert_close(op(x), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("with_batch", [False, True], ids=["chw", "nchw"])
+def test_adaptive_max_pool2d_indices_unbatched_and_batched(with_batch: bool) -> None:
+    shape = (2, 8, 55, 57) if with_batch else (8, 55, 57)
+    x = torch.randn(*shape, device="cuda", dtype=torch.float16)
+    out, idx = AdaptiveMaxPool2dIndicesFwdOp((7, 7))(x)
+    ref_out, ref_idx = F.adaptive_max_pool2d(x, (7, 7), return_indices=True)
+    torch.testing.assert_close(out, ref_out, atol=0, rtol=0)
+    assert idx.dtype == torch.int64 and torch.equal(idx, ref_idx)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_adaptive_max_pool2d_tied_maxima_indices() -> None:
+    # bin 内并列最大值：索引必须与 PyTorch 完全一致（行主序首个）。
+    x = torch.tensor(
+        [[[[1.0, 3.0, 0.0], [3.0, 2.0, 1.0], [0.0, 1.0, 2.0]]]],
+        device="cuda", dtype=torch.float16,
+    )
+    out, idx = AdaptiveMaxPool2dIndicesFwdOp((1, 1))(x)
+    ref_out, ref_idx = F.adaptive_max_pool2d(x, (1, 1), return_indices=True)
+    torch.testing.assert_close(out, ref_out, atol=0, rtol=0)
+    assert torch.equal(idx, ref_idx)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("output_size", "error"),
+    [
+        pytest.param(0, ValueError, id="zero"),
+        pytest.param((3, 0), ValueError, id="zero-entry"),
+        pytest.param((2, 2, 2), TypeError, id="len-3-tuple"),
+        pytest.param("3", TypeError, id="string"),
+        pytest.param(True, TypeError, id="bool"),
+        pytest.param((3.0, 3), TypeError, id="float-entry"),
+    ],
+)
+def test_adaptive_pool_rejects_invalid_output_size(output_size, error: type) -> None:
+    with pytest.raises(error):
+        AdaptiveAvgPool2dFwdOp(output_size)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_adaptive_pool_rejects_invalid_input() -> None:
+    op = AdaptiveAvgPool2dFwdOp((4, 4))
+    with pytest.raises(ValueError, match="3D CHW or 4D NCHW"):
+        op(torch.randn(8, 8, device="cuda", dtype=torch.float16))
+    with pytest.raises(ValueError, match="float16 or bfloat16"):
+        op(torch.randn(1, 4, 8, 8, device="cuda", dtype=torch.float32))
+    with pytest.raises(ValueError, match="CUDA"):
+        op(torch.randn(1, 4, 8, 8, dtype=torch.float16))
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -38,7 +38,7 @@ from tileops.ops import (
     MaxPool3dFwdOp,
     MaxPool3dIndicesFwdOp,
 )
-from workloads.pool import AvgPoolWorkload, MaxPoolWorkload
+from workloads.pool import AdaptivePool2dWorkload, AvgPoolWorkload, MaxPoolWorkload
 
 
 class _DummyKernel(Kernel):
@@ -1760,45 +1760,20 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
     ]
 
 
-class AdaptiveAvgPool2dTest(TestBase):
-    def __init__(
-        self,
-        output_size: int | None | tuple[int | None, int | None],
-        dtype: torch.dtype,
-    ) -> None:
-        self.output_size = output_size
-        self.dtype = dtype
 
-    def gen_inputs(self, *shape: int) -> tuple[torch.Tensor]:
-        x = torch.randn(*shape, device="cuda", dtype=self.dtype).contiguous()
-        return (x,)
-
+class AdaptiveAvgPool2dTest(AdaptivePool2dWorkload, TestBase):
     def ref_program(self, input: torch.Tensor) -> torch.Tensor:
-        # torch 2.10 rejects scalar None; (None, None) is the same semantics.
-        output_size = (None, None) if self.output_size is None else self.output_size
-        return F.adaptive_avg_pool2d(input, output_size)
+        return F.adaptive_avg_pool2d(input, self.torch_output_size)
 
 
-class AdaptiveMaxPool2dTest(TestBase):
-    def __init__(
-        self,
-        output_size: int | None | tuple[int | None, int | None],
-        dtype: torch.dtype,
-        return_indices: bool,
-    ) -> None:
-        self.output_size = output_size
-        self.dtype = dtype
+class AdaptiveMaxPool2dTest(AdaptivePool2dWorkload, TestBase):
+    def __init__(self, *args, return_indices: bool, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self.return_indices = return_indices
 
-    def gen_inputs(self, *shape: int) -> tuple[torch.Tensor]:
-        x = torch.randn(*shape, device="cuda", dtype=self.dtype).contiguous()
-        return (x,)
-
     def ref_program(self, input: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        # torch 2.10 rejects scalar None; (None, None) is the same semantics.
-        output_size = (None, None) if self.output_size is None else self.output_size
         return F.adaptive_max_pool2d(
-            input, output_size, return_indices=self.return_indices
+            input, self.torch_output_size, return_indices=self.return_indices
         )
 
 
@@ -1812,10 +1787,10 @@ def test_adaptive_avg_pool2d(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = AdaptiveAvgPool2dTest(output_size, dtype)
+    test = AdaptiveAvgPool2dTest(n, c_in, h_in, w_in, output_size, dtype)
     op = AdaptiveAvgPool2dFwdOp(output_size, tune=tune)
     atol, rtol = (1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2)
-    test.check(op, *test.gen_inputs(n, c_in, h_in, w_in), atol=atol, rtol=rtol)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
     assert isinstance(op.kernel, AdaptiveAvgPool2dKernel)
 
 
@@ -1831,12 +1806,14 @@ def test_adaptive_max_pool2d(
 ) -> None:
     # Exercise both the plain and the return_indices op on the same config.
     for return_indices in (False, True):
-        test = AdaptiveMaxPool2dTest(output_size, dtype, return_indices)
+        test = AdaptiveMaxPool2dTest(
+            n, c_in, h_in, w_in, output_size, dtype, return_indices=return_indices
+        )
         op_cls = (
             AdaptiveMaxPool2dIndicesFwdOp if return_indices else AdaptiveMaxPool2dFwdOp
         )
         op = op_cls(output_size, tune=tune)
-        test.check(op, *test.gen_inputs(n, c_in, h_in, w_in), atol=0, rtol=0)
+        test.check(op, *test.gen_inputs(), atol=0, rtol=0)
         expected_kernel = (
             AdaptiveMaxPool2dWithIndicesKernel if return_indices else AdaptiveMaxPool2dKernel
         )

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1453,6 +1453,12 @@ _MAX_POOL_CTOR_PARAMS = (
     ("tune", False),
 )
 
+_ADAPTIVE_POOL_CTOR_PARAMS = (
+    ("output_size", _EMPTY),
+    ("kernel_map", None),
+    ("tune", False),
+)
+
 # Manifest-pinned constructor contract: parameter names, order, and defaults.
 _POOL_CTOR_SNAPSHOTS: list = [
     pytest.param(AvgPool1dFwdOp, _AVG_POOL_CTOR_PARAMS_1D, id="avg-pool1d"),
@@ -1464,6 +1470,11 @@ _POOL_CTOR_SNAPSHOTS: list = [
     pytest.param(MaxPool2dIndicesFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool2d-indices"),
     pytest.param(MaxPool3dFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool3d"),
     pytest.param(MaxPool3dIndicesFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool3d-indices"),
+    pytest.param(AdaptiveAvgPool2dFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS, id="adaptive-avg-pool2d"),
+    pytest.param(AdaptiveMaxPool2dFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS, id="adaptive-max-pool2d"),
+    pytest.param(
+        AdaptiveMaxPool2dIndicesFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS,
+        id="adaptive-max-pool2d-indices"),
 ]
 
 
@@ -1530,6 +1541,7 @@ def test_max_pool_forward_return_annotation_snapshot(op_cls: type, expected_retu
         MaxPool1dFwdOp, MaxPool1dIndicesFwdOp,
         MaxPool2dFwdOp, MaxPool2dIndicesFwdOp,
         MaxPool3dFwdOp, MaxPool3dIndicesFwdOp,
+        AdaptiveAvgPool2dFwdOp, AdaptiveMaxPool2dFwdOp, AdaptiveMaxPool2dIndicesFwdOp,
     ],
 )
 def test_pool_codegen_slots_are_class_local(op_cls: type) -> None:
@@ -1626,6 +1638,19 @@ _POOL_INFER_SHAPE_SNAPSHOTS: list = [
         MaxPool3dIndicesFwdOp, {"kernel_size": 3, "stride": 2, "padding": 1},
         (2, 4, 8, 16, 16), {"output": (2, 4, 4, 8, 8), "indices": (2, 4, 4, 8, 8)},
         id="max-pool3d-indices"),
+    pytest.param(
+        AdaptiveAvgPool2dFwdOp, {"output_size": (4, 4)},
+        (2, 4, 16, 16), {"output": (2, 4, 4, 4)}, id="adaptive-avg-pool2d"),
+    pytest.param(
+        AdaptiveMaxPool2dFwdOp, {"output_size": (4, 4)},
+        (2, 4, 16, 16), {"output": (2, 4, 4, 4)}, id="adaptive-max-pool2d"),
+    pytest.param(
+        AdaptiveMaxPool2dIndicesFwdOp, {"output_size": (4, 4)},
+        (2, 4, 16, 16), {"output": (2, 4, 4, 4), "indices": (2, 4, 4, 4)},
+        id="adaptive-max-pool2d-indices"),
+    pytest.param(
+        AdaptiveAvgPool2dFwdOp, {"output_size": (None, 4)},
+        (4, 16, 16), {"output": (4, 16, 4)}, id="adaptive-avg-pool2d-chw-none"),
 ]
 
 
@@ -1949,6 +1974,69 @@ def test_adaptive_pool_rejects_invalid_input() -> None:
         op(torch.randn(1, 4, 8, 8, device="cuda", dtype=torch.float32))
     with pytest.raises(ValueError, match="CUDA"):
         op(torch.randn(1, 4, 8, 8, dtype=torch.float16))
+
+
+_ADAPTIVE_POOL_COMPILE_CASES = [
+    pytest.param(
+        AdaptiveAvgPool2dFwdOp, (2, 4, 16, 16), False, id="adaptive-avg-pool2d"),
+    pytest.param(
+        AdaptiveMaxPool2dFwdOp, (2, 4, 16, 16), False, id="adaptive-max-pool2d"),
+    pytest.param(
+        AdaptiveMaxPool2dIndicesFwdOp, (2, 4, 16, 16), True,
+        id="adaptive-max-pool2d-indices"),
+]
+for _case in _ADAPTIVE_POOL_COMPILE_CASES:
+    register_compile_contract(_case.values[0])
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.usefixtures("isolated_dynamo")
+@pytest.mark.parametrize(
+    ("op_cls", "x_shape", "return_indices"),
+    _ADAPTIVE_POOL_COMPILE_CASES,
+)
+def test_adaptive_pool_compile_fullgraph(
+    op_cls: type,
+    x_shape: tuple[int, ...],
+    return_indices: bool,
+) -> None:
+    op = op_cls(output_size=(4, 4))
+    x = torch.randn(*x_shape, device="cuda", dtype=torch.float16)
+    out = torch.compile(op, fullgraph=True)(x)  # cold start: no eager warmup
+    if op_cls is AdaptiveAvgPool2dFwdOp:
+        ref = F.adaptive_avg_pool2d(x, (4, 4))
+        torch.testing.assert_close(out, ref, atol=1e-3, rtol=1e-3)
+    elif return_indices:
+        ref_out, ref_idx = F.adaptive_max_pool2d(x, (4, 4), return_indices=True)
+        torch.testing.assert_close(out[0], ref_out, atol=0, rtol=0)
+        assert torch.equal(out[1], ref_idx)
+    else:
+        ref = F.adaptive_max_pool2d(x, (4, 4))
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    ("op_cls", "expected_flops", "expected_bytes"),
+    [
+        # input (1, 2, 8, 8) fp16, output_size (2, 2): out (1, 2, 2, 2), kH=kW=4.
+        # flops = 1*2*2*2*4*4 = 128; bytes = (1*2*64 + 1*2*4) * 2 [+ 1*2*4*8].
+        pytest.param(AdaptiveAvgPool2dFwdOp, 128, 272, id="adaptive-avg-pool2d"),
+        pytest.param(AdaptiveMaxPool2dFwdOp, 128, 272, id="adaptive-max-pool2d"),
+        pytest.param(AdaptiveMaxPool2dIndicesFwdOp, 128, 336, id="adaptive-max-pool2d-indices"),
+    ],
+)
+def test_adaptive_pool_eval_roofline_snapshot(
+    op_cls: type,
+    expected_flops: int,
+    expected_bytes: int,
+) -> None:
+    op = op_cls(output_size=(2, 2))
+    x = torch.randn(1, 2, 8, 8, device="cuda", dtype=torch.float16)
+    op(x)
+    assert op.eval_roofline() == (expected_flops, expected_bytes)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1,5 +1,4 @@
 import inspect
-import re
 from typing import Callable, Optional, Tuple
 
 import pytest
@@ -1453,12 +1452,6 @@ _MAX_POOL_CTOR_PARAMS = (
     ("tune", False),
 )
 
-_ADAPTIVE_POOL_CTOR_PARAMS = (
-    ("output_size", _EMPTY),
-    ("kernel_map", None),
-    ("tune", False),
-)
-
 # Manifest-pinned constructor contract: parameter names, order, and defaults.
 _POOL_CTOR_SNAPSHOTS: list = [
     pytest.param(AvgPool1dFwdOp, _AVG_POOL_CTOR_PARAMS_1D, id="avg-pool1d"),
@@ -1470,11 +1463,6 @@ _POOL_CTOR_SNAPSHOTS: list = [
     pytest.param(MaxPool2dIndicesFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool2d-indices"),
     pytest.param(MaxPool3dFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool3d"),
     pytest.param(MaxPool3dIndicesFwdOp, _MAX_POOL_CTOR_PARAMS, id="max-pool3d-indices"),
-    pytest.param(AdaptiveAvgPool2dFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS, id="adaptive-avg-pool2d"),
-    pytest.param(AdaptiveMaxPool2dFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS, id="adaptive-max-pool2d"),
-    pytest.param(
-        AdaptiveMaxPool2dIndicesFwdOp, _ADAPTIVE_POOL_CTOR_PARAMS,
-        id="adaptive-max-pool2d-indices"),
 ]
 
 
@@ -1541,7 +1529,6 @@ def test_max_pool_forward_return_annotation_snapshot(op_cls: type, expected_retu
         MaxPool1dFwdOp, MaxPool1dIndicesFwdOp,
         MaxPool2dFwdOp, MaxPool2dIndicesFwdOp,
         MaxPool3dFwdOp, MaxPool3dIndicesFwdOp,
-        AdaptiveAvgPool2dFwdOp, AdaptiveMaxPool2dFwdOp, AdaptiveMaxPool2dIndicesFwdOp,
     ],
 )
 def test_pool_codegen_slots_are_class_local(op_cls: type) -> None:
@@ -1638,19 +1625,6 @@ _POOL_INFER_SHAPE_SNAPSHOTS: list = [
         MaxPool3dIndicesFwdOp, {"kernel_size": 3, "stride": 2, "padding": 1},
         (2, 4, 8, 16, 16), {"output": (2, 4, 4, 8, 8), "indices": (2, 4, 4, 8, 8)},
         id="max-pool3d-indices"),
-    pytest.param(
-        AdaptiveAvgPool2dFwdOp, {"output_size": (4, 4)},
-        (2, 4, 16, 16), {"output": (2, 4, 4, 4)}, id="adaptive-avg-pool2d"),
-    pytest.param(
-        AdaptiveMaxPool2dFwdOp, {"output_size": (4, 4)},
-        (2, 4, 16, 16), {"output": (2, 4, 4, 4)}, id="adaptive-max-pool2d"),
-    pytest.param(
-        AdaptiveMaxPool2dIndicesFwdOp, {"output_size": (4, 4)},
-        (2, 4, 16, 16), {"output": (2, 4, 4, 4), "indices": (2, 4, 4, 4)},
-        id="adaptive-max-pool2d-indices"),
-    pytest.param(
-        AdaptiveAvgPool2dFwdOp, {"output_size": (None, 4)},
-        (4, 16, 16), {"output": (4, 16, 4)}, id="adaptive-avg-pool2d-chw-none"),
 ]
 
 
@@ -1744,20 +1718,11 @@ class AdaptiveAvgPool2dFixture(FixtureBase):
                     marks=[pytest.mark.smoke, pytest.mark.packaging],
                     id="smoke-spp-6x6-fp16"),
                 pytest.param(
-                    2, 64, 56, 56, (6, 6), torch.bfloat16, False,
-                    marks=pytest.mark.smoke, id="smoke-spp-6x6-bf16"),
-                pytest.param(
-                    1, 32, 7, 7, (1, 1), torch.float16, False,
-                    marks=pytest.mark.smoke, id="smoke-global-fp16"),
+                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
+                    marks=pytest.mark.smoke, id="smoke-asymmetric-bf16"),
                 pytest.param(
                     1, 128, 55, 57, (7, 7), torch.float16, False,
                     marks=pytest.mark.full, id="full-nondiv-fp16"),
-                pytest.param(
-                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
-                    marks=pytest.mark.full, id="full-asymmetric-bf16"),
-                pytest.param(
-                    1, 8, 8, 8, (12, 12), torch.float16, False,
-                    marks=pytest.mark.full, id="full-expand-fp16"),
                 pytest.param(
                     1, 16, 11, 13, (None, 5), torch.float16, False,
                     marks=pytest.mark.full, id="full-partial-none-fp16"),
@@ -1765,14 +1730,8 @@ class AdaptiveAvgPool2dFixture(FixtureBase):
                     1, 16, 10, 10, 4, torch.bfloat16, False,
                     marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
                 pytest.param(
-                    1, 16, 10, 10, [6, 6], torch.float16, False,
-                    marks=pytest.mark.full, id="full-list-output-size-fp16"),
-                pytest.param(
                     1, 8, 9, 11, (None, None), torch.float16, False,
                     marks=pytest.mark.full, id="full-all-none-identity-fp16"),
-                pytest.param(
-                    1, 8, 9, 11, None, torch.float16, False,
-                    marks=pytest.mark.full, id="full-scalar-none-identity-fp16"),
             ],
         ),
     ]
@@ -1788,32 +1747,14 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
                     marks=[pytest.mark.smoke, pytest.mark.packaging],
                     id="smoke-spp-6x6-fp16"),
                 pytest.param(
-                    2, 64, 56, 56, (6, 6), torch.bfloat16, False,
-                    marks=pytest.mark.smoke, id="smoke-spp-6x6-bf16"),
-                pytest.param(
-                    1, 32, 7, 7, (1, 1), torch.float16, False,
-                    marks=pytest.mark.smoke, id="smoke-global-fp16"),
+                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
+                    marks=pytest.mark.smoke, id="smoke-asymmetric-bf16"),
                 pytest.param(
                     1, 128, 55, 57, (7, 7), torch.float16, False,
                     marks=pytest.mark.full, id="full-nondiv-fp16"),
                 pytest.param(
-                    1, 96, 28, 30, (7, 5), torch.bfloat16, False,
-                    marks=pytest.mark.full, id="full-asymmetric-bf16"),
-                pytest.param(
-                    1, 8, 8, 8, (12, 12), torch.float16, False,
-                    marks=pytest.mark.full, id="full-expand-fp16"),
-                pytest.param(
                     1, 16, 11, 13, (5, None), torch.float16, False,
                     marks=pytest.mark.full, id="full-partial-none-fp16"),
-                pytest.param(
-                    1, 16, 10, 10, 4, torch.bfloat16, False,
-                    marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
-                pytest.param(
-                    1, 16, 10, 10, [6, 6], torch.float16, False,
-                    marks=pytest.mark.full, id="full-list-output-size-fp16"),
-                pytest.param(
-                    1, 8, 9, 11, None, torch.float16, False,
-                    marks=pytest.mark.full, id="full-scalar-none-identity-fp16"),
             ],
         ),
     ]
@@ -1902,90 +1843,6 @@ def test_adaptive_max_pool2d(
         assert isinstance(op.kernel, expected_kernel)
 
 
-@pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize("with_batch", [False, True], ids=["chw", "nchw"])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
-def test_adaptive_avg_pool2d_unbatched_and_batched(with_batch: bool, dtype: torch.dtype) -> None:
-    shape = (2, 8, 55, 57) if with_batch else (8, 55, 57)
-    x = torch.randn(*shape, device="cuda", dtype=dtype)
-    op = AdaptiveAvgPool2dFwdOp((7, 7))
-    ref = F.adaptive_avg_pool2d(x, (7, 7))
-    atol, rtol = (1e-3, 1e-3) if dtype == torch.float16 else (1.6e-2, 1.6e-2)
-    torch.testing.assert_close(op(x), ref, atol=atol, rtol=rtol)
-
-
-@pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize("with_batch", [False, True], ids=["chw", "nchw"])
-def test_adaptive_max_pool2d_indices_unbatched_and_batched(with_batch: bool) -> None:
-    shape = (2, 8, 55, 57) if with_batch else (8, 55, 57)
-    x = torch.randn(*shape, device="cuda", dtype=torch.float16)
-    out, idx = AdaptiveMaxPool2dIndicesFwdOp((7, 7))(x)
-    ref_out, ref_idx = F.adaptive_max_pool2d(x, (7, 7), return_indices=True)
-    torch.testing.assert_close(out, ref_out, atol=0, rtol=0)
-    assert idx.dtype == torch.int64 and torch.equal(idx, ref_idx)
-
-
-@pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_adaptive_max_pool2d_tied_maxima_indices() -> None:
-    # Tied maxima inside a bin: indices must match PyTorch exactly (first in
-    # row-major order).
-    x = torch.tensor(
-        [[[[1.0, 3.0, 0.0], [3.0, 2.0, 1.0], [0.0, 1.0, 2.0]]]],
-        device="cuda", dtype=torch.float16,
-    )
-    out, idx = AdaptiveMaxPool2dIndicesFwdOp((1, 1))(x)
-    ref_out, ref_idx = F.adaptive_max_pool2d(x, (1, 1), return_indices=True)
-    torch.testing.assert_close(out, ref_out, atol=0, rtol=0)
-    assert torch.equal(idx, ref_idx)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize(
-    ("output_size", "error", "match"),
-    [
-        pytest.param(
-            0, ValueError, "output_size entries must be positive or None", id="zero"),
-        pytest.param(
-            (3, 0), ValueError, "output_size entries must be positive or None",
-            id="zero-entry"),
-        pytest.param(
-            (2, 2, 2), TypeError,
-            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
-            id="len-3-tuple"),
-        pytest.param(
-            "3", TypeError,
-            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
-            id="string"),
-        pytest.param(
-            True, TypeError,
-            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
-            id="bool"),
-        pytest.param(
-            (3.0, 3), TypeError,
-            re.escape("output_size must be None, an int, or a tuple of (int | None, int | None)"),
-            id="float-entry"),
-    ],
-)
-def test_adaptive_pool_rejects_invalid_output_size(output_size, error: type, match: str) -> None:
-    with pytest.raises(error, match=match):
-        AdaptiveAvgPool2dFwdOp(output_size)
-
-
-@pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_adaptive_pool_rejects_invalid_input() -> None:
-    op = AdaptiveAvgPool2dFwdOp((4, 4))
-    with pytest.raises(ValueError, match="3D CHW or 4D NCHW"):
-        op(torch.randn(8, 8, device="cuda", dtype=torch.float16))
-    with pytest.raises(ValueError, match="float16 or bfloat16"):
-        op(torch.randn(1, 4, 8, 8, device="cuda", dtype=torch.float32))
-    with pytest.raises(ValueError, match="CUDA"):
-        op(torch.randn(1, 4, 8, 8, dtype=torch.float16))
-
-
 _ADAPTIVE_POOL_COMPILE_CASES = [
     pytest.param(
         AdaptiveAvgPool2dFwdOp, (2, 4, 16, 16), False, id="adaptive-avg-pool2d"),
@@ -2024,30 +1881,6 @@ def test_adaptive_pool_compile_fullgraph(
     else:
         ref = F.adaptive_max_pool2d(x, (4, 4))
         torch.testing.assert_close(out, ref, atol=0, rtol=0)
-
-
-@pytest.mark.smoke
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-@pytest.mark.parametrize(
-    ("op_cls", "expected_flops", "expected_bytes"),
-    [
-        # input (1, 2, 8, 8) fp16, output_size (2, 2): bins [0,4) and [4,8),
-        # no overlap, exact scan = 8 per axis.
-        # flops = 1*2*8*8 = 128; bytes = (1*2*64 + 1*2*4) * 2 [+ 1*2*4*8].
-        pytest.param(AdaptiveAvgPool2dFwdOp, 128, 272, id="adaptive-avg-pool2d"),
-        pytest.param(AdaptiveMaxPool2dFwdOp, 128, 272, id="adaptive-max-pool2d"),
-        pytest.param(AdaptiveMaxPool2dIndicesFwdOp, 128, 336, id="adaptive-max-pool2d-indices"),
-    ],
-)
-def test_adaptive_pool_eval_roofline_snapshot(
-    op_cls: type,
-    expected_flops: int,
-    expected_bytes: int,
-) -> None:
-    op = op_cls(output_size=(2, 2))
-    x = torch.randn(1, 2, 8, 8, device="cuda", dtype=torch.float16)
-    op(x)
-    assert op.eval_roofline() == (expected_flops, expected_bytes)
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from typing import Callable, Optional, Tuple
 
 import pytest
@@ -1738,6 +1739,12 @@ class AdaptiveAvgPool2dFixture(FixtureBase):
                 pytest.param(
                     1, 16, 10, 10, 4, torch.bfloat16, False,
                     marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
+                pytest.param(
+                    1, 16, 10, 10, [6, 6], torch.float16, False,
+                    marks=pytest.mark.full, id="full-list-output-size-fp16"),
+                pytest.param(
+                    1, 8, 9, 11, (None, None), torch.float16, False,
+                    marks=pytest.mark.full, id="full-all-none-identity-fp16"),
             ],
         ),
     ]
@@ -1773,13 +1780,20 @@ class AdaptiveMaxPool2dFixture(FixtureBase):
                 pytest.param(
                     1, 16, 10, 10, 4, torch.bfloat16, False,
                     marks=pytest.mark.full, id="full-scalar-output-size-bf16"),
+                pytest.param(
+                    1, 16, 10, 10, [6, 6], torch.float16, False,
+                    marks=pytest.mark.full, id="full-list-output-size-fp16"),
             ],
         ),
     ]
 
 
 class AdaptiveAvgPool2dTest(TestBase):
-    def __init__(self, output_size, dtype: torch.dtype) -> None:
+    def __init__(
+        self,
+        output_size: int | tuple[int | None, int | None],
+        dtype: torch.dtype,
+    ) -> None:
         self.output_size = output_size
         self.dtype = dtype
 
@@ -1792,7 +1806,12 @@ class AdaptiveAvgPool2dTest(TestBase):
 
 
 class AdaptiveMaxPool2dTest(TestBase):
-    def __init__(self, output_size, dtype: torch.dtype, return_indices: bool) -> None:
+    def __init__(
+        self,
+        output_size: int | tuple[int | None, int | None],
+        dtype: torch.dtype,
+        return_indices: bool,
+    ) -> None:
         self.output_size = output_size
         self.dtype = dtype
         self.return_indices = return_indices
@@ -1801,7 +1820,7 @@ class AdaptiveMaxPool2dTest(TestBase):
         x = torch.randn(*shape, device="cuda", dtype=self.dtype).contiguous()
         return (x,)
 
-    def ref_program(self, input: torch.Tensor):
+    def ref_program(self, input: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         return F.adaptive_max_pool2d(
             input, self.output_size, return_indices=self.return_indices
         )
@@ -1813,7 +1832,7 @@ def test_adaptive_avg_pool2d(
     c_in: int,
     h_in: int,
     w_in: int,
-    output_size,
+    output_size: int | tuple[int | None, int | None],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
@@ -1830,7 +1849,7 @@ def test_adaptive_max_pool2d(
     c_in: int,
     h_in: int,
     w_in: int,
-    output_size,
+    output_size: int | tuple[int | None, int | None],
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
@@ -1890,18 +1909,33 @@ def test_adaptive_max_pool2d_tied_maxima_indices() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    ("output_size", "error"),
+    ("output_size", "error", "match"),
     [
-        pytest.param(0, ValueError, id="zero"),
-        pytest.param((3, 0), ValueError, id="zero-entry"),
-        pytest.param((2, 2, 2), TypeError, id="len-3-tuple"),
-        pytest.param("3", TypeError, id="string"),
-        pytest.param(True, TypeError, id="bool"),
-        pytest.param((3.0, 3), TypeError, id="float-entry"),
+        pytest.param(
+            0, ValueError, "output_size entries must be positive or None", id="zero"),
+        pytest.param(
+            (3, 0), ValueError, "output_size entries must be positive or None",
+            id="zero-entry"),
+        pytest.param(
+            (2, 2, 2), TypeError,
+            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            id="len-3-tuple"),
+        pytest.param(
+            "3", TypeError,
+            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            id="string"),
+        pytest.param(
+            True, TypeError,
+            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            id="bool"),
+        pytest.param(
+            (3.0, 3), TypeError,
+            re.escape("output_size must be an int or a tuple of (int | None, int | None)"),
+            id="float-entry"),
     ],
 )
-def test_adaptive_pool_rejects_invalid_output_size(output_size, error: type) -> None:
-    with pytest.raises(error):
+def test_adaptive_pool_rejects_invalid_output_size(output_size, error: type, match: str) -> None:
+    with pytest.raises(error, match=match):
         AdaptiveAvgPool2dFwdOp(output_size)
 
 

--- a/tests/ops/test_pool.py
+++ b/tests/ops/test_pool.py
@@ -2021,8 +2021,9 @@ def test_adaptive_pool_compile_fullgraph(
 @pytest.mark.parametrize(
     ("op_cls", "expected_flops", "expected_bytes"),
     [
-        # input (1, 2, 8, 8) fp16, output_size (2, 2): out (1, 2, 2, 2), kH=kW=4.
-        # flops = 1*2*2*2*4*4 = 128; bytes = (1*2*64 + 1*2*4) * 2 [+ 1*2*4*8].
+        # input (1, 2, 8, 8) fp16, output_size (2, 2): bins [0,4) and [4,8),
+        # no overlap, exact scan = 8 per axis.
+        # flops = 1*2*8*8 = 128; bytes = (1*2*64 + 1*2*4) * 2 [+ 1*2*4*8].
         pytest.param(AdaptiveAvgPool2dFwdOp, 128, 272, id="adaptive-avg-pool2d"),
         pytest.param(AdaptiveMaxPool2dFwdOp, 128, 272, id="adaptive-max-pool2d"),
         pytest.param(AdaptiveMaxPool2dIndicesFwdOp, 128, 336, id="adaptive-max-pool2d-indices"),

--- a/tileops/kernels/__init__.py
+++ b/tileops/kernels/__init__.py
@@ -82,6 +82,9 @@ from .norm import (
     RMSNormKernel,
 )
 from .pool import (
+    AdaptiveAvgPool2dKernel,
+    AdaptiveMaxPool2dKernel,
+    AdaptiveMaxPool2dWithIndicesKernel,
     AvgPool1dKernel,
     AvgPool1dSpatialKernel,
     AvgPool2dKernel,
@@ -107,6 +110,9 @@ from .rope import (
 from .topk_selector import TopkSelectorKernel
 
 __all__ = [
+    "AdaptiveAvgPool2dKernel",
+    "AdaptiveMaxPool2dKernel",
+    "AdaptiveMaxPool2dWithIndicesKernel",
     "AvgPool1dKernel",
     "AvgPool1dSpatialKernel",
     "AvgPool2dKernel",

--- a/tileops/kernels/pool/__init__.py
+++ b/tileops/kernels/pool/__init__.py
@@ -1,3 +1,5 @@
+from .adaptive_avg_pool2d import AdaptiveAvgPool2dKernel
+from .adaptive_max_pool2d import AdaptiveMaxPool2dKernel, AdaptiveMaxPool2dWithIndicesKernel
 from .avg_pool1d import AvgPool1dKernel, AvgPool1dSpatialKernel
 from .avg_pool2d import AvgPool2dKernel, AvgPool2dSpatialKernel
 from .avg_pool3d import AvgPool3dKernel, AvgPool3dSpatialKernel
@@ -7,6 +9,9 @@ from .max_pool3d import MaxPool3dKernel, MaxPool3dWithIndicesKernel
 from .mean_pooling import MeanPoolingFwdKernel
 
 __all__ = [
+    "AdaptiveAvgPool2dKernel",
+    "AdaptiveMaxPool2dKernel",
+    "AdaptiveMaxPool2dWithIndicesKernel",
     "AvgPool1dKernel",
     "AvgPool1dSpatialKernel",
     "AvgPool2dKernel",

--- a/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -1,14 +1,10 @@
 import functools
-import itertools
-from typing import Optional
 
 import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
-
-from .common import adaptive_bin, max_adaptive_bin_extent
+from .common import AdaptivePool2dKernelBase, adaptive_bin, max_adaptive_bin_extent
 
 __all__ = ["AdaptiveAvgPool2dKernel"]
 
@@ -109,64 +105,8 @@ def _(
     return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
-class AdaptiveAvgPool2dKernel(Kernel):
+class AdaptiveAvgPool2dKernel(AdaptivePool2dKernelBase):
     """Adaptive average pooling forward kernel for NCHW inputs."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        out_h: int,
-        out_w: int,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16}:
-            raise ValueError(
-                f"AdaptiveAvgPool2dKernel supports float16 and bfloat16, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.out_h = out_h
-        self.out_w = out_w
-        self.dtype = dtype
-        self.kernel = _adaptive_avg_pool2d_kernel(
-            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
-        )
-        self.init_config(config, tune)
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _adaptive_avg_pool2d_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.out_h,
-            self.out_w,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_adaptive_avg_pool2d_kernel)
+    _dispatch = staticmethod(_adaptive_avg_pool2d_wrapped_kernel)

--- a/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -11,7 +11,7 @@ from tileops.kernels.kernel_base import Kernel
 __all__ = ["AdaptiveAvgPool2dKernel"]
 
 
-@functools.lru_cache(maxsize=64)
+@functools.lru_cache(maxsize=32)
 def _adaptive_avg_pool2d_kernel(
     n: int,
     c_in: int,

--- a/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -21,8 +21,6 @@ def _adaptive_avg_pool2d_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # TileLang rejects dynamic T.serial bounds, so the loops below need these
-    # as compile-time constants.
     max_kh = max_adaptive_bin_extent(h_in, out_h)
     max_kw = max_adaptive_bin_extent(w_in, out_w)
 

--- a/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -8,6 +8,8 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from .common import adaptive_bin, max_adaptive_bin_extent
+
 __all__ = ["AdaptiveAvgPool2dKernel"]
 
 
@@ -23,18 +25,10 @@ def _adaptive_avg_pool2d_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # Static upper bounds for the adaptive bin extents (compile-time constants;
-    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
-    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
-    # expansion in=8/out=12 has bins of 2 > 1.
-    max_kh = max(
-        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
-        for o in range(out_h)
-    )
-    max_kw = max(
-        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
-        for o in range(out_w)
-    )
+    # TileLang rejects dynamic T.serial bounds, so the loops below need these
+    # as compile-time constants.
+    max_kh = max_adaptive_bin_extent(h_in, out_h)
+    max_kw = max_adaptive_bin_extent(w_in, out_w)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_avg_pool2d_func(block_m: int, threads: int):
@@ -54,13 +48,8 @@ def _adaptive_avg_pool2d_kernel(
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
 
-                        # PyTorch adaptive bins partition each spatial axis as
-                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
-                        # non-empty, including output_size > input_size.
-                        ih_start = (oh * h_in) // out_h
-                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
-                        iw_start = (ow * w_in) // out_w
-                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+                        ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
+                        iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
 
                         sum_val = T.alloc_var(T.float32)
                         sum_val = T.cast(0.0, accum_dtype)

--- a/tileops/kernels/pool/adaptive_avg_pool2d.py
+++ b/tileops/kernels/pool/adaptive_avg_pool2d.py
@@ -1,0 +1,183 @@
+import functools
+import itertools
+from typing import Optional
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+
+__all__ = ["AdaptiveAvgPool2dKernel"]
+
+
+@functools.lru_cache(maxsize=64)
+def _adaptive_avg_pool2d_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    total_output = n * c_in * out_h * out_w
+    # Static upper bounds for the adaptive bin extents (compile-time constants;
+    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
+    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
+    # expansion in=8/out=12 has bins of 2 > 1.
+    max_kh = max(
+        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
+        for o in range(out_h)
+    )
+    max_kw = max(
+        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
+        for o in range(out_w)
+    )
+
+    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _adaptive_avg_pool2d_func(block_m: int, threads: int):
+        @T.prim_func
+        def _adaptive_avg_pool2d_main(
+            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        channel_batch_idx = spatial_idx // out_h
+                        c_idx = channel_batch_idx % c_in
+                        batch = channel_batch_idx // c_in
+
+                        # PyTorch adaptive bins partition each spatial axis as
+                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
+                        # non-empty, including output_size > input_size.
+                        ih_start = (oh * h_in) // out_h
+                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
+                        iw_start = (ow * w_in) // out_w
+                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+
+                        sum_val = T.alloc_var(T.float32)
+                        sum_val = T.cast(0.0, accum_dtype)
+                        # Static-bound loops (TileLang rejects dynamic T.serial
+                        # bounds); guard skips lanes outside this output's bin.
+                        for kh in T.serial(max_kh):
+                            for kw in T.serial(max_kw):
+                                if ih_start + kh < ih_end and iw_start + kw < iw_end:
+                                    sum_val += T.cast(
+                                        x[batch, c_idx, ih_start + kh, iw_start + kw],
+                                        accum_dtype,
+                                    )
+
+                        bin_size = (ih_end - ih_start) * (iw_end - iw_start)
+                        out[batch, c_idx, oh, ow] = T.cast(
+                            sum_val / T.cast(bin_size, accum_dtype),
+                            dtype,
+                        )
+
+        return _adaptive_avg_pool2d_main
+
+    return _adaptive_avg_pool2d_func
+
+
+@torch.library.custom_op("top::adaptive_avg_pool2d_wrapped_kernel", mutates_args=())
+def _adaptive_avg_pool2d_wrapped_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _adaptive_avg_pool2d_kernel(
+        n, c_in, h_in, w_in, out_h, out_w, dtype
+    )(block_m, threads)(x)
+
+
+@_adaptive_avg_pool2d_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    _ = (dtype, block_m, threads)
+    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
+
+
+class AdaptiveAvgPool2dKernel(Kernel):
+    """Adaptive average pooling forward kernel for NCHW inputs."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        out_h: int,
+        out_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        if dtype not in {torch.float16, torch.bfloat16}:
+            raise ValueError(
+                f"AdaptiveAvgPool2dKernel supports float16 and bfloat16, got {dtype}"
+            )
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.out_h = out_h
+        self.out_w = out_w
+        self.dtype = dtype
+        self.kernel = _adaptive_avg_pool2d_kernel(
+            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 256,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _adaptive_avg_pool2d_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.h_in,
+            self.w_in,
+            self.out_h,
+            self.out_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )

--- a/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -1,0 +1,393 @@
+import functools
+import itertools
+from typing import Optional, Tuple
+
+import tilelang
+import tilelang.language as T
+import torch
+
+from tileops.kernels.kernel_base import Kernel
+
+__all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
+
+
+@functools.lru_cache(maxsize=32)
+def _adaptive_max_pool2d_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    total_output = n * c_in * out_h * out_w
+    # Static upper bounds for the adaptive bin extents (compile-time constants;
+    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
+    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
+    # expansion in=8/out=12 has bins of 2 > 1.
+    max_kh = max(
+        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
+        for o in range(out_h)
+    )
+    max_kw = max(
+        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
+        for o in range(out_w)
+    )
+
+    @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _adaptive_max_pool2d_func(block_m: int, threads: int):
+        @T.prim_func
+        def _adaptive_max_pool2d_main(
+            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        channel_batch_idx = spatial_idx // out_h
+                        c_idx = channel_batch_idx % c_in
+                        batch = channel_batch_idx // c_in
+
+                        # PyTorch adaptive bins partition each spatial axis as
+                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
+                        # non-empty, including output_size > input_size.
+                        ih_start = (oh * h_in) // out_h
+                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
+                        iw_start = (ow * w_in) // out_w
+                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+
+                        max_val = T.alloc_var(T.float32)
+                        has_nan = T.alloc_var(T.bool)
+                        max_val = T.cast(float("-inf"), accum_dtype)
+                        has_nan = False
+                        # Static-bound loops (TileLang rejects dynamic T.serial
+                        # bounds); guard skips lanes outside this output's bin.
+                        for kh in T.serial(max_kh):
+                            for kw in T.serial(max_kw):
+                                if ih_start + kh < ih_end and iw_start + kw < iw_end:
+                                    val = T.cast(
+                                        x[batch, c_idx, ih_start + kh, iw_start + kw],
+                                        accum_dtype,
+                                    )
+                                    has_nan = has_nan | T.isnan(val)
+                                    max_val = T.max(max_val, val)
+
+                        result = T.if_then_else(
+                            has_nan,
+                            T.cast(float("nan"), accum_dtype),
+                            max_val,
+                        )
+                        out[batch, c_idx, oh, ow] = T.cast(result, dtype)
+
+        return _adaptive_max_pool2d_main
+
+    return _adaptive_max_pool2d_func
+
+
+@torch.library.custom_op("top::adaptive_max_pool2d_wrapped_kernel", mutates_args=())
+def _adaptive_max_pool2d_wrapped_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    return _adaptive_max_pool2d_kernel(
+        n, c_in, h_in, w_in, out_h, out_w, dtype
+    )(block_m, threads)(x)
+
+
+@_adaptive_max_pool2d_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    _ = (dtype, block_m, threads)
+    return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
+
+
+class AdaptiveMaxPool2dKernel(Kernel):
+    """Adaptive max pooling forward kernel for NCHW inputs (return_indices=False)."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        out_h: int,
+        out_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        if dtype not in {torch.float16, torch.bfloat16}:
+            raise ValueError(
+                f"AdaptiveMaxPool2dKernel supports float16 and bfloat16, got {dtype}"
+            )
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.out_h = out_h
+        self.out_w = out_w
+        self.dtype = dtype
+        self.kernel = _adaptive_max_pool2d_kernel(
+            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 256,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _adaptive_max_pool2d_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.h_in,
+            self.w_in,
+            self.out_h,
+            self.out_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )
+
+
+@functools.lru_cache(maxsize=32)
+def _adaptive_max_pool2d_with_indices_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str = "float16",
+):
+    accum_dtype = "float"
+    total_output = n * c_in * out_h * out_w
+    # Static upper bounds for the adaptive bin extents (compile-time constants;
+    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
+    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
+    # expansion in=8/out=12 has bins of 2 > 1.
+    max_kh = max(
+        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
+        for o in range(out_h)
+    )
+    max_kw = max(
+        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
+        for o in range(out_w)
+    )
+
+    @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
+    def _adaptive_max_pool2d_with_indices_func(block_m: int, threads: int):
+        @T.prim_func
+        def _adaptive_max_pool2d_with_indices_main(
+            x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
+            out: T.Tensor((n, c_in, out_h, out_w), dtype),  # type: ignore
+            indices: T.Tensor((n, c_in, out_h, out_w), "int64"),  # type: ignore
+        ):
+            with T.Kernel(T.ceildiv(total_output, block_m), threads=threads) as bx:
+                for i in T.Parallel(block_m):
+                    out_idx = bx * block_m + i
+                    if out_idx < total_output:
+                        ow = out_idx % out_w
+                        spatial_idx = out_idx // out_w
+                        oh = spatial_idx % out_h
+                        channel_batch_idx = spatial_idx // out_h
+                        c_idx = channel_batch_idx % c_in
+                        batch = channel_batch_idx // c_in
+
+                        # PyTorch adaptive bins partition each spatial axis as
+                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
+                        # non-empty, including output_size > input_size.
+                        ih_start = (oh * h_in) // out_h
+                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
+                        iw_start = (ow * w_in) // out_w
+                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+
+                        max_val = T.alloc_var(T.float32)
+                        has_nan = T.alloc_var(T.bool)
+                        max_idx = T.alloc_var(T.int64)
+                        nan_idx = T.alloc_var(T.int64)
+                        first_valid = T.alloc_var(T.bool)
+                        max_val = T.cast(float("-inf"), accum_dtype)
+                        has_nan = False
+                        max_idx = T.cast(0, "int64")
+                        nan_idx = T.cast(0, "int64")
+                        first_valid = True
+                        # Static-bound loops (TileLang rejects dynamic T.serial
+                        # bounds); guard skips lanes outside this output's bin.
+                        for kh in T.serial(max_kh):
+                            for kw in T.serial(max_kw):
+                                if ih_start + kh < ih_end and iw_start + kw < iw_end:
+                                    ih = ih_start + kh
+                                    iw = iw_start + kw
+                                    val = T.cast(x[batch, c_idx, ih, iw], accum_dtype)
+                                    flat_idx = T.cast(ih * w_in + iw, "int64")
+                                    is_nan = T.isnan(val)
+                                    if is_nan:
+                                        # PyTorch records the last NaN visited in
+                                        # a pooling window.
+                                        nan_idx = flat_idx
+                                        has_nan = True
+                                    elif first_valid:
+                                        max_val = val
+                                        max_idx = flat_idx
+                                        first_valid = False
+                                    elif val > max_val:
+                                        max_val = val
+                                        max_idx = flat_idx
+
+                        result = T.if_then_else(
+                            has_nan,
+                            T.cast(float("nan"), accum_dtype),
+                            max_val,
+                        )
+                        out[batch, c_idx, oh, ow] = T.cast(result, dtype)
+                        indices[batch, c_idx, oh, ow] = T.if_then_else(
+                            has_nan,
+                            nan_idx,
+                            max_idx,
+                        )
+
+        return _adaptive_max_pool2d_with_indices_main
+
+    return _adaptive_max_pool2d_with_indices_func
+
+
+@torch.library.custom_op(
+    "top::adaptive_max_pool2d_with_indices_wrapped_kernel", mutates_args=()
+)
+def _adaptive_max_pool2d_with_indices_wrapped_kernel(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return _adaptive_max_pool2d_with_indices_kernel(
+        n, c_in, h_in, w_in, out_h, out_w, dtype
+    )(block_m, threads)(x)
+
+
+@_adaptive_max_pool2d_with_indices_wrapped_kernel.register_fake
+def _(
+    n: int,
+    c_in: int,
+    h_in: int,
+    w_in: int,
+    out_h: int,
+    out_w: int,
+    dtype: str,
+    block_m: int,
+    threads: int,
+    x: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    _ = (dtype, block_m, threads)
+    return (
+        torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device),
+        torch.empty((n, c_in, out_h, out_w), dtype=torch.int64, device=x.device),
+    )
+
+
+class AdaptiveMaxPool2dWithIndicesKernel(Kernel):
+    """Adaptive max pooling forward-with-indices kernel for NCHW inputs."""
+
+    supported_archs: list[int] = [80, 86, 89, 90]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        out_h: int,
+        out_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        if dtype not in {torch.float16, torch.bfloat16}:
+            raise ValueError(
+                f"AdaptiveMaxPool2dWithIndicesKernel supports float16 and bfloat16, got {dtype}"
+            )
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.out_h = out_h
+        self.out_w = out_w
+        self.dtype = dtype
+        self.kernel = _adaptive_max_pool2d_with_indices_kernel(
+            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "block_m": 256,
+            "threads": 256,
+        }
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return _adaptive_max_pool2d_with_indices_wrapped_kernel(
+            self.n,
+            self.c_in,
+            self.h_in,
+            self.w_in,
+            self.out_h,
+            self.out_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )

--- a/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -22,8 +22,6 @@ def _adaptive_max_pool2d_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # TileLang rejects dynamic T.serial bounds, so the loops below need these
-    # as compile-time constants.
     max_kh = max_adaptive_bin_extent(h_in, out_h)
     max_kw = max_adaptive_bin_extent(w_in, out_w)
 
@@ -130,8 +128,6 @@ def _adaptive_max_pool2d_with_indices_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # TileLang rejects dynamic T.serial bounds, so the loops below need these
-    # as compile-time constants.
     max_kh = max_adaptive_bin_extent(h_in, out_h)
     max_kw = max_adaptive_bin_extent(w_in, out_w)
 

--- a/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -8,6 +8,8 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 
+from .common import adaptive_bin, max_adaptive_bin_extent
+
 __all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
 
 
@@ -23,18 +25,10 @@ def _adaptive_max_pool2d_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # Static upper bounds for the adaptive bin extents (compile-time constants;
-    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
-    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
-    # expansion in=8/out=12 has bins of 2 > 1.
-    max_kh = max(
-        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
-        for o in range(out_h)
-    )
-    max_kw = max(
-        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
-        for o in range(out_w)
-    )
+    # TileLang rejects dynamic T.serial bounds, so the loops below need these
+    # as compile-time constants.
+    max_kh = max_adaptive_bin_extent(h_in, out_h)
+    max_kw = max_adaptive_bin_extent(w_in, out_w)
 
     @tilelang.jit(out_idx=[1], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_func(block_m: int, threads: int):
@@ -54,13 +48,8 @@ def _adaptive_max_pool2d_kernel(
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
 
-                        # PyTorch adaptive bins partition each spatial axis as
-                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
-                        # non-empty, including output_size > input_size.
-                        ih_start = (oh * h_in) // out_h
-                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
-                        iw_start = (ow * w_in) // out_w
-                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+                        ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
+                        iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
 
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)
@@ -200,18 +189,10 @@ def _adaptive_max_pool2d_with_indices_kernel(
 ):
     accum_dtype = "float"
     total_output = n * c_in * out_h * out_w
-    # Static upper bounds for the adaptive bin extents (compile-time constants;
-    # TileLang rejects dynamic T.serial bounds). Note ceil(in/out) alone is NOT
-    # a valid bound: e.g. in=55/out=7 has a bin of 9 > ceil(55/7) = 8, and
-    # expansion in=8/out=12 has bins of 2 > 1.
-    max_kh = max(
-        ((o + 1) * h_in + out_h - 1) // out_h - (o * h_in) // out_h
-        for o in range(out_h)
-    )
-    max_kw = max(
-        ((o + 1) * w_in + out_w - 1) // out_w - (o * w_in) // out_w
-        for o in range(out_w)
-    )
+    # TileLang rejects dynamic T.serial bounds, so the loops below need these
+    # as compile-time constants.
+    max_kh = max_adaptive_bin_extent(h_in, out_h)
+    max_kw = max_adaptive_bin_extent(w_in, out_w)
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_with_indices_func(block_m: int, threads: int):
@@ -232,13 +213,8 @@ def _adaptive_max_pool2d_with_indices_kernel(
                         c_idx = channel_batch_idx % c_in
                         batch = channel_batch_idx // c_in
 
-                        # PyTorch adaptive bins partition each spatial axis as
-                        # [floor(o*in/out), ceil((o+1)*in/out)); bins are always
-                        # non-empty, including output_size > input_size.
-                        ih_start = (oh * h_in) // out_h
-                        ih_end = ((oh + 1) * h_in + out_h - 1) // out_h
-                        iw_start = (ow * w_in) // out_w
-                        iw_end = ((ow + 1) * w_in + out_w - 1) // out_w
+                        ih_start, ih_end = adaptive_bin(oh, h_in, out_h)
+                        iw_start, iw_end = adaptive_bin(ow, w_in, out_w)
 
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)

--- a/tileops/kernels/pool/adaptive_max_pool2d.py
+++ b/tileops/kernels/pool/adaptive_max_pool2d.py
@@ -1,14 +1,11 @@
 import functools
-import itertools
-from typing import Optional, Tuple
+from typing import Tuple
 
 import tilelang
 import tilelang.language as T
 import torch
 
-from tileops.kernels.kernel_base import Kernel
-
-from .common import adaptive_bin, max_adaptive_bin_extent
+from .common import AdaptivePool2dKernelBase, adaptive_bin, max_adaptive_bin_extent
 
 __all__ = ["AdaptiveMaxPool2dKernel", "AdaptiveMaxPool2dWithIndicesKernel"]
 
@@ -114,67 +111,11 @@ def _(
     return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
-class AdaptiveMaxPool2dKernel(Kernel):
-    """Adaptive max pooling forward kernel for NCHW inputs (return_indices=False)."""
+class AdaptiveMaxPool2dKernel(AdaptivePool2dKernelBase):
+    """Adaptive max pooling forward kernel for NCHW inputs."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        out_h: int,
-        out_w: int,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16}:
-            raise ValueError(
-                f"AdaptiveMaxPool2dKernel supports float16 and bfloat16, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.out_h = out_h
-        self.out_w = out_w
-        self.dtype = dtype
-        self.kernel = _adaptive_max_pool2d_kernel(
-            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
-        )
-        self.init_config(config, tune)
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _adaptive_max_pool2d_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.out_h,
-            self.out_w,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_adaptive_max_pool2d_kernel)
+    _dispatch = staticmethod(_adaptive_max_pool2d_wrapped_kernel)
 
 
 @functools.lru_cache(maxsize=32)
@@ -196,6 +137,11 @@ def _adaptive_max_pool2d_with_indices_kernel(
 
     @tilelang.jit(out_idx=[1, 2], compile_flags=["-O3", "-DENABLE_BF16"])
     def _adaptive_max_pool2d_with_indices_func(block_m: int, threads: int):
+        # The flat index spans one h_in * w_in plane. Carrying it as int32
+        # keeps the div/mod the compiler sinks into the update path off the
+        # 64-bit path; the stored index stays int64 to match PyTorch.
+        idx_dtype = "int32" if h_in * w_in < 2**31 else "int64"
+
         @T.prim_func
         def _adaptive_max_pool2d_with_indices_main(
             x: T.Tensor((n, c_in, h_in, w_in), dtype),  # type: ignore
@@ -218,13 +164,13 @@ def _adaptive_max_pool2d_with_indices_kernel(
 
                         max_val = T.alloc_var(T.float32)
                         has_nan = T.alloc_var(T.bool)
-                        max_idx = T.alloc_var(T.int64)
-                        nan_idx = T.alloc_var(T.int64)
+                        max_idx = T.alloc_var(idx_dtype)
+                        nan_idx = T.alloc_var(idx_dtype)
                         first_valid = T.alloc_var(T.bool)
                         max_val = T.cast(float("-inf"), accum_dtype)
                         has_nan = False
-                        max_idx = T.cast(0, "int64")
-                        nan_idx = T.cast(0, "int64")
+                        max_idx = T.cast(0, idx_dtype)
+                        nan_idx = T.cast(0, idx_dtype)
                         first_valid = True
                         # Static-bound loops (TileLang rejects dynamic T.serial
                         # bounds); guard skips lanes outside this output's bin.
@@ -234,7 +180,7 @@ def _adaptive_max_pool2d_with_indices_kernel(
                                     ih = ih_start + kh
                                     iw = iw_start + kw
                                     val = T.cast(x[batch, c_idx, ih, iw], accum_dtype)
-                                    flat_idx = T.cast(ih * w_in + iw, "int64")
+                                    flat_idx = T.cast(ih * w_in + iw, idx_dtype)
                                     is_nan = T.isnan(val)
                                     if is_nan:
                                         # PyTorch records the last NaN visited in
@@ -255,10 +201,8 @@ def _adaptive_max_pool2d_with_indices_kernel(
                             max_val,
                         )
                         out[batch, c_idx, oh, ow] = T.cast(result, dtype)
-                        indices[batch, c_idx, oh, ow] = T.if_then_else(
-                            has_nan,
-                            nan_idx,
-                            max_idx,
+                        indices[batch, c_idx, oh, ow] = T.cast(
+                            T.if_then_else(has_nan, nan_idx, max_idx), "int64"
                         )
 
         return _adaptive_max_pool2d_with_indices_main
@@ -306,64 +250,8 @@ def _(
     )
 
 
-class AdaptiveMaxPool2dWithIndicesKernel(Kernel):
-    """Adaptive max pooling forward-with-indices kernel for NCHW inputs."""
+class AdaptiveMaxPool2dWithIndicesKernel(AdaptivePool2dKernelBase):
+    """Adaptive max pooling forward kernel returning values and int64 indices."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
-
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        out_h: int,
-        out_w: int,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16}:
-            raise ValueError(
-                f"AdaptiveMaxPool2dWithIndicesKernel supports float16 and bfloat16, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.out_h = out_h
-        self.out_w = out_w
-        self.dtype = dtype
-        self.kernel = _adaptive_max_pool2d_with_indices_kernel(
-            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
-        )
-        self.init_config(config, tune)
-
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _adaptive_max_pool2d_with_indices_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.out_h,
-            self.out_w,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_adaptive_max_pool2d_with_indices_kernel)
+    _dispatch = staticmethod(_adaptive_max_pool2d_with_indices_wrapped_kernel)

--- a/tileops/kernels/pool/common.py
+++ b/tileops/kernels/pool/common.py
@@ -1,4 +1,10 @@
+import itertools
 from collections.abc import Sequence
+from typing import Any, Callable, ClassVar, Optional
+
+import torch
+
+from tileops.kernels.kernel_base import Kernel
 
 
 def _normalize_pool_dims(name: str, value: int | Sequence[int], ndim: int) -> tuple[int, ...]:
@@ -110,3 +116,77 @@ def max_adaptive_bin_extent(size_in: int, size_out: int) -> int:
     """
     extents = (adaptive_bin(o, size_in, size_out) for o in range(size_out))
     return max(end - start for start, end in extents)
+
+
+class AdaptivePool2dKernelBase(Kernel):
+    """Shared scaffold for the adaptive 2D pool kernels.
+
+    The variants differ only in their reduction and in whether they emit
+    indices. Everything around that -- the dtype gate, the config space, the
+    argument marshalling -- is the same, so a subclass binds two callables and
+    declares nothing else:
+
+    - ``_build`` the cached builder that traces the prim_func.
+    - ``_dispatch`` the registered custom op the forward call goes through.
+
+    Each variant keeps its own ``torch.library`` registration; those need
+    distinct names and are what ``torch.compile`` resolves against.
+    """
+
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
+    _build: ClassVar[Callable[..., Any]]
+    _dispatch: ClassVar[Callable[..., Any]]
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        out_h: int,
+        out_w: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__()
+        if dtype not in {torch.float16, torch.bfloat16}:
+            raise ValueError(
+                f"{type(self).__name__} supports float16 and bfloat16, got {dtype}"
+            )
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.out_h = out_h
+        self.out_w = out_w
+        self.dtype = dtype
+        self.kernel = type(self)._build(
+            n, c_in, h_in, w_in, out_h, out_w, self.dtype_str
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        return {"block_m": 256, "threads": 256}
+
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return [
+            {"block_m": block_m, "threads": threads}
+            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
+        ]
+
+    def forward(self, x: torch.Tensor):
+        return type(self)._dispatch(
+            self.n,
+            self.c_in,
+            self.h_in,
+            self.w_in,
+            self.out_h,
+            self.out_w,
+            self.dtype_str,
+            self.config["block_m"],
+            self.config["threads"],
+            x,
+        )

--- a/tileops/kernels/pool/common.py
+++ b/tileops/kernels/pool/common.py
@@ -89,3 +89,24 @@ def pool_output_dim(
         out -= 1
 
     return max(out, 0)
+
+
+def adaptive_bin(o, size_in: int, size_out: int):
+    """Half-open input range `[start, end)` feeding output index ``o``.
+
+    PyTorch partitions each spatial axis as
+    ``[floor(o*in/out), ceil((o+1)*in/out))``. Bins are never empty, including
+    when ``size_out > size_in``. Evaluated while tracing, so the emitted
+    expression is the same as writing the arithmetic inline.
+    """
+    return (o * size_in) // size_out, ((o + 1) * size_in + size_out - 1) // size_out
+
+
+def max_adaptive_bin_extent(size_in: int, size_out: int) -> int:
+    """Widest bin on this axis — a compile-time bound for a `T.serial` loop.
+
+    `ceil(in/out)` is not a valid bound: in=55/out=7 has a bin of 9 against
+    ceil = 8, and expanding in=8/out=12 gives bins of 2 against 1.
+    """
+    extents = (adaptive_bin(o, size_in, size_out) for o in range(size_out))
+    return max(end - start for start, end in extents)

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -1,9 +1,8 @@
 # pool.yaml -- manifest entries for the 'pool' family.
 #
 # Source of truth for pooling op interfaces. These entries are generated from
-# PyTorch functional reference APIs. The 1d/2d/3d pooling entries are
-# implemented; the adaptive 2D pooling entries remain spec-only pending
-# kernel implementation.
+# PyTorch functional reference APIs. All entries (1d/2d/3d pooling and
+# adaptive 2D pooling) are implemented.
 
 AvgPool1dFwdOp:
   ref_api: "torch.nn.functional.avg_pool1d"

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -1,8 +1,8 @@
 # pool.yaml -- manifest entries for the 'pool' family.
 #
 # Source of truth for pooling op interfaces. These entries are generated from
-# PyTorch functional reference APIs. All entries (1d/2d/3d pooling and
-# adaptive 2D pooling) are implemented.
+# PyTorch functional reference APIs. Each entry's `status` field is the
+# authority on whether it is implemented.
 
 AvgPool1dFwdOp:
   ref_api: "torch.nn.functional.avg_pool1d"

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -627,7 +627,7 @@ AdaptiveAvgPool2dFwdOp:
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C, H_out, W_out]"}
     params:
-      output_size: {type: "int | None | tuple[int | None, int | None]"}
+      output_size: {type: "int | None | tuple[int | None, int | None] | list[int | None]"}
     shape_rules:
       - "output_size is None or isinstance(output_size, int) or (isinstance(output_size, (tuple, list)) and len(output_size) == 2)"
       - "_oH == (None if output_size is None else (output_size[0] if isinstance(output_size, (tuple, list)) else output_size))"
@@ -686,7 +686,7 @@ AdaptiveMaxPool2dFwdOp:
     outputs:
       output: {dtype: "same_as(input)", shape: "[N, C, H_out, W_out]"}
     params:
-      output_size: {type: "int | None | tuple[int | None, int | None]"}
+      output_size: {type: "int | None | tuple[int | None, int | None] | list[int | None]"}
     shape_rules:
       - "output_size is None or isinstance(output_size, int) or (isinstance(output_size, (tuple, list)) and len(output_size) == 2)"
       - "_oH == (None if output_size is None else (output_size[0] if isinstance(output_size, (tuple, list)) else output_size))"
@@ -745,7 +745,7 @@ AdaptiveMaxPool2dIndicesFwdOp:
       output: {dtype: "same_as(input)", shape: "[N, C, H_out, W_out]"}
       indices: {dtype: "int64", shape: "[N, C, H_out, W_out]"}
     params:
-      output_size: {type: "int | None | tuple[int | None, int | None]"}
+      output_size: {type: "int | None | tuple[int | None, int | None] | list[int | None]"}
     shape_rules:
       - "output_size is None or isinstance(output_size, int) or (isinstance(output_size, (tuple, list)) and len(output_size) == 2)"
       - "_oH == (None if output_size is None else (output_size[0] if isinstance(output_size, (tuple, list)) else output_size))"

--- a/tileops/manifest/pool.yaml
+++ b/tileops/manifest/pool.yaml
@@ -619,7 +619,8 @@ AdaptiveAvgPool2dFwdOp:
   # Declared on the batched NCHW form (pool-family convention). The Op layer
   # also accepts unbatched CHW input, unsqueezed to NCHW internally.
   family: pool
-  status: spec-only
+  status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -669,7 +670,7 @@ AdaptiveAvgPool2dFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 AdaptiveMaxPool2dFwdOp:
   ref_api: "torch.nn.functional.adaptive_max_pool2d"
@@ -677,7 +678,8 @@ AdaptiveMaxPool2dFwdOp:
   # Declared on the batched NCHW form (pool-family convention). The Op layer
   # also accepts unbatched CHW input, unsqueezed to NCHW internally.
   family: pool
-  status: spec-only
+  status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:
@@ -725,7 +727,7 @@ AdaptiveMaxPool2dFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true
 
 AdaptiveMaxPool2dIndicesFwdOp:
   ref_api: "torch.nn.functional.adaptive_max_pool2d"
@@ -733,7 +735,8 @@ AdaptiveMaxPool2dIndicesFwdOp:
   # Declared on the batched NCHW form (pool-family convention). The Op layer
   # also accepts unbatched CHW input, unsqueezed to NCHW internally.
   family: pool
-  status: spec-only
+  status: implemented
+  torch_compile_fullgraph: true
   variant_of: AdaptiveMaxPool2dFwdOp
 
   signature:
@@ -783,4 +786,4 @@ AdaptiveMaxPool2dIndicesFwdOp:
     op: tileops/ops/pool.py
     test: tests/ops/test_pool.py
     bench: benchmarks/ops/bench_pool.py
-    bench_manifest_driven: false
+    bench_manifest_driven: true

--- a/tileops/ops/__init__.py
+++ b/tileops/ops/__init__.py
@@ -63,6 +63,9 @@ from .norm import (
 )
 from .op_base import Op
 from .pool import (
+    AdaptiveAvgPool2dFwdOp,
+    AdaptiveMaxPool2dFwdOp,
+    AdaptiveMaxPool2dIndicesFwdOp,
     AvgPool1dFwdOp,
     AvgPool2dFwdOp,
     AvgPool3dFwdOp,
@@ -122,6 +125,9 @@ __all__ = [
     "AvgPool3dFwdOp",
     "AdaLayerNormFwdOp",
     "AdaLayerNormZeroFwdOp",
+    "AdaptiveAvgPool2dFwdOp",
+    "AdaptiveMaxPool2dFwdOp",
+    "AdaptiveMaxPool2dIndicesFwdOp",
     "BatchNormBwdOp",
     "BatchNormFwdOp",
     "BmmFp8Op",

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -4,6 +4,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.pool import (
+    AdaptiveAvgPool2dKernel,
+    AdaptiveMaxPool2dKernel,
+    AdaptiveMaxPool2dWithIndicesKernel,
     AvgPool1dKernel,
     AvgPool1dSpatialKernel,
     AvgPool2dKernel,
@@ -28,6 +31,9 @@ from .compile_boundary import get_instance
 from .op_base import Op
 
 __all__ = [
+    "AdaptiveAvgPool2dFwdOp",
+    "AdaptiveMaxPool2dFwdOp",
+    "AdaptiveMaxPool2dIndicesFwdOp",
     "AvgPool1dFwdOp",
     "AvgPool2dFwdOp",
     "AvgPool3dFwdOp",
@@ -907,6 +913,243 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
         )
         bytes_ = (n * c_in * d_in * h_in * w_in + n * c_in * out_d * out_h * out_w) * elem_bytes
         return flops, bytes_
+
+
+def _normalize_output_size(
+    output_size: int | Tuple[Optional[int], Optional[int]],
+) -> Tuple[Optional[int], Optional[int]]:
+    """Normalize adaptive-pool ``output_size`` to a 2-tuple of ``int | None``."""
+    if isinstance(output_size, bool):
+        raise TypeError(
+            "output_size must be an int or a tuple of (int | None, int | None)"
+        )
+    if isinstance(output_size, int):
+        output_size = (output_size, output_size)
+    if (
+        not isinstance(output_size, (tuple, list))
+        or len(output_size) != 2
+        or any(
+            isinstance(v, bool) or (v is not None and not isinstance(v, int))
+            for v in output_size
+        )
+    ):
+        raise TypeError(
+            "output_size must be an int or a tuple of (int | None, int | None)"
+        )
+    if any(v is not None and v <= 0 for v in output_size):
+        raise ValueError("output_size entries must be positive or None")
+    return tuple(output_size)
+
+
+def _validate_adaptive_pool_input_dtypes(self, input: torch.Tensor) -> None:
+    """Adaptive-pool dtype validator: FP16/BF16 only (bound per concrete class)."""
+    if input.dtype not in {torch.float16, torch.bfloat16}:
+        raise ValueError(
+            f"input.dtype must be float16 or bfloat16, got {input.dtype}"
+        )
+
+
+def _adaptive_pool2d_roofline(op: "_AdaptivePool2dFwdOpBase", *, indices: bool) -> tuple[int, int]:
+    """Shared adaptive-pool roofline mirroring the manifest formulas."""
+    if op._last_roofline_spec is None:
+        raise RuntimeError(
+            f"{type(op).__name__}.eval_roofline() requires a prior forward() "
+            "call to bind input shape and dtype"
+        )
+    n, c_in, h_in, w_in, out_h, out_w, dtype = op._last_roofline_spec
+    elem_bytes = torch.empty((), dtype=dtype).element_size()
+    k_h = (h_in + out_h - 1) // out_h
+    k_w = (w_in + out_w - 1) // out_w
+    flops = n * c_in * out_h * out_w * k_h * k_w
+    bytes_ = (n * c_in * h_in * w_in + n * c_in * out_h * out_w) * elem_bytes
+    if indices:
+        bytes_ += n * c_in * out_h * out_w * 8
+    return flops, bytes_
+
+
+class _AdaptivePool2dFwdOpBase(Op):
+    """Generic adaptive 2D pooling forward over CHW/NCHW inputs.
+
+    Concrete subclasses set ``_kernel_slot`` / ``_returns_indices``, supply
+    ``default_kernel_map``, and keep ``eval_roofline`` / ``_validate_dtypes``
+    in their own class body so manifest codegen resolves them per concrete
+    class.
+    """
+
+    _kernel_slot: ClassVar[str] = ""
+    _returns_indices: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        output_size: int | Tuple[Optional[int], Optional[int]],
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        self.n = None
+        self.c_in = None
+        self.h_in = None
+        self.w_in = None
+        self.output_size = _normalize_output_size(output_size)
+        self.dtype = None
+        self.tune = tune
+        self.dispatch_kernel(kernel_map)
+        if self._kernel_slot not in self.kernel_map:
+            raise NotImplementedError(
+                f"{type(self).__name__} requires {self._kernel_slot!r} in kernel_map"
+            )
+        self._kernel_cache: Dict[tuple, Kernel] = {}
+        self._last_roofline_spec: Optional[tuple] = None
+
+    def _resolve_out_dims(self, h_in: int, w_in: int) -> tuple[int, int]:
+        out_h = h_in if self.output_size[0] is None else self.output_size[0]
+        out_w = w_in if self.output_size[1] is None else self.output_size[1]
+        return out_h, out_w
+
+    def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:
+        if len(input_shape) == 3:
+            c_in, h_in, w_in = input_shape
+            out_h, out_w = self._resolve_out_dims(h_in, w_in)
+            full = (c_in, out_h, out_w)
+        elif len(input_shape) == 4:
+            n, c_in, h_in, w_in = input_shape
+            out_h, out_w = self._resolve_out_dims(h_in, w_in)
+            full = (n, c_in, out_h, out_w)
+        else:
+            raise ValueError(
+                f"{type(self).__name__} expects input_shape to be 3D CHW or 4D NCHW"
+            )
+        if self._returns_indices:
+            return {"output": full, "indices": full}
+        return {"output": full}
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return _pool_fwd(input, self._instance_key)
+
+    def _eager_forward(self, input: torch.Tensor):
+        if input.ndim == 3:
+            squeezed = True
+            x = input.unsqueeze(0)
+        elif input.ndim == 4:
+            squeezed = False
+            x = input
+        else:
+            raise ValueError(
+                f"{type(self).__name__} expects input to be a 3D CHW or 4D NCHW tensor"
+            )
+        if not x.is_cuda:
+            raise ValueError("input must be a CUDA tensor")
+        self._validate_dtypes(x)
+        n, c_in, h_in, w_in = x.shape
+        out_h, out_w = self._resolve_out_dims(h_in, w_in)
+        x = x.contiguous()
+        dtype = x.dtype
+        key = (n, c_in, h_in, w_in, out_h, out_w, dtype, _device_index(x), self.tune)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map[self._kernel_slot](
+                n=n,
+                c_in=c_in,
+                h_in=h_in,
+                w_in=w_in,
+                out_h=out_h,
+                out_w=out_w,
+                dtype=dtype,
+                tune=self.tune,
+            )
+        kernel = self._kernel_cache[key]
+        self.kernel = kernel
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.out_h = out_h
+        self.out_w = out_w
+        self.dtype = dtype
+        self._last_roofline_spec = (n, c_in, h_in, w_in, out_h, out_w, dtype)
+        if self._returns_indices:
+            out, indices = kernel(x)
+            if squeezed:
+                return out.squeeze(0), indices.squeeze(0)
+            return out, indices
+        out = kernel(x)
+        if squeezed:
+            return out.squeeze(0)
+        return out
+
+
+class AdaptiveAvgPool2dFwdOp(_AdaptivePool2dFwdOpBase):
+    """Adaptive average pooling over PyTorch-compatible CHW/NCHW inputs."""
+
+    _kernel_slot = "adaptive_avg_pool2d_kernel"
+    _validate_dtypes = _validate_adaptive_pool_input_dtypes
+
+    def __init__(
+        self,
+        output_size: int | Tuple[Optional[int], Optional[int]],
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "adaptive_avg_pool2d_kernel": AdaptiveAvgPool2dKernel,
+        }
+
+    def eval_roofline(self) -> tuple[int, int]:
+        return _adaptive_pool2d_roofline(self, indices=False)
+
+
+class AdaptiveMaxPool2dFwdOp(_AdaptivePool2dFwdOpBase):
+    """Adaptive max pooling over CHW/NCHW inputs (return_indices=False)."""
+
+    _kernel_slot = "adaptive_max_pool2d_kernel"
+    _validate_dtypes = _validate_adaptive_pool_input_dtypes
+
+    def __init__(
+        self,
+        output_size: int | Tuple[Optional[int], Optional[int]],
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "adaptive_max_pool2d_kernel": AdaptiveMaxPool2dKernel,
+        }
+
+    def eval_roofline(self) -> tuple[int, int]:
+        return _adaptive_pool2d_roofline(self, indices=False)
+
+
+class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
+    """Adaptive max pooling over CHW/NCHW inputs (return_indices=True)."""
+
+    _kernel_slot = "adaptive_max_pool2d_with_indices_kernel"
+    _returns_indices = True
+    _validate_dtypes = _validate_adaptive_pool_input_dtypes
+
+    def __init__(
+        self,
+        output_size: int | Tuple[Optional[int], Optional[int]],
+        kernel_map: Optional[Dict[str, Kernel]] = None,
+        tune: bool = False,
+    ) -> None:
+        super().__init__(output_size=output_size, kernel_map=kernel_map, tune=tune)
+
+    @property
+    def default_kernel_map(self) -> Dict[str, Kernel]:
+        return {
+            "adaptive_max_pool2d_with_indices_kernel": AdaptiveMaxPool2dWithIndicesKernel,
+        }
+
+    def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return _pool_fwd_with_indices(input, self._instance_key)
+
+    def eval_roofline(self) -> tuple[int, int]:
+        return _adaptive_pool2d_roofline(self, indices=True)
 
 
 # torch.compile dispatch boundary (see tileops/ops/compile_boundary.py)

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -962,9 +962,11 @@ def _adaptive_pool2d_roofline(op: "_AdaptivePool2dFwdOpBase", *, indices: bool) 
         )
     n, c_in, h_in, w_in, out_h, out_w, dtype = op._last_roofline_spec
     elem_bytes = torch.empty((), dtype=dtype).element_size()
-    k_h = (h_in + out_h - 1) // out_h
-    k_w = (w_in + out_w - 1) // out_w
-    flops = n * c_in * out_h * out_w * k_h * k_w
+    # Exact adaptive-bin scan: bins are [floor(o*in/out), ceil((o+1)*in/out))
+    # and adjacent bins overlap by one row/col unless out | j*in.
+    scan_h = h_in + sum(1 for j in range(1, out_h) if (j * h_in) % out_h != 0)
+    scan_w = w_in + sum(1 for o in range(1, out_w) if (o * w_in) % out_w != 0)
+    flops = n * c_in * scan_h * scan_w
     bytes_ = (n * c_in * h_in * w_in + n * c_in * out_h * out_w) * elem_bytes
     if indices:
         bytes_ += n * c_in * out_h * out_w * 8

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -918,7 +918,11 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
 def _normalize_output_size(
     output_size: int | Tuple[Optional[int], Optional[int]],
 ) -> Tuple[Optional[int], Optional[int]]:
-    """Normalize adaptive-pool ``output_size`` to a 2-tuple of ``int | None``."""
+    """Normalize adaptive-pool ``output_size`` to a 2-tuple of ``int | None``.
+
+    Accepts an int or a 2-element tuple/list of ``int | None`` (PyTorch-style
+    leniency for list inputs); ``None`` entries resolve to the input size.
+    """
     if isinstance(output_size, bool):
         raise TypeError(
             "output_size must be an int or a tuple of (int | None, int | None)"

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -1005,8 +1005,12 @@ class _AdaptivePool2dFwdOpBase(Op):
         self._last_roofline_spec: Optional[tuple] = None
 
     def _resolve_out_dims(self, h_in: int, w_in: int) -> tuple[int, int]:
-        out_h = h_in if self.output_size[0] is None else self.output_size[0]
-        out_w = w_in if self.output_size[1] is None else self.output_size[1]
+        # Manifest parity probes call _infer_output_shapes on a mock self
+        # without __init__; a missing output_size acts as (None, None),
+        # i.e. pool to the input spatial size.
+        output_size = getattr(self, "output_size", (None, None))
+        out_h = h_in if output_size[0] is None else output_size[0]
+        out_w = w_in if output_size[1] is None else output_size[1]
         return out_h, out_w
 
     def _infer_output_shapes(self, input_shape: tuple[int, ...]) -> Dict[str, tuple[int, ...]]:

--- a/tileops/ops/pool.py
+++ b/tileops/ops/pool.py
@@ -916,16 +916,19 @@ class AvgPool3dFwdOp(_AvgPoolFwdOpBase):
 
 
 def _normalize_output_size(
-    output_size: int | Tuple[Optional[int], Optional[int]],
+    output_size: int | None | Tuple[Optional[int], Optional[int]],
 ) -> Tuple[Optional[int], Optional[int]]:
     """Normalize adaptive-pool ``output_size`` to a 2-tuple of ``int | None``.
 
-    Accepts an int or a 2-element tuple/list of ``int | None`` (PyTorch-style
-    leniency for list inputs); ``None`` entries resolve to the input size.
+    Accepts ``None``, an int, or a 2-element tuple/list of ``int | None``
+    (PyTorch-style leniency for list inputs); ``None`` entries — including a
+    scalar ``None`` — resolve to the input size.
     """
+    if output_size is None:
+        return (None, None)
     if isinstance(output_size, bool):
         raise TypeError(
-            "output_size must be an int or a tuple of (int | None, int | None)"
+            "output_size must be None, an int, or a tuple of (int | None, int | None)"
         )
     if isinstance(output_size, int):
         output_size = (output_size, output_size)
@@ -938,7 +941,7 @@ def _normalize_output_size(
         )
     ):
         raise TypeError(
-            "output_size must be an int or a tuple of (int | None, int | None)"
+            "output_size must be None, an int, or a tuple of (int | None, int | None)"
         )
     if any(v is not None and v <= 0 for v in output_size):
         raise ValueError("output_size entries must be positive or None")
@@ -987,7 +990,7 @@ class _AdaptivePool2dFwdOpBase(Op):
 
     def __init__(
         self,
-        output_size: int | Tuple[Optional[int], Optional[int]],
+        output_size: int | None | Tuple[Optional[int], Optional[int]],
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -1094,7 +1097,7 @@ class AdaptiveAvgPool2dFwdOp(_AdaptivePool2dFwdOpBase):
 
     def __init__(
         self,
-        output_size: int | Tuple[Optional[int], Optional[int]],
+        output_size: int | None | Tuple[Optional[int], Optional[int]],
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -1118,7 +1121,7 @@ class AdaptiveMaxPool2dFwdOp(_AdaptivePool2dFwdOpBase):
 
     def __init__(
         self,
-        output_size: int | Tuple[Optional[int], Optional[int]],
+        output_size: int | None | Tuple[Optional[int], Optional[int]],
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -1143,7 +1146,7 @@ class AdaptiveMaxPool2dIndicesFwdOp(_AdaptivePool2dFwdOpBase):
 
     def __init__(
         self,
-        output_size: int | Tuple[Optional[int], Optional[int]],
+        output_size: int | None | Tuple[Optional[int], Optional[int]],
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:

--- a/workloads/pool.py
+++ b/workloads/pool.py
@@ -275,9 +275,7 @@ class MaxPoolWorkload(WorkloadBase):
 class AdaptivePool2dWorkload(WorkloadBase):
     """One NCHW tensor for the adaptive 2D pool family.
 
-    ``output_size`` shapes no input; it rides along because the op and both
-    oracles need it, and PyTorch's scalar-``None`` spelling is normalised here
-    so neither stage repeats the rule.
+    ``output_size`` shapes no input; it rides along because the op needs it.
     """
 
     def __init__(
@@ -296,10 +294,6 @@ class AdaptivePool2dWorkload(WorkloadBase):
         self.output_size = output_size
         self.dtype = dtype
 
-    @property
-    def torch_output_size(self) -> tuple[int | None, int | None] | int | tuple[int, int]:
-        """torch 2.10 rejects a scalar ``None``; ``(None, None)`` is the same."""
-        return (None, None) if self.output_size is None else self.output_size
 
     def gen_inputs(self) -> tuple[torch.Tensor]:
         x = torch.randn(

--- a/workloads/pool.py
+++ b/workloads/pool.py
@@ -270,3 +270,39 @@ class MaxPoolWorkload(WorkloadBase):
             x = x.transpose(-2, -1).contiguous().transpose(-2, -1)
             assert not x.is_contiguous()
         return (x,)
+
+
+class AdaptivePool2dWorkload(WorkloadBase):
+    """One NCHW tensor for the adaptive 2D pool family.
+
+    ``output_size`` shapes no input; it rides along because the op and both
+    oracles need it, and PyTorch's scalar-``None`` spelling is normalised here
+    so neither stage repeats the rule.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        c_in: int,
+        h_in: int,
+        w_in: int,
+        output_size: int | None | tuple[int | None, int | None],
+        dtype: torch.dtype,
+    ) -> None:
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.output_size = output_size
+        self.dtype = dtype
+
+    @property
+    def torch_output_size(self) -> tuple[int | None, int | None] | int | tuple[int, int]:
+        """torch 2.10 rejects a scalar ``None``; ``(None, None)`` is the same."""
+        return (None, None) if self.output_size is None else self.output_size
+
+    def gen_inputs(self) -> tuple[torch.Tensor]:
+        x = torch.randn(
+            self.n, self.c_in, self.h_in, self.w_in, device="cuda", dtype=self.dtype
+        ).contiguous()
+        return (x,)


### PR DESCRIPTION
Closes #1799

Adds `AdaptiveAvgPool2dFwdOp`, `AdaptiveMaxPool2dFwdOp` and the `return_indices=True` variant `AdaptiveMaxPool2dIndicesFwdOp` in TileLang, matching PyTorch for CHW/NCHW, integer or two-element `output_size`, per-dimension `None`, non-divisible bins, expanded outputs, max ties and `int64` indices. The three manifest entries move to `implemented`.

Rebased onto the main that moved input construction into `workloads/`, so the new code follows that shape: `workloads/pool.py` owns `AdaptivePool2dWorkload` and both stages compose it; the scalar-`None` normalisation is one property there rather than one per `ref_program`; the bin arithmetic and static bin extent, previously identical in three kernel bodies, live in `pool/common.py`.

## Benchmark

H200 @ 1500 MHz, torch 2.10.0+cu129. Latency in ms, global 1x1 / SPP 6x6 / non-divisible 7x7 BF16.

| op | TileOPs | PyTorch |
| --- | ---: | ---: |
| AdaptiveAvg | 0.0034 / 0.0058 / 0.0070 | 0.0077 / 0.0111 / 0.0096 |
| AdaptiveMax | 0.0033 / 0.0058 / 0.0069 | 0.0459 / 0.0147 / 0.0119 |
| AdaptiveMax+indices | 0.0137 / 0.0203 / 0.0173 | 0.0458 / 0.0148 / 0.0120 |

The indices variant is behind PyTorch on the two non-global shapes.

## Validation

`pytest tests/ops/test_pool.py benchmarks/ops/bench_pool.py` 307 passed, adaptive latencies as above; `validate_manifest.py --strict` and per-op; the four structural gates; `pre-commit run --all-files`; `ruff check .`. The extracted bin extent was checked against the original expression over all 16384 axis pairs up to 128.
