### PR TITLE
[Refactor][Attention] select the kernel at forward, not from a ctor dtype

### DIFF
--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -226,8 +226,8 @@ def _torch_gqa_prefill_varlen_ref(test: GQAPrefillVarlenFwdWorkload):
     return fn
 
 
-def _tileops_gqa_variant(op: GroupedQueryAttentionFwdOp) -> str:
-    kernel = op.kernel
+def _tileops_gqa_variant(op: GroupedQueryAttentionFwdOp, dtype: torch.dtype) -> str:
+    kernel = op._get_kernel(dtype)
     if isinstance(kernel, GQAPrefillFwdWsPersistentCausalKernel):
         return "prefill_ws_causal"
     if isinstance(kernel, GQAPrefillFwdKernel):
@@ -275,9 +275,9 @@ def test_gqa_fwd_bench(
     test = GroupedQueryAttentionFwdWorkload(batch, heads, heads_kv, seq_len, dim, causal, dtype)
     inputs = test.gen_inputs()
 
-    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_GQA_FWD_OP, op, test)
-    tileops_variant = _tileops_gqa_variant(op)
+    tileops_variant = _tileops_gqa_variant(op, dtype)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag=f"tileops_{tileops_variant}")
 
@@ -568,7 +568,6 @@ def test_gqa_prefill_paged_with_kv_cache_fwd_bench(
         page_size=page_size,
         dim=dim,
         is_causal=causal,
-        dtype=dtype,
         cache_dtype=cache_dtype,
         softcap=softcap,
         tune=tune,

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -110,7 +110,7 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
     test = MhaFwdWorkload(batch, heads, seq_len, dim, causal, dtype)
     inputs = test.gen_inputs()
 
-    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_MHA_FWD_OP, op, test)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -252,6 +252,28 @@ def test_record_op_with_explicit_config_takes_precedence():
 
 @pytest.mark.full
 @pytest.mark.usefixtures('_reset_records')
+def test_record_composite_op_keeps_delegate_kernel_config():
+    """A composite that owns no kernels still reports the delegate's config."""
+
+    class _DelegateOp:
+        def __init__(self):
+            self._kernel_cache = {torch.float16: _FakeKernel({"block_m": 8})}
+
+    class _CompositeOp:
+        def __init__(self):
+            self._delegate = _DelegateOp()
+
+        @property
+        def _kernel_cache(self):
+            return self._delegate._kernel_cache
+
+    BenchmarkReport.record(_CompositeOp(), params={}, result=_result(), tag="t")
+    records = BenchmarkReport._records["_CompositeOp"]
+    assert records[0].get("config") == {"block_m": 8}
+
+
+@pytest.mark.full
+@pytest.mark.usefixtures('_reset_records')
 def test_record_op_without_any_config_omits_field():
     """Ops with no config sources should not produce a ``config`` field."""
 

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -55,14 +55,15 @@ class GroupedQueryAttentionBwdTest(GroupedQueryAttentionBwdWorkload, TestBase):
 
 class GroupedQueryAttentionFwdTest(GroupedQueryAttentionFwdWorkload, TestBase):
     def ref_program(self, q: torch.Tensor, k: torch.Tensor,
-                    v: torch.Tensor) -> torch.Tensor:
+                    v: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         q_bhsd = q.transpose(1, 2)  # [B, H, S, D]
         k_bhsd = k.transpose(1, 2)
         v_bhsd = v.transpose(1, 2)
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             output_bhsd = F.scaled_dot_product_attention(
                 q_bhsd, k_bhsd, v_bhsd, is_causal=self.is_causal, enable_gqa=True)
-        return output_bhsd.transpose(1, 2).contiguous()
+        output = output_bhsd.transpose(1, 2).contiguous()
+        return output, None  # do not check lse
 
 
 def _gqa_prefill_ref(
@@ -180,6 +181,28 @@ def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, 
     test = GroupedQueryAttentionFwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_gqa_fwd_returns_output_lse_pair() -> None:
+    """The manifest declares outputs (o, lse); the op returns both slots."""
+    batch, seq_len, heads, heads_kv, dim = 1, 128, 8, 2, 64
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, False)
+    q = torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float16)
+    k = torch.randn(batch, seq_len, heads_kv, dim, device="cuda", dtype=torch.float16)
+    v = torch.randn_like(k)
+
+    result = op(q, k, v)
+
+    assert isinstance(result, tuple) and len(result) == 2
+    o, lse = result
+    assert o.shape == q.shape
+    assert o.dtype == q.dtype
+    assert lse is None  # see the FIXME(staged-rollout) on the op
+    assert op._infer_output_shapes(tuple(q.shape), tuple(k.shape), tuple(v.shape)) == {
+        "o": (batch, seq_len, heads, dim),
+        "lse": (batch, heads, seq_len),
+    }
 
 
 @pytest.mark.parametrize("batch, seq_len_q, seq_len_kv, heads, heads_kv, dim, causal, dtype", [
@@ -526,8 +549,9 @@ def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
     monkeypatch.setattr(prefill_op, "_uses_square_dense_fast_path", lambda: False)
     monkeypatch.setattr(prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
 
-    out = op(q, k, v)
+    out, lse = op(q, k, v)
     assert out.shape == q.shape
+    assert lse is None
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -914,7 +914,7 @@ def test_gqa_fwd_dispatch_without_h200_work_threshold() -> None:
     ("auto", False, False, True, "gqa_prefill_fwd_kernel"),
     ("auto", False, False, False, "gqa_prefill_varlen_fwd_kernel"),
     ("varlen", False, False, True, "gqa_prefill_varlen_fwd_kernel"),
-    ("auto", False, True, True, "gqa_sliding_window_varlen_fwd"),
+    ("auto", False, True, True, "gqa_sliding_window_varlen_fwd_kernel"),
     ("auto", True, False, True, "gqa_prefill_fp8_tensor_core_fwd_kernel"),
 ])
 def test_gqa_prefill_dispatch_key_selector(
@@ -945,8 +945,8 @@ def test_gqa_prefill_dispatch_key_selector_rejects_forced_dense_ragged() -> None
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("dim, is_causal, dtype, expected", [
-    (128, True, torch.float16, "gqa_prefill_fwd_ws_persistent_causal_kernel"),
-    (128, True, torch.bfloat16, "gqa_prefill_fwd_ws_persistent_causal_kernel"),
+    (128, True, torch.float16, "gqa_prefill_causal_fwd_kernel"),
+    (128, True, torch.bfloat16, "gqa_prefill_causal_fwd_kernel"),
     (128, False, torch.float16, "gqa_prefill_fwd_kernel"),
     (64, True, torch.float16, "gqa_prefill_fwd_kernel"),
 ])

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -55,7 +55,7 @@ class GroupedQueryAttentionBwdTest(GroupedQueryAttentionBwdWorkload, TestBase):
 
 class GroupedQueryAttentionFwdTest(GroupedQueryAttentionFwdWorkload, TestBase):
     def ref_program(self, q: torch.Tensor, k: torch.Tensor,
-                    v: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+                    v: torch.Tensor) -> torch.Tensor:
         q_bhsd = q.transpose(1, 2)  # [B, H, S, D]
         k_bhsd = k.transpose(1, 2)
         v_bhsd = v.transpose(1, 2)
@@ -63,7 +63,7 @@ class GroupedQueryAttentionFwdTest(GroupedQueryAttentionFwdWorkload, TestBase):
             output_bhsd = F.scaled_dot_product_attention(
                 q_bhsd, k_bhsd, v_bhsd, is_causal=self.is_causal, enable_gqa=True)
         output = output_bhsd.transpose(1, 2).contiguous()
-        return output, None  # do not check lse
+        return output
 
 
 def _gqa_prefill_ref(
@@ -184,24 +184,20 @@ def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, 
 
 
 @pytest.mark.smoke
-def test_gqa_fwd_returns_output_lse_pair() -> None:
-    """The manifest declares outputs (o, lse); the op returns both slots."""
+def test_gqa_fwd_output_matches_the_declared_shape() -> None:
+    """``H % H_kv`` keeps the validator's mocks away, so assert parity here."""
     batch, seq_len, heads, heads_kv, dim = 1, 128, 8, 2, 64
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, False)
     q = torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float16)
     k = torch.randn(batch, seq_len, heads_kv, dim, device="cuda", dtype=torch.float16)
     v = torch.randn_like(k)
 
-    result = op(q, k, v)
+    o = op(q, k, v)
 
-    assert isinstance(result, tuple) and len(result) == 2
-    o, lse = result
     assert o.shape == q.shape
     assert o.dtype == q.dtype
-    assert lse is None  # see the FIXME(staged-rollout) on the op
     assert op._infer_output_shapes(tuple(q.shape), tuple(k.shape), tuple(v.shape)) == {
         "o": (batch, seq_len, heads, dim),
-        "lse": (batch, heads, seq_len),
     }
 
 
@@ -549,9 +545,8 @@ def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
     monkeypatch.setattr(prefill_op, "_uses_square_dense_fast_path", lambda: False)
     monkeypatch.setattr(prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
 
-    out, lse = op(q, k, v)
+    out = op(q, k, v)
     assert out.shape == q.shape
-    assert lse is None
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -21,7 +21,7 @@ from tileops.ops import (
 from tileops.ops.attention.gqa import (
     _select_gqa_fwd_kernel_cls,
     _select_gqa_paged_prefill_kernel_keys,
-    _select_gqa_prefill_fwd_kernel_cls,
+    _select_gqa_prefill_dense_kernel_key,
     _select_gqa_prefill_kernel_key,
 )
 from tileops.utils import is_h200
@@ -178,7 +178,7 @@ class GroupedQueryAttentionBwdFixture(FixtureBase):
 def test_gqa_fwd(batch: int, seq_len: int, heads: int, heads_kv: int, dim: int, causal: bool,
                  dtype: torch.dtype, tune: bool) -> None:
     test = GroupedQueryAttentionFwdTest(batch, heads, heads_kv, seq_len, dim, causal, dtype)
-    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, dtype, tune=tune)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 
@@ -513,7 +513,7 @@ def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
     q = torch.empty(batch, seq_len, heads, dim, dtype=torch.float16)
     k = torch.empty(batch, seq_len, heads_kv, dim, dtype=torch.float16)
     v = torch.empty_like(k)
-    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True, torch.float16)
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True)
 
     def fail_uniform_check(*args: object, **kwargs: object) -> bool:
         pytest.fail("BSHD wrapper should not inspect packed cu_seqlens")
