### PR TITLE
[Fix][Bench] Stop initialising CUDA during benchmark collection, and say which file did

### DIFF
--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -85,13 +85,13 @@ def test_mean_pooling_bench(batch_size: int, seq_len: int, heads: int, dim: int,
     if offsets is not None:
         assert batch_size == 1
         assert offsets[-1] == seq_len
-        offsets = torch.tensor(offsets, dtype=torch.int32, device="cuda")
-        indices = prepare_chunk_indices(offsets, chunk_size)
+        offset_tensor = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+        indices = prepare_chunk_indices(offset_tensor, chunk_size)
         chunks_per_bacth = indices.shape[0]
-        seq_num = offsets.shape[0] - 1
+        seq_num = offset_tensor.shape[0] - 1
         use_offsets = 1
     else:
-        offsets = torch.arange(
+        offset_tensor = torch.arange(
             0, (batch_size + 1) * seq_len,
             seq_len,
             dtype=torch.int32,
@@ -121,7 +121,7 @@ def test_mean_pooling_bench(batch_size: int, seq_len: int, heads: int, dim: int,
         chunk_size=chunk_size, chunks_per_bacth=chunks_per_bacth,
         seq_num=seq_num, use_offsets=use_offsets,
         dtype=dtype, accum_dtype=accum_dtype,
-        offsets=offsets, indices=indices)
+        offsets=offset_tensor, indices=indices)
 
     bm = MeanPoolingBenchmark(test)
     inputs = test.gen_inputs()

--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import pytest
 import torch
@@ -64,12 +64,12 @@ _MEAN_POOLING_BENCH_PARAMS = [
     pytest.param(2, 2048, 64, 128, 64, torch.float16, torch.float32, True, None, id="dense-batched"),
     pytest.param(
         1, 8192, 64, 128, 64, torch.float16, torch.float32, True,
-        torch.tensor([0, 2048, 4096, 6144, 8192], dtype=torch.int32, device="cuda"),
+        [0, 2048, 4096, 6144, 8192],
         id="varlen-long",
     ),
     pytest.param(
         1, 1000, 64, 128, 32, torch.float16, torch.float32, True,
-        torch.tensor([0, 100, 300, 600, 1000], dtype=torch.int32, device="cuda"),
+        [0, 100, 300, 600, 1000],
         id="varlen-tail",
     ),
 ]
@@ -81,10 +81,11 @@ _MEAN_POOLING_BENCH_PARAMS = [
 )
 def test_mean_pooling_bench(batch_size: int, seq_len: int, heads: int, dim: int, chunk_size: int,
                             dtype: torch.dtype, accum_dtype: torch.dtype, tune: bool,
-                            offsets: Optional[torch.Tensor]) -> None:
+                            offsets: Optional[List[int]]) -> None:
     if offsets is not None:
         assert batch_size == 1
         assert offsets[-1] == seq_len
+        offsets = torch.tensor(offsets, dtype=torch.int32, device="cuda")
         indices = prepare_chunk_indices(offsets, chunk_size)
         chunks_per_bacth = indices.shape[0]
         seq_num = offsets.shape[0] - 1

--- a/scripts/ci/run_benchmarks.py
+++ b/scripts/ci/run_benchmarks.py
@@ -31,15 +31,20 @@ TEARDOWN_TIMEOUT_S = 120
 # = the bench file. prctl(PR_SET_PTRACER, parent) lets py-spy attach under
 # yama ptrace_scope=1. The collect-only pass runs while another file owns
 # the GPU, so it must stay GPU-silent; CUDA init happens after the stdin
-# grant. The exit code leaves via the pipe before interpreter teardown.
+# grant. A failing collect is marked in the log so the parent can attribute
+# it: the child cannot fail here for GPU reasons unless it broke that rule.
+# The exit code leaves via the pipe before interpreter teardown.
 _CHILD = """\
 import ctypes, os, sys
+
+_MARK = "COLLECT-FAILED"
 
 ctypes.CDLL(None).prctl(0x59616D61, os.getppid(), 0, 0, 0)
 
 import pytest
 
-pytest.main(["--collect-only", "-q", sys.argv[3]])
+if pytest.main(["--collect-only", "-q", sys.argv[3]]):
+    print("%s: collect-only failed before the GPU grant" % _MARK, flush=True)
 sys.stdin.readline()
 rc = int(pytest.main(sys.argv[2:]))
 os.write(int(sys.argv[1]), str(rc).encode())
@@ -205,6 +210,16 @@ def _fragment_suites(fragment: Path) -> list[ET.Element]:
     return list(root) if root.tag == "testsuites" else [root]
 
 
+COLLECT_FAILED_MARK = "COLLECT-FAILED"
+
+
+def _collect_failed(log_path: Path) -> bool:
+    """Did this child's collect-only pass fail, before it was granted the GPU?"""
+    with contextlib.suppress(OSError):
+        return COLLECT_FAILED_MARK in log_path.read_text(errors="replace")
+    return False
+
+
 def _log_tail(log_path: Path) -> str:
     return "".join(log_path.read_text(errors="replace").splitlines(keepends=True)[-LOG_TAIL_LINES:])
 
@@ -269,6 +284,7 @@ def main() -> int:
             return Child(_CHILD, argv, work_dir / f"{index:03d}.log")
 
         pending: deque[Child] = deque()
+        collect_failed: list[str] = []
         spawned = 0
 
         def top_up() -> None:
@@ -336,6 +352,8 @@ def main() -> int:
                         message = f"pytest exited with {rc} without writing results"
                         suites.append(_synthetic_suite(bench_file, message, _log_tail(log_path)))
                         failed.append(rel)
+                if _collect_failed(log_path):
+                    collect_failed.append(rel)
                 print(f"--- {rel} finished in {elapsed:.0f}s ---", flush=True)
                 _absorb_profile_log(profile_parts)
         finally:
@@ -349,6 +367,24 @@ def main() -> int:
 
     if profile_parts:
         Path("profile_run.log").write_text("\n".join(profile_parts))
+
+    if collect_failed:
+        if len(collect_failed) == len(bench_files):
+            print(
+                "\nevery file failed collect-only: the environment has no usable GPU,"
+                " or an import shared by all of them is broken",
+                flush=True,
+            )
+        else:
+            print(
+                f"\n{len(collect_failed)} file(s) failed collect-only while another file"
+                " owned the GPU. Collection must not initialise CUDA -- a module-level"
+                " CUDA tensor here can fail the whole sweep on a GPU in Exclusive_Process"
+                " mode, and perturbs the file being measured on a shared one:",
+                flush=True,
+            )
+        for rel in collect_failed:
+            print(f"  {rel}", flush=True)
 
     if failed:
         print(f"\n{len(failed)} benchmark file(s) failed:", flush=True)


### PR DESCRIPTION
`benchmarks/ops/bench_mean_pooling.py` built a CUDA tensor at module scope, inside a `pytest.param` entry. It was the only one of 60 bench files to do so.

That breaks a rule the runner states in its child preamble. `scripts/ci/run_benchmarks.py` keeps five children alive: with `--prewarm 4`, four have finished `pytest --collect-only` and are blocked on stdin while the fifth owns the GPU and is being measured. Collection must therefore stay GPU-silent. Importing that param list initialises CUDA, and neither failure mode points at the file responsible:

- `Exclusive_Process` GPU — the driver refuses the second context and the file being **measured** dies with `cudaErrorDevicesUnavailable`. A full sweep lost to what reads as a CUDA fault.
- shared GPU — no error; the prewarmed child just holds a context while another file is timed.

A `cu_seqlens` boundary table is a parameter, not data: it is now a plain list, converted inside the test body.

## Attribution

The child discarded its collect-only exit code, so this left nothing the parent could report. It now writes `TILEOPS_COLLECT_STATUS` — `"started"` before the pass, then the exit code — giving three distinguishable outcomes: died before collection, died during it, or exited with a code outside `(0, 5)`, the pair the runner already accepts. The summary states only what the code proves and offers CUDA init as one possible cause. No new gate, and no behaviour change: a failing collect already reached the report through the second pytest run.

## Validation

- `CUDA_VISIBLE_DEVICES="" pytest --collect-only -q benchmarks/ops/bench_mean_pooling.py` — was `1 error`, now `4 tests collected`.
- `CUDA_VISIBLE_DEVICES=2 pytest -q benchmarks/ops/bench_mean_pooling.py` — 4 passed, `tileops` and `torch-ref` rows unchanged including the derived columns.
- Runner exercised against probe files for each outcome: a broken import is named with its exit code; a file killed mid-collection reports `died during collection`; a file collecting nothing (exit 5) and a file whose node id contains the old marker string are both left alone. Then a clean run over two real bench files — `all benchmark files passed`.
- `ruff check .` clean.
