### PR TITLE
[Refactor][Attention] cache dense-prefill kernels in the square wrapper

### DIFF
--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -18,12 +18,14 @@ from tileops.ops import (
     GroupedQueryAttentionPrefillFwdOp,
     GroupedQueryAttentionPrefillVarlenFwdOp,
 )
+from tileops.ops.attention import gqa as gqa_module
 from tileops.ops.attention.gqa import (
     _select_gqa_fwd_kernel_cls,
     _select_gqa_paged_prefill_kernel_keys,
     _select_gqa_prefill_dense_kernel_key,
     _select_gqa_prefill_kernel_key,
 )
+from tileops.ops.op_base import Op
 from tileops.utils import is_h200
 from workloads.attention.gqa import (
     GroupedQueryAttentionBwdWorkload,
@@ -314,8 +316,7 @@ def test_gqa_prefill_fwd_square_uses_square_fast_path(dtype: torch.dtype) -> Non
         backend="dense",
     )
 
-    assert op._uses_square_dense_fast_path()
-    assert op._get_square_dense_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
+    assert op._get_dense_prefill_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
 
 
 @pytest.mark.parametrize("sm_scale, softcap", [
@@ -344,8 +345,7 @@ def test_gqa_prefill_fwd_square_feature_variants_use_square_fast_path(
         backend="dense",
     )
 
-    assert op._uses_square_dense_fast_path()
-    assert op._get_square_dense_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
+    assert op._get_dense_prefill_kernel().__class__.__name__ == "GQAFwdWsPersistentCausalKernel"
 
 
 @pytest.mark.parametrize("seq_len_q, seq_len_kv, sm_scale, softcap", [
@@ -375,8 +375,8 @@ def test_gqa_prefill_fwd_q_lt_kv_uses_prefill_ws_kernel(
         backend="dense",
     )
 
-    assert not op._uses_square_dense_fast_path()
-    assert op._get_dense_kernel().__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
+    assert op._get_dense_prefill_kernel().__class__.__name__ == (
+        "GQAPrefillFwdWsPersistentCausalKernel")
 
 
 @pytest.mark.smoke
@@ -501,8 +501,7 @@ def test_gqa_prefill_fwd_explicit_dense_can_skip_uniform_validation(
     monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
     monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
     monkeypatch.setattr(op, "_uniform_cu_seqlens", fail_uniform_check)
-    monkeypatch.setattr(op, "_uses_square_dense_fast_path", lambda: False)
-    monkeypatch.setattr(op, "_get_dense_kernel", lambda: fake_dense_kernel)
+    monkeypatch.setattr(op, "_get_dense_prefill_kernel", lambda: fake_dense_kernel)
 
     out = op(q, k, v, cu, cu, q_scale, k_scale, v_scale)
     assert out.shape == q.shape
@@ -525,28 +524,65 @@ def test_gqa_prefill_fwd_auto_backend_requires_uniform_validation() -> None:
 
 
 @pytest.mark.smoke
-def test_gqa_fwd_bshd_wrapper_uses_dense_kernel_without_uniform_check(
+def test_gqa_fwd_bshd_wrapper_caches_its_own_kernel_and_holds_no_child_op(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The wrapper reaches a kernel through the dense-prefill build step alone."""
     batch, seq_len, heads, heads_kv, dim = 2, 64, 8, 2, 64
     q = torch.empty(batch, seq_len, heads, dim, dtype=torch.float16)
     k = torch.empty(batch, seq_len, heads_kv, dim, dtype=torch.float16)
     v = torch.empty_like(k)
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True)
-
-    def fail_uniform_check(*args: object, **kwargs: object) -> bool:
-        pytest.fail("BSHD wrapper should not inspect packed cu_seqlens")
+    builds = 0
 
     def fake_dense_kernel(*args: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(args[0])
 
-    prefill_op = op._prefill_op_for(torch.float16)
-    monkeypatch.setattr(prefill_op, "_uniform_cu_seqlens", fail_uniform_check)
-    monkeypatch.setattr(prefill_op, "_uses_square_dense_fast_path", lambda: False)
-    monkeypatch.setattr(prefill_op, "_get_dense_kernel", lambda: fake_dense_kernel)
+    def count_build(*args: object, **kwargs: object) -> object:
+        nonlocal builds
+        builds += 1
+        return fake_dense_kernel
 
-    out = op(q, k, v)
-    assert out.shape == q.shape
+    monkeypatch.setattr(gqa_module, "_build_gqa_prefill_dense_kernel", count_build)
+
+    assert op(q, k, v).shape == q.shape
+    assert op(q, k, v).shape == q.shape
+
+    assert builds == 1
+    assert list(op._kernel_cache) == [torch.float16]
+    assert not any(isinstance(value, Op) for value in vars(op).values())
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("batch, seq_len, heads, heads_kv, dim", [
+    pytest.param(4, 512, 32, 8, 128, id="square-fast-path"),
+    pytest.param(1, 256, 8, 2, 128, id="dense-causal"),
+    pytest.param(1, 128, 8, 2, 64, id="dense-dim64"),
+])
+def test_gqa_fwd_bshd_wrapper_kernel_matches_packed_dense_prefill(
+    batch: int,
+    seq_len: int,
+    heads: int,
+    heads_kv: int,
+    dim: int,
+    dtype: torch.dtype,
+) -> None:
+    """The wrapper lands on the same kernel the packed dense prefill op would."""
+    wrapper = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True)
+    packed = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+        is_causal=True,
+        dtype=dtype,
+        backend="dense",
+    )
+
+    assert wrapper._get_kernel(dtype).__class__ is packed._get_dense_prefill_kernel().__class__
 
 
 @pytest.mark.smoke
@@ -585,8 +621,7 @@ def test_gqa_prefill_fwd_auto_backend_checks_uniform_cu_seqlens(
     monkeypatch.setattr(op, "_validate_dtypes", lambda *args, **kwargs: None)
     monkeypatch.setattr(op, "_validate_common_shapes", lambda *args, **kwargs: None)
     monkeypatch.setattr(op, "_uniform_cu_seqlens", count_uniform_check)
-    monkeypatch.setattr(op, "_uses_square_dense_fast_path", lambda: False)
-    monkeypatch.setattr(op, "_get_dense_kernel", lambda: fake_dense_kernel)
+    monkeypatch.setattr(op, "_get_dense_prefill_kernel", lambda: fake_dense_kernel)
 
     out = op(q, k, v, cu_q, cu_kv, q_scale, k_scale, v_scale)
     assert out.shape == q.shape
@@ -697,7 +732,8 @@ def test_gqa_prefill_fwd_ws_path_matches_reference(
         sm_scale=sm_scale,
         softcap=softcap,
     )
-    assert op._get_dense_kernel().__class__.__name__ == "GQAPrefillFwdWsPersistentCausalKernel"
+    assert op._get_dense_prefill_kernel().__class__.__name__ == (
+        "GQAPrefillFwdWsPersistentCausalKernel")
     output = op(*packed_inputs).view(batch, seq_len_q, heads, dim)
 
     torch.testing.assert_close(output, ref, atol=atol, rtol=rtol)

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -560,7 +560,7 @@ def test_gqa_fwd_bshd_wrapper_caches_its_own_kernel_and_holds_no_child_op(
     pytest.param(1, 256, 8, 2, 128, id="dense-causal"),
     pytest.param(1, 128, 8, 2, 64, id="dense-dim64"),
 ])
-def test_gqa_fwd_bshd_wrapper_kernel_matches_packed_dense_prefill(
+def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     batch: int,
     seq_len: int,
     heads: int,
@@ -568,8 +568,19 @@ def test_gqa_fwd_bshd_wrapper_kernel_matches_packed_dense_prefill(
     dim: int,
     dtype: torch.dtype,
 ) -> None:
-    """The wrapper lands on the same kernel the packed dense prefill op would."""
-    wrapper = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, True)
+    """Both callers build the chosen slot with the arguments that slot expects.
+
+    Comparing the built classes alone would miss a mistyped ``max_seqlen_kv``,
+    ``sm_scale`` or ``softcap``. Two assertions are needed and neither implies
+    the other: the recorded call must match the slot's documented argument
+    list, which guards the shared build step both callers run; and the two
+    callers must record the same call, which guards each caller's own argument
+    assembly. The expected slot is not hard-coded — whichever branch the
+    machine's fast-path contract selects, both sides must select it alike.
+    """
+    sm_scale, softcap = 0.125, 3.5
+    wrapper = GroupedQueryAttentionFwdOp(
+        batch, heads, heads_kv, seq_len, dim, True, sm_scale=sm_scale, softcap=softcap)
     packed = GroupedQueryAttentionPrefillFwdOp(
         batch=batch,
         heads=heads,
@@ -579,10 +590,67 @@ def test_gqa_fwd_bshd_wrapper_kernel_matches_packed_dense_prefill(
         max_seqlen_kv=seq_len,
         is_causal=True,
         dtype=dtype,
+        sm_scale=sm_scale,
+        softcap=softcap,
         backend="dense",
     )
 
-    assert wrapper._get_kernel(dtype).__class__ is packed._get_dense_prefill_kernel().__class__
+    def record_builds(op: Op) -> list:
+        calls: list = []
+
+        def recorder(slot: str):
+
+            def build(*args: object, **kwargs: object) -> str:
+                calls.append((slot, args, kwargs))
+                return f"built:{slot}"
+
+            return build
+
+        for slot in op.kernel_map:
+            op.kernel_map[slot] = recorder(slot)
+        return calls
+
+    wrapper_calls = record_builds(wrapper)
+    packed_calls = record_builds(packed)
+
+    wrapper._get_kernel(dtype)
+    packed._get_dense_prefill_kernel()
+
+    assert len(wrapper_calls) == 1
+    slot, args, kwargs = wrapper_calls[0]
+    # The square slot derives its key length from a single seq_len; the dense
+    # slots take both. Getting this wrong is the failure the test exists for.
+    if slot == "gqa_prefill_square_fwd_kernel":
+        assert args == (batch, heads, heads_kv, seq_len, dim, True, dtype)
+    else:
+        assert args == (batch, heads, heads_kv, seq_len, seq_len, dim, True, dtype)
+    assert kwargs == {"sm_scale": sm_scale, "softcap": softcap, "tune": False}
+
+    assert wrapper_calls == packed_calls
+
+
+@pytest.mark.smoke
+def test_build_gqa_prefill_dense_kernel_rejects_unsupported_dtype() -> None:
+    """The build step refuses an element type neither selector supports.
+
+    Both selectors decline rather than raise, so without this guard an
+    unsupported element type would quietly build the generic dense slot.
+    """
+    with pytest.raises(ValueError, match="float16 or torch.bfloat16"):
+        gqa_module._build_gqa_prefill_dense_kernel(
+            {},
+            batch=1,
+            heads=8,
+            heads_kv=2,
+            max_seqlen_q=128,
+            max_seqlen_kv=128,
+            dim=128,
+            is_causal=True,
+            dtype=torch.float32,
+            sm_scale=1.0,
+            softcap=0.0,
+            tune=False,
+        )
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -1,4 +1,5 @@
 
+import dataclasses
 from typing import Optional
 
 import pytest
@@ -528,7 +529,8 @@ def _holds_op(value: object, depth: int = 0) -> bool:
 
     The shape to catch is a cache of child ops, not an op bound directly to an
     attribute, so testing the attribute value alone would pass on a dict of
-    them. Descends two levels like ``op_base._iter_kernels``.
+    them. Descends the same containers as ``op_base._iter_kernels``, records
+    included, to the same depth.
     """
     if isinstance(value, Op):
         return True
@@ -538,7 +540,22 @@ def _holds_op(value: object, depth: int = 0) -> bool:
         return any(_holds_op(item, depth + 1) for item in value.values())
     if isinstance(value, (tuple, list)):
         return any(_holds_op(item, depth + 1) for item in value)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return any(
+            _holds_op(getattr(value, field.name), depth + 1)
+            for field in dataclasses.fields(value))
     return False
+
+
+def _op_valued_attrs(op: Op) -> list:
+    """Names of *op*'s attributes that are an ``Op`` or reach one.
+
+    Scans ``dir`` rather than ``vars`` for the same reason ``Op.autotune``
+    does: an attribute reached through a property or bound on the class would
+    otherwise escape.
+    """
+    return sorted(name for name in dir(op)
+                  if not name.startswith("__") and _holds_op(getattr(op, name, None)))
 
 
 @pytest.mark.smoke
@@ -568,14 +585,16 @@ def test_gqa_fwd_bshd_wrapper_caches_its_own_kernel_and_holds_no_child_op(
 
     assert builds == 1
     assert list(op._kernel_cache) == [torch.float16]
-    assert not any(_holds_op(value) for value in vars(op).values())
+    assert _op_valued_attrs(op) == []
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("batch, seq_len, heads, heads_kv, dim, h200, expected_slot", [
     pytest.param(4, 512, 32, 8, 128, True, "gqa_prefill_square_fwd_kernel", id="square"),
-    pytest.param(4, 512, 32, 8, 128, False, "gqa_prefill_causal_fwd_kernel", id="dense-causal"),
-    pytest.param(1, 128, 8, 2, 64, False, "gqa_prefill_fwd_kernel", id="dense-dim64"),
+    pytest.param(4, 512, 32, 8, 128, False, "gqa_prefill_causal_fwd_kernel", id="declines-off-h200"),
+    pytest.param(1, 256, 8, 2, 128, True, "gqa_prefill_causal_fwd_kernel", id="declines-work-items"),
+    pytest.param(4, 384, 64, 16, 128, True, "gqa_prefill_causal_fwd_kernel", id="declines-m-blocks"),
+    pytest.param(4, 512, 32, 8, 64, True, "gqa_prefill_fwd_kernel", id="declines-dim"),
 ])
 def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     monkeypatch: pytest.MonkeyPatch,
@@ -596,9 +615,15 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     callers must record the same call, which guards each caller's own argument
     assembly.
 
-    ``is_h200`` is pinned so each branch is reached on every machine. Left to
-    the runner, the square case would fall through to a dense slot off H200 and
-    the square argument list would go unasserted there.
+    ``is_h200`` is pinned so each case is reached on every machine. Left to the
+    runner, the square argument list would go unasserted off H200. Each case
+    isolates one guard of the fast-path contract — accepted, then declined in
+    turn for the chip, for work items below the SM count, for an odd block
+    count, and for head dim. A geometry must reach the guard it names, or an
+    earlier guard masks it: pinning the chip ``False`` throughout short-circuits
+    the contract at its second guard, and a short sequence declines on block
+    parity before head dim is ever read. The first two cases share one
+    geometry, so the chip is demonstrably what drives the choice.
 
     One element type suffices: neither selector branches between ``float16``
     and ``bfloat16``, so a second would add nodes without a distinct path.

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -547,6 +547,26 @@ def _holds_op(value: object, depth: int = 0) -> bool:
     return False
 
 
+def _record_kernel_builds(op: Op) -> list:
+    """Replace each of *op*'s kernel slots with a recorder of its build call.
+
+    Returns the list the recorders append ``(slot, args, kwargs)`` to.
+    """
+    calls: list = []
+
+    def recorder(slot: str):
+
+        def build(*args: object, **kwargs: object) -> str:
+            calls.append((slot, args, kwargs))
+            return f"built:{slot}"
+
+        return build
+
+    for slot in op.kernel_map:
+        op.kernel_map[slot] = recorder(slot)
+    return calls
+
+
 def _op_valued_attrs(op: Op) -> list:
     """Names of *op*'s attributes that are an ``Op`` or reach one.
 
@@ -647,23 +667,8 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
         backend="dense",
     )
 
-    def record_builds(op: Op) -> list:
-        calls: list = []
-
-        def recorder(slot: str):
-
-            def build(*args: object, **kwargs: object) -> str:
-                calls.append((slot, args, kwargs))
-                return f"built:{slot}"
-
-            return build
-
-        for slot in op.kernel_map:
-            op.kernel_map[slot] = recorder(slot)
-        return calls
-
-    wrapper_calls = record_builds(wrapper)
-    packed_calls = record_builds(packed)
+    wrapper_calls = _record_kernel_builds(wrapper)
+    packed_calls = _record_kernel_builds(packed)
 
     wrapper._get_kernel(dtype)
     packed._get_dense_prefill_kernel()
@@ -680,6 +685,56 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     assert kwargs == {"sm_scale": sm_scale, "softcap": softcap, "tune": False}
 
     assert wrapper_calls == packed_calls
+
+
+@pytest.mark.smoke
+def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
+    """A non-square prefill passes its two sequence lengths in their own places.
+
+    The square wrapper has ``max_seqlen_q == max_seqlen_kv``, so the parity
+    test above cannot tell the two apart; only a geometry where they differ
+    can. Packed-only for that reason — the wrapper cannot express it.
+    """
+    batch, heads, heads_kv, dim = 1, 8, 2, 128
+    max_seqlen_q, max_seqlen_kv = 128, 256
+    packed = GroupedQueryAttentionPrefillFwdOp(
+        batch=batch,
+        heads=heads,
+        heads_kv=heads_kv,
+        dim=dim,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=max_seqlen_kv,
+        is_causal=True,
+        dtype=torch.float16,
+        backend="dense",
+    )
+    calls = _record_kernel_builds(packed)
+
+    packed._get_dense_prefill_kernel()
+
+    assert calls == [("gqa_prefill_causal_fwd_kernel",
+                      (batch, heads, heads_kv, max_seqlen_q, max_seqlen_kv, dim, True,
+                       torch.float16), {
+                           "sm_scale": packed.sm_scale,
+                           "softcap": 0.0,
+                           "tune": False
+                       })]
+
+
+@pytest.mark.smoke
+def test_gqa_fwd_bshd_wrapper_ctor_rejects_non_positive_dims() -> None:
+    """The wrapper validates at construction because nothing downstream does.
+
+    The deleted child op used to raise on these at first forward. The build
+    step that replaced it reaches ``heads % heads_kv`` instead, so a zero
+    ``heads_kv`` would surface as ``ZeroDivisionError``.
+    """
+    with pytest.raises(ValueError, match="heads_kv must be positive"):
+        GroupedQueryAttentionFwdOp(1, 8, 0, 64, 64, True)
+    with pytest.raises(ValueError, match="batch must be positive"):
+        GroupedQueryAttentionFwdOp(0, 8, 2, 64, 64, True)
+    with pytest.raises(ValueError, match="seq_len must be positive"):
+        GroupedQueryAttentionFwdOp(1, 8, 2, 0, 64, True)
 
 
 @pytest.mark.smoke

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -523,6 +523,24 @@ def test_gqa_prefill_fwd_auto_backend_requires_uniform_validation() -> None:
         )
 
 
+def _holds_op(value: object, depth: int = 0) -> bool:
+    """Whether *value* is an ``Op`` or reaches one through its containers.
+
+    The shape to catch is a cache of child ops, not an op bound directly to an
+    attribute, so testing the attribute value alone would pass on a dict of
+    them. Descends two levels like ``op_base._iter_kernels``.
+    """
+    if isinstance(value, Op):
+        return True
+    if depth >= 2:
+        return False
+    if isinstance(value, dict):
+        return any(_holds_op(item, depth + 1) for item in value.values())
+    if isinstance(value, (tuple, list)):
+        return any(_holds_op(item, depth + 1) for item in value)
+    return False
+
+
 @pytest.mark.smoke
 def test_gqa_fwd_bshd_wrapper_caches_its_own_kernel_and_holds_no_child_op(
     monkeypatch: pytest.MonkeyPatch,
@@ -550,35 +568,44 @@ def test_gqa_fwd_bshd_wrapper_caches_its_own_kernel_and_holds_no_child_op(
 
     assert builds == 1
     assert list(op._kernel_cache) == [torch.float16]
-    assert not any(isinstance(value, Op) for value in vars(op).values())
+    assert not any(_holds_op(value) for value in vars(op).values())
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("batch, seq_len, heads, heads_kv, dim", [
-    pytest.param(4, 512, 32, 8, 128, id="square-fast-path"),
-    pytest.param(1, 256, 8, 2, 128, id="dense-causal"),
-    pytest.param(1, 128, 8, 2, 64, id="dense-dim64"),
+@pytest.mark.parametrize("batch, seq_len, heads, heads_kv, dim, h200, expected_slot", [
+    pytest.param(4, 512, 32, 8, 128, True, "gqa_prefill_square_fwd_kernel", id="square"),
+    pytest.param(4, 512, 32, 8, 128, False, "gqa_prefill_causal_fwd_kernel", id="dense-causal"),
+    pytest.param(1, 128, 8, 2, 64, False, "gqa_prefill_fwd_kernel", id="dense-dim64"),
 ])
 def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
+    monkeypatch: pytest.MonkeyPatch,
     batch: int,
     seq_len: int,
     heads: int,
     heads_kv: int,
     dim: int,
-    dtype: torch.dtype,
+    h200: bool,
+    expected_slot: str,
 ) -> None:
-    """Both callers build the chosen slot with the arguments that slot expects.
+    """Both callers build the expected slot with the arguments that slot expects.
 
     Comparing the built classes alone would miss a mistyped ``max_seqlen_kv``,
     ``sm_scale`` or ``softcap``. Two assertions are needed and neither implies
     the other: the recorded call must match the slot's documented argument
     list, which guards the shared build step both callers run; and the two
     callers must record the same call, which guards each caller's own argument
-    assembly. The expected slot is not hard-coded — whichever branch the
-    machine's fast-path contract selects, both sides must select it alike.
+    assembly.
+
+    ``is_h200`` is pinned so each branch is reached on every machine. Left to
+    the runner, the square case would fall through to a dense slot off H200 and
+    the square argument list would go unasserted there.
+
+    One element type suffices: neither selector branches between ``float16``
+    and ``bfloat16``, so a second would add nodes without a distinct path.
     """
+    dtype = torch.float16
     sm_scale, softcap = 0.125, 3.5
+    monkeypatch.setattr(gqa_module, "is_h200", lambda: h200)
     wrapper = GroupedQueryAttentionFwdOp(
         batch, heads, heads_kv, seq_len, dim, True, sm_scale=sm_scale, softcap=softcap)
     packed = GroupedQueryAttentionPrefillFwdOp(
@@ -618,9 +645,10 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
 
     assert len(wrapper_calls) == 1
     slot, args, kwargs = wrapper_calls[0]
-    # The square slot derives its key length from a single seq_len; the dense
-    # slots take both. Getting this wrong is the failure the test exists for.
-    if slot == "gqa_prefill_square_fwd_kernel":
+    assert slot == expected_slot
+    # The square slot takes one seq_len; the dense slots take q and kv both.
+    # Getting this wrong is the failure the test exists for.
+    if expected_slot == "gqa_prefill_square_fwd_kernel":
         assert args == (batch, heads, heads_kv, seq_len, dim, True, dtype)
     else:
         assert args == (batch, heads, heads_kv, seq_len, seq_len, dim, True, dtype)

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -525,13 +525,8 @@ def test_gqa_prefill_fwd_auto_backend_requires_uniform_validation() -> None:
 
 
 def _holds_op(value: object, depth: int = 0) -> bool:
-    """Whether *value* is an ``Op`` or reaches one through its containers.
-
-    The shape to catch is a cache of child ops, not an op bound directly to an
-    attribute, so testing the attribute value alone would pass on a dict of
-    them. Descends the same containers as ``op_base._iter_kernels``, records
-    included, to the same depth.
-    """
+    """Whether *value* is or reaches an ``Op``, descending the same containers
+    and depth as ``op_base._iter_kernels``."""
     if isinstance(value, Op):
         return True
     if depth >= 2:
@@ -568,12 +563,8 @@ def _record_kernel_builds(op: Op) -> list:
 
 
 def _op_valued_attrs(op: Op) -> list:
-    """Names of *op*'s attributes that are an ``Op`` or reach one.
-
-    Scans ``dir`` rather than ``vars`` for the same reason ``Op.autotune``
-    does: an attribute reached through a property or bound on the class would
-    otherwise escape.
-    """
+    """Names of *op*'s attributes that are or reach an ``Op``; scans ``dir``
+    so properties and class-bound attributes are covered."""
     return sorted(name for name in dir(op)
                   if not name.startswith("__") and _holds_op(getattr(op, name, None)))
 
@@ -626,27 +617,11 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     h200: bool,
     expected_slot: str,
 ) -> None:
-    """Both callers build the expected slot with the arguments that slot expects.
+    """Both callers record the identical build call for the expected slot.
 
-    Comparing the built classes alone would miss a mistyped ``max_seqlen_kv``,
-    ``sm_scale`` or ``softcap``. Two assertions are needed and neither implies
-    the other: the recorded call must match the slot's documented argument
-    list, which guards the shared build step both callers run; and the two
-    callers must record the same call, which guards each caller's own argument
-    assembly.
-
-    ``is_h200`` is pinned so each case is reached on every machine. Left to the
-    runner, the square argument list would go unasserted off H200. Each case
-    isolates one guard of the fast-path contract — accepted, then declined in
-    turn for the chip, for work items below the SM count, for an odd block
-    count, and for head dim. A geometry must reach the guard it names, or an
-    earlier guard masks it: pinning the chip ``False`` throughout short-circuits
-    the contract at its second guard, and a short sequence declines on block
-    parity before head dim is ever read. The first two cases share one
-    geometry, so the chip is demonstrably what drives the choice.
-
-    One element type suffices: neither selector branches between ``float16``
-    and ``bfloat16``, so a second would add nodes without a distinct path.
+    ``is_h200`` is pinned so every case runs on any machine. Each case's
+    geometry reaches the guard its id names — an earlier guard would mask
+    it otherwise.
     """
     dtype = torch.float16
     sm_scale, softcap = 0.125, 3.5
@@ -677,7 +652,6 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
     slot, args, kwargs = wrapper_calls[0]
     assert slot == expected_slot
     # The square slot takes one seq_len; the dense slots take q and kv both.
-    # Getting this wrong is the failure the test exists for.
     if expected_slot == "gqa_prefill_square_fwd_kernel":
         assert args == (batch, heads, heads_kv, seq_len, dim, True, dtype)
     else:
@@ -689,12 +663,8 @@ def test_gqa_fwd_bshd_wrapper_builds_kernel_exactly_as_packed_dense_prefill(
 
 @pytest.mark.smoke
 def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
-    """A non-square prefill passes its two sequence lengths in their own places.
-
-    The square wrapper has ``max_seqlen_q == max_seqlen_kv``, so the parity
-    test above cannot tell the two apart; only a geometry where they differ
-    can. Packed-only for that reason — the wrapper cannot express it.
-    """
+    """A non-square geometry passes q and kv lengths in their own places —
+    the square parity test above cannot tell them apart."""
     batch, heads, heads_kv, dim = 1, 8, 2, 128
     max_seqlen_q, max_seqlen_kv = 128, 256
     packed = GroupedQueryAttentionPrefillFwdOp(
@@ -723,12 +693,8 @@ def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
 
 @pytest.mark.smoke
 def test_gqa_fwd_bshd_wrapper_ctor_rejects_non_positive_dims() -> None:
-    """The wrapper validates at construction because nothing downstream does.
-
-    The deleted child op used to raise on these at first forward. The build
-    step that replaced it reaches ``heads % heads_kv`` instead, so a zero
-    ``heads_kv`` would surface as ``ZeroDivisionError``.
-    """
+    """Nothing downstream validates; a zero ``heads_kv`` would surface as
+    ``ZeroDivisionError`` at ``heads % heads_kv``."""
     with pytest.raises(ValueError, match="heads_kv must be positive"):
         GroupedQueryAttentionFwdOp(1, 8, 0, 64, 64, True)
     with pytest.raises(ValueError, match="batch must be positive"):
@@ -739,11 +705,8 @@ def test_gqa_fwd_bshd_wrapper_ctor_rejects_non_positive_dims() -> None:
 
 @pytest.mark.smoke
 def test_build_gqa_prefill_dense_kernel_rejects_unsupported_dtype() -> None:
-    """The build step refuses an element type neither selector supports.
-
-    Both selectors decline rather than raise, so without this guard an
-    unsupported element type would quietly build the generic dense slot.
-    """
+    """Both selectors decline rather than raise, so the build step must
+    refuse unsupported element types itself."""
     with pytest.raises(ValueError, match="float16 or torch.bfloat16"):
         gqa_module._build_gqa_prefill_dense_kernel(
             {},

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -209,7 +209,13 @@ def _build_gqa_prefill_dense_kernel(
     The square fast path wins when its H200 contract holds; otherwise the
     geometry and element type pick a dense slot key. Callers reach a
     dense-prefill kernel through this step without constructing an ``Op``.
+
+    Raises:
+        ValueError: if *dtype* is not a supported dense-prefill element type.
+            Both selectors below merely decline an unsupported element type,
+            so an unguarded call would silently land on the generic dense slot.
     """
+    _validate_attention_dtype(dtype)
     if _supports_gqa_prefill_square_dense(
             batch,
             heads,
@@ -387,7 +393,6 @@ class GroupedQueryAttentionFwdOp(Op):
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         kernel = self._kernel_cache.get(dtype)
         if kernel is None:
-            _validate_attention_dtype(dtype)
             kernel = _build_gqa_prefill_dense_kernel(
                 self.kernel_map,
                 batch=self.batch,

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -189,6 +189,66 @@ def _supports_gqa_prefill_square_dense(
     )
 
 
+def _build_gqa_prefill_dense_kernel(
+    kernel_map: Dict[str, Kernel],
+    *,
+    batch: int,
+    heads: int,
+    heads_kv: int,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
+    dim: int,
+    is_causal: bool,
+    dtype: torch.dtype,
+    sm_scale: float,
+    softcap: float,
+    tune: bool,
+) -> Kernel:
+    """Select and build the dense-prefill kernel for one geometry and element type.
+
+    The square fast path wins when its H200 contract holds; otherwise the
+    geometry and element type pick a dense slot key. Callers reach a
+    dense-prefill kernel through this step without constructing an ``Op``.
+    """
+    if _supports_gqa_prefill_square_dense(
+            batch,
+            heads,
+            heads_kv,
+            max_seqlen_q,
+            max_seqlen_kv,
+            dim,
+            is_causal,
+            dtype,
+            h200=is_h200(),
+    ):
+        return kernel_map["gqa_prefill_square_fwd_kernel"](
+            batch,
+            heads,
+            heads_kv,
+            max_seqlen_q,
+            dim,
+            is_causal,
+            dtype,
+            sm_scale=sm_scale,
+            softcap=softcap,
+            tune=tune,
+        )
+    dense_key = _select_gqa_prefill_dense_kernel_key(dim, is_causal, dtype)
+    return kernel_map[dense_key](
+        batch,
+        heads,
+        heads_kv,
+        max_seqlen_q,
+        max_seqlen_kv,
+        dim,
+        is_causal,
+        dtype,
+        sm_scale=sm_scale,
+        softcap=softcap,
+        tune=tune,
+    )
+
+
 def _select_gqa_prefill_kernel_key(
     *,
     backend: str,
@@ -299,6 +359,11 @@ class GroupedQueryAttentionFwdOp(Op):
                  softcap: Optional[float] = None,
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
+        _validate_gqa_dims(heads, heads_kv, dim)
+        if batch <= 0:
+            raise ValueError("batch must be positive")
+        if seq_len <= 0:
+            raise ValueError("seq_len must be positive")
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -309,7 +374,6 @@ class GroupedQueryAttentionFwdOp(Op):
         self.softcap = _score_softcap(softcap)
         self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self._prefill_ops: Dict[torch.dtype, "GroupedQueryAttentionPrefillFwdOp"] = {}
         self._kernel_cache: Dict[torch.dtype, Kernel] = {}
 
     @property
@@ -320,37 +384,23 @@ class GroupedQueryAttentionFwdOp(Op):
             "gqa_prefill_square_fwd_kernel": GQAFwdWsPersistentCausalKernel,
         }
 
-    def _prefill_op_for(self, dtype: torch.dtype) -> "GroupedQueryAttentionPrefillFwdOp":
-        """Packed prefill op for *dtype*, whose ctor dtype is the output element type."""
-        op = self._prefill_ops.get(dtype)
-        if op is None:
-            op = GroupedQueryAttentionPrefillFwdOp(
-                batch=self.batch,
-                heads=self.heads,
-                heads_kv=self.heads_kv,
-                dim=self.dim,
-                max_seqlen_q=self.seq_len,
-                max_seqlen_kv=self.seq_len,
-                dtype=dtype,
-                is_causal=self.is_causal,
-                sm_scale=self.sm_scale,
-                softcap=self.softcap,
-                backend="dense",
-                kernel_map=self.kernel_map,
-                tune=self.tune,
-            )
-            self._prefill_ops[dtype] = op
-        return op
-
     def _get_kernel(self, dtype: torch.dtype) -> Kernel:
         kernel = self._kernel_cache.get(dtype)
         if kernel is None:
             _validate_attention_dtype(dtype)
-            prefill_op = self._prefill_op_for(dtype)
-            kernel = (
-                prefill_op._get_square_dense_kernel()
-                if prefill_op._uses_square_dense_fast_path()
-                else prefill_op._get_dense_kernel()
+            kernel = _build_gqa_prefill_dense_kernel(
+                self.kernel_map,
+                batch=self.batch,
+                heads=self.heads,
+                heads_kv=self.heads_kv,
+                max_seqlen_q=self.seq_len,
+                max_seqlen_kv=self.seq_len,
+                dim=self.dim,
+                is_causal=self.is_causal,
+                dtype=dtype,
+                sm_scale=self.sm_scale,
+                softcap=self.softcap,
+                tune=self.tune,
             )
             self._kernel_cache[dtype] = kernel
         return kernel
@@ -454,8 +504,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         self.backend = backend
         self.validate_uniform_cu_seqlens = validate_uniform_cu_seqlens
         self.tune = tune
-        self._dense_kernel = None
-        self._square_dense_kernel = None
+        self._dense_prefill_kernel = None
         self._varlen_kernel = None
         self._sliding_window_varlen_kernel = None
         self._fp8_kernel = None
@@ -584,53 +633,24 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         fp8_dtype = getattr(torch, "float8_e4m3fn", None)
         return fp8_dtype is not None and tensor.dtype == fp8_dtype
 
-    def _get_dense_kernel(self) -> Kernel:
-        if self._dense_kernel is None:
-            dense_key = _select_gqa_prefill_dense_kernel_key(
-                self.dim, self.is_causal, self.dtype)
-            self._dense_kernel = self.kernel_map[dense_key](
-                self.batch,
-                self.heads,
-                self.heads_kv,
-                self.max_seqlen_q,
-                self.max_seqlen_kv,
-                self.dim,
-                self.is_causal,
-                self.dtype,
+    def _get_dense_prefill_kernel(self) -> Kernel:
+        """Dense-prefill kernel for this op's geometry and output element type."""
+        if self._dense_prefill_kernel is None:
+            self._dense_prefill_kernel = _build_gqa_prefill_dense_kernel(
+                self.kernel_map,
+                batch=self.batch,
+                heads=self.heads,
+                heads_kv=self.heads_kv,
+                max_seqlen_q=self.max_seqlen_q,
+                max_seqlen_kv=self.max_seqlen_kv,
+                dim=self.dim,
+                is_causal=self.is_causal,
+                dtype=self.dtype,
                 sm_scale=self.sm_scale,
                 softcap=self.softcap,
                 tune=self.tune,
             )
-        return self._dense_kernel
-
-    def _uses_square_dense_fast_path(self) -> bool:
-        return _supports_gqa_prefill_square_dense(
-            self.batch,
-            self.heads,
-            self.heads_kv,
-            self.max_seqlen_q,
-            self.max_seqlen_kv,
-            self.dim,
-            self.is_causal,
-            self.dtype,
-            h200=is_h200(),
-        )
-
-    def _get_square_dense_kernel(self) -> Kernel:
-        if self._square_dense_kernel is None:
-            self._square_dense_kernel = self.kernel_map["gqa_prefill_square_fwd_kernel"](
-                self.batch,
-                self.heads,
-                self.heads_kv,
-                self.max_seqlen_q,
-                self.dim,
-                self.is_causal,
-                self.dtype,
-                sm_scale=self.sm_scale,
-                softcap=self.softcap,
-                tune=self.tune,
-            )
-        return self._square_dense_kernel
+        return self._dense_prefill_kernel
 
     def _get_varlen_kernel(self) -> Kernel:
         if self._varlen_kernel is None:
@@ -753,12 +773,8 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             q_bshd = q.view(self.batch, self.max_seqlen_q, self.heads, self.dim)
             k_bshd = k.view(self.batch, self.max_seqlen_kv, self.heads_kv, self.dim)
             v_bshd = v.view(self.batch, self.max_seqlen_kv, self.heads_kv, self.dim)
-            kernel = (
-                self._get_square_dense_kernel()
-                if self._uses_square_dense_fast_path()
-                else self._get_dense_kernel()
-            )
-            out = _attention_output(kernel(q_bshd, k_bshd, v_bshd))
+            out = _attention_output(
+                self._get_dense_prefill_kernel()(q_bshd, k_bshd, v_bshd))
             self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
             return out.reshape(q.shape)
 

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -310,15 +310,23 @@ def _paged_cache_dtype(cache_dtype: Optional[torch.dtype]) -> Optional[torch.dty
     return cache_dtype
 
 
+def _validate_positive(**values: int) -> None:
+    """Raise for the first named value that is not positive.
+
+    Args:
+        **values: parameter name to value; the name reaches the message, so it
+            must read as the caller's own parameter.
+    """
+    for name, value in values.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be positive")
+
+
 def _validate_gqa_dims(heads: int, heads_kv: int, dim: int) -> None:
-    if heads <= 0:
-        raise ValueError("heads must be positive")
-    if heads_kv <= 0:
-        raise ValueError("heads_kv must be positive")
+    _validate_positive(heads=heads, heads_kv=heads_kv)
     if heads % heads_kv != 0:
         raise ValueError("heads must be divisible by heads_kv")
-    if dim <= 0:
-        raise ValueError("dim must be positive")
+    _validate_positive(dim=dim)
 
 
 def _attention_scale(dim: int, sm_scale: Optional[float]) -> float:
@@ -335,8 +343,7 @@ def _score_softcap(softcap: Optional[float]) -> float:
 
 def _rope_rotary_dim(dim: int, rotary_dim: Optional[int]) -> int:
     rotary_dim = dim if rotary_dim is None else rotary_dim
-    if rotary_dim <= 0:
-        raise ValueError("rotary_dim must be positive")
+    _validate_positive(rotary_dim=rotary_dim)
     if rotary_dim % 2 != 0:
         raise ValueError("rotary_dim must be even")
     if rotary_dim > dim:
@@ -366,10 +373,7 @@ class GroupedQueryAttentionFwdOp(Op):
                  kernel_map: Optional[Dict[str, Kernel]] = None,
                  tune: bool = False) -> None:
         _validate_gqa_dims(heads, heads_kv, dim)
-        if batch <= 0:
-            raise ValueError("batch must be positive")
-        if seq_len <= 0:
-            raise ValueError("seq_len must be positive")
+        _validate_positive(batch=batch, seq_len=seq_len)
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -472,12 +476,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         tune: bool = False,
     ) -> None:
         _validate_gqa_dims(heads, heads_kv, dim)
-        if batch <= 0:
-            raise ValueError("batch must be positive")
-        if max_seqlen_q <= 0:
-            raise ValueError("max_seqlen_q must be positive")
-        if max_seqlen_kv <= 0:
-            raise ValueError("max_seqlen_kv must be positive")
+        _validate_positive(batch=batch, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv)
         if is_causal and max_seqlen_q > max_seqlen_kv:
             raise ValueError("causal prefill requires max_seqlen_q <= max_seqlen_kv")
         if window_size_left != -1 and window_size_left < 0:
@@ -828,12 +827,7 @@ class GroupedQueryAttentionPrefillVarlenFwdOp(Op):
         tune: bool = False,
     ) -> None:
         _validate_gqa_dims(heads, heads_kv, dim)
-        if batch <= 0:
-            raise ValueError("batch must be positive")
-        if max_seqlen_q <= 0:
-            raise ValueError("max_seqlen_q must be positive")
-        if max_seqlen_kv <= 0:
-            raise ValueError("max_seqlen_kv must be positive")
+        _validate_positive(batch=batch, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv)
         self.batch = batch
         self.heads = heads
         self.heads_kv = heads_kv
@@ -1041,16 +1035,11 @@ class GroupedQueryAttentionPrefillPagedWithKVCacheFwdOp(Op):
             rotary_dim = _rope_rotary_dim(dim, rotary_dim)
             if max_position is None:
                 raise ValueError("max_position is required when fuse_rope=True")
-            if max_position <= 0:
-                raise ValueError("max_position must be positive")
+            _validate_positive(max_position=max_position)
         elif rotary_dim is not None:
             raise ValueError("rotary_dim requires fuse_rope=True")
-        if batch <= 0:
-            raise ValueError("batch must be positive")
-        if max_pages_per_req <= 0:
-            raise ValueError("max_pages_per_req must be positive")
-        if page_size <= 0:
-            raise ValueError("page_size must be positive")
+        _validate_positive(
+            batch=batch, max_pages_per_req=max_pages_per_req, page_size=page_size)
         if page_size & (page_size - 1) != 0:
             raise ValueError("page_size must be a power of two")
         cache_dtype = _paged_cache_dtype(cache_dtype)
@@ -1529,8 +1518,7 @@ class GroupedQueryAttentionDecodePagedWithKVCacheFwdOp(Op):
         self.seqlen_kv = seqlen_kv
         self.dim = dim
         self.page_size = page_size
-        if page_size <= 0:
-            raise ValueError("page_size must be positive")
+        _validate_positive(page_size=page_size)
         self.sm_scale = _attention_scale(dim, sm_scale)
         self.softcap = _score_softcap(softcap)
 

--- a/tileops/ops/attention/gqa.py
+++ b/tileops/ops/attention/gqa.py
@@ -206,14 +206,9 @@ def _build_gqa_prefill_dense_kernel(
 ) -> Kernel:
     """Select and build the dense-prefill kernel for one geometry and element type.
 
-    The square fast path wins when its H200 contract holds; otherwise the
-    geometry and element type pick a dense slot key. Callers reach a
-    dense-prefill kernel through this step without constructing an ``Op``.
-
     Raises:
-        ValueError: if *dtype* is not a supported dense-prefill element type.
-            Both selectors below merely decline an unsupported element type,
-            so an unguarded call would silently land on the generic dense slot.
+        ValueError: if *dtype* is unsupported — both selectors below merely
+            decline, so an unguarded call would land on the generic dense slot.
     """
     _validate_attention_dtype(dtype)
     if _supports_gqa_prefill_square_dense(
@@ -311,12 +306,8 @@ def _paged_cache_dtype(cache_dtype: Optional[torch.dtype]) -> Optional[torch.dty
 
 
 def _validate_positive(**values: int) -> None:
-    """Raise for the first named value that is not positive.
-
-    Args:
-        **values: parameter name to value; the name reaches the message, so it
-            must read as the caller's own parameter.
-    """
+    """Raise for the first named value that is not positive; the name appears
+    in the message, so pass the caller's own parameter name."""
     for name, value in values.items():
         if value <= 0:
             raise ValueError(f"{name} must be positive")


### PR DESCRIPTION
Closes #1844

## Summary

`GroupedQueryAttentionFwdOp` (the square BSHD wrapper) built a full child `GroupedQueryAttentionPrefillFwdOp` per dtype just to reach a kernel — re-running `dispatch_kernel` and splitting kernel ownership across `_prefill_ops` and `_kernel_cache`.

Selection and construction are now one module-level step:

```python
_build_gqa_prefill_dense_kernel(kernel_map, *, batch, heads, heads_kv,
                                max_seqlen_q, max_seqlen_kv, dim, is_causal,
                                dtype, sm_scale, softcap, tune) -> Kernel
```

- The wrapper calls it directly and caches per dtype in `_kernel_cache`; `_prefill_ops` / `_prefill_op_for` are gone.
- `GroupedQueryAttentionPrefillFwdOp` consumes the same step through a single `_dense_prefill_kernel` slot, replacing `_uses_square_dense_fast_path` / `_get_dense_kernel` / `_get_square_dense_kernel`.
- The step validates its own element type (both selectors decline rather than raise); the wrapper ctor now validates dims — the deleted child ctor used to, and without it `heads_kv=0` reaches `heads % heads_kv` and throws `ZeroDivisionError`.
- The `dtype` ctor parameter on the packed op is untouched.

## Verification

- `pytest tests/ops/attention -m smoke -q` — 156 passed; `pre-commit run --all-files` clean.
- Wrapper builds no child `Op` (structural check descends containers and records); repo-wide grep confirms all five removed symbols are gone.
- Dispatch parity vs `origin/main`: 36 wrapper + 28 packed dense cases, zero mismatches; autotune reach lists identical.
- New tests checked by mutation: deleting any one guard of the square fast-path contract fails exactly its own parity case. Test nodes 63 → 69: five isolate the fast-path outcomes (accepted; declined for chip, work items, block parity, head dim — block parity had no test before), one covers the refused element type.
- Pre-existing, unrelated: `tests/ops/test_multi_dtype_instance.py::SigmoidFwdOp` fails identically on `origin/main` (nvcc `hexp(cutlass::half_t)` overload).

## Benchmark

NVIDIA H200, CUDA 12.8, PyTorch 2.10.0+cu128. `bench_gqa.py::test_gqa_fwd_bench` — 8 passed; every case stayed on `ws_causal`, matching pre-refactor variant selection.

| Shape | dtype | TileOPs (ms) | torch-sdpa (ms) | Speedup | TFLOPS |
| ----- | ----- | ------------ | --------------- | ------- | ------ |
| (4, 512, 32, 8, 128) | fp16 / bf16 | 0.0327 / 0.0325 | 0.0585 / 0.0586 | 1.79x / 1.80x | 262.8 / 264.3 |
| (2, 2048, 32, 8, 128) | fp16 / bf16 | 0.1420 / 0.1408 | 0.2717 / 0.2713 | 1.91x / 1.93x | 483.9 / 488.1 |
| (2, 512, 64, 8, 128) | fp16 / bf16 | 0.0337 / 0.0336 | 0.0582 / 0.0583 | 1.73x / 1.74x | 255.1 / 256.0 |
| (1, 2048, 64, 8, 128) | fp16 / bf16 | 0.1408 / 0.1400 | 0.2720 / 0.2715 | 1.93x / 1.94x | 488.1 / 491.0 |

## Follow-ups

Two earlier flagged items are closed in-branch: a packed-only non-square case now asserts `max_seqlen_q` / `max_seqlen_kv` thread into their own places (the square parity test cannot tell them apart), and the repeated positivity checks are folded into `_validate_positive(**values)` with messages and firing order unchanged.

Remaining: `is_h200()` stays in the op layer — lifting hardware predicates needs the multi-backend `Target` abstraction; relocating this one alone would spread a chip-level axis to every caller.