@@ -521,9 +521,10 @@ def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
     def fake_dense_kernel(*args: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(args[0])
 
-    monkeypatch.setattr(op._prefill_op, "_uniform_cu_seqlens", fail_uniform_check)
-    monkeypatch.setattr(op._prefill_op, "_uses_square_dense_fast_path", lambda: False)
-    monkeypatch.setattr(op._prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
+    prefill_op = op._prefill_op_for(torch.float16)
+    monkeypatch.setattr(prefill_op, "_uniform_cu_seqlens", fail_uniform_check)
+    monkeypatch.setattr(prefill_op, "_uses_square_dense_fast_path", lambda: False)
+    monkeypatch.setattr(prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
 
     out = op(q, k, v)
     assert out.shape == q.shape
@@ -924,21 +925,20 @@ def test_gqa_prefill_dispatch_key_selector_rejects_forced_dense_ragged() -> None
 
 
 @pytest.mark.smoke
-def test_gqa_prefill_dense_selector_widens_ws_capability() -> None:
-    assert _select_gqa_prefill_fwd_kernel_cls(
-        128,
-        True,
-        torch.float16,
-        sm_scale=0.25,
-        softcap=2.0,
-    ).__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
-    assert _select_gqa_prefill_fwd_kernel_cls(
-        128,
-        True,
-        torch.bfloat16,
-        sm_scale=128**-0.5,
-        softcap=0.0,
-    ).__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
+@pytest.mark.parametrize("dim, is_causal, dtype, expected", [
+    (128, True, torch.float16, "gqa_prefill_fwd_ws_persistent_causal_kernel"),
+    (128, True, torch.bfloat16, "gqa_prefill_fwd_ws_persistent_causal_kernel"),
+    (128, False, torch.float16, "gqa_prefill_fwd_kernel"),
+    (64, True, torch.float16, "gqa_prefill_fwd_kernel"),
+])
+def test_gqa_prefill_dense_slot_key_selector(
+    dim: int,
+    is_causal: bool,
+    dtype: torch.dtype,
+    expected: str,
+) -> None:
+    """Each dense candidate owns a slot key; the element type picks the key."""
+    assert _select_gqa_prefill_dense_kernel_key(dim, is_causal, dtype) == expected
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_gqa_prefill_paged.py
+++ b/tests/ops/attention/test_gqa_prefill_paged.py
@@ -186,7 +186,6 @@ def test_gqa_prefill_paged_with_kv_cache_fwd(
         page_size=page_size,
         dim=dim,
         is_causal=is_causal,
-        dtype=dtype,
     )
     k_scale, v_scale = _ones_cache_scales()
 
@@ -285,7 +284,6 @@ def test_gqa_prefill_paged_with_fp8_kv_cache_fwd(
         page_size=page_size,
         dim=dim,
         is_causal=is_causal,
-        dtype=dtype,
         cache_dtype=cache_dtype,
         softcap=softcap,
     )
@@ -349,7 +347,6 @@ def test_gqa_prefill_paged_with_fp8_kv_cache_rejects_invalid_scales(
         max_pages_per_req=max_pages_per_req,
         page_size=page_size,
         dim=dim,
-        dtype=torch.float16,
         cache_dtype=torch.float8_e4m3fn,
     )
 
@@ -443,7 +440,6 @@ def test_gqa_prefill_paged_with_kv_cache_fused_rope(
         page_size=page_size,
         dim=dim,
         is_causal=is_causal,
-        dtype=dtype,
         softcap=softcap,
         fuse_rope=True,
         max_position=max_position,
@@ -490,7 +486,6 @@ def test_gqa_prefill_paged_with_kv_cache_validates_capacity() -> None:
         max_pages_per_req=max_pages_per_req,
         page_size=page_size,
         dim=dim,
-        dtype=torch.float16,
     )
     k_scale, v_scale = _ones_cache_scales()
 
@@ -510,7 +505,6 @@ def test_gqa_prefill_paged_with_kv_cache_requires_power_of_two_page_size() -> No
             max_pages_per_req=8,
             page_size=24,
             dim=64,
-            dtype=torch.float16,
         )
 
 
@@ -564,7 +558,6 @@ def test_gqa_prefill_paged_with_kv_cache_page_sizes(page_size: int) -> None:
         max_pages_per_req=max_pages_per_req,
         page_size=page_size,
         dim=dim,
-        dtype=dtype,
     )
     k_scale, v_scale = _ones_cache_scales()
 
@@ -573,3 +566,63 @@ def test_gqa_prefill_paged_with_kv_cache_page_sizes(page_size: int) -> None:
         block_table,
         max(q_lens))
     torch.testing.assert_close(output, ref, atol=5e-3, rtol=1e-5)
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_paged_serves_two_dtypes_from_one_instance() -> None:
+    """One instance answers both element types, each on its own kernel."""
+    q_lens = [32, 64]
+    old_lens = [48, 80]
+    batch, heads, heads_kv, dim = 2, 8, 2, 64
+    page_size, max_pages_per_req = 64, 8
+    num_pages = batch * max_pages_per_req
+    total_q = sum(q_lens)
+    block_table = _make_block_table(batch, max_pages_per_req)
+    cu_seqlens_q = _make_cu_seqlens(q_lens)
+    cache_seqlens = torch.tensor(old_lens, device="cuda", dtype=torch.int32)
+    k_scale, v_scale = _ones_cache_scales()
+    op = GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        max_pages_per_req=max_pages_per_req,
+        page_size=page_size,
+        dim=dim,
+    )
+
+    for dtype in (torch.float16, torch.bfloat16):
+        q = torch.randn(total_q, heads, dim, device="cuda", dtype=dtype).contiguous()
+        k_new = torch.randn(total_q, heads_kv, dim, device="cuda", dtype=dtype).contiguous()
+        v_new = torch.randn(total_q, heads_kv, dim, device="cuda", dtype=dtype).contiguous()
+        k_pages = torch.zeros(num_pages * page_size, heads_kv, dim, device="cuda",
+                              dtype=dtype).contiguous()
+        v_pages = torch.zeros_like(k_pages)
+        k_old = [
+            torch.randn(old_len, heads_kv, dim, device="cuda", dtype=dtype).contiguous()
+            for old_len in old_lens
+        ]
+        v_old = [
+            torch.randn(old_len, heads_kv, dim, device="cuda", dtype=dtype).contiguous()
+            for old_len in old_lens
+        ]
+        _fill_paged_cache_from_logical(k_pages, v_pages, k_old, v_old, block_table, page_size)
+        ref = _gqa_prefill_paged_ref(
+            q,
+            k_new,
+            v_new,
+            k_old,
+            v_old,
+            cu_seqlens_q,
+            batch=batch,
+            heads=heads,
+            heads_kv=heads_kv,
+            is_causal=True,
+        )
+        output = op(
+            q, k_new, v_new, k_pages, v_pages, k_scale, v_scale, cu_seqlens_q, cache_seqlens,
+            block_table, max(q_lens))
+        assert output.dtype == dtype
+        atol, rtol = _PREFILL_PAGED_TOLERANCE[dtype]
+        torch.testing.assert_close(output, ref, atol=atol, rtol=rtol)
+
+    assert set(op._kernel_cache) == {torch.float16, torch.bfloat16}

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -1,4 +1,6 @@
 
+from typing import Optional
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -47,14 +49,16 @@ class MhaBwdTest(MhaBwdWorkload, TestBase):
 
 
 class MhaFwdTest(MhaFwdWorkload, TestBase):
-    def ref_program(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    def ref_program(self, q: torch.Tensor, k: torch.Tensor,
+                    v: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         q_bhsd = q.transpose(1, 2)  # [B, H, S, D]
         k_bhsd = k.transpose(1, 2)
         v_bhsd = v.transpose(1, 2)
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             output_bhsd = F.scaled_dot_product_attention(
                 q_bhsd, k_bhsd, v_bhsd, is_causal=self.is_causal)
-        return output_bhsd.transpose(1, 2).contiguous()
+        output = output_bhsd.transpose(1, 2).contiguous()
+        return output, None  # do not check lse
 
 
 class MhaFwdFixture(FixtureBase):
@@ -123,6 +127,23 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
 def test_mha_fwd_dispatches_to_gqa_kernel() -> None:
     op = MultiHeadAttentionFwdOp(1, 8, 128, 64, False)
     assert op._get_kernel(torch.float16).__class__.__name__.startswith("GQA")
+
+
+@pytest.mark.smoke
+def test_mha_fwd_returns_output_lse_pair() -> None:
+    """The public return is the ``(output, lse)`` pair, not a bare tensor."""
+    batch, heads, seq_len, dim = 1, 8, 128, 64
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, False)
+    q = torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float16)
+    k, v = torch.randn_like(q), torch.randn_like(q)
+
+    result = op(q, k, v)
+
+    assert isinstance(result, tuple) and len(result) == 2
+    output, lse = result
+    assert output.shape == q.shape
+    assert output.dtype == q.dtype
+    assert lse is None
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -1,6 +1,4 @@
 
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
@@ -50,7 +48,7 @@ class MhaBwdTest(MhaBwdWorkload, TestBase):
 
 class MhaFwdTest(MhaFwdWorkload, TestBase):
     def ref_program(self, q: torch.Tensor, k: torch.Tensor,
-                    v: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+                    v: torch.Tensor) -> torch.Tensor:
         q_bhsd = q.transpose(1, 2)  # [B, H, S, D]
         k_bhsd = k.transpose(1, 2)
         v_bhsd = v.transpose(1, 2)
@@ -58,7 +56,7 @@ class MhaFwdTest(MhaFwdWorkload, TestBase):
             output_bhsd = F.scaled_dot_product_attention(
                 q_bhsd, k_bhsd, v_bhsd, is_causal=self.is_causal)
         output = output_bhsd.transpose(1, 2).contiguous()
-        return output, None  # do not check lse
+        return output
 
 
 class MhaFwdFixture(FixtureBase):
@@ -127,23 +125,6 @@ def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, d
 def test_mha_fwd_dispatches_to_gqa_kernel() -> None:
     op = MultiHeadAttentionFwdOp(1, 8, 128, 64, False)
     assert op._get_kernel(torch.float16).__class__.__name__.startswith("GQA")
-
-
-@pytest.mark.smoke
-def test_mha_fwd_returns_output_lse_pair() -> None:
-    """The public return is the ``(output, lse)`` pair, not a bare tensor."""
-    batch, heads, seq_len, dim = 1, 8, 128, 64
-    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, False)
-    q = torch.randn(batch, seq_len, heads, dim, device="cuda", dtype=torch.float16)
-    k, v = torch.randn_like(q), torch.randn_like(q)
-
-    result = op(q, k, v)
-
-    assert isinstance(result, tuple) and len(result) == 2
-    output, lse = result
-    assert output.shape == q.shape
-    assert output.dtype == q.dtype
-    assert lse is None
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -139,7 +139,7 @@ def test_mha_fwd_preserves_gqa_square_dense_fast_path(
         dim=128,
         is_causal=True,
         kernel_map={
-            "gqa_prefill_fwd_ws_persistent_causal_kernel": _FakeDenseKernel,
+            "gqa_prefill_causal_fwd_kernel": _FakeDenseKernel,
             "gqa_prefill_square_fwd_kernel": _FakeSquareDenseKernel,
         },
     )

--- a/tests/ops/attention/test_mha.py
+++ b/tests/ops/attention/test_mha.py
@@ -1,6 +1,4 @@
 
-from typing import Optional
-
 import pytest
 import torch
 import torch.nn.functional as F
@@ -49,16 +47,14 @@ class MhaBwdTest(MhaBwdWorkload, TestBase):
 
 
 class MhaFwdTest(MhaFwdWorkload, TestBase):
-    def ref_program(self, q: torch.Tensor, k: torch.Tensor,
-                    v: torch.Tensor) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def ref_program(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         q_bhsd = q.transpose(1, 2)  # [B, H, S, D]
         k_bhsd = k.transpose(1, 2)
         v_bhsd = v.transpose(1, 2)
         with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
             output_bhsd = F.scaled_dot_product_attention(
                 q_bhsd, k_bhsd, v_bhsd, is_causal=self.is_causal)
-        output = output_bhsd.transpose(1, 2).contiguous()
-        return output, None  # do not check lse
+        return output_bhsd.transpose(1, 2).contiguous()
 
 
 class MhaFwdFixture(FixtureBase):
@@ -119,14 +115,14 @@ class MhaBwdFixture(FixtureBase):
 def test_mha_fwd(batch: int, seq_len: int, heads: int, dim: int, causal: bool, dtype: torch.dtype,
                  tune: bool) -> None:
     test = MhaFwdTest(batch, heads, seq_len, dim, causal, dtype)
-    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, dtype, tune=tune)
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, tune=tune)
     test.check(op, *test.gen_inputs(), atol=5e-3, rtol=1e-5)
 
 
 @pytest.mark.smoke
 def test_mha_fwd_dispatches_to_gqa_kernel() -> None:
-    op = MultiHeadAttentionFwdOp(1, 8, 128, 64, False, torch.float16)
-    assert op.kernel.__class__.__name__.startswith("GQA")
+    op = MultiHeadAttentionFwdOp(1, 8, 128, 64, False)
+    assert op._get_kernel(torch.float16).__class__.__name__.startswith("GQA")
 
 
 @pytest.mark.smoke
@@ -140,14 +136,13 @@ def test_mha_fwd_preserves_gqa_square_dense_fast_path(
         seq_len=512,
         dim=128,
         is_causal=True,
-        dtype=torch.float16,
         kernel_map={
-            "gqa_prefill_fwd_kernel": _FakeDenseKernel,
+            "gqa_prefill_fwd_ws_persistent_causal_kernel": _FakeDenseKernel,
             "gqa_prefill_square_fwd_kernel": _FakeSquareDenseKernel,
         },
     )
 
-    assert isinstance(op.kernel, _FakeSquareDenseKernel)
+    assert isinstance(op._get_kernel(torch.float16), _FakeSquareDenseKernel)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -95,6 +95,44 @@ def test_attention_decode_reselects_the_kernel_per_dtype():
 
 
 @pytest.mark.smoke
