### PR TITLE
[Refactor][Ops] Keep pad/slice adaptation on the kernel side

### DIFF
--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -9,6 +9,7 @@ One ``test_*_bench`` per op, so the validator's L4 AST check can tie each
 ``load_workloads("<OpName>")`` call to its manifest entry.
 """
 
+from dataclasses import asdict, dataclass
 from typing import Callable, Optional
 
 import pytest
@@ -42,13 +43,30 @@ class ConvWorkload:
         self.dtype = dtype
 
 
+@dataclass(frozen=True)
+class ConvCase:
+    """One manifest workload row, resolved to concrete convolution arguments."""
+
+    input_shape: tuple[int, ...]
+    c_out: int
+    kernel_size: tuple[int, ...]
+    stride: tuple[int, ...]
+    padding: tuple[int, ...]
+    dilation: tuple[int, ...]
+    groups: int
+    dtype: torch.dtype
+
+    def as_record(self) -> dict:
+        return asdict(self)
+
+
 def _mark(idx: int):
     """First manifest workload of an op is the smoke case; the rest are full."""
     return pytest.mark.smoke if idx == 0 else pytest.mark.full
 
 
 def _conv_params(workloads: list[dict], kernel_keys: tuple[str, ...]) -> list:
-    """Build ``(input_shape, c_out, kernel_size, stride, padding, dtype)`` params.
+    """Build one :class:`ConvCase` parameter per manifest workload row and dtype.
 
     ``kernel_keys`` names the manifest spatial-extent keys in order, e.g.
     ``("kD", "kH", "kW")`` for 3d. Workload entries omitting ``stride`` /
@@ -72,8 +90,10 @@ def _conv_params(workloads: list[dict], kernel_keys: tuple[str, ...]) -> list:
         groups = w.get("groups", 1)
         for dtype_name in w["dtypes"]:
             params.append(pytest.param(
-                input_shape, w["C_out"], kernel_size, stride, padding,
-                dilation, groups, getattr(torch, dtype_name),
+                ConvCase(
+                    input_shape, w["C_out"], kernel_size, stride, padding,
+                    dilation, groups, getattr(torch, dtype_name),
+                ),
                 id=f"{w['label']}-{dtype_name}",
                 marks=_mark(idx),
             ))
@@ -124,6 +144,30 @@ def _torch_conv_baseline(
     return baseline_fn
 
 
+def _run_conv(
+    op,
+    bm: ManifestBenchmark,
+    torch_fn: Callable,
+    case: ConvCase,
+    *,
+    with_bias: bool,
+) -> None:
+    """Profile op and its torch baseline on the same inputs, recording both.
+
+    One caller per manifest op, so each keeps a literal
+    ``ManifestBenchmark(<op name>, ...)`` the manifest validator matches
+    statically.
+    """
+    inputs = _conv_inputs(
+        case.input_shape, case.c_out, case.kernel_size, case.dtype,
+        groups=case.groups, with_bias=with_bias,
+    )
+    baseline = _torch_conv_baseline(
+        torch_fn, case.stride, case.padding, case.dilation, case.groups,
+    )
+    _profile_conv(op, bm, inputs, baseline, case.as_record())
+
+
 def _profile_conv(
     op,
     bm: ManifestBenchmark,
@@ -146,64 +190,32 @@ _CONV1D_KERNEL_KEYS = ("kW",)
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV1D_OP), _CONV1D_KERNEL_KEYS),
 )
-def test_conv1d_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=False)
+def test_conv1d_bench(case: ConvCase) -> None:
     op = Conv1dFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV1D_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv1d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV1D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv1d, case, with_bias=False)
 
 
 _CONV1D_BIAS_OP = "Conv1dBiasFwdOp"
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV1D_BIAS_OP), _CONV1D_KERNEL_KEYS),
 )
-def test_conv1d_bias_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=True)
+def test_conv1d_bias_bench(case: ConvCase) -> None:
     op = Conv1dBiasFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV1D_BIAS_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv1d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV1D_BIAS_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv1d, case, with_bias=True)
 
 
 # Conv2d
@@ -213,64 +225,32 @@ _CONV2D_KERNEL_KEYS = ("kH", "kW")
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV2D_OP), _CONV2D_KERNEL_KEYS),
 )
-def test_conv2d_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=False)
+def test_conv2d_bench(case: ConvCase) -> None:
     op = Conv2dFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV2D_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv2d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV2D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv2d, case, with_bias=False)
 
 
 _CONV2D_BIAS_OP = "Conv2dBiasFwdOp"
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV2D_BIAS_OP), _CONV2D_KERNEL_KEYS),
 )
-def test_conv2d_bias_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=True)
+def test_conv2d_bias_bench(case: ConvCase) -> None:
     op = Conv2dBiasFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV2D_BIAS_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv2d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV2D_BIAS_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv2d, case, with_bias=True)
 
 
 # Conv3d
@@ -280,64 +260,32 @@ _CONV3D_KERNEL_KEYS = ("kD", "kH", "kW")
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV3D_OP), _CONV3D_KERNEL_KEYS),
 )
-def test_conv3d_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=False)
+def test_conv3d_bench(case: ConvCase) -> None:
     op = Conv3dFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV3D_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv3d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV3D_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv3d, case, with_bias=False)
 
 
 _CONV3D_BIAS_OP = "Conv3dBiasFwdOp"
 
 
 @pytest.mark.parametrize(
-    "input_shape, c_out, kernel_size, stride, padding, dilation, groups, dtype",
+    "case",
     _conv_params(load_workloads(_CONV3D_BIAS_OP), _CONV3D_KERNEL_KEYS),
 )
-def test_conv3d_bias_bench(
-    input_shape: tuple[int, ...],
-    c_out: int,
-    kernel_size: tuple[int, ...],
-    stride: tuple[int, ...],
-    padding: tuple[int, ...],
-    dilation: tuple[int, ...],
-    groups: int,
-    dtype: torch.dtype,
-) -> None:
-    inputs = _conv_inputs(input_shape, c_out, kernel_size, dtype,
-                          groups=groups, with_bias=True)
+def test_conv3d_bias_bench(case: ConvCase) -> None:
     op = Conv3dBiasFwdOp(
-        stride=stride, padding=padding,
-        dilation=dilation, groups=groups, tune=_TUNE,
+        stride=case.stride, padding=case.padding,
+        dilation=case.dilation, groups=case.groups, tune=_TUNE,
     )
-    bm = ManifestBenchmark(_CONV3D_BIAS_OP, op, ConvWorkload(input_shape, dtype))
-    _profile_conv(
-        op, bm, inputs, _torch_conv_baseline(F.conv3d, stride, padding, dilation, groups),
-        {"input_shape": input_shape, "c_out": c_out, "kernel_size": kernel_size,
-         "stride": stride, "padding": padding, "dilation": dilation,
-         "groups": groups, "dtype": dtype},
-    )
+    bm = ManifestBenchmark(_CONV3D_BIAS_OP, op, ConvWorkload(case.input_shape, case.dtype))
+    _run_conv(op, bm, F.conv3d, case, with_bias=True)
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -10,6 +10,7 @@ from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
 from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
 from tileops.ops.ssd_decode import SSDDecodeOp
 from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
+from tileops.testing.mamba2_reference import ssd_chunk_scan_fwd_ref
 from workloads.mamba import (
     DaCumsumFwdFixture,
     DaCumsumFwdWorkload,
@@ -149,66 +150,6 @@ def test_da_cumsum_fwd_bench(batch, num_chunks, chunk_len, n_heads, has_dt_bias,
         BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
 
 
-def ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups):
-    """Official-aligned PyTorch reference for chunk scan.
-
-    Inputs (official layouts):
-      x:           [B, S, H, P]        dtype
-      cb:          [B, C, G, L, L]     dtype    group-owned
-      dA_cumsum:   [B, H, C, L]        float32
-      C:           [B, S, G, N]        dtype    group-owned
-      prev_states: [B, C, H, P, N]     dtype    P before N
-      dt:          [B, H, C, L]        dtype
-
-    Output: [B, S, H, P]  float32
-    """
-    b, S, h, p = x.shape
-    _, _, c, L = dA_cumsum.shape
-    n = C.shape[-1]
-    g = n_groups
-    heads_per_group = h // g
-
-    x_chunked = x.float().reshape(b, c, L, h, p)             # [B, C, L, H, P]
-    C_chunked = C.float().reshape(b, c, L, g, n)              # [B, C, L, G, N]
-    # broadcast C from groups to heads: [B, C, L, H, N]
-    C_heads = C_chunked[:, :, :, torch.arange(h, device=x.device) // heads_per_group, :]
-
-    # dA_cumsum: [B, H, C, L] -> [B, C, L, H] for broadcast
-    dA = dA_cumsum.float().permute(0, 2, 3, 1)  # [B, C, L, H]
-
-    # --- History path: exp(dA_l) * C[l] @ prev_states[p, n] ---
-    # prev_states: [B, C, H, P, N]
-    # C_heads:     [B, C, L, H, N] -> einsum over n: [B, C, L, H, P]
-    y_off = torch.einsum("bclhn,bchpn->bclhp", C_heads, prev_states.float())
-    y_off = y_off * torch.exp(dA).unsqueeze(-1)  # scale by exp(dA_l)
-
-    # --- Intra-chunk path: sum_{s<=l} cb[l,s] * exp(dA_l - dA_s) * dt[s] * x[s] ---
-    # cb: [B, C, G, L, L]; broadcast to heads [B, C, H, L, L]
-    cb_chunked = cb.float()  # [B, C, G, L, L]
-    cb_heads = cb_chunked[:, :, torch.arange(h, device=x.device) // heads_per_group, :, :]
-
-    # decay[b,c,h,l,s] = exp(dA_cumsum[l] - dA_cumsum[s])
-    dA_l = dA_cumsum.float().unsqueeze(-1)  # [B, H, C, L, 1]
-    dA_s = dA_cumsum.float().unsqueeze(-2)  # [B, H, C, 1, L]
-    decay = torch.exp(dA_l - dA_s)         # [B, H, C, L, L]
-
-    # causal mask
-    mask = torch.tril(torch.ones(L, L, device=x.device, dtype=torch.bool))
-    decay = decay.masked_fill(~mask.unsqueeze(0).unsqueeze(0).unsqueeze(0), 0.0)
-    decay = decay.permute(0, 2, 1, 3, 4)   # [B, C, H, L, L]
-
-    # dt: [B, H, C, L] -> [B, C, H, 1, L]
-    dt_s = dt.float().permute(0, 2, 1, 3).unsqueeze(-2)  # [B, C, H, 1, L]
-
-    # lcb[b,c,h,l,s] = cb[l,s] * decay[l,s] * dt[s]
-    lcb = cb_heads * decay * dt_s  # [B, C, H, L, L]
-
-    # y_diag[b,c,l,h,p] = sum_s lcb[b,c,h,l,s] * x[b,c,s,h,p]
-    y_diag = torch.einsum("bchls,bcshp->bclhp", lcb, x_chunked)
-
-    # combine and reshape to [B, S, H, P]
-    out = (y_off + y_diag).reshape(b, S, h, p)
-    return out
 
 
 class SSDChunkScanFwdBenchmark(BenchmarkBase[SSDChunkScanFwdWorkload]):

--- a/benchmarks/ops/bench_mhc.py
+++ b/benchmarks/ops/bench_mhc.py
@@ -5,7 +5,6 @@ manifest; roofline FLOP and byte counts come from each op's
 ``eval_roofline()`` via :class:`ManifestBenchmark`.
 """
 
-import math
 
 import pytest
 import torch
@@ -17,6 +16,7 @@ from benchmarks.benchmark_base import (
 )
 from tileops.manifest import load_workloads
 from tileops.ops import MHCPostOp, MHCPreOp
+from tileops.testing.mhc_reference import mhc_post_ref, mhc_pre_ref
 from workloads.mhc import MHCPostWorkload, MHCPreWorkload
 
 # Autotuning is a bench-run policy, not a workload property; manifest
