### PR TITLE
[Fix][Mamba] Validate da_cumsum's output dtype and silence a spurious race warning

### DIFF
--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -170,6 +170,33 @@ def test_da_cumsum_fwd_missing_bias_raises():
         kernel(dt, A, dt_bias=None)
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_da_cumsum_fwd_accepts_declared_output_dtypes(dtype):
+    """``dt_out`` takes any storage dtype the manifest declares."""
+    op = DaCumsumFwdOp(chunk_len=64, dtype=dtype)
+    dt = torch.rand(1, 128, 4, dtype=torch.float32, device="cuda")
+    A = -torch.rand(4, dtype=torch.float32, device="cuda")
+    dt_out, dA_cumsum = op(dt, A)
+    assert dt_out.dtype == dtype
+    assert dA_cumsum.dtype == torch.float32
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.int32, torch.float64])
+def test_da_cumsum_fwd_rejects_undeclared_output_dtype(dtype):
+    """A dtype outside the manifest union must raise, not silently cast.
+
+    ``dt_out``'s dtype is a parameter, not a property of the inputs, so
+    ``_validate_dtypes`` never sees it — the kernel is the only gate.
+    """
+    op = DaCumsumFwdOp(chunk_len=64, dtype=dtype)
+    dt = torch.rand(1, 128, 4, dtype=torch.float32, device="cuda")
+    A = -torch.rand(4, dtype=torch.float32, device="cuda")
+    with pytest.raises(ValueError, match="only supports dtypes"):
+        op(dt, A)
+
+
 
 
 class SSDChunkScanFwdTest(SSDChunkScanFwdWorkload, TestBase):

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -171,26 +171,8 @@ def test_da_cumsum_fwd_missing_bias_raises():
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-def test_da_cumsum_fwd_accepts_declared_output_dtypes(dtype):
-    """``dt_out`` takes any storage dtype the manifest declares."""
-    op = DaCumsumFwdOp(chunk_len=64, dtype=dtype)
-    dt = torch.rand(1, 128, 4, dtype=torch.float32, device="cuda")
-    A = -torch.rand(4, dtype=torch.float32, device="cuda")
-    dt_out, dA_cumsum = op(dt, A)
-    assert dt_out.dtype == dtype
-    assert dA_cumsum.dtype == torch.float32
-
-
-@pytest.mark.smoke
 def test_da_cumsum_fwd_padded_head_tile():
-    """A head count not divisible by block_h exercises the guarded store.
-
-    The write loop covers ``block_h`` heads and masks the tail with
-    ``bh_tile * block_h + i < H``. With H divisible by block_h that mask is
-    never false, so a head count of 5 against block_h=4 is the only shape that
-    reaches the partial tile.
-    """
+    """Five heads against block_h=4 is the only shape reaching the masked tail."""
     batch, n_heads, chunk_len, num_chunks = 1, 5, 64, 2
     seq_len = chunk_len * num_chunks
     op = DaCumsumFwdOp(chunk_len=chunk_len, dtype=torch.float32)
@@ -210,14 +192,12 @@ def test_da_cumsum_fwd_padded_head_tile():
 def test_da_cumsum_fwd_rejects_undeclared_output_dtype(dtype):
     """A dtype outside the manifest union must raise, not silently cast.
 
-    ``dt_out``'s dtype is a parameter, not a property of the inputs, so
-    ``_validate_dtypes`` never sees it. The op enforces the union because the
-    manifest is backend-independent; a kernel-only check would let a
-    ``kernel_map`` override accept a dtype the spec forbids.
+    The op is the gate, not the kernel: the manifest is backend-independent, so
+    a kernel-only check would let a ``kernel_map`` override accept a dtype the
+    spec forbids.
     """
     with pytest.raises(ValueError, match="dt_out dtype must be one of"):
         DaCumsumFwdOp(chunk_len=64, dtype=dtype)
-
 
 
 

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -183,18 +183,40 @@ def test_da_cumsum_fwd_accepts_declared_output_dtypes(dtype):
 
 
 @pytest.mark.smoke
