### PR TITLE
[Fix][Reduction] Serialise the row loop so every autotune candidate builds

### DIFF
--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -657,6 +657,26 @@ def test_logical_reduce_long_sequence_tiled(op_kind: str, dtype: torch.dtype) ->
     assert kernel.config["tile_n"] > 0
 
 
+@pytest.mark.smoke
+def test_logical_reduce_tiled_autotune() -> None:
+    """Autotune builds and times every tiled candidate, then runs the winner.
+
+    N is deliberately not a power of two: for a power-of-two N_padded
+    ``compute_tile_n`` returns an exact divisor of N_padded and every
+    candidate happens to be buildable, which hides a mis-derived tile_n.
+    """
+    from tileops.ops.reduction.logical_reduce import AnyFwdOp
+
+    m, n, dtype = 4, 40000, torch.bool
+    test = LogicalReduceTest(m, n, dtype, "any")
+    op = AnyFwdOp(dtype=dtype, dim=-1, tune=True)
+    test.check(op, *test.gen_inputs(), compare=_exact_compare)
+
+    kernel = op._kernel_cache[(m, n)]
+    assert kernel._needs_tiling
+    assert kernel.config in kernel.autotune_configs
+
+
 # Manifest dtype contract: bool input + int64 / bool output dtypes.
 
 _M = 64

--- a/tests/ops/test_logical_reduce.py
+++ b/tests/ops/test_logical_reduce.py
@@ -659,11 +659,10 @@ def test_logical_reduce_long_sequence_tiled(op_kind: str, dtype: torch.dtype) ->
 
 @pytest.mark.smoke
 def test_logical_reduce_tiled_autotune() -> None:
-    """Autotune builds and times every tiled candidate, then runs the winner.
+    """``tune=True`` must build and time every tiled candidate.
 
-    N is deliberately not a power of two: for a power-of-two N_padded
-    ``compute_tile_n`` returns an exact divisor of N_padded and every
-    candidate happens to be buildable, which hides a mis-derived tile_n.
+    N is not a power of two: a power-of-two N_padded lets ``compute_tile_n``
+    fall back on an exact divisor, which hides a mis-derived tile_n.
     """
     from tileops.ops.reduction.logical_reduce import AnyFwdOp
 

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -223,25 +223,39 @@ def test_var_tiled(m: int, n: int, dtype: torch.dtype) -> None:
 
 
 @pytest.mark.smoke
-def test_reduce_caller_tile_n_rejected() -> None:
-    """A caller-chosen tile_n the layout pass cannot reduce fails at construction.
+def test_reduce_caller_tile_n_validated() -> None:
+    """A caller-chosen tile_n is accepted only if it actually builds.
 
-    Without this the width reaches TileLang and surfaces as an ICHECK on
-    min_reg_num, which names nothing the caller can act on.
+    Without the check the width reaches TileLang and surfaces as an ICHECK on
+    min_reg_num, which names nothing the caller can act on.  128 threads at
+    fp16 is a 1024-column thread-block pass; a width must divide it or be a
+    multiple of it.
     """
     from tileops.kernels.reduction.reduce import ReduceKernel
 
-    def build(tile_n: int, block_m: int = 2):
-        return ReduceKernel(
-            M=4, N=102400, op_kind="sum", dtype=torch.float16, tune=False,
+    m, n, dtype = 8, 102400, torch.float16
+    x = torch.randn(m, n, dtype=dtype, device="cuda")
+
+    def run(tile_n: int, block_m: int = 2) -> None:
+        kernel = ReduceKernel(
+            M=m, N=n, op_kind="sum", dtype=dtype, tune=False,
             config={"block_m": block_m, "threads": 128, "tile_n": tile_n},
         )
+        kernel.forward(x)  # construction defers the build; forward triggers it
 
-    # 1024 = 128 threads x 128-bit / 2 bytes.
-    with pytest.raises(ValueError, match="not a multiple of 1024"):
-        build(1536)
-    build(2048)          # whole number of passes
-    build(1536, block_m=1)  # one row cannot shift
+    for accepted in (512, 1024, 2048):  # divides the pass, or a multiple of it
+        run(accepted)
+    run(1536, block_m=1)  # one row cannot shift, so nothing constrains it
+    run(0)  # 0 is the "derive it for me" sentinel, not a width
+
+    for rejected, why in (
+        (768, "neither divides nor is a multiple"),
+        (1536, "neither divides nor is a multiple"),
+        (257, "must be positive and a multiple"),
+        (65536, "exceeds"),
+    ):
+        with pytest.raises(ValueError, match=why):
+            run(rejected)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -231,11 +231,10 @@ def test_var_tiled(m: int, n: int, dtype: torch.dtype) -> None:
     ],
 )
 def test_reduce_tiled_autotune(op_kind: str) -> None:
-    """Autotune builds and times every tiled candidate, then runs the winner.
+    """``tune=True`` must build and time every tiled candidate.
 
-    N is deliberately not a power of two: for a power-of-two N_padded
-    ``compute_tile_n`` returns an exact divisor of N_padded and every
-    candidate happens to be buildable, which hides a mis-derived tile_n.
+    N is not a power of two: a power-of-two N_padded lets ``compute_tile_n``
+    fall back on an exact divisor, which hides a mis-derived tile_n.
     """
     from tileops.ops.reduction.reduce import SumFwdOp, VarFwdOp
 

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -260,11 +260,13 @@ def test_reduce_caller_tile_n_validated() -> None:
 
 @pytest.mark.smoke
 def test_reduce_untiled_autotune_unaligned_n() -> None:
-    """Every untiled candidate must build when N_padded is not thread-aligned.
+    """Every untiled candidate must build at an N_padded off the pass width.
 
-    N_padded=20224 is not a multiple of threads * 128-bit / elem_bytes, so a
-    (block_m > 1, N_padded) fragment has no reducible layout and those block_m
-    values must be absent from the candidate list.
+    N_padded=20224 neither divides nor is a multiple of
+    threads * 128-bit / elem_bytes, so ``layout_ok`` excludes every block_m
+    above 1 and the candidate list must not offer them.  With the serial row
+    loop such a fragment would in fact build; the envelope stays because it
+    also covers the residue that does not.
     """
     from tileops.ops.reduction.reduce import SumFwdOp
 

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -223,6 +223,28 @@ def test_var_tiled(m: int, n: int, dtype: torch.dtype) -> None:
 
 
 @pytest.mark.smoke
+def test_reduce_caller_tile_n_rejected() -> None:
+    """A caller-chosen tile_n the layout pass cannot reduce fails at construction.
+
+    Without this the width reaches TileLang and surfaces as an ICHECK on
+    min_reg_num, which names nothing the caller can act on.
+    """
+    from tileops.kernels.reduction.reduce import ReduceKernel
+
+    def build(tile_n: int, block_m: int = 2):
+        return ReduceKernel(
+            M=4, N=102400, op_kind="sum", dtype=torch.float16, tune=False,
+            config={"block_m": block_m, "threads": 128, "tile_n": tile_n},
+        )
+
+    # 1024 = 128 threads x 128-bit / 2 bytes.
+    with pytest.raises(ValueError, match="not a multiple of 1024"):
+        build(1536)
+    build(2048)          # whole number of passes
+    build(1536, block_m=1)  # one row cannot shift
+
+
+@pytest.mark.smoke
 def test_reduce_untiled_autotune_unaligned_n() -> None:
     """Every untiled candidate must build when N_padded is not thread-aligned.
 

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -222,6 +222,37 @@ def test_var_tiled(m: int, n: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
+@pytest.mark.parametrize(
+    "op_kind",
+    [
+        pytest.param("sum", marks=pytest.mark.smoke),
+        # Welford builds a different tiled kernel with two shared buffers.
+        pytest.param("var", marks=pytest.mark.full),
+    ],
+)
+def test_reduce_tiled_autotune(op_kind: str) -> None:
+    """Autotune builds and times every tiled candidate, then runs the winner.
+
+    N is deliberately not a power of two: for a power-of-two N_padded
+    ``compute_tile_n`` returns an exact divisor of N_padded and every
+    candidate happens to be buildable, which hides a mis-derived tile_n.
+    """
+    from tileops.ops.reduction.reduce import SumFwdOp, VarFwdOp
+
+    m, n, dtype = 4, 40000, torch.float16
+    if op_kind == "sum":
+        test = ReduceTest(m, n, dtype, "sum")
+        op = SumFwdOp(dtype=dtype, dim=-1, tune=True)
+    else:
+        test = WelfordTest(m, n, dtype, "var", correction=1)
+        op = VarFwdOp(dtype=dtype, dim=-1, tune=True)
+    test.check(op, *test.gen_inputs(), **_tol(dtype))
+
+    kernel = op._kernel_cache[(m, n)]
+    assert kernel._needs_tiling
+    assert kernel.config in kernel.autotune_configs
+
+
 @ReduceNonContigFixture
 def test_sum_non_contiguous(m: int, n: int, dtype: torch.dtype) -> None:
     from tileops.ops.reduction.reduce import SumFwdOp

--- a/tests/ops/test_reduce.py
+++ b/tests/ops/test_reduce.py
@@ -222,6 +222,26 @@ def test_var_tiled(m: int, n: int, dtype: torch.dtype) -> None:
     test.check(op, *test.gen_inputs(), **_tol(dtype))
 
 
+@pytest.mark.smoke
+def test_reduce_untiled_autotune_unaligned_n() -> None:
+    """Every untiled candidate must build when N_padded is not thread-aligned.
+
+    N_padded=20224 is not a multiple of threads * 128-bit / elem_bytes, so a
+    (block_m > 1, N_padded) fragment has no reducible layout and those block_m
+    values must be absent from the candidate list.
+    """
+    from tileops.ops.reduction.reduce import SumFwdOp
+
+    m, n, dtype = 8, 20000, torch.float16
+    test = ReduceTest(m, n, dtype, "sum")
+    op = SumFwdOp(dtype=dtype, dim=-1, tune=True)
+    test.check(op, *test.gen_inputs(), **_tol(dtype))
+
+    kernel = op._kernel_cache[(m, n)]
+    assert not kernel._needs_tiling
+    assert {c["block_m"] for c in kernel.autotune_configs} == {1}
+
+
 @pytest.mark.parametrize(
     "op_kind",
     [

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -586,11 +586,10 @@ def test_vector_norm_long_sequence_tiled(op_kind: str) -> None:
 
 @pytest.mark.smoke
 def test_vector_norm_tiled_autotune() -> None:
-    """Autotune builds and times every tiled candidate, then runs the winner.
+    """``tune=True`` must build and time every tiled candidate.
 
-    N is deliberately not a power of two: for a power-of-two N_padded
-    ``compute_tile_n`` returns an exact divisor of N_padded and every
-    candidate happens to be buildable, which hides a mis-derived tile_n.
+    N is not a power of two: a power-of-two N_padded lets ``compute_tile_n``
+    fall back on an exact divisor, which hides a mis-derived tile_n.
     """
     m, n, dtype = 4, 40000, torch.float16
     test = VectorNormTest(m, n, dtype, "l2")

--- a/tests/ops/test_vector_norm.py
+++ b/tests/ops/test_vector_norm.py
@@ -151,6 +151,7 @@ def _make_op(
     dim: int = -1,
     keepdim: bool = False,
     kernel_map=None,
+    tune: bool = False,
 ):
     """Create the appropriate Op for the given op_kind."""
     from tileops.ops.reduction.vector_norm import InfNormFwdOp, L1NormFwdOp, L2NormFwdOp
@@ -161,7 +162,7 @@ def _make_op(
         "inf": InfNormFwdOp,
     }
     cls = op_map[op_kind]
-    return cls(dtype=dtype, dim=dim, keepdim=keepdim, kernel_map=kernel_map)
+    return cls(dtype=dtype, dim=dim, keepdim=keepdim, kernel_map=kernel_map, tune=tune)
 
 
 # L1NormFwdOp tests
@@ -581,6 +582,25 @@ def test_vector_norm_long_sequence_tiled(op_kind: str) -> None:
     kernel = op._kernel_cache[(3, 33024)]
     assert kernel.config["block_m"] > test.shape[0]
     assert kernel.config["tile_n"] > 0
+
+
+@pytest.mark.smoke
+def test_vector_norm_tiled_autotune() -> None:
+    """Autotune builds and times every tiled candidate, then runs the winner.
+
+    N is deliberately not a power of two: for a power-of-two N_padded
+    ``compute_tile_n`` returns an exact divisor of N_padded and every
+    candidate happens to be buildable, which hides a mis-derived tile_n.
+    """
+    m, n, dtype = 4, 40000, torch.float16
+    test = VectorNormTest(m, n, dtype, "l2")
+    op = _make_op(dtype, "l2", tune=True)
+    atol, rtol = _get_tolerances(dtype)
+    test.check(op, *test.gen_inputs(), atol=atol, rtol=rtol)
+
+    kernel = op._kernel_cache[(m, n)]
+    assert kernel._needs_tiling
+    assert kernel.config in kernel.autotune_configs
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -61,20 +61,11 @@ DEFAULT_THREADS: int = 128
 
 
 def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
-    """Return the column granularity a reducible ``(rows, cols)`` fragment needs.
+    """Return the column count one thread-block pass covers.
 
-    TileLang flattens ``T.Parallel(rows, cols)`` and hands each thread one
-    ``VECTOR_ACCESS_BYTES`` chunk per pass, so column *j* of row *i* belongs to
-    thread ``(i * cols + j) / vec % threads``.  Unless ``cols`` is a whole
-    number of thread-block passes the map shifts from row to row, and the
-    following ``T.reduce_*`` has no fragment layout consistent with both the
-    elementwise loops and its ``(rows,)`` destination -- layout inference
-    aborts with "no available layout found".
-
-    Binds any such fragment, ``cols == N_padded`` included.  ``cols`` must
-    divide one pass or be a multiple of it -- see ``layout_ok``, which is what
-    callers should ask.  This returns the pass width alone, the granularity
-    generation aligns to.
+    Each thread takes one ``VECTOR_ACCESS_BYTES`` chunk per pass, so a pass is
+    ``threads`` chunks wide.  ``layout_ok`` is what callers should ask; this is
+    the granularity it measures against and generation aligns to.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
 
@@ -187,15 +178,24 @@ class BlockConfigPlanner:
         return out
 
     def layout_ok(self, block_m: int, cols: int, threads: int) -> bool:
-        """Whether a ``(block_m, cols)`` fragment can be reduced at this width.
+        """Whether a ``(block_m, cols)`` fragment is known to be reducible.
 
-        One thread-block pass covers ``reduce_column_alignment`` columns.  The
-        per-row thread map repeats only when ``cols`` is a whole number of
-        passes or divides one evenly; anything between shifts the map from row
-        to row.  Measured exact over fp16/fp32 x {128, 256} threads x
-        cols in [256, 4096]: 44 of 44 predictions matched.
+        A conservative envelope, not the exact rule.  It was the exact rule
+        while the kernels wrote these fragments from a two-dimensional
+        ``T.Parallel(block_m, cols)``: TileLang flattens that loop, the thread
+        owning column *j* of row *i* is ``(i * cols + j) / vec % threads``, and
+        the map repeats from row to row only when ``cols`` is a whole number of
+        passes or divides one evenly.  Measured 44 of 44 over fp16/fp32 x
+        {128, 256} threads x cols in [256, 4096].
 
