### PR TITLE
[Perf][Argreduce] Add adaptive streaming pair reduction

### DIFF
--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -17,20 +17,6 @@ _ARGMAX_OP = "ArgmaxFwdOp"
 _ARGMIN_OP = "ArgminFwdOp"
 
 
-def _is_unsupported_large_argreduce_error(exc: Exception) -> bool:
-    """Return True for known staged-rollout large-N argreduce failures."""
-    msg = str(exc)
-    return (
-        "scalable vector" in msg
-        or "No configurations to tune" in msg
-        or (
-            "A single row requires" in msg
-            and "shared memory" in msg
-            and "exceeds" in msg
-        )
-    )
-
-
 # Argmax benchmarks
 
 
@@ -41,18 +27,7 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
 
     op = ArgmaxFwdOp(**extra)
     bm = ManifestBenchmark(_ARGMAX_OP, op, workload)
-    # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
-    #
-    # Broken invariant: benchmark must execute all manifest workload shapes
-    # Why: the current single-tile shared-memory kernel cannot fit lm-head
-    #      N=102400 rows (204800 bytes per fp16/bf16 row exceeds 49152 bytes).
-    # Cleanup: remove try/skip once ArgreduceKernel has a tiled-N path.
-    try:
-        result = bm.profile(op, *inputs)
-    except Exception as exc:
-        if _is_unsupported_large_argreduce_error(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
+    result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     dim = extra["dim"]
@@ -74,18 +49,7 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
 
     op = ArgminFwdOp(**extra)
     bm = ManifestBenchmark(_ARGMIN_OP, op, workload)
-    # FIXME(staged-rollout): ArgreduceKernel skips large-N manifest workloads
-    #
-    # Broken invariant: benchmark must execute all manifest workload shapes
-    # Why: the current single-tile shared-memory kernel cannot fit lm-head
-    #      N=102400 rows (204800 bytes per fp16/bf16 row exceeds 49152 bytes).
-    # Cleanup: remove try/skip once ArgreduceKernel has a tiled-N path.
-    try:
-        result = bm.profile(op, *inputs)
-    except Exception as exc:
-        if _is_unsupported_large_argreduce_error(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
+    result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     dim = extra["dim"]

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -533,8 +533,10 @@ def test_argmin_dim_none(shape: tuple, dtype: torch.dtype) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("op_kind", ["argmax", "argmin"])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    ("op_kind", "dtype"),
+    [("argmax", torch.float16), ("argmin", torch.bfloat16)],
+)
 def test_argreduce_large_n(op_kind: str, dtype: torch.dtype) -> None:
     """The multi-CTA path supports the LM-head workload without tiling skips."""
     from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
@@ -544,9 +546,7 @@ def test_argreduce_large_n(op_kind: str, dtype: torch.dtype) -> None:
     op = op_cls(dtype=dtype, dim=-1)
     ref = getattr(torch, op_kind)(x, dim=-1)
     y = _call(op, x)
-    assert torch.equal(y, ref), (
-        f"large-N {op_kind} mismatch: {(y != ref).sum().item()}"
-    )
+    assert torch.equal(y, ref), f"large-N {op_kind} mismatch: {(y != ref).sum().item()}"
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -543,7 +543,7 @@ def test_argreduce_large_n(op_kind: str, dtype: torch.dtype) -> None:
 
     x = torch.randn(4, 102400, dtype=dtype, device="cuda")
     op_cls = ArgmaxFwdOp if op_kind == "argmax" else ArgminFwdOp
-    op = op_cls(dtype=dtype, dim=-1)
+    op = op_cls(dim=-1)
     ref = getattr(torch, op_kind)(x, dim=-1)
     y = _call(op, x)
     assert torch.equal(y, ref), f"large-N {op_kind} mismatch: {(y != ref).sum().item()}"
@@ -564,10 +564,56 @@ def test_argreduce_first_index_and_nan_semantics(op_kind: str) -> None:
         device="cuda",
     )
     op_cls = ArgmaxFwdOp if op_kind == "argmax" else ArgminFwdOp
-    op = op_cls(dtype=x.dtype, dim=-1)
+    op = op_cls(dim=-1)
     ref = getattr(torch, op_kind)(x, dim=-1)
     y = _call(op, x)
     assert torch.equal(y, ref)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_kind", ["argmax", "argmin"])
