### PR TITLE
[Bench] Add external baselines for common ops

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -6,6 +6,7 @@ are re-exported here, so a bench file keeps importing what it always did.
 
 import statistics
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, Generic, Optional, TypeVar
 
 import pytest
@@ -259,6 +260,16 @@ def workload_field_params(workloads: list, keys: tuple) -> list:
             )
         )
     return params
+
+
+def torch_inductor_baseline(fn: Callable) -> Callable:
+    """Compile a benchmark-local PyTorch baseline with TorchInductor.
+
+    The baseline implementation itself stays in the benchmark file so tests do
+    not become performance oracles. This helper only centralizes the compile
+    policy used by common-op benchmark baselines.
+    """
+    return torch.compile(fn, fullgraph=True)
 
 
 class ManifestBenchmark(BenchmarkBase[Any]):

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -36,7 +36,12 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return scale * normed + shift
 
-    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
@@ -52,4 +57,9 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return gate * (scale * normed + shift)
 
-    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, torch_inductor_baseline
 from tileops.manifest import load_workloads
 from tileops.ops.norm.ada_layer_norm import AdaLayerNormFwdOp
 from tileops.ops.norm.ada_layer_norm_zero import AdaLayerNormZeroFwdOp
@@ -36,7 +36,7 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return scale * normed + shift
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
@@ -52,4 +52,4 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return gate * (scale * normed + shift)
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)}, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -9,7 +9,12 @@ hard-code op parameters that are declared on manifest workload entries.
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
 from workloads.reduction import ArgmaxWorkload, ArgminWorkload
 
@@ -34,7 +39,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
         return x.argmax(dim=dim)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         *inputs,
         record_as=op,
         params={"shape": shape, "dtype": dtype, "dim": dim},