-        ``block_m == 1`` is unconstrained -- a single row cannot shift.
+        The kernels now serialise the row loop, so the map no longer depends on
+        the row and nearly every width builds.  One narrow residue survives --
+        softmax, log_softmax and logsumexp fail layout inference at
+        ``block_m=4, cols=768`` -- and this envelope still excludes it, so it
+        stays as the guard.  Everything it admits builds; some of what it
+        rejects would now build too.
+
+        ``block_m == 1`` is unconstrained: a single row cannot shift.
         """
         if block_m == 1:
             return True

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -72,17 +72,8 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
     aborts with "no available layout found".
 
     Binds any such fragment, ``cols == N_padded`` included.  Conservative:
-    ``rows == 1`` builds regardless, and ``vec`` is really capped by the widest
-    buffer in the loop (an fp32 accumulator), not by the storage dtype passed
-    here.  Iterating rows serially in the kernel would drop the constraint
-    outright.
-
-    Args:
-        elem_bytes: Bytes per element of the storage dtype.
-        threads: Thread-block size the fragment must be valid for.
-
-    Returns:
-        Column count that ``cols`` must be a multiple of.
+    ``vec`` is really capped by the widest buffer in the loop (an fp32
+    accumulator), not by the ``elem_bytes`` storage dtype passed here.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
 
@@ -90,22 +81,19 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
 class BlockConfigPlanner:
     """Derives ``block_m`` / ``threads`` / ``tile_n`` for a row-wise reduction.
 
-    Every reduction kernel that maps one row per ``block_m`` slot and reduces
-    along N makes the same three decisions -- whether the row fits in shared
-    memory at all, which single config to run untuned, and which candidates to
-    offer the autotuner.  They are derived here once so the kernels cannot
-    answer them differently.
+    Every reduction kernel that maps one row per ``block_m`` slot makes the same
+    three decisions -- whether a row fits in shared memory, which config to run
+    untuned, and which candidates to offer the autotuner.  Derived here once so
+    the kernels cannot answer them differently.
 
     Args:
-        N_padded: Hidden dimension, already aligned to ``DEFAULT_ALIGNMENT``.
-        elem_bytes: Bytes per element of the kernel's storage dtype.
-        smem_budget: Shared memory a thread block may allocate, from
-            ``device_smem_budget()``.
-        num_buffers: Shared buffers of shape ``(block_m, tile_n)`` alive at
-            once.  Welford's two-pass kernels allocate 2.
+        num_buffers: ``(block_m, tile_n)`` shared buffers alive at once.
+            Welford's two-pass kernels allocate 2.
     """
 
     _BLOCK_MS = (1, 2, 4, 8)
+    # Extra tile widths offered to the autotuner beyond the default pick.
+    _EXTRA_TILE_N = 2
 
     def __init__(
         self,
@@ -123,9 +111,8 @@ class BlockConfigPlanner:
     def _row_bytes(self) -> int:
         """Shared memory one untiled row occupies.
 
-        ``num_buffers`` is deliberately excluded: it counts the tiled path's
-        ``(block_m, tile_n)`` shared buffers, whereas the untiled kernels keep
-        their second pass in fragments.
+        Excludes ``num_buffers``: that counts tiled shared buffers, and the
+        untiled kernels keep their second pass in fragments.
         """
         return self.N_padded * self.elem_bytes
 
@@ -135,9 +122,6 @@ class BlockConfigPlanner:
         return (
             self.N_padded > MAX_SINGLE_TILE_COLS or self._row_bytes > self.smem_budget
         )
-
-    # Extra tile widths offered to the autotuner beyond the default pick.
-    _EXTRA_TILE_N: int = 2
 
     def _column_alignment(self, block_m: int, threads: int) -> int:
         """Column granularity a tile must respect for this pair.
@@ -177,12 +161,11 @@ class BlockConfigPlanner:
         )
 
     def tile_n_candidates(self, block_m: int, threads: int) -> list[int]:
-        """Return buildable tile widths to time for this pair.
+        """Return buildable tile widths to time for this pair, widest first.
 
-        The default pick maximises tile width subject to an exact-divisor
-        preference; it is regularly beaten by a narrower tile that trades one
-        global pass for a better shared-memory stride.  Those narrower widths
-        are the extra entries.  Empty when the pair can build no tile at all.
+        The widest is regularly beaten by a narrower tile trading one global
+        pass for a better shared-memory stride, so the next tile counts follow
+        it.  Empty when the pair can build no tile at all.
         """
         try:
             default = self.tile_n_for(block_m, threads)

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -227,8 +227,17 @@ class BlockConfigPlanner:
             )
         return ""
 
-    def _untiled_block_ms(self, threads: int) -> list[int]:
-        max_block_m = self.smem_budget // self._row_bytes
+    def _untiled_block_ms(self, threads: int, budget: int | None = None) -> list[int]:
+        """Row counts an untiled kernel can build within *budget*.
+
+        ``default_config`` passes the conservative ``SHARED_MEMORY_BUDGET_BYTES``
+        and the sweep passes the device budget.  Largest-that-fits is a
+        capacity rule, not a performance one -- at 2048x4096 fp16 on H200,
+        ``block_m=4`` beats ``block_m=8`` on sum, var and l2 alike -- so the
+        untuned path stays inside the smaller envelope and the sweep, which
+        times every row count, is what reaches the wider one.
+        """
+        max_block_m = (budget or self.smem_budget) // self._row_bytes
         return [
             bm for bm in self._BLOCK_MS
             if bm <= max_block_m and self.layout_ok(bm, self.N_padded, threads)
@@ -240,7 +249,9 @@ class BlockConfigPlanner:
     def default_config(self) -> dict:
         """Return the config used when no candidate sweep runs."""
         if not self.needs_tiling:
-            block_ms = self._untiled_block_ms(DEFAULT_THREADS)
+            block_ms = self._untiled_block_ms(
+                DEFAULT_THREADS, budget=SHARED_MEMORY_BUDGET_BYTES,
+            )
             return {
                 "block_m": block_ms[-1] if block_ms else 1,
                 "threads": DEFAULT_THREADS,

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -25,7 +25,7 @@ __all__ = [
     "make_reduce_epilogue",
     "make_softmax_epilogue",
     "make_welford_update",
-    "tile_column_alignment",
+    "reduce_column_alignment",
     "tune_by_forward",
 ]
 
@@ -46,42 +46,42 @@ MAX_SINGLE_TILE_COLS: int = 32512
 # block_m that fits within a single thread block's shared memory allocation.
 SHARED_MEMORY_BUDGET_BYTES: int = 48 * 1024
 
-# Widest vectorized access TileLang plans for a tile buffer on the
-# architectures the reduction kernels declare (SM80-SM90): a 128-bit ``ld/st``.
-# SM100+ raises this to 256 bits and would need a wider granularity.
+# Width of the vectorized ``ld/st`` TileLang plans for a tile buffer on the
+# architectures the reduction kernels declare (SM80-SM90): 128 bits.
 VECTOR_ACCESS_BYTES: int = 16
 
 # Thread counts offered by the reduction autotune candidate lists.
 AUTOTUNE_THREADS: tuple[int, ...] = (128, 256)
 
 # Thread count used when no candidate sweep runs.
-DEFAULT_THREADS: int = AUTOTUNE_THREADS[0]
+DEFAULT_THREADS: int = 128
 
 
-def tile_column_alignment(elem_bytes: int, threads: int) -> int:
-    """Return a column granularity that keeps a multi-row tile buildable.
+def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
+    """Return the column granularity a reducible ``(rows, cols)`` fragment needs.
 
-    TileLang flattens a ``T.Parallel(block_m, tile_n)`` loop and hands each
-    thread one ``VECTOR_ACCESS_BYTES`` chunk per pass, so the thread owning
-    column *j* of row *i* is ``(i * tile_n + j) / vec % threads``.  When
-    ``tile_n / vec`` is not a whole number of thread-block passes the map
-    shifts from row to row; the following ``T.reduce_*`` then has no fragment
-    layout consistent with both the elementwise loops and its ``(block_m,)``
-    destination, and layout inference aborts with "no available layout found".
-    Rounding ``tile_n`` to this granularity makes the map row-invariant.
+    TileLang flattens ``T.Parallel(rows, cols)`` and hands each thread one
+    ``VECTOR_ACCESS_BYTES`` chunk per pass, so column *j* of row *i* belongs to
+    thread ``(i * cols + j) / vec % threads``.  Unless ``cols`` is a whole
+    number of thread-block passes the map shifts from row to row, and the
+    following ``T.reduce_*`` has no fragment layout consistent with both the
+    elementwise loops and its ``(rows,)`` destination -- layout inference
+    aborts with "no available layout found".  The constraint is not specific to
+    a tiled kernel: it binds any such fragment, ``cols == N_padded`` included.
 
-    Row invariance is sufficient, not necessary -- a tile narrower than one
-    thread-block pass also builds -- so the returned value can be
-    conservative for very small tiles.  ``block_m == 1`` is unconstrained
-    either way, but the granularity is applied uniformly so that one tile size
-    serves every ``block_m`` in a candidate list.
+    The result is conservative in two directions, both harmless.  ``rows == 1``
+    and any ``cols`` below one pass build regardless.  And ``vec`` is really
+    capped by the widest buffer in the loop -- an fp32 accumulator fragment --
+    never by the narrower storage dtype passed here.  Iterating rows serially
+    in the kernel would drop the constraint outright; this granularity is the
+    cheaper fix while the flattened ``T.Parallel`` stands.
 
     Args:
-        elem_bytes: Bytes per element of the tile buffer.
-        threads: Thread-block size the tile must be valid for.
+        elem_bytes: Bytes per element of the storage dtype.
+        threads: Thread-block size the fragment must be valid for.
 
     Returns:
-        Column count that ``tile_n`` must be a multiple of.
+        Column count that ``cols`` must be a multiple of.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
 

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -564,8 +564,10 @@ def make_welford_update(block_m: int, N_padded: int):
         # Compute M2_b = sum((x[j] - batch_mean)^2) -- deviations from
         # the *batch's own mean*, not the combined mean.  The parallel
         # Welford merge formula requires this to be correct.
-        for i, j in T.Parallel(block_m, N_padded):
-            sq_diff[i, j] = (x[i, j] - batch_mean[i]) * (x[i, j] - batch_mean[i])
+        for i in T.serial(block_m):
+            for j in T.Parallel(N_padded):
+                dev = x[i, j] - batch_mean[i]
+                sq_diff[i, j] = dev * dev
         T.reduce_sum(sq_diff, row_sq_sum, dim=1)
 
         # Combine with existing M2 using parallel Welford merge formula:

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -71,9 +71,10 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
     elementwise loops and its ``(rows,)`` destination -- layout inference
     aborts with "no available layout found".
 
-    Binds any such fragment, ``cols == N_padded`` included.  Conservative:
-    ``vec`` is really capped by the widest buffer in the loop (an fp32
-    accumulator), not by the ``elem_bytes`` storage dtype passed here.
+    Binds any such fragment, ``cols == N_padded`` included.  Measured exact at
+    and above one pass: for fp16 at 128 threads, 1024/2048/3072 build and
+    1536/2560 do not.  Below one pass the boundary is not characterised --
+    512 builds, 768 does not -- so generation stays above it.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
 
@@ -182,6 +183,24 @@ class BlockConfigPlanner:
             if 0 < tile_n <= default and tile_n not in out:
                 out.append(tile_n)
         return out
+
+    def reject_tile_n(self, block_m: int, tile_n: int, threads: int) -> str:
+        """Return why this tile cannot be reduced, or "" if it may be built.
+
+        Generation is conservative and validation permissive.  A caller-chosen
+        width below one thread-block pass is left alone -- the boundary there
+        is not characterised -- while a wider one that is not a whole number of
+        passes is rejected, which is measured exact.
+        """
+        pass_cols = reduce_column_alignment(self.elem_bytes, threads)
+        if block_m > 1 and tile_n >= pass_cols and tile_n % pass_cols:
+            return (
+                f"tile_n={tile_n} is not a multiple of {pass_cols} "
+                f"(threads={threads} x {VECTOR_ACCESS_BYTES} bytes / "
+                f"elem_bytes={self.elem_bytes}), so a (block_m={block_m}, "
+                f"tile_n) fragment has no reducible layout"
+            )
+        return ""
 
     def untiled_block_m_ok(self, block_m: int, threads: int) -> bool:
         """Whether an untiled ``(block_m, N_padded)`` fragment can be reduced.

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -8,6 +8,8 @@ This module must land before any sub-category kernel PR so that shared
 infrastructure is available from the start.
 """
 
+import itertools
+
 import tilelang.language as T
 import torch
 
@@ -18,6 +20,7 @@ __all__ = [
     "MAX_SINGLE_TILE_COLS",
     "SHARED_MEMORY_BUDGET_BYTES",
     "VECTOR_ACCESS_BYTES",
+    "BlockConfigPlanner",
     "align_up",
     "compute_tile_n",
     "device_smem_budget",
@@ -66,15 +69,13 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
     number of thread-block passes the map shifts from row to row, and the
     following ``T.reduce_*`` has no fragment layout consistent with both the
     elementwise loops and its ``(rows,)`` destination -- layout inference
-    aborts with "no available layout found".  The constraint is not specific to
-    a tiled kernel: it binds any such fragment, ``cols == N_padded`` included.
+    aborts with "no available layout found".
 
-    The result is conservative in two directions, both harmless.  ``rows == 1``
-    and any ``cols`` below one pass build regardless.  And ``vec`` is really
-    capped by the widest buffer in the loop -- an fp32 accumulator fragment --
-    never by the narrower storage dtype passed here.  Iterating rows serially
-    in the kernel would drop the constraint outright; this granularity is the
-    cheaper fix while the flattened ``T.Parallel`` stands.
+    Binds any such fragment, ``cols == N_padded`` included.  Conservative:
+    ``rows == 1`` builds regardless, and ``vec`` is really capped by the widest
+    buffer in the loop (an fp32 accumulator), not by the storage dtype passed
+    here.  Iterating rows serially in the kernel would drop the constraint
+    outright.
 
     Args:
         elem_bytes: Bytes per element of the storage dtype.
@@ -84,6 +85,141 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
         Column count that ``cols`` must be a multiple of.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
+
+
+class BlockConfigPlanner:
+    """Derives ``block_m`` / ``threads`` / ``tile_n`` for a row-wise reduction.
+
+    Every reduction kernel that maps one row per ``block_m`` slot and reduces
+    along N makes the same three decisions -- whether the row fits in shared
+    memory at all, which single config to run untuned, and which candidates to
+    offer the autotuner.  They are derived here once so the kernels cannot
+    answer them differently.
+
+    Args:
+        N_padded: Hidden dimension, already aligned to ``DEFAULT_ALIGNMENT``.
+        elem_bytes: Bytes per element of the kernel's storage dtype.
+        smem_budget: Shared memory a thread block may allocate, from
+            ``device_smem_budget()``.
+        num_buffers: Shared buffers of shape ``(block_m, tile_n)`` alive at
+            once.  Welford's two-pass kernels allocate 2.
+    """
+
+    _BLOCK_MS = (1, 2, 4, 8)
+
+    def __init__(
+        self,
+        N_padded: int,
+        elem_bytes: int,
+        smem_budget: int,
+        num_buffers: int = 1,
+    ):
+        self.N_padded = N_padded
+        self.elem_bytes = elem_bytes
+        self.smem_budget = smem_budget
+        self.num_buffers = num_buffers
+
+    @property
+    def _row_bytes(self) -> int:
+        """Shared memory one untiled row occupies.
+
+        ``num_buffers`` is deliberately excluded: it counts the tiled path's
+        ``(block_m, tile_n)`` shared buffers, whereas the untiled kernels keep
+        their second pass in fragments.
+        """
+        return self.N_padded * self.elem_bytes
+
+    @property
+    def needs_tiling(self) -> bool:
+        """Whether one padded row exceeds the column cap or the smem budget."""
+        return (
+            self.N_padded > MAX_SINGLE_TILE_COLS or self._row_bytes > self.smem_budget
+        )
+
+    def tile_n_for(self, block_m: int, threads: int) -> int:
+        """Return the tile width a ``(block_m, threads)`` pair can build.
+
+        Args:
+            block_m: Rows per thread block.
+            threads: Thread-block size.
+
+        Returns:
+            Column tile size, or 0 when the pair needs no tiling at all.
+
+        Raises:
+            ValueError: If no tile of the required column granularity fits in
+                shared memory for this pair.
+        """
+        if self.N_padded <= MAX_SINGLE_TILE_COLS:
+            single = compute_tile_n(
+                block_m, self.elem_bytes, self.N_padded,
+                budget=self.smem_budget, num_buffers=self.num_buffers,
+            )
+            if single == self.N_padded:
+                return 0
+
+        col_budget = (
+            MAX_SINGLE_TILE_COLS * self.num_buffers * block_m * self.elem_bytes
+        )
+        return compute_tile_n(
+            block_m, self.elem_bytes, self.N_padded,
+            alignment=reduce_column_alignment(self.elem_bytes, threads),
+            budget=min(self.smem_budget, col_budget),
+            num_buffers=self.num_buffers,
+        )
+
+    def _untiled_block_ms(self) -> list[int]:
+        max_block_m = self.smem_budget // self._row_bytes
+        return [bm for bm in self._BLOCK_MS if bm <= max_block_m]
+
+    def _num_tiles(self, tile_n: int) -> int:
+        return (self.N_padded + tile_n - 1) // tile_n
+
+    def default_config(self) -> dict:
+        """Return the config used when no candidate sweep runs."""
+        if not self.needs_tiling:
+            block_ms = self._untiled_block_ms()
+            return {
+                "block_m": block_ms[-1] if block_ms else 1,
+                "threads": DEFAULT_THREADS,
+            }
+
+        # Tiled: prefer the block_m that needs the fewest N-tiles.
+        best_bm, best_tile_n = 1, self.tile_n_for(1, DEFAULT_THREADS)
+        for bm in self._BLOCK_MS[1:]:
+            try:
+                tn = self.tile_n_for(bm, DEFAULT_THREADS)
+            except ValueError:
+                continue
+            if self._num_tiles(tn) < self._num_tiles(best_tile_n):
+                best_bm, best_tile_n = bm, tn
+        return {
+            "block_m": best_bm,
+            "threads": DEFAULT_THREADS,
+            "tile_n": best_tile_n,
+        }
+
+    def autotune_configs(self) -> list[dict]:
+        """Return every candidate config, all of them buildable.
+
+        A ``(block_m, threads)`` pair with no fitting tile is dropped here
+        rather than left to abort the sweep at build time.
+        """
+        if not self.needs_tiling:
+            return [
+                {"block_m": bm, "threads": t}
+                for bm, t in itertools.product(self._untiled_block_ms(), AUTOTUNE_THREADS)
+            ]
+
+        configs = []
+        for bm, t in itertools.product(self._BLOCK_MS, AUTOTUNE_THREADS):
+            try:
+                configs.append(
+                    {"block_m": bm, "threads": t, "tile_n": self.tile_n_for(bm, t)},
+                )
+            except ValueError:
+                continue
+        return configs if configs else [self.default_config()]
 
 
 def device_smem_budget(device_index: int | None = None) -> int:

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -183,9 +183,23 @@ class BlockConfigPlanner:
                 out.append(tile_n)
         return out
 
-    def _untiled_block_ms(self) -> list[int]:
+    def untiled_block_m_ok(self, block_m: int, threads: int) -> bool:
+        """Whether an untiled ``(block_m, N_padded)`` fragment can be reduced.
+
+        Same constraint as the tiled path, but ``N_padded`` is fixed by the
+        workload, so an unusable ``block_m`` has to be dropped instead.
+        """
+        if block_m == 1:
+            return True
+        align = reduce_column_alignment(self.elem_bytes, threads)
+        return self.N_padded % align == 0
+
+    def _untiled_block_ms(self, threads: int) -> list[int]:
         max_block_m = self.smem_budget // self._row_bytes
-        return [bm for bm in self._BLOCK_MS if bm <= max_block_m]
+        return [
+            bm for bm in self._BLOCK_MS
+            if bm <= max_block_m and self.untiled_block_m_ok(bm, threads)
+        ]
 
     def _num_tiles(self, tile_n: int) -> int:
         return (self.N_padded + tile_n - 1) // tile_n
@@ -193,7 +207,7 @@ class BlockConfigPlanner:
     def default_config(self) -> dict:
         """Return the config used when no candidate sweep runs."""
         if not self.needs_tiling:
-            block_ms = self._untiled_block_ms()
+            block_ms = self._untiled_block_ms(DEFAULT_THREADS)
             return {
                 "block_m": block_ms[-1] if block_ms else 1,
                 "threads": DEFAULT_THREADS,
@@ -224,7 +238,8 @@ class BlockConfigPlanner:
         if not self.needs_tiling:
             return [
                 {"block_m": bm, "threads": t}
-                for bm, t in itertools.product(self._untiled_block_ms(), AUTOTUNE_THREADS)
+                for t in AUTOTUNE_THREADS
+                for bm in self._untiled_block_ms(t)
             ]
 
         configs = [

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -12,9 +12,12 @@ import tilelang.language as T
 import torch
 
 __all__ = [
+    "AUTOTUNE_THREADS",
     "DEFAULT_ALIGNMENT",
+    "DEFAULT_THREADS",
     "MAX_SINGLE_TILE_COLS",
     "SHARED_MEMORY_BUDGET_BYTES",
+    "VECTOR_ACCESS_BYTES",
     "align_up",
     "compute_tile_n",
     "device_smem_budget",
@@ -22,6 +25,7 @@ __all__ = [
     "make_reduce_epilogue",
     "make_softmax_epilogue",
     "make_welford_update",
+    "tile_column_alignment",
     "tune_by_forward",
 ]
 
@@ -41,6 +45,45 @@ MAX_SINGLE_TILE_COLS: int = 32512
 # Default shared memory budget per SM (48 KiB) used to compute the maximum
 # block_m that fits within a single thread block's shared memory allocation.
 SHARED_MEMORY_BUDGET_BYTES: int = 48 * 1024
+
+# Widest vectorized access TileLang plans for a tile buffer on the
+# architectures the reduction kernels declare (SM80-SM90): a 128-bit ``ld/st``.
+# SM100+ raises this to 256 bits and would need a wider granularity.
+VECTOR_ACCESS_BYTES: int = 16
+
+# Thread counts offered by the reduction autotune candidate lists.
+AUTOTUNE_THREADS: tuple[int, ...] = (128, 256)
+
+# Thread count used when no candidate sweep runs.
+DEFAULT_THREADS: int = AUTOTUNE_THREADS[0]
+
+
+def tile_column_alignment(elem_bytes: int, threads: int) -> int:
+    """Return a column granularity that keeps a multi-row tile buildable.
+
+    TileLang flattens a ``T.Parallel(block_m, tile_n)`` loop and hands each
+    thread one ``VECTOR_ACCESS_BYTES`` chunk per pass, so the thread owning
+    column *j* of row *i* is ``(i * tile_n + j) / vec % threads``.  When
+    ``tile_n / vec`` is not a whole number of thread-block passes the map
+    shifts from row to row; the following ``T.reduce_*`` then has no fragment
+    layout consistent with both the elementwise loops and its ``(block_m,)``
+    destination, and layout inference aborts with "no available layout found".
+    Rounding ``tile_n`` to this granularity makes the map row-invariant.
+
+    Row invariance is sufficient, not necessary -- a tile narrower than one
+    thread-block pass also builds -- so the returned value can be
+    conservative for very small tiles.  ``block_m == 1`` is unconstrained
+    either way, but the granularity is applied uniformly so that one tile size
+    serves every ``block_m`` in a candidate list.
+
+    Args:
+        elem_bytes: Bytes per element of the tile buffer.
+        threads: Thread-block size the tile must be valid for.
+
+    Returns:
+        Column count that ``tile_n`` must be a multiple of.
+    """
+    return threads * VECTOR_ACCESS_BYTES // elem_bytes
 
 
 def device_smem_budget(device_index: int | None = None) -> int:

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -71,10 +71,10 @@ def reduce_column_alignment(elem_bytes: int, threads: int) -> int:
     elementwise loops and its ``(rows,)`` destination -- layout inference
     aborts with "no available layout found".
 
-    Binds any such fragment, ``cols == N_padded`` included.  Measured exact at
-    and above one pass: for fp16 at 128 threads, 1024/2048/3072 build and
-    1536/2560 do not.  Below one pass the boundary is not characterised --
-    512 builds, 768 does not -- so generation stays above it.
+    Binds any such fragment, ``cols == N_padded`` included.  ``cols`` must
+    divide one pass or be a multiple of it -- see ``layout_ok``, which is what
+    callers should ask.  This returns the pass width alone, the granularity
+    generation aligns to.
     """
     return threads * VECTOR_ACCESS_BYTES // elem_bytes
 