+@pytest.mark.parametrize("n", [8, 4096, 40960])
+def test_argreduce_ties_between_two_nans(op_kind: str, n: int) -> None:
+    """Two NaNs tie, so the lower index wins — on every reduction layout.
+
+    No float comparison can express this: every comparison between two NaNs is
+    false, so an ordering that leans on them returns whichever lane merged
+    first. The three row lengths select the warp, CTA and multi-CTA paths, and
+    the NaNs sit far enough apart to land in different lanes.
+    """
+    from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
+
+    x = torch.arange(1, n + 1, dtype=torch.float32, device="cuda")
+    first, second = n // 4, n // 2
+    x[first] = float("nan")
+    x[second] = float("nan")
+
+    op = (ArgmaxFwdOp if op_kind == "argmax" else ArgminFwdOp)(dim=-1)
+    ref = getattr(torch, op_kind)(x)
+    got = _call(op, x)
+    assert got.item() == ref.item() == first, (
+        f"{op_kind} n={n}: got {got.item()}, torch {ref.item()}, expected {first}"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("m, n", [(4, 1024), (4, 8192), (1, 32768)])
+def test_argreduce_autotunes_every_strategy(m: int, n: int) -> None:
+    """Each strategy's tuning space names only knobs its own kernel takes.
+
+    The three shapes select the warp, CTA and multi-CTA kernels, whose JIT
+    signatures differ; a config space shared across them offers one of the
+    kernels a parameter it would reject.
+    """
+    from tileops.kernels.reduction.argreduce import ArgreduceKernel
+
+    kernel = ArgreduceKernel(m, n, "argmax", torch.float16)
+    accepted = set(kernel.kernel.signature.parameters)
+    assert set(kernel.default_config) <= accepted
+    for candidate in kernel.autotune_configs:
+        assert set(candidate) <= accepted, (
+            f"{kernel.strategy}: candidate {candidate} names a knob outside {accepted}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -597,7 +597,7 @@ def test_argreduce_ties_between_two_nans(op_kind: str, n: int) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("ctas_per_row", [31, 33, 47, 64])
+@pytest.mark.parametrize("ctas_per_row", [31, 33, 64])
 def test_argreduce_multicta_reduces_every_partial(ctas_per_row: int) -> None:
     """A split wider than a warp must still see every partial.
 
@@ -624,23 +624,33 @@ def test_argreduce_multicta_reduces_every_partial(ctas_per_row: int) -> None:
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("m, n", [(4, 1024), (4, 8192), (1, 32768)])
-def test_argreduce_autotunes_every_strategy(m: int, n: int) -> None:
-    """Each strategy's tuning space names only knobs its own kernel takes.
+@pytest.mark.parametrize("m, n, inner_stride, strategy", [
+    (4, 1024, 1, "warp"),
+    (4, 8192, 1, "cta"),
+    (4, 65536, 1, "multi_cta"),
+    (4096, 4, 4096, "output"),
+])
+def test_argreduce_tuning_space_matches_its_kernel(
+    m: int, n: int, inner_stride: int, strategy: str,
+) -> None:
+    """A strategy may only offer knobs its own kernel takes.
 
-    The three shapes select the warp, CTA and multi-CTA kernels, whose JIT
-    signatures differ; a config space shared across them offers one of the
-    kernels a parameter it would reject.
+    The four layouts are built from different JIT signatures, so one shared
+    config space hands at least one of them a parameter it would reject.
     """
     from tileops.kernels.reduction.argreduce import ArgreduceKernel
 
-    kernel = ArgreduceKernel(m, n, "argmax", torch.float16)
+    kernel = ArgreduceKernel(m, n, "argmax", torch.float16, inner_stride=inner_stride)
+    assert kernel.strategy == strategy
     accepted = set(kernel.kernel.signature.parameters)
     assert set(kernel.default_config) <= accepted
     for candidate in kernel.autotune_configs:
         assert set(candidate) <= accepted, (
-            f"{kernel.strategy}: candidate {candidate} names a knob outside {accepted}"
+            f"{strategy}: candidate {candidate} names a knob outside {accepted}"
         )
+    assert kernel.default_config in kernel.autotune_configs, (
+        "tuning cannot be worse than not tuning: the default must be a candidate"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -624,6 +624,26 @@ def test_argreduce_multicta_reduces_every_partial(ctas_per_row: int) -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("shape, dim, expect_strided", [
+    ((4, 128, 4096), 0, True),      # short strided axis: read it in place
+    ((1, 32768, 8), 1, False),      # long strided axis: transposing wins
+])
+def test_argreduce_strided_axis_crossover(shape, dim, expect_strided) -> None:
+    """A strided axis is read in place only while walking it stays cheap.
+
+    Output-parallel gives one thread the whole axis, so choosing it on
+    contiguity alone makes a long axis orders of magnitude slower.
+    """
+    from tileops.ops.reduction.argreduce import ArgmaxFwdOp
+
+    x = torch.randn(*shape, device="cuda", dtype=torch.float16)
+    op = ArgmaxFwdOp(dim=dim)
+    torch.testing.assert_close(_call(op, x), torch.argmax(x, dim=dim))
+    strategies = {k.strategy for k in op._kernel_cache.values()}
+    assert ("output" in strategies) is expect_strided, strategies
+
+
+@pytest.mark.smoke
 @pytest.mark.parametrize("m, n, inner_stride, strategy", [
     (4, 1024, 1, "warp"),
     (4, 8192, 1, "cta"),

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -532,5 +532,43 @@ def test_argmin_dim_none(shape: tuple, dtype: torch.dtype) -> None:
     )
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_kind", ["argmax", "argmin"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_argreduce_large_n(op_kind: str, dtype: torch.dtype) -> None:
+    """The multi-CTA path supports the LM-head workload without tiling skips."""
+    from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
+
+    x = torch.randn(4, 102400, dtype=dtype, device="cuda")
+    op_cls = ArgmaxFwdOp if op_kind == "argmax" else ArgminFwdOp
+    op = op_cls(dtype=dtype, dim=-1)
+    ref = getattr(torch, op_kind)(x, dim=-1)
+    y = _call(op, x)
+    assert torch.equal(y, ref), (
+        f"large-N {op_kind} mismatch: {(y != ref).sum().item()}"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("op_kind", ["argmax", "argmin"])
+def test_argreduce_first_index_and_nan_semantics(op_kind: str) -> None:
+    """Pair reduction preserves PyTorch's first-index and NaN behavior."""
+    from tileops.ops.reduction.argreduce import ArgmaxFwdOp, ArgminFwdOp
+
+    x = torch.tensor(
+        [
+            [1.0, float("nan"), 3.0, float("nan"), 3.0],
+            [2.0, 2.0, -1.0, -1.0, 0.0],
+        ],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    op_cls = ArgmaxFwdOp if op_kind == "argmax" else ArgminFwdOp
+    op = op_cls(dtype=x.dtype, dim=-1)
+    ref = getattr(torch, op_kind)(x, dim=-1)
+    y = _call(op, x)
+    assert torch.equal(y, ref)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -597,6 +597,33 @@ def test_argreduce_ties_between_two_nans(op_kind: str, n: int) -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("ctas_per_row", [31, 33, 47, 64])
+def test_argreduce_multicta_reduces_every_partial(ctas_per_row: int) -> None:
+    """A split wider than a warp must still see every partial.
+
+    The final pass assigns partials to lanes; reading one each would drop
+    everything past lane 31 and return an index from the wrong chunk. Splits
+    are chosen by the tuner, so nothing bounds them to a warp.
+    """
+    from tileops.kernels.reduction import argreduce as kernels
+
+    M, N = 3, 65536
+    x = torch.randn(M, N, dtype=torch.float16, device="cuda")
+    # Put the extremes in high chunks, which only a full sweep of the partials
+    # can reach, and a NaN in another so the tie rules run there too.
+    chunk = N // ctas_per_row
+    x[0, min(N - 1, chunk * (ctas_per_row - 1) + 7)] = 100.0
+    x[1, min(N - 1, chunk * (ctas_per_row // 2) + 3)] = -100.0
+    x[2, min(N - 1, chunk * (ctas_per_row - 2) + 1)] = float("nan")
+
+    partial = kernels._argreduce_multicta_partial_kernel(M, N, "argmax", "float16")
+    final = kernels._argreduce_multicta_final_kernel(M, N, "argmax", ctas_per_row)
+    values, indices = partial(256, ctas_per_row)(x)
+    got = final()(values, indices)
+    torch.testing.assert_close(got, torch.argmax(x, dim=-1))
+
+
+@pytest.mark.smoke
 @pytest.mark.parametrize("m, n", [(4, 1024), (4, 8192), (1, 32768)])
 def test_argreduce_autotunes_every_strategy(m: int, n: int) -> None:
     """Each strategy's tuning space names only knobs its own kernel takes.

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -29,6 +29,9 @@ _NUM_ACCUMULATORS = 4
 #   M=256 cta   1.4x  multi 1.5x  multi 2.4x
 #   M=1024 cta  1.3x  cta   1.1x  cta   1.05x
 #
+#: Thresholds below are measured on H200, not derived; the grid behind each is
+#: in the commit that introduced it.
+#:
 #: A row shorter than this is a handful of passes; splitting cannot save more
 #: than the second pass costs.
 _SPLIT_MIN_N = 32768
@@ -37,17 +40,15 @@ _SPLIT_MIN_N = 32768
 _ROWS_SATURATED = 512
 #: A chunk shorter than this cannot amortize its share of the final pass.
 _MIN_CHUNK = 512
+#: Output-parallel gives a thread the whole axis to walk, so it pays only while
+#: that walk is short; it loses from N=32 up.
+_STRIDED_AXIS_MAX_N = 16
 
 
-def _row_split_candidates(M: int, N: int) -> list[int]:
-    """Splits worth ranking for a row of *N*, including the untuned default.
-
-    Leaving the default out lets tuning come back slower than not tuning.
-    """
+def _row_split_candidates(N: int) -> list[int]:
+    """Splits worth ranking for a row of *N*, coarsest first."""
     ceiling = max(1, N // _MIN_CHUNK)
-    candidates = {c for c in (4, 8, 16, 32, 64) if c <= ceiling}
-    candidates.add(_plan_row_split(M, N))
-    return sorted(candidates)
+    return sorted({c for c in (4, 8, 16, 32, 64) if c <= ceiling} or {1})
 
 
 def _splits_row(M: int, N: int) -> bool:
@@ -322,6 +323,7 @@ def _argreduce_output_kernel(
     return _func
 
 
+@functools.lru_cache(maxsize=64)
 def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
     """Build the block-per-row kernel used for long rows."""
 
@@ -396,12 +398,10 @@ def _argreduce_multicta_partial_kernel(
 ):
     """Build the partial stage for rows split across multiple blocks.
 
-    ``ctas_per_row`` is a tuning parameter: how far to split a row trades the
-    block's serial scan against a wider final pass, and where that trade lands
-    depends on the shape. The autotuner measures this stage alone. The final
-    pass does grow slowly with the split (1.7 us at 32 chunks against 2.5 us at
-    64 on the lm-head shape), so the ranking can differ from the pair's at the
-    margin; measured, that has moved the choice once, by 0.3%.
+    ``ctas_per_row`` is a tuning parameter: the trade between the block's serial
+    scan and a wider final pass moves with the shape. The tuner measures this
+    stage alone; the final pass grows slowly with the split, so its ranking can
+    differ from the pair's at the margin (measured once, by 0.3%).
     """
 
     @tilelang.jit(out_idx=[1, 2])
@@ -611,9 +611,9 @@ class ArgreduceKernel(Kernel):
         self.dtype = dtype
         self.inner_stride = inner_stride
 
-        if inner_stride > 1:
-            # The reduction axis is strided, so a thread takes an output element
-            # rather than a block taking a row.
+        if inner_stride > 1 and N <= _STRIDED_AXIS_MAX_N:
+            # A short strided axis: a thread takes an output element and walks
+            # the axis, which reads coalesced and skips the transpose.
             self.strategy = "output"
             self.kernel = _argreduce_output_kernel(M, N, inner_stride, op_kind, self.dtype_str)
         elif _splits_row(M, N):
@@ -659,7 +659,7 @@ class ArgreduceKernel(Kernel):
             candidates = [
                 {"threads": t, "ctas_per_row": c}
                 for t in (128, 256, 512)
-                for c in _row_split_candidates(self.M, self.N)
+                for c in _row_split_candidates(self.N)
             ]
         elif self.strategy == "cta":
             candidates = [{"threads": t} for t in (128, 256, 512)]
@@ -671,7 +671,13 @@ class ArgreduceKernel(Kernel):
             for target_threads in (64, 128, 256, 512):
                 block_m = max(1, target_threads // lanes)
                 candidates.append({"block_m": block_m, "threads": block_m * lanes})
-        return [self._knobs(candidate) for candidate in candidates]
+        # Tuning may not come back worse than not tuning, so the default is
+        # always among the candidates.
+        default = self.default_config
+        ranked = [self._knobs(candidate) for candidate in candidates]
+        if default not in ranked:
+            ranked.append(default)
+        return ranked
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.M == 0:

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -1,22 +1,8 @@
-"""Streaming arg-reduction kernels (argmax and argmin) using TileLang.
+"""Streaming argmax and argmin kernels.
 
-The implementation follows the same broad decomposition as the CUDA
-reduction kernels used by PyTorch:
-
-* values and indices are reduced together in one pass;
-* input elements are streamed directly from global memory (there is no
-  materialized input tile);
-* contiguous reduction axes use input-parallel warp/CTA kernels, while
-  strided reduction axes use an output-parallel kernel;
-* every thread maintains four independent value/index accumulators;
-* long rows are reduced register -> warp shuffle -> shared memory -> global;
-* launch geometry is selected from the reduction and output sizes.
-
-The Op layer passes a flattened contiguous input plus ``inner_stride``.
-For a contiguous tensor reduced along dimension ``d``, ``inner_stride`` is
-the product of the dimensions after ``d``.  This lets the kernel address a
-non-last reduction axis directly instead of materializing ``movedim(...).
-contiguous()``.
+Values and indices are reduced together so first-index and NaN semantics are
+preserved without materializing an input tile. Launch geometry adapts to the
+row length; input layout remains the responsibility of the reduction Op layer.
 """
 
 import functools
@@ -36,301 +22,179 @@ _NUM_ACCUMULATORS = 4
 
 
 def _lanes_per_row(n: int) -> int:
-    """Return a power-of-two subgroup size for an input-parallel row."""
     lanes = 1
     while lanes < min(n, _WARP_SIZE):
         lanes *= 2
     return lanes
 
 
+def _make_pair_ops(op_kind: str, n: int):
+    """Create argreduce-local pair operations shared by all launch paths."""
+
+    @T.macro
+    def set_identity(values, indices, slot):
+        if op_kind == "argmax":
+            values[slot] = -T.infinity("float32")
+        else:
+            values[slot] = T.infinity("float32")
+        indices[slot] = T.int32(n)
+
+    @T.macro
+    def init_accumulators(values, indices):
+        for accumulator in T.serial(_NUM_ACCUMULATORS):
+            set_identity(values, indices, accumulator)
+
+    @T.macro
+    def update(values, indices, slot, candidate_value, candidate_index):
+        candidate_nan = T.isnan(candidate_value)
+        current_nan = T.isnan(values[slot])
+        if op_kind == "argmax":
+            better = (candidate_nan and not current_nan) or (
+                candidate_nan == current_nan
+                and (
+                    candidate_value > values[slot]
+                    or (candidate_value == values[slot] and candidate_index < indices[slot])
+                )
+            )
+        else:
+            better = (candidate_nan and not current_nan) or (
+                candidate_nan == current_nan
+                and (
+                    candidate_value < values[slot]
+                    or (candidate_value == values[slot] and candidate_index < indices[slot])
+                )
+            )
+        if better:
+            values[slot] = candidate_value
+            indices[slot] = T.cast(candidate_index, "int32")
+
+    @T.macro
+    def merge_accumulators(values, indices, best_value, best_index):
+        best_value[0] = values[0]
+        best_index[0] = indices[0]
+        for accumulator in T.serial(1, _NUM_ACCUMULATORS):
+            update(
+                best_value,
+                best_index,
+                0,
+                values[accumulator],
+                indices[accumulator],
+            )
+
+    @T.macro
+    def warp_reduce(best_value, best_index, stages, width):
+        for stage in T.serial(stages):
+            mask = T.int32(width // 2) >> stage
+            candidate_value = T.shfl_xor(best_value[0], mask, width=width)
+            candidate_index = T.shfl_xor(best_index[0], mask, width=width)
+            update(
+                best_value,
+                best_index,
+                0,
+                candidate_value,
+                candidate_index,
+            )
+
+    return (
+        set_identity,
+        init_accumulators,
+        update,
+        merge_accumulators,
+        warp_reduce,
+    )
+
+
+def _make_block_reduce(
+    set_identity,
+    merge_accumulators,
+    warp_reduce,
+    num_warps: int,
+):
+    """Create the register-to-block pair reduction used by CTA kernels."""
+
+    @T.macro
+    def block_reduce(
+        values,
+        indices,
+        best_value,
+        best_index,
+        warp_values,
+        warp_indices,
+        tx,
+    ):
+        lane = tx % _WARP_SIZE
+        warp = tx // _WARP_SIZE
+
+        merge_accumulators(values, indices, best_value, best_index)
+        warp_reduce(best_value, best_index, 5, _WARP_SIZE)
+
+        if lane == 0:
+            warp_values[warp] = best_value[0]
+            warp_indices[warp] = best_index[0]
+        T.sync_threads()
+
+        set_identity(best_value, best_index, 0)
+        if lane < num_warps:
+            best_value[0] = warp_values[lane]
+            best_index[0] = warp_indices[lane]
+
+        if warp == 0:
+            warp_reduce(best_value, best_index, 5, _WARP_SIZE)
+
+    return block_reduce
+
+
 @functools.lru_cache(maxsize=64)
 def _argreduce_warp_kernel(M: int, N: int, op_kind: str, dtype: str):
-    """Build the input-parallel kernel used for the common contiguous case."""
+    """Build the subgroup-per-row kernel used for ordinary row lengths."""
     lanes = _lanes_per_row(N)
-    num_accumulators = _NUM_ACCUMULATORS
-    items_per_iteration = lanes * num_accumulators
+    items_per_iteration = lanes * _NUM_ACCUMULATORS
     iterations = (N + items_per_iteration - 1) // items_per_iteration
     log_lanes = lanes.bit_length() - 1
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m: int, threads: int):
+        (
+            _,
+            init_accumulators,
+            update,
+            merge_accumulators,
+            warp_reduce,
+        ) = _make_pair_ops(op_kind, N)
+
         @T.prim_func
         def main(
-            x: T.Tensor[(M * N,), dtype],
+            x: T.Tensor[(M, N), dtype],
             out: T.Tensor[(M,), "int64"],  # noqa: F821
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid:
                 tx = T.get_thread_binding()
-                row_in_block = tx // lanes
+                row = pid * block_m + tx // lanes
                 lane = tx % lanes
-                row = pid * block_m + row_in_block
 
-                best_values = T.alloc_local((num_accumulators,), "float32")
-                best_indices = T.alloc_local((num_accumulators,), "int32")
+                values = T.alloc_local((_NUM_ACCUMULATORS,), "float32")
+                indices = T.alloc_local((_NUM_ACCUMULATORS,), "int32")
+                best_value = T.alloc_local((1,), "float32")
+                best_index = T.alloc_local((1,), "int32")
+                init_accumulators(values, indices)
 
-                for accumulator in T.serial(num_accumulators):
-                    if op_kind == "argmax":
-                        best_values[accumulator] = -T.infinity("float32")
-                    else:
-                        best_values[accumulator] = T.infinity("float32")
-                    best_indices[accumulator] = T.int32(N)
-
-                # Four independent dependency chains hide comparison latency.
                 for iteration in T.serial(iterations):
-                    for accumulator in T.serial(num_accumulators):
-                        index = (
-                            iteration * items_per_iteration
-                            + accumulator * lanes
-                            + lane
-                        )
+                    for accumulator in T.serial(_NUM_ACCUMULATORS):
+                        index = iteration * items_per_iteration + accumulator * lanes + lane
                         if row < M and index < N:
-                            value = T.cast(x[row * N + index], "float32")
-                            value_nan = T.isnan(value)
-                            best_nan = T.isnan(best_values[accumulator])
-                            if op_kind == "argmax":
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value > best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            else:
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value < best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            if better:
-                                best_values[accumulator] = value
-                                best_indices[accumulator] = T.cast(index, "int32")
-
-                # Merge the four thread-local pairs.
-                best_value = T.alloc_var(T.float32)
-                best_index = T.alloc_var(T.int32)
-                best_value = best_values[0]
-                best_index = best_indices[0]
-                for accumulator in T.serial(1, num_accumulators):
-                    other_value = best_values[accumulator]
-                    other_index = best_indices[accumulator]
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
+                            update(
+                                values,
+                                indices,
+                                accumulator,
+                                T.cast(x[row, index], "float32"),
+                                index,
                             )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
 
-                # Pair reduction within each power-of-two subgroup.
-                for stage in T.serial(log_lanes):
-                    mask = T.int32(lanes // 2) >> stage
-                    other_value = T.shfl_xor(best_value, mask, width=lanes)
-                    other_index = T.shfl_xor(best_index, mask, width=lanes)
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
+                merge_accumulators(values, indices, best_value, best_index)
+                warp_reduce(best_value, best_index, log_lanes, lanes)
 
-                if lane == 0 and row < M:
-                    out[row] = T.cast(best_index, "int64")
-
-        return main
-
-    return _func
-
-
-@functools.lru_cache(maxsize=64)
-def _argreduce_output_kernel(
-    M: int,
-    N: int,
-    inner_stride: int,
-    op_kind: str,
-    dtype: str,
-):
-    """Build an output-parallel kernel for contiguous non-last-axis reductions."""
-    num_accumulators = _NUM_ACCUMULATORS
-    iterations = (N + num_accumulators - 1) // num_accumulators
-
-    @tilelang.jit(out_idx=[1])
-    def _func(block_m: int, threads: int):
-        @T.prim_func
-        def main(
-            x: T.Tensor[(M * N,), dtype],
-            out: T.Tensor[(M,), "int64"],  # noqa: F821
-        ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid:
-                tx = T.get_thread_binding()
-                row = pid * block_m + tx
-                outer = row // inner_stride
-                inner = row % inner_stride
-
-                best_values = T.alloc_local((num_accumulators,), "float32")
-                best_indices = T.alloc_local((num_accumulators,), "int32")
-                for accumulator in T.serial(num_accumulators):
-                    if op_kind == "argmax":
-                        best_values[accumulator] = -T.infinity("float32")
-                    else:
-                        best_values[accumulator] = T.infinity("float32")
-                    best_indices[accumulator] = T.int32(N)
-
-                # Threads expand along output, so each iteration performs
-                # coalesced reads across adjacent output elements.
-                for iteration in T.serial(iterations):
-                    for accumulator in T.serial(num_accumulators):
-                        index = iteration * num_accumulators + accumulator
-                        if row < M and index < N:
-                            offset = (
-                                outer * N * inner_stride
-                                + index * inner_stride
-                                + inner
-                            )
-                            value = T.cast(x[offset], "float32")
-                            value_nan = T.isnan(value)
-                            best_nan = T.isnan(best_values[accumulator])
-                            if op_kind == "argmax":
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value > best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            else:
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value < best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            if better:
-                                best_values[accumulator] = value
-                                best_indices[accumulator] = T.cast(index, "int32")
-
-                best_value = T.alloc_var(T.float32)
-                best_index = T.alloc_var(T.int32)
-                best_value = best_values[0]
-                best_index = best_indices[0]
-                for accumulator in T.serial(1, num_accumulators):
-                    other_value = best_values[accumulator]
-                    other_index = best_indices[accumulator]
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
-                if row < M:
-                    out[row] = T.cast(best_index, "int64")
+                if row < M and lane == 0:
+                    out[row] = T.cast(best_index[0], "int64")
 
         return main
 
@@ -339,217 +203,64 @@ def _argreduce_output_kernel(
 
 @functools.lru_cache(maxsize=64)
 def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
-    """Build a block-per-row hierarchical kernel for long contiguous rows."""
-    num_accumulators = _NUM_ACCUMULATORS
+    """Build the block-per-row kernel used for long rows."""
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m: int, threads: int):
         num_warps = threads // _WARP_SIZE
-        iterations = (N + threads * num_accumulators - 1) // (
-            threads * num_accumulators
+        iterations = (N + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
+        (
+            set_identity,
+            init_accumulators,
+            update,
+            merge_accumulators,
+            warp_reduce,
+        ) = _make_pair_ops(op_kind, N)
+        block_reduce = _make_block_reduce(
+            set_identity,
+            merge_accumulators,
+            warp_reduce,
+            num_warps,
         )
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M * N,), dtype],
+            x: T.Tensor[(M, N), dtype],
             out: T.Tensor[(M,), "int64"],  # noqa: F821
         ):
             with T.Kernel(M, threads=threads) as row:
                 tx = T.get_thread_binding()
-                lane = tx % _WARP_SIZE
-                warp = tx // _WARP_SIZE
                 warp_values = T.alloc_shared((num_warps,), "float32")
                 warp_indices = T.alloc_shared((num_warps,), "int32")
-                best_values = T.alloc_local((num_accumulators,), "float32")
-                best_indices = T.alloc_local((num_accumulators,), "int32")
-
-                for accumulator in T.serial(num_accumulators):
-                    if op_kind == "argmax":
-                        best_values[accumulator] = -T.infinity("float32")
-                    else:
-                        best_values[accumulator] = T.infinity("float32")
-                    best_indices[accumulator] = T.int32(N)
+                values = T.alloc_local((_NUM_ACCUMULATORS,), "float32")
+                indices = T.alloc_local((_NUM_ACCUMULATORS,), "int32")
+                best_value = T.alloc_local((1,), "float32")
+                best_index = T.alloc_local((1,), "int32")
+                init_accumulators(values, indices)
 
                 for iteration in T.serial(iterations):
-                    for accumulator in T.serial(num_accumulators):
-                        index = (
-                            iteration * threads * num_accumulators
-                            + accumulator * threads
-                            + tx
-                        )
+                    for accumulator in T.serial(_NUM_ACCUMULATORS):
+                        index = iteration * threads * _NUM_ACCUMULATORS + accumulator * threads + tx
                         if index < N:
-                            value = T.cast(x[row * N + index], "float32")
-                            value_nan = T.isnan(value)
-                            best_nan = T.isnan(best_values[accumulator])
-                            if op_kind == "argmax":
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value > best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            else:
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value < best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            if better:
-                                best_values[accumulator] = value
-                                best_indices[accumulator] = T.cast(index, "int32")
+                            update(
+                                values,
+                                indices,
+                                accumulator,
+                                T.cast(x[row, index], "float32"),
+                                index,
+                            )
 
-                best_value = T.alloc_var(T.float32)
-                best_index = T.alloc_var(T.int32)
-                best_value = best_values[0]
-                best_index = best_indices[0]
-                for accumulator in T.serial(1, num_accumulators):
-                    other_value = best_values[accumulator]
-                    other_index = best_indices[accumulator]
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
-                # register -> warp shuffle
-                for stage in T.serial(5):
-                    mask = T.int32(16) >> stage
-                    other_value = T.shfl_xor(best_value, mask)
-                    other_index = T.shfl_xor(best_index, mask)
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
-                # warp -> shared
-                if lane == 0:
-                    warp_values[warp] = best_value
-                    warp_indices[warp] = best_index
-                T.sync_threads()
-
-                # shared -> final warp -> global
-                if lane < num_warps:
-                    best_value = warp_values[lane]
-                    best_index = warp_indices[lane]
-                else:
-                    if op_kind == "argmax":
-                        best_value = -T.infinity("float32")
-                    else:
-                        best_value = T.infinity("float32")
-                    best_index = T.int32(N)
-
-                if warp == 0:
-                    for stage in T.serial(5):
-                        mask = T.int32(16) >> stage
-                        other_value = T.shfl_xor(best_value, mask)
-                        other_index = T.shfl_xor(best_index, mask)
-                        other_nan = T.isnan(other_value)
-                        best_nan = T.isnan(best_value)
-                        if op_kind == "argmax":
-                            better = (
-                                (other_nan and not best_nan)
-                                or (
-                                    other_nan == best_nan
-                                    and (
-                                        other_value > best_value
-                                        or (
-                                            other_value == best_value
-                                            and other_index < best_index
-                                        )
-                                    )
-                                )
-                            )
-                        else:
-                            better = (
-                                (other_nan and not best_nan)
-                                or (
-                                    other_nan == best_nan
-                                    and (
-                                        other_value < best_value
-                                        or (
-                                            other_value == best_value
-                                            and other_index < best_index
-                                        )
-                                    )
-                                )
-                            )
-                        if better:
-                            best_value = other_value
-                            best_index = other_index
-                    if lane == 0:
-                        out[row] = T.cast(best_index, "int64")
+                block_reduce(
+                    values,
+                    indices,
+                    best_value,
+                    best_index,
+                    warp_values,
+                    warp_indices,
+                    tx,
+                )
+                if tx == 0:
+                    out[row] = T.cast(best_index[0], "int64")
 
         return main
 
@@ -564,28 +275,36 @@ def _argreduce_multicta_partial_kernel(
     dtype: str,
     ctas_per_row: int,
 ):
-    """Build stage one of the multi-CTA long-row reduction."""
-    num_accumulators = _NUM_ACCUMULATORS
+    """Build the partial stage for rows split across multiple blocks."""
     chunk_size = (N + ctas_per_row - 1) // ctas_per_row
     num_partials = M * ctas_per_row
 
     @tilelang.jit(out_idx=[1, 2])
     def _func(threads: int):
         num_warps = threads // _WARP_SIZE
-        iterations = (
-            chunk_size + threads * num_accumulators - 1
-        ) // (threads * num_accumulators)
+        iterations = (chunk_size + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
+        (
+            set_identity,
+            init_accumulators,
+            update,
+            merge_accumulators,
+            warp_reduce,
+        ) = _make_pair_ops(op_kind, N)
+        block_reduce = _make_block_reduce(
+            set_identity,
+            merge_accumulators,
+            warp_reduce,
+            num_warps,
+        )
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M * N,), dtype],
+            x: T.Tensor[(M, N), dtype],
             partial_values: T.Tensor[(num_partials,), "float32"],  # noqa: F821
             partial_indices: T.Tensor[(num_partials,), "int32"],  # noqa: F821
         ):
             with T.Kernel(num_partials, threads=threads) as partial:
                 tx = T.get_thread_binding()
-                lane = tx % _WARP_SIZE
-                warp = tx // _WARP_SIZE
                 row = partial // ctas_per_row
                 split = partial % ctas_per_row
                 chunk_start = split * chunk_size
@@ -593,195 +312,41 @@ def _argreduce_multicta_partial_kernel(
 
                 warp_values = T.alloc_shared((num_warps,), "float32")
                 warp_indices = T.alloc_shared((num_warps,), "int32")
-                best_values = T.alloc_local((num_accumulators,), "float32")
-                best_indices = T.alloc_local((num_accumulators,), "int32")
-
-                for accumulator in T.serial(num_accumulators):
-                    if op_kind == "argmax":
-                        best_values[accumulator] = -T.infinity("float32")
-                    else:
-                        best_values[accumulator] = T.infinity("float32")
-                    best_indices[accumulator] = T.int32(N)
+                values = T.alloc_local((_NUM_ACCUMULATORS,), "float32")
+                indices = T.alloc_local((_NUM_ACCUMULATORS,), "int32")
+                best_value = T.alloc_local((1,), "float32")
+                best_index = T.alloc_local((1,), "int32")
+                init_accumulators(values, indices)
 
                 for iteration in T.serial(iterations):
-                    for accumulator in T.serial(num_accumulators):
+                    for accumulator in T.serial(_NUM_ACCUMULATORS):
                         index = (
                             chunk_start
-                            + iteration * threads * num_accumulators
+                            + iteration * threads * _NUM_ACCUMULATORS
                             + accumulator * threads
                             + tx
                         )
                         if index < chunk_end:
-                            value = T.cast(x[row * N + index], "float32")
-                            value_nan = T.isnan(value)
-                            best_nan = T.isnan(best_values[accumulator])
-                            if op_kind == "argmax":
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value > best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            else:
-                                better = (
-                                    (value_nan and not best_nan)
-                                    or (
-                                        value_nan == best_nan
-                                        and (
-                                            value < best_values[accumulator]
-                                            or (
-                                                value == best_values[accumulator]
-                                                and index < best_indices[accumulator]
-                                            )
-                                        )
-                                    )
-                                )
-                            if better:
-                                best_values[accumulator] = value
-                                best_indices[accumulator] = T.cast(index, "int32")
+                            update(
+                                values,
+                                indices,
+                                accumulator,
+                                T.cast(x[row, index], "float32"),
+                                index,
+                            )
 
-                best_value = T.alloc_var(T.float32)
-                best_index = T.alloc_var(T.int32)
-                best_value = best_values[0]
-                best_index = best_indices[0]
-                for accumulator in T.serial(1, num_accumulators):
-                    other_value = best_values[accumulator]
-                    other_index = best_indices[accumulator]
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
-                for stage in T.serial(5):
-                    mask = T.int32(16) >> stage
-                    other_value = T.shfl_xor(best_value, mask)
-                    other_index = T.shfl_xor(best_index, mask)
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
-                if lane == 0:
-                    warp_values[warp] = best_value
-                    warp_indices[warp] = best_index
-                T.sync_threads()
-
-                if lane < num_warps:
-                    best_value = warp_values[lane]
-                    best_index = warp_indices[lane]
-                else:
-                    if op_kind == "argmax":
-                        best_value = -T.infinity("float32")
-                    else:
-                        best_value = T.infinity("float32")
-                    best_index = T.int32(N)
-
-                if warp == 0:
-                    for stage in T.serial(5):
-                        mask = T.int32(16) >> stage
-                        other_value = T.shfl_xor(best_value, mask)
-                        other_index = T.shfl_xor(best_index, mask)
-                        other_nan = T.isnan(other_value)
-                        best_nan = T.isnan(best_value)
-                        if op_kind == "argmax":
-                            better = (
-                                (other_nan and not best_nan)
-                                or (
-                                    other_nan == best_nan
-                                    and (
-                                        other_value > best_value
-                                        or (
-                                            other_value == best_value
-                                            and other_index < best_index
-                                        )
-                                    )
-                                )
-                            )
-                        else:
-                            better = (
-                                (other_nan and not best_nan)
-                                or (
-                                    other_nan == best_nan
-                                    and (
-                                        other_value < best_value
-                                        or (
-                                            other_value == best_value
-                                            and other_index < best_index
-                                        )
-                                    )
-                                )
-                            )
-                        if better:
-                            best_value = other_value
-                            best_index = other_index
-                    if lane == 0:
-                        partial_values[partial] = best_value
-                        partial_indices[partial] = best_index
+                block_reduce(
+                    values,
+                    indices,
+                    best_value,
+                    best_index,
+                    warp_values,
+                    warp_indices,
+                    tx,
+                )
+                if tx == 0:
+                    partial_values[partial] = best_value[0]
+                    partial_indices[partial] = best_index[0]
 
         return main
 
@@ -795,13 +360,15 @@ def _argreduce_multicta_final_kernel(
     op_kind: str,
     ctas_per_row: int,
 ):
-    """Build stage two, reducing multi-CTA value/index partials per row."""
+    """Build the final reduction over per-row block partials."""
     num_partials = M * ctas_per_row
     rows_per_block = 8
     threads = rows_per_block * _WARP_SIZE
 
     @tilelang.jit(out_idx=[2])
     def _func():
+        set_identity, _, _, _, warp_reduce = _make_pair_ops(op_kind, N)
+
         @T.prim_func
         def main(
             partial_values: T.Tensor[(num_partials,), "float32"],  # noqa: F821
@@ -810,62 +377,19 @@ def _argreduce_multicta_final_kernel(
         ):
             with T.Kernel(T.ceildiv(M, rows_per_block), threads=threads) as pid:
                 tx = T.get_thread_binding()
-                row_in_block = tx // _WARP_SIZE
+                row = pid * rows_per_block + tx // _WARP_SIZE
                 lane = tx % _WARP_SIZE
-                row = pid * rows_per_block + row_in_block
-
-                best_value = T.alloc_var(T.float32)
-                best_index = T.alloc_var(T.int32)
-                if op_kind == "argmax":
-                    best_value = -T.infinity("float32")
-                else:
-                    best_value = T.infinity("float32")
-                best_index = T.int32(N)
+                best_value = T.alloc_local((1,), "float32")
+                best_index = T.alloc_local((1,), "int32")
+                set_identity(best_value, best_index, 0)
 
                 if row < M and lane < ctas_per_row:
-                    best_value = partial_values[row * ctas_per_row + lane]
-                    best_index = partial_indices[row * ctas_per_row + lane]
+                    best_value[0] = partial_values[row * ctas_per_row + lane]
+                    best_index[0] = partial_indices[row * ctas_per_row + lane]
 
-                for stage in T.serial(5):
-                    mask = T.int32(16) >> stage
-                    other_value = T.shfl_xor(best_value, mask)
-                    other_index = T.shfl_xor(best_index, mask)
-                    other_nan = T.isnan(other_value)
-                    best_nan = T.isnan(best_value)
-                    if op_kind == "argmax":
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value > best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    else:
-                        better = (
-                            (other_nan and not best_nan)
-                            or (
-                                other_nan == best_nan
-                                and (
-                                    other_value < best_value
-                                    or (
-                                        other_value == best_value
-                                        and other_index < best_index
-                                    )
-                                )
-                            )
-                        )
-                    if better:
-                        best_value = other_value
-                        best_index = other_index
-
+                warp_reduce(best_value, best_index, 5, _WARP_SIZE)
                 if row < M and lane == 0:
-                    out[row] = T.cast(best_index, "int64")
+                    out[row] = T.cast(best_index[0], "int64")
 
         return main
 
@@ -876,7 +400,6 @@ def _argreduce_multicta_final_kernel(
 def _argreduce_fwd_wrapped(
     M: int,
     N: int,
-    inner_stride: int,
     op_kind: str,
     dtype_str: str,
     strategy: str,
@@ -885,31 +408,22 @@ def _argreduce_fwd_wrapped(
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    if strategy == "output":
-        return _argreduce_output_kernel(
-            M, N, inner_stride, op_kind, dtype_str
-        )(block_m, threads)(x)
     if strategy == "cta":
-        return _argreduce_cta_kernel(
-            M, N, op_kind, dtype_str
-        )(block_m, threads)(x)
+        return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
     if strategy == "multi_cta":
         partial_values, partial_indices = _argreduce_multicta_partial_kernel(
             M, N, op_kind, dtype_str, ctas_per_row
         )(threads)(x)
-        return _argreduce_multicta_final_kernel(
-            M, N, op_kind, ctas_per_row
-        )()(partial_values, partial_indices)
-    return _argreduce_warp_kernel(
-        M, N, op_kind, dtype_str
-    )(block_m, threads)(x)
+        return _argreduce_multicta_final_kernel(M, N, op_kind, ctas_per_row)()(
+            partial_values, partial_indices
+        )
+    return _argreduce_warp_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
 
 
 @_argreduce_fwd_wrapped.register_fake
 def _(
     M,
     N,
-    inner_stride,
     op_kind,
     dtype_str,
     strategy,
@@ -922,14 +436,7 @@ def _(
 
 
 class ArgreduceKernel(Kernel):
-    """Adaptive streaming argmax/argmin kernel.
-
-    ``inner_stride == 1`` means the reduction axis is contiguous.  A warp
-    processes each ordinary row; very long rows use a full CTA and shared
-    memory only for the small set of warp partials.  ``inner_stride > 1``
-    selects output-parallel traversal, which keeps global accesses coalesced
-    without transposing the input.
-    """
+    """Adaptive streaming argmax/argmin over contiguous rows."""
 
     supported_archs: list[int] = [80, 86, 89, 90, 100]
 
@@ -939,40 +446,28 @@ class ArgreduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
-        inner_stride: int = 1,
         config: Optional[dict] = None,
         tune: bool = False,
     ):
         super().__init__()
         if op_kind not in _ARGREDUCE_KINDS:
             raise ValueError(
-                f"Unsupported op_kind '{op_kind}'. "
-                f"Expected one of {sorted(_ARGREDUCE_KINDS)}."
+                f"Unsupported op_kind '{op_kind}'. " f"Expected one of {sorted(_ARGREDUCE_KINDS)}."
             )
         if N <= 0:
             raise ValueError(
                 "Reduction dimension is empty (N=0). "
                 "argmax/argmin over an empty dimension is undefined."
             )
-        if inner_stride <= 0 or M % inner_stride != 0:
-            raise ValueError(
-                f"Invalid inner_stride={inner_stride} for M={M}."
-            )
+
         self.M = M
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
-        self.inner_stride = inner_stride
         self.ctas_per_row = 1
-        if inner_stride > 1:
-            self.strategy = "output"
-            self.kernel = _argreduce_output_kernel(
-                M, N, inner_stride, op_kind, self.dtype_str
-            )
-        elif N >= 32768 and M < 64:
+
+        if N >= 32768 and M < 64:
             self.strategy = "multi_cta"
-            # About one 4K-element chunk per CTA, capped at one warp of
-            # partials so the final reduction remains a single shuffle tree.
             self.ctas_per_row = min(32, (N + 4095) // 4096)
             self.kernel = _argreduce_multicta_partial_kernel(
                 M, N, op_kind, self.dtype_str, self.ctas_per_row
@@ -989,9 +484,7 @@ class ArgreduceKernel(Kernel):
     def default_config(self) -> dict:
         if self.strategy in {"cta", "multi_cta"}:
             return {"block_m": 1, "threads": 256}
-        if self.strategy == "output":
-            threads = 256
-            return {"block_m": threads, "threads": threads}
+
         lanes = _lanes_per_row(self.N)
         target_threads = 256 if self.M >= 8 else max(32, self.M * lanes)
         block_m = max(1, target_threads // lanes)
@@ -1000,30 +493,19 @@ class ArgreduceKernel(Kernel):
     @property
     def autotune_configs(self) -> list[dict]:
         if self.strategy in {"cta", "multi_cta"}:
-            return [
-                {"block_m": 1, "threads": threads}
-                for threads in (128, 256, 512)
-            ]
-        if self.strategy == "output":
-            return [
-                {"block_m": threads, "threads": threads}
-                for threads in (128, 256, 512)
-            ]
+            return [{"block_m": 1, "threads": threads} for threads in (128, 256, 512)]
+
         lanes = _lanes_per_row(self.N)
         configs = []
         for target_threads in (64, 128, 256, 512):
             block_m = max(1, target_threads // lanes)
-            configs.append(
-                {"block_m": block_m, "threads": block_m * lanes}
-            )
+            configs.append({"block_m": block_m, "threads": block_m * lanes})
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the selected arg-reduction strategy on a flattened input."""
         return _argreduce_fwd_wrapped(
             self.M,
             self.N,
-            self.inner_stride,
             self.op_kind,
             self.dtype_str,
             self.strategy,

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -1,12 +1,22 @@
-"""Argreduce kernels (argmax, argmin) using TileLang.
+"""Streaming arg-reduction kernels (argmax and argmin) using TileLang.
 
-Implements a two-step kernel: first finds the extreme value via parallel reduce,
-then scans for the first index matching that value.
-Operates on 2D (M, N_padded) tensors; the Op layer handles reshape.
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions.
+The implementation follows the same broad decomposition as the CUDA
+reduction kernels used by PyTorch:
 
-Output is always int64 (index values).
+* values and indices are reduced together in one pass;
+* input elements are streamed directly from global memory (there is no
+  materialized input tile);
+* contiguous reduction axes use input-parallel warp/CTA kernels, while
+  strided reduction axes use an output-parallel kernel;
+* every thread maintains four independent value/index accumulators;
+* long rows are reduced register -> warp shuffle -> shared memory -> global;
+* launch geometry is selected from the reduction and output sizes.
+
+The Op layer passes a flattened contiguous input plus ``inner_stride``.
+For a contiguous tensor reduced along dimension ``d``, ``inner_stride`` is
+the product of the dimensions after ``d``.  This lets the kernel address a
+non-last reduction axis directly instead of materializing ``movedim(...).
+contiguous()``.
 """
 
 import functools
@@ -17,139 +27,911 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import (
-    DEFAULT_ALIGNMENT,
-    SHARED_MEMORY_BUDGET_BYTES,
-    align_up,
-)
 
 __all__ = ["ArgreduceKernel"]
 
 _ARGREDUCE_KINDS = {"argmax", "argmin"}
+_WARP_SIZE = 32
+_NUM_ACCUMULATORS = 4
 
 
-# Argreduce kernel
+def _lanes_per_row(n: int) -> int:
+    """Return a power-of-two subgroup size for an input-parallel row."""
+    lanes = 1
+    while lanes < min(n, _WARP_SIZE):
+        lanes *= 2
+    return lanes
 
 
-@functools.lru_cache(maxsize=32)
-def _argreduce_kernel(M: int, N: int, op_kind: str, dtype: str):
-    """Build a TileLang argmax/argmin kernel.
-
-    Uses a two-step approach:
-      Step 1: Load data, cast to fp32, find row-wise max/min using T.reduce_max.
-      Step 2: Serial scan to find the index of the first occurrence of
-              the max/min value.
-
-    Args:
-        M: Number of rows (product of all leading dimensions).
-        N: Original hidden dimension (last dim, before padding).
-        op_kind: One of "argmax", "argmin".
-        dtype: TileLang dtype string (e.g. "float16", "bfloat16", "float32").
-
-    Returns:
-        A TileLang JIT-compiled kernel factory accepting (block_m, threads).
-    """
-    N_padded = align_up(N, DEFAULT_ALIGNMENT)
+@functools.lru_cache(maxsize=64)
+def _argreduce_warp_kernel(M: int, N: int, op_kind: str, dtype: str):
+    """Build the input-parallel kernel used for the common contiguous case."""
+    lanes = _lanes_per_row(N)
+    num_accumulators = _NUM_ACCUMULATORS
+    items_per_iteration = lanes * num_accumulators
+    iterations = (N + items_per_iteration - 1) // items_per_iteration
+    log_lanes = lanes.bit_length() - 1
 
     @tilelang.jit(out_idx=[1])
-    def _func(block_m, threads):
+    def _func(block_m: int, threads: int):
         @T.prim_func
         def main(
-            x: T.Tensor[(M, N_padded), dtype],
+            x: T.Tensor[(M * N,), dtype],
             out: T.Tensor[(M,), "int64"],  # noqa: F821
         ):
-            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
-                shared_buf = T.alloc_shared((block_m, N_padded), dtype)
-                x_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                row_extreme = T.alloc_fragment((block_m,), "float32")
-                out_idx = T.alloc_fragment((block_m,), "int64")
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid:
+                tx = T.get_thread_binding()
+                row_in_block = tx // lanes
+                lane = tx % lanes
+                row = pid * block_m + row_in_block
 
-                # Load via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
+                best_values = T.alloc_local((num_accumulators,), "float32")
+                best_indices = T.alloc_local((num_accumulators,), "int32")
 
-                # Cast to fp32
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                for accumulator in T.serial(num_accumulators):
+                    if op_kind == "argmax":
+                        best_values[accumulator] = -T.infinity("float32")
+                    else:
+                        best_values[accumulator] = T.infinity("float32")
+                    best_indices[accumulator] = T.int32(N)
 
-                if op_kind == "argmax":
-                    # For argmax: negate padded positions so they never win
-                    # Padded positions are filled with -inf by the Op layer,
-                    # so they already cannot win a max.
-                    # Find row-wise max value using T.reduce_max
-                    T.fill(row_extreme, -T.infinity("float32"))
-                    T.reduce_max(x_f32, row_extreme, dim=1, clear=False)
-                else:
-                    # For argmin: padded positions are filled with +inf by Op layer,
-                    # so they cannot win a min.
-                    # Find row-wise min = -max(-x)
-                    neg_x = T.alloc_fragment((block_m, N_padded), "float32")
-                    for i, j in T.Parallel(block_m, N_padded):
-                        neg_x[i, j] = -x_f32[i, j]
-                    T.fill(row_extreme, -T.infinity("float32"))
-                    T.reduce_max(neg_x, row_extreme, dim=1, clear=False)
-                    # Negate back to get min value
-                    for i in T.Parallel(block_m):
-                        row_extreme[i] = -row_extreme[i]
+                # Four independent dependency chains hide comparison latency.
+                for iteration in T.serial(iterations):
+                    for accumulator in T.serial(num_accumulators):
+                        index = (
+                            iteration * items_per_iteration
+                            + accumulator * lanes
+                            + lane
+                        )
+                        if row < M and index < N:
+                            value = T.cast(x[row * N + index], "float32")
+                            value_nan = T.isnan(value)
+                            best_nan = T.isnan(best_values[accumulator])
+                            if op_kind == "argmax":
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value > best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            else:
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value < best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            if better:
+                                best_values[accumulator] = value
+                                best_indices[accumulator] = T.cast(index, "int32")
 
-                # Serial scan to find index of first occurrence matching extreme
-                T.fill(out_idx, T.cast(0, "int64"))
-                for i in T.Parallel(block_m):
-                    for j in T.Serial(N):
-                        if x_f32[i, j] == row_extreme[i]:
-                            out_idx[i] = T.cast(j, "int64")
-                            T.loop_break()
+                # Merge the four thread-local pairs.
+                best_value = T.alloc_var(T.float32)
+                best_index = T.alloc_var(T.int32)
+                best_value = best_values[0]
+                best_index = best_indices[0]
+                for accumulator in T.serial(1, num_accumulators):
+                    other_value = best_values[accumulator]
+                    other_index = best_indices[accumulator]
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
 
-                # Write output
-                T.copy(out_idx, out[pid_m * block_m])
+                # Pair reduction within each power-of-two subgroup.
+                for stage in T.serial(log_lanes):
+                    mask = T.int32(lanes // 2) >> stage
+                    other_value = T.shfl_xor(best_value, mask, width=lanes)
+                    other_index = T.shfl_xor(best_index, mask, width=lanes)
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                if lane == 0 and row < M:
+                    out[row] = T.cast(best_index, "int64")
 
         return main
 
     return _func
 
 
-# custom_op wrappers for torch.compile compatibility
+@functools.lru_cache(maxsize=64)
+def _argreduce_output_kernel(
+    M: int,
+    N: int,
+    inner_stride: int,
+    op_kind: str,
+    dtype: str,
+):
+    """Build an output-parallel kernel for contiguous non-last-axis reductions."""
+    num_accumulators = _NUM_ACCUMULATORS
+    iterations = (N + num_accumulators - 1) // num_accumulators
+
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m: int, threads: int):
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M * N,), dtype],
+            out: T.Tensor[(M,), "int64"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid:
+                tx = T.get_thread_binding()
+                row = pid * block_m + tx
+                outer = row // inner_stride
+                inner = row % inner_stride
+
+                best_values = T.alloc_local((num_accumulators,), "float32")
+                best_indices = T.alloc_local((num_accumulators,), "int32")
+                for accumulator in T.serial(num_accumulators):
+                    if op_kind == "argmax":
+                        best_values[accumulator] = -T.infinity("float32")
+                    else:
+                        best_values[accumulator] = T.infinity("float32")
+                    best_indices[accumulator] = T.int32(N)
+
+                # Threads expand along output, so each iteration performs
+                # coalesced reads across adjacent output elements.
+                for iteration in T.serial(iterations):
+                    for accumulator in T.serial(num_accumulators):
+                        index = iteration * num_accumulators + accumulator
+                        if row < M and index < N:
+                            offset = (
+                                outer * N * inner_stride
+                                + index * inner_stride
+                                + inner
+                            )
+                            value = T.cast(x[offset], "float32")
+                            value_nan = T.isnan(value)
+                            best_nan = T.isnan(best_values[accumulator])
+                            if op_kind == "argmax":
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value > best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            else:
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value < best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            if better:
+                                best_values[accumulator] = value
+                                best_indices[accumulator] = T.cast(index, "int32")
+
+                best_value = T.alloc_var(T.float32)
+                best_index = T.alloc_var(T.int32)
+                best_value = best_values[0]
+                best_index = best_indices[0]
+                for accumulator in T.serial(1, num_accumulators):
+                    other_value = best_values[accumulator]
+                    other_index = best_indices[accumulator]
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                if row < M:
+                    out[row] = T.cast(best_index, "int64")
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=64)
+def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
+    """Build a block-per-row hierarchical kernel for long contiguous rows."""
+    num_accumulators = _NUM_ACCUMULATORS
+
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m: int, threads: int):
+        num_warps = threads // _WARP_SIZE
+        iterations = (N + threads * num_accumulators - 1) // (
+            threads * num_accumulators
+        )
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M * N,), dtype],
+            out: T.Tensor[(M,), "int64"],  # noqa: F821
+        ):
+            with T.Kernel(M, threads=threads) as row:
+                tx = T.get_thread_binding()
+                lane = tx % _WARP_SIZE
+                warp = tx // _WARP_SIZE
+                warp_values = T.alloc_shared((num_warps,), "float32")
+                warp_indices = T.alloc_shared((num_warps,), "int32")
+                best_values = T.alloc_local((num_accumulators,), "float32")
+                best_indices = T.alloc_local((num_accumulators,), "int32")
+
+                for accumulator in T.serial(num_accumulators):
+                    if op_kind == "argmax":
+                        best_values[accumulator] = -T.infinity("float32")
+                    else:
+                        best_values[accumulator] = T.infinity("float32")
+                    best_indices[accumulator] = T.int32(N)
+
+                for iteration in T.serial(iterations):
+                    for accumulator in T.serial(num_accumulators):
+                        index = (
+                            iteration * threads * num_accumulators
+                            + accumulator * threads
+                            + tx
+                        )
+                        if index < N:
+                            value = T.cast(x[row * N + index], "float32")
+                            value_nan = T.isnan(value)
+                            best_nan = T.isnan(best_values[accumulator])
+                            if op_kind == "argmax":
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value > best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            else:
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value < best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            if better:
+                                best_values[accumulator] = value
+                                best_indices[accumulator] = T.cast(index, "int32")
+
+                best_value = T.alloc_var(T.float32)
+                best_index = T.alloc_var(T.int32)
+                best_value = best_values[0]
+                best_index = best_indices[0]
+                for accumulator in T.serial(1, num_accumulators):
+                    other_value = best_values[accumulator]
+                    other_index = best_indices[accumulator]
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                # register -> warp shuffle
+                for stage in T.serial(5):
+                    mask = T.int32(16) >> stage
+                    other_value = T.shfl_xor(best_value, mask)
+                    other_index = T.shfl_xor(best_index, mask)
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                # warp -> shared
+                if lane == 0:
+                    warp_values[warp] = best_value
+                    warp_indices[warp] = best_index
+                T.sync_threads()
+
+                # shared -> final warp -> global
+                if lane < num_warps:
+                    best_value = warp_values[lane]
+                    best_index = warp_indices[lane]
+                else:
+                    if op_kind == "argmax":
+                        best_value = -T.infinity("float32")
+                    else:
+                        best_value = T.infinity("float32")
+                    best_index = T.int32(N)
+
+                if warp == 0:
+                    for stage in T.serial(5):
+                        mask = T.int32(16) >> stage
+                        other_value = T.shfl_xor(best_value, mask)
+                        other_index = T.shfl_xor(best_index, mask)
+                        other_nan = T.isnan(other_value)
+                        best_nan = T.isnan(best_value)
+                        if op_kind == "argmax":
+                            better = (
+                                (other_nan and not best_nan)
+                                or (
+                                    other_nan == best_nan
+                                    and (
+                                        other_value > best_value
+                                        or (
+                                            other_value == best_value
+                                            and other_index < best_index
+                                        )
+                                    )
+                                )
+                            )
+                        else:
+                            better = (
+                                (other_nan and not best_nan)
+                                or (
+                                    other_nan == best_nan
+                                    and (
+                                        other_value < best_value
+                                        or (
+                                            other_value == best_value
+                                            and other_index < best_index
+                                        )
+                                    )
+                                )
+                            )
+                        if better:
+                            best_value = other_value
+                            best_index = other_index
+                    if lane == 0:
+                        out[row] = T.cast(best_index, "int64")
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _argreduce_multicta_partial_kernel(
+    M: int,
+    N: int,
+    op_kind: str,
+    dtype: str,
+    ctas_per_row: int,
+):
+    """Build stage one of the multi-CTA long-row reduction."""
+    num_accumulators = _NUM_ACCUMULATORS
+    chunk_size = (N + ctas_per_row - 1) // ctas_per_row
+    num_partials = M * ctas_per_row
+
+    @tilelang.jit(out_idx=[1, 2])
+    def _func(threads: int):
+        num_warps = threads // _WARP_SIZE
+        iterations = (
+            chunk_size + threads * num_accumulators - 1
+        ) // (threads * num_accumulators)
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M * N,), dtype],
+            partial_values: T.Tensor[(num_partials,), "float32"],  # noqa: F821
+            partial_indices: T.Tensor[(num_partials,), "int32"],  # noqa: F821
+        ):
+            with T.Kernel(num_partials, threads=threads) as partial:
+                tx = T.get_thread_binding()
+                lane = tx % _WARP_SIZE
+                warp = tx // _WARP_SIZE
+                row = partial // ctas_per_row
+                split = partial % ctas_per_row
+                chunk_start = split * chunk_size
+                chunk_end = T.min(chunk_start + chunk_size, N)
+
+                warp_values = T.alloc_shared((num_warps,), "float32")
+                warp_indices = T.alloc_shared((num_warps,), "int32")
+                best_values = T.alloc_local((num_accumulators,), "float32")
+                best_indices = T.alloc_local((num_accumulators,), "int32")
+
+                for accumulator in T.serial(num_accumulators):
+                    if op_kind == "argmax":
+                        best_values[accumulator] = -T.infinity("float32")
+                    else:
+                        best_values[accumulator] = T.infinity("float32")
+                    best_indices[accumulator] = T.int32(N)
+
+                for iteration in T.serial(iterations):
+                    for accumulator in T.serial(num_accumulators):
+                        index = (
+                            chunk_start
+                            + iteration * threads * num_accumulators
+                            + accumulator * threads
+                            + tx
+                        )
+                        if index < chunk_end:
+                            value = T.cast(x[row * N + index], "float32")
+                            value_nan = T.isnan(value)
+                            best_nan = T.isnan(best_values[accumulator])
+                            if op_kind == "argmax":
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value > best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            else:
+                                better = (
+                                    (value_nan and not best_nan)
+                                    or (
+                                        value_nan == best_nan
+                                        and (
+                                            value < best_values[accumulator]
+                                            or (
+                                                value == best_values[accumulator]
+                                                and index < best_indices[accumulator]
+                                            )
+                                        )
+                                    )
+                                )
+                            if better:
+                                best_values[accumulator] = value
+                                best_indices[accumulator] = T.cast(index, "int32")
+
+                best_value = T.alloc_var(T.float32)
+                best_index = T.alloc_var(T.int32)
+                best_value = best_values[0]
+                best_index = best_indices[0]
+                for accumulator in T.serial(1, num_accumulators):
+                    other_value = best_values[accumulator]
+                    other_index = best_indices[accumulator]
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                for stage in T.serial(5):
+                    mask = T.int32(16) >> stage
+                    other_value = T.shfl_xor(best_value, mask)
+                    other_index = T.shfl_xor(best_index, mask)
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                if lane == 0:
+                    warp_values[warp] = best_value
+                    warp_indices[warp] = best_index
+                T.sync_threads()
+
+                if lane < num_warps:
+                    best_value = warp_values[lane]
+                    best_index = warp_indices[lane]
+                else:
+                    if op_kind == "argmax":
+                        best_value = -T.infinity("float32")
+                    else:
+                        best_value = T.infinity("float32")
+                    best_index = T.int32(N)
+
+                if warp == 0:
+                    for stage in T.serial(5):
+                        mask = T.int32(16) >> stage
+                        other_value = T.shfl_xor(best_value, mask)
+                        other_index = T.shfl_xor(best_index, mask)
+                        other_nan = T.isnan(other_value)
+                        best_nan = T.isnan(best_value)
+                        if op_kind == "argmax":
+                            better = (
+                                (other_nan and not best_nan)
+                                or (
+                                    other_nan == best_nan
+                                    and (
+                                        other_value > best_value
+                                        or (
+                                            other_value == best_value
+                                            and other_index < best_index
+                                        )
+                                    )
+                                )
+                            )
+                        else:
+                            better = (
+                                (other_nan and not best_nan)
+                                or (
+                                    other_nan == best_nan
+                                    and (
+                                        other_value < best_value
+                                        or (
+                                            other_value == best_value
+                                            and other_index < best_index
+                                        )
+                                    )
+                                )
+                            )
+                        if better:
+                            best_value = other_value
+                            best_index = other_index
+                    if lane == 0:
+                        partial_values[partial] = best_value
+                        partial_indices[partial] = best_index
+
+        return main
+
+    return _func
+
+
+@functools.lru_cache(maxsize=32)
+def _argreduce_multicta_final_kernel(
+    M: int,
+    N: int,
+    op_kind: str,
+    ctas_per_row: int,
+):
+    """Build stage two, reducing multi-CTA value/index partials per row."""
+    num_partials = M * ctas_per_row
+    rows_per_block = 8
+    threads = rows_per_block * _WARP_SIZE
+
+    @tilelang.jit(out_idx=[2])
+    def _func():
+        @T.prim_func
+        def main(
+            partial_values: T.Tensor[(num_partials,), "float32"],  # noqa: F821
+            partial_indices: T.Tensor[(num_partials,), "int32"],  # noqa: F821
+            out: T.Tensor[(M,), "int64"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, rows_per_block), threads=threads) as pid:
+                tx = T.get_thread_binding()
+                row_in_block = tx // _WARP_SIZE
+                lane = tx % _WARP_SIZE
+                row = pid * rows_per_block + row_in_block
+
+                best_value = T.alloc_var(T.float32)
+                best_index = T.alloc_var(T.int32)
+                if op_kind == "argmax":
+                    best_value = -T.infinity("float32")
+                else:
+                    best_value = T.infinity("float32")
+                best_index = T.int32(N)
+
+                if row < M and lane < ctas_per_row:
+                    best_value = partial_values[row * ctas_per_row + lane]
+                    best_index = partial_indices[row * ctas_per_row + lane]
+
+                for stage in T.serial(5):
+                    mask = T.int32(16) >> stage
+                    other_value = T.shfl_xor(best_value, mask)
+                    other_index = T.shfl_xor(best_index, mask)
+                    other_nan = T.isnan(other_value)
+                    best_nan = T.isnan(best_value)
+                    if op_kind == "argmax":
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value > best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    else:
+                        better = (
+                            (other_nan and not best_nan)
+                            or (
+                                other_nan == best_nan
+                                and (
+                                    other_value < best_value
+                                    or (
+                                        other_value == best_value
+                                        and other_index < best_index
+                                    )
+                                )
+                            )
+                        )
+                    if better:
+                        best_value = other_value
+                        best_index = other_index
+
+                if row < M and lane == 0:
+                    out[row] = T.cast(best_index, "int64")
+
+        return main
+
+    return _func
 
 
 @torch.library.custom_op("top::argreduce_fwd", mutates_args=())
 def _argreduce_fwd_wrapped(
     M: int,
     N: int,
+    inner_stride: int,
     op_kind: str,
     dtype_str: str,
+    strategy: str,
+    ctas_per_row: int,
     block_m: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
-    return _argreduce_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
+    if strategy == "output":
+        return _argreduce_output_kernel(
+            M, N, inner_stride, op_kind, dtype_str
+        )(block_m, threads)(x)
+    if strategy == "cta":
+        return _argreduce_cta_kernel(
+            M, N, op_kind, dtype_str
+        )(block_m, threads)(x)
+    if strategy == "multi_cta":
+        partial_values, partial_indices = _argreduce_multicta_partial_kernel(
+            M, N, op_kind, dtype_str, ctas_per_row
+        )(threads)(x)
+        return _argreduce_multicta_final_kernel(
+            M, N, op_kind, ctas_per_row
+        )()(partial_values, partial_indices)
+    return _argreduce_warp_kernel(
+        M, N, op_kind, dtype_str
+    )(block_m, threads)(x)
 
 
 @_argreduce_fwd_wrapped.register_fake
-def _(M, N, op_kind, dtype_str, block_m, threads, x):
+def _(
+    M,
+    N,
+    inner_stride,
+    op_kind,
+    dtype_str,
+    strategy,
+    ctas_per_row,
+    block_m,
+    threads,
+    x,
+):
     return torch.empty((M,), dtype=torch.int64, device=x.device)
 
 
-# ArgreduceKernel class
-
-
 class ArgreduceKernel(Kernel):
-    """Argmax / argmin forward kernel.
+    """Adaptive streaming argmax/argmin kernel.
 
-    Supports SM80+ architectures. Uses 256-element alignment for shared
-    memory copies. Implements a two-step approach: parallel reduce to find
-    the extreme value, then serial scan to find the first matching index.
-
-    Output dtype is always int64.
-
-    Args:
-        M: Number of rows (product of all dims except last).
-        N: Hidden dimension (last dim).
-        op_kind: One of "argmax", "argmin".
-        dtype: Input data type (float32, float16, or bfloat16).
-        config: Optional kernel configuration dict.
-        tune: Whether to autotune (default False).
+    ``inner_stride == 1`` means the reduction axis is contiguous.  A warp
+    processes each ordinary row; very long rows use a full CTA and shared
+    memory only for the small set of warp partials.  ``inner_stride > 1``
+    selects output-parallel traversal, which keeps global accesses coalesced
+    without transposing the input.
     """
 
-    supported_archs: list[int] = [80, 86, 89, 90]
+    supported_archs: list[int] = [80, 86, 89, 90, 100]
 
     def __init__(
         self,
@@ -157,107 +939,95 @@ class ArgreduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        inner_stride: int = 1,
         config: Optional[dict] = None,
         tune: bool = False,
     ):
         super().__init__()
         if op_kind not in _ARGREDUCE_KINDS:
             raise ValueError(
-                f"Unsupported op_kind '{op_kind}'. Expected one of {sorted(_ARGREDUCE_KINDS)}."
+                f"Unsupported op_kind '{op_kind}'. "
+                f"Expected one of {sorted(_ARGREDUCE_KINDS)}."
+            )
+        if N <= 0:
+            raise ValueError(
+                "Reduction dimension is empty (N=0). "
+                "argmax/argmin over an empty dimension is undefined."
+            )
+        if inner_stride <= 0 or M % inner_stride != 0:
+            raise ValueError(
+                f"Invalid inner_stride={inner_stride} for M={M}."
             )
         self.M = M
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
-        self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        self.kernel = _argreduce_kernel(
-            self.M,
-            self.N,
-            self.op_kind,
-            self.dtype_str,
-        )
+        self.inner_stride = inner_stride
+        self.ctas_per_row = 1
+        if inner_stride > 1:
+            self.strategy = "output"
+            self.kernel = _argreduce_output_kernel(
+                M, N, inner_stride, op_kind, self.dtype_str
+            )
+        elif N >= 32768 and M < 64:
+            self.strategy = "multi_cta"
+            # About one 4K-element chunk per CTA, capped at one warp of
+            # partials so the final reduction remains a single shuffle tree.
+            self.ctas_per_row = min(32, (N + 4095) // 4096)
+            self.kernel = _argreduce_multicta_partial_kernel(
+                M, N, op_kind, self.dtype_str, self.ctas_per_row
+            )
+        elif N >= 4096:
+            self.strategy = "cta"
+            self.kernel = _argreduce_cta_kernel(M, N, op_kind, self.dtype_str)
+        else:
+            self.strategy = "warp"
+            self.kernel = _argreduce_warp_kernel(M, N, op_kind, self.dtype_str)
         self.init_config(config, tune)
 
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget.
-
-        When the original reduction dimension *N* is smaller than the
-        alignment boundary (``DEFAULT_ALIGNMENT``), padding inflates the row
-        width and TileLang's copy-layout inference requires
-        ``block_m * N_padded <= 2 * threads``.  For large *N* (>= alignment)
-        the rows are dense and the layout works at any block_m that fits in
-        shared memory, so the constraint is skipped.
-        """
-        if self.N_padded == 0:
-            raise ValueError(
-                "Reduction dimension is empty (N=0). "
-                "argmax/argmin over an empty dimension is undefined."
-            )
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m_smem = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        if max_block_m_smem == 0:
-            raise ValueError(
-                f"A single row requires {smem_per_row} bytes of shared memory, "
-                f"which exceeds the {SHARED_MEMORY_BUDGET_BYTES}-byte budget "
-                f"(N_padded={self.N_padded}, dtype={self.dtype}). "
-                f"Reduce the reduction dimension or use a dtype with smaller element size."
-            )
-        threads = 128
-        max_block_m = max_block_m_smem
-        if self.N < DEFAULT_ALIGNMENT:
-            # TileLang layout constraint: only needed when heavy padding
-            max_block_m_layout = (2 * threads) // self.N_padded
-            max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
-        block_m = 1
-        for bm in [1, 2, 4, 8]:
-            if bm <= max_block_m:
-                block_m = bm
-        return {"block_m": block_m, "threads": threads}
+        if self.strategy in {"cta", "multi_cta"}:
+            return {"block_m": 1, "threads": 256}
+        if self.strategy == "output":
+            threads = 256
+            return {"block_m": threads, "threads": threads}
+        lanes = _lanes_per_row(self.N)
+        target_threads = 256 if self.M >= 8 else max(32, self.M * lanes)
+        block_m = max(1, target_threads // lanes)
+        return {"block_m": block_m, "threads": block_m * lanes}
 
     @property
     def autotune_configs(self) -> list[dict]:
-        if self.N_padded == 0:
-            raise ValueError(
-                "Reduction dimension is empty (N=0). "
-                "argmax/argmin over an empty dimension is undefined."
-            )
-        smem_per_row = self.N_padded * torch.tensor([], dtype=self.dtype).element_size()
-        max_block_m_smem = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-        if max_block_m_smem == 0:
-            raise ValueError(
-                f"A single row requires {smem_per_row} bytes of shared memory, "
-                f"which exceeds the {SHARED_MEMORY_BUDGET_BYTES}-byte budget "
-                f"(N_padded={self.N_padded}, dtype={self.dtype}). "
-                f"Reduce the reduction dimension or use a dtype with smaller element size."
-            )
-        threads_list = [128, 256]
+        if self.strategy in {"cta", "multi_cta"}:
+            return [
+                {"block_m": 1, "threads": threads}
+                for threads in (128, 256, 512)
+            ]
+        if self.strategy == "output":
+            return [
+                {"block_m": threads, "threads": threads}
+                for threads in (128, 256, 512)
+            ]
+        lanes = _lanes_per_row(self.N)
         configs = []
-        for threads in threads_list:
-            max_block_m = max_block_m_smem
-            if self.N < DEFAULT_ALIGNMENT:
-                # TileLang layout constraint: only needed when heavy padding
-                max_block_m_layout = (2 * threads) // self.N_padded
-                max_block_m = min(max_block_m_smem, max(max_block_m_layout, 1))
-            for bm in [1, 2, 4, 8]:
-                if bm <= max_block_m:
-                    configs.append({"block_m": bm, "threads": threads})
+        for target_threads in (64, 128, 256, 512):
+            block_m = max(1, target_threads // lanes)
+            configs.append(
+                {"block_m": block_m, "threads": block_m * lanes}
+            )
         return configs
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the argmax/argmin kernel.
-
-        Args:
-            x: Input tensor of shape (M, N_padded).
-
-        Returns:
-            Output tensor of shape (M,) with dtype int64.
-        """
+        """Run the selected arg-reduction strategy on a flattened input."""
         return _argreduce_fwd_wrapped(
             self.M,
             self.N,
+            self.inner_stride,
             self.op_kind,
             self.dtype_str,
+            self.strategy,
+            self.ctas_per_row,
             self.config["block_m"],
             self.config["threads"],
             x,

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -29,11 +29,9 @@ _NUM_ACCUMULATORS = 4
 #   M=256 cta   1.4x  multi 1.5x  multi 2.4x
 #   M=1024 cta  1.3x  cta   1.1x  cta   1.05x
 #
-#: Rows this short only pay to split when there are too few of them to occupy
-#: the device at all.
+#: A row shorter than this is a handful of passes; splitting cannot save more
+#: than the second pass costs.
 _SPLIT_MIN_N = 32768
-#: Below this many rows the device is idle whatever the row length.
-_ROWS_TOO_FEW = 4
 #: Above this many rows the blocks already queue, and splitting only adds the
 #: final pass.
 _ROWS_SATURATED = 512
@@ -41,21 +39,29 @@ _ROWS_SATURATED = 512
 _MIN_CHUNK = 512
 
 
-def _row_split_candidates(N: int) -> list[int]:
-    """Splits worth ranking for a row of *N*, coarsest first."""
+def _row_split_candidates(M: int, N: int) -> list[int]:
+    """Splits worth ranking for a row of *N*, including the untuned default.
+
+    Leaving the default out lets tuning come back slower than not tuning.
+    """
     ceiling = max(1, N // _MIN_CHUNK)
-    return [c for c in (4, 8, 16, 32, 64) if c <= ceiling] or [1]
+    candidates = {c for c in (4, 8, 16, 32, 64) if c <= ceiling}
+    candidates.add(_plan_row_split(M, N))
+    return sorted(candidates)
 
 
 def _splits_row(M: int, N: int) -> bool:
     """Whether a row is worth splitting across blocks.
 
     Splitting trades one block's serial scan for a second pass over the
-    partials. It wins while the rows alone leave the device underused, and
-    stops winning once they queue on their own.
+    partials. It wins while the row is long enough for the scan to dominate
+    that pass and the rows alone leave the device underused.
+
+    The surface this approximates is not monotonic — 4 rows of 8192 want the
+    split while 16 do not — so the rule is deliberately the conservative one:
+    it declines a win on a few mid-sized shapes rather than taking a loss on
+    short ones, which is where `dim=None` and small tensors land.
     """
-    if M <= _ROWS_TOO_FEW:
-        return True
     return N >= _SPLIT_MIN_N and M < _ROWS_SATURATED
 
 
@@ -254,6 +260,68 @@ def _argreduce_warp_kernel(M: int, N: int, op_kind: str, dtype: str):
 
 
 @functools.lru_cache(maxsize=64)
+def _argreduce_output_kernel(
+    M: int,
+    N: int,
+    inner_stride: int,
+    op_kind: str,
+    dtype: str,
+):
+    """Build the output-parallel kernel for a contiguous non-last-axis reduction.
+
+    The reduction axis is strided here and the output axis is contiguous, so a
+    thread takes an output element and walks the axis: adjacent threads then
+    read adjacent addresses. Transposing into a last-axis layout instead copies
+    the whole tensor and hands a row of ``N`` elements to a block built for long
+    rows — on the manifest's 3d workload the copy alone is nearly half the time.
+    """
+    iterations = (N + _NUM_ACCUMULATORS - 1) // _NUM_ACCUMULATORS
+
+    @tilelang.jit(out_idx=[1])
+    def _func(block_m: int, threads: int):
+        set_identity, init_accumulators, update, merge_accumulators, _ = _make_pair_ops(
+            op_kind, N
+        )
+
+        @T.prim_func
+        def main(
+            x: T.Tensor[(M * N,), dtype],
+            out: T.Tensor[(M,), "int64"],  # noqa: F821
+        ):
+            with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid:
+                tx = T.get_thread_binding()
+                row = pid * block_m + tx
+                outer = row // inner_stride
+                inner = row % inner_stride
+
+                values = T.alloc_local((_NUM_ACCUMULATORS,), "float32")
+                indices = T.alloc_local((_NUM_ACCUMULATORS,), "int32")
+                best_value = T.alloc_local((1,), "float32")
+                best_index = T.alloc_local((1,), "int32")
+                init_accumulators(values, indices)
+
+                for iteration in T.serial(iterations):
+                    for accumulator in T.serial(_NUM_ACCUMULATORS):
+                        index = iteration * _NUM_ACCUMULATORS + accumulator
+                        if row < M and index < N:
+                            offset = outer * N * inner_stride + index * inner_stride + inner
+                            update(
+                                values,
+                                indices,
+                                accumulator,
+                                T.cast(x[offset], "float32"),
+                                index,
+                            )
+
+                merge_accumulators(values, indices, best_value, best_index)
+                if row < M:
+                    out[row] = T.cast(best_index[0], "int64")
+
+        return main
+
+    return _func
+
+
 def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
     """Build the block-per-row kernel used for long rows."""
 
@@ -330,9 +398,10 @@ def _argreduce_multicta_partial_kernel(
 
     ``ctas_per_row`` is a tuning parameter: how far to split a row trades the
     block's serial scan against a wider final pass, and where that trade lands
-    depends on the shape. The autotuner measures this stage alone, which ranks
-    the candidates the same way the pair does — the final pass costs the same
-    whatever the split.
+    depends on the shape. The autotuner measures this stage alone. The final
+    pass does grow slowly with the split (1.7 us at 32 chunks against 2.5 us at
+    64 on the lm-head shape), so the ranking can differ from the pair's at the
+    margin; measured, that has moved the choice once, by 0.3%.
     """
 
     @tilelang.jit(out_idx=[1, 2])
@@ -472,11 +541,16 @@ def _argreduce_fwd_wrapped(
     op_kind: str,
     dtype_str: str,
     strategy: str,
+    inner_stride: int,
     ctas_per_row: int,
     block_m: int,
     threads: int,
     x: torch.Tensor,
 ) -> torch.Tensor:
+    if strategy == "output":
+        return _argreduce_output_kernel(M, N, inner_stride, op_kind, dtype_str)(
+            block_m, threads
+        )(x)
     if strategy == "cta":
         return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(threads)(x)
     if strategy == "multi_cta":
@@ -496,6 +570,7 @@ def _(
     op_kind,
     dtype_str,
     strategy,
+    inner_stride,
     ctas_per_row,
     block_m,
     threads,
@@ -515,6 +590,7 @@ class ArgreduceKernel(Kernel):
         N: int,
         op_kind: str,
         dtype: torch.dtype,
+        inner_stride: int = 1,
         config: Optional[dict] = None,
         tune: bool = False,
     ):
@@ -533,8 +609,14 @@ class ArgreduceKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
+        self.inner_stride = inner_stride
 
-        if _splits_row(M, N):
+        if inner_stride > 1:
+            # The reduction axis is strided, so a thread takes an output element
+            # rather than a block taking a row.
+            self.strategy = "output"
+            self.kernel = _argreduce_output_kernel(M, N, inner_stride, op_kind, self.dtype_str)
+        elif _splits_row(M, N):
             self.strategy = "multi_cta"
             self.kernel = _argreduce_multicta_partial_kernel(M, N, op_kind, self.dtype_str)
         elif N >= 4096:
@@ -563,6 +645,8 @@ class ArgreduceKernel(Kernel):
         block_m = max(1, target_threads // lanes)
         if self.strategy in {"cta", "multi_cta"}:
             block_m, threads = 1, 256
+        elif self.strategy == "output":
+            block_m, threads = 256, 256
         else:
             threads = block_m * lanes
         return self._knobs(
@@ -575,10 +659,12 @@ class ArgreduceKernel(Kernel):
             candidates = [
                 {"threads": t, "ctas_per_row": c}
                 for t in (128, 256, 512)
-                for c in _row_split_candidates(self.N)
+                for c in _row_split_candidates(self.M, self.N)
             ]
         elif self.strategy == "cta":
             candidates = [{"threads": t} for t in (128, 256, 512)]
+        elif self.strategy == "output":
+            candidates = [{"block_m": t, "threads": t} for t in (128, 256, 512, 1024)]
         else:
             lanes = _lanes_per_row(self.N)
             candidates = []
@@ -588,12 +674,15 @@ class ArgreduceKernel(Kernel):
         return [self._knobs(candidate) for candidate in candidates]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.M == 0:
+            return torch.empty((0,), dtype=torch.int64, device=x.device)
         return _argreduce_fwd_wrapped(
             self.M,
             self.N,
             self.op_kind,
             self.dtype_str,
             self.strategy,
+            self.inner_stride,
             self.config.get("ctas_per_row", 1),
             self.config.get("block_m", 1),
             self.config["threads"],

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -19,6 +19,36 @@ __all__ = ["ArgreduceKernel"]
 _ARGREDUCE_KINDS = {"argmax", "argmin"}
 _WARP_SIZE = 32
 _NUM_ACCUMULATORS = 4
+#: Rows shorter than this finish faster in one block than they do split: the
+#: partial pass plus the final pass costs more than the serial scan it removes.
+_SPLIT_MIN_N = 32768
+#: A chunk below two passes of a block (256 threads x 4 accumulators) leaves
+#: the block underfed, and measured several times slower than a coarser split.
+_MIN_CHUNK = 2048
+#: Splitting past this stops paying: the partial pass is already short and the
+#: final pass grows with the number of chunks.
+_MAX_ROW_SPLIT = 16
+
+
+def _row_split_candidates(N: int) -> list[int]:
+    """Splits worth ranking for a row of *N*, coarsest first.
+
+    Bounded below by ``_MIN_CHUNK`` so no candidate underfeeds a block.
+    """
+    ceiling = max(1, N // _MIN_CHUNK)
+    return [c for c in (8, 16, 32, 64) if c <= ceiling] or [1]
+
+
+def _plan_row_split(N: int) -> int:
+    """Chunks per row for the multi-CTA layout; 1 means the row stays whole.
+
+    The split depends on the row length alone. What it removes is one block's
+    serial scan, which is set by ``N``; how many rows there are changes how many
+    blocks run, not how long each one takes.
+    """
+    if N < _SPLIT_MIN_N:
+        return 1
+    return max(1, min(_MAX_ROW_SPLIT, N // _MIN_CHUNK))
 
 
 def _lanes_per_row(n: int) -> int:
@@ -276,14 +306,20 @@ def _argreduce_multicta_partial_kernel(
     N: int,
     op_kind: str,
     dtype: str,
-    ctas_per_row: int,
 ):
-    """Build the partial stage for rows split across multiple blocks."""
-    chunk_size = (N + ctas_per_row - 1) // ctas_per_row
-    num_partials = M * ctas_per_row
+    """Build the partial stage for rows split across multiple blocks.
+
+    ``ctas_per_row`` is a tuning parameter: how far to split a row trades the
+    block's serial scan against a wider final pass, and where that trade lands
+    depends on the shape. The autotuner measures this stage alone, which ranks
+    the candidates the same way the pair does — the final pass costs the same
+    whatever the split.
+    """
 
     @tilelang.jit(out_idx=[1, 2])
-    def _func(threads: int):
+    def _func(threads: int, ctas_per_row: int):
+        chunk_size = (N + ctas_per_row - 1) // ctas_per_row
+        num_partials = M * ctas_per_row
         num_warps = threads // _WARP_SIZE
         iterations = (chunk_size + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
         (
@@ -368,9 +404,13 @@ def _argreduce_multicta_final_kernel(
     rows_per_block = 8
     threads = rows_per_block * _WARP_SIZE
 
+    # A lane walks its share of the row's partials, so the split is free to be
+    # wider than a warp; reading one partial per lane would drop the rest.
+    partials_per_lane = -(-ctas_per_row // _WARP_SIZE)
+
     @tilelang.jit(out_idx=[2])
     def _func():
-        set_identity, _, _, _, warp_reduce = _make_pair_ops(op_kind, N)
+        set_identity, _, update, _, warp_reduce = _make_pair_ops(op_kind, N)
 
         @T.prim_func
         def main(
@@ -386,9 +426,16 @@ def _argreduce_multicta_final_kernel(
                 best_index = T.alloc_local((1,), "int32")
                 set_identity(best_value, best_index, 0)
 
-                if row < M and lane < ctas_per_row:
-                    best_value[0] = partial_values[row * ctas_per_row + lane]
-                    best_index[0] = partial_indices[row * ctas_per_row + lane]
+                for step in T.serial(partials_per_lane):
+                    partial = step * _WARP_SIZE + lane
+                    if row < M and partial < ctas_per_row:
+                        update(
+                            best_value,
+                            best_index,
+                            0,
+                            partial_values[row * ctas_per_row + partial],
+                            partial_indices[row * ctas_per_row + partial],
+                        )
 
                 warp_reduce(best_value, best_index, 5, _WARP_SIZE)
                 if row < M and lane == 0:
@@ -415,8 +462,8 @@ def _argreduce_fwd_wrapped(
         return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(threads)(x)
     if strategy == "multi_cta":
         partial_values, partial_indices = _argreduce_multicta_partial_kernel(
-            M, N, op_kind, dtype_str, ctas_per_row
-        )(threads)(x)
+            M, N, op_kind, dtype_str
+        )(threads, ctas_per_row)(x)
         return _argreduce_multicta_final_kernel(M, N, op_kind, ctas_per_row)()(
             partial_values, partial_indices
         )
@@ -467,14 +514,10 @@ class ArgreduceKernel(Kernel):
         self.N = N
         self.op_kind = op_kind
         self.dtype = dtype
-        self.ctas_per_row = 1
 
-        if N >= 32768 and M < 64:
+        if _plan_row_split(N) > 1:
             self.strategy = "multi_cta"
-            self.ctas_per_row = min(32, (N + 4095) // 4096)
-            self.kernel = _argreduce_multicta_partial_kernel(
-                M, N, op_kind, self.dtype_str, self.ctas_per_row
-            )
+            self.kernel = _argreduce_multicta_partial_kernel(M, N, op_kind, self.dtype_str)
         elif N >= 4096:
             self.strategy = "cta"
             self.kernel = _argreduce_cta_kernel(M, N, op_kind, self.dtype_str)
@@ -503,12 +546,20 @@ class ArgreduceKernel(Kernel):
             block_m, threads = 1, 256
         else:
             threads = block_m * lanes
-        return self._knobs({"block_m": block_m, "threads": threads})
+        return self._knobs(
+            {"block_m": block_m, "threads": threads, "ctas_per_row": _plan_row_split(self.N)}
+        )
 
     @property
     def autotune_configs(self) -> list[dict]:
-        if self.strategy in {"cta", "multi_cta"}:
-            candidates = [{"block_m": 1, "threads": t} for t in (128, 256, 512)]
+        if self.strategy == "multi_cta":
+            candidates = [
+                {"threads": t, "ctas_per_row": c}
+                for t in (128, 256, 512)
+                for c in _row_split_candidates(self.N)
+            ]
+        elif self.strategy == "cta":
+            candidates = [{"threads": t} for t in (128, 256, 512)]
         else:
             lanes = _lanes_per_row(self.N)
             candidates = []
@@ -524,7 +575,7 @@ class ArgreduceKernel(Kernel):
             self.op_kind,
             self.dtype_str,
             self.strategy,
-            self.ctas_per_row,
+            self.config.get("ctas_per_row", 1),
             self.config.get("block_m", 1),
             self.config["threads"],
             x,

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -19,36 +19,55 @@ __all__ = ["ArgreduceKernel"]
 _ARGREDUCE_KINDS = {"argmax", "argmin"}
 _WARP_SIZE = 32
 _NUM_ACCUMULATORS = 4
-#: Rows shorter than this finish faster in one block than they do split: the
-#: partial pass plus the final pass costs more than the serial scan it removes.
+# Where splitting a row pays, measured on H200 (132 SMs) over M x N with CUPTI
+# kernel time, best split against the block-per-row kernel:
+#
+#         N=8192      N=32768     N=102400
+#   M=4   multi 3.3x  multi 7.3x  multi 4.2x
+#   M=16  cta   1.4x  multi 1.7x  multi 3.6x
+#   M=64  cta   1.4x  multi 1.5x  multi 3.8x
+#   M=256 cta   1.4x  multi 1.5x  multi 2.4x
+#   M=1024 cta  1.3x  cta   1.1x  cta   1.05x
+#
+#: Rows this short only pay to split when there are too few of them to occupy
+#: the device at all.
 _SPLIT_MIN_N = 32768
-#: A chunk below two passes of a block (256 threads x 4 accumulators) leaves
-#: the block underfed, and measured several times slower than a coarser split.
-_MIN_CHUNK = 2048
-#: Splitting past this stops paying: the partial pass is already short and the
-#: final pass grows with the number of chunks.
-_MAX_ROW_SPLIT = 16
+#: Below this many rows the device is idle whatever the row length.
+_ROWS_TOO_FEW = 4
+#: Above this many rows the blocks already queue, and splitting only adds the
+#: final pass.
+_ROWS_SATURATED = 512
+#: A chunk shorter than this cannot amortize its share of the final pass.
+_MIN_CHUNK = 512
 
 
 def _row_split_candidates(N: int) -> list[int]:
-    """Splits worth ranking for a row of *N*, coarsest first.
-
-    Bounded below by ``_MIN_CHUNK`` so no candidate underfeeds a block.
-    """
+    """Splits worth ranking for a row of *N*, coarsest first."""
     ceiling = max(1, N // _MIN_CHUNK)
-    return [c for c in (8, 16, 32, 64) if c <= ceiling] or [1]
+    return [c for c in (4, 8, 16, 32, 64) if c <= ceiling] or [1]
 
 
-def _plan_row_split(N: int) -> int:
-    """Chunks per row for the multi-CTA layout; 1 means the row stays whole.
+def _splits_row(M: int, N: int) -> bool:
+    """Whether a row is worth splitting across blocks.
 
-    The split depends on the row length alone. What it removes is one block's
-    serial scan, which is set by ``N``; how many rows there are changes how many
-    blocks run, not how long each one takes.
+    Splitting trades one block's serial scan for a second pass over the
+    partials. It wins while the rows alone leave the device underused, and
+    stops winning once they queue on their own.
     """
-    if N < _SPLIT_MIN_N:
+    if M <= _ROWS_TOO_FEW:
+        return True
+    return N >= _SPLIT_MIN_N and M < _ROWS_SATURATED
+
+
+def _plan_row_split(M: int, N: int) -> int:
+    """Chunks per row when untuned; 1 means the row stays whole.
+
+    Only a default — the split is a tuning parameter, and the best value moves
+    with the shape by more than an order of magnitude.
+    """
+    if not _splits_row(M, N):
         return 1
-    return max(1, min(_MAX_ROW_SPLIT, N // _MIN_CHUNK))
+    return max(1, min(16, N // _MIN_CHUNK))
 
 
 def _lanes_per_row(n: int) -> int:
@@ -515,7 +534,7 @@ class ArgreduceKernel(Kernel):
         self.op_kind = op_kind
         self.dtype = dtype
 
-        if _plan_row_split(N) > 1:
+        if _splits_row(M, N):
             self.strategy = "multi_cta"
             self.kernel = _argreduce_multicta_partial_kernel(M, N, op_kind, self.dtype_str)
         elif N >= 4096:
@@ -547,7 +566,7 @@ class ArgreduceKernel(Kernel):
         else:
             threads = block_m * lanes
         return self._knobs(
-            {"block_m": block_m, "threads": threads, "ctas_per_row": _plan_row_split(self.N)}
+            {"block_m": block_m, "threads": threads, "ctas_per_row": _plan_row_split(self.M, self.N)}
         )
 
     @property

--- a/tileops/kernels/reduction/argreduce.py
+++ b/tileops/kernels/reduction/argreduce.py
@@ -46,24 +46,27 @@ def _make_pair_ops(op_kind: str, n: int):
 
     @T.macro
     def update(values, indices, slot, candidate_value, candidate_index):
+        """Merge a candidate into a slot under PyTorch's argreduce ordering.
+
+        NaN outranks every number, equal rank breaks to the lower index, and
+        two NaNs are equal in rank — the last of which no float comparison can
+        express, since every comparison between them is false.
+        """
         candidate_nan = T.isnan(candidate_value)
         current_nan = T.isnan(values[slot])
+        both_numeric = not candidate_nan and not current_nan
         if op_kind == "argmax":
-            better = (candidate_nan and not current_nan) or (
-                candidate_nan == current_nan
-                and (
-                    candidate_value > values[slot]
-                    or (candidate_value == values[slot] and candidate_index < indices[slot])
-                )
-            )
+            outranks = both_numeric and candidate_value > values[slot]
         else:
-            better = (candidate_nan and not current_nan) or (
-                candidate_nan == current_nan
-                and (
-                    candidate_value < values[slot]
-                    or (candidate_value == values[slot] and candidate_index < indices[slot])
-                )
-            )
+            outranks = both_numeric and candidate_value < values[slot]
+        same_rank = (candidate_nan and current_nan) or (
+            both_numeric and candidate_value == values[slot]
+        )
+        better = (
+            (candidate_nan and not current_nan)
+            or outranks
+            or (same_rank and candidate_index < indices[slot])
+        )
         if better:
             values[slot] = candidate_value
             indices[slot] = T.cast(candidate_index, "int32")
@@ -206,7 +209,7 @@ def _argreduce_cta_kernel(M: int, N: int, op_kind: str, dtype: str):
     """Build the block-per-row kernel used for long rows."""
 
     @tilelang.jit(out_idx=[1])
-    def _func(block_m: int, threads: int):
+    def _func(threads: int):
         num_warps = threads // _WARP_SIZE
         iterations = (N + threads * _NUM_ACCUMULATORS - 1) // (threads * _NUM_ACCUMULATORS)
         (
@@ -409,7 +412,7 @@ def _argreduce_fwd_wrapped(
     x: torch.Tensor,
 ) -> torch.Tensor:
     if strategy == "cta":
-        return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(block_m, threads)(x)
+        return _argreduce_cta_kernel(M, N, op_kind, dtype_str)(threads)(x)
     if strategy == "multi_cta":
         partial_values, partial_indices = _argreduce_multicta_partial_kernel(
             M, N, op_kind, dtype_str, ctas_per_row
@@ -480,27 +483,39 @@ class ArgreduceKernel(Kernel):
             self.kernel = _argreduce_warp_kernel(M, N, op_kind, self.dtype_str)
         self.init_config(config, tune)
 
+    def _knobs(self, config: dict) -> dict:
+        """Keep only the knobs this strategy's kernel actually takes.
+
+        ``block_m`` packs several rows into one block, which only the warp
+        layout does — the other two give a row its own block or its own group of
+        them. Deriving the keys from the built kernel keeps a config space from
+        naming a knob the kernel would reject.
+        """
+        parameters = self.kernel.signature.parameters
+        return {name: value for name, value in config.items() if name in parameters}
+
     @property
     def default_config(self) -> dict:
-        if self.strategy in {"cta", "multi_cta"}:
-            return {"block_m": 1, "threads": 256}
-
         lanes = _lanes_per_row(self.N)
         target_threads = 256 if self.M >= 8 else max(32, self.M * lanes)
         block_m = max(1, target_threads // lanes)
-        return {"block_m": block_m, "threads": block_m * lanes}
+        if self.strategy in {"cta", "multi_cta"}:
+            block_m, threads = 1, 256
+        else:
+            threads = block_m * lanes
+        return self._knobs({"block_m": block_m, "threads": threads})
 
     @property
     def autotune_configs(self) -> list[dict]:
         if self.strategy in {"cta", "multi_cta"}:
-            return [{"block_m": 1, "threads": threads} for threads in (128, 256, 512)]
-
-        lanes = _lanes_per_row(self.N)
-        configs = []
-        for target_threads in (64, 128, 256, 512):
-            block_m = max(1, target_threads // lanes)
-            configs.append({"block_m": block_m, "threads": block_m * lanes})
-        return configs
+            candidates = [{"block_m": 1, "threads": t} for t in (128, 256, 512)]
+        else:
+            lanes = _lanes_per_row(self.N)
+            candidates = []
+            for target_threads in (64, 128, 256, 512):
+                block_m = max(1, target_threads // lanes)
+                candidates.append({"block_m": block_m, "threads": block_m * lanes})
+        return [self._knobs(candidate) for candidate in candidates]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return _argreduce_fwd_wrapped(
@@ -510,7 +525,7 @@ class ArgreduceKernel(Kernel):
             self.dtype_str,
             self.strategy,
             self.ctas_per_row,
-            self.config["block_m"],
+            self.config.get("block_m", 1),
             self.config["threads"],
             x,
         )

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -1,6 +1,5 @@
 """Arg-reduction operators (argmax, argmin)."""
 
-from math import prod
 from typing import Dict, Optional
 
 from tileops.kernels.kernel_base import Kernel
@@ -11,78 +10,7 @@ from .reduce import _ReduceOpBase
 __all__ = ["ArgmaxFwdOp", "ArgminFwdOp"]
 
 
-class _ArgreduceOpBase(_ReduceOpBase):
-    """Prepare argreduce inputs without materializing a transposed tensor.
-
-    A contiguous non-last-axis input is flattened in its existing layout and
-    the product of trailing dimensions is passed to :class:`ArgreduceKernel`
-    as ``inner_stride``.  Truly non-contiguous inputs retain the compatibility
-    fallback through ``movedim(...).contiguous()``.
-    """
-
-    def _get_or_create_strided_kernel(
-        self,
-        M: int,
-        N: int,
-        inner_stride: int,
-    ) -> object:
-        key = (M, N, inner_stride)
-        if key not in self._kernel_cache:
-            kernel_cls = self.kernel_map[self._kernel_key]
-            self._kernel_cache[key] = kernel_cls(
-                M,
-                N,
-                self._op_kind,
-                self.dtype,
-                inner_stride=inner_stride,
-                tune=self._tune,
-                **self._build_kernel_kwargs(),
-            )
-        return self._kernel_cache[key]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run argreduce with stride-aware input/output traversal."""
-        self._validate_input_tensor(x)
-        orig_shape = x.shape
-
-        if self.dim is None:
-            # torch.argmax/argmin(dim=None) use logical contiguous order.
-            N = x.numel()
-            M = 1
-            dim_info = list(range(x.ndim))
-            x_flat = x.contiguous().reshape(-1)
-            inner_stride = 1
-        else:
-            if self.dim < -x.ndim or self.dim >= x.ndim:
-                raise IndexError(
-                    f"Dimension out of range (expected to be in range of "
-                    f"[{-x.ndim}, {x.ndim - 1}], but got {self.dim})"
-                )
-            dim = self.dim % x.ndim
-            N = x.shape[dim]
-            M = prod(s for i, s in enumerate(x.shape) if i != dim)
-            dim_info = dim
-
-            if x.is_contiguous():
-                # Keep the original layout.  Adjacent output threads read
-                # adjacent elements for non-last-axis reductions.
-                inner_stride = prod(x.shape[dim + 1 :])
-                x_flat = x.reshape(-1)
-            else:
-                # Storage strides are not part of the public Kernel contract;
-                # compact unusual views once, then use the contiguous path.
-                if dim != x.ndim - 1:
-                    x = x.movedim(dim, -1)
-                x_flat = x.contiguous().reshape(-1)
-                inner_stride = 1
-
-        self._last_roofline_mn = (M, N)
-        kernel = self._get_or_create_strided_kernel(M, N, inner_stride)
-        y = kernel(x_flat)
-        return self._reshape_output(y, orig_shape, dim_info)
-
-
-class ArgmaxFwdOp(_ArgreduceOpBase):
+class ArgmaxFwdOp(_ReduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.  M and N are
@@ -102,6 +30,7 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
     _op_kind = "argmax"
     _kernel_key = "argreduce"
     _kernel_cls = ArgreduceKernel
+    _kernel_handles_padding = True
 
     def __init__(
         self,
@@ -136,7 +65,7 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
 
 
 
-class ArgminFwdOp(_ArgreduceOpBase):
+class ArgminFwdOp(_ReduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.  M and N are
@@ -156,6 +85,7 @@ class ArgminFwdOp(_ArgreduceOpBase):
     _op_kind = "argmin"
     _kernel_key = "argreduce"
     _kernel_cls = ArgreduceKernel
+    _kernel_handles_padding = True
 
     def __init__(
         self,

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -1,6 +1,9 @@
 """Arg-reduction operators (argmax, argmin)."""
 
-from typing import Dict, Optional
+from math import prod
+from typing import Dict, Optional, Tuple, Union
+
+import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction.argreduce import ArgreduceKernel
@@ -10,7 +13,45 @@ from .reduce import _ReduceOpBase
 __all__ = ["ArgmaxFwdOp", "ArgminFwdOp"]
 
 
-class ArgmaxFwdOp(_ReduceOpBase):
+class _ArgreduceOpBase(_ReduceOpBase):
+    """Reduce a non-last axis in place rather than transposing to reach it.
+
+    The base transposes so the reduction axis is last, which copies the whole
+    tensor. When the input is contiguous the copy is avoidable: the output axis
+    is the contiguous one, so a kernel that assigns a thread per output element
+    and strides along the reduction axis reads the original buffer coalesced.
+    Only the preparation differs, so that is all this overrides.
+    """
+
+    def _get_or_create_strided_kernel(self, M: int, N: int, inner_stride: int, dtype):
+        key = (M, N, dtype, inner_stride)
+        if key not in self._kernel_cache:
+            self._kernel_cache[key] = self.kernel_map[self._kernel_key](
+                M, N, self._op_kind, dtype, inner_stride=inner_stride,
+                tune=self._tune, **self._build_kernel_kwargs(),
+            )
+        return self._kernel_cache[key]
+
+    def _prepare_input(
+        self, x: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Size, Union[int, list], object]:
+        if self.dim is None or not x.is_contiguous():
+            return super()._prepare_input(x)
+        if self.dim < -x.ndim or self.dim >= x.ndim:
+            return super()._prepare_input(x)  # the base raises with the right message
+        dim = self.dim % x.ndim
+        inner_stride = prod(x.shape[dim + 1:])
+        if inner_stride == 1:
+            return super()._prepare_input(x)
+
+        N = x.shape[dim]
+        M = prod(s for i, s in enumerate(x.shape) if i != dim)
+        self._last_roofline_mn = (M, N)
+        kernel = self._get_or_create_strided_kernel(M, N, inner_stride, x.dtype)
+        return x.reshape(-1), x.shape, dim, kernel
+
+
+class ArgmaxFwdOp(_ArgreduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.  M and N are
@@ -65,7 +106,7 @@ class ArgmaxFwdOp(_ReduceOpBase):
 
 
 
-class ArgminFwdOp(_ReduceOpBase):
+class ArgminFwdOp(_ArgreduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.  M and N are

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -1,5 +1,6 @@
 """Arg-reduction operators (argmax, argmin)."""
 
+from math import prod
 from typing import Dict, Optional
 
 from tileops.kernels.kernel_base import Kernel
@@ -10,7 +11,78 @@ from .reduce import _ReduceOpBase
 __all__ = ["ArgmaxFwdOp", "ArgminFwdOp"]
 
 
-class ArgmaxFwdOp(_ReduceOpBase):
+class _ArgreduceOpBase(_ReduceOpBase):
+    """Prepare argreduce inputs without materializing a transposed tensor.
+
+    A contiguous non-last-axis input is flattened in its existing layout and
+    the product of trailing dimensions is passed to :class:`ArgreduceKernel`
+    as ``inner_stride``.  Truly non-contiguous inputs retain the compatibility
+    fallback through ``movedim(...).contiguous()``.
+    """
+
+    def _get_or_create_strided_kernel(
+        self,
+        M: int,
+        N: int,
+        inner_stride: int,
+    ) -> object:
+        key = (M, N, inner_stride)
+        if key not in self._kernel_cache:
+            kernel_cls = self.kernel_map[self._kernel_key]
+            self._kernel_cache[key] = kernel_cls(
+                M,
+                N,
+                self._op_kind,
+                self.dtype,
+                inner_stride=inner_stride,
+                tune=self._tune,
+                **self._build_kernel_kwargs(),
+            )
+        return self._kernel_cache[key]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run argreduce with stride-aware input/output traversal."""
+        self._validate_input_tensor(x)
+        orig_shape = x.shape
+
+        if self.dim is None:
+            # torch.argmax/argmin(dim=None) use logical contiguous order.
+            N = x.numel()
+            M = 1
+            dim_info = list(range(x.ndim))
+            x_flat = x.contiguous().reshape(-1)
+            inner_stride = 1
+        else:
+            if self.dim < -x.ndim or self.dim >= x.ndim:
+                raise IndexError(
+                    f"Dimension out of range (expected to be in range of "
+                    f"[{-x.ndim}, {x.ndim - 1}], but got {self.dim})"
+                )
+            dim = self.dim % x.ndim
+            N = x.shape[dim]
+            M = prod(s for i, s in enumerate(x.shape) if i != dim)
+            dim_info = dim
+
+            if x.is_contiguous():
+                # Keep the original layout.  Adjacent output threads read
+                # adjacent elements for non-last-axis reductions.
+                inner_stride = prod(x.shape[dim + 1 :])
+                x_flat = x.reshape(-1)
+            else:
+                # Storage strides are not part of the public Kernel contract;
+                # compact unusual views once, then use the contiguous path.
+                if dim != x.ndim - 1:
+                    x = x.movedim(dim, -1)
+                x_flat = x.contiguous().reshape(-1)
+                inner_stride = 1
+
+        self._last_roofline_mn = (M, N)
+        kernel = self._get_or_create_strided_kernel(M, N, inner_stride)
+        y = kernel(x_flat)
+        return self._reshape_output(y, orig_shape, dim_info)
+
+
+class ArgmaxFwdOp(_ArgreduceOpBase):
     """Argmax reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgmaxFwdOp(dim=None, keepdim=False)``.  M and N are
@@ -64,7 +136,7 @@ class ArgmaxFwdOp(_ReduceOpBase):
 
 
 
-class ArgminFwdOp(_ReduceOpBase):
+class ArgminFwdOp(_ArgreduceOpBase):
     """Argmin reduction along an arbitrary dim, returning int64 indices.
 
     Construction: ``ArgminFwdOp(dim=None, keepdim=False)``.  M and N are

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Tuple, Union
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction.argreduce import ArgreduceKernel
+from tileops.kernels.reduction.argreduce import _STRIDED_AXIS_MAX_N, ArgreduceKernel
 
 from .reduce import _ReduceOpBase
 
@@ -45,6 +45,11 @@ class _ArgreduceOpBase(_ReduceOpBase):
             return super()._prepare_input(x)
 
         N = x.shape[dim]
+        if N > _STRIDED_AXIS_MAX_N:
+            # A long axis is faster transposed and reduced in parallel than
+            # walked serially by one thread per output.
+            return super()._prepare_input(x)
+
         M = prod(s for i, s in enumerate(x.shape) if i != dim)
         self._last_roofline_mn = (M, N)
         kernel = self._get_or_create_strided_kernel(M, N, inner_stride, x.dtype)


### PR DESCRIPTION
Supersedes #1804. Closes the review findings on this branch.

## What changes

The shared-memory + serial-scan argreduce kernel is replaced by a single-pass `(value, index)` pair reduction that streams from global memory. Four layouts, chosen by shape:

| layout | when | why |
|---|---|---|
| warp | short rows | one row per subgroup |
| CTA | long rows, many of them | one block per row |
| multi-CTA | long rows, few of them | a block's serial scan dominates; split the row |
| output-parallel | non-last axis, contiguous | the output axis is the contiguous one, so read along it |

`ctas_per_row` is a tuning parameter, not a constant: the best split at N=102400 is 32 chunks at M=4, 16 at M=64 and 8 at M=256. The dispatch heuristic supplies only the untuned default.

## H200, CUPTI kernel time, manifest workloads, untuned

| workload | dtype | TileOPs | PyTorch | |
|---|---|---:|---:|---:|
| lm-head argmax/argmin (4, 102400) | fp16 | 0.0162 | 0.0357 | 2.20x |
| lm-head argmax/argmin (4, 102400) | bf16 | 0.0164 | 0.0362 | 2.21x |
| hidden-state argmax/argmin (2048, 4096) | fp16 | 0.0244 | 0.0252 | 1.04x |
| hidden-state argmax/argmin (2048, 4096) | bf16 | 0.0244 | 0.0254 | 1.04x |
| 3d non-last-axis argmax (4, 128, 4096) dim=0 | fp16 | 0.0061 | 0.0114 | 1.87x |

Every manifest workload beats PyTorch. The four LM-head cases go from unsupported to passing. Autotuning raises the lm-head case further (best split 32 rather than the default 16).

## Defects fixed during review

- **Two NaNs kept the wrong index.** Every comparison between two NaNs is false, so the ordering kept whichever lane merged first; a length-8 row with NaNs at 2 and 4 returned 4 where PyTorch returns 2.
- **The multi-CTA final pass dropped partials.** It read one per lane, so any split above 32 silently returned an index from the wrong chunk. The `min(32, ...)` in the dispatch was holding the invariant up without saying so.
- **`tune=True` raised on multi-CTA.** `block_m` belongs to the warp layout; the CTA kernel took it and never read it, and the multi-CTA kernel rejects it. Config spaces are filtered through the built kernel's signature now.
- **An `M < 64` threshold cost 4.9x.** Measured over a 5x3 grid of M and N; the block-per-row kernel is bound by its serial scan, so the rule reads that way.
- **An empty reduction dimension launched a zero-block grid** and crashed.

## Validation

`pytest tests/ops/ -m smoke`: 2597 passed, 16 skipped. `pytest tests/ops/test_argreduce.py`: 101 passed. `validate_manifest --strict`: clean.