@@ -58,7 +63,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
         return x.argmin(dim=dim)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         *inputs,
         record_as=op,
         params={"shape": shape, "dtype": dtype, "dim": dim},

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -15,6 +15,7 @@ from benchmarks.benchmark_base import (
     BenchmarkBase,
     BenchmarkReport,
     ManifestBenchmark,
+    torch_inductor_baseline,
 )
 from tileops.kernels.elementwise import (
     GeluAndMulFwdKernel,
@@ -358,7 +359,12 @@ def test_binary_arith_bench(
 
     op = op_cls(a_shape=shape, b_shape=shape)
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Comparison ops (6)
@@ -404,7 +410,12 @@ def test_comparison_bench(
 
     op = _CMP_OPS[op_name](a_shape=shape, b_shape=shape)
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Logical ops (2)
@@ -469,8 +480,8 @@ def test_logical_bench(
 
     # Baseline uses bool tensors
     a_bool, b_bool = inputs[0].bool(), inputs[1].bool()
-    functors["torch"] = (
-        baseline_fn,
+    functors["torch-inductor"] = (
+        torch_inductor_baseline(baseline_fn),
         (
             a_bool,
             b_bool,
@@ -534,7 +545,12 @@ def test_bitwise_bench(
 
     op = op_cls(a_shape=shape, b_shape=shape)
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 # Fused gated ops (2)
@@ -601,7 +617,7 @@ _FUSED_BASELINES = {
 def _profile_fused_gated(bm: ManifestBenchmark, op, test, baseline_key: str, params: dict) -> None:
     inputs = test.gen_inputs()
     bm.compare(
-        {"tileops": op, "torch-ref": _FUSED_BASELINES[baseline_key]},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(_FUSED_BASELINES[baseline_key])},
         *inputs,
         record_as=op,
         params=params,
@@ -696,7 +712,7 @@ def test_fused_gated_strategy_bench(
     kernel = kernel_cls(M=M, N=N, dtype=dtype, config={"strategy": strategy})
     baseline_fn = _FUSED_BASELINES[op_name]
     bm.compare(
-        {f"tileops-{strategy}": kernel, "torch": baseline_fn},
+        {f"tileops-{strategy}": kernel, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         *inputs,
         record_as=f"{op_name}_strategy",
         params=locals(),
@@ -839,7 +855,7 @@ def test_broadcast_bench(
     op = op_cls(a_shape=a_shape, b_shape=b_shape)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         *inputs,
         record_as=f"{op_name}_bcast",
         params=locals(),

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -11,6 +11,7 @@ import torch
 from benchmarks.benchmark_base import (
     BenchmarkReport,
     ManifestBenchmark,
+    torch_inductor_baseline,
     workloads_to_params,
 )
 from workloads.reduction import CumulativeWorkload
@@ -49,7 +50,7 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumsum")
     bm = ManifestBenchmark(_CUMSUM_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
@@ -60,4 +61,4 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumprod")
     bm = ManifestBenchmark(_CUMPROD_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)}, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -50,7 +50,12 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumsum")
     bm = ManifestBenchmark(_CUMSUM_OP, op, test)
 
-    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
@@ -61,4 +66,9 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumprod")
     bm = ManifestBenchmark(_CUMPROD_OP, op, test)
 
-    bm.compare({"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -10,7 +10,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.dropout import DropoutFwdOp
 from workloads.elementwise import ShapedRandnWorkload
 
@@ -34,4 +39,9 @@ def test_dropout_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = DropoutFwdOp(p=test.p, seed=42)
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, x, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)},
+        x,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, torch_inductor_baseline
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AddFwdOp,
@@ -234,7 +234,10 @@ def _record_unary(
     baseline_fn: Callable,
 ) -> None:
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm)
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=_manifest_params(bm),
     )
 
 
@@ -245,7 +248,10 @@ def _record_binary(
     baseline_fn: Callable,
 ) -> None:
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm)
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=_manifest_params(bm),
     )
 
 
@@ -417,7 +423,13 @@ def test_prelu_manifest_bench(
     x, weight = test.gen_inputs()
     op = PreluFwdOp(shape=input_shape, num_channels=test.num_channels)
     bm = ManifestBenchmark(_PRELU_OP, op, test)
-    bm.compare({"tileops": op, "torch": F.prelu}, x, weight, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(F.prelu)},
+        x,
+        weight,
+        record_as=op,
+        params=locals(),
+    )
 
 
 _MASKED_FILL_OP = "MaskedFillFwdOp"
@@ -439,7 +451,10 @@ def test_masked_fill_tensor_manifest_bench(
     op = MaskedFillFwdOp(input=input_shape, mask=mask_shape, value=value_shape)
     bm = ManifestBenchmark(_MASKED_FILL_OP, op, test)
     bm.compare(
-        {"tileops": op, "torch": lambda a, m, v: a.masked_fill(m, v)},
+        {
+            "tileops": op,
+            "torch-inductor": torch_inductor_baseline(lambda a, m, v: a.masked_fill(m, v)),
+        },
         x,
         mask,
         value,
@@ -461,7 +476,10 @@ def test_masked_fill_scalar_manifest_bench(
     op = MaskedFillScalarFwdOp(input=shape, mask=shape, value=-100.0)
     bm = ManifestBenchmark(_MASKED_FILL_SCALAR_OP, op, test)
     bm.compare(
-        {"tileops": op, "torch": lambda a, m: a.masked_fill(m, -100.0)},
+        {
+            "tileops": op,
+            "torch-inductor": torch_inductor_baseline(lambda a, m: a.masked_fill(m, -100.0)),
+        },
         x,
         mask,
         record_as=op,
@@ -740,7 +758,14 @@ def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> Non
     cond, x, other = test.gen_inputs()
     op = WhereFwdOp(condition=shape, input=shape, other=shape)
     bm = ManifestBenchmark(_WHERE_OP, op, test)
-    bm.compare({"tileops": op, "torch": torch.where}, cond, x, other, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(torch.where)},
+        cond,
+        x,
+        other,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_LERP_TENSOR_OP)))
@@ -749,4 +774,11 @@ def test_lerp_tensor_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     x, end, weight = test.gen_inputs()
     op = LerpTensorFwdOp(input=shape, end=shape, weight=shape)
     bm = ManifestBenchmark(_LERP_TENSOR_OP, op, test)
-    bm.compare({"tileops": op, "torch": torch.lerp}, x, end, weight, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(torch.lerp)},
+        x,
+        end,
+        weight,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -2,12 +2,16 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, torch_inductor_baseline
 from tileops.manifest import load_workloads
-from tileops.ops.norm.group_norm import GroupNormFwdOp
+from tileops.ops.norm.group_norm import (
+    GroupNormFwdOp,
+    GroupNormNoAffineFwdOp,
+)
 from workloads.normalization import GroupNormWorkload
 
 _OP_NAME = "GroupNormFwdOp"
+_OP_NAME_NO_AFFINE = "GroupNormNoAffineFwdOp"
 
 
 def _build_params(workloads):
@@ -27,9 +31,8 @@ def _build_params(workloads):
     return params
 
 
-_WORKLOADS = load_workloads(_OP_NAME)
-_AFFINE_PARAMS = _build_params([w for w in _WORKLOADS if "weight_shape" in w])
-_NO_AFFINE_PARAMS = _build_params([w for w in _WORKLOADS if "weight_shape" not in w])
+_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME))
+_NO_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME_NO_AFFINE))
 
 
 @pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune", _AFFINE_PARAMS)
@@ -47,7 +50,12 @@ def test_group_norm_bench(
         return F.group_norm(x, num_groups, weight=weight, bias=bias, eps=1e-5)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn}, x, weight, bias, record_as=op, params=locals()
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        x,
+        weight,
+        bias,
+        record_as=op,
+        params=locals(),
     )
 
 
@@ -58,10 +66,15 @@ def test_group_norm_no_affine_bench(
     test = GroupNormWorkload(n, c, spatial, num_groups, dtype)
     x, _, _ = test.gen_inputs()
 
-    op = GroupNormFwdOp(num_groups=num_groups, tune=tune)
-    bm = ManifestBenchmark(_OP_NAME, op, test)
+    op = GroupNormNoAffineFwdOp(num_groups=num_groups, tune=tune)
+    bm = ManifestBenchmark(_OP_NAME_NO_AFFINE, op, test)
 
     def baseline_no_affine(x):
         return F.group_norm(x, num_groups, weight=None, bias=None, eps=1e-5)
 
-    bm.compare({"tileops": op, "torch": baseline_no_affine}, x, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_no_affine)},
+        x,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -11,11 +11,18 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+)
 from tileops.manifest import load_workloads
 from tileops.ops.elementwise import (
     AlibiFwdOp,
     ClampFwdOp,
+    ClampMaxFwdOp,
+    ClampMinFwdOp,
     ClampScalarFwdOp,
     EluFwdOp,
     HardtanhFwdOp,
@@ -55,21 +62,26 @@ class UnaryBenchmark(BenchmarkBase[ShapedRandnWorkload]):
         return self.workload.n_total * self.workload.dtype.itemsize * 2
 
 
-# Tensor-bound clamp. N_total is post-broadcast, i.e. product(out_shape).
+# Tensor-bound clamp ops: ClampFwdOp, ClampMinFwdOp, ClampMaxFwdOp.
+# N_total is post-broadcast, i.e. product(out_shape).
 
 _CLAMP_FWD_OP = "ClampFwdOp"
+_CLAMP_MIN_OP = "ClampMinFwdOp"
+_CLAMP_MAX_OP = "ClampMaxFwdOp"
 
 
-def _workloads_to_clamp_params(workloads: list) -> list:
-    """Convert manifest workload dicts to clamp-bench pytest params.
-
-    A row passes a bound exactly when it declares that bound's shape (R18.1).
-    """
+def _workloads_to_clamp_params(
+    workloads: list,
+    *,
+    needs_min: bool,
+    needs_max: bool,
+) -> list:
+    """Convert manifest workload dicts to clamp-bench pytest params."""
     params = []
     for idx, w in enumerate(workloads):
         input_shape = tuple(w["input_shape"])
-        min_shape = tuple(w["min_shape"]) if "min_shape" in w else None
-        max_shape = tuple(w["max_shape"]) if "max_shape" in w else None
+        min_shape = tuple(w["min_shape"]) if needs_min else None
+        max_shape = tuple(w["max_shape"]) if needs_max else None
         label = w.get("label", "x".join(str(s) for s in input_shape))
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)
@@ -90,24 +102,20 @@ def _workloads_to_clamp_params(workloads: list) -> list:
 
 @pytest.mark.parametrize(
     "input_shape, min_shape, max_shape, dtype",
-    _workloads_to_clamp_params(load_workloads(_CLAMP_FWD_OP)),
+    _workloads_to_clamp_params(
+        load_workloads(_CLAMP_FWD_OP),
+        needs_min=True,
+        needs_max=True,
+    ),
 )
 def test_clamp_tensor_bench(
     input_shape: tuple,
-    min_shape: Optional[tuple],
-    max_shape: Optional[tuple],
+    min_shape: tuple,
+    max_shape: tuple,
     dtype: torch.dtype,
 ) -> None:
-    test = TensorClampBenchCase(
-        input_shape,
-        dtype,
-        min_shape=min_shape,
-        max_shape=max_shape,
-    )
-    # gen_inputs yields only the bounds this row passes; widen to (x, min, max).
-    x, *bounds = test.gen_inputs()
-    t_min = bounds.pop(0) if min_shape is not None else None
-    t_max = bounds.pop(0) if max_shape is not None else None
+    test = TensorClampBenchCase(input_shape, dtype, min_shape=min_shape, max_shape=max_shape)
+    x, t_min, t_max = test.gen_inputs()
 
     op = ClampFwdOp(input=input_shape, min=min_shape, max=max_shape)
     bm = ManifestBenchmark(_CLAMP_FWD_OP, op, test)
@@ -116,9 +124,73 @@ def test_clamp_tensor_bench(
         return torch.clamp(x, t_min, t_max)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         x,
         t_min,
+        t_max,
+        record_as=op,
+        params=locals(),
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, min_shape, _max_shape, dtype",
+    _workloads_to_clamp_params(
+        load_workloads(_CLAMP_MIN_OP),
+        needs_min=True,
+        needs_max=False,
+    ),
+)
+def test_clamp_min_bench(
+    input_shape: tuple,
+    min_shape: tuple,
+    _max_shape: Optional[tuple],
+    dtype: torch.dtype,
+) -> None:
+    test = TensorClampBenchCase(input_shape, dtype, min_shape=min_shape)
+    x, t_min = test.gen_inputs()
+
+    op = ClampMinFwdOp(input=input_shape, min=min_shape)
+    bm = ManifestBenchmark(_CLAMP_MIN_OP, op, test)
+
+    def baseline_fn(x, t_min):
+        return torch.maximum(x, t_min)
+
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        x,
+        t_min,
+        record_as=op,
+        params=locals(),
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, _min_shape, max_shape, dtype",
+    _workloads_to_clamp_params(
+        load_workloads(_CLAMP_MAX_OP),
+        needs_min=False,
+        needs_max=True,
+    ),
+)
+def test_clamp_max_bench(
+    input_shape: tuple,
+    _min_shape: Optional[tuple],
+    max_shape: tuple,
+    dtype: torch.dtype,
+) -> None:
+    test = TensorClampBenchCase(input_shape, dtype, max_shape=max_shape)
+    x, t_max = test.gen_inputs()
+
+    op = ClampMaxFwdOp(input=input_shape, max=max_shape)
+    bm = ManifestBenchmark(_CLAMP_MAX_OP, op, test)
+
+    def baseline_fn(x, t_max):
+        return torch.minimum(x, t_max)
+
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        x,
         t_max,
         record_as=op,
         params=locals(),
@@ -189,7 +261,12 @@ def test_alibi_bench(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
     bm = ManifestBenchmark(_ALIBI_OP, op, workload)
 
     bm.compare(
-        {"tileops": op, "torch-ref": lambda: _alibi_reference(seq_len, num_heads, dtype)},
+        {
+            "tileops": op,
+            "torch-inductor": torch_inductor_baseline(
+                lambda: _alibi_reference(seq_len, num_heads, dtype)
+            ),
+        },
         record_as=op,
         params=locals(),
     )
@@ -202,7 +279,12 @@ def test_sinusoidal_bench(seq_len: int, d_model: int, dtype: torch.dtype) -> Non
     bm = ManifestBenchmark(_SINUSOIDAL_OP, op, workload)
 
     bm.compare(
-        {"tileops": op, "torch-ref": lambda: _sinusoidal_reference(seq_len, d_model, dtype)},
+        {
+            "tileops": op,
+            "torch-inductor": torch_inductor_baseline(
+                lambda: _sinusoidal_reference(seq_len, d_model, dtype)
+            ),
+        },
         record_as=op,
         params=locals(),
     )
@@ -340,7 +422,7 @@ def test_fp8_selection_bench(op_name: str, shape: tuple, dtype: torch.dtype) -> 
             return torch.where(cond, x, y)
 
         result_bl = bm.profile(baseline, cond, x, y)
-        BenchmarkReport.record("where_fp8", locals(), result_bl, tag="torch-ref")
+        BenchmarkReport.record("where_fp8", locals(), result_bl, tag="torch_ref")
     else:
         test = Fp8MaskedFillBenchCase(shape, dtype)
         bm = Fp8MaskedFillBenchmark(test)

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -2,58 +2,75 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, torch_inductor_baseline
 from tileops.manifest import load_workloads
-from tileops.ops.norm.instance_norm import InstanceNormFwdOp
+from tileops.ops.norm.instance_norm import (
+    InstanceNormFwdOp,
+    InstanceNormNoAffineFwdOp,
+)
 from workloads.normalization import InstanceNormWorkload
 
 _OP_NAME = "InstanceNormFwdOp"
+_OP_NAME_NO_AFFINE = "InstanceNormNoAffineFwdOp"
 
 
 def _build_params(workloads):
-    """One param per workload row and dtype.
-
-    A row applies the affine exactly when it declares ``weight_shape`` (R18.1).
-    """
     params = []
     for w in workloads:
         shape = w["x_shape"]
         n, c, spatial = shape[0], shape[1], tuple(shape[2:])
         label = w.get("label", f"{n}x{c}x{'x'.join(map(str, spatial))}")
-        affine = "weight_shape" in w
         for dtype_str in w["dtypes"]:
             dtype = getattr(torch, dtype_str)
-            params.append(
-                pytest.param(n, c, spatial, dtype, True, affine, id=f"{label}-{dtype_str}")
-            )
+            params.append(pytest.param(n, c, spatial, dtype, True, id=f"{label}-{dtype_str}"))
     return params
 
 
-@pytest.mark.parametrize(
-    "n, c, spatial, dtype, tune, affine", _build_params(load_workloads(_OP_NAME))
-)
+_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME))
+_NO_AFFINE_PARAMS = _build_params(load_workloads(_OP_NAME_NO_AFFINE))
+
+
+@pytest.mark.parametrize("n, c, spatial, dtype, tune", _AFFINE_PARAMS)
 def test_instance_norm_bench(
-    n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool, affine: bool
+    n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool
 ) -> None:
     test = InstanceNormWorkload(n, c, spatial, dtype)
-    x, _, _, weight, bias = test.gen_inputs()
-    if not affine:
-        weight = bias = None
+    x, weight, bias = test.gen_inputs()
 
     op = InstanceNormFwdOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
 
     # Baseline: torch.nn.functional.instance_norm
-    def baseline_fn(x, running_mean, running_var, weight, bias):
+    def baseline_fn(x, weight, bias):
         return F.instance_norm(x, weight=weight, bias=bias, eps=1e-5)
 
     bm.compare(
-        {"tileops": op, "torch": baseline_fn},
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
         x,
-        None,
-        None,
         weight,
         bias,
         record_as=op,
         params=locals(),
     )
+
+
+@pytest.mark.parametrize("n, c, spatial, dtype, tune", _NO_AFFINE_PARAMS)
+def test_instance_norm_no_affine_bench(
+    n: int, c: int, spatial: tuple, dtype: torch.dtype, tune: bool
+) -> None:
+    test = InstanceNormWorkload(n, c, spatial, dtype)
+    x, _, _ = test.gen_inputs()
+
+    op = InstanceNormNoAffineFwdOp(tune=tune)
+    bm = ManifestBenchmark(_OP_NAME_NO_AFFINE, op, test)
+    # Running stats are required positional args (R16) but ignored on the
+    # use_input_stats=True path; pass placeholders.
+    rm = torch.zeros(c, dtype=torch.float32, device="cuda")
+    rv = torch.ones(c, dtype=torch.float32, device="cuda")
+    functors = {"tileops": op}
+
+    def baseline_no_affine(x):
+        return F.instance_norm(x, weight=None, bias=None, eps=1e-5)
+
+    functors["torch-inductor"] = (torch_inductor_baseline(baseline_no_affine), (x,))
+    bm.compare(functors, x, rm, rv, record_as=op, params=locals())

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -7,7 +7,12 @@ Workload shapes and roofline formulas are loaded from the ops manifest (src/tile
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.reduction.logical_reduce import AllFwdOp, AnyFwdOp, CountNonzeroFwdOp
 from workloads.reduction import AllWorkload, AnyWorkload, CountNonzeroWorkload
 
@@ -39,7 +44,12 @@ def test_any_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.bool().any(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -67,7 +77,12 @@ def test_all_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.bool().all(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -94,7 +109,12 @@ def test_count_nonzero_bench(shape: tuple, dtype: torch.dtype, op_params: dict) 
         return torch.count_nonzero(x, dim=dim).to(torch.int64)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -3,7 +3,11 @@ from typing import List, Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    BenchmarkReport,
+    torch_inductor_baseline,
+)
 from tileops.ops import MeanPoolingForwardOp
 from workloads.nsa_utils import prepare_chunk_indices
 from workloads.pool import MeanPoolingWorkload
@@ -127,6 +131,12 @@ def test_mean_pooling_bench(
 
     op = MeanPoolingForwardOp(**params)
 
+    # The offsets path is not fullgraph-compilable, so it keeps the eager baseline.
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(test.ref_program)}
+        if use_offsets == 0
+        else {"tileops": op, "torch-ref": test.ref_program},
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -4,7 +4,11 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+)
 from tileops.manifest import load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
@@ -16,6 +20,16 @@ from workloads.normalization import (
     LayerNormWorkload,
     RMSNormWorkload,
 )
+
+
+def _flashinfer_module():
+    """Return the ``flashinfer`` module, or None when it is not installed."""
+    try:
+        import flashinfer
+    except ImportError:
+        return None
+    return flashinfer
+
 
 _RMS_OP_NAME = "RMSNormFwdOp"
 
@@ -40,9 +54,15 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     op = RMSNormFwdOp(normalized_shape=(n,), tune=tune)
     bm = ManifestBenchmark(_RMS_OP_NAME, op, test)
 
-    bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
-    )
+    functors = {
+        "tileops": op,
+        "torch-inductor": torch_inductor_baseline(test.ref_program),
+    }
+    flashinfer = _flashinfer_module()
+    if flashinfer is not None:
+        functors["flashinfer"] = lambda x, weight: flashinfer.rmsnorm(x, weight, eps=test.eps)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 _FUSED_RMS_OP_NAME = "FusedAddRMSNormFwdOp"
@@ -81,7 +101,20 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
         y = ((add_result.float() / rms) * weight.float()).to(x.dtype)
         return y, add_result
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    functors = {
+        "tileops": op,
+        "torch-inductor": torch_inductor_baseline(baseline_fn),
+    }
+    flashinfer = _flashinfer_module()
+    if flashinfer is not None:
+
+        def flashinfer_baseline(x, residual, weight):
+            flashinfer.fused_add_rmsnorm(x, residual, weight, eps=test.eps)
+            return x, residual
+
+        functors["flashinfer"] = flashinfer_baseline
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 _LN_OP_NAME = "LayerNormFwdOp"
@@ -110,7 +143,12 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
     def baseline_fn(x, weight, bias):
         return F.layer_norm(x, (n,), weight=weight, bias=bias, eps=1e-5)
 
-    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 _FUSED_LN_OP_NAME = "FusedAddLayerNormFwdOp"
@@ -140,4 +178,9 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
         add_result = (x.float() + residual.float()).to(x.dtype)
         return F.layer_norm(add_result, (n,), weight=weight, bias=bias, eps=test.eps), add_result
 
-    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -7,7 +7,12 @@ Workload shapes and roofline formulas are loaded from the ops manifest (src/tile
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.reduction.reduce import (
     AmaxFwdOp,
     AminFwdOp,
@@ -62,7 +67,12 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.float().sum(dim=dim, keepdim=keepdim).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -90,7 +100,12 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -118,7 +133,12 @@ def test_amax_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.amax(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -146,7 +166,12 @@ def test_amin_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.amin(dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -168,7 +193,12 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
         return x.float().prod(dim=-1).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -196,7 +226,12 @@ def test_std_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.float().std(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -224,7 +259,12 @@ def test_var_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
         return x.float().var(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -254,7 +294,12 @@ def test_var_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
         return (v, m)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -11,6 +11,8 @@ Baselines build their cos/sin tables outside the timed window, so only the
 rotation itself is measured.
 """
 
+import math
+
 import pytest
 import torch
 
@@ -91,28 +93,111 @@ def _position_ids_params(workloads: list[dict]) -> list:
 
 
 def _rope_tables(seq_len: int, head_dim: int, dtype: torch.dtype):
-    """Half-split cos/sin tables, shape ``(seq_len, head_dim)``.
+    cos, sin = _rope_half_tables(seq_len, head_dim)
+    return torch.cat([cos] * 2, dim=-1).to(dtype), torch.cat([sin] * 2, dim=-1).to(dtype)
 
-    Frequency values are variant-specific, but the timed rotation cost depends
-    only on table geometry, which every RoPE variant shares — so one baseline
-    serves all of them.
-    """
+
+def _rope_half_tables(
+    seq_len: int,
+    head_dim: int,
+    *,
+    variant: str = "neox",
+) -> tuple[torch.Tensor, torch.Tensor]:
     half = head_dim // 2
-    freqs = 1.0 / (_BASE ** (torch.arange(0, half, device="cuda", dtype=torch.float32) / half))
-    angles = torch.outer(
-        torch.arange(seq_len, device="cuda", dtype=torch.float32),
+    dim = torch.arange(0, half, device="cuda", dtype=torch.float32)
+    if variant == "llama31":
+        freqs = _llama31_inv_freqs(dim, half)
+    elif variant == "yarn":
+        freqs = _yarn_inv_freqs(dim, half)
+    elif variant == "longrope":
+        freqs = _longrope_inv_freqs(dim, half)
+    else:
+        freqs = 1.0 / (_BASE ** (dim / half))
+    angles = torch.outer(torch.arange(seq_len, device="cuda", dtype=torch.float32), freqs)
+    return torch.cos(angles), torch.sin(angles)
+
+
+def _llama31_inv_freqs(dim: torch.Tensor, half: int) -> torch.Tensor:
+    freqs = 1.0 / (_BASE ** (dim / half))
+    wavelen = 2 * math.pi / freqs
+    low_freq_wavelen = 8192.0
+    high_freq_wavelen = 8192.0 / 4.0
+    smooth = (8192.0 / wavelen - 1.0) / 3.0
+    blended = (1.0 - smooth) * freqs / 8.0 + smooth * freqs
+    return torch.where(
+        wavelen < high_freq_wavelen,
         freqs,
+        torch.where(wavelen > low_freq_wavelen, freqs / 8.0, blended),
     )
-    return (
-        torch.cat([torch.cos(angles)] * 2, dim=-1).to(dtype),
-        torch.cat([torch.sin(angles)] * 2, dim=-1).to(dtype),
-    )
+
+
+def _yarn_find_correction_dim(num_rotations: float, dim: int) -> float:
+    return dim * math.log(4096 / (num_rotations * 2 * math.pi)) / (2 * math.log(_BASE))
+
+
+def _yarn_inv_freqs(dim: torch.Tensor, half: int) -> torch.Tensor:
+    beta_fast = 32.0
+    beta_slow = 1.0
+    scale = 16.0
+    low = max(math.floor(_yarn_find_correction_dim(beta_fast, half)), 0)
+    high = min(math.ceil(_yarn_find_correction_dim(beta_slow, half)), half - 1)
+    if low == high:
+        high += 1
+    freq_extra = 1.0 / (_BASE ** (dim / half))
+    freq_inter = 1.0 / ((scale * _BASE) ** (dim / half))
+    inv_freq_mask = 1.0 - torch.clamp((dim - low) / (high - low), 0.0, 1.0)
+    return freq_inter * (1.0 - inv_freq_mask) + freq_extra * inv_freq_mask
+
+
+def _longrope_inv_freqs(dim: torch.Tensor, half: int) -> torch.Tensor:
+    # Manifest workloads use RopeLongRopeFwdOp defaults: no rescale factors and
+    # equal max/original position lengths, so the scale amplitude remains 1.
+    return 1.0 / (_BASE ** (dim / half))
 
 
 def _rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     half = x.shape[-1] // 2
     x1, x2 = x[..., :half], x[..., half:]
     return x * cos + torch.cat((-x2, x1), dim=-1) * sin
+
+
+def _rotate_interleaved(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    x_even, x_odd = x[..., ::2], x[..., 1::2]
+    out = torch.empty_like(x)
+    out[..., ::2] = x_even * cos - x_odd * sin
+    out[..., 1::2] = x_odd * cos + x_even * sin
+    return out
+
+
+def _rope_reference(
+    x: torch.Tensor,
+    layout: str,
+    *,
+    variant: str,
+    interleave: bool = False,
+) -> torch.Tensor:
+    seq_len = x.shape[0] if layout == "1d" else x.shape[1]
+    cos_half, sin_half = _rope_half_tables(seq_len, x.shape[-1], variant=variant)
+    if interleave:
+        if layout != "1d":
+            cos_half, sin_half = (
+                t.view(1, seq_len, 1, x.shape[-1] // 2) for t in (cos_half, sin_half)
+            )
+        return _rotate_interleaved(x, cos_half.to(x.dtype), sin_half.to(x.dtype))
+
+    cos = torch.cat([cos_half] * 2, dim=-1).to(x.dtype)
+    sin = torch.cat([sin_half] * 2, dim=-1).to(x.dtype)
+    if layout != "1d":
+        cos, sin = (t.view(1, seq_len, 1, x.shape[-1]) for t in (cos, sin))
+    return _rotate(x, cos, sin)
+
+
+def _assert_flashinfer_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    torch.testing.assert_close(actual, expected, rtol=5e-2, atol=5e-2)
 
 
 def _flashinfer_module():
@@ -151,14 +236,14 @@ def _flashinfer_flat_qk_pos_ids(
     return q.reshape(q.shape[0], -1), k.reshape(k.shape[0], -1), pos_ids, output_shape
 
 
-def _rope_cos_sin_cache(seq_len: int, head_dim: int) -> torch.Tensor:
-    half = head_dim // 2
-    freqs = 1.0 / (_BASE ** (torch.arange(0, half, device="cuda", dtype=torch.float32) / half))
-    angles = torch.outer(
-        torch.arange(seq_len, device="cuda", dtype=torch.float32),
-        freqs,
-    )
-    return torch.cat([torch.cos(angles), torch.sin(angles)], dim=-1)
+def _rope_cos_sin_cache(
+    seq_len: int,
+    head_dim: int,
+    *,
+    variant: str = "neox",
+) -> torch.Tensor:
+    cos, sin = _rope_half_tables(seq_len, head_dim, variant=variant)
+    return torch.cat([cos, sin], dim=-1)
 
 
 def _record_flashinfer_rope(
@@ -174,31 +259,31 @@ def _record_flashinfer_rope(
 ) -> None:
     q, k, pos_ids, output_shape = _flashinfer_qk_pos_ids(x, layout)
     if variant == "llama31":
-        result_fi = bm.profile(
-            lambda q, k, p: flashinfer.apply_llama31_rope_pos_ids(
+
+        def flashinfer_baseline(q, k, p):
+            return flashinfer.apply_llama31_rope_pos_ids(
                 q,
                 k,
                 p,
                 interleave=interleave,
                 rope_theta=_BASE,
-            )[0].reshape(output_shape),
-            q,
-            k,
-            pos_ids,
-        )
+            )[0].reshape(output_shape)
     else:
-        result_fi = bm.profile(
-            lambda q, k, p: flashinfer.apply_rope_pos_ids(
+
+        def flashinfer_baseline(q, k, p):
+            return flashinfer.apply_rope_pos_ids(
                 q,
                 k,
                 p,
                 interleave=interleave,
                 rope_theta=_BASE,
-            )[0].reshape(output_shape),
-            q,
-            k,
-            pos_ids,
-        )
+            )[0].reshape(output_shape)
+
+    _assert_flashinfer_close(
+        flashinfer_baseline(q, k, pos_ids),
+        _rope_reference(x, layout, variant=variant, interleave=interleave),
+    )
+    result_fi = bm.profile(flashinfer_baseline, q, k, pos_ids)
     BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
 
 
@@ -210,24 +295,28 @@ def _record_flashinfer_cached_rope(
     x: torch.Tensor,
     layout: str,
     *,
+    variant: str,
     is_neox: bool = True,
 ) -> None:
     seq_len = x.shape[0] if layout == "1d" else x.shape[1]
     q, k, pos_ids, output_shape = _flashinfer_flat_qk_pos_ids(x, layout)
-    cos_sin_cache = _rope_cos_sin_cache(seq_len, x.shape[-1])
-    result_fi = bm.profile(
-        lambda p, q, k: flashinfer.apply_rope_with_cos_sin_cache(
+    cos_sin_cache = _rope_cos_sin_cache(seq_len, x.shape[-1], variant=variant)
+
+    def flashinfer_baseline(p, q, k):
+        return flashinfer.apply_rope_with_cos_sin_cache(
             p,
             q,
             k,
             x.shape[-1],
             cos_sin_cache,
             is_neox=is_neox,
-        )[0].reshape(output_shape),
-        pos_ids,
-        q,
-        k,
+        )[0].reshape(output_shape)
+
+    _assert_flashinfer_close(
+        flashinfer_baseline(pos_ids, q, k),
+        _rope_reference(x, layout, variant=variant, interleave=(not is_neox)),
     )
+    result_fi = bm.profile(flashinfer_baseline, pos_ids, q, k)
     BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
 
 
@@ -266,15 +355,23 @@ def _profile_rope(
                 params,
                 x,
                 layout,
+                variant=variant,
                 is_neox=(not interleave),
             )
 
-    seq_len = shape[0] if layout == "1d" else shape[1]
-    cos, sin = _rope_tables(seq_len, shape[-1], dtype)
-    if layout != "1d":
-        cos, sin = (t.view(1, seq_len, 1, shape[-1]) for t in (cos, sin))
     bm.compare(
-        {"tileops": op, "torch-ref": lambda t: _rotate(t, cos, sin)}, x, record_as=op, params=params
+        {
+            "tileops": op,
+            "torch-ref": lambda t: _rope_reference(
+                t,
+                layout,
+                variant=variant,
+                interleave=interleave,
+            ),
+        },
+        x,
+        record_as=op,
+        params=params,
     )
 
 
@@ -392,27 +489,29 @@ def test_rope_neox_position_ids_bench(
     bm = ManifestBenchmark(_POSITION_IDS_OP, op, RopeWorkload(shape, dtype))
     params = {"shape": shape, "dtype": dtype, "max_position": max_position}
 
-    flashinfer = _flashinfer_module()
-    if flashinfer is not None:
-        k = x.new_empty((num_tokens, 0, head_dim))
-        result_fi = bm.profile(
-            lambda t, k, p: flashinfer.apply_rope_pos_ids(
-                t,
-                k,
-                p,
-                rope_theta=_BASE,
-            )[0],
-            x,
-            k,
-            position_ids,
-        )
-        BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
-
     cos, sin = _rope_tables(max_position, head_dim, dtype)
 
     def baseline_fn(t: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
         idx = pos.long()
         return _rotate(t, cos[idx].unsqueeze(1), sin[idx].unsqueeze(1))
+
+    flashinfer = _flashinfer_module()
+    if flashinfer is not None:
+        k = x.new_empty((num_tokens, 0, head_dim))
+
+        def flashinfer_baseline(t, k, p):
+            return flashinfer.apply_rope_pos_ids(
+                t,
+                k,
+                p,
+                rope_theta=_BASE,
+            )[0]
+
+        _assert_flashinfer_close(
+            flashinfer_baseline(x, k, position_ids), baseline_fn(x, position_ids)
+        )
+        result_fi = bm.profile(flashinfer_baseline, x, k, position_ids)
+        BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
 
     bm.compare(
         {"tileops": op, "torch-ref": baseline_fn}, x, position_ids, record_as=op, params=params

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -115,12 +115,159 @@ def _rotate(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tens
     return x * cos + torch.cat((-x2, x1), dim=-1) * sin
 
 
+def _flashinfer_module():
+    try:
+        import flashinfer
+    except ImportError:
+        return None
+    return flashinfer
+
+
+def _flashinfer_qk_pos_ids(
+    x: torch.Tensor,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, tuple[int, ...]]:
+    if layout == "1d":
+        seq_len, head_dim = x.shape
+        q = x.view(seq_len, 1, head_dim)
+        pos_ids = torch.arange(seq_len, device=x.device, dtype=torch.int32)
+    else:
+        batch, seq_len, num_heads, head_dim = x.shape
+        q = x.reshape(batch * seq_len, num_heads, head_dim)
+        pos_ids = torch.arange(
+            seq_len,
+            device=x.device,
+            dtype=torch.int32,
+        ).repeat(batch)
+    k = x.new_empty((q.shape[0], 0, q.shape[-1]))
+    return q, k, pos_ids, tuple(x.shape)
+
+
+def _flashinfer_flat_qk_pos_ids(
+    x: torch.Tensor,
+    layout: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, tuple[int, ...]]:
+    q, k, pos_ids, output_shape = _flashinfer_qk_pos_ids(x, layout)
+    return q.reshape(q.shape[0], -1), k.reshape(k.shape[0], -1), pos_ids, output_shape
+
+
+def _rope_cos_sin_cache(seq_len: int, head_dim: int) -> torch.Tensor:
+    half = head_dim // 2
+    freqs = 1.0 / (_BASE ** (torch.arange(0, half, device="cuda", dtype=torch.float32) / half))
+    angles = torch.outer(
+        torch.arange(seq_len, device="cuda", dtype=torch.float32),
+        freqs,
+    )
+    return torch.cat([torch.cos(angles), torch.sin(angles)], dim=-1)
+
+
+def _record_flashinfer_rope(
+    flashinfer,
+    op,
+    bm: ManifestBenchmark,
+    params: dict,
+    x: torch.Tensor,
+    layout: str,
+    *,
+    variant: str,
+    interleave: bool = False,
+) -> None:
+    q, k, pos_ids, output_shape = _flashinfer_qk_pos_ids(x, layout)
+    if variant == "llama31":
+        result_fi = bm.profile(
+            lambda q, k, p: flashinfer.apply_llama31_rope_pos_ids(
+                q,
+                k,
+                p,
+                interleave=interleave,
+                rope_theta=_BASE,
+            )[0].reshape(output_shape),
+            q,
+            k,
+            pos_ids,
+        )
+    else:
+        result_fi = bm.profile(
+            lambda q, k, p: flashinfer.apply_rope_pos_ids(
+                q,
+                k,
+                p,
+                interleave=interleave,
+                rope_theta=_BASE,
+            )[0].reshape(output_shape),
+            q,
+            k,
+            pos_ids,
+        )
+    BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
+
+
+def _record_flashinfer_cached_rope(
+    flashinfer,
+    op,
+    bm: ManifestBenchmark,
+    params: dict,
+    x: torch.Tensor,
+    layout: str,
+    *,
+    is_neox: bool = True,
+) -> None:
+    seq_len = x.shape[0] if layout == "1d" else x.shape[1]
+    q, k, pos_ids, output_shape = _flashinfer_flat_qk_pos_ids(x, layout)
+    cos_sin_cache = _rope_cos_sin_cache(seq_len, x.shape[-1])
+    result_fi = bm.profile(
+        lambda p, q, k: flashinfer.apply_rope_with_cos_sin_cache(
+            p,
+            q,
+            k,
+            x.shape[-1],
+            cos_sin_cache,
+            is_neox=is_neox,
+        )[0].reshape(output_shape),
+        pos_ids,
+        q,
+        k,
+    )
+    BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
+
+
 def _profile_rope(
-    op, bm: ManifestBenchmark, shape: tuple[int, ...], dtype: torch.dtype, layout: str
+    op,
+    bm: ManifestBenchmark,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    layout: str,
+    *,
+    variant: str,
+    interleave: bool = False,
 ) -> None:
     """Profile op and the torch rotation baseline on the same input."""
     x = torch.randn(shape, device="cuda", dtype=dtype)
     params = {"shape": shape, "dtype": dtype, "layout": layout}
+
+    flashinfer = _flashinfer_module()
+    if flashinfer is not None:
+        if variant in ("neox", "non_neox", "llama31"):
+            _record_flashinfer_rope(
+                flashinfer,
+                op,
+                bm,
+                params,
+                x,
+                layout,
+                variant=variant,
+                interleave=interleave,
+            )
+        else:
+            _record_flashinfer_cached_rope(
+                flashinfer,
+                op,
+                bm,
+                params,
+                x,
+                layout,
+                is_neox=(not interleave),
+            )
 
     seq_len = shape[0] if layout == "1d" else shape[1]
     cos, sin = _rope_tables(seq_len, shape[-1], dtype)
@@ -147,7 +294,7 @@ def test_rope_neox_bench(
 ) -> None:
     op = RopeNeoxFwdOp(layout=layout, base=_BASE)
     bm = ManifestBenchmark(_NEOX_OP, op, RopeWorkload(shape, dtype))
-    _profile_rope(op, bm, shape, dtype, layout)
+    _profile_rope(op, bm, shape, dtype, layout, variant="neox")
 
 
 _NON_NEOX_OP = "RopeNonNeoxFwdOp"
@@ -164,7 +311,7 @@ def test_rope_non_neox_bench(
 ) -> None:
     op = RopeNonNeoxFwdOp(layout=layout, base=_BASE)
     bm = ManifestBenchmark(_NON_NEOX_OP, op, RopeWorkload(shape, dtype))
-    _profile_rope(op, bm, shape, dtype, layout)
+    _profile_rope(op, bm, shape, dtype, layout, variant="non_neox", interleave=True)
 
 
 _LLAMA31_OP = "RopeLlama31FwdOp"
@@ -181,7 +328,7 @@ def test_rope_llama31_bench(
 ) -> None:
     op = RopeLlama31FwdOp(layout=layout, base=_BASE)
     bm = ManifestBenchmark(_LLAMA31_OP, op, RopeWorkload(shape, dtype))
-    _profile_rope(op, bm, shape, dtype, layout)
+    _profile_rope(op, bm, shape, dtype, layout, variant="llama31")
 
 
 _YARN_OP = "RopeYarnFwdOp"
@@ -198,7 +345,7 @@ def test_rope_yarn_bench(
 ) -> None:
     op = RopeYarnFwdOp(layout=layout, base=_BASE)
     bm = ManifestBenchmark(_YARN_OP, op, RopeWorkload(shape, dtype))
-    _profile_rope(op, bm, shape, dtype, layout)
+    _profile_rope(op, bm, shape, dtype, layout, variant="yarn")
 
 
 _LONGROPE_OP = "RopeLongRopeFwdOp"
@@ -215,7 +362,7 @@ def test_rope_longrope_bench(
 ) -> None:
     op = RopeLongRopeFwdOp(layout=layout, base=_BASE)
     bm = ManifestBenchmark(_LONGROPE_OP, op, RopeWorkload(shape, dtype))
-    _profile_rope(op, bm, shape, dtype, layout)
+    _profile_rope(op, bm, shape, dtype, layout, variant="longrope")
 
 
 _POSITION_IDS_OP = "RopeNeoxPositionIdsFwdOp"
@@ -244,6 +391,22 @@ def test_rope_neox_position_ids_bench(
     op = RopeNeoxPositionIdsFwdOp(max_position=max_position, base=_BASE)
     bm = ManifestBenchmark(_POSITION_IDS_OP, op, RopeWorkload(shape, dtype))
     params = {"shape": shape, "dtype": dtype, "max_position": max_position}
+
+    flashinfer = _flashinfer_module()
+    if flashinfer is not None:
+        k = x.new_empty((num_tokens, 0, head_dim))
+        result_fi = bm.profile(
+            lambda t, k, p: flashinfer.apply_rope_pos_ids(
+                t,
+                k,
+                p,
+                rope_theta=_BASE,
+            )[0],
+            x,
+            k,
+            position_ids,
+        )
+        BenchmarkReport.record(op, params, result_fi, tag="flashinfer")
 
     cos, sin = _rope_tables(max_position, head_dim, dtype)
 

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -8,7 +8,12 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.reduction.softmax import LogSoftmaxFwdOp, LogSumExpFwdOp, SoftmaxFwdOp
 from workloads.reduction import (
     LogSoftmaxWorkload,
@@ -38,7 +43,12 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
         return F.softmax(x, dim=-1)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -60,7 +70,12 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
         return F.log_softmax(x, dim=-1)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -88,7 +103,12 @@ def test_logsumexp_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> N
         return torch.logsumexp(x, dim=dim, keepdim=keepdim)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -15,7 +15,12 @@ from typing import Callable
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.elementwise import (
     AbsFwdOp,
     BitwiseNotFwdOp,
@@ -85,7 +90,12 @@ def _profile_and_record(
     instead of reflecting only this helper's locals.
     """
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=params)
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=params,
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -7,7 +7,12 @@ Workload shapes and roofline formulas are loaded from the ops manifest (src/tile
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import (
+    BenchmarkReport,
+    ManifestBenchmark,
+    torch_inductor_baseline,
+    workloads_to_params,
+)
 from tileops.ops.reduction.vector_norm import InfNormFwdOp, L1NormFwdOp, L2NormFwdOp
 from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
 
@@ -44,7 +49,12 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
         ).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -77,7 +87,12 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
         ).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -110,7 +125,12 @@ def test_inf_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
         ).to(x.dtype)
 
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare(
+            {"tileops": op, "torch-inductor": torch_inductor_baseline(baseline_fn)},
+            *inputs,
+            record_as=op,
+            params=locals(),
+        )
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import torch
 
-from benchmarks.benchmark_base import workloads_to_params
+from benchmarks.benchmark_base import torch_inductor_baseline, workloads_to_params
 from benchmarks.timing import (
     Trace,
     _attributed_samples,
@@ -229,3 +229,20 @@ def test_kernel_runtime_error_propagates():
 
     with pytest.raises(RuntimeError, match="kernel failure"):
         bench_kernel(boom)
+
+
+@pytest.mark.smoke
+def test_torch_inductor_baseline_uses_fullgraph_compile(monkeypatch):
+    calls = []
+
+    def baseline(x):
+        return x
+
+    def fake_compile(fn, **kwargs):
+        calls.append((fn, kwargs))
+        return "compiled-baseline"
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+
+    assert torch_inductor_baseline(baseline) == "compiled-baseline"
+    assert calls == [(baseline, {"fullgraph": True})]

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -576,6 +576,16 @@ def _ratio_emoji(ratio: float) -> str:
     return _RED
 
 
+def _strongest_baseline_ratio(bl_rows: list[tuple[str, float | None]]) -> float | None:
+    """Return the fastest baseline ratio for a config.
+
+    Ratio is ``baseline_latency / tileops_latency``. Smaller means the baseline
+    is faster and therefore the stronger competitor for table coloring.
+    """
+    ratios = [ratio for _, ratio in bl_rows if ratio is not None]
+    return min(ratios, default=None)
+
+
 def generate_report(
     test_ops: dict | None,
     bench_ops: dict | None,
@@ -827,8 +837,7 @@ def generate_report(
                         r_str = f"{bratio:.1%}" if bratio else "-"
                         via_parts.append(f"{btag} {r_str}")
                     via_str = ", ".join(via_parts)
-                    # Use the best (highest) ratio for the emoji
-                    best_ratio = max((r for _, r in bl_rows if r), default=None)
+                    best_ratio = _strongest_baseline_ratio(bl_rows)
                     emoji = _ratio_emoji(best_ratio) if best_ratio else ""
                     lines.append(
                         f"| {emoji} | {op} | {cfg['name']} "

--- a/tests/test_nightly_report.py
+++ b/tests/test_nightly_report.py
@@ -1,0 +1,34 @@
+import pytest
+
+from scripts import nightly_report
+
+pytestmark = pytest.mark.smoke
+
+
+def test_full_benchmark_results_uses_strongest_baseline_for_color(monkeypatch):
+    monkeypatch.setattr(nightly_report, "_get_git_commit", lambda: "deadbeef")
+    monkeypatch.setattr(nightly_report, "_get_gpu_name", lambda: "Test GPU")
+
+    report = nightly_report.generate_report(
+        test_ops=None,
+        bench_ops={
+            "RMSNormFwdOp": {
+                "module": None,
+                "configs": [
+                    {
+                        "name": "cfg",
+                        "tileops_latency_ms": 1.0,
+                        "baseline_tag": "flashinfer",
+                        "baseline_ratio": 0.5,
+                        "baselines": {"torch_inductor": {"ratio": 2.0}},
+                    },
+                ],
+            },
+        },
+        bench_failures=[],
+        regressions=[],
+        improvements=[],
+        baseline_alerts=[],
+    )
+
+    assert f"| {nightly_report._RED} | RMSNormFwdOp | cfg " in report


### PR DESCRIPTION
## Summary

Draft PR for #1806.

- Add external baseline tags for common-op benchmarks: `torch_inductor`, `torch_cudnn`, `torch_cufft`, `torch_native`, and `flashinfer`.
- Add a shared `torch_inductor_baseline()` helper for benchmark-local PyTorch baselines compiled with `torch.compile(..., fullgraph=True)`.
- Add FlashInfer baselines for RMSNorm, fused add RMSNorm, and semantic-equivalent RoPE variants.
- Keep optional third-party baselines local to benchmark files and preserve existing roofline reporting.
- Fix nightly report coloring to use the strongest competitive baseline when multiple baselines are present.

## Validation

Official runner image: `ghcr.io/tile-ai/tileops-runner:65dbc98-torch2.10`.

- `compileall` and `ruff check` on changed files.
- `pytest -q tests/test_nightly_report.py benchmarks/tests/test_benchmark_base.py --tb=short` -> 19 passed.
- RoPE/Pool benchmark collect-only -> 52 cases collected.
- Targeted manifest checks for RoPE, RMSNorm, Conv/Pool, and FFT passed with advisory warnings only.
- TorchInductor and FlashInfer smoke checks passed.

Closes #1806.