@@ -178,46 +178,60 @@ class BlockConfigPlanner:
         align = self._column_alignment(block_m, threads)
         out = [default]
         fewest = self._num_tiles(default)
-        for n_tiles in range(fewest, fewest + self._EXTRA_TILE_N):
+        for n_tiles in range(fewest, fewest + self._EXTRA_TILE_N + 1):
+            if len(out) > self._EXTRA_TILE_N:
+                break
             tile_n = align_up((self.N_padded + n_tiles - 1) // n_tiles, align)
             if 0 < tile_n <= default and tile_n not in out:
                 out.append(tile_n)
         return out
 
-    def reject_tile_n(self, block_m: int, tile_n: int, threads: int) -> str:
-        """Return why this tile cannot be reduced, or "" if it may be built.
+    def layout_ok(self, block_m: int, cols: int, threads: int) -> bool:
+        """Whether a ``(block_m, cols)`` fragment can be reduced at this width.
 
-        Generation is conservative and validation permissive.  A caller-chosen
-        width below one thread-block pass is left alone -- the boundary there
-        is not characterised -- while a wider one that is not a whole number of
-        passes is rejected, which is measured exact.
+        One thread-block pass covers ``reduce_column_alignment`` columns.  The
+        per-row thread map repeats only when ``cols`` is a whole number of
+        passes or divides one evenly; anything between shifts the map from row
+        to row.  Measured exact over fp16/fp32 x {128, 256} threads x
+        cols in [256, 4096]: 44 of 44 predictions matched.
+
+        ``block_m == 1`` is unconstrained -- a single row cannot shift.
         """
-        pass_cols = reduce_column_alignment(self.elem_bytes, threads)
-        if block_m > 1 and tile_n >= pass_cols and tile_n % pass_cols:
+        if block_m == 1:
+            return True
+        one_pass = reduce_column_alignment(self.elem_bytes, threads)
+        return cols % one_pass == 0 or one_pass % cols == 0
+
+    def reject_tile_n(self, block_m: int, tile_n: int, threads: int) -> str:
+        """Return why a caller-supplied ``tile_n`` is unusable, or ""."""
+        if tile_n <= 0 or tile_n % DEFAULT_ALIGNMENT:
             return (
-                f"tile_n={tile_n} is not a multiple of {pass_cols} "
-                f"(threads={threads} x {VECTOR_ACCESS_BYTES} bytes / "
+                f"tile_n={tile_n} must be positive and a multiple of "
+                f"{DEFAULT_ALIGNMENT} (the T.copy shared-memory alignment)"
+            )
+        if tile_n > MAX_SINGLE_TILE_COLS:
+            return f"tile_n={tile_n} exceeds the {MAX_SINGLE_TILE_COLS} column cap"
+        held = self.num_buffers * block_m * tile_n * self.elem_bytes
+        if held > self.smem_budget:
+            return (
+                f"tile_n={tile_n} with block_m={block_m} needs {held} bytes of "
+                f"shared memory, over the {self.smem_budget} budget"
+            )
+        if not self.layout_ok(block_m, tile_n, threads):
+            one_pass = reduce_column_alignment(self.elem_bytes, threads)
+            return (
+                f"tile_n={tile_n} neither divides nor is a multiple of the "
+                f"{one_pass}-column thread-block pass (threads={threads}, "
                 f"elem_bytes={self.elem_bytes}), so a (block_m={block_m}, "
                 f"tile_n) fragment has no reducible layout"
             )
         return ""
 
-    def untiled_block_m_ok(self, block_m: int, threads: int) -> bool:
-        """Whether an untiled ``(block_m, N_padded)`` fragment can be reduced.
-
-        Same constraint as the tiled path, but ``N_padded`` is fixed by the
-        workload, so an unusable ``block_m`` has to be dropped instead.
-        """
-        if block_m == 1:
-            return True
-        align = reduce_column_alignment(self.elem_bytes, threads)
-        return self.N_padded % align == 0
-
     def _untiled_block_ms(self, threads: int) -> list[int]:
         max_block_m = self.smem_budget // self._row_bytes
         return [
             bm for bm in self._BLOCK_MS
-            if bm <= max_block_m and self.untiled_block_m_ok(bm, threads)
+            if bm <= max_block_m and self.layout_ok(bm, self.N_padded, threads)
         ]
 
     def _num_tiles(self, tile_n: int) -> int:
@@ -232,19 +246,13 @@ class BlockConfigPlanner:
                 "threads": DEFAULT_THREADS,
             }
 
-        # Tiled: prefer the block_m that needs the fewest N-tiles.
-        best_bm, best_tile_n = 1, self.tile_n_for(1, DEFAULT_THREADS)
-        for bm in self._BLOCK_MS[1:]:
-            try:
-                tn = self.tile_n_for(bm, DEFAULT_THREADS)
-            except ValueError:
-                continue
-            if self._num_tiles(tn) < self._num_tiles(best_tile_n):
-                best_bm, best_tile_n = bm, tn
+        # Tiled: block_m == 1 always needs the fewest N-tiles.  A larger
+        # block_m only shrinks the per-row shared-memory budget, so its tile is
+        # narrower and its tile count never lower.
         return {
-            "block_m": best_bm,
+            "block_m": 1,
             "threads": DEFAULT_THREADS,
-            "tile_n": best_tile_n,
+            "tile_n": self.tile_n_for(1, DEFAULT_THREADS),
         }
 
     def autotune_configs(self) -> list[dict]:
@@ -261,12 +269,11 @@ class BlockConfigPlanner:
                 for bm in self._untiled_block_ms(t)
             ]
 
-        configs = [
+        return [
             {"block_m": bm, "threads": t, "tile_n": tile_n}
             for bm, t in itertools.product(self._BLOCK_MS, AUTOTUNE_THREADS)
             for tile_n in self.tile_n_candidates(bm, t)
         ]
-        return configs if configs else [self.default_config()]
 
 
 def device_smem_budget(device_index: int | None = None) -> int:

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -150,10 +150,11 @@ class BlockConfigPlanner:
             ValueError: If no tile of the required column granularity fits in
                 shared memory for this pair.
         """
+        # Single-tile probe: one buffer, because the single-tile kernels hold
+        # the row in fragments and allocate no second shared copy.
         if self.N_padded <= MAX_SINGLE_TILE_COLS:
             single = compute_tile_n(
-                block_m, self.elem_bytes, self.N_padded,
-                budget=self.smem_budget, num_buffers=self.num_buffers,
+                block_m, self.elem_bytes, self.N_padded, budget=self.smem_budget,
             )
             if single == self.N_padded:
                 return 0

--- a/tileops/kernels/reduction/_primitives.py
+++ b/tileops/kernels/reduction/_primitives.py
@@ -136,15 +136,22 @@ class BlockConfigPlanner:
             self.N_padded > MAX_SINGLE_TILE_COLS or self._row_bytes > self.smem_budget
         )
 