+def test_attention_square_prefill_reselects_the_kernel_per_dtype():
+    """The BSHD square wrapper resolves its prefill kernel from the tensors.
+
+    Causal dim-128 takes the warp-specialized dense slot; the element type used
+    to reach that slot through a constructor dtype read by default_kernel_map.
+    """
+    from tileops.ops.attention.gqa import GroupedQueryAttentionFwdOp
+
+    batch, heads, heads_kv, seq_len, dim = 1, 8, 2, 256, 128
+    op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, is_causal=True)
+    for dtype in _DTYPES:
+        q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
+        k = torch.randn(batch, seq_len, heads_kv, dim, dtype=dtype, device="cuda")
+        v = torch.randn_like(k)
+        assert op(q, k, v).dtype == dtype
+        kernel = op._get_kernel(dtype)
+        assert kernel.__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
+        assert kernel.dtype == dtype
+    _assert_two_entries(op)
+
+
+@pytest.mark.smoke
+def test_attention_mha_serves_two_dtypes_from_one_instance():
+    """MHA delegates to the GQA wrapper and shares its per-dtype kernel cache."""
+    from tileops.ops.attention.mha import MultiHeadAttentionFwdOp
+
+    batch, heads, seq_len, dim = 1, 8, 256, 64
+    op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, is_causal=False)
+    for dtype in _DTYPES:
+        q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
+        k = torch.randn_like(q)
+        v = torch.randn_like(q)
+        assert op(q, k, v).dtype == dtype
+        assert op._get_kernel(dtype).__class__.__name__ == "GQAPrefillFwdKernel"
+    _assert_two_entries(op)
+
+
+@pytest.mark.smoke
 def test_moe_unpermute_serves_two_dtypes_from_one_instance():
     from tileops.ops.moe.routed_expert.unpermute import MoeUnpermuteFwdOp
 

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -118,7 +118,7 @@ def test_attention_square_prefill_reselects_the_kernel_per_dtype():
 
 @pytest.mark.smoke
 def test_attention_mha_serves_two_dtypes_from_one_instance():
-    """MHA delegates to the GQA wrapper and shares its per-dtype kernel cache."""
+    """MHA owns no kernels; the per-dtype cache lives on the GQA delegate."""
     from tileops.ops.attention.mha import MultiHeadAttentionFwdOp
 
     batch, heads, seq_len, dim = 1, 8, 256, 64
@@ -130,7 +130,7 @@ def test_attention_mha_serves_two_dtypes_from_one_instance():
         output = op(q, k, v)
         assert output.dtype == dtype
         assert op._get_kernel(dtype).__class__.__name__ == "GQAPrefillFwdKernel"
-    _assert_two_entries(op)
+    _assert_two_entries(op._gqa_op)
 
 
 @pytest.mark.smoke

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -127,7 +127,8 @@ def test_attention_mha_serves_two_dtypes_from_one_instance():
         q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
         k = torch.randn_like(q)
         v = torch.randn_like(q)
-        assert op(q, k, v).dtype == dtype
+        output, _ = op(q, k, v)
+        assert output.dtype == dtype
         assert op._get_kernel(dtype).__class__.__name__ == "GQAPrefillFwdKernel"
     _assert_two_entries(op)
 

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -98,8 +98,7 @@ def test_attention_decode_reselects_the_kernel_per_dtype():
 def test_attention_square_prefill_reselects_the_kernel_per_dtype():
     """The BSHD square wrapper resolves its prefill kernel from the tensors.
 
-    Causal dim-128 takes the warp-specialized dense slot; the element type used
-    to reach that slot through a constructor dtype read by default_kernel_map.
+    Causal dim-128 takes the warp-specialized dense slot.
     """
     from tileops.ops.attention.gqa import GroupedQueryAttentionFwdOp
 

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -108,7 +108,7 @@ def test_attention_square_prefill_reselects_the_kernel_per_dtype():
         q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
         k = torch.randn(batch, seq_len, heads_kv, dim, dtype=dtype, device="cuda")
         v = torch.randn_like(k)
-        output, _ = op(q, k, v)
+        output = op(q, k, v)
         assert output.dtype == dtype
         kernel = op._get_kernel(dtype)
         assert kernel.__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
@@ -127,7 +127,7 @@ def test_attention_mha_serves_two_dtypes_from_one_instance():
         q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
         k = torch.randn_like(q)
         v = torch.randn_like(q)
-        output, _ = op(q, k, v)
+        output = op(q, k, v)
         assert output.dtype == dtype
         assert op._get_kernel(dtype).__class__.__name__ == "GQAPrefillFwdKernel"
     _assert_two_entries(op)

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -109,7 +109,8 @@ def test_attention_square_prefill_reselects_the_kernel_per_dtype():
         q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, device="cuda")
         k = torch.randn(batch, seq_len, heads_kv, dim, dtype=dtype, device="cuda")
         v = torch.randn_like(k)
-        assert op(q, k, v).dtype == dtype
+        output, _ = op(q, k, v)
+        assert output.dtype == dtype
         kernel = op._get_kernel(dtype)
         assert kernel.__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
         assert kernel.dtype == dtype

--- a/tests/ops/test_multi_dtype_instance.py
+++ b/tests/ops/test_multi_dtype_instance.py
@@ -132,6 +132,14 @@ def test_attention_mha_serves_two_dtypes_from_one_instance():
         assert op._get_kernel(dtype).__class__.__name__ == "GQAPrefillFwdKernel"
     _assert_two_entries(op._gqa_op)
 
+    # MHA owns no cache, so autotune has to reach the delegate's kernels — one
+    # per dtype — rather than relying on attribute traversal finding them here.
+    tuned = []
+    for kernel in op._gqa_op._kernel_cache.values():
+        kernel.autotune = lambda *_args, _k=kernel: tuned.append(id(_k))
+    op.autotune()
+    assert len(tuned) == len(_DTYPES)
+
 
 @pytest.mark.smoke
 def test_moe_unpermute_serves_two_dtypes_from_one_instance():

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -32,5 +32,21 @@ def test_mha_kernel_compile(B: int, S: int, H: int, D: int, causal: bool, dtype:
     test.check(compiled_op, *inputs, atol=5e-3, rtol=1e-5)
 
 
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_mha_compiled_returns_output_lse_pair():
+    """A cold fullgraph trace returns the same ``(output, lse)`` pair as eager."""
+    B, S, H, D = 1, 128, 8, 64
+    op = MultiHeadAttentionFwdOp(B, H, S, D, False)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
+    k, v = torch.randn_like(q), torch.randn_like(q)
+
+    output, lse = torch.compile(op, fullgraph=True)(q, k, v)
+
+    assert output.shape == q.shape
+    assert lse is None
+    torch.testing.assert_close(output, op(q, k, v)[0])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-vvs"])

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -34,18 +34,17 @@ def test_mha_kernel_compile(B: int, S: int, H: int, D: int, causal: bool, dtype:
 
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
-def test_mha_compiled_returns_output_lse_pair():
-    """A cold fullgraph trace returns the same ``(output, lse)`` pair as eager."""
+def test_mha_cold_fullgraph_trace_matches_eager():
+    """The kernel is built inside the custom op, so a cold trace must still match."""
     B, S, H, D = 1, 128, 8, 64
     op = MultiHeadAttentionFwdOp(B, H, S, D, False)
     q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16)
     k, v = torch.randn_like(q), torch.randn_like(q)
 
-    output, lse = torch.compile(op, fullgraph=True)(q, k, v)
+    output = torch.compile(op, fullgraph=True)(q, k, v)
 
     assert output.shape == q.shape
-    assert lse is None
-    torch.testing.assert_close(output, op(q, k, v)[0])
+    torch.testing.assert_close(output, op(q, k, v))
 
 
 if __name__ == "__main__":

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -26,7 +26,7 @@ class MhaCompileFixture(FixtureBase):
 @MhaCompileFixture
 def test_mha_kernel_compile(B: int, S: int, H: int, D: int, causal: bool, dtype: torch.dtype):
     test = MhaFwdTest(B, H, S, D, causal, dtype)
-    op = MultiHeadAttentionFwdOp(B, H, S, D, causal, dtype)
+    op = MultiHeadAttentionFwdOp(B, H, S, D, causal)
     compiled_op = torch.compile(op, fullgraph=True)
     inputs = test.gen_inputs()
     test.check(compiled_op, *inputs, atol=5e-3, rtol=1e-5)

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -39,7 +39,8 @@ MultiHeadAttentionFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
+      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
@@ -132,7 +133,8 @@ GroupedQueryAttentionFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
+      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
@@ -207,7 +209,8 @@ GroupedQueryAttentionPrefillFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
-      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
+      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
       gqa_prefill_varlen_fwd_kernel: GQAPrefillVarlenFwdKernel
       gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdWgmmaPipelinedKernel

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -40,7 +40,7 @@ MultiHeadAttentionFwdOp:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
       gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
-      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_causal_fwd_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/mha.py
     test: tests/ops/attention/test_mha.py
@@ -134,7 +134,7 @@ GroupedQueryAttentionFwdOp:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
       gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
-      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_causal_fwd_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
@@ -210,10 +210,10 @@ GroupedQueryAttentionPrefillFwdOp:
     kernel: tileops/kernels/attention/gqa_fwd.py
     kernel_map:
       gqa_prefill_fwd_kernel: GQAPrefillFwdKernel
-      gqa_prefill_fwd_ws_persistent_causal_kernel: GQAPrefillFwdWsPersistentCausalKernel
+      gqa_prefill_causal_fwd_kernel: GQAPrefillFwdWsPersistentCausalKernel
       gqa_prefill_square_fwd_kernel: GQAFwdWsPersistentCausalKernel
       gqa_prefill_varlen_fwd_kernel: GQAPrefillVarlenFwdKernel
-      gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
+      gqa_sliding_window_varlen_fwd_kernel: GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
       gqa_prefill_fp8_tensor_core_fwd_kernel: GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa.py
@@ -589,7 +589,7 @@ GroupedQueryAttentionSlidingWindowFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_sliding_window_fwd.py
     kernel_map:
-      gqa_sliding_window_fwd: GQASlidingWindowFwdWgmmaPipelinedKernel
+      gqa_sliding_window_fwd_kernel: GQASlidingWindowFwdWgmmaPipelinedKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_sliding_window.py
     bench: benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -637,7 +637,7 @@ GroupedQueryAttentionSlidingWindowVarlenFwdOp:
   source:
     kernel: tileops/kernels/attention/gqa_sliding_window_varlen_fwd.py
     kernel_map:
-      gqa_sliding_window_varlen_fwd: GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
+      gqa_sliding_window_varlen_fwd_kernel: GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
     op: tileops/ops/attention/gqa.py
     test: tests/ops/attention/test_gqa_sliding_window_varlen.py
     bench: benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -17,6 +17,7 @@ MultiHeadAttentionFwdOp:
       v: {dtype: "same_as(q)"}
     outputs:
       o: {dtype: "same_as(q)"}
+      lse: {dtype: "float32"}
     params:
       is_causal: {type: bool, default: true}
     shape_rules:
@@ -24,6 +25,7 @@ MultiHeadAttentionFwdOp:
       - "k.shape == (B, S, H, D)"
       - "v.shape == (B, S, H, D)"
       - "o.shape == (B, S, H, D)"
+      - "lse.shape == (B, H, S)"
 
   workloads:
     # Llama-3.1-8B (H=32, D=128)
@@ -110,6 +112,7 @@ GroupedQueryAttentionFwdOp:
       v: {dtype: "same_as(q)"}
     outputs:
       o: {dtype: "same_as(q)"}
+      lse: {dtype: "float32"}
     params:
       is_causal: {type: bool, default: true}
     shape_rules:
@@ -118,6 +121,7 @@ GroupedQueryAttentionFwdOp:
       - "v.shape == (B, S, H_kv, D)"
       - "o.shape == (B, S, H, D)"
       - "H % H_kv == 0"
+      - "lse.shape == (B, H, S)"
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)

--- a/tileops/manifest/attention.yaml
+++ b/tileops/manifest/attention.yaml
@@ -17,7 +17,6 @@ MultiHeadAttentionFwdOp:
       v: {dtype: "same_as(q)"}
     outputs:
       o: {dtype: "same_as(q)"}