+def test_da_cumsum_fwd_padded_head_tile():
+    """A head count not divisible by block_h exercises the guarded store.
+
+    The write loop covers ``block_h`` heads and masks the tail with
+    ``bh_tile * block_h + i < H``. With H divisible by block_h that mask is
+    never false, so a head count of 5 against block_h=4 is the only shape that
+    reaches the partial tile.
+    """
+    batch, n_heads, chunk_len, num_chunks = 1, 5, 64, 2
+    seq_len = chunk_len * num_chunks
+    op = DaCumsumFwdOp(chunk_len=chunk_len, dtype=torch.float32)
+    dt = torch.rand(batch, seq_len, n_heads, dtype=torch.float32, device="cuda")
+    A = -torch.rand(n_heads, dtype=torch.float32, device="cuda")
+
+    dt_out, dA_cumsum = op(dt, A)
+    ref_dt, ref_cumsum = da_cumsum_fwd_ref(
+        dt, A, num_chunks, chunk_len, dtype=torch.float32,
+    )
+    torch.testing.assert_close(dt_out, ref_dt, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(dA_cumsum, ref_cumsum, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.smoke
 @pytest.mark.parametrize("dtype", [torch.int32, torch.float64])
 def test_da_cumsum_fwd_rejects_undeclared_output_dtype(dtype):
     """A dtype outside the manifest union must raise, not silently cast.
 
     ``dt_out``'s dtype is a parameter, not a property of the inputs, so
-    ``_validate_dtypes`` never sees it — the kernel is the only gate.
+    ``_validate_dtypes`` never sees it. The op enforces the union because the
+    manifest is backend-independent; a kernel-only check would let a
+    ``kernel_map`` override accept a dtype the spec forbids.
     """
-    op = DaCumsumFwdOp(chunk_len=64, dtype=dtype)
-    dt = torch.rand(1, 128, 4, dtype=torch.float32, device="cuda")
-    A = -torch.rand(4, dtype=torch.float32, device="cuda")
-    with pytest.raises(ValueError, match="only supports dtypes"):
-        op(dt, A)
+    with pytest.raises(ValueError, match="dt_out dtype must be one of"):
+        DaCumsumFwdOp(chunk_len=64, dtype=dtype)
 
 
 

--- a/tileops/kernels/mamba/da_cumsum.py
+++ b/tileops/kernels/mamba/da_cumsum.py
@@ -146,10 +146,9 @@ def _da_cumsum_fwd_kernel(
 
                 # ── Step 3: write outputs ─────────────────────────────────────
                 for i, j in T.Parallel(block_h, Q):
-                    bh = bh_tile * block_h + i
-                    with T.If(bh < H), T.Then():
-                        dt_out[bb, bh, bc, j]    = T.cast(dt_shared[i, j], dtype)  # Cast to dtype for storage
-                        dA_cumsum[bb, bh, bc, j] = dA_shared[i, j]
+                    with T.If(bh_tile * block_h + i < H), T.Then():
+                        dt_out[bb, bh_tile * block_h + i, bc, j] = T.cast(dt_shared[i, j], dtype)
+                        dA_cumsum[bb, bh_tile * block_h + i, bc, j] = dA_shared[i, j]
 
         return main
 
@@ -228,6 +227,11 @@ class DaCumsumFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
+    #: Storage dtypes ``dt_out`` may take. ``dt`` and ``A`` are always float32
+    #: and the prefix sum is computed in float32, so this constrains only the
+    #: output cast — which is why it cannot be derived from the inputs.
+    SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
     def __init__(
         self,
         batch: int,
@@ -244,6 +248,11 @@ class DaCumsumFwdKernel(Kernel):
         tune: bool = False,
     ) -> None:
         super().__init__()
+        if dtype not in self.SUPPORTED_DTYPES:
+            supported = ", ".join(str(dt) for dt in self.SUPPORTED_DTYPES)
+            raise ValueError(
+                f"{self.__class__.__name__} only supports dtypes [{supported}], got {dtype}"
+            )
         self.batch = batch
         self.num_chunks = num_chunks
         self.chunk_len = chunk_len

--- a/tileops/kernels/mamba/da_cumsum.py
+++ b/tileops/kernels/mamba/da_cumsum.py
@@ -227,9 +227,9 @@ class DaCumsumFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: Storage dtypes ``dt_out`` may take. ``dt`` and ``A`` are always float32
-    #: and the prefix sum is computed in float32, so this constrains only the
-    #: output cast — which is why it cannot be derived from the inputs.
+    #: This backend's own capability for the ``dt_out`` cast. The manifest
+    #: union is enforced by the op; a backend may support a narrower set, and
+    #: declines the call by raising here.
     SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
     def __init__(

--- a/tileops/kernels/mamba/da_cumsum.py
+++ b/tileops/kernels/mamba/da_cumsum.py
@@ -227,9 +227,8 @@ class DaCumsumFwdKernel(Kernel):
 
     supported_archs: list[int] = [80, 86, 89, 90]
 
-    #: This backend's own capability for the ``dt_out`` cast. The manifest
-    #: union is enforced by the op; a backend may support a narrower set, and
-    #: declines the call by raising here.
+    #: This backend's own capability, which may be narrower than the manifest
+    #: union the op enforces.
     SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 
     def __init__(

--- a/tileops/ops/da_cumsum.py
+++ b/tileops/ops/da_cumsum.py
@@ -10,6 +10,13 @@ from .op_base import Op
 __all__ = ["DaCumsumFwdOp"]
 
 
+#: Storage dtypes ``dt_out`` may take, per the manifest ``outputs.dt_out``
+#: union. ``dt`` and ``A`` are always float32 and the prefix sum runs in
+#: float32, so this constrains only the output cast — no input tensor supplies
+#: it, which is why ``_validate_dtypes`` cannot be the gate.
+_DT_OUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
 class DaCumsumFwdOp(Op):
     """Mamba-2 dA_cumsum forward operator.
 
@@ -43,6 +50,12 @@ class DaCumsumFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
+        if dtype not in _DT_OUT_DTYPES:
+            supported = ", ".join(str(dt) for dt in _DT_OUT_DTYPES)
+            raise ValueError(
+                f"{type(self).__name__} dt_out dtype must be one of "
+                f"[{supported}], got {dtype}"
+            )
         self.batch = None
         self.num_chunks = None
         self.chunk_len = chunk_len

--- a/tileops/ops/da_cumsum.py
+++ b/tileops/ops/da_cumsum.py
@@ -16,10 +16,8 @@ __all__ = ["DaCumsumFwdOp"]
 def _dt_out_dtypes() -> tuple:
     """Storage dtypes ``dt_out`` may take, read from the manifest.
 
-    ``dt`` and ``A`` are always float32 and the prefix sum runs in float32, so
-    the ``dtype`` parameter constrains only the output cast. No input tensor
-    supplies it, which is why ``_validate_dtypes`` cannot be the gate — and why
-    the union is read from the spec rather than restated here.
+    No input tensor supplies this dtype — ``dt`` and ``A`` are always float32 —
+    so ``_validate_dtypes`` cannot be the gate.
     """
     expr = load_manifest()["DaCumsumFwdOp"]["signature"]["outputs"]["dt_out"]["dtype"]
     return tuple(getattr(torch, name.strip()) for name in expr.split("|"))

--- a/tileops/ops/da_cumsum.py
+++ b/tileops/ops/da_cumsum.py
@@ -1,20 +1,28 @@
+import functools
 from typing import Dict, Optional, Tuple
 
 import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.mamba import DaCumsumFwdKernel
+from tileops.manifest import load_manifest
 
 from .op_base import Op
 
 __all__ = ["DaCumsumFwdOp"]
 
 
-#: Storage dtypes ``dt_out`` may take, per the manifest ``outputs.dt_out``
-#: union. ``dt`` and ``A`` are always float32 and the prefix sum runs in
-#: float32, so this constrains only the output cast — no input tensor supplies
-#: it, which is why ``_validate_dtypes`` cannot be the gate.
-_DT_OUT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+@functools.lru_cache(maxsize=1)
+def _dt_out_dtypes() -> tuple:
+    """Storage dtypes ``dt_out`` may take, read from the manifest.
+
+    ``dt`` and ``A`` are always float32 and the prefix sum runs in float32, so
+    the ``dtype`` parameter constrains only the output cast. No input tensor
+    supplies it, which is why ``_validate_dtypes`` cannot be the gate — and why
+    the union is read from the spec rather than restated here.
+    """
+    expr = load_manifest()["DaCumsumFwdOp"]["signature"]["outputs"]["dt_out"]["dtype"]
+    return tuple(getattr(torch, name.strip()) for name in expr.split("|"))
 
 
 class DaCumsumFwdOp(Op):
@@ -50,8 +58,9 @@ class DaCumsumFwdOp(Op):
         tune: bool = False,
         kernel_map: Optional[Dict[str, Kernel]] = None,
     ):
-        if dtype not in _DT_OUT_DTYPES:
-            supported = ", ".join(str(dt) for dt in _DT_OUT_DTYPES)
+        declared = _dt_out_dtypes()
+        if dtype not in declared:
+            supported = ", ".join(str(dt) for dt in declared)
             raise ValueError(
                 f"{type(self).__name__} dt_out dtype must be one of "
                 f"[{supported}], got {dtype}"


### PR DESCRIPTION
`DaCumsumFwdOp.dtype` is a constructor parameter by design: `dt` and `A` are always float32 and the prefix sum runs in float32, so `dtype` chooses only how `dt_out` is stored, which no input tensor determines.

### The dtype union was unenforced

The manifest declares `dt_out` as `float16 | bfloat16 | float32`. Nothing checked it — `_validate_dtypes` inspects input tensors, and this is a parameter — so `dtype=torch.int32` was accepted and returned an int32 `dt_out`, silently truncating the float result.

The op enforces the union, read from the manifest rather than restated in code. `Kernel.SUPPORTED_DTYPES` stays as that backend's own capability, which may be narrower: the manifest is backend-independent, so a kernel-only check would let a `kernel_map` override accept a dtype the spec forbids.

### A spurious race warning

The output store bound `bh = bh_tile * block_h + i` before indexing with it. TileLang's parallel-loop verifier does not substitute the binding, so it read the store as `i`-independent and warned about a data race on every compile. Indexing with the expression directly emits byte-identical CUDA and no warning. The suite now reports no race warnings at all; this kernel was the only source.

### Tests

A five-head case against `block_h=4` — every existing workload uses a head count divisible by it, so the guarded partial-tile store the index change touches was never executed.

`pytest tests/ops/ -m smoke`: 2467 passed, 16 skipped. `validate_manifest --strict`: clean.