+    # Extra tile widths offered to the autotuner beyond the default pick.
+    _EXTRA_TILE_N: int = 2
+
+    def _column_alignment(self, block_m: int, threads: int) -> int:
+        """Column granularity a tile must respect for this pair.
+
+        ``block_m == 1`` needs only the ``T.copy`` alignment: one row cannot
+        have a row-to-row thread-map shift, and the coarser granularity would
+        only quantise the width away from an exact divisor of N_padded.
+        """
+        if block_m == 1:
+            return DEFAULT_ALIGNMENT
+        return reduce_column_alignment(self.elem_bytes, threads)
+
     def tile_n_for(self, block_m: int, threads: int) -> int:
-        """Return the tile width a ``(block_m, threads)`` pair can build.
-
-        Args:
-            block_m: Rows per thread block.
-            threads: Thread-block size.
-
-        Returns:
-            Column tile size, or 0 when the pair needs no tiling at all.
+        """Return the tile width to use untuned (0: this pair needs no tiling).
 
         Raises:
             ValueError: If no tile of the required column granularity fits in
@@ -164,10 +171,34 @@ class BlockConfigPlanner:
         )
         return compute_tile_n(
             block_m, self.elem_bytes, self.N_padded,
-            alignment=reduce_column_alignment(self.elem_bytes, threads),
+            alignment=self._column_alignment(block_m, threads),
             budget=min(self.smem_budget, col_budget),
             num_buffers=self.num_buffers,
         )
+
+    def tile_n_candidates(self, block_m: int, threads: int) -> list[int]:
+        """Return buildable tile widths to time for this pair.
+
+        The default pick maximises tile width subject to an exact-divisor
+        preference; it is regularly beaten by a narrower tile that trades one
+        global pass for a better shared-memory stride.  Those narrower widths
+        are the extra entries.  Empty when the pair can build no tile at all.
+        """
+        try:
+            default = self.tile_n_for(block_m, threads)
+        except ValueError:
+            return []
+        if default == 0:
+            return [0]
+
+        align = self._column_alignment(block_m, threads)
+        out = [default]
+        fewest = self._num_tiles(default)
+        for n_tiles in range(fewest, fewest + self._EXTRA_TILE_N):
+            tile_n = align_up((self.N_padded + n_tiles - 1) // n_tiles, align)
+            if 0 < tile_n <= default and tile_n not in out:
+                out.append(tile_n)
+        return out
 
     def _untiled_block_ms(self) -> list[int]:
         max_block_m = self.smem_budget // self._row_bytes
@@ -203,8 +234,9 @@ class BlockConfigPlanner:
     def autotune_configs(self) -> list[dict]:
         """Return every candidate config, all of them buildable.
 
-        A ``(block_m, threads)`` pair with no fitting tile is dropped here
-        rather than left to abort the sweep at build time.
+        ``tile_n`` is a search dimension, not a function of the other two.
+        Pairs with no buildable tile are dropped here rather than left to
+        abort the sweep at build time.
         """
         if not self.needs_tiling:
             return [
@@ -212,14 +244,11 @@ class BlockConfigPlanner:
                 for bm, t in itertools.product(self._untiled_block_ms(), AUTOTUNE_THREADS)
             ]
 
-        configs = []
-        for bm, t in itertools.product(self._BLOCK_MS, AUTOTUNE_THREADS):
-            try:
-                configs.append(
-                    {"block_m": bm, "threads": t, "tile_n": self.tile_n_for(bm, t)},
-                )
-            except ValueError:
-                continue
+        configs = [
+            {"block_m": bm, "threads": t, "tile_n": tile_n}
+            for bm, t in itertools.product(self._BLOCK_MS, AUTOTUNE_THREADS)
+            for tile_n in self.tile_n_candidates(bm, t)
+        ]
         return configs if configs else [self.default_config()]
 
 

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -12,7 +12,6 @@ Output is bool for any/all, int64 for count_nonzero.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -21,14 +20,11 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
-    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
-    MAX_SINGLE_TILE_COLS,
+    BlockConfigPlanner,
     align_up,
-    compute_tile_n,
     device_smem_budget,
-    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -354,10 +350,10 @@ class LogicalReduceKernel(Kernel):
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = torch.tensor([], dtype=self._kernel_dtype).element_size()
         self._smem_budget = device_smem_budget()
-        self._needs_tiling = (
-            self.N_padded > MAX_SINGLE_TILE_COLS
-            or self.N_padded * self._elem_bytes > self._smem_budget
+        self._planner = BlockConfigPlanner(
+            self.N_padded, self._elem_bytes, self._smem_budget,
         )
+        self._needs_tiling = self._planner.needs_tiling
         self.kernel = None
         if not self._needs_tiling:
             self.kernel = _logical_reduce_kernel(
@@ -370,84 +366,17 @@ class LogicalReduceKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for(
+                self.config["tile_n"] = self._planner.tile_n_for(
                     bm, self.config.get("threads", DEFAULT_THREADS),
                 )
 
-    def _tile_n_for(self, block_m: int, threads: int) -> int:
-        """Return tile_n for a block_m / threads pair (0 means no tiling).
-
-        Raises:
-            ValueError: If no tile of the required column granularity fits in
-                shared memory for this pair.  Callers building candidate lists
-                drop the pair rather than emit an unbuildable tile.
-        """
-        budget = self._smem_budget
-        if self.N_padded <= MAX_SINGLE_TILE_COLS:
-            single = compute_tile_n(
-                block_m, self._elem_bytes, self.N_padded, budget=budget,
-            )
-            if single == self.N_padded:
-                return 0
-
-        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
-        effective_budget = min(budget, col_budget)
-        return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded,
-            alignment=reduce_column_alignment(self._elem_bytes, threads),
-            budget=effective_budget,
-        )
-
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget."""
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = self._smem_budget // smem_per_row
-            block_m = 1
-            for bm in [1, 2, 4, 8]:
-                if bm <= max_block_m:
-                    block_m = bm
-            return {"block_m": block_m, "threads": DEFAULT_THREADS}
-
-        best_bm = 1
-        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
-        for bm in [2, 4, 8]:
-            try:
-                tn = self._tile_n_for(bm, DEFAULT_THREADS)
-            except ValueError:
-                continue
-            best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
-            curr_num = (self.N_padded + tn - 1) // tn
-            if curr_num < best_num:
-                best_bm = bm
-                best_tile_n = tn
-        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
+        return self._planner.default_config()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = self._smem_budget // smem_per_row
-            block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
-            return [{"block_m": bm, "threads": t} for bm, t in configs]
-
-        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
-        # column granularity that pair can build, so every emitted triple
-        # builds; a pair with no fitting tile is dropped here rather than left
-        # to fail during the sweep.
-        configs = []
-        for bm in [1, 2, 4, 8]:
-            for t in AUTOTUNE_THREADS:
-                try:
-                    tn = self._tile_n_for(bm, t)
-                except ValueError:
-                    continue
-                if tn == 0:
-                    continue
-                configs.append({"block_m": bm, "threads": t, "tile_n": tn})
-        return configs if configs else [self.default_config]
+        return self._planner.autotune_configs()
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Autotune logical reduce, benchmarking tiled configs directly."""

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -28,7 +28,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
-    tile_column_alignment,
+    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -394,7 +394,7 @@ class LogicalReduceKernel(Kernel):
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
             block_m, self._elem_bytes, self.N_padded,
-            alignment=tile_column_alignment(self._elem_bytes, threads),
+            alignment=reduce_column_alignment(self._elem_bytes, threads),
             budget=effective_budget,
         )
 

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -365,10 +365,12 @@ class LogicalReduceKernel(Kernel):
         self.init_config(config, tune)
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
+            threads = self.config.get("threads", DEFAULT_THREADS)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._planner.tile_n_for(
-                    bm, self.config.get("threads", DEFAULT_THREADS),
-                )
+                self.config["tile_n"] = self._planner.tile_n_for(bm, threads)
+            reason = self._planner.reject_tile_n(bm, self.config["tile_n"], threads)
+            if reason:
+                raise ValueError(reason)
 
     @property
     def default_config(self) -> dict:

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -110,23 +110,26 @@ def _logical_reduce_kernel(M: int, N: int, op_kind: str, dtype: str):
                 )
 
                 if _needs_pad:
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            T.cast(x[pid_m * block_m + i, j], "float32"),
-                            T.cast(_pad_val, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(_pad_val, "float32"),
+                            )
                 else:
                     # Load via shared memory
                     T.copy(x[pid_m * block_m, 0], shared_buf)
 
                     # Cast to fp32
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Cast to bool (0.0 or 1.0)
-                for i, j in T.Parallel(block_m, N_padded):
-                    bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
+                for i in T.serial(block_m):
+                    for j in T.Parallel(N_padded):
+                        bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
 
                 if op_kind == "any":
                     # any: result is 1 if max(bool_vals) == 1
@@ -194,18 +197,20 @@ def _logical_reduce_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_
                     T.fill(acc, 0.0)
 
                 for t in T.Serial(num_tiles):
-                    for i, j in T.Parallel(block_m, tile_n):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                            T.cast(
-                                x[pid_m * block_m + i, t * tile_n + j],
-                                "float32",
-                            ),
-                            T.cast(_pad_val, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                T.cast(
+                                    x[pid_m * block_m + i, t * tile_n + j],
+                                    "float32",
+                                ),
+                                T.cast(_pad_val, "float32"),
+                            )
 
-                    for i, j in T.Parallel(block_m, tile_n):
-                        bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            bool_vals[i, j] = T.if_then_else(x_f32[i, j] != 0.0, 1.0, 0.0)
 
                     if op_kind == "any":
                         T.reduce_max(bool_vals, tile_acc, dim=1)

--- a/tileops/kernels/reduction/logical_reduce.py
+++ b/tileops/kernels/reduction/logical_reduce.py
@@ -21,11 +21,14 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
+    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
+    DEFAULT_THREADS,
     MAX_SINGLE_TILE_COLS,
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tile_column_alignment,
     tune_by_forward,
 )
 
@@ -367,10 +370,18 @@ class LogicalReduceKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for_block_m(bm)
+                self.config["tile_n"] = self._tile_n_for(
+                    bm, self.config.get("threads", DEFAULT_THREADS),
+                )
 
-    def _tile_n_for_block_m(self, block_m: int) -> int:
-        """Return tile_n for a given block_m (0 means no tiling needed)."""
+    def _tile_n_for(self, block_m: int, threads: int) -> int:
+        """Return tile_n for a block_m / threads pair (0 means no tiling).
+
+        Raises:
+            ValueError: If no tile of the required column granularity fits in
+                shared memory for this pair.  Callers building candidate lists
+                drop the pair rather than emit an unbuildable tile.
+        """
         budget = self._smem_budget
         if self.N_padded <= MAX_SINGLE_TILE_COLS:
             single = compute_tile_n(
@@ -382,7 +393,9 @@ class LogicalReduceKernel(Kernel):
         col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
+            block_m, self._elem_bytes, self.N_padded,
+            alignment=tile_column_alignment(self._elem_bytes, threads),
+            budget=effective_budget,
         )
 
     @property
@@ -395,13 +408,13 @@ class LogicalReduceKernel(Kernel):
             for bm in [1, 2, 4, 8]:
                 if bm <= max_block_m:
                     block_m = bm
-            return {"block_m": block_m, "threads": 128}
+            return {"block_m": block_m, "threads": DEFAULT_THREADS}
 
         best_bm = 1
-        best_tile_n = self._tile_n_for_block_m(1)
+        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
         for bm in [2, 4, 8]:
             try:
-                tn = self._tile_n_for_block_m(bm)
+                tn = self._tile_n_for(bm, DEFAULT_THREADS)
             except ValueError:
                 continue
             best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
@@ -409,7 +422,7 @@ class LogicalReduceKernel(Kernel):
             if curr_num < best_num:
                 best_bm = bm
                 best_tile_n = tn
-        return {"block_m": best_bm, "threads": 128, "tile_n": best_tile_n}
+        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -417,19 +430,22 @@ class LogicalReduceKernel(Kernel):
             smem_per_row = self.N_padded * self._elem_bytes
             max_block_m = self._smem_budget // smem_per_row
             block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            threads_list = [128, 256]
-            configs = list(itertools.product(block_ms, threads_list))
+            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
             return [{"block_m": bm, "threads": t} for bm, t in configs]
 
+        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
+        # column granularity that pair can build, so every emitted triple
+        # builds; a pair with no fitting tile is dropped here rather than left
+        # to fail during the sweep.
         configs = []
         for bm in [1, 2, 4, 8]:
-            try:
-                tn = self._tile_n_for_block_m(bm)
-            except ValueError:
-                continue
-            if tn == 0:
-                continue
-            for t in [128, 256]:
+            for t in AUTOTUNE_THREADS:
+                try:
+                    tn = self._tile_n_for(bm, t)
+                except ValueError:
+                    continue
+                if tn == 0:
+                    continue
                 configs.append({"block_m": bm, "threads": t, "tile_n": tn})
         return configs if configs else [self.default_config]
 

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -302,15 +302,8 @@ class LogSumExpKernel(Kernel):
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
         #