-      lse: {dtype: "float32"}
     params:
       is_causal: {type: bool, default: true}
     shape_rules:
@@ -25,7 +24,6 @@ MultiHeadAttentionFwdOp:
       - "k.shape == (B, S, H, D)"
       - "v.shape == (B, S, H, D)"
       - "o.shape == (B, S, H, D)"
-      - "lse.shape == (B, H, S)"
 
   workloads:
     # Llama-3.1-8B (H=32, D=128)
@@ -112,7 +110,6 @@ GroupedQueryAttentionFwdOp:
       v: {dtype: "same_as(q)"}
     outputs:
       o: {dtype: "same_as(q)"}
-      lse: {dtype: "float32"}
     params:
       is_causal: {type: bool, default: true}
     shape_rules:
@@ -121,7 +118,6 @@ GroupedQueryAttentionFwdOp:
       - "v.shape == (B, S, H_kv, D)"
       - "o.shape == (B, S, H, D)"
       - "H % H_kv == 0"
-      - "lse.shape == (B, H, S)"
 
   workloads:
     # Llama-3.1-8B (H=32, H_kv=8, D=128)

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -387,21 +387,10 @@ class GroupedQueryAttentionFwdOp(Op):
         k_shape: tuple[int, ...],
         v_shape: tuple[int, ...],
     ) -> Dict[str, tuple[int, ...]]:
-        batch, seq_len, heads, _ = q_shape
-        return {"o": tuple(q_shape), "lse": (batch, heads, seq_len)}
+        return {"o": tuple(q_shape)}
 