@@ -34,53 +34,10 @@ class MHCPreTestBaseline(MHCPreWorkload):
     def ref_program(self, phi: torch.Tensor, x: torch.Tensor, b: torch.Tensor,
                     alpha_pre, alpha_post, alpha_res,
                     sinkhorn_repeat: int, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
-        batch = self.batch
-        n_expand = self.n_expand
-        c_x = self.c_x
-
-        xsqr = x * x
-        norm_eps = 0.0001
-        r_ref = torch.sqrt(xsqr.sum(dim=1)) / math.sqrt(n_expand * c_x) + norm_eps
-        H = torch.zeros([batch, n_expand * n_expand + 2 * n_expand],
-                        device="cuda", dtype=torch.float)
-        for i in range(batch):
-            H[i, :] = x[i, :].float() @ phi
-
-        H_pre_ref = H[:, :n_expand]
-        H_res_ref = H[:, 2 * n_expand:]
-        H_res_ref = H_res_ref.reshape(batch, n_expand, n_expand)
-
-        b_pre_ref = b[:n_expand]
-        b_res_ref = b[2 * n_expand:]
-        b_res_ref = b_res_ref.reshape([n_expand, n_expand])
-
-        H_pre_ref = torch.sigmoid(alpha_pre * H_pre_ref / r_ref.unsqueeze(-1) + b_pre_ref)
-        H_res_ref = alpha_res * H_res_ref / r_ref.unsqueeze(-1).unsqueeze(-1) + b_res_ref
-
-        H_res_ref_tmp = H_res_ref.max(dim=-1, keepdim=True).values
-
-        H_res_ref = torch.exp(H_res_ref - H_res_ref_tmp)
-        for _i in range(sinkhorn_repeat):
-            H_res_ref = H_res_ref / (H_res_ref.sum(dim=-1, keepdim=True) + eps)
-            H_res_ref = H_res_ref / (H_res_ref.sum(dim=-2, keepdim=True) + eps)
-        x_in_reshaped = x.reshape([batch, n_expand, c_x])
-        x_res_ref = torch.zeros([batch, n_expand, c_x], device="cuda", dtype=torch.bfloat16)
-        x_layer_ref = torch.zeros([batch, c_x], device="cuda", dtype=torch.bfloat16)
-
-        h_res_ref = H_res_ref
-        h_pre_ref = H_pre_ref
-        for i in range(batch):
-            h_res_tmp = h_res_ref[i, :, :].float()
-            h_pre_tmp = h_pre_ref[i, :].float()
-            x_in_reshaped_tmp = x_in_reshaped[i, :, :].float()
-            x_res_ref[i, :, :] = h_res_tmp @ x_in_reshaped_tmp
-            x_layer_ref[i, :] = h_pre_tmp @ x_in_reshaped_tmp
-
-        x_res_ref = x_res_ref.reshape(batch, n_expand * c_x)
-
-        x_res_ref = x_res_ref.bfloat16()
-        x_layer_ref = x_layer_ref.bfloat16()
-        return x_res_ref, x_layer_ref
+        return mhc_pre_ref(
+            self.batch, self.n_expand, self.c_x,
+            phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat, eps,
+        )
 
 
 _MHC_PRE_OP = "MHCPreOp"
@@ -118,14 +75,9 @@ class MHCPostTestBaseline(MHCPostWorkload):
 
     def ref_program(self, x_layer_out: torch.Tensor, h_post: torch.Tensor,
                     x_res: torch.Tensor) -> torch.Tensor:
-        batch = self.batch
-        n_expand = self.n_expand
-        c_x = self.c_x
-
-        x_out_ref = (h_post.unsqueeze(2).float() @ x_layer_out.unsqueeze(1).float()).reshape(
-            batch, n_expand * c_x) + x_res.float()
-        x_out_ref = x_out_ref.bfloat16()
-        return x_out_ref
+        return mhc_post_ref(
+            self.batch, self.n_expand, self.c_x, x_layer_out, h_post, x_res,
+        )
 
 
 _MHC_POST_OP = "MHCPostOp"

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -40,6 +40,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import tileops.manifest as manifest_pkg  # noqa: E402
+from tileops.manifest.dtype_rules import PROMOTE_INT_TO_FLOAT_RE, SAME_AS_RE  # noqa: E402
 from tileops.manifest.shape_rules import (  # noqa: E402
     dim_range_validity,
     dim_uniqueness,
@@ -58,12 +59,10 @@ _TORCH_DTYPES = {
     "float8_e4m3", "float8_e5m2fnuz", "float8_e4m3fnuz",
 }
 
-_SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
 # ``promote_int_to_float(ref)``: ``float32`` for integral ``ref``, else
 # ``same_as(ref)``. Models PyTorch int-input promotion (``torch.reciprocal``).
-_PROMOTE_INT_TO_FLOAT_RE = re.compile(
-    r"^promote_int_to_float\(\s*(\w+)\s*\)$"
-)
+_SAME_AS_RE = SAME_AS_RE
+_PROMOTE_INT_TO_FLOAT_RE = PROMOTE_INT_TO_FLOAT_RE
 
 # Integral torch dtypes that ``promote_int_to_float`` rewrites to ``float32``.
 # Restricted to the dtypes PyTorch's int-input promotion treats as integral
@@ -1072,6 +1071,10 @@ def _parse_dtype_expr(dtype_str: str) -> list[str]:
 
     Handles: "float16", "float16 | bfloat16", "same_as(x)".
     Returns list of raw tokens (may include same_as references).
+
+    Empty tokens are kept, unlike ``manifest.dtype_rules.parse_tokens``: a
+    trailing or doubled ``|`` must surface downstream as an unknown-dtype
+    error rather than being silently dropped.
     """
     return [t.strip() for t in dtype_str.split("|")]
 

--- a/start-runner.sh
+++ b/start-runner.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-CUDA_VISIBLE_DEVICES=4 ./start-fork-runner-once.sh

--- a/start-runner.sh
+++ b/start-runner.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+CUDA_VISIBLE_DEVICES=4 ./start-fork-runner-once.sh

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -10,7 +10,10 @@ from tileops.ops.ssd_chunk_scan import SSDChunkScanFwdOp
 from tileops.ops.ssd_chunk_state import SSDChunkStateFwdOp
 from tileops.ops.ssd_decode import SSDDecodeOp
 from tileops.ops.ssd_state_passing import SSDStatePassingFwdOp
-from tileops.testing.mamba2_reference import mamba2_fwd_ref
+from tileops.testing.mamba2_reference import (
+    mamba2_fwd_ref,
+    ssd_chunk_scan_fwd_ref,
+)
 from workloads.mamba import (
     DaCumsumFwdFixture,
     DaCumsumFwdWorkload,
@@ -167,66 +170,6 @@ def test_da_cumsum_fwd_missing_bias_raises():
         kernel(dt, A, dt_bias=None)
 
 
-def ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups):
-    """Official-aligned PyTorch reference for chunk scan.
-
-    Inputs (official layouts):
-      x:           [B, S, H, P]        dtype
-      cb:          [B, C, G, L, L]     dtype    group-owned
-      dA_cumsum:   [B, H, C, L]        float32
-      C:           [B, S, G, N]        dtype    group-owned
-      prev_states: [B, C, H, P, N]     float32  P before N
-      dt:          [B, H, C, L]        dtype
-
-    Output: [B, S, H, P]  float32
-    """
-    b, S, h, p = x.shape
-    _, _, c, L = dA_cumsum.shape
-    n = C.shape[-1]
-    g = n_groups
-    heads_per_group = h // g
-
-    x_chunked = x.float().reshape(b, c, L, h, p)             # [B, C, L, H, P]
-    C_chunked = C.float().reshape(b, c, L, g, n)              # [B, C, L, G, N]
-    # broadcast C from groups to heads: [B, C, L, H, N]
-    C_heads = C_chunked[:, :, :, torch.arange(h, device=x.device) // heads_per_group, :]
-
-    # dA_cumsum: [B, H, C, L] -> [B, C, L, H] for broadcast
-    dA = dA_cumsum.float().permute(0, 2, 3, 1)  # [B, C, L, H]
-
-    # --- History path: exp(dA_l) * C[l] @ prev_states[p, n] ---
-    # prev_states: [B, C, H, P, N]
-    # C_heads:     [B, C, L, H, N] -> einsum over n: [B, C, L, H, P]
-    y_off = torch.einsum("bclhn,bchpn->bclhp", C_heads, prev_states.float())
-    y_off = y_off * torch.exp(dA).unsqueeze(-1)  # scale by exp(dA_l)
-
-    # --- Intra-chunk path: sum_{s<=l} cb[l,s] * exp(dA_l - dA_s) * dt[s] * x[s] ---
-    # cb: [B, C, G, L, L]; broadcast to heads [B, C, H, L, L]
-    cb_chunked = cb.float()  # [B, C, G, L, L]
-    cb_heads = cb_chunked[:, :, torch.arange(h, device=x.device) // heads_per_group, :, :]
-
-    # decay[b,c,h,l,s] = exp(dA_cumsum[l] - dA_cumsum[s])
-    dA_l = dA_cumsum.float().unsqueeze(-1)  # [B, H, C, L, 1]
-    dA_s = dA_cumsum.float().unsqueeze(-2)  # [B, H, C, 1, L]
-    decay = torch.exp(dA_l - dA_s)         # [B, H, C, L, L]
-
-    # causal mask
-    mask = torch.tril(torch.ones(L, L, device=x.device, dtype=torch.bool))
-    decay = decay.masked_fill(~mask.unsqueeze(0).unsqueeze(0).unsqueeze(0), 0.0)
-    decay = decay.permute(0, 2, 1, 3, 4)   # [B, C, H, L, L]
-
-    # dt: [B, H, C, L] -> [B, C, H, 1, L]
-    dt_s = dt.float().permute(0, 2, 1, 3).unsqueeze(-2)  # [B, C, H, 1, L]
-
-    # lcb[b,c,h,l,s] = cb[l,s] * decay[l,s] * dt[s]
-    lcb = cb_heads * decay * dt_s  # [B, C, H, L, L]
-
-    # y_diag[b,c,l,h,p] = sum_s lcb[b,c,h,l,s] * x[b,c,s,h,p]
-    y_diag = torch.einsum("bchls,bcshp->bclhp", lcb, x_chunked)
-
-    # combine and reshape to [B, S, H, P]
-    out = (y_off + y_diag).reshape(b, S, h, p)
-    return out
 
 
 class SSDChunkScanFwdTest(SSDChunkScanFwdWorkload, TestBase):

--- a/tests/ops/test_mhc.py
+++ b/tests/ops/test_mhc.py
@@ -1,6 +1,5 @@
 """Tests for the MHC pre/post ops."""
 
-import math
 
 import pytest
 import torch
@@ -8,6 +7,7 @@ import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops import MHCPostOp, MHCPreOp
+from tileops.testing.mhc_reference import mhc_post_ref, mhc_pre_ref
 from workloads.mhc import MHCPostWorkload, MHCPreWorkload
 
 
@@ -15,53 +15,10 @@ class MHCPreTest(MHCPreWorkload, TestBase):
     def ref_program(self, phi: torch.Tensor, x: torch.Tensor, b: torch.Tensor,
                     alpha_pre, alpha_post, alpha_res,
                     sinkhorn_repeat: int, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
-        batch = self.batch
-        n_expand = self.n_expand
-        c_x = self.c_x
-
-        xsqr = x * x
-        norm_eps = 0.0001
-        r_ref = torch.sqrt(xsqr.sum(dim=1)) / math.sqrt(n_expand * c_x) + norm_eps
-        H = torch.zeros([batch, n_expand * n_expand + 2 * n_expand],
-                        device="cuda", dtype=torch.float)
-        for i in range(batch):
-            H[i, :] = x[i, :].float() @ phi
-
-        H_pre_ref = H[:, :n_expand]
-        H_res_ref = H[:, 2 * n_expand:]
-        H_res_ref = H_res_ref.reshape(batch, n_expand, n_expand)
-
-        b_pre_ref = b[:n_expand]
-        b_res_ref = b[2 * n_expand:]
-        b_res_ref = b_res_ref.reshape([n_expand, n_expand])
-
-        H_pre_ref = torch.sigmoid(alpha_pre * H_pre_ref / r_ref.unsqueeze(-1) + b_pre_ref)
-        H_res_ref = alpha_res * H_res_ref / r_ref.unsqueeze(-1).unsqueeze(-1) + b_res_ref
-
-        H_res_ref_tmp = H_res_ref.max(dim=-1, keepdim=True).values
-
-        H_res_ref = torch.exp(H_res_ref - H_res_ref_tmp)
-        for _i in range(sinkhorn_repeat):
-            H_res_ref = H_res_ref / (H_res_ref.sum(dim=-1, keepdim=True) + eps)
-            H_res_ref = H_res_ref / (H_res_ref.sum(dim=-2, keepdim=True) + eps)
-        x_in_reshaped = x.reshape([batch, n_expand, c_x])
-        x_res_ref = torch.zeros([batch, n_expand, c_x], device="cuda", dtype=torch.bfloat16)
-        x_layer_ref = torch.zeros([batch, c_x], device="cuda", dtype=torch.bfloat16)
-
-        h_res_ref = H_res_ref
-        h_pre_ref = H_pre_ref
-        for i in range(batch):
-            h_res_tmp = h_res_ref[i, :, :].float()
-            h_pre_tmp = h_pre_ref[i, :].float()
-            x_in_reshaped_tmp = x_in_reshaped[i, :, :].float()
-            x_res_ref[i, :, :] = h_res_tmp @ x_in_reshaped_tmp
-            x_layer_ref[i, :] = h_pre_tmp @ x_in_reshaped_tmp
-
-        x_res_ref = x_res_ref.reshape(batch, n_expand * c_x)
-
-        x_res_ref = x_res_ref.bfloat16()
-        x_layer_ref = x_layer_ref.bfloat16()
-        return x_res_ref, x_layer_ref
+        return mhc_pre_ref(
+            self.batch, self.n_expand, self.c_x,
+            phi, x, b, alpha_pre, alpha_post, alpha_res, sinkhorn_repeat, eps,
+        )
 
 
 class MHCPreFixture(FixtureBase):
@@ -92,14 +49,9 @@ def test_mhc_pre_op(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
 class MHCPostTest(MHCPostWorkload, TestBase):
     def ref_program(self, x_layer_out: torch.Tensor, h_post: torch.Tensor,
                     x_res: torch.Tensor) -> torch.Tensor:
-        batch = self.batch
-        n_expand = self.n_expand
-        c_x = self.c_x
-
-        x_out_ref = (h_post.unsqueeze(2).float() @ x_layer_out.unsqueeze(1).float()).reshape(
-            batch, n_expand * c_x) + x_res.float()
-        x_out_ref = x_out_ref.bfloat16()
-        return x_out_ref
+        return mhc_post_ref(
+            self.batch, self.n_expand, self.c_x, x_layer_out, h_post, x_res,
+        )
 
 
 class MHCPostFixture(FixtureBase):

--- a/tileops/kernels/attention/_config.py
+++ b/tileops/kernels/attention/_config.py
@@ -1,0 +1,18 @@
+"""Shared autotune search spaces for the attention kernels."""
+
+import itertools
+
+_BLOCK_M = (32, 64, 128)
+_BLOCK_N = (32, 64, 128)
+_NUM_STAGES = (1, 2, 3)
+_THREADS = (128, 256)
+
+
+def tile_stage_thread_configs() -> list[dict]:
+    """The default GQA search space: block_m x block_n x num_stages x threads."""
+    return [
+        {"block_m": bm, "block_n": bn, "num_stages": ns, "threads": th}
+        for bm, bn, ns, th in itertools.product(
+            _BLOCK_M, _BLOCK_N, _NUM_STAGES, _THREADS,
+        )
+    ]

--- a/tileops/kernels/attention/gqa_bwd.py
+++ b/tileops/kernels/attention/gqa_bwd.py
@@ -9,6 +9,8 @@ import torch
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.online_softmax import LOG2E
 
+from ._config import tile_stage_thread_configs
+
 __all__ = [
     'FlashAttnBwdPostprocessKernel',
     'FlashAttnBwdPreprocessKernel',
@@ -267,18 +269,7 @@ class MHABwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, *inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, ...]:
         return self.kernel(**self.config)(*inputs)
@@ -616,18 +607,7 @@ class GQABwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, *inputs: Tuple[torch.Tensor, ...]) -> Tuple[torch.Tensor, ...]:
         return self.kernel(**self.config)(*inputs)

--- a/tileops/kernels/attention/gqa_fwd.py
+++ b/tileops/kernels/attention/gqa_fwd.py
@@ -1,5 +1,4 @@
 import functools
-import itertools
 from typing import Callable, Optional, Tuple
 
 import tilelang
@@ -15,6 +14,8 @@ from tileops.kernels.online_softmax import (
     make_online_softmax_with_mask_guard,
     make_rescale,
 )
+
+from ._config import tile_stage_thread_configs
 
 __all__ = [
     'GQAFwdKernel',
@@ -208,18 +209,7 @@ class MHAFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor,
                 v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -401,17 +391,7 @@ class MHAFwdWgmmaPipelinedKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor,
                 v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -587,18 +567,7 @@ class GQAFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor,
                 v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -801,17 +770,7 @@ class GQAFwdWgmmaPipelinedKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor,
                 v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1064,18 +1023,7 @@ class GQAPrefillFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k: torch.Tensor,
                 v: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1387,18 +1335,7 @@ class GQAPrefillWithKVCacheFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_cache: torch.Tensor, v_cache: torch.Tensor,
@@ -1772,18 +1709,7 @@ class GQAPrefillWithKVCacheRopeFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_cache: torch.Tensor, v_cache: torch.Tensor, cache_seqlens: torch.Tensor,
@@ -2135,18 +2061,7 @@ class GQAPrefillPagedWithKVCacheFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, cu_seqlens_q: torch.Tensor,
@@ -2524,18 +2439,7 @@ class GQAPrefillPagedWithFP8KVCacheFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, k_scale: torch.Tensor,
@@ -3052,18 +2956,7 @@ class GQAPrefillPagedWithKVCacheRopeFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        block_m = [32, 64, 128]
-        block_n = [32, 64, 128]
-        num_stages = [1, 2, 3]
-        threads = [128, 256]
-        _configs = list(itertools.product(block_m, block_n, num_stages, threads))
-
-        return [{
-            'block_m': c[0],
-            'block_n': c[1],
-            'num_stages': c[2],
-            'threads': c[3]
-        } for c in _configs]
+        return tile_stage_thread_configs()
 
     def forward(self, q: torch.Tensor, k_new: torch.Tensor, v_new: torch.Tensor,
                 k_pages: torch.Tensor, v_pages: torch.Tensor, cu_seqlens_q: torch.Tensor,

--- a/tileops/kernels/convolution.py
+++ b/tileops/kernels/convolution.py
@@ -24,6 +24,30 @@ __all__ = [
 
 # Shared helpers
 
+def conv_autotune_configs(
+    dtype,
+    *,
+    block_m=(32, 64, 128),
+    block_n=(64, 128, 256),
+    block_k=(32, 64, 128),
+    num_stages=(2, 3),
+    threads=(128, 256),
+) -> list[dict]:
+    """Search space filtered to combinations that fit in shared memory."""
+    limit = get_shared_memory_limit_bytes()
+    valid = []
+    for bm, bn, bk, ns, th in itertools.product(
+        block_m, block_n, block_k, num_stages, threads,
+    ):
+        if conv_shared_memory_bytes(bm, bn, bk, ns, dtype) > limit:
+            continue
+        valid.append({
+            "block_m": bm, "block_n": bn, "block_k": bk,
+            "num_stages": ns, "threads": th, "enable_rasterization": True,
+        })
+    return valid
+
+
 def get_shared_memory_limit_bytes() -> int:
     return torch.cuda.get_device_properties(
         torch.cuda.current_device()
@@ -695,30 +719,7 @@ class Conv1dPointwiseKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [32, 64, 128],
-            [64, 128, 256],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
-        )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
+        return conv_autotune_configs(self.dtype)
 
     def forward(
         self,
@@ -822,30 +823,7 @@ class Conv1dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [32, 64, 128],
-            [64, 128, 256],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
-        )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
+        return conv_autotune_configs(self.dtype)
 
     def _get_weight_flat(self, weight: torch.Tensor) -> torch.Tensor:
         weight_version = weight._version
@@ -1031,30 +1009,10 @@ class GroupConv1dKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         if self.use_direct:
             return [self.default_config]
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            self._block_m_choices,
-            [64, 128, 256],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
+        return conv_autotune_configs(
+            self.dtype,
+            block_m=self._block_m_choices,
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
 
     def forward(
         self,
@@ -1963,33 +1921,12 @@ class Conv2dSymmetricKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [64, 128],
-            [64, 128, 256],
-            [16, 32, 64],
-            [2, 3],
-            [128, 256],
-            [True],
+        configs = conv_autotune_configs(
+            self.dtype,
+            block_m=[64, 128],
+            block_k=[16, 32, 64],
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            if self.c_in % block_k != 0:
-                continue
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype
-            )
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
+        return [c for c in configs if self.c_in % c["block_k"] == 0]
 
     def forward(
         self,
@@ -2136,30 +2073,11 @@ class Conv2dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [64, 128],
-            [64, 128, 256],
-            [64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
+        return conv_autotune_configs(
+            self.dtype,
+            block_m=[64, 128],
+            block_k=[64, 128],
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
 
     def forward(
         self,
@@ -2302,30 +2220,7 @@ class GroupConv2dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [32, 64, 128],
-            [64, 128, 256],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
-        )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
+        return conv_autotune_configs(self.dtype)
 
     def forward(
         self,
@@ -2445,30 +2340,10 @@ class Conv2d1x1Kernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [64, 128, 256],
-            [64, 128, 256],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
+        return conv_autotune_configs(
+            self.dtype,
+            block_m=[64, 128, 256],
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
 
     def forward(
         self,
@@ -3082,30 +2957,10 @@ class Conv3dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [32, 64, 128],
-            [32, 64, 128],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
+        return conv_autotune_configs(
+            self.dtype,
+            block_n=[32, 64, 128],
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
 
     def forward(
         self,
@@ -3269,30 +3124,10 @@ class GroupConv3dKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        shared_memory_limit_bytes = get_shared_memory_limit_bytes()
-        configs = itertools.product(
-            [32, 64, 128],
-            [32, 64, 128],
-            [32, 64, 128],
-            [2, 3],
-            [128, 256],
-            [True],
+        return conv_autotune_configs(
+            self.dtype,
+            block_n=[32, 64, 128],
         )
-        valid_configs = []
-        for block_m, block_n, block_k, num_stages, threads, enable_rasterization in configs:
-            shared_memory_bytes = conv_shared_memory_bytes(
-                block_m, block_n, block_k, num_stages, self.dtype)
-            if shared_memory_bytes > shared_memory_limit_bytes:
-                continue
-            valid_configs.append({
-                "block_m": block_m,
-                "block_n": block_n,
-                "block_k": block_k,
-                "num_stages": num_stages,
-                "threads": threads,
-                "enable_rasterization": enable_rasterization,
-            })
-        return valid_configs
 
     def forward(
         self,

--- a/tileops/kernels/engram/engram_bwd.py
+++ b/tileops/kernels/engram/engram_bwd.py
@@ -20,6 +20,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -450,9 +451,49 @@ class EngramGateConvBwdKernel(Kernel):
         rrms_k: torch.Tensor,
         rrms_v: torch.Tensor,
     ) -> list[torch.Tensor]:
-        return _engram_gate_conv_bwd_wrapped(
+        """Run the fused gate + conv backward pass.
+
+        Args:
+            dY: Gradient of the output, shape ``(M, seq_len, d)``.
+            H: Hidden states of shape ``(M, seq_len, d)``.
+            k: Key projection of shape ``(M, seq_len, d)``.
+            v: Value projection of shape ``(M, seq_len, d)``.
+            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``H`` and ``k``.
+            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
+            conv_w: Depthwise conv weights of shape ``(4, d)``.
+            vhat: Gated value saved by the forward pass, ``(M, seq_len, d)``.
+            alpha: Scalar gate saved by the forward pass, ``(M, seq_len)``.
+            rrms_h: Reciprocal RMS of ``H``, shape ``(M, seq_len)``.
+            rrms_k: Reciprocal RMS of ``k``, shape ``(M, seq_len)``.
+            rrms_v: Reciprocal RMS of ``vhat``, shape ``(M, seq_len)``.
+
+        Returns:
+            ``[dH, dk, dv, drms_w_h, drms_w_v, dconv_w]``, trimmed to ``d``.
+            The staging buffers the prim_func writes are internal and are not
+            returned.
+        """
+        pad = self.d_padded - self.d
+        if pad:
+            dY = F.pad(dY, (0, pad))
+            H = F.pad(H, (0, pad))
+            k = F.pad(k, (0, pad))
+            v = F.pad(v, (0, pad))
+            vhat = F.pad(vhat, (0, pad))
+            rms_w_h = F.pad(rms_w_h, (0, pad))
+            rms_w_v = F.pad(rms_w_v, (0, pad))
+            conv_w = F.pad(conv_w, (0, pad))
+        results = _engram_gate_conv_bwd_wrapped(
             self.M, self.seq_len, self.d, self.eps,
             self.dtype_str, self.config["threads"],
             dY, H, k, v, rms_w_h, rms_w_v, conv_w,
             vhat, alpha, rrms_h, rrms_k, rrms_v,
         )
+        dH, dk, dv, drms_w_h, drms_w_v, dconv_w = results[:6]
+        if pad:
+            dH = dH[:, :, : self.d]
+            dk = dk[:, :, : self.d]
+            dv = dv[:, :, : self.d]
+            drms_w_h = drms_w_h[: self.d]
+            drms_w_v = drms_w_v[: self.d]
+            dconv_w = dconv_w[:, : self.d]
+        return [dH, dk, dv, drms_w_h, drms_w_v, dconv_w]

--- a/tileops/kernels/engram/engram_decode.py
+++ b/tileops/kernels/engram/engram_decode.py
@@ -33,8 +33,8 @@ Outputs:
 
 Grid: (B,) — one thread block per batch element.
 
-The conv_state is padded to max_conv_len by the op before calling this kernel,
-so the kernel is compiled once with max_conv_len.
+``forward`` left-pads conv_state to max_conv_len, so the kernel is compiled
+once with max_conv_len regardless of the caller's history length.
 """
 
 import functools

--- a/tileops/kernels/engram/engram_decode.py
+++ b/tileops/kernels/engram/engram_decode.py
@@ -43,6 +43,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -280,8 +281,6 @@ class EngramDecodeKernel(Kernel):
     Fuses GEMV projection, RMSNorm gating, dilated causal conv with state
     update, and SiLU activation into a single kernel launch.
 
-    The conv_state is padded to max_conv_len by the op before calling this kernel.
-
     Args:
         batch: batch size.
         d_mem: memory embedding dimension.
@@ -351,9 +350,44 @@ class EngramDecodeKernel(Kernel):
         rms_w_v: torch.Tensor,
         conv_w: torch.Tensor,
     ) -> list[torch.Tensor]:
-        return _engram_decode_wrapped(
+        """Run one fused decode step.
+
+        Args:
+            e_t: Gathered N-gram embedding, shape ``(B, d_mem)``.
+            h_t: Hidden state for the current token, shape ``(B, d)``.
+            conv_state: Conv history of shape ``(B, L, d)`` with
+                ``L <= max_conv_len``; left-padded to the compiled capacity
+                here.
+            W_K: Key projection weight of shape ``(d_mem, d)``.
+            W_V: Value projection weight of shape ``(d_mem, d)``.
+            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``h`` and ``k``.
+            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
+            conv_w: Depthwise conv weights of shape ``(w, d)``.
+
+        Returns:
+            ``[y_t, new_conv_state]`` of shapes ``(B, d)`` and
+            ``(B, max_conv_len, d)``. The alignment padding the prim_func
+            requires is applied and trimmed here.
+        """
+        state_pad = self.max_conv_len - conv_state.shape[1]
+        if state_pad > 0:
+            conv_state = F.pad(conv_state, (0, 0, state_pad, 0))
+        pad = self.d_padded - self.d
+        if pad:
+            h_t = F.pad(h_t, (0, pad))
+            conv_state = F.pad(conv_state, (0, pad))
+            W_K = F.pad(W_K, (0, pad))
+            W_V = F.pad(W_V, (0, pad))
+            rms_w_h = F.pad(rms_w_h, (0, pad))
+            rms_w_v = F.pad(rms_w_v, (0, pad))
+            conv_w = F.pad(conv_w, (0, pad))
+        results = _engram_decode_wrapped(
             self.batch, self.d_mem, self.d, self.max_conv_len,
             self.conv_kernel_size, self.dilation, self.eps,
             self.dtype_str, self.config["threads"],
             e_t, h_t, conv_state, W_K, W_V, rms_w_h, rms_w_v, conv_w,
         )
+        if pad:
+            results[0] = results[0][:, : self.d]
+            results[1] = results[1][:, :, : self.d]
+        return results

--- a/tileops/kernels/engram/engram_fwd.py
+++ b/tileops/kernels/engram/engram_fwd.py
@@ -24,6 +24,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -274,8 +275,35 @@ class EngramGateConvFwdKernel(Kernel):
         rms_w_v: torch.Tensor,
         conv_w: torch.Tensor,
     ) -> list[torch.Tensor]:
-        return _engram_gate_conv_fwd_wrapped(
+        """Run the fused gate + conv forward pass.
+
+        Args:
+            H: Hidden states of shape ``(M, seq_len, d)``.
+            k: Key projection of shape ``(M, seq_len, d)``.
+            v: Value projection of shape ``(M, seq_len, d)``.
+            rms_w_h: RMSNorm weight of shape ``(d,)`` for ``H`` and ``k``.
+            rms_w_v: RMSNorm weight of shape ``(d,)`` for the gated value.
+            conv_w: Depthwise conv weights of shape ``(4, d)``.
+
+        Returns:
+            ``[Y, vhat, alpha, rrms_h, rrms_k, rrms_v]``. ``Y`` and ``vhat``
+            are ``(M, seq_len, d)``; the alignment padding the prim_func
+            requires is applied and trimmed here.
+        """
+        pad = self.d_padded - self.d
+        if pad:
+            H = F.pad(H, (0, pad))
+            k = F.pad(k, (0, pad))
+            v = F.pad(v, (0, pad))
+            rms_w_h = F.pad(rms_w_h, (0, pad))
+            rms_w_v = F.pad(rms_w_v, (0, pad))
+            conv_w = F.pad(conv_w, (0, pad))
+        results = _engram_gate_conv_fwd_wrapped(
             self.M, self.seq_len, self.d, self.eps,
             self.dtype_str, self.config["threads"],
             H, k, v, rms_w_h, rms_w_v, conv_w,
         )
+        if pad:
+            results[0] = results[0][:, :, : self.d]
+            results[1] = results[1][:, :, : self.d]
+        return results

--- a/tileops/kernels/norm/fused_add_norm.py
+++ b/tileops/kernels/norm/fused_add_norm.py
@@ -18,6 +18,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -193,7 +194,25 @@ class FusedAddLayerNormKernel(Kernel):
         weight: torch.Tensor,
         bias: torch.Tensor,
     ) -> list[torch.Tensor]:
-        return _fused_add_layer_norm_wrapped(
+        """Run fused add + LayerNorm on ``N``-wide rows.
+
+        Args:
+            x: Input of shape ``(M, N)``.
+            residual: Residual of shape ``(M, N)``.
+            weight: Affine scale of shape ``(N,)``.
+            bias: Affine shift of shape ``(N,)``.
+
+        Returns:
+            ``[y, residual_out]``, both of shape ``(M, N)``. The alignment
+            padding the prim_func requires is applied and trimmed here.
+        """
+        pad = self.N_padded - self.N
+        if pad:
+            x = F.pad(x, (0, pad))
+            residual = F.pad(residual, (0, pad))
+            weight = F.pad(weight, (0, pad))
+            bias = F.pad(bias, (0, pad))
+        outputs = _fused_add_layer_norm_wrapped(
             self.M,
             self.N,
             self.eps,
@@ -205,6 +224,9 @@ class FusedAddLayerNormKernel(Kernel):
             weight,
             bias,
         )
+        if pad:
+            return [out[:, : self.N] for out in outputs]
+        return outputs
 
 
 # Fused Add + RMSNorm kernel
@@ -352,7 +374,23 @@ class FusedAddRMSNormKernel(Kernel):
         residual: torch.Tensor,
         weight: torch.Tensor,
     ) -> list[torch.Tensor]:
-        return _fused_add_rms_norm_wrapped(
+        """Run fused add + RMSNorm on ``N``-wide rows.
+
+        Args:
+            x: Input of shape ``(M, N)``.
+            residual: Residual of shape ``(M, N)``.
+            weight: Affine scale of shape ``(N,)``.
+
+        Returns:
+            ``[y, residual_out]``, both of shape ``(M, N)``. The alignment
+            padding the prim_func requires is applied and trimmed here.
+        """
+        pad = self.N_padded - self.N
+        if pad:
+            x = F.pad(x, (0, pad))
+            residual = F.pad(residual, (0, pad))
+            weight = F.pad(weight, (0, pad))
+        outputs = _fused_add_rms_norm_wrapped(
             self.M,
             self.N,
             self.eps,
@@ -363,3 +401,6 @@ class FusedAddRMSNormKernel(Kernel):
             residual,
             weight,
         )
+        if pad:
+            return [out[:, : self.N] for out in outputs]
+        return outputs

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -22,6 +22,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -30,6 +31,11 @@ from ._config import select_row_config, select_row_configs
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
 ALIGNMENT = 256
+
+# Largest candidate block_m in GroupNormNoAffineKernel.autotune_configs. The
+# row count is padded to a multiple of this value so the full-tile T.copy
+# never crosses the M boundary regardless of the selected block_m.
+_M_BLOCK_ALIGN = 16
 
 
 def _align_up(n: int, alignment: int) -> int:
@@ -183,7 +189,23 @@ class GroupNormKernel(Kernel):
         return select_row_configs(self.D_padded, self.dtype)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
-        return _group_norm_wrapped(
+        """Normalize ``(M, D)`` rows with a row-broadcast affine.
+
+        Args:
+            x: Input of shape ``(M, D)``.
+            weight: Affine scale of shape ``(D,)``.
+            bias: Affine shift of shape ``(D,)``.
+
+        Returns:
+            Tensor of shape ``(M, D)``. The alignment padding the prim_func
+            requires is applied and trimmed here.
+        """
+        pad = self.D_padded - self.D
+        if pad:
+            x = F.pad(x, (0, pad))
+            weight = F.pad(weight, (0, pad))
+            bias = F.pad(bias, (0, pad))
+        y = _group_norm_wrapped(
             self.M,
             self.D,
             self.eps,
@@ -194,6 +216,7 @@ class GroupNormKernel(Kernel):
             weight,
             bias,
         )
+        return y[:, : self.D] if pad else y
 
 
 @functools.lru_cache(maxsize=32)
@@ -294,7 +317,8 @@ class GroupNormNoAffineKernel(Kernel):
     InstanceNorm.
 
     Args:
-        M: Number of rows = N * G.
+        M: Number of rows = N * G. Rounded up internally to a whole number
+            of ``block_m`` tiles.
         D: Row length = (C / G) * spatial_size.
         eps: Epsilon for numerical stability.
         dtype: Data type (float32, float16, or bfloat16).
@@ -319,8 +343,9 @@ class GroupNormNoAffineKernel(Kernel):
         self.eps = eps
         self.dtype = dtype
         self.D_padded = _align_up(D, ALIGNMENT)
+        self.M_padded = _align_up(M, _M_BLOCK_ALIGN)
         self.kernel = _group_norm_no_affine_kernel(
-            self.M, self.D, self.eps, self.dtype_str,
+            self.M_padded, self.D, self.eps, self.dtype_str,
         )
         self.init_config(config, tune)
 
@@ -333,8 +358,23 @@ class GroupNormNoAffineKernel(Kernel):
         return select_row_configs(self.D_padded, self.dtype)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _group_norm_no_affine_wrapped(
-            self.M,
+        """Normalize ``(M, D)`` rows without an affine.
+
+        Args:
+            x: Input of shape ``(M, D)``.
+
+        Returns:
+            Tensor of shape ``(M, D)``. Both the row-count and row-length
+            padding the prim_func requires are applied and trimmed here.
+        """
+        d_pad = self.D_padded - self.D
+        m_pad = self.M_padded - self.M
+        if d_pad:
+            x = F.pad(x, (0, d_pad))
+        if m_pad:
+            x = F.pad(x, (0, 0, 0, m_pad))
+        y = _group_norm_no_affine_wrapped(
+            self.M_padded,
             self.D,
             self.eps,
             self.dtype_str,
@@ -342,3 +382,8 @@ class GroupNormNoAffineKernel(Kernel):
             self.config["threads"],
             x,
         )
+        if m_pad:
+            y = y[: self.M, :]
+        if d_pad:
+            y = y[:, : self.D]
+        return y

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -32,9 +32,9 @@ __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
 ALIGNMENT = 256
 
-# Largest candidate block_m in GroupNormNoAffineKernel.autotune_configs. The
-# row count is padded to a multiple of this value so the full-tile T.copy
-# never crosses the M boundary regardless of the selected block_m.
+# A multiple of every candidate block_m (_config._CANDIDATE_BLOCK_M tops out
+# at 8). The row count is padded to this value so the full-tile T.copy never
+# crosses the M boundary regardless of the selected block_m.
 _M_BLOCK_ALIGN = 16
 
 

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -178,6 +178,7 @@ class GroupNormKernel(Kernel):
         self.dtype = dtype
         self.D_padded = _align_up(D, ALIGNMENT)
         self.kernel = _group_norm_kernel(self.M, self.D, self.eps, self.dtype_str)
+        self._identity_affine: dict[torch.device, tuple[torch.Tensor, torch.Tensor]] = {}
         self.init_config(config, tune)
 
     @property
@@ -188,21 +189,49 @@ class GroupNormKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return select_row_configs(self.D_padded, self.dtype)
 
-    def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+    def _identity_affine_for(
+        self, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return cached unit-scale / zero-shift buffers of the launch width."""
+        buffers = self._identity_affine.get(device)
+        if buffers is None:
+            buffers = (
+                torch.ones(self.D_padded, dtype=self.dtype, device=device),
+                torch.zeros(self.D_padded, dtype=self.dtype, device=device),
+            )
+            self._identity_affine[device] = buffers
+        return buffers
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        weight: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Normalize ``(M, D)`` rows with a row-broadcast affine.
 
         Args:
             x: Input of shape ``(M, D)``.
-            weight: Affine scale of shape ``(D,)``.
-            bias: Affine shift of shape ``(D,)``.
+            weight: Affine scale of shape ``(D,)``. Omit together with *bias*
+                to normalize without an affine.
+            bias: Affine shift of shape ``(D,)``. Omit together with *weight*
+                to normalize without an affine.
 
         Returns:
             Tensor of shape ``(M, D)``. The alignment padding the prim_func
             requires is applied and trimmed here.
+
+        Raises:
+            ValueError: If exactly one of *weight* / *bias* is omitted.
         """
+        if (weight is None) != (bias is None):
+            raise ValueError("weight and bias must be supplied together")
         pad = self.D_padded - self.D
         if pad:
             x = F.pad(x, (0, pad))
+        if weight is None:
+            weight, bias = self._identity_affine_for(x.device)
+        elif pad:
             weight = F.pad(weight, (0, pad))
             bias = F.pad(bias, (0, pad))
         y = _group_norm_wrapped(

--- a/tileops/kernels/norm/rms_norm.py
+++ b/tileops/kernels/norm/rms_norm.py
@@ -13,6 +13,7 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
+import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -136,7 +137,22 @@ class RMSNormKernel(Kernel):
         return select_row_configs(self.N_padded, self.dtype)
 
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        return _rms_norm_wrapped(
+        """Normalize ``x`` row-wise.
+
+        Args:
+            x: Input of shape ``(M, N)``.
+            weight: Affine scale of shape ``(N,)``.
+
+        Returns:
+            Tensor of shape ``(M, N)``. The alignment padding the prim_func
+            requires is applied and trimmed here, so callers only ever see
+            the semantic ``N``-wide result.
+        """
+        pad = self.N_padded - self.N
+        if pad:
+            x = F.pad(x, (0, pad))
+            weight = F.pad(weight, (0, pad))
+        y = _rms_norm_wrapped(
             self.M,
             self.N,
             self.eps,
@@ -146,3 +162,4 @@ class RMSNormKernel(Kernel):
             x,
             weight,
         )
+        return y[:, : self.N] if pad else y

--- a/tileops/kernels/pool/max_pool1d.py
+++ b/tileops/kernels/pool/max_pool1d.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional, Tuple
+from typing import Any, Callable, ClassVar, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -116,10 +116,18 @@ def _(
     return torch.empty((n, c_in, out_l), dtype=x.dtype, device=x.device)
 
 
-class MaxPool1dKernel(Kernel):
-    """Max pooling forward kernel for NCL inputs (return_indices=False)."""
+class _MaxPool1dKernelBase(Kernel):
+    """Shared construction and dispatch for the 1d max-pool kernels.
 
-    supported_archs: list[int] = [80, 86, 89, 90]
+    Concrete kernels supply ``_build`` and ``_dispatch``; everything else —
+    parameter capture, output extents, config and launch — is identical
+    between the value-only and with-indices variants.
+    """
+
+    _build: ClassVar[Callable[..., Any]]
+    _dispatch: ClassVar[Callable[..., Any]]
+
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
 
     def __init__(
         self,
@@ -138,7 +146,7 @@ class MaxPool1dKernel(Kernel):
         super().__init__()
         if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
             raise ValueError(
-                f"MaxPool1dKernel supports float16, bfloat16, and float32, got {dtype}"
+                f"{type(self).__name__} supports float16, bfloat16, and float32, got {dtype}"
             )
         self.n = n
         self.c_in = c_in
@@ -150,7 +158,7 @@ class MaxPool1dKernel(Kernel):
         self.ceil_mode = ceil_mode
         self.dtype = dtype
         self.out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool1d_kernel(
+        self.kernel = type(self)._build(
             n,
             c_in,
             l_in,
@@ -177,8 +185,8 @@ class MaxPool1dKernel(Kernel):
             for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
         ]
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _max_pool1d_wrapped_kernel(
+    def forward(self, x: torch.Tensor) -> Any:
+        return type(self)._dispatch(
             self.n,
             self.c_in,
             self.l_in,
@@ -192,6 +200,13 @@ class MaxPool1dKernel(Kernel):
             self.config["threads"],
             x,
         )
+
+
+class MaxPool1dKernel(_MaxPool1dKernelBase):
+    """Max pooling forward kernel (return_indices=False)."""
+
+    _build = staticmethod(_max_pool1d_kernel)
+    _dispatch = staticmethod(_max_pool1d_wrapped_kernel)
 
 
 @functools.lru_cache(maxsize=32)
@@ -324,79 +339,10 @@ def _(
     )
 
 
-class MaxPool1dWithIndicesKernel(Kernel):
-    """Max pooling forward-with-indices kernel for NCL inputs."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
 
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        l_in: int,
-        kernel_w: int,
-        stride_w: int,
-        pad_w: int,
-        dilation_w: int,
-        ceil_mode: bool,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
-            raise ValueError(
-                f"MaxPool1dWithIndicesKernel supports float16, bfloat16, and float32, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.l_in = l_in
-        self.kernel_w = kernel_w
-        self.stride_w = stride_w
-        self.pad_w = pad_w
-        self.dilation_w = dilation_w
-        self.ceil_mode = ceil_mode
-        self.dtype = dtype
-        self.out_l = pool_output_dim(l_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool1d_with_indices_kernel(
-            n,
-            c_in,
-            l_in,
-            kernel_w,
-            stride_w,
-            pad_w,
-            dilation_w,
-            ceil_mode,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
+class MaxPool1dWithIndicesKernel(_MaxPool1dKernelBase):
+    """Max pooling forward-with-indices kernel."""
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _max_pool1d_with_indices_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.l_in,
-            self.kernel_w,
-            self.stride_w,
-            self.pad_w,
-            self.dilation_w,
-            self.ceil_mode,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_max_pool1d_with_indices_kernel)
+    _dispatch = staticmethod(_max_pool1d_with_indices_wrapped_kernel)

--- a/tileops/kernels/pool/max_pool2d.py
+++ b/tileops/kernels/pool/max_pool2d.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional, Tuple
+from typing import Any, Callable, ClassVar, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -141,10 +141,18 @@ def _(
     return torch.empty((n, c_in, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
-class MaxPool2dKernel(Kernel):
-    """Max pooling forward kernel for NCHW inputs (return_indices=False)."""
+class _MaxPool2dKernelBase(Kernel):
+    """Shared construction and dispatch for the 2d max-pool kernels.
 
-    supported_archs: list[int] = [80, 86, 89, 90]
+    Concrete kernels supply ``_build`` and ``_dispatch``; everything else —
+    parameter capture, output extents, config and launch — is identical
+    between the value-only and with-indices variants.
+    """
+
+    _build: ClassVar[Callable[..., Any]]
+    _dispatch: ClassVar[Callable[..., Any]]
+
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
 
     def __init__(
         self,
@@ -168,7 +176,7 @@ class MaxPool2dKernel(Kernel):
         super().__init__()
         if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
             raise ValueError(
-                f"MaxPool2dKernel supports float16, bfloat16, and float32, got {dtype}"
+                f"{type(self).__name__} supports float16, bfloat16, and float32, got {dtype}"
             )
         self.n = n
         self.c_in = c_in
@@ -186,7 +194,7 @@ class MaxPool2dKernel(Kernel):
         self.dtype = dtype
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool2d_kernel(
+        self.kernel = type(self)._build(
             n,
             c_in,
             h_in,
@@ -218,8 +226,8 @@ class MaxPool2dKernel(Kernel):
             for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
         ]
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _max_pool2d_wrapped_kernel(
+    def forward(self, x: torch.Tensor) -> Any:
+        return type(self)._dispatch(
             self.n,
             self.c_in,
             self.h_in,
@@ -238,6 +246,13 @@ class MaxPool2dKernel(Kernel):
             self.config["threads"],
             x,
         )
+
+
+class MaxPool2dKernel(_MaxPool2dKernelBase):
+    """Max pooling forward kernel (return_indices=False)."""
+
+    _build = staticmethod(_max_pool2d_kernel)
+    _dispatch = staticmethod(_max_pool2d_wrapped_kernel)
 
 
 @functools.lru_cache(maxsize=32)
@@ -396,100 +411,10 @@ def _(
     )
 
 
-class MaxPool2dWithIndicesKernel(Kernel):
-    """Max pooling forward-with-indices kernel for NCHW inputs."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
 
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        h_in: int,
-        w_in: int,
-        kernel_h: int,
-        kernel_w: int,
-        stride_h: int,
-        stride_w: int,
-        pad_h: int,
-        pad_w: int,
-        dilation_h: int,
-        dilation_w: int,
-        ceil_mode: bool,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
-            raise ValueError(
-                f"MaxPool2dWithIndicesKernel supports float16, bfloat16, and float32, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.kernel_h = kernel_h
-        self.kernel_w = kernel_w
-        self.stride_h = stride_h
-        self.stride_w = stride_w
-        self.pad_h = pad_h
-        self.pad_w = pad_w
-        self.dilation_h = dilation_h
-        self.dilation_w = dilation_w
-        self.ceil_mode = ceil_mode
-        self.dtype = dtype
-        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool2d_with_indices_kernel(
-            n,
-            c_in,
-            h_in,
-            w_in,
-            kernel_h,
-            kernel_w,
-            stride_h,
-            stride_w,
-            pad_h,
-            pad_w,
-            dilation_h,
-            dilation_w,
-            ceil_mode,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
+class MaxPool2dWithIndicesKernel(_MaxPool2dKernelBase):
+    """Max pooling forward-with-indices kernel."""
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _max_pool2d_with_indices_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.h_in,
-            self.w_in,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_h,
-            self.stride_w,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_h,
-            self.dilation_w,
-            self.ceil_mode,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_max_pool2d_with_indices_kernel)
+    _dispatch = staticmethod(_max_pool2d_with_indices_wrapped_kernel)

--- a/tileops/kernels/pool/max_pool3d.py
+++ b/tileops/kernels/pool/max_pool3d.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Optional, Tuple
+from typing import Any, Callable, ClassVar, Optional, Tuple
 
 import tilelang
 import tilelang.language as T
@@ -175,10 +175,18 @@ def _(
     return torch.empty((n, c_in, out_d, out_h, out_w), dtype=x.dtype, device=x.device)
 
 
-class MaxPool3dKernel(Kernel):
-    """Max pooling forward kernel for NCDHW inputs (return_indices=False)."""
+class _MaxPool3dKernelBase(Kernel):
+    """Shared construction and dispatch for the 3d max-pool kernels.
 
-    supported_archs: list[int] = [80, 86, 89, 90]
+    Concrete kernels supply ``_build`` and ``_dispatch``; everything else —
+    parameter capture, output extents, config and launch — is identical
+    between the value-only and with-indices variants.
+    """
+
+    _build: ClassVar[Callable[..., Any]]
+    _dispatch: ClassVar[Callable[..., Any]]
+
+    supported_archs: ClassVar[list[int]] = [80, 86, 89, 90]
 
     def __init__(
         self,
@@ -207,7 +215,7 @@ class MaxPool3dKernel(Kernel):
         super().__init__()
         if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
             raise ValueError(
-                f"MaxPool3dKernel supports float16, bfloat16, and float32, got {dtype}"
+                f"{type(self).__name__} supports float16, bfloat16, and float32, got {dtype}"
             )
         self.n = n
         self.c_in = c_in
@@ -231,7 +239,7 @@ class MaxPool3dKernel(Kernel):
         self.out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
         self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
         self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool3d_kernel(
+        self.kernel = type(self)._build(
             n,
             c_in,
             d_in,
@@ -268,8 +276,8 @@ class MaxPool3dKernel(Kernel):
             for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
         ]
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _max_pool3d_wrapped_kernel(
+    def forward(self, x: torch.Tensor) -> Any:
+        return type(self)._dispatch(
             self.n,
             self.c_in,
             self.d_in,
@@ -293,6 +301,13 @@ class MaxPool3dKernel(Kernel):
             self.config["threads"],
             x,
         )
+
+
+class MaxPool3dKernel(_MaxPool3dKernelBase):
+    """Max pooling forward kernel (return_indices=False)."""
+
+    _build = staticmethod(_max_pool3d_kernel)
+    _dispatch = staticmethod(_max_pool3d_wrapped_kernel)
 
 
 @functools.lru_cache(maxsize=32)
@@ -484,121 +499,10 @@ def _(
     )
 
 
-class MaxPool3dWithIndicesKernel(Kernel):
-    """Max pooling forward-with-indices kernel for NCDHW inputs."""
 
-    supported_archs: list[int] = [80, 86, 89, 90]
 
-    def __init__(
-        self,
-        n: int,
-        c_in: int,
-        d_in: int,
-        h_in: int,
-        w_in: int,
-        kernel_d: int,
-        kernel_h: int,
-        kernel_w: int,
-        stride_d: int,
-        stride_h: int,
-        stride_w: int,
-        pad_d: int,
-        pad_h: int,
-        pad_w: int,
-        dilation_d: int,
-        dilation_h: int,
-        dilation_w: int,
-        ceil_mode: bool,
-        dtype: torch.dtype,
-        config: Optional[dict] = None,
-        tune: bool = False,
-    ) -> None:
-        super().__init__()
-        if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
-            raise ValueError(
-                f"MaxPool3dWithIndicesKernel supports float16, bfloat16, and float32, got {dtype}"
-            )
-        self.n = n
-        self.c_in = c_in
-        self.d_in = d_in
-        self.h_in = h_in
-        self.w_in = w_in
-        self.kernel_d = kernel_d
-        self.kernel_h = kernel_h
-        self.kernel_w = kernel_w
-        self.stride_d = stride_d
-        self.stride_h = stride_h
-        self.stride_w = stride_w
-        self.pad_d = pad_d
-        self.pad_h = pad_h
-        self.pad_w = pad_w
-        self.dilation_d = dilation_d
-        self.dilation_h = dilation_h
-        self.dilation_w = dilation_w
-        self.ceil_mode = ceil_mode
-        self.dtype = dtype
-        self.out_d = pool_output_dim(d_in, kernel_d, stride_d, pad_d, ceil_mode, dilation_d)
-        self.out_h = pool_output_dim(h_in, kernel_h, stride_h, pad_h, ceil_mode, dilation_h)
-        self.out_w = pool_output_dim(w_in, kernel_w, stride_w, pad_w, ceil_mode, dilation_w)
-        self.kernel = _max_pool3d_with_indices_kernel(
-            n,
-            c_in,
-            d_in,
-            h_in,
-            w_in,
-            kernel_d,
-            kernel_h,
-            kernel_w,
-            stride_d,
-            stride_h,
-            stride_w,
-            pad_d,
-            pad_h,
-            pad_w,
-            dilation_d,
-            dilation_h,
-            dilation_w,
-            ceil_mode,
-            self.dtype_str,
-        )
-        self.init_config(config, tune)
+class MaxPool3dWithIndicesKernel(_MaxPool3dKernelBase):
+    """Max pooling forward-with-indices kernel."""
 
-    @property
-    def default_config(self) -> dict:
-        return {
-            "block_m": 256,
-            "threads": 256,
-        }
-
-    @property
-    def autotune_configs(self) -> list[dict]:
-        return [
-            {"block_m": block_m, "threads": threads}
-            for block_m, threads in itertools.product([128, 256, 512], [128, 256, 512])
-        ]
-
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return _max_pool3d_with_indices_wrapped_kernel(
-            self.n,
-            self.c_in,
-            self.d_in,
-            self.h_in,
-            self.w_in,
-            self.kernel_d,
-            self.kernel_h,
-            self.kernel_w,
-            self.stride_d,
-            self.stride_h,
-            self.stride_w,
-            self.pad_d,
-            self.pad_h,
-            self.pad_w,
-            self.dilation_d,
-            self.dilation_h,
-            self.dilation_w,
-            self.ceil_mode,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            x,
-        )
+    _build = staticmethod(_max_pool3d_with_indices_kernel)
+    _dispatch = staticmethod(_max_pool3d_with_indices_wrapped_kernel)

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -9,6 +9,7 @@ infrastructure is available from the start.
 """
 
 import tilelang.language as T
+import torch
 
 __all__ = [
     "DEFAULT_ALIGNMENT",
@@ -21,6 +22,7 @@ __all__ = [
     "make_reduce_epilogue",
     "make_softmax_epilogue",
     "make_welford_update",
+    "tune_by_forward",
 ]
 
 # 256-element alignment (512 bytes for fp16/bf16) required by T.copy()
@@ -197,6 +199,44 @@ _REDUCE_KINDS = {"sum", "max", "min"}
 _SOFTMAX_KINDS = {"softmax", "log_softmax"}
 _SCAN_KINDS = {"sum", "prod"}
 
+
+
+def tune_by_forward(kernel, *probe_inputs, warmup: int = 10, rep: int = 10) -> None:
+    """Select the fastest candidate config by timing ``kernel.forward``.
+
+    The tiled reduction paths have no single ``self.kernel`` object for
+    TileLang's autotuner to decorate — they dispatch through wrapped helper
+    functions — so each candidate is timed through ``forward`` instead.
+    Leaves ``kernel.config`` set to the winner, or to ``default_config`` when
+    the kernel declares no candidates.
+    """
+    configs = kernel.autotune_configs
+    if not configs:
+        kernel.config = kernel.default_config
+        return
+
+    print(f'Start autotuning {kernel.__class__.__name__} (tiled path)...')
+    best_config, best_time = configs[0], float('inf')
+    for cfg in configs:
+        kernel.config = cfg
+        for _ in range(warmup):
+            kernel.forward(*probe_inputs)
+        torch.cuda.synchronize()
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(rep):
+            kernel.forward(*probe_inputs)
+        end.record()
+        torch.cuda.synchronize()
+        elapsed = start.elapsed_time(end) / rep
+
+        if elapsed < best_time:
+            best_time, best_config = elapsed, cfg
+
+    kernel.config = best_config
+    print(f'Best config: {kernel.config}')
 
 def make_reduce_epilogue(op_kind: str):
     """Create a post-reduce processing T.macro.

--- a/tileops/kernels/reduction/cumulative.py
+++ b/tileops/kernels/reduction/cumulative.py
@@ -418,10 +418,11 @@ class CumulativeKernel(Kernel):
                 handled internally via masked loads.
 
         Returns:
-            Output tensor of shape (M, N_padded).
+            Output tensor of shape (M, N). The prim_func writes an
+            alignment-padded row; the surplus columns are trimmed here.
         """
         if self.use_parallel:
-            return _cumulative_parallel_fwd_wrapped(
+            y = _cumulative_parallel_fwd_wrapped(
                 self.M,
                 self.N,
                 self.dtype_str,
@@ -431,7 +432,7 @@ class CumulativeKernel(Kernel):
                 x,
             )
         else:
-            return _cumulative_fwd_wrapped(
+            y = _cumulative_fwd_wrapped(
                 self.M,
                 self.N,
                 self.op_kind,
@@ -441,6 +442,7 @@ class CumulativeKernel(Kernel):
                 self.config["threads"],
                 x,
             )
+        return y[:, : self.N] if y.shape[1] > self.N else y
 
 
 # ---------------------------------------------------------------------------

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -26,6 +26,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tune_by_forward,
 )
 
 __all__ = ["LogicalReduceKernel", "to_logical_float32"]
@@ -436,41 +437,10 @@ class LogicalReduceKernel(Kernel):
         """Autotune logical reduce, benchmarking tiled configs directly."""
         if not self._needs_tiling:
             return super().autotune(warmup=warmup, rep=rep)
-
-        configs = self.autotune_configs
-        if not configs:
-            self.config = self.default_config
-            return
-
-        print(f'Start autotuning {self.__class__.__name__} (tiled path)...')
-
-        device = torch.cuda.current_device()
-        x = torch.randn(self.M, self.N, dtype=self._kernel_dtype, device=device)
-
-        best_config = configs[0]
-        best_time = float('inf')
-
-        for cfg in configs:
-            self.config = cfg
-            for _ in range(warmup):
-                self.forward(x)
-            torch.cuda.synchronize()
-
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
-            start.record()
-            for _ in range(rep):
-                self.forward(x)
-            end.record()
-            torch.cuda.synchronize()
-            elapsed = start.elapsed_time(end) / rep
-
-            if elapsed < best_time:
-                best_time = elapsed
-                best_config = cfg
-
-        self.config = best_config
-        print(f'Best config: {self.config}')
+        x = torch.randn(
+            self.M, self.N, dtype=self._kernel_dtype, device=torch.cuda.current_device()
+        )
+        tune_by_forward(self, x, warmup=warmup, rep=rep)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the any/all/count_nonzero kernel.

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -34,6 +34,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tune_by_forward,
 )
 
 __all__ = ["ReduceKernel"]
@@ -1023,54 +1024,13 @@ class ReduceKernel(Kernel):
         return configs if configs else [self.default_config]
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Autotune the reduce kernel by benchmarking candidate configs.
-
-        The non-tiled path delegates to the base ``Kernel.autotune`` which
-        applies TileLang's ``autotune`` decorator to ``self.kernel``.
-
-        The tiled path has no single ``self.kernel`` object -- it dispatches
-        through wrapped helper functions -- so we benchmark each candidate
-        config via :meth:`forward` directly and pick the fastest.
-        """
+        """Autotune the reduce kernel by benchmarking candidate configs."""
         if not self._needs_tiling:
             return super().autotune(warmup=warmup, rep=rep)
-
-        configs = self.autotune_configs
-        if not configs:
-            self.config = self.default_config
-            return
-
-        print(f'Start autotuning {self.__class__.__name__} (tiled path)...')
-
-        device = torch.cuda.current_device()
-        x = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
-
-        best_config = configs[0]
-        best_time = float('inf')
-
-        for cfg in configs:
-            self.config = cfg
-            # Warmup
-            for _ in range(warmup):
-                self.forward(x)
-            torch.cuda.synchronize()
-
-            # Benchmark
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
-            start.record()
-            for _ in range(rep):
-                self.forward(x)
-            end.record()
-            torch.cuda.synchronize()
-            elapsed = start.elapsed_time(end) / rep
-
-            if elapsed < best_time:
-                best_time = elapsed
-                best_config = cfg
-
-        self.config = best_config
-        print(f'Best config: {self.config}')
+        x = torch.randn(
+            self.M, self.N, dtype=self.dtype, device=torch.cuda.current_device()
+        )
+        tune_by_forward(self, x, warmup=warmup, rep=rep)
 
     def forward(self, x: torch.Tensor) -> object:
         if self._is_welford:

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -813,9 +813,14 @@ class SoftmaxKernel(Kernel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the softmax/log_softmax kernel.
 
-        Accepts an ``(M, N)`` tensor.  Boundary handling for non-aligned
-        ``N`` is performed inside the GPU kernel (masked loads + ``-inf``
-        fill), so no host-side ``F.pad`` is needed.
+        Args:
+            x: Input of shape ``(M, N)``. Boundary handling for non-aligned
+                ``N`` happens inside the GPU kernel (masked loads + ``-inf``
+                fill), so no host-side ``F.pad`` is needed.
+
+        Returns:
+            Tensor of shape ``(M, N)``. The prim_func writes an
+            alignment-padded row; the surplus columns are trimmed here.
         """
         tile_n = self._tile_n
 
@@ -830,10 +835,4 @@ class SoftmaxKernel(Kernel):
             x,
         )
 
-        # Trim back to N_padded if needed (when tile_n does not divide
-        # N_padded, e.g. compute_tile_n chose tile_n_max over a small
-        # divisor for better shared memory utilisation).
-        if y.shape[1] > self.N_padded:
-            y = y[:, : self.N_padded]
-
-        return y
+        return y[:, : self.N] if y.shape[1] > self.N else y

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -26,6 +26,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tune_by_forward,
 )
 
 __all__ = ["VectorNormKernel"]
@@ -372,41 +373,10 @@ class VectorNormKernel(Kernel):
         """Autotune vector norm, benchmarking tiled configs directly."""
         if not self._needs_tiling:
             return super().autotune(warmup=warmup, rep=rep)
-
-        configs = self.autotune_configs
-        if not configs:
-            self.config = self.default_config
-            return
-
-        print(f'Start autotuning {self.__class__.__name__} (tiled path)...')
-
-        device = torch.cuda.current_device()
-        x = torch.randn(self.M, self.N, dtype=self.dtype, device=device)
-
-        best_config = configs[0]
-        best_time = float('inf')
-
-        for cfg in configs:
-            self.config = cfg
-            for _ in range(warmup):
-                self.forward(x)
-            torch.cuda.synchronize()
-
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
-            start.record()
-            for _ in range(rep):
-                self.forward(x)
-            end.record()
-            torch.cuda.synchronize()
-            elapsed = start.elapsed_time(end) / rep
-
-            if elapsed < best_time:
-                best_time = elapsed
-                best_config = cfg
-
-        self.config = best_config
-        print(f'Best config: {self.config}')
+        x = torch.randn(
+            self.M, self.N, dtype=self.dtype, device=torch.cuda.current_device()
+        )
+        tune_by_forward(self, x, warmup=warmup, rep=rep)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the l1/l2/inf norm kernel.

--- a/tileops/manifest/__init__.py
+++ b/tileops/manifest/__init__.py
@@ -61,6 +61,21 @@ def load_manifest() -> dict[str, Any]:
     return merged
 
 
+
+def try_load_entry(op_name: str) -> dict[str, Any] | None:
+    """Return the manifest entry for *op_name*, or None if unavailable.
+
+    Every failure — missing key, unreadable manifest — downgrades to None so
+    an incomplete manifest never blocks op-class construction at import time.
+    """
+    try:
+        ops = load_manifest()
+    except Exception:
+        return None
+    entry = ops.get(op_name)
+    return entry if isinstance(entry, dict) else None
+
+
 def load_workloads(op_name: str) -> list[dict[str, Any]]:
     """Return the workloads list for *op_name*.
 
@@ -114,4 +129,5 @@ __all__ = [
     "load_workloads",
     "manifest_files",
     "single_input_workload_contract",
+    "try_load_entry",
 ]

--- a/tileops/manifest/dtype_rules.py
+++ b/tileops/manifest/dtype_rules.py
@@ -1,0 +1,68 @@
+"""Shared parsers for manifest ``signature`` dtype expressions.
+
+A dtype expression is one of:
+
+- a concrete dtype name — ``"float16"``;
+- a ``|`` union of tokens — ``"float16 | bfloat16 | same_as(input)"``;
+- ``same_as(<name>)`` — follow another tensor in the same signature;
+- ``promote_int_to_float(<name>)`` — follow another tensor, promoting
+  integral dtypes to float, matching PyTorch's int-input promotion.
+
+Several consumers read this grammar, and each used to carry its own copy of
+the regex. The copies had already drifted apart. This module owns the
+grammar so the wording cannot diverge again.
+
+The parsers return the *referenced name* rather than a dtype: this package
+depends on nothing beyond the standard library and PyYAML, so mapping a name
+onto a concrete dtype stays with the caller.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
+_PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*(\w+)\s*\)$")
+
+
+def parse_tokens(expr: str) -> list[str]:
+    """Split a dtype expression into its ``|``-separated tokens.
+
+    Args:
+        expr: A dtype expression, e.g. ``"float16 | same_as(input)"``.
+
+    Returns:
+        The non-empty tokens, stripped of surrounding whitespace.
+    """
+    return [t.strip() for t in expr.split("|") if t.strip()]
+
+
+def same_as_ref(token: str) -> str | None:
+    """Return the tensor named by a ``same_as(...)`` token.
+
+    Args:
+        token: A single dtype token, already split out of any union.
+
+    Returns:
+        The referenced tensor name, or ``None`` if *token* is not a
+        ``same_as`` expression.
+    """
+    m = _SAME_AS_RE.match(token)
+    return m.group(1) if m else None
+
+
+def promote_int_to_float_ref(token: str) -> str | None:
+    """Return the tensor named by a ``promote_int_to_float(...)`` token.
+
+    Args:
+        token: A single dtype token, already split out of any union.
+
+    Returns:
+        The referenced tensor name, or ``None`` if *token* is not a
+        ``promote_int_to_float`` expression.
+    """
+    m = _PROMOTE_INT_TO_FLOAT_RE.match(token)
+    return m.group(1) if m else None
+
+
+__all__ = ["parse_tokens", "promote_int_to_float_ref", "same_as_ref"]

--- a/tileops/manifest/dtype_rules.py
+++ b/tileops/manifest/dtype_rules.py
@@ -1,68 +1,43 @@
-"""Shared parsers for manifest ``signature`` dtype expressions.
+"""Grammar for manifest ``signature`` dtype expressions.
 
-A dtype expression is one of:
+A dtype expression is a concrete dtype name, a ``|`` union of tokens,
+``same_as(<name>)``, or ``promote_int_to_float(<name>)``. Three consumers read
+it and each used to carry its own regex; the copies had already drifted.
 
-- a concrete dtype name — ``"float16"``;
-- a ``|`` union of tokens — ``"float16 | bfloat16 | same_as(input)"``;
-- ``same_as(<name>)`` — follow another tensor in the same signature;
-- ``promote_int_to_float(<name>)`` — follow another tensor, promoting
-  integral dtypes to float, matching PyTorch's int-input promotion.
-
-Several consumers read this grammar, and each used to carry its own copy of
-the regex. The copies had already drifted apart. This module owns the
-grammar so the wording cannot diverge again.
-
-The parsers return the *referenced name* rather than a dtype: this package
-depends on nothing beyond the standard library and PyYAML, so mapping a name
-onto a concrete dtype stays with the caller.
+Accessors return the referenced *name*, not a dtype — this package depends on
+nothing beyond the standard library and PyYAML.
 """
 
 from __future__ import annotations
 
 import re
 
-_SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
-_PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*(\w+)\s*\)$")
+#: Group 1 is the referenced tensor name.
+SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
+PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*(\w+)\s*\)$")
 
 
 def parse_tokens(expr: str) -> list[str]:
-    """Split a dtype expression into its ``|``-separated tokens.
-
-    Args:
-        expr: A dtype expression, e.g. ``"float16 | same_as(input)"``.
-
-    Returns:
-        The non-empty tokens, stripped of surrounding whitespace.
-    """
+    """Split a dtype expression into its non-empty ``|``-separated tokens."""
     return [t.strip() for t in expr.split("|") if t.strip()]
 
 
 def same_as_ref(token: str) -> str | None:
-    """Return the tensor named by a ``same_as(...)`` token.
-
-    Args:
-        token: A single dtype token, already split out of any union.
-
-    Returns:
-        The referenced tensor name, or ``None`` if *token* is not a
-        ``same_as`` expression.
-    """
-    m = _SAME_AS_RE.match(token)
+    """Return the name in a ``same_as(...)`` token, or None if not one."""
+    m = SAME_AS_RE.match(token)
     return m.group(1) if m else None
 
 
 def promote_int_to_float_ref(token: str) -> str | None:
-    """Return the tensor named by a ``promote_int_to_float(...)`` token.
-
-    Args:
-        token: A single dtype token, already split out of any union.
-
-    Returns:
-        The referenced tensor name, or ``None`` if *token* is not a
-        ``promote_int_to_float`` expression.
-    """
-    m = _PROMOTE_INT_TO_FLOAT_RE.match(token)
+    """Return the name in a ``promote_int_to_float(...)`` token, or None."""
+    m = PROMOTE_INT_TO_FLOAT_RE.match(token)
     return m.group(1) if m else None
 
 
-__all__ = ["parse_tokens", "promote_int_to_float_ref", "same_as_ref"]
+__all__ = [
+    "PROMOTE_INT_TO_FLOAT_RE",
+    "SAME_AS_RE",
+    "parse_tokens",
+    "promote_int_to_float_ref",
+    "same_as_ref",
+]

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -27,6 +27,7 @@ from typing import Any, Callable
 
 import torch
 
+from tileops.manifest import try_load_entry
 from tileops.manifest.dtype_rules import parse_tokens, same_as_ref
 
 
@@ -290,26 +291,6 @@ def synthesize_validate_dtypes(
     return _validate_dtypes
 
 
-def _lookup_manifest_entry(op_name: str) -> dict[str, Any] | None:
-    """Return the manifest entry for *op_name* or None if absent.
-
-    Lazy-imports the manifest loader to avoid pulling YAML I/O in the
-    ``Op`` base import path when no subclass has been declared yet.
-    Failures (missing key, load errors) downgrade to ``None`` so an
-    incomplete manifest never blocks op-class construction.
-    """
-    try:
-        from tileops.manifest import load_manifest
-    except Exception:
-        return None
-    try:
-        ops = load_manifest()
-    except Exception:
-        return None
-    entry = ops.get(op_name)
-    if not isinstance(entry, dict):
-        return None
-    return entry
 
 
 def maybe_install_validator(cls: type) -> None:
@@ -341,7 +322,7 @@ def maybe_install_validator(cls: type) -> None:
     sig = getattr(cls, "__manifest_signature__", None)
     status = getattr(cls, "__manifest_status__", None)
     if sig is None or status is None:
-        entry = _lookup_manifest_entry(cls.__name__)
+        entry = try_load_entry(cls.__name__)
         if entry is None:
             return
         sig = entry.get("signature")

--- a/tileops/ops/_dtype_codegen.py
+++ b/tileops/ops/_dtype_codegen.py
@@ -23,17 +23,11 @@ unchanged.
 
 from __future__ import annotations
 
-import re
 from typing import Any, Callable
 
 import torch
 
-_SAME_AS_RE = re.compile(r"^same_as\(\s*(\w+)\s*\)$")
-
-
-def _parse_tokens(dtype_str: str) -> list[str]:
-    """Split a dtype expression into ``|``-separated tokens."""
-    return [t.strip() for t in dtype_str.split("|") if t.strip()]
+from tileops.manifest.dtype_rules import parse_tokens, same_as_ref
 
 
 def _classify_tokens(
@@ -47,9 +41,9 @@ def _classify_tokens(
     concrete: list[torch.dtype] = []
     refs: list[str] = []
     for tok in tokens:
-        m = _SAME_AS_RE.match(tok)
-        if m:
-            refs.append(m.group(1))
+        ref = same_as_ref(tok)
+        if ref is not None:
+            refs.append(ref)
             continue
         dt = getattr(torch, tok, None)
         if not isinstance(dt, torch.dtype):
@@ -133,8 +127,8 @@ def _parse_dtype_combos(
                     )
                 seen.append(cur)
                 tok = raw[cur]
-                m = _SAME_AS_RE.match(tok)
-                if not m:
+                ref = same_as_ref(tok)
+                if ref is None:
                     dt = getattr(torch, tok, None)
                     if not isinstance(dt, torch.dtype):
                         raise ValueError(
@@ -143,7 +137,6 @@ def _parse_dtype_combos(
                         )
                     norm[name] = dt
                     break
-                ref = m.group(1)
                 if ref not in raw:
                     raise ValueError(
                         f"{op_name}: signature.dtype_combos[{idx}]"
@@ -192,7 +185,7 @@ def synthesize_validate_dtypes(
                 f"{op_name}: signature.inputs[{name!r}] must be a mapping"
             )
         dtype_str = attrs.get("dtype", "")
-        tokens = _parse_tokens(dtype_str)
+        tokens = parse_tokens(dtype_str)
         if not tokens:
             raise ValueError(
                 f"{op_name}: signature.inputs[{name!r}].dtype is empty"

--- a/tileops/ops/_roofline_codegen.py
+++ b/tileops/ops/_roofline_codegen.py
@@ -37,6 +37,8 @@ import math
 from math import prod
 from typing import Any, Callable
 
+from tileops.manifest import try_load_entry
+
 
 # Names bound into the vars-layer namespace per
 # ``docs/design/roofline.md`` §4.4.4. Helper names map to their Python
@@ -642,20 +644,6 @@ def synthesize_eval_roofline(
     return _synthesize_inline_mode(op_name, roofline, signature)
 
 
-def _lookup_manifest_entry(op_name: str) -> dict[str, Any] | None:
-    """Return the manifest entry for *op_name* or ``None`` if absent."""
-    try:
-        from tileops.manifest import load_manifest
-    except Exception:
-        return None
-    try:
-        ops = load_manifest()
-    except Exception:
-        return None
-    entry = ops.get(op_name)
-    if not isinstance(entry, dict):
-        return None
-    return entry
 
 
 def maybe_install_eval_roofline(cls: type) -> None:
@@ -695,7 +683,7 @@ def maybe_install_eval_roofline(cls: type) -> None:
     sig = getattr(cls, "__manifest_signature__", None)
     status = getattr(cls, "__manifest_status__", None)
     if roofline is None or status is None:
-        entry = _lookup_manifest_entry(cls.__name__)
+        entry = try_load_entry(cls.__name__)
         if entry is None:
             return
         roofline = entry.get("roofline")

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -15,8 +15,10 @@ Utility:
 - coalesce_broadcast_dims: reduces N-dim broadcast to minimal effective dims
 """
 
+import functools
 import inspect
 import math
+import re
 import weakref
 from math import prod
 from typing import Callable, Dict, List, Optional
@@ -24,6 +26,7 @@ from typing import Callable, Dict, List, Optional
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.manifest import load_manifest
 
 from ..op_base import Op
 
@@ -543,16 +546,70 @@ def coalesce_broadcast_dims(a_shape, b_shape):
     return out_shape, coalesced_shape, a_strides, b_strides
 
 
-def _apply_fp8_post_cast(result: torch.Tensor, kernel) -> torch.Tensor:
-    """Apply fp8 output cast if the kernel requires it.
+_SAME_AS_RE = re.compile(r"^same_as\(\s*\w+\s*\)$")
+_PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*\w+\s*\)$")
+# Target dtype for integral inputs under ``promote_int_to_float``, matching
+# PyTorch's int-input promotion (e.g. ``torch.reciprocal``).
+_PROMOTED_FLOAT_DTYPE = torch.float32
 
-    For e5m2 dtypes the kernel produces fp16 output to preserve Inf/NaN;
-    this helper performs the final non-saturating cast via PyTorch.
+
+@functools.lru_cache(maxsize=None)
+def _manifest_output_dtype_expr(op_class_name: str) -> str:
+    """Return the manifest ``signature.outputs`` dtype expression for an op.
+
+    Args:
+        op_class_name: Op class name, which is the manifest entry key.
+
+    Returns:
+        The declared dtype expression, e.g. ``"same_as(input)"`` or ``"bool"``.
+
+    Raises:
+        KeyError: If the manifest has no entry for *op_class_name*.
+        ValueError: If the entry declares other than exactly one output.
     """
-    fp8_out = getattr(kernel, "_fp8_output_dtype", None)
-    if fp8_out is not None:
-        return result.to(fp8_out)
-    return result
+    entry = load_manifest().get(op_class_name)
+    if entry is None:
+        raise KeyError(
+            f"{op_class_name} has no manifest entry; the output dtype is "
+            "declared under signature.outputs"
+        )
+    outputs = entry["signature"]["outputs"]
+    if len(outputs) != 1:
+        raise ValueError(
+            f"{op_class_name} declares {len(outputs)} outputs; the elementwise "
+            "bases resolve a single output dtype"
+        )
+    return next(iter(outputs.values()))["dtype"]
+
+
+def resolve_output_dtype(op_class_name: str, input_dtype: torch.dtype) -> torch.dtype:
+    """Resolve an op's output dtype from its manifest declaration.
+
+    Args:
+        op_class_name: Op class name, which is the manifest entry key.
+        input_dtype: Declared input dtype of the op instance.
+
+    Returns:
+        The output dtype. ``same_as(...)`` and dtype unions follow the input;
+        ``promote_int_to_float(...)`` promotes integral inputs to float32; a
+        bare dtype name resolves to that dtype.
+
+    Raises:
+        ValueError: If the declared expression names an unknown dtype.
+    """
+    expr = _manifest_output_dtype_expr(op_class_name)
+    if _SAME_AS_RE.match(expr) or "|" in expr:
+        return input_dtype
+    if _PROMOTE_INT_TO_FLOAT_RE.match(expr):
+        if input_dtype.is_floating_point:
+            return input_dtype
+        return _PROMOTED_FLOAT_DTYPE
+    resolved = getattr(torch, expr, None)
+    if not isinstance(resolved, torch.dtype):
+        raise ValueError(
+            f"{op_class_name}: manifest output dtype {expr!r} is not a torch dtype"
+        )
+    return resolved
 
 
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
@@ -615,12 +672,8 @@ class UnaryOp(Op):
         return self.kernel_map[self._op_name](N_total, dtype, tune=tune)
 
     def _resolve_output_dtype(self) -> torch.dtype:
-        # Use _fp8_output_dtype (the final dtype after Op-layer post-cast)
-        # rather than kernel.output_dtype (which is fp16 for e5m2).
-        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
-        return fp8_out or getattr(
-            self.kernel, "output_dtype", self.dtype,
-        )
+        """Return the manifest-declared output dtype for this op."""
+        return resolve_output_dtype(type(self).__name__, self.dtype)
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -650,10 +703,7 @@ class UnaryOp(Op):
         """Direct kernel call for use inside custom_op implementation."""
         orig_shape = input.shape
         flat = input.contiguous().reshape(-1)
-        result = self.kernel(flat).reshape(orig_shape)
-        # For e5m2: kernel produces fp16 to preserve Inf/NaN;
-        # cast to e5m2 here using PyTorch's non-saturating conversion.
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel(flat).reshape(orig_shape)
 
     def _validate_input(self, input: torch.Tensor) -> None:
         """Validate input tensor against the op's dtype / numel contract."""
@@ -777,8 +827,7 @@ class BinaryOp(Op):
     def total_memory(self) -> float:
         """Read a + read b + write y."""
         in_elem = self.dtype.itemsize
-        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
-        out_elem = fp8_out.itemsize if fp8_out is not None else in_elem
+        out_elem = resolve_output_dtype(type(self).__name__, self.dtype).itemsize
         return (self.a_numel + self.b_numel) * in_elem + self.N_total * out_elem
 
     def _eager_forward(
@@ -787,10 +836,9 @@ class BinaryOp(Op):
         other: torch.Tensor,
     ) -> torch.Tensor:
         """Direct kernel call for use inside custom_op implementation."""
-        result = self.kernel(
+        return self.kernel(
             input.contiguous().view(-1), other.contiguous().view(-1),
         ).reshape(self.out_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
 
     def forward(
         self,
@@ -882,12 +930,7 @@ class FusedGatedOp(Op):
                 "Fused gated dimensions are available after first forward"
             )
         in_elem = self.dtype.itemsize
-        fp8_out = (
-            getattr(self.kernel, "_fp8_output_dtype", None)
-            if self.kernel is not None
-            else None
-        )
-        out_elem = fp8_out.itemsize if fp8_out is not None else in_elem
+        out_elem = resolve_output_dtype(type(self).__name__, self.dtype).itemsize
         return self.M * 2 * self.N * in_elem + self.M * self.N * out_elem
 
     def eval_roofline(self) -> tuple[int, int]:
@@ -940,8 +983,7 @@ class FusedGatedOp(Op):
         M, N = self._validate_runtime_input(x)
         self._ensure_kernel(M, N, x.dtype)
         x = x.contiguous()
-        result = self.kernel(x)
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel(x)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         M, N = self._validate_runtime_input(x)
@@ -1051,11 +1093,9 @@ class _ParametricActivationOp(_UnaryActivationMixin, UnaryOp):
         self.dtype = dtype
         self.inplace = inplace
         self.kernel = kernel
-        # Surface ``output_dtype`` for FP8 post-cast accounting in
-        # ``total_memory``, as ``UnaryOp.__init__`` does. No parametric
-        # activation declares an FP8 path yet, so this resolves to self.dtype.
-        fp8_out = getattr(self.kernel, "_fp8_output_dtype", None)
-        self.output_dtype = fp8_out or getattr(self.kernel, "output_dtype", dtype)
+        # Surface ``output_dtype`` for ``total_memory`` accounting, as
+        # ``UnaryOp.__init__`` does.
+        self.output_dtype = resolve_output_dtype(type(self).__name__, dtype)
         self._instance_key = id(self)
         _OP_REGISTRY[self._instance_key] = self
 

--- a/tileops/ops/elementwise/_base.py
+++ b/tileops/ops/elementwise/_base.py
@@ -18,7 +18,6 @@ Utility:
 import functools
 import inspect
 import math
-import re
 import weakref
 from math import prod
 from typing import Callable, Dict, List, Optional
@@ -27,6 +26,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.manifest import load_manifest
+from tileops.manifest.dtype_rules import promote_int_to_float_ref, same_as_ref
 
 from ..op_base import Op
 
@@ -546,8 +546,6 @@ def coalesce_broadcast_dims(a_shape, b_shape):
     return out_shape, coalesced_shape, a_strides, b_strides
 
 
-_SAME_AS_RE = re.compile(r"^same_as\(\s*\w+\s*\)$")
-_PROMOTE_INT_TO_FLOAT_RE = re.compile(r"^promote_int_to_float\(\s*\w+\s*\)$")
 # Target dtype for integral inputs under ``promote_int_to_float``, matching
 # PyTorch's int-input promotion (e.g. ``torch.reciprocal``).
 _PROMOTED_FLOAT_DTYPE = torch.float32
@@ -598,9 +596,9 @@ def resolve_output_dtype(op_class_name: str, input_dtype: torch.dtype) -> torch.
         ValueError: If the declared expression names an unknown dtype.
     """
     expr = _manifest_output_dtype_expr(op_class_name)
-    if _SAME_AS_RE.match(expr) or "|" in expr:
+    if same_as_ref(expr) is not None or "|" in expr:
         return input_dtype
-    if _PROMOTE_INT_TO_FLOAT_RE.match(expr):
+    if promote_int_to_float_ref(expr) is not None:
         if input_dtype.is_floating_point:
             return input_dtype
         return _PROMOTED_FLOAT_DTYPE

--- a/tileops/ops/elementwise/alibi.py
+++ b/tileops/ops/elementwise/alibi.py
@@ -8,7 +8,6 @@ from tileops.kernels.elementwise import AlibiFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
 from ..op_base import Op
-from ._base import _apply_fp8_post_cast
 
 
 class AlibiFwdOp(Op):
@@ -66,6 +65,4 @@ class AlibiFwdOp(Op):
         return 3 * n_elem, self.total_memory
 
     def forward(self) -> torch.Tensor:
-        out = self.kernel()
-        result = out.reshape(self.num_heads, self.seq_len, self.seq_len)
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel().reshape(self.num_heads, self.seq_len, self.seq_len)

--- a/tileops/ops/elementwise/clamp.py
+++ b/tileops/ops/elementwise/clamp.py
@@ -11,7 +11,6 @@ from tileops.kernels.kernel_base import Kernel
 from ..op_base import Op
 from ._base import (
     _OP_REGISTRY,
-    _apply_fp8_post_cast,
     _ClampTensorBase,
     _validate_scalar_param_repr,
 )
@@ -326,8 +325,7 @@ class ClampScalarFwdOp(Op):
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:
         orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if not input.is_cuda:

--- a/tileops/ops/elementwise/masked_fill.py
+++ b/tileops/ops/elementwise/masked_fill.py
@@ -12,7 +12,7 @@ from tileops.kernels.elementwise import (
 from tileops.kernels.kernel_base import Kernel
 
 from ..op_base import Op
-from ._base import _OP_REGISTRY, _apply_fp8_post_cast, _validate_scalar_param_repr
+from ._base import _OP_REGISTRY, _validate_scalar_param_repr
 
 
 class MaskedFillFwdOp(Op):
@@ -227,8 +227,7 @@ class MaskedFillScalarFwdOp(Op):
         result = self.kernel(x_flat, mask_flat)
         if self._bool_storage:
             result = result.view(torch.bool)
-        result = result.view(self.out_shape if self.out_shape else ())
-        return _apply_fp8_post_cast(result, self.kernel)
+        return result.view(self.out_shape if self.out_shape else ())
 
     def forward(self, input: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         if not input.is_cuda:

--- a/tileops/ops/elementwise/nan_to_num.py
+++ b/tileops/ops/elementwise/nan_to_num.py
@@ -8,7 +8,7 @@ from tileops.kernels.elementwise import NanToNumFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
 from ..op_base import Op
-from ._base import _OP_REGISTRY, _apply_fp8_post_cast, _validate_scalar_param_repr
+from ._base import _OP_REGISTRY, _validate_scalar_param_repr
 
 
 class NanToNumFwdOp(Op):
@@ -91,8 +91,7 @@ class NanToNumFwdOp(Op):
 
     def _eager_forward(self, input: torch.Tensor) -> torch.Tensor:
         orig_shape = input.shape
-        result = self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel(input.contiguous().reshape(-1)).reshape(orig_shape)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if not input.is_cuda:

--- a/tileops/ops/elementwise/prelu.py
+++ b/tileops/ops/elementwise/prelu.py
@@ -9,7 +9,7 @@ from tileops.kernels.elementwise import PreluFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
 from ..op_base import Op
-from ._base import _OP_REGISTRY, _apply_fp8_post_cast
+from ._base import _OP_REGISTRY
 
 
 class PreluFwdOp(Op):
@@ -66,10 +66,9 @@ class PreluFwdOp(Op):
         weight: torch.Tensor,
     ) -> torch.Tensor:
         orig_shape = input.shape
-        result = self.kernel(
+        return self.kernel(
             input.contiguous().reshape(-1), weight.contiguous().reshape(-1),
         ).reshape(orig_shape)
-        return _apply_fp8_post_cast(result, self.kernel)
 
     def forward(
         self,

--- a/tileops/ops/elementwise/sinusoidal.py
+++ b/tileops/ops/elementwise/sinusoidal.py
@@ -8,7 +8,6 @@ from tileops.kernels.elementwise import SinusoidalFwdKernel
 from tileops.kernels.kernel_base import Kernel
 
 from ..op_base import Op
-from ._base import _apply_fp8_post_cast
 
 
 class SinusoidalFwdOp(Op):
@@ -66,6 +65,4 @@ class SinusoidalFwdOp(Op):
         return 6 * n_elem, self.total_memory
 
     def forward(self) -> torch.Tensor:
-        out = self.kernel()
-        result = out.reshape(self.seq_len, self.d_model)
-        return _apply_fp8_post_cast(result, self.kernel)
+        return self.kernel().reshape(self.seq_len, self.d_model)

--- a/tileops/ops/engram.py
+++ b/tileops/ops/engram.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.engram import EngramGateConvBwdKernel, EngramGateConvFwdKernel
 from tileops.kernels.kernel_base import Kernel
@@ -10,12 +9,7 @@ from .op_base import Op
 
 __all__ = ["EngramGateConvBwdOp", "EngramGateConvFwdOp"]
 
-ALIGNMENT = 256
 CONV_KERNEL_SIZE = 4
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class EngramGateConvFwdOp(Op):
@@ -52,7 +46,6 @@ class EngramGateConvFwdOp(Op):
         self.d = d
         self.dtype = dtype
         self.eps = eps
-        self.d_padded = _align_up(d, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["engram_gate_conv_fwd"](
             M, seq_len, d, eps, dtype, tune=tune,
@@ -106,24 +99,7 @@ class EngramGateConvFwdOp(Op):
         k = k.contiguous()
         v = v.contiguous()
 
-        # Pad hidden dim to alignment if needed
-        if self.d_padded != self.d:
-            H = F.pad(H, (0, self.d_padded - self.d))
-            k = F.pad(k, (0, self.d_padded - self.d))
-            v = F.pad(v, (0, self.d_padded - self.d))
-            rms_w_h = F.pad(rms_w_h, (0, self.d_padded - self.d))
-            rms_w_v = F.pad(rms_w_v, (0, self.d_padded - self.d))
-            conv_w = F.pad(conv_w, (0, self.d_padded - self.d))
-
-        results = self.kernel(H, k, v, rms_w_h, rms_w_v, conv_w)
-        # results: [Y, vhat, alpha, rrms_h, rrms_k, rrms_v]
-
-        # Trim padding on d-dim tensors
-        if self.d_padded != self.d:
-            results[0] = results[0][:, :, :self.d]   # Y
-            results[1] = results[1][:, :, :self.d]   # vhat
-
-        return results
+        return self.kernel(H, k, v, rms_w_h, rms_w_v, conv_w)
 
 
 class EngramGateConvBwdOp(Op):
@@ -160,7 +136,6 @@ class EngramGateConvBwdOp(Op):
         self.d = d
         self.dtype = dtype
         self.eps = eps
-        self.d_padded = _align_up(d, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["engram_gate_conv_bwd"](
             M, seq_len, d, eps, dtype, tune=tune,
@@ -220,33 +195,7 @@ class EngramGateConvBwdOp(Op):
         v = v.contiguous()
         vhat = vhat.contiguous()
 
-        # Pad hidden dim if needed
-        if self.d_padded != self.d:
-            dY = F.pad(dY, (0, self.d_padded - self.d))
-            H = F.pad(H, (0, self.d_padded - self.d))
-            k = F.pad(k, (0, self.d_padded - self.d))
-            v = F.pad(v, (0, self.d_padded - self.d))
-            vhat = F.pad(vhat, (0, self.d_padded - self.d))
-            rms_w_h = F.pad(rms_w_h, (0, self.d_padded - self.d))
-            rms_w_v = F.pad(rms_w_v, (0, self.d_padded - self.d))
-            conv_w = F.pad(conv_w, (0, self.d_padded - self.d))
-
-        results = self.kernel(
+        return self.kernel(
             dY, H, k, v, rms_w_h, rms_w_v, conv_w,
             vhat, alpha, rrms_h, rrms_k, rrms_v,
         )
-        # results: [dH, dk, dv, drms_w_h, drms_w_v, dconv_w, dvhat_buf]
-
-        dH, dk, dv = results[0], results[1], results[2]
-        drms_w_h, drms_w_v, dconv_w = results[3], results[4], results[5]
-
-        # Trim padding
-        if self.d_padded != self.d:
-            dH = dH[:, :, :self.d]
-            dk = dk[:, :, :self.d]
-            dv = dv[:, :, :self.d]
-            drms_w_h = drms_w_h[:self.d]
-            drms_w_v = drms_w_v[:self.d]
-            dconv_w = dconv_w[:, :self.d]
-
-        return [dH, dk, dv, drms_w_h, drms_w_v, dconv_w]

--- a/tileops/ops/engram_decode.py
+++ b/tileops/ops/engram_decode.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.engram import EngramDecodeKernel
 from tileops.kernels.kernel_base import Kernel
@@ -9,12 +8,6 @@ from tileops.kernels.kernel_base import Kernel
 from .op_base import Op
 
 __all__ = ["EngramDecodeOp"]
-
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 class EngramDecodeOp(Op):
@@ -58,7 +51,6 @@ class EngramDecodeOp(Op):
         self.dilation = dilation
         self.dtype = dtype
         self.eps = eps
-        self.d_padded = _align_up(d, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self.kernel = self.kernel_map["engram_decode"](
             batch, d_mem, d, max_conv_len, conv_kernel_size, dilation,
@@ -106,30 +98,6 @@ class EngramDecodeOp(Op):
         h_t = h_t.contiguous()
         conv_state = conv_state.contiguous()
 
-        # Left-pad conv_state to max_conv_len if needed
-        if conv_state.shape[1] < self.max_conv_len:
-            conv_state = F.pad(
-                conv_state,
-                (0, 0, self.max_conv_len - conv_state.shape[1], 0),
-                mode='constant', value=0,
-            )
-
-        # Pad d dimension to alignment
-        if self.d_padded != self.d:
-            h_t = F.pad(h_t, (0, self.d_padded - self.d))
-            conv_state = F.pad(conv_state, (0, self.d_padded - self.d))
-            W_K = F.pad(W_K, (0, self.d_padded - self.d))
-            W_V = F.pad(W_V, (0, self.d_padded - self.d))
-            rms_w_h = F.pad(rms_w_h, (0, self.d_padded - self.d))
-            rms_w_v = F.pad(rms_w_v, (0, self.d_padded - self.d))
-            conv_w = F.pad(conv_w, (0, self.d_padded - self.d))
-
-        results = self.kernel(
+        return self.kernel(
             e_t, h_t, conv_state, W_K, W_V, rms_w_h, rms_w_v, conv_w,
         )
-
-        if self.d_padded != self.d:
-            results[0] = results[0][:, :self.d]
-            results[1] = results[1][:, :, :self.d]
-
-        return results

--- a/tileops/ops/norm/fused_add_layer_norm.py
+++ b/tileops/ops/norm/fused_add_layer_norm.py
@@ -1,13 +1,11 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import FusedAddLayerNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["FusedAddLayerNormFwdOp"]
 
@@ -170,22 +168,9 @@ class FusedAddLayerNormFwdOp(Op):
         dtype = expected_dtype
         assert dtype is not None
         self.dtype = dtype
-        N_padded = align_up(N, ALIGNMENT)
-
-        # Pad hidden dim to 256-element alignment if needed
-        if N_padded != N:
-            x = F.pad(x, (0, N_padded - N))
-            residual = F.pad(residual, (0, N_padded - N))
-            weight = F.pad(weight, (0, N_padded - N))
-            bias = F.pad(bias, (0, N_padded - N))
 
         kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
         y, residual_out = kernel(x, residual, weight, bias)
         self._last_roofline_mn = (M_actual, N)
-
-        # Trim padding
-        if N_padded != N:
-            y = y[:, :N]
-            residual_out = residual_out[:, :N]
 
         return y.reshape(orig_shape), residual_out.reshape(orig_shape)

--- a/tileops/ops/norm/fused_add_rms_norm.py
+++ b/tileops/ops/norm/fused_add_rms_norm.py
@@ -1,13 +1,11 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import FusedAddRMSNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["FusedAddRMSNormFwdOp"]
 
@@ -158,21 +156,9 @@ class FusedAddRMSNormFwdOp(Op):
         dtype = expected_dtype
         assert dtype is not None
         self.dtype = dtype
-        N_padded = align_up(N, ALIGNMENT)
-
-        # Pad hidden dim to 256-element alignment if needed
-        if N_padded != N:
-            x = F.pad(x, (0, N_padded - N))
-            residual = F.pad(residual, (0, N_padded - N))
-            weight = F.pad(weight, (0, N_padded - N))
 
         kernel = self._get_kernel(M_actual, N, dtype, x.device.index)
         y, residual_out = kernel(x, residual, weight)
         self._last_roofline_mn = (M_actual, N)
-
-        # Trim padding
-        if N_padded != N:
-            y = y[:, :N]
-            residual_out = residual_out[:, :N]
 
         return y.reshape(orig_shape), residual_out.reshape(orig_shape)

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -8,28 +8,20 @@ User-facing API mirrors torch.nn.functional.group_norm:
     y = op(x, weight, bias)
 
 Input tensors accept shape (N, C, *spatial); the op reshapes to
-(N*num_groups, D_padded) internally where
-D = (C/num_groups) * spatial_size.
+(N*num_groups, D) internally where D = (C/num_groups) * spatial_size.
 """
 
 import math
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["GroupNormFwdOp", "GroupNormNoAffineFwdOp"]
-
-# Largest candidate block_m in GroupNormNoAffineKernel.autotune_configs.
-# The op pads M to a multiple of this value so the kernel's full-tile
-# T.copy never crosses the M boundary regardless of the selected block_m.
-_M_BLOCK_ALIGN = 16
 
 
 class GroupNormFwdOp(Op):
@@ -79,7 +71,6 @@ class GroupNormFwdOp(Op):
         self.spatial_size: Optional[int] = None
         self.D: Optional[int] = None
         self.M: Optional[int] = None
-        self.D_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
@@ -104,7 +95,7 @@ class GroupNormFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:
@@ -124,8 +115,7 @@ class GroupNormFwdOp(Op):
         cpg = C // self.num_groups
         D = cpg * spatial_size
         M = N * self.num_groups
-        D_padded = align_up(D, ALIGNMENT)
-        return N, C, spatial, spatial_size, cpg, D, M, D_padded, x.dtype
+        return N, C, spatial, spatial_size, cpg, D, M, x.dtype
 
     def _bind_spec(
         self,
@@ -135,7 +125,6 @@ class GroupNormFwdOp(Op):
         spatial_size: int,
         D: int,
         M: int,
-        D_padded: int,
         dtype: torch.dtype,
     ) -> None:
         self.N = N
@@ -144,7 +133,6 @@ class GroupNormFwdOp(Op):
         self.spatial_size = spatial_size
         self.D = D
         self.M = M
-        self.D_padded = D_padded
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
@@ -152,20 +140,19 @@ class GroupNormFwdOp(Op):
         self,
         M: int,
         D: int,
-        D_padded: int,
         dtype: torch.dtype,
         device: torch.device,
         device_index: Optional[int],
     ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
-        key = (M, D, D_padded, dtype, device_index, self.eps, self.tune)
+        key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["group_norm"](
                 M, D, self.eps, dtype, tune=self.tune,
             )
         if key not in self._constant_cache:
             self._constant_cache[key] = (
-                torch.ones(D_padded, dtype=dtype, device=device),
-                torch.zeros(D_padded, dtype=dtype, device=device),
+                torch.ones(D, dtype=dtype, device=device),
+                torch.zeros(D, dtype=dtype, device=device),
             )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
@@ -202,7 +189,6 @@ class GroupNormFwdOp(Op):
             cpg,
             D,
             M,
-            D_padded,
             dtype,
         ) = self._resolve_spec(x)
         if not isinstance(weight, torch.Tensor):
@@ -244,9 +230,9 @@ class GroupNormFwdOp(Op):
                 f"Expected bias shape ({C},), got {bias.shape}"
             )
 
-        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, dtype)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
         kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
-            M, D, D_padded, dtype, x.device, x.device.index,
+            M, D, dtype, x.device, x.device.index,
         )
         orig_shape = x.shape
         x = x.contiguous()
@@ -255,16 +241,10 @@ class GroupNormFwdOp(Op):
         )
         x_2d = x_reshaped.reshape(M, D)
 
-        if D_padded != D:
-            x_2d = F.pad(x_2d, (0, D_padded - D))
-
         # Kernel broadcasts 1D weight/bias row-wise; GroupNorm's per-group
         # affine doesn't fit that layout, so run the kernel with identity
         # (unit/zero) and apply per-channel affine after.
         y_2d = kernel(x_2d, unit_weight, zero_bias)
-
-        if D_padded != D:
-            y_2d = y_2d[:, :D]
 
         y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
         y = y.reshape(orig_shape)
@@ -317,8 +297,6 @@ class GroupNormNoAffineFwdOp(Op):
         self.spatial_size: Optional[int] = None
         self.D: Optional[int] = None
         self.M: Optional[int] = None
-        self.D_padded: Optional[int] = None
-        self.M_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self.kernel: Optional[Kernel] = None
@@ -342,7 +320,7 @@ class GroupNormNoAffineFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:
@@ -362,9 +340,7 @@ class GroupNormNoAffineFwdOp(Op):
         cpg = C // self.num_groups
         D = cpg * spatial_size
         M = N * self.num_groups
-        D_padded = align_up(D, ALIGNMENT)
-        M_padded = align_up(M, _M_BLOCK_ALIGN)
-        return N, C, spatial, spatial_size, cpg, D, M, D_padded, M_padded, x.dtype
+        return N, C, spatial, spatial_size, cpg, D, M, x.dtype
 
     def _bind_spec(
         self,
@@ -374,8 +350,6 @@ class GroupNormNoAffineFwdOp(Op):
         spatial_size: int,
         D: int,
         M: int,
-        D_padded: int,
-        M_padded: int,
         dtype: torch.dtype,
     ) -> None:
         self.N = N
@@ -384,22 +358,20 @@ class GroupNormNoAffineFwdOp(Op):
         self.spatial_size = spatial_size
         self.D = D
         self.M = M
-        self.D_padded = D_padded
-        self.M_padded = M_padded
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
     def _get_kernel(
         self,
-        M_padded: int,
+        M: int,
         D: int,
         dtype: torch.dtype,
         device_index: Optional[int],
     ) -> Kernel:
-        key = (M_padded, D, dtype, device_index, self.eps, self.tune)
+        key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["group_norm_no_affine"](
-                M_padded, D, self.eps, dtype, tune=self.tune,
+                M, D, self.eps, dtype, tune=self.tune,
             )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
@@ -427,30 +399,17 @@ class GroupNormNoAffineFwdOp(Op):
             cpg,
             D,
             M,
-            D_padded,
-            M_padded,
             dtype,
         ) = self._resolve_spec(x)
-        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, M_padded, dtype)
-        kernel = self._get_kernel(M_padded, D, dtype, x.device.index)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
+        kernel = self._get_kernel(M, D, dtype, x.device.index)
 
         orig_shape = x.shape
         x = x.contiguous()
         x_reshaped = x.reshape(N, self.num_groups, cpg, *spatial)
         x_2d = x_reshaped.reshape(M, D)
 
-        if D_padded != D:
-            x_2d = F.pad(x_2d, (0, D_padded - D))
-        if M_padded != M:
-            # Pad along dim 0 (M); padded rows are dropped after the kernel.
-            x_2d = F.pad(x_2d, (0, 0, 0, M_padded - M))
-
         y_2d = kernel(x_2d)
-
-        if M_padded != M:
-            y_2d = y_2d[:M, :]
-        if D_padded != D:
-            y_2d = y_2d[:, :D]
 
         y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
         return y.reshape(orig_shape)

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -73,7 +73,6 @@ class GroupNormFwdOp(Op):
         self.M: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
-        self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
         self.kernel: Optional[Kernel] = None
         self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
@@ -136,28 +135,21 @@ class GroupNormFwdOp(Op):
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
-    def _get_kernel_and_constants(
+    def _get_kernel(
         self,
         M: int,
         D: int,
         dtype: torch.dtype,
-        device: torch.device,
         device_index: Optional[int],
-    ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
+    ) -> Kernel:
         key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["group_norm"](
                 M, D, self.eps, dtype, tune=self.tune,
             )
-        if key not in self._constant_cache:
-            self._constant_cache[key] = (
-                torch.ones(D, dtype=dtype, device=device),
-                torch.zeros(D, dtype=dtype, device=device),
-            )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
-        unit_weight, zero_bias = self._constant_cache[key]
-        return kernel, unit_weight, zero_bias
+        return kernel
 
     def forward(
         self,
@@ -231,9 +223,7 @@ class GroupNormFwdOp(Op):
             )
 
         self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
-        kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
-            M, D, dtype, x.device, x.device.index,
-        )
+        kernel = self._get_kernel(M, D, dtype, x.device.index)
         orig_shape = x.shape
         x = x.contiguous()
         x_reshaped = x.reshape(
@@ -241,10 +231,10 @@ class GroupNormFwdOp(Op):
         )
         x_2d = x_reshaped.reshape(M, D)
 
-        # Kernel broadcasts 1D weight/bias row-wise; GroupNorm's per-group
-        # affine doesn't fit that layout, so run the kernel with identity
-        # (unit/zero) and apply per-channel affine after.
-        y_2d = kernel(x_2d, unit_weight, zero_bias)
+        # The kernel broadcasts its affine row-wise; GroupNorm's per-channel
+        # affine doesn't fit that layout, so normalize without an affine and
+        # apply the per-channel scale/shift after.
+        y_2d = kernel(x_2d)
 
         y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
         y = y.reshape(orig_shape)

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -16,7 +16,6 @@ import math
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import (
@@ -25,14 +24,8 @@ from tileops.kernels.norm import (
 )
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["InstanceNormFwdOp", "InstanceNormNoAffineFwdOp"]
-
-# Largest candidate block_m in InstanceNormNoAffineKernel.autotune_configs.
-# The op pads M to a multiple of this value so the kernel's full-tile
-# T.copy never crosses the M boundary regardless of the selected block_m.
-_M_BLOCK_ALIGN = 16
 
 
 class InstanceNormFwdOp(Op):
@@ -104,7 +97,6 @@ class InstanceNormFwdOp(Op):
         self.spatial_size: Optional[int] = None
         self.D: Optional[int] = None
         self.M: Optional[int] = None
-        self.D_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
@@ -146,7 +138,7 @@ class InstanceNormFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:
@@ -161,8 +153,7 @@ class InstanceNormFwdOp(Op):
         spatial_size = math.prod(spatial)
         D = spatial_size
         M = N * C
-        D_padded = align_up(D, ALIGNMENT)
-        return N, C, spatial, spatial_size, D, M, D_padded, x.dtype
+        return N, C, spatial, spatial_size, D, M, x.dtype
 
     def _bind_spec(
         self,
@@ -172,7 +163,6 @@ class InstanceNormFwdOp(Op):
         spatial_size: int,
         D: int,
         M: int,
-        D_padded: int,
         dtype: torch.dtype,
     ) -> None:
         self.N = N
@@ -181,7 +171,6 @@ class InstanceNormFwdOp(Op):
         self.spatial_size = spatial_size
         self.D = D
         self.M = M
-        self.D_padded = D_padded
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
@@ -189,20 +178,19 @@ class InstanceNormFwdOp(Op):
         self,
         M: int,
         D: int,
-        D_padded: int,
         dtype: torch.dtype,
         device: torch.device,
         device_index: Optional[int],
     ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
-        key = (M, D, D_padded, dtype, device_index, self.eps, self.tune)
+        key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["group_norm"](
                 M, D, self.eps, dtype, tune=self.tune,
             )
         if key not in self._constant_cache:
             self._constant_cache[key] = (
-                torch.ones(D_padded, dtype=dtype, device=device),
-                torch.zeros(D_padded, dtype=dtype, device=device),
+                torch.ones(D, dtype=dtype, device=device),
+                torch.zeros(D, dtype=dtype, device=device),
             )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
@@ -242,7 +230,7 @@ class InstanceNormFwdOp(Op):
                 "affine-free path"
             )
         self._validate_dtypes(x, weight, bias)
-        N, C, spatial, spatial_size, D, M, D_padded, dtype = self._resolve_spec(x)
+        N, C, spatial, spatial_size, D, M, dtype = self._resolve_spec(x)
         if not weight.is_cuda:
             raise ValueError("weight must be a CUDA tensor")
         if weight.device != x.device:
@@ -264,24 +252,17 @@ class InstanceNormFwdOp(Op):
                 f"Expected bias shape ({C},), got {bias.shape}"
             )
 
-        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, dtype)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
         kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
-            M, D, D_padded, dtype, x.device, x.device.index,
+            M, D, dtype, x.device, x.device.index,
         )
         orig_shape = x.shape
         x = x.contiguous()
         x_2d = x.reshape(M, D)
 
-        if D_padded != D:
-            x_2d = F.pad(x_2d, (0, D_padded - D))
-
         # Kernel broadcasts 1D weight/bias row-wise; per-channel affine is
         # applied after, so run the kernel with identity (unit/zero) buffers.
         y_2d = kernel(x_2d, unit_weight, zero_bias)
-
-        # Trim padding
-        if D_padded != D:
-            y_2d = y_2d[:, :D]
 
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)
@@ -343,8 +324,6 @@ class InstanceNormNoAffineFwdOp(Op):
         self.D: Optional[int] = None
         self.M: Optional[int] = None
         self._running_stats_broadcast_shape: Optional[list[int]] = None
-        self.D_padded: Optional[int] = None
-        self.M_padded: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
         self.kernel: Optional[Kernel] = None
@@ -423,7 +402,7 @@ class InstanceNormNoAffineFwdOp(Op):
 
     def _resolve_spec(
         self, x: torch.Tensor
-    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, int, int, torch.dtype]:
+    ) -> Tuple[int, int, Tuple[int, ...], int, int, int, torch.dtype]:
         if not x.is_cuda:
             raise ValueError("x must be a CUDA tensor")
         if x.ndim < 2:
@@ -438,9 +417,7 @@ class InstanceNormNoAffineFwdOp(Op):
         spatial_size = math.prod(spatial)
         D = spatial_size
         M = N * C
-        D_padded = align_up(D, ALIGNMENT)
-        M_padded = align_up(M, _M_BLOCK_ALIGN)
-        return N, C, spatial, spatial_size, D, M, D_padded, M_padded, x.dtype
+        return N, C, spatial, spatial_size, D, M, x.dtype
 
     def _bind_spec(
         self,
@@ -450,8 +427,6 @@ class InstanceNormNoAffineFwdOp(Op):
         spatial_size: int,
         D: int,
         M: int,
-        D_padded: int,
-        M_padded: int,
         dtype: torch.dtype,
     ) -> None:
         self.N = N
@@ -460,23 +435,21 @@ class InstanceNormNoAffineFwdOp(Op):
         self.spatial_size = spatial_size
         self.D = D
         self.M = M
-        self.D_padded = D_padded
-        self.M_padded = M_padded
         self._running_stats_broadcast_shape = [1, C] + [1] * len(spatial)
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
     def _get_kernel(
         self,
-        M_padded: int,
+        M: int,
         D: int,
         dtype: torch.dtype,
         device_index: Optional[int],
     ) -> Kernel:
-        key = (M_padded, D, dtype, device_index, self.eps, self.tune)
+        key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["instance_norm_no_affine"](
-                M_padded, D, self.eps, dtype, tune=self.tune,
+                M, D, self.eps, dtype, tune=self.tune,
             )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
@@ -516,13 +489,11 @@ class InstanceNormNoAffineFwdOp(Op):
             spatial_size,
             D,
             M,
-            D_padded,
-            M_padded,
             dtype,
         ) = self._resolve_spec(x)
         self._validate_running_stats("running_mean", running_mean, x.device, C)
         self._validate_running_stats("running_var", running_var, x.device, C)
-        self._bind_spec(N, C, spatial, spatial_size, D, M, D_padded, M_padded, dtype)
+        self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
 
         if not self.use_input_stats:
             # Eval-mode path: y = (x - running_mean[c]) / sqrt(running_var[c] + eps).
@@ -538,18 +509,7 @@ class InstanceNormNoAffineFwdOp(Op):
         x = x.contiguous()
         x_2d = x.reshape(M, D)
 
-        if D_padded != D:
-            x_2d = F.pad(x_2d, (0, D_padded - D))
-        if M_padded != M:
-            # Pad along dim 0 (M); padded rows are dropped after the kernel.
-            x_2d = F.pad(x_2d, (0, 0, 0, M_padded - M))
-
-        kernel = self._get_kernel(M_padded, D, dtype, x.device.index)
+        kernel = self._get_kernel(M, D, dtype, x.device.index)
         y_2d = kernel(x_2d)
-
-        if M_padded != M:
-            y_2d = y_2d[:M, :]
-        if D_padded != D:
-            y_2d = y_2d[:, :D]
 
         return y_2d.reshape(orig_shape)

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -99,7 +99,6 @@ class InstanceNormFwdOp(Op):
         self.M: Optional[int] = None
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[tuple, Kernel] = {}
-        self._constant_cache: Dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
         self.kernel: Optional[Kernel] = None
         self._last_roofline_spec: Optional[tuple[int, int, int, torch.dtype]] = None
 
@@ -174,28 +173,21 @@ class InstanceNormFwdOp(Op):
         self.dtype = dtype
         self._last_roofline_spec = (N, C, spatial_size, dtype)
 
-    def _get_kernel_and_constants(
+    def _get_kernel(
         self,
         M: int,
         D: int,
         dtype: torch.dtype,
-        device: torch.device,
         device_index: Optional[int],
-    ) -> Tuple[Kernel, torch.Tensor, torch.Tensor]:
+    ) -> Kernel:
         key = (M, D, dtype, device_index, self.eps, self.tune)
         if key not in self._kernel_cache:
             self._kernel_cache[key] = self.kernel_map["group_norm"](
                 M, D, self.eps, dtype, tune=self.tune,
             )
-        if key not in self._constant_cache:
-            self._constant_cache[key] = (
-                torch.ones(D, dtype=dtype, device=device),
-                torch.zeros(D, dtype=dtype, device=device),
-            )
         kernel = self._kernel_cache[key]
         self.kernel = kernel
-        unit_weight, zero_bias = self._constant_cache[key]
-        return kernel, unit_weight, zero_bias
+        return kernel
 
     def forward(
         self,
@@ -253,16 +245,14 @@ class InstanceNormFwdOp(Op):
             )
 
         self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
-        kernel, unit_weight, zero_bias = self._get_kernel_and_constants(
-            M, D, dtype, x.device, x.device.index,
-        )
+        kernel = self._get_kernel(M, D, dtype, x.device.index)
         orig_shape = x.shape
         x = x.contiguous()
         x_2d = x.reshape(M, D)
 
-        # Kernel broadcasts 1D weight/bias row-wise; per-channel affine is
-        # applied after, so run the kernel with identity (unit/zero) buffers.
-        y_2d = kernel(x_2d, unit_weight, zero_bias)
+        # The kernel broadcasts its affine row-wise; the per-channel affine
+        # is applied after, so normalize without an affine here.
+        y_2d = kernel(x_2d)
 
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
         y = y_2d.reshape(orig_shape)

--- a/tileops/ops/norm/rms_norm.py
+++ b/tileops/ops/norm/rms_norm.py
@@ -2,13 +2,11 @@ import math
 from typing import Dict, Optional, Sequence, Tuple
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import RMSNormKernel
 
 from ..op_base import Op
-from .norm_base import ALIGNMENT, align_up
 
 __all__ = ["RMSNormFwdOp"]
 
@@ -57,7 +55,6 @@ class RMSNormFwdOp(Op):
         self.dtype = dtype
         self.eps = _DEFAULT_EPS if eps is None else float(eps)
         self.tune = tune
-        self.N_padded = align_up(self.N, ALIGNMENT)
         self.dispatch_kernel(kernel_map)
         self._kernel_cache: Dict[int, Kernel] = {}
         self._last_roofline_mn: Optional[Tuple[int, int]] = None
@@ -123,11 +120,6 @@ class RMSNormFwdOp(Op):
         x_flat = x.contiguous().reshape(-1, self.N)
         w_flat = weight.contiguous().reshape(self.N)
         m = x_flat.shape[0]
-        if self.N_padded != self.N:
-            x_flat = F.pad(x_flat, (0, self.N_padded - self.N))
-            w_flat = F.pad(w_flat, (0, self.N_padded - self.N))
         y = self._get_kernel(m)(x_flat, w_flat)
-        if self.N_padded != self.N:
-            y = y[:, : self.N]
         self._last_roofline_mn = (m, self.N)
         return y.reshape(orig_shape)

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -71,6 +71,18 @@ class Op(ABC):
         maybe_install_validator(cls)
         maybe_install_eval_roofline(cls)
 
+    # FIXME(staged-rollout): the three contract stubs below — _infer_output_shapes,
+    # _validate_dtypes and eval_roofline — raise NotImplementedError instead of
+    # being @abstractmethod.
+    #
+    # Broken invariant: L1 does not enforce that every concrete Op implements them.
+    # Why: marking them abstract today breaks every op under tileops/ops/ that has
+    #     not been migrated to docs/design/ops-design.md, and eval_roofline bodies
+    #     are emitted by scaffold-op codegen that has not run for most ops yet. The
+    #     trust model requires one migration PR per op.
+    # Cleanup: when all three are implemented across tileops/ops/, make all three
+    #     @abstractmethod and delete this marker.
+
     @property
     @abstractmethod
     def default_kernel_map(self) -> dict[str, Kernel]:
@@ -85,18 +97,6 @@ class Op(ABC):
         ``**shape_kwargs`` base signature exists only to make the L1 contract
         grepable and discoverable; see docs/design/ops-design.md §``_infer_output_shapes``.
         """
-        # FIXME(staged-rollout): L1 Op does not yet strictly enforce _infer_output_shapes
-        # via @abstractmethod; base raises NotImplementedError instead.
-        #
-        # Broken invariant: L1 base does not strictly enforce implementation
-        #     of _infer_output_shapes on every concrete Op subclass.
-        # Why: Introducing @abstractmethod now would break all existing concrete
-        #     ops under tileops/ops/ that have not yet been migrated to the spec
-        #     in docs/design/ops-design.md; the trust model requires a separate
-        #     per-op migration PR.
-        # Cleanup: once all concrete ops under tileops/ops/ implement
-        #     _infer_output_shapes, _validate_dtypes, and eval_roofline,
-        #     convert this stub (and the two below) to `@abstractmethod`.
         raise NotImplementedError(
             "_infer_output_shapes must be implemented by the concrete Op subclass; "
             "see docs/design/ops-design.md §`_infer_output_shapes` (codegen)")
@@ -108,18 +108,6 @@ class Op(ABC):
         ``signature.inputs`` (e.g. ``_validate_dtypes(self, x, weight)``).
         See docs/design/ops-design.md §``_validate_dtypes``.
         """
-        # FIXME(staged-rollout): L1 Op does not yet strictly enforce _validate_dtypes
-        # via @abstractmethod; base raises NotImplementedError instead.
-        #
-        # Broken invariant: L1 base does not strictly enforce implementation
-        #     of _validate_dtypes on every concrete Op subclass.
-        # Why: Introducing @abstractmethod now would break all existing concrete
-        #     ops under tileops/ops/ that have not yet been migrated to the spec
-        #     in docs/design/ops-design.md; the trust model requires a separate
-        #     per-op migration PR.
-        # Cleanup: once all concrete ops under tileops/ops/ implement
-        #     _infer_output_shapes, _validate_dtypes, and eval_roofline,
-        #     convert this stub (and the others) to `@abstractmethod`.
         raise NotImplementedError(
             "_validate_dtypes must be implemented by the concrete Op subclass; "
             "see docs/design/ops-design.md §`_validate_dtypes` (codegen)")
@@ -133,21 +121,6 @@ class Op(ABC):
         evaluator at L1, by design (§4.4.6 rejects "Op-local AST evaluator").
         The L1 base only declares the contract; concrete ops supply the body.
         """
-        # FIXME(staged-rollout): L1 Op does not yet strictly enforce eval_roofline
-        # via @abstractmethod; base raises NotImplementedError instead.
-        #
-        # Broken invariant: L1 base does not strictly enforce implementation
-        #     of eval_roofline on every concrete Op subclass.
-        # Why: Introducing @abstractmethod now would break every existing
-        #     concrete op under tileops/ops/ (none of them ship an
-        #     eval_roofline yet). The scaffold-op codegen work that will
-        #     generate these bodies per docs/design/roofline.md §4.4 is pre-
-        #     requisite; the trust model requires a separate per-op migration
-        #     PR to flip any given op from stub to generated body.
-        # Cleanup: once all concrete ops under tileops/ops/ implement
-        #     eval_roofline (via codegen emission per docs/design/roofline.md §4.4),
-        #     convert this stub and the two stubs above (_infer_output_shapes,
-        #     _validate_dtypes) to `@abstractmethod`.
         raise NotImplementedError(
             "eval_roofline must be implemented by the concrete Op subclass, "
             "emitted per docs/design/roofline.md §4.4 (codegen); the L1 base "

--- a/tileops/ops/reduction/cumulative.py
+++ b/tileops/ops/reduction/cumulative.py
@@ -6,7 +6,6 @@ from typing import Dict, Optional, Tuple
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
 from tileops.kernels.reduction.cumulative import CumulativeKernel
 
 from ..op_base import Op
@@ -130,10 +129,6 @@ class CumulativeOp(Op):
         y = self._get_kernel(M, N, dtype, x.device.index)(x)
         self._last_roofline_mn = (M, N)
 
-        # Kernel output is N_padded-wide along last dim; trim to N.
-        N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        if N_padded != N:
-            y = y[:, :N]
         y = y.reshape(post_move_shape)
         if dim_norm != ndim - 1:
             y = y.movedim(-1, dim_norm)

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
 from tileops.kernels.reduction.logsumexp import LogSumExpKernel
 from tileops.kernels.reduction.softmax import SoftmaxKernel
 
@@ -33,7 +32,7 @@ def _resolve_implicit_softmax_dim(name: str, ndim: int) -> int:
 class _SoftmaxBaseOp(Op):
     """Base class for softmax-family ops.
 
-    Handles shared validation, reshape, pad/trim logic. Subclasses only
+    Handles shared validation and reshape logic. Subclasses only
     need to set ``_op_kind``, ``_kernel_key``, ``_kernel_class`` and
     override output reshaping if needed.
 
@@ -141,9 +140,6 @@ class _SoftmaxBaseOp(Op):
             self.kernel = kernel
             # Alignment padding is handled by the kernel's forward().
             y = kernel(x)
-            N_padded = align_up(N, DEFAULT_ALIGNMENT)
-            if N_padded != N:
-                y = y[:, :N] if y.ndim == 2 else y
             return restore_multidim_shape(y, orig_shape, dims, self.keepdim)
 
         # --- single-dim path ---
@@ -185,11 +181,6 @@ class _SoftmaxBaseOp(Op):
 
         # Alignment padding is handled by the kernel's forward().
         y = kernel(x)
-
-        # Trim padding (kernel output may still be N_padded-wide).
-        N_padded = align_up(N, DEFAULT_ALIGNMENT)
-        if N_padded != N:
-            y = y[:, :N] if y.ndim == 2 else y
 
         return self._reshape_output(y, orig_shape, dim, needs_transpose)
 

--- a/tileops/testing/mamba2_reference.py
+++ b/tileops/testing/mamba2_reference.py
@@ -93,3 +93,65 @@ def mamba2_fwd_ref(
     y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
 
     return (y_hist + y_intra).reshape(b, S, h, p)
+
+
+def ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups):
+    """Official-aligned PyTorch reference for chunk scan.
+
+    Inputs (official layouts):
+      x:           [B, S, H, P]        dtype
+      cb:          [B, C, G, L, L]     dtype    group-owned
+      dA_cumsum:   [B, H, C, L]        float32
+      C:           [B, S, G, N]        dtype    group-owned
+      prev_states: [B, C, H, P, N]     float32  P before N
+      dt:          [B, H, C, L]        dtype
+
+    Output: [B, S, H, P]  float32
+    """
+    b, S, h, p = x.shape
+    _, _, c, L = dA_cumsum.shape
+    n = C.shape[-1]
+    g = n_groups
+    heads_per_group = h // g
+
+    x_chunked = x.float().reshape(b, c, L, h, p)             # [B, C, L, H, P]
+    C_chunked = C.float().reshape(b, c, L, g, n)              # [B, C, L, G, N]
+    # broadcast C from groups to heads: [B, C, L, H, N]
+    C_heads = C_chunked[:, :, :, torch.arange(h, device=x.device) // heads_per_group, :]
+
+    # dA_cumsum: [B, H, C, L] -> [B, C, L, H] for broadcast
+    dA = dA_cumsum.float().permute(0, 2, 3, 1)  # [B, C, L, H]
+
+    # --- History path: exp(dA_l) * C[l] @ prev_states[p, n] ---
+    # prev_states: [B, C, H, P, N]
+    # C_heads:     [B, C, L, H, N] -> einsum over n: [B, C, L, H, P]
+    y_off = torch.einsum("bclhn,bchpn->bclhp", C_heads, prev_states.float())
+    y_off = y_off * torch.exp(dA).unsqueeze(-1)  # scale by exp(dA_l)
+
+    # --- Intra-chunk path: sum_{s<=l} cb[l,s] * exp(dA_l - dA_s) * dt[s] * x[s] ---
+    # cb: [B, C, G, L, L]; broadcast to heads [B, C, H, L, L]
+    cb_chunked = cb.float()  # [B, C, G, L, L]
+    cb_heads = cb_chunked[:, :, torch.arange(h, device=x.device) // heads_per_group, :, :]
+
+    # decay[b,c,h,l,s] = exp(dA_cumsum[l] - dA_cumsum[s])
+    dA_l = dA_cumsum.float().unsqueeze(-1)  # [B, H, C, L, 1]
+    dA_s = dA_cumsum.float().unsqueeze(-2)  # [B, H, C, 1, L]
+    decay = torch.exp(dA_l - dA_s)         # [B, H, C, L, L]
+
+    # causal mask
+    mask = torch.tril(torch.ones(L, L, device=x.device, dtype=torch.bool))
+    decay = decay.masked_fill(~mask.unsqueeze(0).unsqueeze(0).unsqueeze(0), 0.0)
+    decay = decay.permute(0, 2, 1, 3, 4)   # [B, C, H, L, L]
+
+    # dt: [B, H, C, L] -> [B, C, H, 1, L]
+    dt_s = dt.float().permute(0, 2, 1, 3).unsqueeze(-2)  # [B, C, H, 1, L]
+
+    # lcb[b,c,h,l,s] = cb[l,s] * decay[l,s] * dt[s]
+    lcb = cb_heads * decay * dt_s  # [B, C, H, L, L]
+
+    # y_diag[b,c,l,h,p] = sum_s lcb[b,c,h,l,s] * x[b,c,s,h,p]
+    y_diag = torch.einsum("bchls,bcshp->bclhp", lcb, x_chunked)
+
+    # combine and reshape to [B, S, H, P]
+    out = (y_off + y_diag).reshape(b, S, h, p)
+    return out

--- a/tileops/testing/mhc_reference.py
+++ b/tileops/testing/mhc_reference.py
@@ -1,0 +1,90 @@
+"""Pure-PyTorch references for the Multi-Head Compression (MHC) stages.
+
+Shared by the MHC tests and benchmarks so each stage has one oracle instead
+of a verbatim copy on both sides.
+"""
+
+import math
+
+import torch
+
+
+def mhc_pre_ref(
+    batch: int,
+    n_expand: int,
+    c_x: int,
+    phi: torch.Tensor,
+    x: torch.Tensor,
+    b: torch.Tensor,
+    alpha_pre,
+    alpha_post,
+    alpha_res,
+    sinkhorn_repeat: int,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference for the MHC pre-projection stage.
+
+    Returns:
+        ``(x_res_ref, x_layer_ref)``, both bfloat16.
+    """
+
+    xsqr = x * x
+    norm_eps = 0.0001
+    r_ref = torch.sqrt(xsqr.sum(dim=1)) / math.sqrt(n_expand * c_x) + norm_eps
+    H = torch.zeros([batch, n_expand * n_expand + 2 * n_expand],
+                    device="cuda", dtype=torch.float)
+    for i in range(batch):
+        H[i, :] = x[i, :].float() @ phi
+
+    H_pre_ref = H[:, :n_expand]
+    H_res_ref = H[:, 2 * n_expand:]
+    H_res_ref = H_res_ref.reshape(batch, n_expand, n_expand)
+
+    b_pre_ref = b[:n_expand]
+    b_res_ref = b[2 * n_expand:]
+    b_res_ref = b_res_ref.reshape([n_expand, n_expand])
+
+    H_pre_ref = torch.sigmoid(alpha_pre * H_pre_ref / r_ref.unsqueeze(-1) + b_pre_ref)
+    H_res_ref = alpha_res * H_res_ref / r_ref.unsqueeze(-1).unsqueeze(-1) + b_res_ref
+
+    H_res_ref_tmp = H_res_ref.max(dim=-1, keepdim=True).values
+
+    H_res_ref = torch.exp(H_res_ref - H_res_ref_tmp)
+    for _i in range(sinkhorn_repeat):
+        H_res_ref = H_res_ref / (H_res_ref.sum(dim=-1, keepdim=True) + eps)
+        H_res_ref = H_res_ref / (H_res_ref.sum(dim=-2, keepdim=True) + eps)
+    x_in_reshaped = x.reshape([batch, n_expand, c_x])
+    x_res_ref = torch.zeros([batch, n_expand, c_x], device="cuda", dtype=torch.bfloat16)
+    x_layer_ref = torch.zeros([batch, c_x], device="cuda", dtype=torch.bfloat16)
+
+    h_res_ref = H_res_ref
+    h_pre_ref = H_pre_ref
+    for i in range(batch):
+        h_res_tmp = h_res_ref[i, :, :].float()
+        h_pre_tmp = h_pre_ref[i, :].float()
+        x_in_reshaped_tmp = x_in_reshaped[i, :, :].float()
+        x_res_ref[i, :, :] = h_res_tmp @ x_in_reshaped_tmp
+        x_layer_ref[i, :] = h_pre_tmp @ x_in_reshaped_tmp
+
+    x_res_ref = x_res_ref.reshape(batch, n_expand * c_x)
+
+    x_res_ref = x_res_ref.bfloat16()
+    x_layer_ref = x_layer_ref.bfloat16()
+    return x_res_ref, x_layer_ref
+
+
+
+def mhc_post_ref(
+    batch: int,
+    n_expand: int,
+    c_x: int,
+    x_layer_out: torch.Tensor,
+    h_post: torch.Tensor,
+    x_res: torch.Tensor,
+) -> torch.Tensor:
+    """Reference for the MHC post-projection stage."""
+
+    x_out_ref = (h_post.unsqueeze(2).float() @ x_layer_out.unsqueeze(1).float()).reshape(
+        batch, n_expand * c_x) + x_res.float()
+    x_out_ref = x_out_ref.bfloat16()
+    return x_out_ref

--- a/tileops/testing/mhc_reference.py
+++ b/tileops/testing/mhc_reference.py
@@ -32,7 +32,7 @@ def mhc_pre_ref(
     norm_eps = 0.0001
     r_ref = torch.sqrt(xsqr.sum(dim=1)) / math.sqrt(n_expand * c_x) + norm_eps
     H = torch.zeros([batch, n_expand * n_expand + 2 * n_expand],
-                    device="cuda", dtype=torch.float)
+                    device=x.device, dtype=torch.float)
     for i in range(batch):
         H[i, :] = x[i, :].float() @ phi
 
@@ -54,8 +54,8 @@ def mhc_pre_ref(
         H_res_ref = H_res_ref / (H_res_ref.sum(dim=-1, keepdim=True) + eps)
         H_res_ref = H_res_ref / (H_res_ref.sum(dim=-2, keepdim=True) + eps)
     x_in_reshaped = x.reshape([batch, n_expand, c_x])
-    x_res_ref = torch.zeros([batch, n_expand, c_x], device="cuda", dtype=torch.bfloat16)
-    x_layer_ref = torch.zeros([batch, c_x], device="cuda", dtype=torch.bfloat16)
+    x_res_ref = torch.zeros([batch, n_expand, c_x], device=x.device, dtype=torch.bfloat16)
+    x_layer_ref = torch.zeros([batch, c_x], device=x.device, dtype=torch.bfloat16)
 
     h_res_ref = H_res_ref
     h_pre_ref = H_pre_ref


### PR DESCRIPTION
Closes #1818

## Summary

The op layer no longer reads kernel-internal state (#1818), plus the duplication cleanup folded in on top. Behaviour-preserving throughout: same outputs, shapes and dtypes, no manifest content changes.

- 11 slots returned padded or workspace buffers the op then trimmed; that adaptation moved into kernel-side wrappers, no `prim_func` touched
- Elementwise output dtype comes from the manifest instead of `getattr(kernel, "_fp8_output_dtype")`
- One dtype-expression grammar, was 3 regexes that had already drifted apart
- One manifest-entry lookup, was 2
- One `op_base` FIXME block, was 3 for a single degradation
- One tiled-autotune sweep, was 3 differing only in probe dtype
- One base per max-pool dimension, was value/indices pairs 98% identical
- One GQA search space, was 12 byte-identical copies
- One parameterised convolution search space, was 9 near-copies
- Two more shared oracles in `tileops/testing/`, was a verbatim copy in both the test and the benchmark — the mamba docstrings had already disagreed
- Convolution rows as a `ConvCase`, was 8 flattened params across 6 functions

48 files, +955/−1601. Collected test nodes unchanged at 5000.

## Reviewer notes

- `GroupNormKernel` affine args became optional with cached identity buffers. Without it, relocating the padding cost 25-35% on unaligned shapes; the first benchmark pass caught it.
- Deliberately **not** unified: `validate_manifest.py` keeps its own token splitter (it must see empty tokens so a trailing `|` still errors); max-pool dimensions stay separate (different constructor signatures are the calling contract); the six convolution benchmarks stay separate (the validator matches `ManifestBenchmark(<op name>, …)` statically).
- Out of scope: the `deltanet_fwd` / `gated_deltanet_fwd` autotune pair — nothing covers `tune=True` there and #1821 is a live bug in the same area. Tracked as #1822.

## Test plan

- [x] Modified files pass unit tests
- [x] `pytest tests/ -m smoke` 2626 passed; full tier on every touched op 3736 passed
- [x] `grep -rn '_fp8_output_dtype' tileops/ops/` empty; no op file trims kernel output
- [x] Max-pool checked against `torch.nn.functional` for 1d/2d/3d including indices (`torch.equal`, not a tolerance)
- [x] `bench_convolution` collects the same 57 ids as main, smoke subset unchanged at 10
- [x] `validate_manifest.py` clean, its 121 tests pass
- [x] Search spaces unchanged: identical config lists for 3 dtypes across all 5 convolution spaces, identical ordering for the 54 GQA entries
- [x] `tune_by_forward` verified with a stub kernel — every candidate tried, fastest wins, empty list falls back to `default_config`

## Benchmark

H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.11. 84 workloads measured at `upstream/main` and at HEAD.

| Family | Rows | Mean | Best | Worst |
| --- | ---: | ---: | ---: | ---: |
| norm | 49 | -0.01% | -0.76% | +0.71% |
| softmax | 20 | +0.03% | -0.28% | +0.44% |
| cumulative | 6 | -0.12% | -0.23% | +0.00% |
| engram | 9 | +0.07% | -0.24% | +0.85% |

```
CUDA_VISIBLE_DEVICES=2 pytest -q benchmarks/ops/bench_norm.py benchmarks/ops/bench_group_norm.py \
  benchmarks/ops/bench_instance_norm.py benchmarks/ops/bench_softmax.py \
  benchmarks/ops/bench_cumulative.py benchmarks/ops/bench_engram.py
```

## Regression

Largest absolute movement 0.85%, consistent with timing noise. Pool and convolution benchmarks pass at HEAD (48 and 57).