-        # tile_n is baked into the kernel at build time, so we pre-compute
-        # it from the heuristic block_m in default_config. The matching
-        # `autotune_configs` property below filters out any block_m whose
-        # tile_n differs from this pre-built one, so the autotuner stays
-        # within a single tiling regime by design.
-        #
-        # Cross-tile_n autotune exploration is a known limitation; the
-        # single-regime restriction is inherited from prior tiling design
-        # and not introduced here.
+        # tile_n is baked into the kernel at build time, so pre-compute it from
+        # default_config; autotune() rebuilds once per candidate width.
         self._tile_n = self.default_config["tile_n"]
         self.kernel = _logsumexp_kernel(
             self.M,
@@ -329,6 +322,8 @@ class LogSumExpKernel(Kernel):
             # previous autotuner result), honour it.  Only fall back to
             # the heuristic when tile_n was not provided.
             caller_tile_n = config.get("tile_n") if config is not None else None
+            if caller_tile_n == 0:
+                caller_tile_n = None
             if caller_tile_n is not None:
                 reason = self._planner.reject_tile_n(
                     self.config["block_m"], caller_tile_n,
@@ -375,7 +370,7 @@ class LogSumExpKernel(Kernel):
         best_tile_n = self._tile_n_for_block_m(1)
 
         for bm in [2, 4, 8, 16]:
-            if not self._planner.untiled_block_m_ok(bm, _DEFAULT_TUNE_THREADS):
+            if not self._planner.layout_ok(bm, self.N_padded, _DEFAULT_TUNE_THREADS):
                 continue
             try:
                 tn = self._tile_n_for_block_m(bm)
@@ -475,7 +470,7 @@ class LogSumExpKernel(Kernel):
                     if bm > max_block_m_no_tile:
                         continue
                     for t in threads_list:
-                        if not self._planner.untiled_block_m_ok(bm, t):
+                        if not self._planner.layout_ok(bm, self.N_padded, t):
                             continue
                         configs.append({"block_m": bm, "threads": t, "tile_n": 0})
             else:

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -330,6 +330,12 @@ class LogSumExpKernel(Kernel):
             # the heuristic when tile_n was not provided.
             caller_tile_n = config.get("tile_n") if config is not None else None
             if caller_tile_n is not None:
+                reason = self._planner.reject_tile_n(
+                    self.config["block_m"], caller_tile_n,
+                    self.config.get("threads", _DEFAULT_TUNE_THREADS),
+                )
+                if reason:
+                    raise ValueError(reason)
                 target_tile_n = caller_tile_n
             else:
                 target_tile_n = self._tile_n_for_block_m(self.config["block_m"])

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -74,23 +74,26 @@ def _logsumexp_kernel_single(M: int, N: int, dtype: str):
                     # Kernel-side boundary handling: element-wise load
                     # with T.if_then_else masking for padding columns
                     # and row-tail safety (M % block_m != 0).
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            T.cast(x[pid_m * block_m + i, j], "float32"),
-                            T.cast(_neg_inf, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(_neg_inf, "float32"),
+                            )
                 else:
                     T.copy(x[pid_m * block_m, 0], shared_buf)
                     T.copy(shared_buf, x_local)
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 T.fill(row_max, -T.infinity("float32"))
                 T.reduce_max(x_f32, row_max, dim=1, clear=False)
 
-                for i, j in T.Parallel(block_m, N_padded):
-                    x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                for i in T.serial(block_m):
+                    for j in T.Parallel(N_padded):
+                        x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
                 T.reduce_sum(x_f32, row_sum, dim=1)
 
                 out_local = T.alloc_fragment((block_m,), dtype)
@@ -154,22 +157,25 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
                             with T.Then():
                                 T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                                 T.copy(shared_buf, tile_local)
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
                             with T.Else():
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.if_then_else(
-                                        T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                        T.cast(
-                                            x[pid_m * block_m + i, t * tile_n + j], "float32"
-                                        ),
-                                        T.cast(_neg_inf, "float32"),
-                                    )
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                            ),
+                                            T.cast(_neg_inf, "float32"),
+                                        )
                     else:
                         T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                         T.copy(shared_buf, tile_local)
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                     T.fill(tile_max, -T.infinity("float32"))
                     T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -178,8 +184,9 @@ def _logsumexp_kernel_tiled(M: int, N: int, dtype: str, tile_n: int):
                         prev_max[i] = row_max[i]
                         row_max[i] = T.max(row_max[i], tile_max[i])
 
-                    for i, j in T.Parallel(block_m, tile_n):
-                        tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
                     T.reduce_sum(tile_f32, tile_sum, dim=1)
 
                     for i in T.Parallel(block_m):

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -24,8 +24,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
+    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
-    MAX_SINGLE_TILE_COLS,
+    BlockConfigPlanner,
     align_up,
     compute_tile_n,
     device_smem_budget,
@@ -290,6 +291,9 @@ class LogSumExpKernel(Kernel):
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
+        self._planner = BlockConfigPlanner(
+            self.N_padded, self._elem_bytes, self._smem_budget,
+        )
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
@@ -338,26 +342,12 @@ class LogSumExpKernel(Kernel):
     def _tile_n_for_block_m(self, block_m: int) -> int:
         """Return tile_n for a given block_m (0 means no tiling needed).
 
-        Uses the device's actual shared memory budget (not the
-        conservative 48 KiB default) so that large-N workloads can
-        use fewer, larger tiles or even the single-tile fast path.
-
-        Both paths are subject to the MAX_SINGLE_TILE_COLS column
-        cap (TileLang's vectorizer fails at the 32768 column boundary).
+        Derived at the granularity the *coarsest* candidate thread count
+        needs: tile_n is baked into the kernel at build time and then reused
+        across every ``threads`` value the autotuner tries, so one tile has to
+        satisfy all of them.
         """
-        budget = self._smem_budget
-        # Single-tile path: cap by column count and smem budget.
-        if self.N_padded <= MAX_SINGLE_TILE_COLS:
-            tile_n = compute_tile_n(block_m, self._elem_bytes, self.N_padded, budget=budget)
-            if tile_n == self.N_padded:
-                return 0
-        # Tiled path (logsumexp uses 1 shared buffer).
-        # Cap the smem budget so tile_n stays within the column limit.
-        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
-        effective_budget = min(budget, col_budget)
-        return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
-        )
+        return self._planner.tile_n_for(block_m, max(AUTOTUNE_THREADS))
 
     @property
     def default_config(self) -> dict:

--- a/tileops/kernels/reduction/logsumexp.py
+++ b/tileops/kernels/reduction/logsumexp.py
@@ -32,6 +32,10 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
 )
 
+# These two kernels bake tile_n in at build time and default to the wider
+# thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
+_DEFAULT_TUNE_THREADS = 256
+
 __all__ = ["LogSumExpKernel"]
 
 
@@ -365,6 +369,8 @@ class LogSumExpKernel(Kernel):
         best_tile_n = self._tile_n_for_block_m(1)
 
         for bm in [2, 4, 8, 16]:
+            if not self._planner.untiled_block_m_ok(bm, _DEFAULT_TUNE_THREADS):
+                continue
             try:
                 tn = self._tile_n_for_block_m(bm)
             except ValueError:
@@ -382,7 +388,8 @@ class LogSumExpKernel(Kernel):
                     best_bm = bm
                     best_tile_n = tn
 
-        return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
+        return {"block_m": best_bm, "threads": _DEFAULT_TUNE_THREADS,
+                "tile_n": best_tile_n}
 
     def _tile_n_candidates(self) -> list[int]:
         """Return candidate tile_n values for autotune exploration.
@@ -462,6 +469,8 @@ class LogSumExpKernel(Kernel):
                     if bm > max_block_m_no_tile:
                         continue
                     for t in threads_list:
+                        if not self._planner.untiled_block_m_ok(bm, t):
+                            continue
                         configs.append({"block_m": bm, "threads": t, "tile_n": 0})
             else:
                 # Tiled regime: use block_m=1 with each tile_n candidate.

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -28,12 +28,15 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
+    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
+    DEFAULT_THREADS,
     MAX_SINGLE_TILE_COLS,
     SHARED_MEMORY_BUDGET_BYTES,
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tile_column_alignment,
     tune_by_forward,
 )
 
@@ -938,13 +941,20 @@ class ReduceKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for_block_m(bm)
+                self.config["tile_n"] = self._tile_n_for(
+                    bm, self.config.get("threads", DEFAULT_THREADS),
+                )
 
-    def _tile_n_for_block_m(self, block_m: int) -> int:
-        """Return tile_n for a given block_m (0 means no tiling needed).
+    def _tile_n_for(self, block_m: int, threads: int) -> int:
+        """Return tile_n for a block_m / threads pair (0 means no tiling).
 
         Welford kernels allocate 2 shared buffers per pass, so
         ``num_buffers=2`` is used to ensure both fit in shared memory.
+
+        Raises:
+            ValueError: If no tile of the required column granularity fits in
+                shared memory for this pair.  Callers building candidate lists
+                drop the pair rather than emit an unbuildable tile.
         """
         budget = self._smem_budget
         if self.N_padded <= MAX_SINGLE_TILE_COLS:
@@ -959,6 +969,7 @@ class ReduceKernel(Kernel):
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
             block_m, self._elem_bytes, self.N_padded,
+            alignment=tile_column_alignment(self._elem_bytes, threads),
             num_buffers=num_buffers,
             budget=effective_budget,
         )
@@ -972,15 +983,15 @@ class ReduceKernel(Kernel):
             for bm in [1, 2, 4, 8]:
                 if bm <= max_block_m:
                     block_m = bm
-            return {"block_m": block_m, "threads": 128}
+            return {"block_m": block_m, "threads": DEFAULT_THREADS}
 
         # Tiled path: pick block_m that minimizes tile count
         best_bm = 1
-        best_tile_n = self._tile_n_for_block_m(1)
+        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
 
         for bm in [2, 4, 8]:
             try:
-                tn = self._tile_n_for_block_m(bm)
+                tn = self._tile_n_for(bm, DEFAULT_THREADS)
             except ValueError:
                 continue
             if tn == 0:
@@ -998,7 +1009,7 @@ class ReduceKernel(Kernel):
                     best_bm = bm
                     best_tile_n = tn
 
-        return {"block_m": best_bm, "threads": 128, "tile_n": best_tile_n}
+        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -1006,20 +1017,22 @@ class ReduceKernel(Kernel):
             smem_per_row = self.N_padded * self._elem_bytes
             max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
             block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            threads_list = [128, 256]
-            configs = list(itertools.product(block_ms, threads_list))
+            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
             return [{"block_m": bm, "threads": t} for bm, t in configs]
 
-        # Tiled path
+        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
+        # column granularity that pair can build, so every emitted triple
+        # builds; a pair with no fitting tile is dropped here rather than left
+        # to fail during the sweep.
         configs = []
         for bm in [1, 2, 4, 8]:
-            try:
-                tn = self._tile_n_for_block_m(bm)
-            except ValueError:
-                continue
-            if tn == 0:
-                continue
-            for t in [128, 256]:
+            for t in AUTOTUNE_THREADS:
+                try:
+                    tn = self._tile_n_for(bm, t)
+                except ValueError:
+                    continue
+                if tn == 0:
+                    continue
                 configs.append({"block_m": bm, "threads": t, "tile_n": tn})
         return configs if configs else [self.default_config]
 

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -36,7 +36,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
-    tile_column_alignment,
+    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -969,7 +969,7 @@ class ReduceKernel(Kernel):
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
             block_m, self._elem_bytes, self.N_padded,
-            alignment=tile_column_alignment(self._elem_bytes, threads),
+            alignment=reduce_column_alignment(self._elem_bytes, threads),
             num_buffers=num_buffers,
             budget=effective_budget,
         )

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -470,7 +470,8 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     # Variance: sum((x - mean)^2) / (N - correction)
                     for i in T.serial(block_m):
                         for j in T.Parallel(N_padded):
-                            sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+                            dev = x_f32[i, j] - mean_val[i]
+                            sq_diff[i, j] = dev * dev
 
                     T.reduce_sum(sq_diff, var_sum, dim=1)
 
@@ -524,7 +525,8 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     # Variance
                     for i in T.serial(block_m):
                         for j in T.Parallel(N_padded):
-                            sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+                            dev = x_f32[i, j] - mean_val[i]
+                            sq_diff[i, j] = dev * dev
 
                     T.reduce_sum(sq_diff, var_sum, dim=1)
 

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -937,10 +937,12 @@ class ReduceKernel(Kernel):
         # A caller-provided config may have block_m without tile_n.
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
+            threads = self.config.get("threads", DEFAULT_THREADS)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._planner.tile_n_for(
-                    bm, self.config.get("threads", DEFAULT_THREADS),
-                )
+                self.config["tile_n"] = self._planner.tile_n_for(bm, threads)
+            reason = self._planner.reject_tile_n(bm, self.config["tile_n"], threads)
+            if reason:
+                raise ValueError(reason)
 
     @property
     def default_config(self) -> dict:

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -19,7 +19,6 @@ memory instructions.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -28,15 +27,11 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
-    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
-    MAX_SINGLE_TILE_COLS,
-    SHARED_MEMORY_BUDGET_BYTES,
+    BlockConfigPlanner,
     align_up,
-    compute_tile_n,
     device_smem_budget,
-    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -911,9 +906,11 @@ class ReduceKernel(Kernel):
         self._is_welford = op_kind in _WELFORD_KINDS
         self._elem_bytes = torch.tensor([], dtype=dtype).element_size()
         self._smem_budget = device_smem_budget()
-
-        # Determine whether tiling is needed
-        self._needs_tiling = self.N_padded > MAX_SINGLE_TILE_COLS
+        self._planner = BlockConfigPlanner(
+            self.N_padded, self._elem_bytes, self._smem_budget,
+            num_buffers=2 if self._is_welford else 1,
+        )
+        self._needs_tiling = self._planner.needs_tiling
 
         if not self._needs_tiling:
             if self._is_welford:
@@ -941,100 +938,17 @@ class ReduceKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for(
+                self.config["tile_n"] = self._planner.tile_n_for(
                     bm, self.config.get("threads", DEFAULT_THREADS),
                 )
 
-    def _tile_n_for(self, block_m: int, threads: int) -> int:
-        """Return tile_n for a block_m / threads pair (0 means no tiling).
-
-        Welford kernels allocate 2 shared buffers per pass, so
-        ``num_buffers=2`` is used to ensure both fit in shared memory.
-
-        Raises:
-            ValueError: If no tile of the required column granularity fits in
-                shared memory for this pair.  Callers building candidate lists
-                drop the pair rather than emit an unbuildable tile.
-        """
-        budget = self._smem_budget
-        if self.N_padded <= MAX_SINGLE_TILE_COLS:
-            single = compute_tile_n(
-                block_m, self._elem_bytes, self.N_padded, budget=budget,
-            )
-            if single == self.N_padded:
-                return 0
-
-        num_buffers = 2 if self._is_welford else 1
-        col_budget = MAX_SINGLE_TILE_COLS * num_buffers * block_m * self._elem_bytes
-        effective_budget = min(budget, col_budget)
-        return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded,
-            alignment=reduce_column_alignment(self._elem_bytes, threads),
-            num_buffers=num_buffers,
-            budget=effective_budget,
-        )
-
     @property
     def default_config(self) -> dict:
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-            block_m = 1
-            for bm in [1, 2, 4, 8]:
-                if bm <= max_block_m:
-                    block_m = bm
-            return {"block_m": block_m, "threads": DEFAULT_THREADS}
-
-        # Tiled path: pick block_m that minimizes tile count
-        best_bm = 1
-        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
-
-        for bm in [2, 4, 8]:
-            try:
-                tn = self._tile_n_for(bm, DEFAULT_THREADS)
-            except ValueError:
-                continue
-            if tn == 0:
-                # No tiling needed at this block_m — always prefer
-                best_bm = bm
-                best_tile_n = tn
-            elif best_tile_n == 0:
-                # Current best doesn't need tiling; keep it
-                pass
-            else:
-                # Both need tiling — pick fewer tiles
-                best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
-                curr_num = (self.N_padded + tn - 1) // tn
-                if curr_num < best_num:
-                    best_bm = bm
-                    best_tile_n = tn
-
-        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
+        return self._planner.default_config()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = SHARED_MEMORY_BUDGET_BYTES // smem_per_row
-            block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
-            return [{"block_m": bm, "threads": t} for bm, t in configs]
-
-        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
-        # column granularity that pair can build, so every emitted triple
-        # builds; a pair with no fitting tile is dropped here rather than left
-        # to fail during the sweep.
-        configs = []
-        for bm in [1, 2, 4, 8]:
-            for t in AUTOTUNE_THREADS:
-                try:
-                    tn = self._tile_n_for(bm, t)
-                except ValueError:
-                    continue
-                if tn == 0:
-                    continue
-                configs.append({"block_m": bm, "threads": t, "tile_n": tn})
-        return configs if configs else [self.default_config]
+        return self._planner.autotune_configs()
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Autotune the reduce kernel by benchmarking candidate configs."""

--- a/tileops/kernels/reduction/reduce.py
+++ b/tileops/kernels/reduction/reduce.py
@@ -102,19 +102,21 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
                     # Kernel-side boundary handling: element-wise load
                     # with T.if_then_else masking for padding columns
                     # and row-tail safety (M % block_m != 0).
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            T.cast(x[pid_m * block_m + i, j], "float32"),
-                            T.cast(_pad_val, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(_pad_val, "float32"),
+                            )
                 else:
                     # Load via shared memory (fast vectorized path)
                     T.copy(x[pid_m * block_m, 0], shared_buf)
 
                     # Cast to fp32
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Reduce
                 if op_kind == "sum":
@@ -127,8 +129,9 @@ def _simple_reduce_kernel(M, N, op_kind, dtype):
                     T.reduce_max(x_f32, acc, dim=1)
                 elif op_kind == "amin":
                     # Negate, reduce_max, negate back
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = -x_f32[i, j]
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = -x_f32[i, j]
                     T.reduce_max(x_f32, acc, dim=1)
                     for i in T.Parallel(block_m):
                         acc[i] = -acc[i]
@@ -189,25 +192,28 @@ def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n):
                         with T.If(t < num_tiles - 1):
                             with T.Then():
                                 T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                             with T.Else():
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.if_then_else(
-                                        T.And(
-                                            pid_m * block_m + i < M,
-                                            t * tile_n + j < N,
-                                        ),
-                                        T.cast(
-                                            x[pid_m * block_m + i, t * tile_n + j],
-                                            "float32",
-                                        ),
-                                        T.cast(_pad_val, "float32"),
-                                    )
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            T.And(
+                                                pid_m * block_m + i < M,
+                                                t * tile_n + j < N,
+                                            ),
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j],
+                                                "float32",
+                                            ),
+                                            T.cast(_pad_val, "float32"),
+                                        )
                     else:
                         T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                     # Tile-local reduce
                     if op_kind in ("sum", "mean"):
@@ -220,8 +226,9 @@ def _simple_reduce_kernel_tiled(M, N, op_kind, dtype, tile_n):
                             acc[i] = T.max(acc[i], tile_acc[i])
                     elif op_kind == "amin":
                         # Negate, reduce_max, negate back
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = -tile_f32[i, j]
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = -tile_f32[i, j]
                         T.reduce_max(tile_f32, tile_acc, dim=1)
                         for i in T.Parallel(block_m):
                             acc[i] = T.min(acc[i], -tile_acc[i])
@@ -271,27 +278,30 @@ def _prod_reduce_kernel(M, N, dtype):
                 if _needs_pad:
                     # Kernel-side boundary handling: fill out-of-bounds
                     # columns with 1.0 (identity for product).
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            T.cast(x[pid_m * block_m + i, j], "float32"),
-                            T.cast(1.0, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(1.0, "float32"),
+                            )
                 else:
                     T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                 # Compute log(|x|) and count negatives
                 # Padded positions are 1.0, so log(1.0)=0 (neutral for sum)
                 # and sign_neg=0 (non-negative).
-                for i, j in T.Parallel(block_m, N_padded):
-                    abs_val = T.abs(x_f32[i, j])
-                    # Use a small epsilon to avoid log(0)
-                    log_abs[i, j] = T.log(T.max(abs_val, 1e-38))
-                    # 1 if negative, 0 if non-negative
-                    sign_neg[i, j] = T.if_then_else(x_f32[i, j] < 0.0, 1.0, 0.0)
+                for i in T.serial(block_m):
+                    for j in T.Parallel(N_padded):
+                        abs_val = T.abs(x_f32[i, j])
+                        # Use a small epsilon to avoid log(0)
+                        log_abs[i, j] = T.log(T.max(abs_val, 1e-38))
+                        # 1 if negative, 0 if non-negative
+                        sign_neg[i, j] = T.if_then_else(x_f32[i, j] < 0.0, 1.0, 0.0)
 
                 T.reduce_sum(log_abs, acc_log, dim=1)
                 T.reduce_sum(sign_neg, acc_sign, dim=1)
@@ -349,32 +359,36 @@ def _prod_reduce_kernel_tiled(M, N, dtype, tile_n):
                         with T.If(t < num_tiles - 1):
                             with T.Then():
                                 T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                             with T.Else():
-                                for i, j in T.Parallel(block_m, tile_n):
-                                    tile_f32[i, j] = T.if_then_else(
-                                        T.And(
-                                            pid_m * block_m + i < M,
-                                            t * tile_n + j < N,
-                                        ),
-                                        T.cast(
-                                            x[pid_m * block_m + i, t * tile_n + j],
-                                            "float32",
-                                        ),
-                                        T.cast(1.0, "float32"),
-                                    )
+                                for i in T.serial(block_m):
+                                    for j in T.Parallel(tile_n):
+                                        tile_f32[i, j] = T.if_then_else(
+                                            T.And(
+                                                pid_m * block_m + i < M,
+                                                t * tile_n + j < N,
+                                            ),
+                                            T.cast(
+                                                x[pid_m * block_m + i, t * tile_n + j],
+                                                "float32",
+                                            ),
+                                            T.cast(1.0, "float32"),
+                                        )
                     else:
                         T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
-                    for i, j in T.Parallel(block_m, tile_n):
-                        abs_val = T.abs(tile_f32[i, j])
-                        log_abs[i, j] = T.log(T.max(abs_val, 1e-38))
-                        sign_neg[i, j] = T.if_then_else(
-                            tile_f32[i, j] < 0.0, 1.0, 0.0,
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            abs_val = T.abs(tile_f32[i, j])
+                            log_abs[i, j] = T.log(T.max(abs_val, 1e-38))
+                            sign_neg[i, j] = T.if_then_else(
+                                tile_f32[i, j] < 0.0, 1.0, 0.0,
+                            )
 
                     T.reduce_sum(log_abs, tile_log, dim=1)
                     T.reduce_sum(sign_neg, tile_sign, dim=1)
@@ -434,17 +448,19 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     out_m = T.alloc_fragment((block_m,), dtype)
 
                     if _needs_pad:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(0.0, "float32"),
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.if_then_else(
+                                    T.And(pid_m * block_m + i < M, j < N),
+                                    T.cast(x[pid_m * block_m + i, j], "float32"),
+                                    T.cast(0.0, "float32"),
+                                )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                     # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
@@ -452,8 +468,9 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                         mean_val[i] = row_sum[i] / float(N)
 
                     # Variance: sum((x - mean)^2) / (N - correction)
-                    for i, j in T.Parallel(block_m, N_padded):
-                        sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
 
                     T.reduce_sum(sq_diff, var_sum, dim=1)
 
@@ -485,17 +502,19 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                     out_local = T.alloc_fragment((block_m,), dtype)
 
                     if _needs_pad:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(0.0, "float32"),
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.if_then_else(
+                                    T.And(pid_m * block_m + i < M, j < N),
+                                    T.cast(x[pid_m * block_m + i, j], "float32"),
+                                    T.cast(0.0, "float32"),
+                                )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)
 
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                     # Mean
                     T.reduce_sum(x_f32, row_sum, dim=1)
@@ -503,8 +522,9 @@ def _welford_reduce_kernel(M, N, op_kind, correction, dtype):
                         mean_val[i] = row_sum[i] / float(N)
 
                     # Variance
-                    for i, j in T.Parallel(block_m, N_padded):
-                        sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            sq_diff[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
 
                     T.reduce_sum(sq_diff, var_sum, dim=1)
 
@@ -576,25 +596,28 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                             with T.If(t < num_tiles - 1):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.if_then_else(
-                                            T.And(
-                                                pid_m * block_m + i < M,
-                                                t * tile_n + j < N,
-                                            ),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j],
-                                                "float32",
-                                            ),
-                                            0.0,
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.if_then_else(
+                                                T.And(
+                                                    pid_m * block_m + i < M,
+                                                    t * tile_n + j < N,
+                                                ),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j],
+                                                    "float32",
+                                                ),
+                                                0.0,
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                         T.reduce_sum(tile_f32, tile_sum, dim=1)
                         for i in T.Parallel(block_m):
@@ -613,30 +636,34 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                             with T.If(t < num_tiles - 1):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.if_then_else(
-                                            T.And(
-                                                pid_m * block_m + i < M,
-                                                t * tile_n + j < N,
-                                            ),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j],
-                                                "float32",
-                                            ),
-                                            0.0,
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.if_then_else(
+                                                T.And(
+                                                    pid_m * block_m + i < M,
+                                                    t * tile_n + j < N,
+                                                ),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j],
+                                                    "float32",
+                                                ),
+                                                0.0,
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            sq_diff[i, j] = (p2_f32[i, j] - mean_val[i]) * (
-                                p2_f32[i, j] - mean_val[i]
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                sq_diff[i, j] = (p2_f32[i, j] - mean_val[i]) * (
+                                    p2_f32[i, j] - mean_val[i]
+                                )
                         T.reduce_sum(sq_diff, tile_sq, dim=1)
                         for i in T.Parallel(block_m):
                             var_sum[i] = var_sum[i] + tile_sq[i]
@@ -678,25 +705,28 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                             with T.If(t < num_tiles - 1):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.if_then_else(
-                                            T.And(
-                                                pid_m * block_m + i < M,
-                                                t * tile_n + j < N,
-                                            ),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j],
-                                                "float32",
-                                            ),
-                                            0.0,
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.if_then_else(
+                                                T.And(
+                                                    pid_m * block_m + i < M,
+                                                    t * tile_n + j < N,
+                                                ),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j],
+                                                    "float32",
+                                                ),
+                                                0.0,
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    tile_f32[i, j] = T.cast(shared_buf[i, j], "float32")
 
                         T.reduce_sum(tile_f32, tile_sum, dim=1)
                         for i in T.Parallel(block_m):
@@ -715,30 +745,34 @@ def _welford_reduce_kernel_tiled(M, N, op_kind, correction, dtype, tile_n):
                             with T.If(t < num_tiles - 1):
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.if_then_else(
-                                            T.And(
-                                                pid_m * block_m + i < M,
-                                                t * tile_n + j < N,
-                                            ),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j],
-                                                "float32",
-                                            ),
-                                            0.0,
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.if_then_else(
+                                                T.And(
+                                                    pid_m * block_m + i < M,
+                                                    t * tile_n + j < N,
+                                                ),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j],
+                                                    "float32",
+                                                ),
+                                                0.0,
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    p2_f32[i, j] = T.cast(p2_shared[i, j], "float32")
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            sq_diff[i, j] = (p2_f32[i, j] - mean_val[i]) * (
-                                p2_f32[i, j] - mean_val[i]
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                sq_diff[i, j] = (p2_f32[i, j] - mean_val[i]) * (
+                                    p2_f32[i, j] - mean_val[i]
+                                )
                         T.reduce_sum(sq_diff, tile_sq, dim=1)
                         for i in T.Parallel(block_m):
                             var_sum[i] = var_sum[i] + tile_sq[i]

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -25,8 +25,9 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
+    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
-    MAX_SINGLE_TILE_COLS,
+    BlockConfigPlanner,
     align_up,
     compute_tile_n,
     device_smem_budget,
@@ -541,6 +542,10 @@ class SoftmaxKernel(Kernel):
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = _elem_bytes(dtype)
         self._smem_budget = device_smem_budget(device_index)
+        self._planner = BlockConfigPlanner(
+            self.N_padded, self._elem_bytes, self._smem_budget,
+            num_buffers=self._NUM_SHARED_BUFFERS,
+        )
 
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
@@ -596,31 +601,12 @@ class SoftmaxKernel(Kernel):
     def _tile_n_for_block_m(self, block_m: int) -> int:
         """Return tile_n for a given block_m (0 means no tiling needed).
 