-    def forward(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Run square GQA forward.
-
-        Returns:
-            ``(o, lse)``, the pair ``MultiHeadAttentionFwdOp`` returns for the
-            same kernels.
-        """
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Run square GQA forward."""
         expected_q = (self.batch, self.seq_len, self.heads, self.dim)
         expected_kv = (self.batch, self.seq_len, self.heads_kv, self.dim)
         if tuple(q.shape) != expected_q:
@@ -417,13 +406,7 @@ class GroupedQueryAttentionFwdOp(Op):
         v = v.contiguous()
         self.dtype = q.dtype
 
-        # FIXME(staged-rollout): the manifest `lse` output is returned as None.
-        #
-        # Broken invariant: the op declares outputs (o, lse) but yields no log-sum-exp.
-        # Why: of its three dispatch targets only GQAPrefillFwdKernel emits lse.
-        # Cleanup: when fwd emits a real lse consumable by the bwd op, return it
-        #     from every dispatch target and delete this marker.
-        return _attention_output(self._get_kernel(q.dtype)(q, k, v)), None
+        return _attention_output(self._get_kernel(q.dtype)(q, k, v))
 
 
 class GroupedQueryAttentionPrefillFwdOp(Op):

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -155,7 +155,7 @@ def _select_gqa_prefill_dense_kernel_key(
     rather than a class and stays out of ``default_kernel_map``.
     """
     if is_causal and dim == 128 and dtype in (torch.float16, torch.bfloat16):
-        return "gqa_prefill_fwd_ws_persistent_causal_kernel"
+        return "gqa_prefill_causal_fwd_kernel"
     return "gqa_prefill_fwd_kernel"
 
 
@@ -205,7 +205,7 @@ def _select_gqa_prefill_kernel_key(
         if backend not in ("auto", "sliding_window"):
             raise ValueError(
                 "sliding-window prefill requires backend='auto' or backend='sliding_window'.")
-        return "gqa_sliding_window_varlen_fwd"
+        return "gqa_sliding_window_varlen_fwd_kernel"
     if is_uniform and backend in ("auto", "dense"):
         return "gqa_prefill_fwd_kernel"
     if backend == "dense":
@@ -316,7 +316,7 @@ class GroupedQueryAttentionFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
-            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
+            "gqa_prefill_causal_fwd_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
         }
 
@@ -468,10 +468,10 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
-            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
+            "gqa_prefill_causal_fwd_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
             "gqa_prefill_varlen_fwd_kernel": GQAPrefillVarlenFwdKernel,
-            "gqa_sliding_window_varlen_fwd": GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
+            "gqa_sliding_window_varlen_fwd_kernel": GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
             "gqa_prefill_fp8_tensor_core_fwd_kernel":
                 GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
         }
@@ -650,7 +650,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
     def _get_sliding_window_varlen_kernel(self) -> Kernel:
         if self._sliding_window_varlen_kernel is None:
             self._sliding_window_varlen_kernel = self.kernel_map[
-                "gqa_sliding_window_varlen_fwd"](
+                "gqa_sliding_window_varlen_fwd_kernel"](
                     batch=self.batch,
                     heads=self.heads,
                     heads_kv=self.heads_kv,
@@ -743,7 +743,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
             return out.reshape(q.shape)
 
-        if kernel_key == "gqa_sliding_window_varlen_fwd":
+        if kernel_key == "gqa_sliding_window_varlen_fwd_kernel":
             output, _ = self._get_sliding_window_varlen_kernel()(
                 q, k, v, cu_seqlens_q, cu_seqlens_kv, self.max_seqlen_q)
             self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
@@ -1625,7 +1625,7 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
 
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         if dtype not in self._kernel_cache:
-            self._kernel_cache[dtype] = self.kernel_map["gqa_sliding_window_fwd"](
+            self._kernel_cache[dtype] = self.kernel_map["gqa_sliding_window_fwd_kernel"](
                 batch=self.batch,
                 heads=self.heads,
                 heads_kv=self.heads_kv,
@@ -1642,7 +1642,7 @@ class GroupedQueryAttentionSlidingWindowFwdOp(Op):
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         kernel = GQASlidingWindowFwdWgmmaPipelinedKernel
-        return {"gqa_sliding_window_fwd": kernel}
+        return {"gqa_sliding_window_fwd_kernel": kernel}
 
     def forward(
         self,
@@ -1783,7 +1783,7 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         if dtype not in self._kernel_cache:
             self._kernel_cache[dtype] = self.kernel_map[
-                "gqa_sliding_window_varlen_fwd"
+                "gqa_sliding_window_varlen_fwd_kernel"
             ](
                 batch=self.batch,
                 heads=self.heads,
@@ -1801,7 +1801,7 @@ class GroupedQueryAttentionSlidingWindowVarlenFwdOp(Op):
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         kernel = GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
-        return {"gqa_sliding_window_varlen_fwd": kernel}
+        return {"gqa_sliding_window_varlen_fwd_kernel": kernel}
 
     def forward(
         self,

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -381,7 +381,27 @@ class GroupedQueryAttentionFwdOp(Op):
             self._kernel_cache[dtype] = kernel
         return kernel
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    def _infer_output_shapes(
+        self,
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+    ) -> Dict[str, tuple[int, ...]]:
+        batch, seq_len, heads, _ = q_shape
+        return {"o": tuple(q_shape), "lse": (batch, heads, seq_len)}
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Run square GQA forward.
+
+        Returns:
+            ``(o, lse)``, the pair ``MultiHeadAttentionFwdOp`` returns for the
+            same kernels.
+        """
         expected_q = (self.batch, self.seq_len, self.heads, self.dim)
         expected_kv = (self.batch, self.seq_len, self.heads_kv, self.dim)
         if tuple(q.shape) != expected_q:
@@ -396,7 +416,19 @@ class GroupedQueryAttentionFwdOp(Op):
         k = k.contiguous()
         v = v.contiguous()
         self.dtype = q.dtype
-        return _attention_output(self._get_kernel(q.dtype)(q, k, v))
+
+        # FIXME(staged-rollout): the manifest `lse` output is returned as None.
+        #
+        # Broken invariant: the op declares outputs (o, lse) but yields no
+        #     log-sum-exp, so GroupedQueryAttentionBwdOp cannot source lse here
+        #     and its workload recomputes it in torch.
+        # Why: of the three kernels this op dispatches to, only GQAPrefillFwdKernel
+        #     emits lse; GQAFwdWsPersistentCausalKernel returns o alone and
+        #     GQAPrefillFwdWsPersistentCausalKernel returns (o, None), so no
+        #     dtype-and-geometry-independent contract can carry a tensor yet.
+        # Cleanup: when fwd emits a real lse consumable by the bwd op, return it
+        #     from every dispatch target and delete this marker.
+        return _attention_output(self._get_kernel(q.dtype)(q, k, v)), None
 
 
 class GroupedQueryAttentionPrefillFwdOp(Op):

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -419,13 +419,8 @@ class GroupedQueryAttentionFwdOp(Op):
 
         # FIXME(staged-rollout): the manifest `lse` output is returned as None.
         #
-        # Broken invariant: the op declares outputs (o, lse) but yields no
-        #     log-sum-exp, so GroupedQueryAttentionBwdOp cannot source lse here
-        #     and its workload recomputes it in torch.
-        # Why: of the three kernels this op dispatches to, only GQAPrefillFwdKernel
-        #     emits lse; GQAFwdWsPersistentCausalKernel returns o alone and
-        #     GQAPrefillFwdWsPersistentCausalKernel returns (o, None), so no
-        #     dtype-and-geometry-independent contract can carry a tensor yet.
+        # Broken invariant: the op declares outputs (o, lse) but yields no log-sum-exp.
+        # Why: of its three dispatch targets only GQAPrefillFwdKernel emits lse.
         # Cleanup: when fwd emits a real lse consumable by the bwd op, return it
         #     from every dispatch target and delete this marker.
         return _attention_output(self._get_kernel(q.dtype)(q, k, v)), None
@@ -1093,7 +1088,7 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         self.max_cache_len = max_pages_per_req * page_size
         self.dim = dim
         self.is_causal = is_causal
-        # None: the cache holds the attention element type, whatever forward gets.
+        # None means the cache holds whatever element type forward is given.
         self.cache_dtype = cache_dtype
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -144,17 +144,49 @@ def _select_gqa_fwd_kernel_cls(
     return GQAFwdWgmmaPipelinedKernel
 
 
-def _select_gqa_prefill_fwd_kernel_cls(
+def _select_gqa_prefill_dense_kernel_key(
     dim: int,
     is_causal: bool,
     dtype: torch.dtype,
-    sm_scale: float,
-    softcap: float,
-) -> Type[Kernel]:
-    del sm_scale, softcap
+) -> str:
+    """Select the dense prefill slot key for one call's geometry and dtype.
+
+    Each dense candidate owns a single-valued slot, so the choice is a key
+    rather than a class and stays out of ``default_kernel_map``.
+    """
     if is_causal and dim == 128 and dtype in (torch.float16, torch.bfloat16):
-        return GQAPrefillFwdWsPersistentCausalKernel
-    return GQAPrefillFwdKernel
+        return "gqa_prefill_fwd_ws_persistent_causal_kernel"
+    return "gqa_prefill_fwd_kernel"
+
+
+def _supports_gqa_prefill_square_dense(
+    batch: int,
+    heads: int,
+    heads_kv: int,
+    seq_len_q: int,
+    seq_len_kv: int,
+    dim: int,
+    is_causal: bool,
+    dtype: torch.dtype,
+    *,
+    h200: bool,
+    num_sms: int = _H200_SMS,
+) -> bool:
+    """Return whether a square prefill call satisfies the H200 fast-path contract."""
+    if dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if not h200 or dim != 128:
+        return False
+    if heads % heads_kv != 0 or seq_len_q % _WS_BLOCK_M != 0:
+        return False
+    m_blocks = math.ceil(seq_len_q / _WS_BLOCK_M)
+    if m_blocks % 2 != 0:
+        return False
+    return (
+        is_causal
+        and seq_len_q == seq_len_kv
+        and _gqa_ws_causal_total_work_items(batch, heads, heads_kv, seq_len_q) >= num_sms
+    )
 
 
 def _select_gqa_prefill_kernel_key(
@@ -200,6 +232,21 @@ def _select_gqa_paged_prefill_kernel_keys(
     if fp8_dtype is not None and cache_dtype == fp8_dtype:
         return ("gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel",)
     return ("gqa_prefill_paged_with_kv_cache_fwd_kernel",)
+
+
+def _paged_cache_dtype(cache_dtype: torch.dtype | str | None) -> Optional[torch.dtype]:
+    """Normalize a paged KV cache element type; ``None`` follows the attention dtype."""
+    if cache_dtype is None:
+        return None
+    if isinstance(cache_dtype, str):
+        candidate = getattr(torch, cache_dtype, None)
+        if not isinstance(candidate, torch.dtype):
+            raise ValueError(f"Unknown cache_dtype {cache_dtype}")
+        cache_dtype = candidate
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if cache_dtype != fp8_dtype:
+        _validate_attention_dtype(cache_dtype)
+    return cache_dtype
 
 
 def _select_gqa_prefill_varlen_fwd_kernel_cls() -> Type[Kernel]:
@@ -274,7 +321,6 @@ class GroupedQueryAttentionFwdOp(Op):
                  seq_len: int,
                  dim: int,
                  is_causal: bool = True,
-                 dtype: torch.dtype = torch.float16,
                  sm_scale: Optional[float] = None,
                  softcap: Optional[float] = None,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -285,43 +331,55 @@ class GroupedQueryAttentionFwdOp(Op):
         self.seq_len = seq_len
         self.dim = dim
         self.is_causal = is_causal
-        self.dtype = dtype
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self._prefill_op = GroupedQueryAttentionPrefillFwdOp(
-            batch=batch,
-            heads=heads,
-            heads_kv=heads_kv,
-            dim=dim,
-            max_seqlen_q=seq_len,
-            max_seqlen_kv=seq_len,
-            dtype=dtype,
-            is_causal=is_causal,
-            sm_scale=sm_scale,
-            softcap=softcap,
-            backend="dense",
-            kernel_map=self.kernel_map,
-            tune=tune,
-        )
+        self._prefill_ops: Dict[torch.dtype, "GroupedQueryAttentionPrefillFwdOp"] = {}
+        self._kernel_cache: Dict[torch.dtype, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        dense_kernel_cls = _select_gqa_prefill_fwd_kernel_cls(
-            self.dim,
-            self.is_causal,
-            self.dtype,
-            sm_scale=self.sm_scale,
-            softcap=self.softcap,
-        )
         return {
-            "gqa_prefill_fwd_kernel": dense_kernel_cls,
+            "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
+            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
         }
 
-    @property
-    def kernel(self) -> Kernel:
-        return self._prefill_op._get_dense_kernel()
+    def _prefill_op_for(self, dtype: torch.dtype) -> "GroupedQueryAttentionPrefillFwdOp":
+        """Packed prefill op for *dtype*, whose ctor dtype is the output element type."""
+        op = self._prefill_ops.get(dtype)
+        if op is None:
+            op = GroupedQueryAttentionPrefillFwdOp(
+                batch=self.batch,
+                heads=self.heads,
+                heads_kv=self.heads_kv,
+                dim=self.dim,
+                max_seqlen_q=self.seq_len,
+                max_seqlen_kv=self.seq_len,
+                dtype=dtype,
+                is_causal=self.is_causal,
+                sm_scale=self.sm_scale,
+                softcap=self.softcap,
+                backend="dense",
+                kernel_map=self.kernel_map,
+                tune=self.tune,
+            )
+            self._prefill_ops[dtype] = op
+        return op
+
+    def _get_kernel(self, dtype: torch.dtype) -> Kernel:
+        kernel = self._kernel_cache.get(dtype)
+        if kernel is None:
+            _validate_attention_dtype(dtype)
+            prefill_op = self._prefill_op_for(dtype)
+            kernel = (
+                prefill_op._get_square_dense_kernel()
+                if prefill_op._uses_square_dense_fast_path()
+                else prefill_op._get_dense_kernel()
+            )
+            self._kernel_cache[dtype] = kernel
+        return kernel
 
     def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         expected_q = (self.batch, self.seq_len, self.heads, self.dim)
@@ -332,18 +390,13 @@ class GroupedQueryAttentionFwdOp(Op):
             raise ValueError(f"k must have shape {expected_kv}, got {tuple(k.shape)}")
         if tuple(v.shape) != expected_kv:
             raise ValueError(f"v must have shape {expected_kv}, got {tuple(v.shape)}")
-        if q.dtype != self.dtype or k.dtype != self.dtype or v.dtype != self.dtype:
-            raise ValueError(f"q/k/v dtype must match op dtype {self.dtype}.")
+        self._validate_dtypes(q, k, v)
 
         q = q.contiguous()
         k = k.contiguous()
         v = v.contiguous()
-        kernel = (
-            self._prefill_op._get_square_dense_kernel()
-            if self._prefill_op._uses_square_dense_fast_path()
-            else self._prefill_op._get_dense_kernel()
-        )
-        return _attention_output(kernel(q, k, v))
+        self.dtype = q.dtype
+        return _attention_output(self._get_kernel(q.dtype)(q, k, v))
 
 
 class GroupedQueryAttentionPrefillFwdOp(Op):
@@ -352,6 +405,12 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
     Dense and square prefill are represented with uniform ``cu_seqlens``. Ragged
     prefill uses the same fixed public tensor list. Scale tensors are required
     for manifest stability; non-FP8 kernels ignore them.
+
+    Args:
+        dtype: Element type of ``o``. The inputs do not determine it: identical
+            float8_e4m3fn q/k/v admit either a float16 or a bfloat16 output, so
+            the caller chooses here. For float16 / bfloat16 inputs it must equal
+            their element type.
     """
 
     def __init__(
@@ -423,19 +482,12 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        dense_kernel_cls = _select_gqa_prefill_fwd_kernel_cls(
-            self.dim,
-            self.is_causal,
-            self.dtype,
-            self.sm_scale,
-            self.softcap,
-        )
-        sliding_kernel_cls = GQASlidingWindowVarlenFwdWgmmaPipelinedKernel
         return {
-            "gqa_prefill_fwd_kernel": dense_kernel_cls,
+            "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
+            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
             "gqa_prefill_varlen_fwd_kernel": _select_gqa_prefill_varlen_fwd_kernel_cls(),
-            "gqa_sliding_window_varlen_fwd": sliding_kernel_cls,
+            "gqa_sliding_window_varlen_fwd": GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
             "gqa_prefill_fp8_tensor_core_fwd_kernel":
                 GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
         }
@@ -550,7 +602,9 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
 
     def _get_dense_kernel(self) -> Kernel:
         if self._dense_kernel is None:
-            self._dense_kernel = self.kernel_map["gqa_prefill_fwd_kernel"](
+            dense_key = _select_gqa_prefill_dense_kernel_key(
+                self.dim, self.is_causal, self.dtype)
+            self._dense_kernel = self.kernel_map[dense_key](
                 self.batch,
                 self.heads,
                 self.heads_kv,
@@ -566,21 +620,16 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         return self._dense_kernel
 
     def _uses_square_dense_fast_path(self) -> bool:
-        if self.dtype not in (torch.float16, torch.bfloat16):
-            return False
-        if not is_h200() or self.dim != 128:
-            return False
-        if self.heads % self.heads_kv != 0 or self.max_seqlen_q % _WS_BLOCK_M != 0:
-            return False
-        m_blocks = math.ceil(self.max_seqlen_q / _WS_BLOCK_M)
-        if m_blocks % 2 != 0:
-            return False
-        return (
-            self.is_causal
-            and self.max_seqlen_q == self.max_seqlen_kv
-            and _gqa_ws_causal_total_work_items(
-                self.batch, self.heads, self.heads_kv, self.max_seqlen_q
-            ) >= _H200_SMS
+        return _supports_gqa_prefill_square_dense(
+            self.batch,
+            self.heads,
+            self.heads_kv,
+            self.max_seqlen_q,
+            self.max_seqlen_kv,
+            self.dim,
+            self.is_causal,
+            self.dtype,
+            h200=is_h200(),
         )
 
     def _get_square_dense_kernel(self) -> Kernel:
@@ -972,7 +1021,6 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         page_size: int,
         dim: int,
         is_causal: bool = True,
-        dtype: torch.dtype = torch.float16,
         cache_dtype: torch.dtype | str | None = None,
         sm_scale: Optional[float] = None,
         softcap: Optional[float] = None,
@@ -1000,26 +1048,8 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
             raise ValueError("page_size must be positive")
         if page_size & (page_size - 1) != 0:
             raise ValueError("page_size must be a power of two")
-        _validate_attention_dtype(dtype)
-        if cache_dtype is None:
-            cache_dtype = dtype
-        elif isinstance(cache_dtype, str):
-            if cache_dtype == "float8_e4m3fn":
-                fp8_dtype = getattr(torch, "float8_e4m3fn", None)
-                if fp8_dtype is None:
-                    raise ValueError(
-                        "torch.float8_e4m3fn is not supported on this PyTorch version")
-                cache_dtype = fp8_dtype
-            else:
-                candidate = getattr(torch, cache_dtype, None)
-                if not isinstance(candidate, torch.dtype):
-                    raise ValueError(f"Unknown cache_dtype {cache_dtype}")
-                cache_dtype = candidate
+        cache_dtype = _paged_cache_dtype(cache_dtype)
         fp8_dtype = getattr(torch, "float8_e4m3fn", None)
-        if cache_dtype != dtype and cache_dtype != fp8_dtype:
-            raise ValueError(
-                "cache_dtype must be either same as dtype or torch.float8_e4m3fn, "
-                f"got {cache_dtype}")
         if fuse_rope and cache_dtype == fp8_dtype:
             raise ValueError("fuse_rope is not supported with FP8 paged KV cache yet")
         self.batch = batch
@@ -1031,7 +1061,7 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         self.max_cache_len = max_pages_per_req * page_size
         self.dim = dim
         self.is_causal = is_causal
-        self.dtype = dtype
+        # None: the cache holds the attention element type, whatever forward gets.
         self.cache_dtype = cache_dtype
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)
@@ -1039,95 +1069,78 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         self.rope_base = rope_base
         self.max_position = max_position
         self.rotary_dim = rotary_dim
-        self._rope_cos_cache: Optional[torch.Tensor] = None
-        self._rope_sin_cache: Optional[torch.Tensor] = None
-        self._rope_cache_device: Optional[torch.device] = None
+        self._rope_cos_cache: Dict[tuple[torch.device, torch.dtype],
+                                   tuple[torch.Tensor, torch.Tensor]] = {}
 
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self.append_kernel: Optional[Kernel] = None
-        if self.fuse_rope:
-            self.append_kernel = self.kernel_map[
-                "gqa_prefill_paged_with_kv_cache_rope_append_kernel"](
-                    batch=batch,
-                    heads_kv=heads_kv,
-                    max_pages_per_req=max_pages_per_req,
-                    page_size=page_size,
-                    dim=dim,
-                    max_position=self.max_position,
-                    rotary_dim=self.rotary_dim,
-                    dtype=dtype,
-                    tune=tune,
-                )
-            self.kernel = self.kernel_map["gqa_prefill_paged_with_kv_cache_rope_fwd_kernel"](
-                batch=batch,
-                heads=heads,
-                heads_kv=heads_kv,
-                max_pages_per_req=max_pages_per_req,
-                page_size=page_size,
-                dim=dim,
-                max_position=self.max_position,
-                rotary_dim=self.rotary_dim,
-                is_causal=is_causal,
-                dtype=dtype,
-                sm_scale=self.sm_scale,
-                softcap=self.softcap,
-                tune=tune,
-            )
-        elif self.cache_dtype == fp8_dtype:
-            self.kernel = self.kernel_map["gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel"](
-                batch=batch,
-                heads=heads,
-                heads_kv=heads_kv,
-                max_pages_per_req=max_pages_per_req,
-                page_size=page_size,
-                dim=dim,
-                is_causal=is_causal,
-                dtype=dtype,
-                sm_scale=self.sm_scale,
-                softcap=self.softcap,
-                tune=tune,
-            )
-        else:
-            self.kernel = self.kernel_map["gqa_prefill_paged_with_kv_cache_fwd_kernel"](
-                batch=batch,
-                heads=heads,
-                heads_kv=heads_kv,
-                max_pages_per_req=max_pages_per_req,
-                page_size=page_size,
-                dim=dim,
-                is_causal=is_causal,
-                dtype=dtype,
-                sm_scale=self.sm_scale,
-                softcap=self.softcap,
-                tune=tune,
-            )
+        self._kernel_cache: Dict[torch.dtype, Kernel] = {}
+        self._append_kernel_cache: Dict[torch.dtype, Kernel] = {}
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        keys = _select_gqa_paged_prefill_kernel_keys(
-            cache_dtype=self.cache_dtype,
-            attention_dtype=self.dtype,
-            fuse_rope=self.fuse_rope,
-        )
-        if keys == (
-            "gqa_prefill_paged_with_kv_cache_rope_append_kernel",
-            "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel",
-        ):
-            return {
-                "gqa_prefill_paged_with_kv_cache_rope_append_kernel":
-                    _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls(),
-                "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
-                    _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls()
-            }
-        if keys == ("gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel",):
-            return {
-                "gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel":
-                    _select_gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel_cls()
-            }
         return {
             "gqa_prefill_paged_with_kv_cache_fwd_kernel":
-                _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls()
+                _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls(),
+            "gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel":
+                _select_gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel_cls(),
+            "gqa_prefill_paged_with_kv_cache_rope_append_kernel":
+                _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls(),
+            "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
+                _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls(),
         }
+
+    def _resolved_cache_dtype(self, dtype: torch.dtype) -> torch.dtype:
+        """Cache element type for an attention element type of *dtype*."""
+        return dtype if self.cache_dtype is None else self.cache_dtype
+
+    def _get_kernel(self, dtype: torch.dtype) -> Kernel:
+        kernel = self._kernel_cache.get(dtype)
+        if kernel is None:
+            _validate_attention_dtype(dtype)
+            # The attention kernel is the last key; fused RoPE prepends its append kernel.
+            key = _select_gqa_paged_prefill_kernel_keys(
+                cache_dtype=self._resolved_cache_dtype(dtype),
+                attention_dtype=dtype,
+                fuse_rope=self.fuse_rope,
+            )[-1]
+            kwargs: Dict[str, object] = dict(
+                batch=self.batch,
+                heads=self.heads,
+                heads_kv=self.heads_kv,
+                max_pages_per_req=self.max_pages_per_req,
+                page_size=self.page_size,
+                dim=self.dim,
+                is_causal=self.is_causal,
+                dtype=dtype,
+                sm_scale=self.sm_scale,
+                softcap=self.softcap,
+                tune=self.tune,
+            )
+            if key == "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
+                kwargs["max_position"] = self.max_position
+                kwargs["rotary_dim"] = self.rotary_dim
+            kernel = self.kernel_map[key](**kwargs)
+            self._kernel_cache[dtype] = kernel
+        return kernel
+
+    def _get_append_kernel(self, dtype: torch.dtype) -> Kernel:
+        """RoPE-fused cache append kernel; only the ``fuse_rope`` path has one."""
+        kernel = self._append_kernel_cache.get(dtype)
+        if kernel is None:
+            kernel = self.kernel_map["gqa_prefill_paged_with_kv_cache_rope_append_kernel"](
+                batch=self.batch,
+                heads_kv=self.heads_kv,
+                max_pages_per_req=self.max_pages_per_req,
+                page_size=self.page_size,
+                dim=self.dim,
+                max_position=self.max_position,
+                rotary_dim=self.rotary_dim,
+                dtype=dtype,
+                tune=self.tune,
+            )
+            self._append_kernel_cache[dtype] = kernel
+        return kernel
 
     def _validate_forward_inputs(
         self,
@@ -1204,17 +1217,25 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
                 f"block_table shape must be ({self.batch}, {self.max_pages_per_req}), "
                 f"got {tuple(block_table.shape)}")
 
-        for name, tensor in [("q", q), ("k_new", k_new), ("v_new", v_new)]:
-            if tensor.dtype != self.dtype:
-                raise ValueError(f"Expected {name}.dtype {self.dtype}, got {tensor.dtype}")
+        # q carries the attention element type; k_new / v_new must agree with it.
+        _validate_attention_dtype(q.dtype)
+        cache_dtype = self._resolved_cache_dtype(q.dtype)
+        fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+        if cache_dtype != q.dtype and cache_dtype != fp8_dtype:
+            raise ValueError(
+                "cache_dtype must be either same as the q element type or "
+                f"torch.float8_e4m3fn, got {cache_dtype}")
+        for name, tensor in [("k_new", k_new), ("v_new", v_new)]:
+            if tensor.dtype != q.dtype:
+                raise ValueError(f"Expected {name}.dtype {q.dtype}, got {tensor.dtype}")
         for name, tensor in [("k_pages", k_pages), ("v_pages", v_pages)]:
-            if tensor.dtype != self.cache_dtype:
+            if tensor.dtype != cache_dtype:
                 raise ValueError(
-                    f"Expected {name}.dtype {self.cache_dtype}, got {tensor.dtype}")
+                    f"Expected {name}.dtype {cache_dtype}, got {tensor.dtype}")
         for name, tensor in [("k_scale", k_scale), ("v_scale", v_scale)]:
             if tensor.dtype != torch.float32:
                 raise ValueError(f"{name} must have dtype torch.float32, got {tensor.dtype}")
-            if self.cache_dtype == getattr(torch, "float8_e4m3fn", None) and not torch.all(
+            if cache_dtype == fp8_dtype and not torch.all(
                 torch.isfinite(tensor) & (tensor > 0)
             ).item():
                 raise ValueError(f"{name} must contain finite positive values")
@@ -1260,19 +1281,24 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
             raise ValueError(
                 f"block_table references page {max_page}, but only {num_pages} pages exist")
 
-    def _get_rope_cos_sin(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    def _get_rope_cos_sin(
+        self,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.max_position is None:
             raise ValueError("max_position is required when fuse_rope=True")
-        if self._rope_cos_cache is None or self._rope_cache_device != device:
-            self._rope_cos_cache, self._rope_sin_cache = _base_freqs(
+        cached = self._rope_cos_cache.get((device, dtype))
+        if cached is None:
+            cached = _base_freqs(
                 self.rotary_dim,
                 self.max_position,
                 base=self.rope_base,
-                dtype=self.dtype,
+                dtype=dtype,
                 device=device,
             )
-            self._rope_cache_device = device
-        return self._rope_cos_cache, self._rope_sin_cache
+            self._rope_cos_cache[(device, dtype)] = cached
+        return cached
 
     def forward(
         self,
@@ -1291,21 +1317,23 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         self._validate_forward_inputs(
             q, k_new, v_new, k_pages, v_pages, k_scale, v_scale, cu_seqlens_q, cache_seqlens,
             block_table, max_seqlen_q)
-        if self.cache_dtype == getattr(torch, "float8_e4m3fn", None):
+        self.dtype = q.dtype
+        kernel = self._get_kernel(q.dtype)
+        if self._resolved_cache_dtype(q.dtype) == getattr(torch, "float8_e4m3fn", None):
             return _attention_output(
-                self.kernel(q, k_new, v_new, k_pages, v_pages, k_scale, v_scale, cu_seqlens_q,
-                            cache_seqlens, block_table, max_seqlen_q))
+                kernel(q, k_new, v_new, k_pages, v_pages, k_scale, v_scale, cu_seqlens_q,
+                       cache_seqlens, block_table, max_seqlen_q))
         if self.fuse_rope:
-            cos, sin = self._get_rope_cos_sin(q.device)
-            self.append_kernel(
+            cos, sin = self._get_rope_cos_sin(q.device, q.dtype)
+            self._get_append_kernel(q.dtype)(
                 k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens, block_table,
                 max_seqlen_q, cos, sin)
             return _attention_output(
-                self.kernel(q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens,
-                            block_table, max_seqlen_q, cos, sin))
+                kernel(q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens,
+                       block_table, max_seqlen_q, cos, sin))
         return _attention_output(
-            self.kernel(q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens,
-                        block_table, max_seqlen_q))
+            kernel(q, k_new, v_new, k_pages, v_pages, cu_seqlens_q, cache_seqlens,
+                   block_table, max_seqlen_q))
 
     @property
     def total_flops(self) -> int:

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -234,40 +234,14 @@ def _select_gqa_paged_prefill_kernel_keys(
     return ("gqa_prefill_paged_with_kv_cache_fwd_kernel",)
 
 
-def _paged_cache_dtype(cache_dtype: torch.dtype | str | None) -> Optional[torch.dtype]:
-    """Normalize a paged KV cache element type; ``None`` follows the attention dtype."""
+def _paged_cache_dtype(cache_dtype: Optional[torch.dtype]) -> Optional[torch.dtype]:
+    """Validate a paged KV cache element type; ``None`` follows the attention dtype."""
     if cache_dtype is None:
         return None
-    if isinstance(cache_dtype, str):
-        candidate = getattr(torch, cache_dtype, None)
-        if not isinstance(candidate, torch.dtype):
-            raise ValueError(f"Unknown cache_dtype {cache_dtype}")
-        cache_dtype = candidate
     fp8_dtype = getattr(torch, "float8_e4m3fn", None)
     if cache_dtype != fp8_dtype:
         _validate_attention_dtype(cache_dtype)
     return cache_dtype
-
-
-def _select_gqa_prefill_varlen_fwd_kernel_cls() -> Type[Kernel]:
-    return GQAPrefillVarlenFwdKernel
-
-
-def _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls() -> Type[Kernel]:
-    return GQAPrefillPagedWithKVCacheFwdKernel
-
-
-def _select_gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel_cls() -> Type[Kernel]:
-    # Selector hook for future FP8 paged-cache kernel variants.
-    return GQAPrefillPagedWithFP8KVCacheFwdKernel
-
-
-def _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls() -> Type[Kernel]:
-    return GQAPrefillPagedWithKVCacheRopeFwdKernel
-
-
-def _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls() -> Type[Kernel]:
-    return GQAPrefillPagedWithKVCacheRopeAppendKernel
 
 
 def _validate_gqa_dims(heads: int, heads_kv: int, dim: int) -> None:
@@ -496,7 +470,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
             "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
-            "gqa_prefill_varlen_fwd_kernel": _select_gqa_prefill_varlen_fwd_kernel_cls(),
+            "gqa_prefill_varlen_fwd_kernel": GQAPrefillVarlenFwdKernel,
             "gqa_sliding_window_varlen_fwd": GQASlidingWindowVarlenFwdWgmmaPipelinedKernel,
             "gqa_prefill_fp8_tensor_core_fwd_kernel":
                 GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
@@ -875,7 +849,7 @@ class GroupedQueryAttentionPrefillVarlenFwdOp(Op):
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
-        return {"gqa_prefill_varlen_fwd_kernel": _select_gqa_prefill_varlen_fwd_kernel_cls()}
+        return {"gqa_prefill_varlen_fwd_kernel": GQAPrefillVarlenFwdKernel}
 
     @staticmethod
     def _lengths_from_cu_seqlens(cu_seqlens: torch.Tensor) -> list[int]:
@@ -1031,7 +1005,7 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
         page_size: int,
         dim: int,
         is_causal: bool = True,
-        cache_dtype: torch.dtype | str | None = None,
+        cache_dtype: Optional[torch.dtype] = None,
         sm_scale: Optional[float] = None,
         softcap: Optional[float] = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -1091,13 +1065,13 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "gqa_prefill_paged_with_kv_cache_fwd_kernel":
-                _select_gqa_prefill_paged_with_kv_cache_fwd_kernel_cls(),
+                GQAPrefillPagedWithKVCacheFwdKernel,
             "gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel":
-                _select_gqa_prefill_paged_with_fp8_kv_cache_fwd_kernel_cls(),
+                GQAPrefillPagedWithFP8KVCacheFwdKernel,
             "gqa_prefill_paged_with_kv_cache_rope_append_kernel":
-                _select_gqa_prefill_paged_with_kv_cache_rope_append_kernel_cls(),
+                GQAPrefillPagedWithKVCacheRopeAppendKernel,
             "gqa_prefill_paged_with_kv_cache_rope_fwd_kernel":
-                _select_gqa_prefill_paged_with_kv_cache_rope_fwd_kernel_cls(),
+                GQAPrefillPagedWithKVCacheRopeFwdKernel,
         }
 
     def _resolved_cache_dtype(self, dtype: torch.dtype) -> torch.dtype:

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -58,8 +58,6 @@ class MultiHeadAttentionFwdOp(Op):
             kernel_map=self.kernel_map,
             tune=tune,
         )
-        # MHA holds no kernels of its own; report the delegate's cache.
-        self._kernel_cache = self._gqa_op._kernel_cache
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -71,6 +69,10 @@ class MultiHeadAttentionFwdOp(Op):
 
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         return self._gqa_op._get_kernel(dtype)
+
+    def autotune(self) -> None:
+        """Tune through the delegate: every kernel this op runs is built there."""
+        self._gqa_op.autotune()
 
     def _infer_output_shapes(
         self,

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -80,8 +80,20 @@ class MultiHeadAttentionFwdOp(Op):
     ) -> Dict[str, tuple[int, ...]]:
         return {"o": tuple(q_shape)}
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
-        return _mha_fwd(q, k, v, self._instance_key)
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Run MHA forward.
+
+        Returns:
+            ``(output, lse)``. The log-sum-exp slot is ``None``: a dispatch
+            ``custom_op`` return type admits tensors only, and the
+            warp-specialized prefill kernels emit no log-sum-exp.
+        """
+        return _mha_fwd(q, k, v, self._instance_key), None
 
     def _eager_forward(self, q: torch.Tensor, k: torch.Tensor,
                        v: torch.Tensor) -> torch.Tensor:

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -70,6 +70,11 @@ class MultiHeadAttentionFwdOp(Op):
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         return self._gqa_op._get_kernel(dtype)
 
+    @property
+    def _kernel_cache(self) -> Dict[torch.dtype, Kernel]:
+        """Read-only view of the delegate's cache, the lazy-op introspection shape."""
+        return self._gqa_op._kernel_cache
+
     def autotune(self) -> None:
         """Tune through the delegate: every kernel this op runs is built there."""
         self._gqa_op.autotune()

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -63,7 +63,7 @@ class MultiHeadAttentionFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
             "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
-            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
+            "gqa_prefill_causal_fwd_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
         }
 

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -78,33 +78,16 @@ class MultiHeadAttentionFwdOp(Op):
         k_shape: tuple[int, ...],
         v_shape: tuple[int, ...],
     ) -> Dict[str, tuple[int, ...]]:
-        batch, seq_len, heads, _ = q_shape
-        return {"o": tuple(q_shape), "lse": (batch, heads, seq_len)}
+        return {"o": tuple(q_shape)}
 
-    def forward(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Run MHA forward.
-
-        Returns:
-            ``(output, lse)``.
-        """
-        # FIXME(staged-rollout): the manifest `lse` output is returned as None.
-        #
-        # Broken invariant: the op declares outputs (o, lse) but yields no log-sum-exp.
-        # Why: the delegate emits none, and a custom_op return admits tensors only.
-        # Cleanup: when fwd emits a real lse consumable by the bwd op, widen the
-        #     custom op to return both tensors and delete this marker.
-        return _mha_fwd(q, k, v, self._instance_key), None
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        """Run MHA forward."""
+        return _mha_fwd(q, k, v, self._instance_key)
 
     def _eager_forward(self, q: torch.Tensor, k: torch.Tensor,
                        v: torch.Tensor) -> torch.Tensor:
         self.dtype = q.dtype
-        output, _ = self._gqa_op(q, k, v)
-        return output
+        return self._gqa_op(q, k, v)
 
 
 class MultiHeadAttentionBwdOp(Op):

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -7,17 +7,16 @@ from tileops.kernels.attention import (
     FlashAttnBwdPreprocessKernel,
     GQABwdWgmmaPipelinedKernel,
     GQAFwdWsPersistentCausalKernel,
+    GQAPrefillFwdKernel,
+    GQAPrefillFwdWsPersistentCausalKernel,
     MHADecodeKernel,
     MHADecodePagedKernel,
 )
 from tileops.kernels.kernel_base import Kernel
 
+from ..compile_boundary import get_instance
 from ..op_base import Op
-from .gqa import (
-    GroupedQueryAttentionBwdOp,
-    GroupedQueryAttentionFwdOp,
-    _select_gqa_prefill_fwd_kernel_cls,
-)
+from .gqa import GroupedQueryAttentionBwdOp, GroupedQueryAttentionFwdOp
 
 __all__ = [
     "MultiHeadAttentionBwdOp",
@@ -31,8 +30,7 @@ class MultiHeadAttentionFwdOp(Op):
     """Layout: BSHD.
 
     MHA is the heads_kv == heads specialization of GQA, so route the
-    maintained forward path through the GQA prefill dispatcher while keeping
-    the historical MHA return contract `(output, lse)`.
+    maintained forward path through the GQA prefill dispatcher.
     """
 
     def __init__(self,
@@ -41,7 +39,6 @@ class MultiHeadAttentionFwdOp(Op):
                  seq_len: int,
                  dim: int,
                  is_causal: bool = True,
-                 dtype: torch.dtype = torch.float16,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
         self.batch = batch
@@ -49,7 +46,6 @@ class MultiHeadAttentionFwdOp(Op):
         self.seq_len = seq_len  # TODO: support s_q != s_kv
         self.dim = dim
         self.is_causal = is_causal
-        self.dtype = dtype
 
         self.dispatch_kernel(kernel_map)
         self._gqa_op = GroupedQueryAttentionFwdOp(
@@ -59,43 +55,38 @@ class MultiHeadAttentionFwdOp(Op):
             seq_len=seq_len,
             dim=dim,
             is_causal=is_causal,
-            dtype=dtype,
             kernel_map=self.kernel_map,
             tune=tune,
         )
-        # GroupedQueryAttentionFwdOp instantiates its kernel lazily. MHA's
-        # torch.compile smoke expects forward to call an already-built custom op,
-        # so instantiate the same dense-path choice at construction time.
-        self._kernel = (
-            self._gqa_op._prefill_op._get_square_dense_kernel()
-            if self._gqa_op._prefill_op._uses_square_dense_fast_path()
-            else self._gqa_op.kernel
-        )
+        # MHA holds no kernels of its own; report the delegate's cache.
+        self._kernel_cache = self._gqa_op._kernel_cache
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
-            "gqa_prefill_fwd_kernel": _select_gqa_prefill_fwd_kernel_cls(
-                self.dim,
-                self.is_causal,
-                self.dtype,
-                sm_scale=None,
-                softcap=0.0,
-            ),
+            "gqa_prefill_fwd_kernel": GQAPrefillFwdKernel,
+            "gqa_prefill_fwd_ws_persistent_causal_kernel": GQAPrefillFwdWsPersistentCausalKernel,
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
         }
 
-    @property
-    def kernel(self) -> Kernel:
-        return self._kernel
+    def _get_kernel(self, dtype: torch.dtype) -> Kernel:
+        return self._gqa_op._get_kernel(dtype)
 
-    def forward(
+    def _infer_output_shapes(
         self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        return self.kernel(q, k, v)
+        q_shape: tuple[int, ...],
+        k_shape: tuple[int, ...],
+        v_shape: tuple[int, ...],
+    ) -> Dict[str, tuple[int, ...]]:
+        return {"o": tuple(q_shape)}
+
+    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return _mha_fwd(q, k, v, self._instance_key)
+
+    def _eager_forward(self, q: torch.Tensor, k: torch.Tensor,
+                       v: torch.Tensor) -> torch.Tensor:
+        self.dtype = q.dtype
+        return self._gqa_op(q, k, v)
 
 
 class MultiHeadAttentionBwdOp(Op):
@@ -252,3 +243,20 @@ class MultiHeadAttentionDecodePagedWithKVCacheFwdOp(Op):
                 real_seqlen_kv: torch.Tensor, block_table: torch.Tensor) -> torch.Tensor:
         self.dtype = q.dtype
         return self._get_kernel(q.dtype)(q, k, v, real_seqlen_kv, block_table)
+
+
+# torch.compile dispatch boundary (see tileops/ops/compile_boundary.py)
+
+
+@torch.library.custom_op("top::mha_fwd", mutates_args=())
+def _mha_fwd(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+             instance_key: str) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(q, k, v)
+
+
+@_mha_fwd.register_fake
+def _mha_fwd_fake(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                  instance_key: str) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(tuple(q.shape), tuple(k.shape), tuple(v.shape))
+    return q.new_empty(shapes["o"])

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -78,7 +78,8 @@ class MultiHeadAttentionFwdOp(Op):
         k_shape: tuple[int, ...],
         v_shape: tuple[int, ...],
     ) -> Dict[str, tuple[int, ...]]:
-        return {"o": tuple(q_shape)}
+        batch, seq_len, heads, _ = q_shape
+        return {"o": tuple(q_shape), "lse": (batch, heads, seq_len)}
 
     def forward(
         self,
@@ -89,16 +90,25 @@ class MultiHeadAttentionFwdOp(Op):
         """Run MHA forward.
 
         Returns:
-            ``(output, lse)``. The log-sum-exp slot is ``None``: a dispatch
-            ``custom_op`` return type admits tensors only, and the
-            warp-specialized prefill kernels emit no log-sum-exp.
+            ``(output, lse)``.
         """
+        # FIXME(staged-rollout): the manifest `lse` output is returned as None.
+        #
+        # Broken invariant: the op declares outputs (o, lse) but yields no
+        #     log-sum-exp, so MultiHeadAttentionBwdOp cannot source lse here.
+        # Why: the GQA prefill kernels this op delegates to emit none (see the
+        #     marker on GroupedQueryAttentionFwdOp.forward), and a dispatch
+        #     custom_op return type admits tensors only, so the boundary could
+        #     not carry an Optional even once they do.
+        # Cleanup: when fwd emits a real lse consumable by the bwd op, widen the
+        #     custom op to return both tensors and delete this marker.
         return _mha_fwd(q, k, v, self._instance_key), None
 
     def _eager_forward(self, q: torch.Tensor, k: torch.Tensor,
                        v: torch.Tensor) -> torch.Tensor:
         self.dtype = q.dtype
-        return self._gqa_op(q, k, v)
+        output, _ = self._gqa_op(q, k, v)
+        return output
 
 
 class MultiHeadAttentionBwdOp(Op):

--- a/tileops/ops/attention/mha.py
+++ b/tileops/ops/attention/mha.py
@@ -94,12 +94,8 @@ class MultiHeadAttentionFwdOp(Op):
         """
         # FIXME(staged-rollout): the manifest `lse` output is returned as None.
         #
-        # Broken invariant: the op declares outputs (o, lse) but yields no
-        #     log-sum-exp, so MultiHeadAttentionBwdOp cannot source lse here.
-        # Why: the GQA prefill kernels this op delegates to emit none (see the
-        #     marker on GroupedQueryAttentionFwdOp.forward), and a dispatch
-        #     custom_op return type admits tensors only, so the boundary could
-        #     not carry an Optional even once they do.
+        # Broken invariant: the op declares outputs (o, lse) but yields no log-sum-exp.
+        # Why: the delegate emits none, and a custom_op return admits tensors only.
         # Cleanup: when fwd emits a real lse consumable by the bwd op, widen the
         #     custom op to return both tensors and delete this marker.
         return _mha_fwd(q, k, v, self._instance_key), None

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -43,7 +43,7 @@ class Op(ABC):
         >>> from tileops.ops import MultiHeadAttentionFwdOp
         >>> op = MultiHeadAttentionFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
         >>> Q, K, V = op.gen_inputs()
-        >>> output = op(Q, K, V)
+        >>> output, lse = op(Q, K, V)
         >>> op.check()  # Verify correctness
         >>> latency = op.profile()  # Benchmark performance
 

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -43,7 +43,7 @@ class Op(ABC):
         >>> from tileops.ops import MultiHeadAttentionFwdOp
         >>> op = MultiHeadAttentionFwdOp(batch=1, heads=8, seq_len=512, dim=64, is_causal=True)
         >>> Q, K, V = op.gen_inputs()
-        >>> output, lse = op(Q, K, V)
+        >>> output = op(Q, K, V)
         >>> op.check()  # Verify correctness
         >>> latency = op.profile()  # Benchmark performance
 

--- a/workloads/attention/gqa.py
+++ b/workloads/attention/gqa.py
@@ -74,7 +74,7 @@ class GroupedQueryAttentionBwdWorkload(WorkloadBase):
         fwd_op = GroupedQueryAttentionFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
                                             self.dim, self.is_causal)
         with torch.no_grad():
-            o, _ = fwd_op(q, k, v)
+            o = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(
                 q,
                 k,

--- a/workloads/attention/gqa.py
+++ b/workloads/attention/gqa.py
@@ -72,7 +72,7 @@ class GroupedQueryAttentionBwdWorkload(WorkloadBase):
             self.batch, self.seq_len, self.heads, self.dim, dtype=self.dtype, device='cuda')
 
         fwd_op = GroupedQueryAttentionFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
-                                            self.dim, self.is_causal, self.dtype)
+                                            self.dim, self.is_causal)
         with torch.no_grad():
             o = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(

--- a/workloads/attention/gqa.py
+++ b/workloads/attention/gqa.py
@@ -74,7 +74,7 @@ class GroupedQueryAttentionBwdWorkload(WorkloadBase):
         fwd_op = GroupedQueryAttentionFwdOp(self.batch, self.heads, self.heads_kv, self.seq_len,
                                             self.dim, self.is_causal)
         with torch.no_grad():
-            o = fwd_op(q, k, v)
+            o, _ = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(
                 q,
                 k,

--- a/workloads/attention/mha.py
+++ b/workloads/attention/mha.py
@@ -51,7 +51,7 @@ class MhaBwdWorkload(WorkloadBase):
         fwd_op = MultiHeadAttentionFwdOp(self.batch, self.heads, self.seq_len, self.dim,
                                          self.is_causal)
         with torch.no_grad():
-            o = fwd_op(q, k, v)
+            o, _ = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(
                 q,
                 k,

--- a/workloads/attention/mha.py
+++ b/workloads/attention/mha.py
@@ -51,7 +51,7 @@ class MhaBwdWorkload(WorkloadBase):
         fwd_op = MultiHeadAttentionFwdOp(self.batch, self.heads, self.seq_len, self.dim,
                                          self.is_causal)
         with torch.no_grad():
-            o, _ = fwd_op(q, k, v)
+            o = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(
                 q,
                 k,

--- a/workloads/attention/mha.py
+++ b/workloads/attention/mha.py
@@ -49,10 +49,9 @@ class MhaBwdWorkload(WorkloadBase):
             self.batch, self.seq_len, self.heads, self.dim, dtype=self.dtype, device='cuda')
 
         fwd_op = MultiHeadAttentionFwdOp(self.batch, self.heads, self.seq_len, self.dim,
-                                         self.is_causal, self.dtype)
+                                         self.is_causal)
         with torch.no_grad():
-            result = fwd_op(q, k, v)
-            o = result[0] if isinstance(result, tuple) else result
+            o = fwd_op(q, k, v)
             lse = _compute_gqa_square_lse(
                 q,
                 k,


### PR DESCRIPTION
Closes #1833

## Summary

- `default_kernel_map` reads no instance state on any attention op; the kernel choice moved to `forward` and is cached per dtype.
- `GroupedQueryAttentionFwdOp`, `MultiHeadAttentionFwdOp` and `GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp` no longer take `dtype`. `GroupedQueryAttentionPrefillFwdOp` still does, with the reason at the definition.
- `gqa_prefill_fwd_kernel: GQAPrefillFwdKernel | GQAPrefillFwdWsPersistentCausalKernel` split into two single-valued slots (3 sites); the slot key is selected at `forward`.
- `MultiHeadAttentionFwdOp.__init__` no longer builds a kernel eagerly; it dispatches through `top::mha_fwd` + `register_fake`.
- Both composite parents declare a single output `o` and both forwards return a bare tensor, matching `F.scaled_dot_product_attention`. No fwd kernel emits a real `lse`, so nothing is dropped. `MultiHeadAttentionBwdOp` and `GroupedQueryAttentionBwdOp` keep their `lse` input and their workloads keep computing it — unchanged by this PR.

## Test plan

- [x] `pre-commit run --all-files` — 0 non-passing hooks
- [x] `python scripts/validate_manifest.py --strict` — all manifest checks passed
- [x] `pytest tests/ops/attention tests/ops/test_multi_dtype_instance.py -m smoke -q` — 160 passed, 47 deselected
- [x] `pytest <5 modified test files> tests/test_op_base.py tests/test_workload_placement.py -q` — 129 passed, including the `full`-tier `test_mha_kernel_compile`
- [x] One instance serves float16 and bfloat16: new tests assert per-dtype cache entries and the selected kernel class for GQA, MHA and paged prefill
- [x] A cold `torch.compile(fullgraph=True)` trace of MHA matches eager — the kernel is built inside the custom op, so the trace has to survive an empty cache
- [x] Dispatch identity: a probe recording the kernel class of every `Kernel.__call__` over 20 cases (GQA + MHA × 4 manifest shapes × fp16/bf16 causal, plus 4 paged branches) was byte-identical between `upstream/main` and HEAD at the point the selection logic settled; nothing touched it afterwards, and the per-dtype tests still assert the exact kernel class each op lands on

## Test node delta

| File | Base | HEAD | Delta |
| ---- | ---- | ---- | ----- |
| `tests/ops/attention/test_gqa.py` | 59 | 63 | +4 |
| `tests/ops/attention/test_gqa_prefill_paged.py` | 27 | 28 | +1 |
| `tests/ops/attention/test_mha.py` | 11 | 11 | 0 |
| `tests/ops/test_multi_dtype_instance.py` | 8 | 10 | +2 |
| `tests/test_compile.py` | 2 | 3 | +1 |
| **Total** | **107** | **115** | **+8 (+7.5%)** |

`scripts/test_node_delta.py` reports `test_gqa.py` as `Base=0`, inflating the total: the base revision of that file imports the pre-rename selector and fails collection against HEAD sources. The 59 above is a collection of the base file in a clean `upstream/main` worktree.

One node per new contract: `+4` on `test_gqa.py` is the dense-slot selector test parametrized over its four (causal, dtype) combinations plus an output-shape parity assertion — `H % H_kv == 0` keeps the manifest validator's synthetic mocks away from that op, so parity is only checked there. The rest pin one-instance-two-dtypes behaviour. `test_mha.py` nets zero: it gained the square-dense fast-path test and lost a return-shape test that strict manifest validation already covers for MHA.

## Benchmark

**Environment**: NVIDIA H200, CUDA 12.8, PyTorch 2.9.1+cu128, TileLang 0.1.11+cuda.git65dbc983

### GroupedQueryAttentionFwdOp

| Shape | dtype | TileOPs (ms) | torch-sdpa (ms) | Speedup | TFLOPS |
| ----- | ----- | ------------ | --------------- | ------- | ------ |
| q=(4, 512, 32, 128); kv=(4, 512, 8, 128) | float16 | 0.0392 | 0.0699 | 1.78× | 219.0 |
| q=(4, 512, 32, 128); kv=(4, 512, 8, 128) | bfloat16 | 0.0392 | 0.0694 | 1.77× | 218.9 |
| q=(2, 2048, 32, 128); kv=(2, 2048, 8, 128) | float16 | 0.1668 | 0.3212 | 1.93× | 412.0 |
| q=(2, 2048, 32, 128); kv=(2, 2048, 8, 128) | bfloat16 | 0.1655 | 0.3199 | 1.93× | 415.3 |
| q=(2, 512, 64, 128); kv=(2, 512, 8, 128) | float16 | 0.0389 | 0.0694 | 1.78× | 220.7 |
| q=(2, 512, 64, 128); kv=(2, 512, 8, 128) | bfloat16 | 0.0389 | 0.0691 | 1.78× | 220.7 |
| q=(1, 2048, 64, 128); kv=(1, 2048, 8, 128) | float16 | 0.1644 | 0.3206 | 1.95× | 418.1 |
| q=(1, 2048, 64, 128); kv=(1, 2048, 8, 128) | bfloat16 | 0.1630 | 0.3199 | 1.96× | 421.7 |

### MultiHeadAttentionFwdOp

| Shape | dtype | TileOPs (ms) | torch-sdpa (ms) | Speedup | TFLOPS |
| ----- | ----- | ------------ | --------------- | ------- | ------ |
| q=k=v=(4, 512, 32, 128) | float16 | 0.0453 | 0.0706 | 1.56× | 189.6 |
| q=k=v=(4, 512, 32, 128) | bfloat16 | 0.0453 | 0.0704 | 1.55× | 189.5 |
| q=k=v=(2, 2048, 32, 128) | float16 | 0.1741 | 0.3218 | 1.85× | 394.7 |
| q=k=v=(2, 2048, 32, 128) | bfloat16 | 0.1730 | 0.3193 | 1.85× | 397.2 |
| q=k=v=(2, 512, 64, 128) | float16 | 0.0456 | 0.0702 | 1.54× | 188.2 |
| q=k=v=(2, 512, 64, 128) | bfloat16 | 0.0454 | 0.0702 | 1.55× | 189.0 |
| q=k=v=(1, 2048, 64, 128) | float16 | 0.1746 | 0.3208 | 1.84× | 393.6 |
| q=k=v=(1, 2048, 64, 128) | bfloat16 | 0.1734 | 0.3221 | 1.86× | 396.2 |

### GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp

No baseline recorded by this benchmark, so no Speedup — #1837.

| Shape | dtype | TileOPs (ms) | TFLOPS |
| ----- | ----- | ------------ | ------ |
| q=(8192, 32, 256); cache=(270336, 8, 256) | float16, fused RoPE, rotary_dim=64 | 60.8977 | 146.7 |
| q=(4608, 32, 256); cache=(270336, 8, 256) | float16, fused RoPE, rotary_dim=64 | 31.0182 | 107.0 |
| q=(4096, 32, 128); cache=(36864, 8, 128) | float16, fused RoPE, full | 1.9903 | 146.8 |
| q=(2048, 8, 64); cache=(18432, 2, 64) | float16, softcap 50 | 0.1782 | 102.4 |
| q=(8192, 32, 256); cache=(270336, 8, 256) | float16, fp8_e4m3fn cache | 55.8359 | 160.0 |
| q=(4096, 32, 128); cache=(36864, 8, 128) | float16, fp8_e4m3fn cache | 2.0450 | 142.8 |
| q=(2048, 8, 64); cache=(18432, 2, 64) | float16, fp8_e4m3fn cache, softcap 50 | 0.2462 | 74.2 |

**Takeaways:** GQA beats torch-sdpa by 1.77×–1.96×, MHA by 1.54×–1.86×, across every manifest workload. Both reach 412–422 TFLOPS at seq_len 2048 against 188–221 at 512, where the workload does not fill the SMs. float16 and bfloat16 land within 1% of each other everywhere. Paged prefill's fp8-cache path beats its fp16-cache path at equal shape (55.84 vs 60.90 ms at q=(8192, 32, 256)), moving half the cache bytes.

Each cell is the row-wise minimum of two consecutive runs at HEAD on an idle GPU; the `torch-sdpa` column is the minimum of the same two runs. Paged shapes come from the manifest workload each row corresponds to — the report records `batch`/`heads`/`page_size`, not `total_q`/`physical_tokens`.

**Command:** `CUDA_VISIBLE_DEVICES=2 python -m pytest benchmarks/ops/attention/bench_gqa.py benchmarks/ops/attention/bench_mha.py -q -k "gqa_fwd_bench or paged or mha_fwd_bench"`

## Regression

HEAD against `upstream/main` on one idle H200, alternating HEAD/base/HEAD/base, co-tenant count sampled 0 before and after all four runs:

| Op | Workloads | Delta vs `upstream/main` |
| -- | --------- | ------------------------ |
| `GroupedQueryAttentionFwdOp` | 8 | −0.25% … +0.26% |
| `MultiHeadAttentionFwdOp` | 8 | +0.00% … +0.46% |
| `GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp` | 6 | −0.61% … +0.03% |

The MHA delta is the custom-op dispatch boundary: `custom_op` 0.0458 vs raw kernel 0.0457 ms at b2 s512 h64 bf16, ~0.1–0.2 µs/call.

The measuring GPU is in compute mode `Default`; exclusivity rests on the co-tenant samples above, not on the driver. An earlier round measured HEAD as up to 1.65× faster than base — a JIT-cache artifact, reproduced on `upstream/main` alone by pointing `TILELANG_CACHE_DIR` at a fresh directory and running the same benchmark twice, cold then warm. A separate attempt reported up to +121% and was discarded after `nvidia-smi` showed another process holding 40 GB / 100% util on that GPU.