-        Uses the device's actual shared memory budget (not the
-        conservative 48 KiB default) so that large-N workloads can
-        use fewer, larger tiles or even the single-tile fast path.
-
-        Both paths are subject to the MAX_SINGLE_TILE_COLS column
-        cap (TileLang's vectorizer fails at the 32768 column boundary).
+        Derived at the granularity the *coarsest* candidate thread count
+        needs: tile_n is baked into the kernel at build time and then reused
+        across every ``threads`` value the autotuner tries, so one tile has to
+        satisfy all of them.
         """
-        budget = self._smem_budget
-        # Single-tile path requires the full row in register fragments.
-        # Cap by column count (vectorizer limit) and smem budget.
-        if self.N_padded <= MAX_SINGLE_TILE_COLS:
-            single = compute_tile_n(
-                block_m, self._elem_bytes, self.N_padded, budget=budget,
-            )
-            if single == self.N_padded:
-                return 0
-        # Tiled path: budget must accommodate num_buffers shared allocations.
-        # Cap the smem budget so tile_n stays within the column limit.
-        col_budget = MAX_SINGLE_TILE_COLS * self._NUM_SHARED_BUFFERS * block_m * self._elem_bytes
-        effective_budget = min(budget, col_budget)
-        return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded,
-            num_buffers=self._NUM_SHARED_BUFFERS,
-            budget=effective_budget,
-        )
+        return self._planner.tile_n_for(block_m, max(AUTOTUNE_THREADS))
 
     @property
     def default_config(self) -> dict:

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -79,31 +79,36 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                         # Kernel-side boundary handling: element-wise load
                         # with T.if_then_else masking for padding columns
                         # and row-tail safety (M % block_m != 0).
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(_neg_inf, "float32"),
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.if_then_else(
+                                    T.And(pid_m * block_m + i < M, j < N),
+                                    T.cast(x[pid_m * block_m + i, j], "float32"),
+                                    T.cast(_neg_inf, "float32"),
+                                )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)
                         T.copy(shared_buf, x_local)
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     T.fill(row_max, -T.infinity("float32"))
                     T.reduce_max(x_f32, row_max, dim=1, clear=False)
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
                     T.reduce_sum(x_f32, row_sum, dim=1)
 
                     out_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                    for i, j in T.Parallel(block_m, N_padded):
-                        out_f32[i, j] = x_f32[i, j] / row_sum[i]
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            out_f32[i, j] = x_f32[i, j] / row_sum[i]
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = out_f32[i, j]
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_local[i, j] = out_f32[i, j]
                     T.copy(x_local, shared_buf)
                     T.copy(shared_buf, y[pid_m * block_m, 0])
 
@@ -126,17 +131,19 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     row_sum = T.alloc_fragment((block_m,), "float32")
 
                     if _needs_pad:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                T.And(pid_m * block_m + i < M, j < N),
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(_neg_inf, "float32"),
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.if_then_else(
+                                    T.And(pid_m * block_m + i < M, j < N),
+                                    T.cast(x[pid_m * block_m + i, j], "float32"),
+                                    T.cast(_neg_inf, "float32"),
+                                )
                     else:
                         T.copy(x[pid_m * block_m, 0], shared_buf)
                         T.copy(shared_buf, x_local)
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                     T.fill(row_max, -T.infinity("float32"))
                     T.reduce_max(x_f32, row_max, dim=1, clear=False)
@@ -145,8 +152,9 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     # retains the original values for the stable log_softmax
                     # formula: (x - max) - log(sum(exp(x - max))).
                     exp_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                    for i, j in T.Parallel(block_m, N_padded):
-                        exp_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            exp_f32[i, j] = T.exp(x_f32[i, j] - row_max[i])
                     T.reduce_sum(exp_f32, row_sum, dim=1)
 
                     log_sum = T.alloc_fragment((block_m,), "float32")
@@ -156,11 +164,13 @@ def _softmax_kernel_single(M: int, N: int, op_kind: str, dtype: str):
                     # log_softmax = (x - max) - log(sum), avoids log(0) on
                     # padding columns (they stay at -inf via subtraction).
                     out_f32 = T.alloc_fragment((block_m, N_padded), "float32")
-                    for i, j in T.Parallel(block_m, N_padded):
-                        out_f32[i, j] = x_f32[i, j] - row_max[i] - log_sum[i]
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            out_f32[i, j] = x_f32[i, j] - row_max[i] - log_sum[i]
 
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_local[i, j] = out_f32[i, j]
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_local[i, j] = out_f32[i, j]
                     T.copy(x_local, shared_buf)
                     T.copy(shared_buf, y[pid_m * block_m, 0])
 
@@ -235,22 +245,25 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                                     T.copy(shared_buf, tile_local)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.if_then_else(
-                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
-                                            ),
-                                            T.cast(_neg_inf, "float32"),
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.if_then_else(
+                                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                ),
+                                                T.cast(_neg_inf, "float32"),
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                             T.copy(shared_buf, tile_local)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                         T.fill(tile_max, -T.infinity("float32"))
                         T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -259,8 +272,9 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                             prev_max[i] = row_max[i]
                             row_max[i] = T.max(row_max[i], tile_max[i])
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
                         T.reduce_sum(tile_f32, tile_sum, dim=1)
 
                         for i in T.Parallel(block_m):
@@ -293,34 +307,38 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                                     T.copy(p2_shared, p2_local)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.exp(
-                                            T.cast(p2_local[i, j], "float32") - row_max[i]
-                                        ) * inv_sum[i]
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.exp(
+                                                T.cast(p2_local[i, j], "float32") - row_max[i]
+                                            ) * inv_sum[i]
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.if_then_else(
-                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                            T.exp(
-                                                T.cast(
-                                                    x[pid_m * block_m + i, t * tile_n + j],
-                                                    "float32",
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.if_then_else(
+                                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                                T.exp(
+                                                    T.cast(
+                                                        x[pid_m * block_m + i, t * tile_n + j],
+                                                        "float32",
+                                                    )
+                                                    - row_max[i]
                                                 )
-                                                - row_max[i]
+                                                * inv_sum[i],
+                                                0.0,
                                             )
-                                            * inv_sum[i],
-                                            0.0,
-                                        )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                             T.copy(p2_shared, p2_local)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = T.exp(
-                                    T.cast(p2_local[i, j], "float32") - row_max[i]
-                                ) * inv_sum[i]
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    p2_f32[i, j] = T.exp(
+                                        T.cast(p2_local[i, j], "float32") - row_max[i]
+                                    ) * inv_sum[i]
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_local[i, j] = p2_f32[i, j]
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                p2_local[i, j] = p2_f32[i, j]
                         T.copy(p2_local, p2_shared)
                         T.copy(p2_shared, y[pid_m * block_m, t * tile_n])
 
@@ -357,22 +375,25 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                                     T.copy(shared_buf, tile_local)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
                                 with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        tile_f32[i, j] = T.if_then_else(
-                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
-                                            ),
-                                            T.cast(_neg_inf, "float32"),
-                                        )
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            tile_f32[i, j] = T.if_then_else(
+                                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                ),
+                                                T.cast(_neg_inf, "float32"),
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], shared_buf)
                             T.copy(shared_buf, tile_local)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    tile_f32[i, j] = T.cast(tile_local[i, j], "float32")
 
                         T.fill(tile_max, -T.infinity("float32"))
                         T.reduce_max(tile_f32, tile_max, dim=1, clear=False)
@@ -381,8 +402,9 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                             prev_max[i] = row_max[i]
                             row_max[i] = T.max(row_max[i], tile_max[i])
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                tile_f32[i, j] = T.exp(tile_f32[i, j] - row_max[i])
                         T.reduce_sum(tile_f32, tile_sum, dim=1)
 
                         for i in T.Parallel(block_m):
@@ -408,33 +430,37 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                 with T.Then():
                                     T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                                     T.copy(p2_shared, p2_local)
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = (
-                                            T.cast(p2_local[i, j], "float32")
-                                            - row_max[i]
-                                            - log_sum[i]
-                                        )
-                                with T.Else():
-                                    for i, j in T.Parallel(block_m, tile_n):
-                                        p2_f32[i, j] = T.if_then_else(
-                                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                                            T.cast(
-                                                x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = (
+                                                T.cast(p2_local[i, j], "float32")
+                                                - row_max[i]
+                                                - log_sum[i]
                                             )
-                                            - row_max[i]
-                                            - log_sum[i],
-                                            T.cast(_neg_inf, "float32"),
-                                        )
+                                with T.Else():
+                                    for i in T.serial(block_m):
+                                        for j in T.Parallel(tile_n):
+                                            p2_f32[i, j] = T.if_then_else(
+                                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                                T.cast(
+                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                )
+                                                - row_max[i]
+                                                - log_sum[i],
+                                                T.cast(_neg_inf, "float32"),
+                                            )
                         else:
                             T.copy(x[pid_m * block_m, t * tile_n], p2_shared)
                             T.copy(p2_shared, p2_local)
-                            for i, j in T.Parallel(block_m, tile_n):
-                                p2_f32[i, j] = (
-                                    T.cast(p2_local[i, j], "float32") - row_max[i] - log_sum[i]
-                                )
+                            for i in T.serial(block_m):
+                                for j in T.Parallel(tile_n):
+                                    p2_f32[i, j] = (
+                                        T.cast(p2_local[i, j], "float32") - row_max[i] - log_sum[i]
+                                    )
 
-                        for i, j in T.Parallel(block_m, tile_n):
-                            p2_local[i, j] = p2_f32[i, j]
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                p2_local[i, j] = p2_f32[i, j]
                         T.copy(p2_local, p2_shared)
                         T.copy(p2_shared, y[pid_m * block_m, t * tile_n])
 

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -583,6 +583,12 @@ class SoftmaxKernel(Kernel):
             # the heuristic when tile_n was not provided.
             caller_tile_n = config.get("tile_n") if config is not None else None
             if caller_tile_n is not None:
+                reason = self._planner.reject_tile_n(
+                    self.config["block_m"], caller_tile_n,
+                    self.config.get("threads", _DEFAULT_TUNE_THREADS),
+                )
+                if reason:
+                    raise ValueError(reason)
                 target_tile_n = caller_tile_n
             else:
                 target_tile_n = self._tile_n_for_block_m(self.config["block_m"])

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -33,6 +33,10 @@ from tileops.kernels.reduction._primitives import (
     device_smem_budget,
 )
 
+# These two kernels bake tile_n in at build time and default to the wider
+# thread block; AUTOTUNE_THREADS still bounds what the sweep explores.
+_DEFAULT_TUNE_THREADS = 256
+
 __all__ = ["SoftmaxKernel"]
 
 
@@ -628,6 +632,8 @@ class SoftmaxKernel(Kernel):
         best_tile_n = self._tile_n_for_block_m(1)
 
         for bm in [2, 4, 8, 16]:
+            if not self._planner.untiled_block_m_ok(bm, _DEFAULT_TUNE_THREADS):
+                continue
             try:
                 tn = self._tile_n_for_block_m(bm)
             except ValueError:
@@ -651,7 +657,8 @@ class SoftmaxKernel(Kernel):
                     best_bm = bm
                     best_tile_n = tn
 
-        return {"block_m": best_bm, "threads": 256, "tile_n": best_tile_n}
+        return {"block_m": best_bm, "threads": _DEFAULT_TUNE_THREADS,
+                "tile_n": best_tile_n}
 
     def _tile_n_candidates(self) -> list[int]:
         """Return candidate tile_n values for autotune exploration.
@@ -731,6 +738,8 @@ class SoftmaxKernel(Kernel):
                     if bm > max_block_m_no_tile:
                         continue
                     for t in threads_list:
+                        if not self._planner.untiled_block_m_ok(bm, t):
+                            continue
                         configs.append({"block_m": bm, "threads": t, "tile_n": 0})
             else:
                 # Tiled regime: use block_m=1 with each tile_n candidate.

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -254,7 +254,9 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                             tile_f32[i, j] = T.if_then_else(
                                                 T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                                 T.cast(
-                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                    x[pid_m * block_m + i,
+                                                      t * tile_n + j],
+                                                    "float32",
                                                 ),
                                                 T.cast(_neg_inf, "float32"),
                                             )
@@ -384,7 +386,9 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                             tile_f32[i, j] = T.if_then_else(
                                                 T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                                 T.cast(
-                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                    x[pid_m * block_m + i,
+                                                      t * tile_n + j],
+                                                    "float32",
                                                 ),
                                                 T.cast(_neg_inf, "float32"),
                                             )
@@ -443,7 +447,9 @@ def _softmax_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: int)
                                             p2_f32[i, j] = T.if_then_else(
                                                 T.And(pid_m * block_m + i < M, t * tile_n + j < N),
                                                 T.cast(
-                                                    x[pid_m * block_m + i, t * tile_n + j], "float32"
+                                                    x[pid_m * block_m + i,
+                                                      t * tile_n + j],
+                                                    "float32",
                                                 )
                                                 - row_max[i]
                                                 - log_sum[i],

--- a/tileops/kernels/reduction/softmax.py
+++ b/tileops/kernels/reduction/softmax.py
@@ -554,15 +554,8 @@ class SoftmaxKernel(Kernel):
         # Build self.kernel BEFORE init_config: when tune=True, init_config
         # delegates to autotune() which requires self.kernel to exist.
         #
-        # tile_n is baked into the kernel at build time, so we pre-compute
-        # it from the heuristic block_m in default_config. The matching
-        # `autotune_configs` property below filters out any block_m whose
-        # tile_n differs from this pre-built one, so the autotuner stays
-        # within a single tiling regime by design.
-        #
-        # Cross-tile_n autotune exploration is a known limitation; the
-        # single-regime restriction is inherited from prior tiling design
-        # and not introduced here.
+        # tile_n is baked into the kernel at build time, so pre-compute it from
+        # default_config; autotune() rebuilds once per candidate width.
         self._tile_n = self.default_config["tile_n"]
         self.kernel = _softmax_kernel(
             self.M,
@@ -582,6 +575,8 @@ class SoftmaxKernel(Kernel):
             # previous autotuner result), honour it.  Only fall back to
             # the heuristic when tile_n was not provided.
             caller_tile_n = config.get("tile_n") if config is not None else None
+            if caller_tile_n == 0:
+                caller_tile_n = None
             if caller_tile_n is not None:
                 reason = self._planner.reject_tile_n(
                     self.config["block_m"], caller_tile_n,
@@ -638,7 +633,7 @@ class SoftmaxKernel(Kernel):
         best_tile_n = self._tile_n_for_block_m(1)
 
         for bm in [2, 4, 8, 16]:
-            if not self._planner.untiled_block_m_ok(bm, _DEFAULT_TUNE_THREADS):
+            if not self._planner.layout_ok(bm, self.N_padded, _DEFAULT_TUNE_THREADS):
                 continue
             try:
                 tn = self._tile_n_for_block_m(bm)
@@ -744,7 +739,7 @@ class SoftmaxKernel(Kernel):
                     if bm > max_block_m_no_tile:
                         continue
                     for t in threads_list:
-                        if not self._planner.untiled_block_m_ok(bm, t):
+                        if not self._planner.layout_ok(bm, self.N_padded, t):
                             continue
                         configs.append({"block_m": bm, "threads": t, "tile_n": 0})
             else:

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -71,38 +71,43 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
                 out_local = T.alloc_fragment((block_m,), dtype)
 
                 if _needs_pad:
-                    for i, j in T.Parallel(block_m, N_padded):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, j < N),
-                            T.cast(x[pid_m * block_m + i, j], "float32"),
-                            T.cast(0.0, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, j < N),
+                                T.cast(x[pid_m * block_m + i, j], "float32"),
+                                T.cast(0.0, "float32"),
+                            )
                 else:
                     # Optimization: fused load and cast - load directly to fp32 fragment
                     # This saves one intermediate buffer copy
                     # Need to guard M-dimension tail when M % block_m != 0
                     if M % block_m != 0:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.if_then_else(
-                                pid_m * block_m + i < M,
-                                T.cast(x[pid_m * block_m + i, j], "float32"),
-                                T.cast(0.0, "float32"),
-                            )
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.if_then_else(
+                                    pid_m * block_m + i < M,
+                                    T.cast(x[pid_m * block_m + i, j], "float32"),
+                                    T.cast(0.0, "float32"),
+                                )
                     else:
-                        for i, j in T.Parallel(block_m, N_padded):
-                            x_f32[i, j] = T.cast(x[pid_m * block_m + i, j], "float32")
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(N_padded):
+                                x_f32[i, j] = T.cast(x[pid_m * block_m + i, j], "float32")
 
                 if op_kind == "l1":
                     # l1 norm: sum(|x|)
-                    for i, j in T.Parallel(block_m, N_padded):
-                        transformed[i, j] = T.abs(x_f32[i, j])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            transformed[i, j] = T.abs(x_f32[i, j])
                     T.reduce_sum(transformed, acc, dim=1)
                 elif op_kind == "l2":
                     # l2 norm: sqrt(sum(x^2))
                     # Optimization B: inline square computation to potentially reduce memory traffic
-                    for i, j in T.Parallel(block_m, N_padded):
-                        val = x_f32[i, j]
-                        transformed[i, j] = val * val
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            val = x_f32[i, j]
+                            transformed[i, j] = val * val
                     T.reduce_sum(transformed, acc, dim=1)
                     for i in T.Parallel(block_m):
                         acc[i] = T.sqrt(acc[i])
@@ -111,8 +116,9 @@ def _vector_norm_kernel(M: int, N: int, op_kind: str, dtype: str):
                     # Note: T.reduce_max does not propagate NaN.
                     # NaN handling is done at the Op layer (InfNormFwdOp)
                     # by detecting NaN rows and patching the output.
-                    for i, j in T.Parallel(block_m, N_padded):
-                        transformed[i, j] = T.abs(x_f32[i, j])
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(N_padded):
+                            transformed[i, j] = T.abs(x_f32[i, j])
                     T.reduce_max(transformed, acc, dim=1)
 
                 # Cast back to output dtype
@@ -154,33 +160,37 @@ def _vector_norm_kernel_tiled(M: int, N: int, op_kind: str, dtype: str, tile_n: 
                 T.fill(acc, 0.0)
 
                 for t in T.Serial(num_tiles):
-                    for i, j in T.Parallel(block_m, tile_n):
-                        x_f32[i, j] = T.if_then_else(
-                            T.And(pid_m * block_m + i < M, t * tile_n + j < N),
-                            T.cast(
-                                x[pid_m * block_m + i, t * tile_n + j],
-                                "float32",
-                            ),
-                            T.cast(0.0, "float32"),
-                        )
+                    for i in T.serial(block_m):
+                        for j in T.Parallel(tile_n):
+                            x_f32[i, j] = T.if_then_else(
+                                T.And(pid_m * block_m + i < M, t * tile_n + j < N),
+                                T.cast(
+                                    x[pid_m * block_m + i, t * tile_n + j],
+                                    "float32",
+                                ),
+                                T.cast(0.0, "float32"),
+                            )
 
                     if op_kind == "l1":
-                        for i, j in T.Parallel(block_m, tile_n):
-                            transformed[i, j] = T.abs(x_f32[i, j])
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                transformed[i, j] = T.abs(x_f32[i, j])
                         T.reduce_sum(transformed, tile_acc, dim=1)
                         for i in T.Parallel(block_m):
                             acc[i] = acc[i] + tile_acc[i]
                     elif op_kind == "l2":
-                        for i, j in T.Parallel(block_m, tile_n):
-                            transformed[i, j] = x_f32[i, j] * x_f32[i, j]
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                transformed[i, j] = x_f32[i, j] * x_f32[i, j]
                         T.reduce_sum(transformed, tile_acc, dim=1)
                         for i in T.Parallel(block_m):
                             acc[i] = acc[i] + tile_acc[i]
                     else:
                         # Note: T.reduce_max does not propagate NaN.
                         # NaN handling remains in the Op layer.
-                        for i, j in T.Parallel(block_m, tile_n):
-                            transformed[i, j] = T.abs(x_f32[i, j])
+                        for i in T.serial(block_m):
+                            for j in T.Parallel(tile_n):
+                                transformed[i, j] = T.abs(x_f32[i, j])
                         T.reduce_max(transformed, tile_acc, dim=1)
                         for i in T.Parallel(block_m):
                             acc[i] = T.max(acc[i], tile_acc[i])

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -21,11 +21,14 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
+    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
+    DEFAULT_THREADS,
     MAX_SINGLE_TILE_COLS,
     align_up,
     compute_tile_n,
     device_smem_budget,
+    tile_column_alignment,
     tune_by_forward,
 )
 
@@ -303,10 +306,18 @@ class VectorNormKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for_block_m(bm)
+                self.config["tile_n"] = self._tile_n_for(
+                    bm, self.config.get("threads", DEFAULT_THREADS),
+                )
 
-    def _tile_n_for_block_m(self, block_m: int) -> int:
-        """Return tile_n for a given block_m (0 means no tiling needed)."""
+    def _tile_n_for(self, block_m: int, threads: int) -> int:
+        """Return tile_n for a block_m / threads pair (0 means no tiling).
+
+        Raises:
+            ValueError: If no tile of the required column granularity fits in
+                shared memory for this pair.  Callers building candidate lists
+                drop the pair rather than emit an unbuildable tile.
+        """
         budget = self._smem_budget
         if self.N_padded <= MAX_SINGLE_TILE_COLS:
             single = compute_tile_n(
@@ -318,7 +329,9 @@ class VectorNormKernel(Kernel):
         col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded, budget=effective_budget,
+            block_m, self._elem_bytes, self.N_padded,
+            alignment=tile_column_alignment(self._elem_bytes, threads),
+            budget=effective_budget,
         )
 
     @property
@@ -331,13 +344,13 @@ class VectorNormKernel(Kernel):
             for bm in [1, 2, 4, 8]:
                 if bm <= max_block_m:
                     block_m = bm
-            return {"block_m": block_m, "threads": 128}
+            return {"block_m": block_m, "threads": DEFAULT_THREADS}
 
         best_bm = 1
-        best_tile_n = self._tile_n_for_block_m(1)
+        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
         for bm in [2, 4, 8]:
             try:
-                tn = self._tile_n_for_block_m(bm)
+                tn = self._tile_n_for(bm, DEFAULT_THREADS)
             except ValueError:
                 continue
             best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
@@ -345,7 +358,7 @@ class VectorNormKernel(Kernel):
             if curr_num < best_num:
                 best_bm = bm
                 best_tile_n = tn
-        return {"block_m": best_bm, "threads": 128, "tile_n": best_tile_n}
+        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
 
     @property
     def autotune_configs(self) -> list[dict]:
@@ -353,19 +366,22 @@ class VectorNormKernel(Kernel):
             smem_per_row = self.N_padded * self._elem_bytes
             max_block_m = self._smem_budget // smem_per_row
             block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            threads_list = [128, 256]
-            configs = list(itertools.product(block_ms, threads_list))
+            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
             return [{"block_m": bm, "threads": t} for bm, t in configs]
 
+        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
+        # column granularity that pair can build, so every emitted triple
+        # builds; a pair with no fitting tile is dropped here rather than left
+        # to fail during the sweep.
         configs = []
         for bm in [1, 2, 4, 8]:
-            try:
-                tn = self._tile_n_for_block_m(bm)
-            except ValueError:
-                continue
-            if tn == 0:
-                continue
-            for t in [128, 256]:
+            for t in AUTOTUNE_THREADS:
+                try:
+                    tn = self._tile_n_for(bm, t)
+                except ValueError:
+                    continue
+                if tn == 0:
+                    continue
                 configs.append({"block_m": bm, "threads": t, "tile_n": tn})
         return configs if configs else [self.default_config]
 

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -12,7 +12,6 @@ Output dtype matches input dtype; internal computation in fp32.
 """
 
 import functools
-import itertools
 from typing import Optional
 
 import tilelang
@@ -21,14 +20,11 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.reduction._primitives import (
-    AUTOTUNE_THREADS,
     DEFAULT_ALIGNMENT,
     DEFAULT_THREADS,
-    MAX_SINGLE_TILE_COLS,
+    BlockConfigPlanner,
     align_up,
-    compute_tile_n,
     device_smem_budget,
-    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -290,10 +286,10 @@ class VectorNormKernel(Kernel):
         self.N_padded = align_up(N, DEFAULT_ALIGNMENT)
         self._elem_bytes = torch.tensor([], dtype=dtype).element_size()
         self._smem_budget = device_smem_budget()
-        self._needs_tiling = (
-            self.N_padded > MAX_SINGLE_TILE_COLS
-            or self.N_padded * self._elem_bytes > self._smem_budget
+        self._planner = BlockConfigPlanner(
+            self.N_padded, self._elem_bytes, self._smem_budget,
         )
+        self._needs_tiling = self._planner.needs_tiling
         self.kernel = None
         if not self._needs_tiling:
             self.kernel = _vector_norm_kernel(
@@ -306,84 +302,17 @@ class VectorNormKernel(Kernel):
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._tile_n_for(
+                self.config["tile_n"] = self._planner.tile_n_for(
                     bm, self.config.get("threads", DEFAULT_THREADS),
                 )
 
-    def _tile_n_for(self, block_m: int, threads: int) -> int:
-        """Return tile_n for a block_m / threads pair (0 means no tiling).
-
-        Raises:
-            ValueError: If no tile of the required column granularity fits in
-                shared memory for this pair.  Callers building candidate lists
-                drop the pair rather than emit an unbuildable tile.
-        """
-        budget = self._smem_budget
-        if self.N_padded <= MAX_SINGLE_TILE_COLS:
-            single = compute_tile_n(
-                block_m, self._elem_bytes, self.N_padded, budget=budget,
-            )
-            if single == self.N_padded:
-                return 0
-
-        col_budget = MAX_SINGLE_TILE_COLS * block_m * self._elem_bytes
-        effective_budget = min(budget, col_budget)
-        return compute_tile_n(
-            block_m, self._elem_bytes, self.N_padded,
-            alignment=reduce_column_alignment(self._elem_bytes, threads),
-            budget=effective_budget,
-        )
-
     @property
     def default_config(self) -> dict:
-        """Select default block_m based on shared memory budget."""
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = self._smem_budget // smem_per_row
-            block_m = 1
-            for bm in [1, 2, 4, 8]:
-                if bm <= max_block_m:
-                    block_m = bm
-            return {"block_m": block_m, "threads": DEFAULT_THREADS}
-
-        best_bm = 1
-        best_tile_n = self._tile_n_for(1, DEFAULT_THREADS)
-        for bm in [2, 4, 8]:
-            try:
-                tn = self._tile_n_for(bm, DEFAULT_THREADS)
-            except ValueError:
-                continue
-            best_num = (self.N_padded + best_tile_n - 1) // best_tile_n
-            curr_num = (self.N_padded + tn - 1) // tn
-            if curr_num < best_num:
-                best_bm = bm
-                best_tile_n = tn
-        return {"block_m": best_bm, "threads": DEFAULT_THREADS, "tile_n": best_tile_n}
+        return self._planner.default_config()
 
     @property
     def autotune_configs(self) -> list[dict]:
-        if not self._needs_tiling:
-            smem_per_row = self.N_padded * self._elem_bytes
-            max_block_m = self._smem_budget // smem_per_row
-            block_ms = [bm for bm in [1, 2, 4, 8] if bm <= max_block_m]
-            configs = list(itertools.product(block_ms, AUTOTUNE_THREADS))
-            return [{"block_m": bm, "threads": t} for bm, t in configs]
-
-        # Tiled path.  tile_n is derived per (block_m, threads) pair at a
-        # column granularity that pair can build, so every emitted triple
-        # builds; a pair with no fitting tile is dropped here rather than left
-        # to fail during the sweep.
-        configs = []
-        for bm in [1, 2, 4, 8]:
-            for t in AUTOTUNE_THREADS:
-                try:
-                    tn = self._tile_n_for(bm, t)
-                except ValueError:
-                    continue
-                if tn == 0:
-                    continue
-                configs.append({"block_m": bm, "threads": t, "tile_n": tn})
-        return configs if configs else [self.default_config]
+        return self._planner.autotune_configs()
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Autotune vector norm, benchmarking tiled configs directly."""

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -28,7 +28,7 @@ from tileops.kernels.reduction._primitives import (
     align_up,
     compute_tile_n,
     device_smem_budget,
-    tile_column_alignment,
+    reduce_column_alignment,
     tune_by_forward,
 )
 
@@ -330,7 +330,7 @@ class VectorNormKernel(Kernel):
         effective_budget = min(budget, col_budget)
         return compute_tile_n(
             block_m, self._elem_bytes, self.N_padded,
-            alignment=tile_column_alignment(self._elem_bytes, threads),
+            alignment=reduce_column_alignment(self._elem_bytes, threads),
             budget=effective_budget,
         )
 

--- a/tileops/kernels/reduction/vector_norm.py
+++ b/tileops/kernels/reduction/vector_norm.py
@@ -301,10 +301,12 @@ class VectorNormKernel(Kernel):
         self.init_config(config, tune)
         if self._needs_tiling and not tune:
             bm = self.config.get("block_m", 1)
+            threads = self.config.get("threads", DEFAULT_THREADS)
             if "tile_n" not in self.config or self.config["tile_n"] == 0:
-                self.config["tile_n"] = self._planner.tile_n_for(
-                    bm, self.config.get("threads", DEFAULT_THREADS),
-                )
+                self.config["tile_n"] = self._planner.tile_n_for(bm, threads)
+            reason = self._planner.reject_tile_n(bm, self.config["tile_n"], threads)
+            if reason:
+                raise ValueError(reason)
 
     @property
     def default_config(self) -> dict:


### PR DESCRIPTION
Closes #1821
Closes #1824

`tune=True` on a tiled reduction aborted before any timing: half the candidates could not be compiled.

## Root cause: a 2D iteration space over a 1D thread block

The kernels wrote their reduction fragment from `T.Parallel(block_m, cols)`. TileLang flattens that loop:

```
thread = (i * cols + j) / vec % threads      # i, j are data indices; threads is a scalar
```

The `i * cols` term makes ownership depend on the row. Unless `cols` is a whole number of thread-block passes, or divides one, the map shifts row to row, the following `T.reduce_*` has no layout consistent with both the elementwise loops and its `(block_m,)` destination, and inference aborts on `ICHECK(min_reg_num < INT64_MAX)`.

**Fix: stop flattening.** All 83 two-dimensional `T.Parallel(block_m, cols)` loops become an outer `T.serial` over rows and an inner `T.Parallel` over columns, so the map is `(j / vec) % threads` and no width can shift it.

Widths that fail today and build after — `block_m ∈ {2,4} × cols ∈ {768, 1536, 2560}`, fp16/128 threads:

| | before | after |
| --- | --- | --- |
| tiled `reduce/sum`, `reduce/var`, `vector_norm/l2` | 18 of 18 fail | all build |
| untiled `N_padded ∈ {768, 20224}`, `block_m ∈ {2,4,8}` | 6 of 6 fail | all build |
| tiled `softmax`, `log_softmax`, `logsumexp` | 18 of 18 fail | 15 build; 3 fail at `block_m=4, cols=768` |

`layout_ok()` — the exact rule under flattening — is kept as a conservative envelope because it still excludes that residue. Verified both ways: everything it admits builds under the serial form.

**Serialising is free.** Both variants in one process, timed in alternation, 11 paired rounds, on shapes where kernel time dominates dispatch:

```
sum  4096x40000 fp16  328 MB   flat 120.3us   serial 120.4us   -0.10us
var  128x200000 fp32  102 MB   flat  66.5us   serial  66.5us   +0.01us
l2   4096x40000 fp16  328 MB   flat 122.3us   serial 122.3us   +0.01us
smax 1024x32768 bf16   67 MB   flat  69.2us   serial  69.1us   -0.03us
any  4096x32768 bool  537 MB   flat 125.4us   serial 125.4us   -0.02us
```

Every paired delta is at or under 0.1 µs against a 0.4–1.3 µs within-group spread. Parallel width is set by the launch, not the loop nest, and the access volume is unchanged.

## Four defects found behind it

- **`tile_n` was derived, not searched** — one width per `(block_m, threads)` from a capacity formula. `autotune_configs` now offers two narrower widths as well; `var 64x200000` fp32 goes from 47.2 µs at the heuristic's `1/128/28928` to 39.3 µs at `1/256/28672`.
- **Three kernels answered the same question three ways** — `reduce.py` divided the untiled budget by 48 KiB where `logical_reduce.py`/`vector_norm.py` used the 227 KiB device opt-in, and its `_needs_tiling` omitted the shared-memory check. `ReduceKernel` therefore offered **zero** autotune candidates at fp32 `N=20000`/`30000`. `BlockConfigPlanner` now holds the single copy; five kernels delegate.
- **The untiled default came from whichever constant a kernel had copied** — largest-that-fits is a capacity rule, not a performance one, so the untuned path uses the conservative 48 KiB envelope and the sweep keeps the device budget. `reduce`'s defaults are unchanged; `logical_reduce`'s and `vector_norm`'s move from `block_m=8` to `4`, with no measurable cost.
- **A caller-supplied `tile_n` reached TileLang unchecked** — all five now validate positivity, `T.copy` alignment, the column cap, the budget and `layout_ok` at construction, and `tile_n=0` means "derive one" everywhere.

## Test plan

- [x] pre-commit; **539 passed** (`test_reduce` + `test_logical_reduce` + `test_vector_norm` + `test_softmax`)
- [x] Issue repro returns a tensor; winner `block_m=8, threads=256, tile_n=10240`
- [x] Every `autotune_configs` entry builds — 320 candidates, 0 failures. Before: 4 of 8 failed at every tiled shape.
- [x] `test_node_delta.py`: +6 nodes (+1.5%)

**On measurement.** `2048x4096` moves 16 MB at ~27 µs, of which ~3.5 µs is memory traffic; cross-process comparisons there swung 18% in both directions across runs. Every number above is either paired in-process or on a kernel-bound shape. The untiled default change rests on no measurable difference, not on one option being faster.
