### PR TITLE
[Refactor][LinearAttn] one autotune sweep for the delta-rule forward kernels

### DIFF
--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -59,8 +59,9 @@ class _StubKernel:
             "o_threads": 256,
         }
 
-    def tune_jit_kernel(self, jit_kernel, configs, warmup, rep, seed_config):
+    def tune_jit_kernel(self, jit_kernel, configs, warmup, rep, seed_config, supply_prog):
         assert seed_config is configs[0], "the sweep must seed from its first candidate"
+        assert supply_prog is None, "a sub-kernel sweep must not inherit the kernel's supplier"
         self.sweeps.append((jit_kernel.name, jit_kernel.build_kwargs, tuple(configs)))
         key = (jit_kernel.name, jit_kernel.build_kwargs.get("block_v", 0))
         config, latency = self.results.get(key, (configs[-1], 1.0))
@@ -198,11 +199,48 @@ def test_default_h_block_v_is_always_a_declared_candidate() -> None:
             assert la.default_h_block_v(dim_v, chunk_size) in declared
 
 
-def test_default_h_block_v_refuses_a_shape_with_no_buildable_width() -> None:
-    """Below the minimum gemm N extent there is no width to default to."""
+def test_a_shape_with_no_buildable_width_is_refused_by_both_entry_points() -> None:
+    """The default and the declared set must refuse the same shapes.
+
+    An empty config list reads as "tunable, with nothing to try": ``[]`` is not
+    ``None``, so ``init_config`` would skip its warning and walk into the sweep.
+    """
     assert la.h_block_v_candidates(8) == ()
     with pytest.raises(ValueError, match="no buildable"):
         la.default_h_block_v(8, 64)
+    with pytest.raises(ValueError, match="no buildable"):
+        la.delta_rule_fwd_autotune_configs(8)
+
+
+def test_widths_resolving_to_one_tile_are_a_single_candidate() -> None:
+    """At dim_v=32 both widths give a 32-column tile, so building both is waste."""
+    assert la.h_block_v_candidates(32) == (0,)
+    assert {config["h_block_v"] for config in la.delta_rule_fwd_autotune_configs(32)} == {0}
+
+
+def test_a_width_that_fails_to_build_does_not_sink_the_sweep() -> None:
+    """resolve_block_v cannot see shared-memory or codegen failures.
+
+    Those surface only when the width is built, and they disqualify that width,
+    not the whole sweep — the other width must still be measured and win.
+    """
+    kernel = _StubKernel(chunk_size=64)
+    failing = {"h": 32}
+
+    def h_builder(*shape, block_v):
+        if block_v == failing["h"]:
+            raise RuntimeError("out of shared memory")
+        return _StubJit("h", block_v=block_v)
+
+    config = la.tune_delta_rule_fwd(
+        kernel,
+        fused_builder=lambda *shape: _StubJit("fused"),
+        h_builder=h_builder,
+        o_builder=lambda *shape: _StubJit("o"),
+    )
+
+    assert config["h_block_v"] == 0
+    assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
 
 
 def test_default_h_block_v_takes_the_narrowest_buildable_tiled_width() -> None:

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -134,7 +134,10 @@ def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
 
     config = _run(kernel)
 
-    assert config == kernel.default_config
+    assert config == {
+        **kernel.default_config,
+        "h_block_v": la.default_h_block_v(kernel.dim_v, kernel.chunk_size),
+    }
 
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
@@ -226,12 +229,12 @@ def test_a_width_that_fails_to_tune_does_not_sink_the_sweep() -> None:
     assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
 
 
-def test_a_width_that_failed_to_build_is_never_the_fallback() -> None:
-    """The untuned preference only counts if that width actually built.
+def test_a_width_that_compiled_is_used_even_when_another_failed() -> None:
+    """The untuned preference only counts if that width compiled.
 
-    At chunk 64 the preference is 32. If 32 fails to build and 0 builds but
-    tunes to nothing, returning the preference would name the width the sweep
-    just proved unbuildable, and the error would resurface inside forward.
+    At chunk 64 the preference is 32. If 32's sweep raises and 0's returns
+    without a measurement, 0 still compiled — the autotuner would have raised
+    otherwise — so it answers, rather than naming 32 or refusing outright.
     """
     kernel = _StubKernel(chunk_size=64)
     kernel.results = {("h", 0): (None, None)}
@@ -245,8 +248,29 @@ def test_a_width_that_failed_to_build_is_never_the_fallback() -> None:
     kernel.tune_jit_kernel = fail_wide_tile
 
     assert la.default_h_block_v(64, 64) == 32, "the preference must diverge for this to bite"
-    with pytest.warns(UserWarning), pytest.raises(RuntimeError, match="no recurrence V-tile"):
+    with pytest.warns(UserWarning, match="unavailable"):
+        config = _run(kernel)
+
+    assert config["h_block_v"] == 0
+
+
+def test_every_failure_reaches_the_raised_error() -> None:
+    """Warnings can be filtered away, so the error carries every cause itself."""
+    kernel = _StubKernel(chunk_size=64)
+    inner = kernel.tune_jit_kernel
+
+    def fail_each_differently(jit_kernel, *args, **kwargs):
+        if jit_kernel.name == "h":
+            raise RuntimeError(f"smem overflow at block_v={jit_kernel.build_kwargs['block_v']}")
+        return inner(jit_kernel, *args, **kwargs)
+
+    kernel.tune_jit_kernel = fail_each_differently
+
+    with pytest.warns(UserWarning), pytest.raises(RuntimeError) as e:
         _run(kernel)
+
+    assert "block_v=0" in str(e.value)
+    assert "block_v=32" in str(e.value)
 
 
 def test_no_width_tuning_reports_the_failure_with_its_cause() -> None:

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -224,7 +224,7 @@ def test_a_width_that_fails_to_tune_does_not_sink_the_sweep() -> None:
     assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
     # When a width is dropped but the sweep survives, the warning is the only
     # diagnostic, so it is bounded the same way the raised error is.
-    dropped = str(warned[0].message)
+    dropped = next(str(w.message) for w in warned if "unavailable" in str(w.message))
     assert "\n" not in dropped and len(dropped) < 400
 
 
@@ -276,7 +276,8 @@ def test_the_raised_error_bounds_a_long_failure_text() -> None:
     """A compile failure can carry a whole log; the error must stay readable."""
     kernel = _StubKernel(chunk_size=64)
     inner = kernel.tune_jit_kernel
-    log = "header line\n" + "x" * 5000
+    # A padded preamble must not eat the slice and leave the summary empty.
+    log = "\n" * 30000 + "header line\n" + "x" * 5000
 
     def fail_with_a_log(jit_kernel, *args, **kwargs):
         if jit_kernel.name == "h":
@@ -291,6 +292,7 @@ def test_the_raised_error_bounds_a_long_failure_text() -> None:
     message = str(e.value)
     widths = len(la.h_block_v_candidates(kernel.dim_v))
     assert "\n" not in message
+    assert "header line" in message, "a padded preamble must not consume the summary"
     # One bounded summary per width, plus a fixed prefix naming the shape, so
     # the bound scales with the candidate set rather than with however many
     # widths happen to be offered today.

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -186,6 +186,25 @@ def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> No
     assert config in la.delta_rule_fwd_autotune_configs(48)
 
 
+def test_default_h_block_v_is_always_a_declared_candidate() -> None:
+    """The untuned width must be one the sweep also declares.
+
+    The default is what ``init_config`` falls back to, so a width outside the
+    declared set would be one no candidate check could have vetted.
+    """
+    for dim_v in (64, 48):
+        declared = {config["h_block_v"] for config in la.delta_rule_fwd_autotune_configs(dim_v)}
+        for chunk_size in (32, 64):
+            assert la.default_h_block_v(dim_v, chunk_size) in declared
+
+
+def test_default_h_block_v_refuses_a_shape_with_no_buildable_width() -> None:
+    """Below the minimum gemm N extent there is no width to default to."""
+    assert la.h_block_v_candidates(8) == ()
+    with pytest.raises(ValueError, match="no buildable"):
+        la.default_h_block_v(8, 64)
+
+
 def test_default_h_block_v_takes_the_narrowest_buildable_tiled_width() -> None:
     assert la.default_h_block_v(64, 64) == 32
     assert la.default_h_block_v(48, 64) == 0  # 32 does not divide 48

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -164,12 +164,6 @@ def test_short_chunks_still_sweep_the_tiled_width() -> None:
     assert [build.get("block_v") for name, build, _ in kernel.sweeps if name == "h"] == [0, 32]
 
 
-def test_v_tile_candidates_are_the_widths_the_recurrence_accepts() -> None:
-    """The candidate set is whatever ``resolve_block_v`` admits, nothing else."""
-    assert la.h_block_v_candidates(48) == (0,)  # 32 does not divide 48
-    assert la.h_block_v_candidates(64) == (0, 32)
-
-
 def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> None:
     """The fallback width must come from the candidates, not from default_config.
 
@@ -272,6 +266,28 @@ def test_every_failure_reaches_the_raised_error() -> None:
 
     assert "block_v=0" in str(e.value)
     assert "block_v=32" in str(e.value)
+
+
+def test_the_raised_error_bounds_a_long_failure_text() -> None:
+    """A compile failure can carry a whole log; the error must stay readable."""
+    kernel = _StubKernel(chunk_size=64)
+    inner = kernel.tune_jit_kernel
+    log = "header line\n" + "x" * 5000
+
+    def fail_with_a_log(jit_kernel, *args, **kwargs):
+        if jit_kernel.name == "h":
+            raise RuntimeError(log)
+        return inner(jit_kernel, *args, **kwargs)
+
+    kernel.tune_jit_kernel = fail_with_a_log
+
+    with pytest.warns(UserWarning), pytest.raises(RuntimeError) as e:
+        _run(kernel)
+
+    message = str(e.value)
+    assert "\n" not in message
+    assert len(message) < 1000
+    assert log in str(e.value.__cause__), "the chained cause keeps the whole text"
 
 
 def test_no_width_tuning_reports_the_failure_with_its_cause() -> None:

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -7,6 +7,7 @@ tuned. ``tests/ops/test_deltanet_fwd.py`` covers the same helper on the device.
 """
 
 import inspect
+import sys
 
 import pytest
 
@@ -123,20 +124,21 @@ def test_fastest_v_tile_width_wins() -> None:
 
 def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
     """An autotuner that returns without a result leaves every key at its default."""
-    # dim_v=48, where the stub's default_config width (32) is not buildable,
-    # so taking it straight from there would be visible.
-    kernel = _StubKernel(chunk_size=64, dim_v=48)
+    # dim_v=64 offers two widths, so the untuned preference (32) differs from
+    # the first that compiled (0) and the choice between them is visible.
+    kernel = _StubKernel(chunk_size=64, dim_v=64)
     kernel.results = {
         ("fused", 0): (None, None),
         ("h", 0): (None, None),
+        ("h", 32): (None, None),
         ("o", 0): (None, None),
     }
 
     config = _run(kernel)
 
-    assert kernel.default_config["h_block_v"] == 32
-    assert config == {**kernel.default_config, "h_block_v": la.default_h_block_v(48, 64)}
-    assert config["h_block_v"] == 0
+    assert la.h_block_v_candidates(64) == (0, 32), "both widths must compile for this to bite"
+    assert config == {**kernel.default_config, "h_block_v": la.default_h_block_v(64, 64)}
+    assert config["h_block_v"] == 32
 
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
@@ -324,6 +326,8 @@ def test_default_config_width_is_one_the_kernel_builds(kernel_cls) -> None:
 
     assert kernel.config["h_block_v"] in la.h_block_v_candidates(48)
     assert kernel.config in kernel.autotune_configs
+    # Nothing else fails if a kernel grows its own copy of the sweep.
+    assert sys.modules[kernel_cls.__module__].tune_delta_rule_fwd is la.tune_delta_rule_fwd
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -137,7 +137,7 @@ def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
     kernel = _StubKernel()
-    declared = la.delta_rule_fwd_autotune_configs(kernel.dim_v, kernel.chunk_size)
+    declared = la.delta_rule_fwd_autotune_configs(kernel.dim_v)
 
     assert _run(kernel) in declared
     kernel.results = {("fused", 0): (None, None), ("h", 0): (None, None),
@@ -145,20 +145,27 @@ def test_selected_config_is_always_a_declared_candidate() -> None:
     assert _run(kernel) in declared
 
 
-def test_v_tiling_is_not_offered_below_the_minimum_chunk_size() -> None:
-    """A tiled recurrence the kernel does not build must stay out of the sweep."""
+def test_short_chunks_still_sweep_the_tiled_width() -> None:
+    """The chunk preference steers the untuned default, not the sweep.
+
+    A width the recurrence can build stays measurable at any chunk length; only
+    the default declines it below the threshold.
+    """
     kernel = _StubKernel(chunk_size=32)
 
     config = _run(kernel)
 
-    assert la.h_block_v_candidates(64, 32) == (0,)
-    assert [build.get("block_v") for name, build, _ in kernel.sweeps if name == "h"] == [0]
-    assert config["h_block_v"] == 0
+    assert la.h_block_v_candidates(64) == (0, 32)
+    assert [build.get("block_v") for name, build, _ in kernel.sweeps if name == "h"] == [0, 32]
+    assert la.default_h_block_v(64, 32) == 0
+    assert config["h_block_v"] in la.h_block_v_candidates(64)
 
 
-def test_v_tile_width_must_divide_dim_v() -> None:
-    assert la.h_block_v_candidates(48, 64) == (0,)
-    assert la.h_block_v_candidates(64, 64) == (0, 32)
+def test_v_tile_candidates_are_the_widths_the_recurrence_accepts() -> None:
+    """The candidate set is whatever ``resolve_block_v`` admits, nothing else."""
+    assert la.h_block_v_candidates(48) == (0,)  # 32 does not divide 48
+    assert la.h_block_v_candidates(64) == (0, 32)
+    assert la.h_block_v_candidates(8) == ()  # below the minimum gemm N extent
 
 
 def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> None:
@@ -176,13 +183,13 @@ def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> No
 
     assert kernel.default_config["h_block_v"] == 32, "stub must diverge for this to bite"
     assert config["h_block_v"] == 0
-    assert config in la.delta_rule_fwd_autotune_configs(48, 64)
+    assert config in la.delta_rule_fwd_autotune_configs(48)
 
 
 def test_default_h_block_v_takes_the_narrowest_buildable_tiled_width() -> None:
     assert la.default_h_block_v(64, 64) == 32
     assert la.default_h_block_v(48, 64) == 0  # 32 does not divide 48
-    assert la.default_h_block_v(64, 32) == 0  # chunk below the tiling minimum
+    assert la.default_h_block_v(64, 32) == 0  # short chunk prefers no tiling
 
 
 @pytest.mark.parametrize(
@@ -199,7 +206,7 @@ def test_default_config_width_is_one_the_kernel_builds(
         dtype="bfloat16",
     )
 
-    assert kernel.config["h_block_v"] in la.h_block_v_candidates(dim_v, chunk_size)
+    assert kernel.config["h_block_v"] in la.h_block_v_candidates(dim_v)
     assert kernel.config in kernel.autotune_configs
 
 
@@ -228,7 +235,7 @@ def test_tune_true_reaches_the_sweep(monkeypatch, kernel_cls) -> None:
     )
 
     assert calls == [kernel_cls.__name__]
-    assert kernel.autotune_configs == la.delta_rule_fwd_autotune_configs(64, 64)
+    assert kernel.autotune_configs == la.delta_rule_fwd_autotune_configs(64)
 
 
 if __name__ == "__main__":

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -108,6 +108,28 @@ def test_every_candidate_is_swept_and_the_winner_lands_in_its_key() -> None:
     }
 
 
+def test_a_tuned_config_without_a_latency_is_not_silent() -> None:
+    """Widths are compared on latency; losing it would tie them invisibly."""
+    kernel = _StubKernel()
+    kernel.results = {("h", 0): ({"num_stages": 1, "threads": 128}, None)}
+
+    with pytest.warns(UserWarning, match="no latency"):
+        _run(kernel)
+
+
+def test_the_sweep_cannot_mutate_the_shared_candidate_tuples() -> None:
+    """The candidate tuples are module-level and shared by every sweep."""
+    kernel = _StubKernel()
+    before = [dict(config) for config in la.PIPELINE_CONFIGS]
+
+    _run(kernel)
+
+    for _, _, configs in kernel.sweeps:
+        for config in configs:
+            config["threads"] = -1
+    assert [dict(config) for config in la.PIPELINE_CONFIGS] == before
+
+
 def test_fastest_v_tile_width_wins() -> None:
     """Widths are compared on latency, not on candidate or default order."""
     kernel = _StubKernel()

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -7,6 +7,7 @@ tuned. ``tests/ops/test_deltanet_fwd.py`` covers the same helper on the device.
 """
 
 import inspect
+import sys
 
 import pytest
 
@@ -121,8 +122,13 @@ def test_fastest_v_tile_width_wins() -> None:
     assert (config["h_num_stages"], config["h_threads"]) == (2, 256)
 
 
-def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
-    """A sub-kernel the autotuner cannot tune must not leave the config unbuildable."""
+def test_untunable_launch_params_fall_back_but_the_width_does_not() -> None:
+    """Launch params keep their default; the V-tile width takes the safe one.
+
+    A width with no measurement has no evidence it compiles — that is how a
+    per-candidate build failure reaches us — so the untuned preference is not
+    taken on faith. Candidate order puts the untiled width first.
+    """
     kernel = _StubKernel()
     kernel.results = {
         ("fused", 0): (None, None),
@@ -133,7 +139,8 @@ def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
 
     config = _run(kernel)
 
-    assert config == kernel.default_config
+    assert kernel.default_config["h_block_v"] == 32, "the preference must diverge to bite"
+    assert config == {**kernel.default_config, "h_block_v": 0}
 
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
@@ -254,6 +261,28 @@ def test_a_width_that_failed_to_build_is_never_the_fallback() -> None:
     assert config["h_block_v"] == 0
 
 
+def test_a_tuning_failure_is_not_reported_as_a_dropped_width() -> None:
+    """Only the builder call is width-specific.
+
+    A failure inside the autotuner is the device's or the tuner's; reporting it
+    as a dropped width would hide it behind a config that looks tuned.
+    """
+    kernel = _StubKernel()
+    inner = kernel.tune_jit_kernel
+
+    def explode_on_recurrence(jit_kernel, *args, **kwargs):
+        # Only the recurrence, so the failure lands inside the width loop —
+        # the fused sub-kernel is tuned before it and would mask this.
+        if jit_kernel.name == "h":
+            raise RuntimeError("device lost")
+        return inner(jit_kernel, *args, **kwargs)
+
+    kernel.tune_jit_kernel = explode_on_recurrence
+
+    with pytest.raises(RuntimeError, match="device lost"):
+        _run(kernel)
+
+
 def test_no_width_building_at_all_reports_the_build_failure() -> None:
     """A width is not the caller's to choose, so a config naming one is no answer."""
     kernel = _StubKernel(chunk_size=64)
@@ -261,7 +290,7 @@ def test_no_width_building_at_all_reports_the_build_failure() -> None:
     def h_builder(*shape, block_v):
         raise RuntimeError("out of shared memory")
 
-    with pytest.raises(RuntimeError, match="no recurrence V-tile width built"):
+    with pytest.raises(RuntimeError, match="no recurrence V-tile width could be built"):
         la.tune_delta_rule_fwd(
             kernel,
             fused_builder=lambda *shape: _StubJit("fused"),
@@ -271,15 +300,12 @@ def test_no_width_building_at_all_reports_the_build_failure() -> None:
 
 
 def test_default_h_block_v_prefers_a_tiled_width_and_stays_declared() -> None:
-    """The untuned width is the narrowest buildable tile, and always declared.
-
-    It is what ``init_config`` falls back to, so a width outside the declared
-    set would be one no candidate check could have vetted.
-    """
+    """Always declared: it is what ``init_config`` falls back to."""
     assert la.default_h_block_v(64, 64) == 32
+    assert la.default_h_block_v(96, 64) == 32  # 32 divides 96
     assert la.default_h_block_v(48, 64) == 0  # 32 does not divide 48
     assert la.default_h_block_v(64, 32) == 0  # short chunk prefers no tiling
-    for dim_v, chunk_size in ((64, 64), (48, 64), (64, 32)):
+    for dim_v, chunk_size in ((64, 64), (96, 64), (48, 64), (64, 32)):
         declared = {c["h_block_v"] for c in la.delta_rule_fwd_autotune_configs(dim_v)}
         assert la.default_h_block_v(dim_v, chunk_size) in declared
 
@@ -302,6 +328,9 @@ def test_default_config_width_is_one_the_kernel_builds(kernel_cls) -> None:
 
     assert kernel.config["h_block_v"] in la.h_block_v_candidates(48)
     assert kernel.config in kernel.autotune_configs
+    # No second copy of the sweep may reappear in either kernel module.
+    module = sys.modules[kernel_cls.__module__]
+    assert module.tune_delta_rule_fwd is la.tune_delta_rule_fwd
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -48,6 +48,8 @@ class _StubKernel:
 
     @property
     def default_config(self) -> dict:
+        # h_block_v deliberately ignores dim_v divisibility, so a sweep that
+        # took its fallback width from here would return an unbuildable one.
         return {
             "fused_num_stages": 2,
             "fused_threads": 256,
@@ -157,6 +159,48 @@ def test_v_tiling_is_not_offered_below_the_minimum_chunk_size() -> None:
 def test_v_tile_width_must_divide_dim_v() -> None:
     assert la.h_block_v_candidates(48, 64) == (0,)
     assert la.h_block_v_candidates(64, 64) == (0, 32)
+
+
+def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> None:
+    """The fallback width must come from the candidates, not from default_config.
+
+    At dim_v=48 a tiled width of 32 gives the recurrence a V grid of
+    ``48 // 32 == 1`` tile, covering 32 of 48 columns. The width must therefore
+    stay out of the returned config even when no candidate could be tuned.
+    """
+    kernel = _StubKernel(chunk_size=64, dim_v=48)
+    kernel.results = {("fused", 0): (None, None), ("h", 0): (None, None),
+                      ("o", 0): (None, None)}
+
+    config = _run(kernel)
+
+    assert kernel.default_config["h_block_v"] == 32, "stub must diverge for this to bite"
+    assert config["h_block_v"] == 0
+    assert config in la.delta_rule_fwd_autotune_configs(48, 64)
+
+
+def test_default_h_block_v_takes_the_narrowest_buildable_tiled_width() -> None:
+    assert la.default_h_block_v(64, 64) == 32
+    assert la.default_h_block_v(48, 64) == 0  # 32 does not divide 48
+    assert la.default_h_block_v(64, 32) == 0  # chunk below the tiling minimum
+
+
+@pytest.mark.parametrize(
+    "kernel_cls",
+    [deltanet_fwd.DeltaNetFwdKernel, gated_deltanet_fwd.GatedDeltaNetFwdKernel],
+)
+@pytest.mark.parametrize("dim_v, chunk_size", [(64, 64), (48, 64), (64, 32), (96, 64)])
+def test_default_config_width_is_one_the_kernel_builds(
+    kernel_cls, dim_v: int, chunk_size: int
+) -> None:
+    """The untuned width must be declared too, or forward truncates the V range."""
+    kernel = kernel_cls(
+        batch=1, head=1, seq_len=128, chunk_size=chunk_size, dim_k=64, dim_v=dim_v,
+        dtype="bfloat16",
+    )
+
+    assert kernel.config["h_block_v"] in la.h_block_v_candidates(dim_v, chunk_size)
+    assert kernel.config in kernel.autotune_configs
 
 
 def test_both_forward_kernels_share_one_sweep_implementation() -> None:

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -285,8 +285,12 @@ def test_the_raised_error_bounds_a_long_failure_text() -> None:
         _run(kernel)
 
     message = str(e.value)
+    widths = len(la.h_block_v_candidates(kernel.dim_v))
     assert "\n" not in message
-    assert len(message) < 1000
+    # One bounded summary per width, so the bound scales with the candidate set
+    # rather than with however many widths happen to be offered today.
+    assert len(message) < 300 * widths
+    assert "x" * 300 not in message, "the log body must not survive whole"
     assert log in str(e.value.__cause__), "the chained cause keeps the whole text"
 
 

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -1,0 +1,191 @@
+"""Sweep behaviour of the shared delta-rule forward autotune helper.
+
+The real sweep compiles fifteen kernels, so the selection logic is checked here
+against stub JIT builders: which candidates reach the autotuner, which sub-kernel
+winner lands in which merged key, and what happens when a sub-kernel cannot be
+tuned. ``tests/ops/test_deltanet_fwd.py`` covers the same helper on the device.
+"""
+
+import inspect
+
+import pytest
+
+from tileops.kernels import linear_attn_autotune as la
+from tileops.kernels.deltanet import deltanet_fwd
+from tileops.kernels.gated_deltanet import gated_deltanet_fwd
+
+pytestmark = pytest.mark.smoke
+
+
+class _StubJit:
+    """Stands in for a ``@tilelang.jit`` builder with tunable launch params."""
+
+    def __init__(self, name: str, **build_kwargs: int) -> None:
+        self.name = name
+        self.build_kwargs = build_kwargs
+        if name == "o":
+            self.signature = inspect.signature(lambda threads: None)
+        else:
+            self.signature = inspect.signature(lambda num_stages, threads: None)
+
+
+class _StubTuned:
+    def __init__(self, config: dict | None, latency: float | None) -> None:
+        self.config = config
+        self.latency = latency
+
+
+class _StubKernel:
+    """A delta-rule forward kernel with the sweep's inputs and nothing else."""
+
+    def __init__(self, chunk_size: int = 64, dim_v: int = 64) -> None:
+        self.batch, self.head, self.seq_len = 2, 2, 128
+        self.chunk_size, self.dim_k, self.dim_v = chunk_size, 64, dim_v
+        self.dtype_str = "bfloat16"
+        self.sweeps: list[tuple[str, dict, tuple[dict, ...]]] = []
+        #: ``(sub-kernel name, block_v) -> (config, latency)`` the stub reports.
+        self.results: dict[tuple[str, int], tuple[dict | None, float | None]] = {}
+
+    @property
+    def default_config(self) -> dict:
+        return {
+            "fused_num_stages": 2,
+            "fused_threads": 256,
+            "h_num_stages": 2,
+            "h_threads": 256,
+            "h_block_v": 32 if self.chunk_size >= 64 else 0,
+            "o_threads": 256,
+        }
+
+    def tune_jit_kernel(self, jit_kernel, configs, warmup, rep, seed_config):
+        assert seed_config is configs[0], "the sweep must seed from its first candidate"
+        self.sweeps.append((jit_kernel.name, jit_kernel.build_kwargs, tuple(configs)))
+        key = (jit_kernel.name, jit_kernel.build_kwargs.get("block_v", 0))
+        config, latency = self.results.get(key, (configs[-1], 1.0))
+        return _StubTuned(config, latency)
+
+
+def _run(kernel: _StubKernel) -> dict:
+    return la.tune_delta_rule_fwd(
+        kernel,
+        fused_builder=lambda *shape: _StubJit("fused"),
+        h_builder=lambda *shape, block_v: _StubJit("h", block_v=block_v),
+        o_builder=lambda *shape: _StubJit("o"),
+        warmup=1,
+        rep=1,
+    )
+
+
+def test_every_candidate_is_swept_and_the_winner_lands_in_its_key() -> None:
+    kernel = _StubKernel()
+    kernel.results = {
+        ("fused", 0): ({"num_stages": 1, "threads": 128}, 3.0),
+        ("h", 0): ({"num_stages": 1, "threads": 256}, 2.0),
+        ("h", 32): ({"num_stages": 2, "threads": 128}, 5.0),
+        ("o", 0): ({"threads": 64}, 1.0),
+    }
+
+    config = _run(kernel)
+
+    swept = {(name, build["block_v"] if build else 0): configs
+             for name, build, configs in kernel.sweeps}
+    assert swept[("fused", 0)] == la.PIPELINE_CONFIGS
+    assert swept[("h", 0)] == la.PIPELINE_CONFIGS
+    assert swept[("h", 32)] == la.PIPELINE_CONFIGS
+    assert swept[("o", 0)] == la.OUTPUT_CONFIGS
+    assert config == {
+        "fused_num_stages": 1,
+        "fused_threads": 128,
+        # block_v=0 measured 2.0 ms against 5.0 ms for block_v=32.
+        "h_num_stages": 1,
+        "h_threads": 256,
+        "h_block_v": 0,
+        "o_threads": 64,
+    }
+
+
+def test_fastest_v_tile_width_wins() -> None:
+    """Widths are compared on latency, not on candidate or default order."""
+    kernel = _StubKernel()
+    kernel.results = {
+        ("h", 0): ({"num_stages": 1, "threads": 128}, 4.0),
+        ("h", 32): ({"num_stages": 2, "threads": 256}, 0.5),
+    }
+
+    config = _run(kernel)
+
+    assert config["h_block_v"] == 32
+    assert (config["h_num_stages"], config["h_threads"]) == (2, 256)
+
+
+def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
+    """A sub-kernel the autotuner cannot tune must not leave the config unbuildable."""
+    kernel = _StubKernel()
+    kernel.results = {
+        ("fused", 0): (None, None),
+        ("h", 0): (None, None),
+        ("h", 32): (None, None),
+        ("o", 0): (None, None),
+    }
+
+    config = _run(kernel)
+
+    assert config == kernel.default_config
+
+
+def test_selected_config_is_always_a_declared_candidate() -> None:
+    kernel = _StubKernel()
+    declared = la.delta_rule_fwd_autotune_configs(kernel.dim_v, kernel.chunk_size)
+
+    assert _run(kernel) in declared
+    kernel.results = {("fused", 0): (None, None), ("h", 0): (None, None),
+                      ("h", 32): (None, None), ("o", 0): (None, None)}
+    assert _run(kernel) in declared
+
+
+def test_v_tiling_is_not_offered_below_the_minimum_chunk_size() -> None:
+    """A tiled recurrence the kernel does not build must stay out of the sweep."""
+    kernel = _StubKernel(chunk_size=32)
+
+    config = _run(kernel)
+
+    assert la.h_block_v_candidates(64, 32) == (0,)
+    assert [build.get("block_v") for name, build, _ in kernel.sweeps if name == "h"] == [0]
+    assert config["h_block_v"] == 0
+
+
+def test_v_tile_width_must_divide_dim_v() -> None:
+    assert la.h_block_v_candidates(48, 64) == (0,)
+    assert la.h_block_v_candidates(64, 64) == (0, 32)
+
+
+def test_both_forward_kernels_share_one_sweep_implementation() -> None:
+    """Neither kernel may carry its own copy of the sweep."""
+    assert deltanet_fwd.tune_delta_rule_fwd is la.tune_delta_rule_fwd
+    assert gated_deltanet_fwd.tune_delta_rule_fwd is la.tune_delta_rule_fwd
+    assert (deltanet_fwd.delta_rule_fwd_autotune_configs
+            is gated_deltanet_fwd.delta_rule_fwd_autotune_configs)
+
+
+@pytest.mark.parametrize(
+    "kernel_cls",
+    [deltanet_fwd.DeltaNetFwdKernel, gated_deltanet_fwd.GatedDeltaNetFwdKernel],
+)
+def test_tune_true_reaches_the_sweep(monkeypatch, kernel_cls) -> None:
+    """``init_config`` must not fall back for want of declared candidates."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        kernel_cls, "autotune", lambda self, **kwargs: calls.append(type(self).__name__)
+    )
+
+    kernel = kernel_cls(
+        batch=1, head=1, seq_len=128, chunk_size=64, dim_k=64, dim_v=64,
+        dtype="bfloat16", tune=True,
+    )
+
+    assert calls == [kernel_cls.__name__]
+    assert kernel.autotune_configs == la.delta_rule_fwd_autotune_configs(64, 64)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -204,16 +204,16 @@ def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> No
     assert config in la.delta_rule_fwd_autotune_configs(48)
 
 
-def test_a_shape_with_no_buildable_width_is_refused_by_both_entry_points() -> None:
+def test_a_shape_with_no_admissible_width_is_refused_by_both_entry_points() -> None:
     """The default and the declared set must refuse the same shapes.
 
     An empty config list reads as "tunable, with nothing to try": ``[]`` is not
     ``None``, so ``init_config`` would skip its warning and walk into the sweep.
     """
     assert la.h_block_v_candidates(8) == ()  # below the minimum gemm N extent
-    with pytest.raises(ValueError, match="no buildable"):
+    with pytest.raises(ValueError, match="no admissible"):
         la.default_h_block_v(8, 64)
-    with pytest.raises(ValueError, match="no buildable"):
+    with pytest.raises(ValueError, match="no admissible"):
         la.delta_rule_fwd_autotune_configs(8)
 
 

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -154,19 +154,15 @@ def test_short_chunks_still_sweep_the_tiled_width() -> None:
     """
     kernel = _StubKernel(chunk_size=32)
 
-    config = _run(kernel)
+    _run(kernel)
 
-    assert la.h_block_v_candidates(64) == (0, 32)
     assert [build.get("block_v") for name, build, _ in kernel.sweeps if name == "h"] == [0, 32]
-    assert la.default_h_block_v(64, 32) == 0
-    assert config["h_block_v"] in la.h_block_v_candidates(64)
 
 
 def test_v_tile_candidates_are_the_widths_the_recurrence_accepts() -> None:
     """The candidate set is whatever ``resolve_block_v`` admits, nothing else."""
     assert la.h_block_v_candidates(48) == (0,)  # 32 does not divide 48
     assert la.h_block_v_candidates(64) == (0, 32)
-    assert la.h_block_v_candidates(8) == ()  # below the minimum gemm N extent
 
 
 def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> None:
@@ -187,25 +183,13 @@ def test_untunable_fallback_width_is_buildable_when_dim_v_is_indivisible() -> No
     assert config in la.delta_rule_fwd_autotune_configs(48)
 
 
-def test_default_h_block_v_is_always_a_declared_candidate() -> None:
-    """The untuned width must be one the sweep also declares.
-
-    The default is what ``init_config`` falls back to, so a width outside the
-    declared set would be one no candidate check could have vetted.
-    """
-    for dim_v in (64, 48):
-        declared = {config["h_block_v"] for config in la.delta_rule_fwd_autotune_configs(dim_v)}
-        for chunk_size in (32, 64):
-            assert la.default_h_block_v(dim_v, chunk_size) in declared
-
-
 def test_a_shape_with_no_buildable_width_is_refused_by_both_entry_points() -> None:
     """The default and the declared set must refuse the same shapes.
 
     An empty config list reads as "tunable, with nothing to try": ``[]`` is not
     ``None``, so ``init_config`` would skip its warning and walk into the sweep.
     """
-    assert la.h_block_v_candidates(8) == ()
+    assert la.h_block_v_candidates(8) == ()  # below the minimum gemm N extent
     with pytest.raises(ValueError, match="no buildable"):
         la.default_h_block_v(8, 64)
     with pytest.raises(ValueError, match="no buildable"):
@@ -232,6 +216,33 @@ def test_a_width_that_fails_to_build_does_not_sink_the_sweep() -> None:
             raise RuntimeError("out of shared memory")
         return _StubJit("h", block_v=block_v)
 
+    with pytest.warns(UserWarning, match="unavailable"):
+        config = la.tune_delta_rule_fwd(
+            kernel,
+            fused_builder=lambda *shape: _StubJit("fused"),
+            h_builder=h_builder,
+            o_builder=lambda *shape: _StubJit("o"),
+        )
+
+    assert config["h_block_v"] == 0
+    assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
+
+
+def test_a_width_that_failed_to_build_is_never_the_fallback() -> None:
+    """The untuned preference only counts if that width actually built.
+
+    At chunk 64 the preference is 32. If 32 fails to build and 0 builds but
+    tunes to nothing, returning the preference would name the width the sweep
+    just proved unbuildable, and the error would resurface inside forward.
+    """
+    kernel = _StubKernel(chunk_size=64)
+    kernel.results = {("h", 0): (None, None)}
+
+    def h_builder(*shape, block_v):
+        if block_v == 32:
+            raise RuntimeError("out of shared memory")
+        return _StubJit("h", block_v=block_v)
+
     config = la.tune_delta_rule_fwd(
         kernel,
         fused_builder=lambda *shape: _StubJit("fused"),
@@ -239,40 +250,58 @@ def test_a_width_that_fails_to_build_does_not_sink_the_sweep() -> None:
         o_builder=lambda *shape: _StubJit("o"),
     )
 
+    assert la.default_h_block_v(64, 64) == 32, "the preference must diverge for this to bite"
     assert config["h_block_v"] == 0
-    assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
 
 
-def test_default_h_block_v_takes_the_narrowest_buildable_tiled_width() -> None:
+def test_no_width_building_at_all_reports_the_build_failure() -> None:
+    """A width is not the caller's to choose, so a config naming one is no answer."""
+    kernel = _StubKernel(chunk_size=64)
+
+    def h_builder(*shape, block_v):
+        raise RuntimeError("out of shared memory")
+
+    with pytest.raises(RuntimeError, match="no recurrence V-tile width built"):
+        la.tune_delta_rule_fwd(
+            kernel,
+            fused_builder=lambda *shape: _StubJit("fused"),
+            h_builder=h_builder,
+            o_builder=lambda *shape: _StubJit("o"),
+        )
+
+
+def test_default_h_block_v_prefers_a_tiled_width_and_stays_declared() -> None:
+    """The untuned width is the narrowest buildable tile, and always declared.
+
+    It is what ``init_config`` falls back to, so a width outside the declared
+    set would be one no candidate check could have vetted.
+    """
     assert la.default_h_block_v(64, 64) == 32
     assert la.default_h_block_v(48, 64) == 0  # 32 does not divide 48
     assert la.default_h_block_v(64, 32) == 0  # short chunk prefers no tiling
+    for dim_v, chunk_size in ((64, 64), (48, 64), (64, 32)):
+        declared = {c["h_block_v"] for c in la.delta_rule_fwd_autotune_configs(dim_v)}
+        assert la.default_h_block_v(dim_v, chunk_size) in declared
 
 
 @pytest.mark.parametrize(
     "kernel_cls",
     [deltanet_fwd.DeltaNetFwdKernel, gated_deltanet_fwd.GatedDeltaNetFwdKernel],
 )
-@pytest.mark.parametrize("dim_v, chunk_size", [(64, 64), (48, 64), (64, 32), (96, 64)])
-def test_default_config_width_is_one_the_kernel_builds(
-    kernel_cls, dim_v: int, chunk_size: int
-) -> None:
-    """The untuned width must be declared too, or forward truncates the V range."""
+def test_default_config_width_is_one_the_kernel_builds(kernel_cls) -> None:
+    """Both kernels draw their untuned width from the shared candidates.
+
+    dim_v=48 is the shape that regressed silently: a tiled width of 32 gives
+    one tile covering 32 of 48 columns. The width rules themselves are checked
+    on the helper; this checks the kernels are wired to them.
+    """
     kernel = kernel_cls(
-        batch=1, head=1, seq_len=128, chunk_size=chunk_size, dim_k=64, dim_v=dim_v,
+        batch=1, head=1, seq_len=128, chunk_size=64, dim_k=64, dim_v=48,
         dtype="bfloat16",
     )
 
-    assert kernel.config["h_block_v"] in la.h_block_v_candidates(dim_v)
+    assert kernel.config["h_block_v"] in la.h_block_v_candidates(48)
     assert kernel.config in kernel.autotune_configs
-
-
-def test_both_forward_kernels_share_one_sweep_implementation() -> None:
-    """Neither kernel may carry its own copy of the sweep."""
-    assert deltanet_fwd.tune_delta_rule_fwd is la.tune_delta_rule_fwd
-    assert gated_deltanet_fwd.tune_delta_rule_fwd is la.tune_delta_rule_fwd
-    assert (deltanet_fwd.delta_rule_fwd_autotune_configs
-            is gated_deltanet_fwd.delta_rule_fwd_autotune_configs)
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -212,16 +212,20 @@ def test_a_width_that_fails_to_tune_does_not_sink_the_sweep() -> None:
 
     def fail_wide_tile(jit_kernel, *args, **kwargs):
         if jit_kernel.build_kwargs.get("block_v") == 32:
-            raise RuntimeError("Auto-tuning failed: No configuration successfully compiled")
+            raise RuntimeError("header line\n" + "x" * 5000)
         return inner(jit_kernel, *args, **kwargs)
 
     kernel.tune_jit_kernel = fail_wide_tile
 
-    with pytest.warns(UserWarning, match="unavailable"):
+    with pytest.warns(UserWarning, match="unavailable") as warned:
         config = _run(kernel)
 
     assert config["h_block_v"] == 0
     assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
+    # When a width is dropped but the sweep survives, the warning is the only
+    # diagnostic, so it is bounded the same way the raised error is.
+    dropped = str(warned[0].message)
+    assert "\n" not in dropped and len(dropped) < 400
 
 
 def test_a_width_that_compiled_is_used_even_when_another_failed() -> None:
@@ -287,9 +291,10 @@ def test_the_raised_error_bounds_a_long_failure_text() -> None:
     message = str(e.value)
     widths = len(la.h_block_v_candidates(kernel.dim_v))
     assert "\n" not in message
-    # One bounded summary per width, so the bound scales with the candidate set
-    # rather than with however many widths happen to be offered today.
-    assert len(message) < 300 * widths
+    # One bounded summary per width, plus a fixed prefix naming the shape, so
+    # the bound scales with the candidate set rather than with however many
+    # widths happen to be offered today.
+    assert len(message) < 250 * widths + 100
     assert "x" * 300 not in message, "the log body must not survive whole"
     assert log in str(e.value.__cause__), "the chained cause keeps the whole text"
 

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -122,13 +122,8 @@ def test_fastest_v_tile_width_wins() -> None:
     assert (config["h_num_stages"], config["h_threads"]) == (2, 256)
 
 
-def test_untunable_launch_params_fall_back_but_the_width_does_not() -> None:
-    """Launch params keep their default; the V-tile width takes the safe one.
-
-    A width with no measurement has no evidence it compiles — that is how a
-    per-candidate build failure reaches us — so the untuned preference is not
-    taken on faith. Candidate order puts the untiled width first.
-    """
+def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
+    """An autotuner that returns without a result leaves every key at its default."""
     kernel = _StubKernel()
     kernel.results = {
         ("fused", 0): (None, None),
@@ -139,8 +134,7 @@ def test_untunable_launch_params_fall_back_but_the_width_does_not() -> None:
 
     config = _run(kernel)
 
-    assert kernel.default_config["h_block_v"] == 32, "the preference must diverge to bite"
-    assert config == {**kernel.default_config, "h_block_v": 0}
+    assert config == kernel.default_config
 
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
@@ -209,27 +203,24 @@ def test_widths_resolving_to_one_tile_are_a_single_candidate() -> None:
     assert {config["h_block_v"] for config in la.delta_rule_fwd_autotune_configs(32)} == {0}
 
 
-def test_a_width_that_fails_to_build_does_not_sink_the_sweep() -> None:
-    """resolve_block_v cannot see shared-memory or codegen failures.
+def test_a_width_that_fails_to_tune_does_not_sink_the_sweep() -> None:
+    """Compilation happens inside the autotuner, which raises when none survives.
 
-    Those surface only when the width is built, and they disqualify that width,
-    not the whole sweep — the other width must still be measured and win.
+    That failure is this width's, so it is dropped with a warning and the other
+    width still wins — the sweep aborting would waste a usable width.
     """
     kernel = _StubKernel(chunk_size=64)
-    failing = {"h": 32}
+    inner = kernel.tune_jit_kernel
 
-    def h_builder(*shape, block_v):
-        if block_v == failing["h"]:
-            raise RuntimeError("out of shared memory")
-        return _StubJit("h", block_v=block_v)
+    def fail_wide_tile(jit_kernel, *args, **kwargs):
+        if jit_kernel.build_kwargs.get("block_v") == 32:
+            raise RuntimeError("Auto-tuning failed: No configuration successfully compiled")
+        return inner(jit_kernel, *args, **kwargs)
+
+    kernel.tune_jit_kernel = fail_wide_tile
 
     with pytest.warns(UserWarning, match="unavailable"):
-        config = la.tune_delta_rule_fwd(
-            kernel,
-            fused_builder=lambda *shape: _StubJit("fused"),
-            h_builder=h_builder,
-            o_builder=lambda *shape: _StubJit("o"),
-        )
+        config = _run(kernel)
 
     assert config["h_block_v"] == 0
     assert config in la.delta_rule_fwd_autotune_configs(kernel.dim_v)
@@ -244,59 +235,41 @@ def test_a_width_that_failed_to_build_is_never_the_fallback() -> None:
     """
     kernel = _StubKernel(chunk_size=64)
     kernel.results = {("h", 0): (None, None)}
-
-    def h_builder(*shape, block_v):
-        if block_v == 32:
-            raise RuntimeError("out of shared memory")
-        return _StubJit("h", block_v=block_v)
-
-    config = la.tune_delta_rule_fwd(
-        kernel,
-        fused_builder=lambda *shape: _StubJit("fused"),
-        h_builder=h_builder,
-        o_builder=lambda *shape: _StubJit("o"),
-    )
-
-    assert la.default_h_block_v(64, 64) == 32, "the preference must diverge for this to bite"
-    assert config["h_block_v"] == 0
-
-
-def test_a_tuning_failure_is_not_reported_as_a_dropped_width() -> None:
-    """Only the builder call is width-specific.
-
-    A failure inside the autotuner is the device's or the tuner's; reporting it
-    as a dropped width would hide it behind a config that looks tuned.
-    """
-    kernel = _StubKernel()
     inner = kernel.tune_jit_kernel
 
-    def explode_on_recurrence(jit_kernel, *args, **kwargs):
-        # Only the recurrence, so the failure lands inside the width loop —
-        # the fused sub-kernel is tuned before it and would mask this.
+    def fail_wide_tile(jit_kernel, *args, **kwargs):
+        if jit_kernel.build_kwargs.get("block_v") == 32:
+            raise RuntimeError("Auto-tuning failed: No configuration successfully compiled")
+        return inner(jit_kernel, *args, **kwargs)
+
+    kernel.tune_jit_kernel = fail_wide_tile
+
+    assert la.default_h_block_v(64, 64) == 32, "the preference must diverge for this to bite"
+    with pytest.warns(UserWarning), pytest.raises(RuntimeError, match="no recurrence V-tile"):
+        _run(kernel)
+
+
+def test_no_width_tuning_reports_the_failure_with_its_cause() -> None:
+    """A width is not the caller's to choose, so a config naming one is no answer.
+
+    A failure that is not width-specific looks the same from here, so it is not
+    lost either: it is what the raised error chains.
+    """
+    kernel = _StubKernel(chunk_size=64)
+    inner = kernel.tune_jit_kernel
+
+    def fail_every_width(jit_kernel, *args, **kwargs):
         if jit_kernel.name == "h":
             raise RuntimeError("device lost")
         return inner(jit_kernel, *args, **kwargs)
 
-    kernel.tune_jit_kernel = explode_on_recurrence
+    kernel.tune_jit_kernel = fail_every_width
 
-    with pytest.raises(RuntimeError, match="device lost"):
+    with pytest.warns(UserWarning), pytest.raises(RuntimeError, match="no recurrence V-tile") as e:
         _run(kernel)
 
-
-def test_no_width_building_at_all_reports_the_build_failure() -> None:
-    """A width is not the caller's to choose, so a config naming one is no answer."""
-    kernel = _StubKernel(chunk_size=64)
-
-    def h_builder(*shape, block_v):
-        raise RuntimeError("out of shared memory")
-
-    with pytest.raises(RuntimeError, match="no recurrence V-tile width could be built"):
-        la.tune_delta_rule_fwd(
-            kernel,
-            fused_builder=lambda *shape: _StubJit("fused"),
-            h_builder=h_builder,
-            o_builder=lambda *shape: _StubJit("o"),
-        )
+    assert isinstance(e.value.__cause__, RuntimeError)
+    assert "device lost" in str(e.value.__cause__)
 
 
 def test_default_h_block_v_prefers_a_tiled_width_and_stays_declared() -> None:

--- a/tests/kernels/test_linear_attn_autotune.py
+++ b/tests/kernels/test_linear_attn_autotune.py
@@ -7,7 +7,6 @@ tuned. ``tests/ops/test_deltanet_fwd.py`` covers the same helper on the device.
 """
 
 import inspect
-import sys
 
 import pytest
 
@@ -124,20 +123,20 @@ def test_fastest_v_tile_width_wins() -> None:
 
 def test_untunable_sub_kernel_falls_back_to_default_config() -> None:
     """An autotuner that returns without a result leaves every key at its default."""
-    kernel = _StubKernel()
+    # dim_v=48, where the stub's default_config width (32) is not buildable,
+    # so taking it straight from there would be visible.
+    kernel = _StubKernel(chunk_size=64, dim_v=48)
     kernel.results = {
         ("fused", 0): (None, None),
         ("h", 0): (None, None),
-        ("h", 32): (None, None),
         ("o", 0): (None, None),
     }
 
     config = _run(kernel)
 
-    assert config == {
-        **kernel.default_config,
-        "h_block_v": la.default_h_block_v(kernel.dim_v, kernel.chunk_size),
-    }
+    assert kernel.default_config["h_block_v"] == 32
+    assert config == {**kernel.default_config, "h_block_v": la.default_h_block_v(48, 64)}
+    assert config["h_block_v"] == 0
 
 
 def test_selected_config_is_always_a_declared_candidate() -> None:
@@ -325,9 +324,6 @@ def test_default_config_width_is_one_the_kernel_builds(kernel_cls) -> None:
 
     assert kernel.config["h_block_v"] in la.h_block_v_candidates(48)
     assert kernel.config in kernel.autotune_configs
-    # No second copy of the sweep may reappear in either kernel module.
-    module = sys.modules[kernel_cls.__module__]
-    assert module.tune_delta_rule_fwd is la.tune_delta_rule_fwd
 
 
 @pytest.mark.parametrize(

--- a/tests/kernels/test_v_tile.py
+++ b/tests/kernels/test_v_tile.py
@@ -7,13 +7,35 @@ this test, removing the guard passes CI on the pinned image unnoticed.
 
 import pytest
 
-from tileops.kernels.gated_deltanet.gated_deltanet_fwd import _h_recurrence_tl
+from tileops.kernels.deltanet.deltanet_fwd import _h_recurrence_tl as deltanet_h_recurrence
+from tileops.kernels.gated_deltanet.gated_deltanet_fwd import (
+    _h_recurrence_tl as gated_h_recurrence,
+)
 from tileops.kernels.v_tile import GEMM_MIN_N
 
 pytestmark = pytest.mark.smoke
 
+#: Both delta-rule recurrences tile V the same way, so both owe the same guard.
+_H_RECURRENCE_BUILDERS = [
+    pytest.param(deltanet_h_recurrence, id="deltanet"),
+    pytest.param(gated_h_recurrence, id="gated"),
+]
 
-def test_h_recurrence_rejects_previously_defaulted_narrow_v_tile() -> None:
+
+@pytest.mark.parametrize("build", _H_RECURRENCE_BUILDERS)
+def test_h_recurrence_rejects_previously_defaulted_narrow_v_tile(build) -> None:
     # The shape whose default config formerly selected block_v = 8.
     with pytest.raises(ValueError, match=str(GEMM_MIN_N)):
-        _h_recurrence_tl(1, 4, 128, 64, 64, 64, "float16", block_v=8)
+        build(1, 4, 128, 64, 64, 64, "float16", block_v=8)
+
+
+@pytest.mark.parametrize("build", _H_RECURRENCE_BUILDERS)
+def test_h_recurrence_rejects_a_v_tile_that_does_not_divide_dim_v(build) -> None:
+    """A width that leaves a partial tile would silently drop the trailing columns.
+
+    ``dim_v=48`` with ``block_v=32`` yields ``48 // 32 == 1`` tile, so the
+    recurrence would write 32 of 48 columns and leave the rest uninitialized
+    for the output projection to consume.
+    """
+    with pytest.raises(ValueError, match="divisible"):
+        build(1, 4, 128, 64, 64, 48, "float16", block_v=32)

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -115,7 +115,9 @@ class DeltaNetFwdFixture(FixtureBase):
             pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            pytest.param(2, 64, 2, 64, 64, 32, torch.bfloat16, True, marks=pytest.mark.full,
+            # chunk_size=64 is the smallest chunk for which the sweep offers a
+            # tiled recurrence, so this case covers the V-tile width comparison.
+            pytest.param(2, 128, 2, 64, 64, 64, torch.bfloat16, True, marks=pytest.mark.full,
                          id="full-bf16-tuned"),
         ]),
     ]
@@ -140,6 +142,10 @@ def test_deltanet_fwd(
     ref_o = test.ref_program(*inputs)
     op_o, _S, _Aw, _Au, _w, _u = op(*inputs)
     torch.testing.assert_close(op_o, ref_o, **tols)
+    if tune:
+        # The forward above already proves the selected config builds and runs;
+        # this pins it to the declared candidate set the sweep draws from.
+        assert op.kernel.config in op.kernel.autotune_configs
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_deltanet_fwd.py
+++ b/tests/ops/test_deltanet_fwd.py
@@ -115,8 +115,8 @@ class DeltaNetFwdFixture(FixtureBase):
             pytest.param(1, 128, 4, 64, 64, 32, torch.bfloat16, False, marks=pytest.mark.full),
             pytest.param(2, 8192, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
             pytest.param(2, 16384, 4, 64, 64, 64, torch.float16, False, marks=pytest.mark.full),
-            # chunk_size=64 is the smallest chunk for which the sweep offers a
-            # tiled recurrence, so this case covers the V-tile width comparison.
+            # chunk_size=64 is where the untuned default takes a tiled width, so
+            # the tuned run has to beat a tiled baseline rather than no tiling.
             pytest.param(2, 128, 2, 64, 64, 64, torch.bfloat16, True, marks=pytest.mark.full,
                          id="full-bf16-tuned"),
         ]),

--- a/tests/ops/test_gated_deltanet_fwd.py
+++ b/tests/ops/test_gated_deltanet_fwd.py
@@ -162,6 +162,8 @@ def test_gated_deltanet_fwd(
     ref_o = test.ref_program(*inputs)
     op_o, _S, _Aw, _Au = op(*inputs)
     torch.testing.assert_close(op_o, ref_o, **tols)
+    if tune:
+        assert op.kernel.config in op.kernel.autotune_configs
 
 
 if __name__ == "__main__":

--- a/tileops/kernels/deltanet/deltanet_fwd.py
+++ b/tileops/kernels/deltanet/deltanet_fwd.py
@@ -21,6 +21,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.linear_attn_autotune import (
+    default_h_block_v,
     delta_rule_fwd_autotune_configs,
     tune_delta_rule_fwd,
 )
@@ -282,13 +283,12 @@ class DeltaNetFwdKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        h_block_v = 32 if self.chunk_size >= 64 else 0
         return {
             "fused_num_stages": 2,
             "fused_threads": 256,
             "h_num_stages": 2,
             "h_threads": 256,
-            "h_block_v": h_block_v,
+            "h_block_v": default_h_block_v(self.dim_v, self.chunk_size),
             "o_threads": 256,
         }
 

--- a/tileops/kernels/deltanet/deltanet_fwd.py
+++ b/tileops/kernels/deltanet/deltanet_fwd.py
@@ -20,6 +20,10 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.linear_attn_autotune import (
+    delta_rule_fwd_autotune_configs,
+    tune_delta_rule_fwd,
+)
 
 from .fused_prepare_compute_w_u import fused_prepare_compute_w_u_tl
 
@@ -288,88 +292,20 @@ class DeltaNetFwdKernel(Kernel):
             "o_threads": 256,
         }
 
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return delta_rule_fwd_autotune_configs(self.dim_v, self.chunk_size)
+
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Autotune each sub-kernel independently and merge best configs."""
-        from tilelang.autotuner import autotune as tl_autotune
-        from tilelang.profiler import do_bench as _do_bench
-
-        B, H, S, BC = self.batch, self.head, self.seq_len, self.chunk_size
-        DK, DV, dt = self.dim_k, self.dim_v, self.dtype_str
-
-        # --- Tune fused_prepare_compute_w_u ---
-        fused_configs = [
-            {"num_stages": ns, "threads": t}
-            for ns in [1, 2] for t in [128, 256]
-        ]
-        print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
-        fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
-        _fused_at = dict(configs=fused_configs, warmup=warmup, rep=rep)
-        _fused_dns = list(self._autotune_initial_kwargs(fused_jit, fused_configs[0]).keys())
-        if _fused_dns:
-            _fused_at["do_not_specialize"] = _fused_dns
-        tuned_fused = self._call_autotuned_kernel(
-            tl_autotune(**_fused_at)(fused_jit),
-            fused_jit,
-            fused_configs[0],
+        """Tune the three sub-kernels independently and merge the winners."""
+        self.config = tune_delta_rule_fwd(
+            self,
+            fused_builder=fused_prepare_compute_w_u_tl,
+            h_builder=_h_recurrence_tl,
+            o_builder=_output_o_tl,
+            warmup=warmup,
+            rep=rep,
         )
-        fused_best = tuned_fused.config
-        print(f"  Best: {fused_best}")
-
-        # --- Tune h_recurrence ---
-        best_h_latency = float("inf")
-        best_h_cfg = None
-        bv_candidates = [bv for bv in [0, 32] if DV % (bv or DV) == 0]
-        for bv in bv_candidates:
-            h_configs = [
-                {"num_stages": ns, "threads": t}
-                for ns in [1, 2] for t in [128, 256]
-            ]
-            label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
-            print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
-            h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
-            _h_at = dict(configs=h_configs, warmup=warmup, rep=rep)
-            _h_dns = list(self._autotune_initial_kwargs(h_jit, h_configs[0]).keys())
-            if _h_dns:
-                _h_at["do_not_specialize"] = _h_dns
-            tuned_h = self._call_autotuned_kernel(
-                tl_autotune(**_h_at)(h_jit),
-                h_jit,
-                h_configs[0],
-            )
-            if tuned_h.config is not None:
-                lat = _do_bench(tuned_h, warmup=warmup, rep=rep)
-                print(f"  Best: {tuned_h.config}, latency={lat:.4f} ms")
-                if lat < best_h_latency:
-                    best_h_latency = lat
-                    best_h_cfg = {**tuned_h.config, "block_v": bv}
-        h_best = best_h_cfg or {"num_stages": 2, "threads": 256, "block_v": 32}
-        print(f"  Overall best h_recurrence: {h_best}")
-
-        # --- Tune output_o ---
-        o_configs = [{"threads": t} for t in [64, 128, 256]]
-        print(f"Autotuning output_o ({len(o_configs)} configs)...")
-        o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
-        _o_at = dict(configs=o_configs, warmup=warmup, rep=rep)
-        _o_dns = list(self._autotune_initial_kwargs(o_jit, o_configs[0]).keys())
-        if _o_dns:
-            _o_at["do_not_specialize"] = _o_dns
-        tuned_o = self._call_autotuned_kernel(
-            tl_autotune(**_o_at)(o_jit),
-            o_jit,
-            o_configs[0],
-        )
-        o_best = tuned_o.config
-        print(f"  Best: {o_best}")
-
-        self.config = {
-            "fused_num_stages": fused_best["num_stages"],
-            "fused_threads": fused_best["threads"],
-            "h_num_stages": h_best["num_stages"],
-            "h_threads": h_best["threads"],
-            "h_block_v": h_best.get("block_v", 32),
-            "o_threads": o_best["threads"],
-        }
-        print(f"DeltaNetFwdKernel autotuned config: {self.config}")
 
     def forward(
         self,

--- a/tileops/kernels/deltanet/deltanet_fwd.py
+++ b/tileops/kernels/deltanet/deltanet_fwd.py
@@ -25,6 +25,7 @@ from tileops.kernels.linear_attn_autotune import (
     delta_rule_fwd_autotune_configs,
     tune_delta_rule_fwd,
 )
+from tileops.kernels.v_tile import resolve_block_v
 
 from .fused_prepare_compute_w_u import fused_prepare_compute_w_u_tl
 
@@ -56,7 +57,7 @@ def _h_recurrence_tl(
     accum_dtype = "float32"
     block_C = chunk_size
     num_chunks = seq_len // block_C
-    BV = dim_v if block_v <= 0 else block_v
+    BV = resolve_block_v(dim_v, block_v)
     num_v_tiles = dim_v // BV
 
     @tilelang.jit(
@@ -294,7 +295,7 @@ class DeltaNetFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return delta_rule_fwd_autotune_configs(self.dim_v, self.chunk_size)
+        return delta_rule_fwd_autotune_configs(self.dim_v)
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Tune the three sub-kernels independently and merge the winners."""

--- a/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -318,7 +318,7 @@ class GatedDeltaNetFwdKernel(Kernel):
 
     @property
     def autotune_configs(self) -> list[dict]:
-        return delta_rule_fwd_autotune_configs(self.dim_v, self.chunk_size)
+        return delta_rule_fwd_autotune_configs(self.dim_v)
 
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
         """Tune the three sub-kernels independently and merge the winners."""

--- a/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -18,6 +18,10 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.linear_attn_autotune import (
+    delta_rule_fwd_autotune_configs,
+    tune_delta_rule_fwd,
+)
 from tileops.kernels.v_tile import resolve_block_v
 
 from .fused_prepare_compute_w_u import fused_prepare_compute_w_u_tl
@@ -314,88 +318,20 @@ class GatedDeltaNetFwdKernel(Kernel):
             "o_threads": 256,
         }
 
+    @property
+    def autotune_configs(self) -> list[dict]:
+        return delta_rule_fwd_autotune_configs(self.dim_v, self.chunk_size)
+
     def autotune(self, warmup: int = 10, rep: int = 10) -> None:
-        """Autotune each sub-kernel independently and merge best configs."""
-        from tilelang.autotuner import autotune as tl_autotune
-        from tilelang.profiler import do_bench as _do_bench
-
-        B, H, S, BC = self.batch, self.head, self.seq_len, self.chunk_size
-        DK, DV, dt = self.dim_k, self.dim_v, self.dtype_str
-
-        # --- Tune fused_prepare_compute_w_u ---
-        fused_configs = [
-            {"num_stages": ns, "threads": t}
-            for ns in [1, 2] for t in [128, 256]
-        ]
-        print(f"Autotuning fused_prepare_compute_w_u ({len(fused_configs)} configs)...")
-        fused_jit = fused_prepare_compute_w_u_tl(B, H, S, BC, DK, DV, dt)
-        _fused_at = dict(configs=fused_configs, warmup=warmup, rep=rep)
-        _fused_dns = list(self._autotune_initial_kwargs(fused_jit, fused_configs[0]).keys())
-        if _fused_dns:
-            _fused_at["do_not_specialize"] = _fused_dns
-        tuned_fused = self._call_autotuned_kernel(
-            tl_autotune(**_fused_at)(fused_jit),
-            fused_jit,
-            fused_configs[0],
+        """Tune the three sub-kernels independently and merge the winners."""
+        self.config = tune_delta_rule_fwd(
+            self,
+            fused_builder=fused_prepare_compute_w_u_tl,
+            h_builder=_h_recurrence_tl,
+            o_builder=_output_o_tl,
+            warmup=warmup,
+            rep=rep,
         )
-        fused_best = tuned_fused.config
-        print(f"  Best: {fused_best}")
-
-        # --- Tune h_recurrence (sweep block_v separately since it changes kernel shape) ---
-        best_h_latency = float("inf")
-        best_h_cfg = None
-        bv_candidates = [bv for bv in [0, 32] if DV % (bv or DV) == 0]
-        for bv in bv_candidates:
-            h_configs = [
-                {"num_stages": ns, "threads": t}
-                for ns in [1, 2] for t in [128, 256]
-            ]
-            label = f"block_v={bv}" if bv else "block_v=0 (no tile)"
-            print(f"Autotuning h_recurrence {label} ({len(h_configs)} configs)...")
-            h_jit = _h_recurrence_tl(B, H, S, BC, DK, DV, dt, block_v=bv)
-            _h_at = dict(configs=h_configs, warmup=warmup, rep=rep)
-            _h_dns = list(self._autotune_initial_kwargs(h_jit, h_configs[0]).keys())
-            if _h_dns:
-                _h_at["do_not_specialize"] = _h_dns
-            tuned_h = self._call_autotuned_kernel(
-                tl_autotune(**_h_at)(h_jit),
-                h_jit,
-                h_configs[0],
-            )
-            if tuned_h.config is not None:
-                lat = _do_bench(tuned_h, warmup=warmup, rep=rep)
-                print(f"  Best: {tuned_h.config}, latency={lat:.4f} ms")
-                if lat < best_h_latency:
-                    best_h_latency = lat
-                    best_h_cfg = {**tuned_h.config, "block_v": bv}
-        h_best = best_h_cfg or {"num_stages": 2, "threads": 256, "block_v": 32}
-        print(f"  Overall best h_recurrence: {h_best}")
-
-        # --- Tune output_o ---
-        o_configs = [{"threads": t} for t in [64, 128, 256]]
-        print(f"Autotuning output_o ({len(o_configs)} configs)...")
-        o_jit = _output_o_tl(B, H, S, BC, DK, DV, dt)
-        _o_at = dict(configs=o_configs, warmup=warmup, rep=rep)
-        _o_dns = list(self._autotune_initial_kwargs(o_jit, o_configs[0]).keys())
-        if _o_dns:
-            _o_at["do_not_specialize"] = _o_dns
-        tuned_o = self._call_autotuned_kernel(
-            tl_autotune(**_o_at)(o_jit),
-            o_jit,
-            o_configs[0],
-        )
-        o_best = tuned_o.config
-        print(f"  Best: {o_best}")
-
-        self.config = {
-            "fused_num_stages": fused_best["num_stages"],
-            "fused_threads": fused_best["threads"],
-            "h_num_stages": h_best["num_stages"],
-            "h_threads": h_best["threads"],
-            "h_block_v": h_best.get("block_v", 32),
-            "o_threads": o_best["threads"],
-        }
-        print(f"GatedDeltaNetFwdKernel autotuned config: {self.config}")
 
     def forward(
         self,

--- a/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
+++ b/tileops/kernels/gated_deltanet/gated_deltanet_fwd.py
@@ -19,6 +19,7 @@ import torch
 
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.linear_attn_autotune import (
+    default_h_block_v,
     delta_rule_fwd_autotune_configs,
     tune_delta_rule_fwd,
 )
@@ -306,15 +307,12 @@ class GatedDeltaNetFwdKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
-        # bv=32 V-tiling for chunk_size>=64; bv=16 has numerical issues in fp16.
-        # Fall back to no tiling for smaller chunks.
-        h_block_v = 32 if self.chunk_size >= 64 else 0
         return {
             "fused_num_stages": 2,
             "fused_threads": 256,
             "h_num_stages": 2,
             "h_threads": 256,
-            "h_block_v": h_block_v,
+            "h_block_v": default_h_block_v(self.dim_v, self.chunk_size),
             "o_threads": 256,
         }
 

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -139,6 +139,48 @@ class Kernel(ABC):
             **self._autotune_initial_kwargs(kernel=kernel, config=config)
         )
 
+    def tune_jit_kernel(
+        self,
+        jit_kernel: Callable,
+        configs: list[dict],
+        warmup: int = 25,
+        rep: int = 50,
+        seed_config: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Benchmark *configs* against one JIT kernel and return the winner.
+
+        A kernel built from several sub-kernels tunes each one on its own
+        candidate list, so the JIT object and the candidates are arguments here
+        rather than being read from ``self.kernel`` / ``self.autotune_configs``.
+
+        Args:
+            jit_kernel: The ``@tilelang.jit``-decorated builder to tune.
+            configs: Candidate configs handed to TileLang's autotuner.
+            warmup: Warmup iterations per candidate.
+            rep: Timed iterations per candidate.
+            seed_config: Config supplying the seeded JIT parameter values;
+                ``default_config`` when omitted.
+
+        Returns:
+            The tuned kernel, carrying the winning ``config`` and its measured
+            ``latency``.
+        """
+        # Pass do_not_specialize so TileLang excludes the seeded JIT parameters
+        # from the cache key; without this, the seed values read as "already
+        # tuned" and the benchmarking sweep is skipped (returning config=None).
+        seeds = self._autotune_initial_kwargs(jit_kernel, seed_config)
+        autotune_kwargs: Dict[str, Any] = dict(configs=configs, warmup=warmup, rep=rep)
+        if seeds:
+            autotune_kwargs["do_not_specialize"] = list(seeds)
+        if self.autotune_supply_prog is not None:
+            autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+        autotuned_kernel_fn = autotune(**autotune_kwargs)(jit_kernel)
+
+        # Seed required tunable JIT parameters for TileLang's pre-autotune
+        # validation/binding step. Candidate configs still override these
+        # initial values during the actual autotune run.
+        return self._call_autotuned_kernel(autotuned_kernel_fn, jit_kernel, seed_config)
+
     def autotune(self, warmup: int = 25, rep: int = 50) -> None:
         if self.autotune_configs is None:
             return  # kernel doesn't support autotuning
@@ -148,25 +190,8 @@ class Kernel(ABC):
                 "Set 'self.kernel' in __init__ before calling init_config with tune=True.")
         print(f'Start autotuning {self.__class__.__name__}...')
 
-        # Apply autotune decorator to the kernel function.
-        # Pass do_not_specialize so TileLang 0.1.11 excludes the seeded JIT
-        # parameters from the cache key; without this, providing the default
-        # config values below would cause the autotuner to treat them as
-        # "already tuned" and skip the benchmarking sweep entirely
-        # (returning config=None).
-        tunable_params = list(self._autotune_initial_kwargs(self.kernel).keys())
-        autotune_kwargs: Dict[str, Any] = dict(
-            configs=self.autotune_configs, warmup=warmup, rep=rep)
-        if tunable_params:
-            autotune_kwargs["do_not_specialize"] = tunable_params
-        if self.autotune_supply_prog is not None:
-            autotune_kwargs["supply_prog"] = self.autotune_supply_prog
-        autotuned_kernel_fn = autotune(**autotune_kwargs)(self.kernel)
-
-        # Seed required tunable JIT parameters for TileLang's pre-autotune
-        # validation/binding step. Candidate configs still override these
-        # initial values during the actual autotune run.
-        tuned_kernel = self._call_autotuned_kernel(autotuned_kernel_fn, self.kernel)
+        tuned_kernel = self.tune_jit_kernel(
+            self.kernel, self.autotune_configs, warmup=warmup, rep=rep)
 
         # Extract and store the best config
         self.config = tuned_kernel.config

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 from tilelang.autotuner import autotune
@@ -150,7 +150,7 @@ class Kernel(ABC):
         warmup: int = 25,
         rep: int = 50,
         seed_config: Optional[Dict[str, Any]] = None,
-        supply_prog: Optional[Callable] = _INHERIT_SUPPLY_PROG,
+        supply_prog: Union[Callable, None, object] = _INHERIT_SUPPLY_PROG,
     ) -> Any:
         """Benchmark *configs* against one JIT kernel and return the winner.
 

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -4,6 +4,10 @@ from typing import Any, Callable, Dict, Optional
 import torch
 from tilelang.autotuner import autotune
 
+#: Sentinel for ``tune_jit_kernel(supply_prog=...)``: inherit the whole-kernel
+#: supplier. Distinct from ``None``, which means "no supplier".
+_INHERIT_SUPPLY_PROG = object()
+
 
 class Kernel(ABC):
     dtype: Optional[torch.dtype] = None
@@ -146,6 +150,7 @@ class Kernel(ABC):
         warmup: int = 25,
         rep: int = 50,
         seed_config: Optional[Dict[str, Any]] = None,
+        supply_prog: Optional[Callable] = _INHERIT_SUPPLY_PROG,
     ) -> Any:
         """Benchmark *configs* against one JIT kernel and return the winner.
 
@@ -160,6 +165,11 @@ class Kernel(ABC):
             rep: Timed iterations per candidate.
             seed_config: Config supplying the seeded JIT parameter values;
                 ``default_config`` when omitted.
+            supply_prog: Input supplier for the candidates. Defaults to
+                ``autotune_supply_prog``, which is written against
+                ``self.kernel``; a sub-kernel taking different inputs must pass
+                its own, since the whole-kernel supplier would feed it the
+                wrong ones. Pass ``None`` for no supplier.
 
         Returns:
             The tuned kernel, carrying the winning ``config`` and its measured
@@ -172,8 +182,10 @@ class Kernel(ABC):
         autotune_kwargs: Dict[str, Any] = dict(configs=configs, warmup=warmup, rep=rep)
         if seeds:
             autotune_kwargs["do_not_specialize"] = list(seeds)
-        if self.autotune_supply_prog is not None:
-            autotune_kwargs["supply_prog"] = self.autotune_supply_prog
+        if supply_prog is _INHERIT_SUPPLY_PROG:
+            supply_prog = self.autotune_supply_prog
+        if supply_prog is not None:
+            autotune_kwargs["supply_prog"] = supply_prog
         autotuned_kernel_fn = autotune(**autotune_kwargs)(jit_kernel)
 
         # Seed required tunable JIT parameters for TileLang's pre-autotune

--- a/tileops/kernels/kernel_base.py
+++ b/tileops/kernels/kernel_base.py
@@ -188,9 +188,6 @@ class Kernel(ABC):
             autotune_kwargs["supply_prog"] = supply_prog
         autotuned_kernel_fn = autotune(**autotune_kwargs)(jit_kernel)
 
-        # Seed required tunable JIT parameters for TileLang's pre-autotune
-        # validation/binding step. Candidate configs still override these
-        # initial values during the actual autotune run.
         return self._call_autotuned_kernel(autotuned_kernel_fn, jit_kernel, seed_config)
 
     def autotune(self, warmup: int = 25, rep: int = 50) -> None:
@@ -205,6 +202,5 @@ class Kernel(ABC):
         tuned_kernel = self.tune_jit_kernel(
             self.kernel, self.autotune_configs, warmup=warmup, rep=rep)
 
-        # Extract and store the best config
         self.config = tuned_kernel.config
         print(f'Best config: {self.config}')

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -7,6 +7,7 @@ merges the winners into the single flat config the wrapped kernel reads.
 """
 
 import itertools
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from tileops.kernels.v_tile import resolve_block_v
@@ -244,10 +245,9 @@ def tune_delta_rule_fwd(
     )
 
     h_config: Optional[Dict[str, int]] = None
-    # Derived here rather than read from default_config: this is the one key
-    # whose valid set depends on the shape, so taking it from the kernel would
-    # let an untuned width the sweep never offers escape through the fallback.
-    h_block_v = default_h_block_v(kernel.dim_v, kernel.chunk_size)
+    h_block_v: Optional[int] = None
+    built: List[int] = []
+    build_error: Optional[Exception] = None
     best_latency = float("inf")
     for block_v in h_block_v_candidates(kernel.dim_v):
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
@@ -264,12 +264,29 @@ def tune_delta_rule_fwd(
             # resolve_block_v answers what the tile geometry allows; shared
             # memory limits and codegen failures surface only on build, and
             # they disqualify this width rather than the whole sweep.
-            print(f"  {label} unavailable: {type(exc).__name__}: {exc}")
+            build_error = exc
+            warnings.warn(  # noqa: B028
+                f"{label} unavailable, dropping it from the sweep: "
+                f"{type(exc).__name__}: {exc}")
             continue
+        built.append(block_v)
         if config is None or latency is None:
             continue
         if latency < best_latency:
             h_config, h_block_v, best_latency = config, block_v, latency
+
+    if not built:
+        # Every width failed to build, so there is none to fall back to. The
+        # width is not the caller's to choose, so report the build failure
+        # rather than return a config naming a width just proved unbuildable.
+        raise RuntimeError(
+            f"no recurrence V-tile width built for dim_v={kernel.dim_v}") from build_error
+    if h_block_v is None:
+        # Nothing tuned, but something built. The untuned preference only
+        # counts if it was one of them; otherwise take the first width that
+        # built, which candidate order makes the untiled one where buildable.
+        preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
+        h_block_v = preferred if preferred in built else built[0]
 
     o_config, _ = _tune_sub_kernel(
         kernel, "output_o", o_builder(*shape), OUTPUT_CONFIGS, warmup, rep

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -51,19 +51,43 @@ def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
     Whether a width is buildable is ``resolve_block_v``'s question — minimum
     gemm N extent and divisibility — so ask it rather than restate its rules
     here, which is what keeps the candidate set from drifting from what the
-    recurrence will accept.
+    recurrence will accept. Widths resolving to the same tile are one
+    candidate: at ``dim_v == 32`` both 0 and 32 give a 32-column tile and the
+    same generated kernel, so offering both would build and time it twice.
 
     Args:
         dim_v: Value dimension.
     """
     buildable = []
+    resolved = set()
     for block_v in H_BLOCK_V_WIDTHS:
         try:
-            resolve_block_v(dim_v, block_v)
+            width = resolve_block_v(dim_v, block_v)
         except ValueError:
             continue
+        if width in resolved:
+            continue
+        resolved.add(width)
         buildable.append(block_v)
     return tuple(buildable)
+
+
+def _require_h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
+    """Return the buildable widths, refusing a shape that has none.
+
+    Both the untuned default and the declared config set answer for the same
+    shape, so they refuse the same shapes here rather than each deciding what
+    an empty candidate set means.
+
+    Raises:
+        ValueError: if no V-tile width is buildable at *dim_v*.
+    """
+    candidates = h_block_v_candidates(dim_v)
+    if not candidates:
+        raise ValueError(
+            f"no buildable recurrence V-tile width for dim_v={dim_v}; "
+            f"widths are {H_BLOCK_V_WIDTHS} and none satisfies resolve_block_v")
+    return candidates
 
 
 def default_h_block_v(dim_v: int, chunk_size: int) -> int:
@@ -86,14 +110,12 @@ def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     Raises:
         ValueError: if no V-tile width is buildable at *dim_v*.
     """
-    candidates = h_block_v_candidates(dim_v)
-    if not candidates:
-        raise ValueError(
-            f"no buildable recurrence V-tile width for dim_v={dim_v}; "
-            f"widths are {H_BLOCK_V_WIDTHS} and none satisfies resolve_block_v")
+    candidates = _require_h_block_v_candidates(dim_v)
     tiled = [block_v for block_v in candidates if block_v]
     if tiled and chunk_size >= TILED_DEFAULT_MIN_CHUNK_SIZE:
         return min(tiled)
+    # A shape whose only buildable width is tiled has no untiled width to
+    # prefer, so the preference yields to what the recurrence can build.
     return 0 if 0 in candidates else min(tiled)
 
 
@@ -108,6 +130,11 @@ def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:
 
     Args:
         dim_v: Value dimension.
+
+    Raises:
+        ValueError: if no V-tile width is buildable at *dim_v*, so the shape is
+            refused here rather than declaring an empty set that reads as
+            "tunable, with nothing to try".
     """
     return [
         {
@@ -121,7 +148,7 @@ def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:
         for fused, recurrence, block_v, output in itertools.product(
             PIPELINE_CONFIGS,
             PIPELINE_CONFIGS,
-            h_block_v_candidates(dim_v),
+            _require_h_block_v_candidates(dim_v),
             OUTPUT_CONFIGS,
         )
     ]
@@ -141,8 +168,15 @@ def _tune_sub_kernel(
     which is how a sub-kernel whose candidates all fail to build reports back.
     """
     print(f"Autotuning {label} ({len(configs)} configs)...")
+    # supply_prog=None, not the kernel's: a whole-kernel supplier is written
+    # against the forward's inputs, which are not this sub-kernel's.
     tuned = kernel.tune_jit_kernel(
-        jit_kernel, list(configs), warmup=warmup, rep=rep, seed_config=configs[0]
+        jit_kernel,
+        list(configs),
+        warmup=warmup,
+        rep=rep,
+        seed_config=configs[0],
+        supply_prog=None,
     )
     config = getattr(tuned, "config", None)
     latency = getattr(tuned, "latency", None)
@@ -217,14 +251,21 @@ def tune_delta_rule_fwd(
     best_latency = float("inf")
     for block_v in h_block_v_candidates(kernel.dim_v):
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
-        config, latency = _tune_sub_kernel(
-            kernel,
-            label,
-            h_builder(*shape, block_v=block_v),
-            PIPELINE_CONFIGS,
-            warmup,
-            rep,
-        )
+        try:
+            config, latency = _tune_sub_kernel(
+                kernel,
+                label,
+                h_builder(*shape, block_v=block_v),
+                PIPELINE_CONFIGS,
+                warmup,
+                rep,
+            )
+        except Exception as exc:  # noqa: BLE001 - one width failing must not sink the rest
+            # resolve_block_v answers what the tile geometry allows; shared
+            # memory limits and codegen failures surface only on build, and
+            # they disqualify this width rather than the whole sweep.
+            print(f"  {label} unavailable: {type(exc).__name__}: {exc}")
+            continue
         if config is None or latency is None:
             continue
         if latency < best_latency:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -1,0 +1,203 @@
+"""Autotune sweep shared by the chunked delta-rule forward kernels.
+
+DeltaNet and Gated DeltaNet forward each run as three sub-kernels — the fused
+w/u preparation, the state recurrence, and the output projection — and each
+sub-kernel carries its own launch config. The sweep tunes them independently and
+merges the winners into the single flat config the wrapped kernel reads.
+"""
+
+import itertools
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+__all__ = [
+    "H_BLOCK_V_WIDTHS",
+    "MIN_TILED_CHUNK_SIZE",
+    "OUTPUT_CONFIGS",
+    "PIPELINE_CONFIGS",
+    "delta_rule_fwd_autotune_configs",
+    "h_block_v_candidates",
+    "tune_delta_rule_fwd",
+]
+
+#: ``num_stages`` / ``threads`` candidates for the two matmul-heavy sub-kernels.
+PIPELINE_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
+    {"num_stages": num_stages, "threads": threads}
+    for num_stages in (1, 2)
+    for threads in (128, 256)
+)
+
+#: ``threads`` candidates for the output projection, which takes no pipeline depth.
+OUTPUT_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
+    {"threads": threads} for threads in (64, 128, 256)
+)
+
+#: V-tile widths the recurrence may be built with. 0 means one tile spanning dim_v.
+#: 16 is absent because it loses too much precision in fp16.
+H_BLOCK_V_WIDTHS: Tuple[int, ...] = (0, 32)
+
+#: Smallest chunk size for which a tiled recurrence is offered. Below it the
+#: kernels only build the untiled recurrence, so the sweep must not select a
+#: tiled width the kernel cannot run.
+MIN_TILED_CHUNK_SIZE: int = 64
+
+
+def h_block_v_candidates(dim_v: int, chunk_size: int) -> Tuple[int, ...]:
+    """Return the recurrence V-tile widths buildable at this shape.
+
+    Args:
+        dim_v: Value dimension; a tile width must divide it.
+        chunk_size: Chunk length; tiled widths need ``MIN_TILED_CHUNK_SIZE``.
+    """
+    return tuple(
+        block_v
+        for block_v in H_BLOCK_V_WIDTHS
+        if dim_v % (block_v or dim_v) == 0
+        and (block_v == 0 or chunk_size >= MIN_TILED_CHUNK_SIZE)
+    )
+
+
+def delta_rule_fwd_autotune_configs(dim_v: int, chunk_size: int) -> List[Dict[str, int]]:
+    """Return every merged config the sweep can select at this shape.
+
+    The three sub-kernels are tuned independently, so the reachable set is their
+    product. Declaring it is what makes ``init_config(tune=True)`` reach
+    ``autotune`` instead of falling back to ``default_config``, and it gives a
+    test a set to check the selected config against.
+
+    Args:
+        dim_v: Value dimension.
+        chunk_size: Chunk length.
+    """
+    return [
+        {
+            "fused_num_stages": fused["num_stages"],
+            "fused_threads": fused["threads"],
+            "h_num_stages": recurrence["num_stages"],
+            "h_threads": recurrence["threads"],
+            "h_block_v": block_v,
+            "o_threads": output["threads"],
+        }
+        for fused, recurrence, block_v, output in itertools.product(
+            PIPELINE_CONFIGS,
+            PIPELINE_CONFIGS,
+            h_block_v_candidates(dim_v, chunk_size),
+            OUTPUT_CONFIGS,
+        )
+    ]
+
+
+def _tune_sub_kernel(
+    kernel,
+    label: str,
+    jit_kernel: Callable,
+    configs: Sequence[Dict[str, int]],
+    warmup: int,
+    rep: int,
+) -> Tuple[Optional[Dict[str, int]], Optional[float]]:
+    """Sweep one sub-kernel and return its ``(winning config, latency)``.
+
+    Either element is ``None`` when TileLang's autotuner produced no result,
+    which is how a sub-kernel whose candidates all fail to build reports back.
+    """
+    print(f"Autotuning {label} ({len(configs)} configs)...")
+    tuned = kernel.tune_jit_kernel(
+        jit_kernel, list(configs), warmup=warmup, rep=rep, seed_config=configs[0]
+    )
+    config = getattr(tuned, "config", None)
+    latency = getattr(tuned, "latency", None)
+    print(f"  Best: {config}")
+    return config, latency
+
+
+def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:
+    """Return the tuned value for *key*, or *fallback* if the sweep found none."""
+    if config is None or config.get(key) is None:
+        return fallback
+    return config[key]
+
+
+def tune_delta_rule_fwd(
+    kernel,
+    fused_builder: Callable[..., Callable],
+    h_builder: Callable[..., Callable],
+    o_builder: Callable[..., Callable],
+    warmup: int = 10,
+    rep: int = 10,
+) -> Dict[str, int]:
+    """Return the merged best config for a three-sub-kernel delta-rule forward.
+
+    The recurrence's V-tile width changes the generated kernel, so TileLang's
+    autotuner cannot sweep it as a config key: each width is built and tuned
+    separately, and the widths are then compared on the autotuner's own measured
+    latency. Any sub-kernel the autotuner cannot tune keeps its
+    ``default_config`` value, so every key of the returned config is one the
+    kernel can build and run.
+
+    Args:
+        kernel: The forward kernel being tuned. Supplies the shape, the default
+            config, and the per-sub-kernel sweep through ``tune_jit_kernel``.
+        fused_builder: ``(*shape) -> jit`` for the fused w/u preparation.
+        h_builder: ``(*shape, block_v=...) -> jit`` for the state recurrence.
+        o_builder: ``(*shape) -> jit`` for the output projection.
+        warmup: Warmup iterations per candidate.
+        rep: Timed iterations per candidate.
+
+    Returns:
+        A config with the flat ``fused_`` / ``h_`` / ``o_`` keys the wrapped
+        kernel reads. It is always a member of
+        ``delta_rule_fwd_autotune_configs(kernel.dim_v, kernel.chunk_size)``.
+    """
+    shape = (
+        kernel.batch,
+        kernel.head,
+        kernel.seq_len,
+        kernel.chunk_size,
+        kernel.dim_k,
+        kernel.dim_v,
+        kernel.dtype_str,
+    )
+    default = kernel.default_config
+    print(f"Start autotuning {kernel.__class__.__name__}...")
+
+    fused_config, _ = _tune_sub_kernel(
+        kernel,
+        "fused_prepare_compute_w_u",
+        fused_builder(*shape),
+        PIPELINE_CONFIGS,
+        warmup,
+        rep,
+    )
+
+    h_config: Optional[Dict[str, int]] = None
+    h_block_v = default["h_block_v"]
+    best_latency = float("inf")
+    for block_v in h_block_v_candidates(kernel.dim_v, kernel.chunk_size):
+        label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
+        config, latency = _tune_sub_kernel(
+            kernel,
+            label,
+            h_builder(*shape, block_v=block_v),
+            PIPELINE_CONFIGS,
+            warmup,
+            rep,
+        )
+        if config is None or latency is None:
+            continue
+        if latency < best_latency:
+            h_config, h_block_v, best_latency = config, block_v, latency
+
+    o_config, _ = _tune_sub_kernel(
+        kernel, "output_o", o_builder(*shape), OUTPUT_CONFIGS, warmup, rep
+    )
+
+    config = {
+        "fused_num_stages": _tuned_value(
+            fused_config, "num_stages", default["fused_num_stages"]),
+        "fused_threads": _tuned_value(fused_config, "threads", default["fused_threads"]),
+        "h_num_stages": _tuned_value(h_config, "num_stages", default["h_num_stages"]),
+        "h_threads": _tuned_value(h_config, "threads", default["h_threads"]),
+        "h_block_v": h_block_v,
+        "o_threads": _tuned_value(o_config, "threads", default["o_threads"]),
+    }
+    print(f"{kernel.__class__.__name__} autotuned config: {config}")
+    return config

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -172,11 +172,11 @@ def _summarize(exc: Exception) -> str:
     Which width failed is carried by the label beside this, not by the text:
     tilelang reports every failed sweep with the same sentence. The text is
     kept for everything else raised here, bounded because it may be a whole
-    compiler log. The generous slice keeps a megabyte of it out of the split;
-    the bound is applied after the collapse, since applying it before lets a
-    blank preamble consume the budget and leave nothing.
+    compiler log. Leading blank text is stripped before the slice that keeps a
+    megabyte out of the collapse, so a padded preamble cannot eat the slice and
+    leave nothing behind; the budget itself is applied last.
     """
-    return f"{type(exc).__name__}: {' '.join(str(exc)[:20000].split())[:200]}"
+    return f"{type(exc).__name__}: {' '.join(str(exc).lstrip()[:20000].split())[:200]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -14,6 +14,7 @@ __all__ = [
     "MIN_TILED_CHUNK_SIZE",
     "OUTPUT_CONFIGS",
     "PIPELINE_CONFIGS",
+    "default_h_block_v",
     "delta_rule_fwd_autotune_configs",
     "h_block_v_candidates",
     "tune_delta_rule_fwd",
@@ -54,6 +55,25 @@ def h_block_v_candidates(dim_v: int, chunk_size: int) -> Tuple[int, ...]:
         if dim_v % (block_v or dim_v) == 0
         and (block_v == 0 or chunk_size >= MIN_TILED_CHUNK_SIZE)
     )
+
+
+def default_h_block_v(dim_v: int, chunk_size: int) -> int:
+    """Return the V-tile width the recurrence runs with when it is not tuned.
+
+    Prefers the narrowest tiled width the shape allows, since tiling is what
+    keeps the recurrence's state within shared memory, and falls back to no
+    tiling when the shape supports no tiled width. Sharing
+    ``h_block_v_candidates`` with the sweep is what keeps the untuned width and
+    the tuned candidates from disagreeing: a width that divides ``dim_v`` for
+    neither is one the recurrence would build with a V grid too short to cover
+    every column.
+
+    Args:
+        dim_v: Value dimension.
+        chunk_size: Chunk length.
+    """
+    tiled = [block_v for block_v in h_block_v_candidates(dim_v, chunk_size) if block_v]
+    return min(tiled) if tiled else 0
 
 
 def delta_rule_fwd_autotune_configs(dim_v: int, chunk_size: int) -> List[Dict[str, int]]:
@@ -169,7 +189,10 @@ def tune_delta_rule_fwd(
     )
 
     h_config: Optional[Dict[str, int]] = None
-    h_block_v = default["h_block_v"]
+    # Derived here rather than read from default_config: this is the one key
+    # whose valid set depends on the shape, so taking it from the kernel would
+    # let an untuned width the sweep never offers escape through the fallback.
+    h_block_v = default_h_block_v(kernel.dim_v, kernel.chunk_size)
     best_latency = float("inf")
     for block_v in h_block_v_candidates(kernel.dim_v, kernel.chunk_size):
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -74,15 +74,7 @@ def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
 
 
 def _require_h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
-    """Return the buildable widths, refusing a shape that has none.
-
-    Both the untuned default and the declared config set answer for the same
-    shape, so they refuse the same shapes here rather than each deciding what
-    an empty candidate set means.
-
-    Raises:
-        ValueError: if no V-tile width is buildable at *dim_v*.
-    """
+    """Return the buildable widths, so both callers refuse the same shapes."""
     candidates = h_block_v_candidates(dim_v)
     if not candidates:
         raise ValueError(
@@ -94,15 +86,9 @@ def _require_h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
 def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     """Return the V-tile width the recurrence runs with when it is not tuned.
 
-    Prefers the narrowest buildable tiled width, since tiling is what keeps the
-    recurrence's state within shared memory. Short chunks take no tiling — a
-    preference the per-kernel defaults carried without stating a reason, kept
-    here rather than imposed on the sweep, which is free to measure a tiled
-    width and win.
-
-    The width is drawn from the candidates rather than written out again, so
-    the untuned config stays inside the set ``delta_rule_fwd_autotune_configs``
-    declares. A shape with no buildable width has no default to give.
+    The narrowest buildable tiled width, since tiling keeps the recurrence's
+    state in shared memory; short chunks take none. Drawn from the candidates
+    so the untuned config stays inside the declared set.
 
     Args:
         dim_v: Value dimension.
@@ -115,8 +101,6 @@ def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     tiled = [block_v for block_v in candidates if block_v]
     if tiled and chunk_size >= TILED_DEFAULT_MIN_CHUNK_SIZE:
         return min(tiled)
-    # A shape whose only buildable width is tiled has no untiled width to
-    # prefer, so the preference yields to what the recurrence can build.
     return 0 if 0 in candidates else min(tiled)
 
 
@@ -205,9 +189,10 @@ def tune_delta_rule_fwd(
     The recurrence's V-tile width changes the generated kernel, so TileLang's
     autotuner cannot sweep it as a config key: each width is built and tuned
     separately, and the widths are then compared on the autotuner's own measured
-    latency. Any sub-kernel the autotuner cannot tune keeps its
-    ``default_config`` value, so every key of the returned config is one the
-    kernel can build and run.
+    latency. A launch parameter the autotuner cannot tune keeps its
+    ``default_config`` value. The V-tile width does not: it decides which kernel
+    exists, so it is taken from the widths that produced a measurement, and from
+    the first width offered when none did.
 
     Args:
         kernel: The forward kernel being tuned. Supplies the shape, the default
@@ -220,8 +205,13 @@ def tune_delta_rule_fwd(
 
     Returns:
         A config with the flat ``fused_`` / ``h_`` / ``o_`` keys the wrapped
-        kernel reads. It is always a member of
+        kernel reads, always a member of
         ``delta_rule_fwd_autotune_configs(kernel.dim_v)``.
+
+    Raises:
+        ValueError: if no V-tile width is buildable at this shape.
+        RuntimeError: if every width's builder raised, since the sweep then has
+            no width to name and the caller does not choose one.
     """
     shape = (
         kernel.batch,
@@ -246,47 +236,48 @@ def tune_delta_rule_fwd(
 
     h_config: Optional[Dict[str, int]] = None
     h_block_v: Optional[int] = None
-    built: List[int] = []
-    build_error: Optional[Exception] = None
+    #: Widths whose builder returned. Says nothing about the kernel compiling.
+    offered: List[int] = []
+    #: Widths the autotuner returned a measurement for — the only evidence
+    #: that this width compiles and runs, since per-candidate build failures
+    #: reach us as a missing measurement rather than an exception.
+    measured: List[int] = []
+    builder_error: Optional[Exception] = None
     best_latency = float("inf")
-    for block_v in h_block_v_candidates(kernel.dim_v):
+    for block_v in _require_h_block_v_candidates(kernel.dim_v):
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
         try:
-            config, latency = _tune_sub_kernel(
-                kernel,
-                label,
-                h_builder(*shape, block_v=block_v),
-                PIPELINE_CONFIGS,
-                warmup,
-                rep,
-            )
-        except Exception as exc:  # noqa: BLE001 - one width failing must not sink the rest
-            # resolve_block_v answers what the tile geometry allows; shared
-            # memory limits and codegen failures surface only on build, and
-            # they disqualify this width rather than the whole sweep.
-            build_error = exc
+            jit_kernel = h_builder(*shape, block_v=block_v)
+        except Exception as exc:  # noqa: BLE001 - one width must not sink the rest
+            # Only the builder call is guarded, and only this width is dropped.
+            # Tuning is not: a failure there is the autotuner's or the device's,
+            # not this width's, and reporting it as a dropped width would hide
+            # it behind a config that looks tuned.
+            builder_error = exc
             warnings.warn(  # noqa: B028
                 f"{label} unavailable, dropping it from the sweep: "
                 f"{type(exc).__name__}: {exc}")
             continue
-        built.append(block_v)
+        offered.append(block_v)
+        config, latency = _tune_sub_kernel(
+            kernel, label, jit_kernel, PIPELINE_CONFIGS, warmup, rep)
         if config is None or latency is None:
             continue
+        measured.append(block_v)
         if latency < best_latency:
             h_config, h_block_v, best_latency = config, block_v, latency
 
-    if not built:
-        # Every width failed to build, so there is none to fall back to. The
-        # width is not the caller's to choose, so report the build failure
-        # rather than return a config naming a width just proved unbuildable.
+    if not offered:
         raise RuntimeError(
-            f"no recurrence V-tile width built for dim_v={kernel.dim_v}") from build_error
+            f"no recurrence V-tile width could be built for dim_v={kernel.dim_v}"
+        ) from builder_error
     if h_block_v is None:
-        # Nothing tuned, but something built. The untuned preference only
-        # counts if it was one of them; otherwise take the first width that
-        # built, which candidate order makes the untiled one where buildable.
+        # Nothing was measured, so no width is known to run. The untuned
+        # preference is taken only on that evidence; without it the first
+        # candidate is the safer answer, since candidate order puts the
+        # untiled width first and that one builds whenever any width does.
         preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
-        h_block_v = preferred if preferred in built else built[0]
+        h_block_v = preferred if preferred in measured else offered[0]
 
     o_config, _ = _tune_sub_kernel(
         kernel, "output_o", o_builder(*shape), OUTPUT_CONFIGS, warmup, rep

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -167,14 +167,15 @@ def _tune_sub_kernel(
 
 
 def _summarize(exc: Exception) -> str:
-    """Return a bounded one-line form; compile failures carry a whole nvcc log.
+    """Return a bounded one-line form of *exc*.
 
-    Trimmed to a prefix rather than to the first line: tilelang's first line is
-    the same generic sentence for every width, and the diagnostic that tells
-    them apart is below it.
+    Which width failed is carried by the label beside this, not by the text:
+    tilelang reports every failed sweep with the same sentence. The text is
+    still worth keeping for everything else that can be raised here, bounded
+    because it may be a whole compiler log, and sliced before it is joined so
+    that log is never materialized whole.
     """
-    body = " ".join(str(exc).split())
-    return f"{type(exc).__name__}: {body[:400]}"
+    return f"{type(exc).__name__}: {' '.join(str(exc)[:1000].split())[:200]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -151,17 +151,28 @@ def _tune_sub_kernel(
     """
     print(f"Autotuning {label} ({len(configs)} configs)...")
     # supply_prog=None, not the kernel's: a whole-kernel supplier is written
-    # against the forward's inputs, which are not this sub-kernel's.
+    # against the forward's inputs, which are not this sub-kernel's. The
+    # candidates are copied because the module-level tuples are shared by every
+    # sweep in the process, and an autotuner that annotates one in place would
+    # otherwise corrupt them for good.
+    candidates = [dict(config) for config in configs]
     tuned = kernel.tune_jit_kernel(
         jit_kernel,
-        list(configs),
+        candidates,
         warmup=warmup,
         rep=rep,
-        seed_config=configs[0],
+        seed_config=candidates[0],
         supply_prog=None,
     )
     config = getattr(tuned, "config", None)
     latency = getattr(tuned, "latency", None)
+    if config is not None and latency is None:
+        # A tuned config with no latency is not the skip path; it means the
+        # attribute this comparison rests on has gone, and every width would
+        # silently tie.
+        warnings.warn(  # noqa: B028
+            f"{label} tuned to {config} but reported no latency; "
+            "the V-tile widths cannot be compared")
     print(f"  Best: {config}")
     return config, latency
 

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -171,11 +171,11 @@ def _summarize(exc: Exception) -> str:
 
     Which width failed is carried by the label beside this, not by the text:
     tilelang reports every failed sweep with the same sentence. The text is
-    still worth keeping for everything else that can be raised here, bounded
-    because it may be a whole compiler log, and sliced before it is joined so
-    that log is never materialized whole.
+    kept for everything else raised here, bounded because it may be a whole
+    compiler log. Bounded after collapsing whitespace, not before, or a long
+    blank preamble consumes the budget and leaves nothing.
     """
-    return f"{type(exc).__name__}: {' '.join(str(exc)[:1000].split())[:200]}"
+    return f"{type(exc).__name__}: {' '.join(str(exc).split())[:200]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -172,10 +172,11 @@ def _summarize(exc: Exception) -> str:
     Which width failed is carried by the label beside this, not by the text:
     tilelang reports every failed sweep with the same sentence. The text is
     kept for everything else raised here, bounded because it may be a whole
-    compiler log. Bounded after collapsing whitespace, not before, or a long
-    blank preamble consumes the budget and leaves nothing.
+    compiler log. The generous slice keeps a megabyte of it out of the split;
+    the bound is applied after the collapse, since applying it before lets a
+    blank preamble consume the budget and leave nothing.
     """
-    return f"{type(exc).__name__}: {' '.join(str(exc).split())[:200]}"
+    return f"{type(exc).__name__}: {' '.join(str(exc)[:20000].split())[:200]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:
@@ -266,8 +267,7 @@ def tune_delta_rule_fwd(
             # autotuner, which raises when no candidate of this width survives.
             failures.append((label, exc))
             warnings.warn(  # noqa: B028
-                f"{label} unavailable, dropping it from the sweep: "
-                f"{type(exc).__name__}: {exc}")
+                f"{label} unavailable, dropping it from the sweep: {_summarize(exc)}")
             continue
         compiled.append(block_v)
         if config is None or latency is None:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -40,9 +40,8 @@ OUTPUT_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
 H_BLOCK_V_WIDTHS: Tuple[int, ...] = (0, 32)
 
 #: Chunk length at or above which the untuned recurrence prefers a tiled width.
-#: Carried over from the per-kernel defaults this module replaced, which stated
-#: no reason for it. No builder enforces it, so it stays a default preference
-#: and does not narrow what the sweep may try.
+#: Inherited from the per-kernel defaults with no reason stated; no builder
+#: enforces it, so it steers the default only, never the sweep.
 TILED_DEFAULT_MIN_CHUNK_SIZE: int = 64
 
 
@@ -144,10 +143,11 @@ def _tune_sub_kernel(
 ) -> Tuple[Optional[Dict[str, int]], Optional[float]]:
     """Sweep one sub-kernel and return its ``(winning config, latency)``.
 
-    Either element is ``None`` when the autotuner skipped the sweep because the
-    seeded parameters read as already tuned — the case ``do_not_specialize``
-    exists to prevent. It is not how every candidate failing to compile is
-    reported: that raises, so a caller sweeping variants must catch, not test.
+    Either element is ``None`` when the seeded parameters read as already
+    tuned: the autotuner then skips the search and JIT-compiles the kernel
+    directly, so it is built but never timed. That is not how every candidate
+    failing to compile is reported — that raises — so a caller sweeping
+    variants must catch, not test.
     """
     print(f"Autotuning {label} ({len(configs)} configs)...")
     # supply_prog=None, not the kernel's: a whole-kernel supplier is written
@@ -164,6 +164,12 @@ def _tune_sub_kernel(
     latency = getattr(tuned, "latency", None)
     print(f"  Best: {config}")
     return config, latency
+
+
+def _first_line(exc: Exception) -> str:
+    """Return a one-line summary; compile failures carry a whole nvcc log."""
+    head = str(exc).strip().splitlines()
+    return f"{type(exc).__name__}: {head[0][:200] if head else ''}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:
@@ -210,8 +216,8 @@ def tune_delta_rule_fwd(
 
     Raises:
         ValueError: if no V-tile width is buildable at this shape.
-        RuntimeError: if no width tuned and at least one failed, chaining the
-            failure, since the sweep then has no width to name.
+        RuntimeError: if no width compiled, listing every failure and chaining
+            the last, since the sweep then has no width to name.
     """
     shape = (
         kernel.batch,
@@ -223,9 +229,7 @@ def tune_delta_rule_fwd(
         kernel.dtype_str,
     )
     default = kernel.default_config
-    # Refused here, before any sub-kernel is swept, so an unsupported shape
-    # does not cost a full sweep before being turned away.
-    candidates = _require_h_block_v_candidates(kernel.dim_v)
+    candidates = _require_h_block_v_candidates(kernel.dim_v)  # before any sweep
     print(f"Start autotuning {kernel.__class__.__name__}...")
 
     fused_config, _ = _tune_sub_kernel(
@@ -239,8 +243,9 @@ def tune_delta_rule_fwd(
 
     h_config: Optional[Dict[str, int]] = None
     h_block_v: Optional[int] = None
-    #: Widths whose sweep returned. The autotuner raises when no candidate of a
-    #: width compiles, so returning at all is the evidence that this one does.
+    #: Widths whose sweep returned, having compiled: the autotuner raises when
+    #: no candidate of a width compiles, and JIT-compiles directly when it skips
+    #: the search. Only a measurement, not membership here, says one is fast.
     compiled: List[int] = []
     failures: List[Tuple[str, Exception]] = []
     best_latency = float("inf")
@@ -268,10 +273,9 @@ def tune_delta_rule_fwd(
         if not compiled:
             raise RuntimeError(
                 f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}: "
-                + "; ".join(f"{label}: {type(exc).__name__}: {exc}" for label, exc in failures)
+                + "; ".join(f"{label}: {_first_line(exc)}" for label, exc in failures)
             ) from failures[-1][1]
-        # Some width compiled but none was measured. The untuned width answers,
-        # as it does for a launch parameter, but only if it was one of them.
+        # Compiled but unmeasured: the untuned width answers if it is one.
         preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
         h_block_v = preferred if preferred in compiled else compiled[0]
 

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -149,8 +149,9 @@ def _tune_sub_kernel(
 ) -> Tuple[Optional[Dict[str, int]], Optional[float]]:
     """Sweep one sub-kernel and return its ``(winning config, latency)``.
 
-    Either element is ``None`` when TileLang's autotuner produced no result,
-    which is how a sub-kernel whose candidates all fail to build reports back.
+    Either element is ``None`` when the autotuner returns without a result.
+    That is not how it reports every candidate failing to compile — it raises
+    for that, so a caller sweeping several variants must catch, not test.
     """
     print(f"Autotuning {label} ({len(configs)} configs)...")
     # supply_prog=None, not the kernel's: a whole-kernel supplier is written
@@ -190,9 +191,8 @@ def tune_delta_rule_fwd(
     autotuner cannot sweep it as a config key: each width is built and tuned
     separately, and the widths are then compared on the autotuner's own measured
     latency. A launch parameter the autotuner cannot tune keeps its
-    ``default_config`` value. The V-tile width does not: it decides which kernel
-    exists, so it is taken from the widths that produced a measurement, and from
-    the first width offered when none did.
+    ``default_config`` value. The width is only kept from a sweep that measured
+    it; when every width failed, the failure is raised rather than answered.
 
     Args:
         kernel: The forward kernel being tuned. Supplies the shape, the default
@@ -210,8 +210,8 @@ def tune_delta_rule_fwd(
 
     Raises:
         ValueError: if no V-tile width is buildable at this shape.
-        RuntimeError: if every width's builder raised, since the sweep then has
-            no width to name and the caller does not choose one.
+        RuntimeError: if no width tuned and at least one failed, chaining the
+            failure, since the sweep then has no width to name.
     """
     shape = (
         kernel.batch,
@@ -223,6 +223,9 @@ def tune_delta_rule_fwd(
         kernel.dtype_str,
     )
     default = kernel.default_config
+    # Refused here, before any sub-kernel is swept, so an unsupported shape
+    # does not cost a full sweep before being turned away.
+    candidates = _require_h_block_v_candidates(kernel.dim_v)
     print(f"Start autotuning {kernel.__class__.__name__}...")
 
     fused_config, _ = _tune_sub_kernel(
@@ -236,48 +239,41 @@ def tune_delta_rule_fwd(
 
     h_config: Optional[Dict[str, int]] = None
     h_block_v: Optional[int] = None
-    #: Widths whose builder returned. Says nothing about the kernel compiling.
-    offered: List[int] = []
-    #: Widths the autotuner returned a measurement for — the only evidence
-    #: that this width compiles and runs, since per-candidate build failures
-    #: reach us as a missing measurement rather than an exception.
-    measured: List[int] = []
-    builder_error: Optional[Exception] = None
+    sweep_error: Optional[Exception] = None
     best_latency = float("inf")
-    for block_v in _require_h_block_v_candidates(kernel.dim_v):
+    for block_v in candidates:
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
         try:
-            jit_kernel = h_builder(*shape, block_v=block_v)
+            config, latency = _tune_sub_kernel(
+                kernel, label, h_builder(*shape, block_v=block_v),
+                PIPELINE_CONFIGS, warmup, rep)
         except Exception as exc:  # noqa: BLE001 - one width must not sink the rest
-            # Only the builder call is guarded, and only this width is dropped.
-            # Tuning is not: a failure there is the autotuner's or the device's,
-            # not this width's, and reporting it as a dropped width would hide
-            # it behind a config that looks tuned.
-            builder_error = exc
+            # The whole attempt is guarded, not just the builder: the builder
+            # only wraps the kernel, and the compile happens inside the
+            # autotuner, which raises when no candidate of this width survives.
+            # A failure that is not width-specific is not lost — it is re-raised
+            # below if no width tunes.
+            sweep_error = exc
             warnings.warn(  # noqa: B028
                 f"{label} unavailable, dropping it from the sweep: "
                 f"{type(exc).__name__}: {exc}")
             continue
-        offered.append(block_v)
-        config, latency = _tune_sub_kernel(
-            kernel, label, jit_kernel, PIPELINE_CONFIGS, warmup, rep)
         if config is None or latency is None:
             continue
-        measured.append(block_v)
         if latency < best_latency:
             h_config, h_block_v, best_latency = config, block_v, latency
 
-    if not offered:
-        raise RuntimeError(
-            f"no recurrence V-tile width could be built for dim_v={kernel.dim_v}"
-        ) from builder_error
     if h_block_v is None:
-        # Nothing was measured, so no width is known to run. The untuned
-        # preference is taken only on that evidence; without it the first
-        # candidate is the safer answer, since candidate order puts the
-        # untiled width first and that one builds whenever any width does.
-        preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
-        h_block_v = preferred if preferred in measured else offered[0]
+        if sweep_error is not None:
+            # Every width was tried and none tuned, so the last failure is the
+            # answer. Choosing a width here would bury it under a config that
+            # reads as tuned.
+            raise RuntimeError(
+                f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}") from sweep_error
+        # Nothing failed and nothing measured: the autotuner returned without a
+        # result, the same case a launch parameter meets, so the untuned width
+        # answers it.
+        h_block_v = default_h_block_v(kernel.dim_v, kernel.chunk_size)
 
     o_config, _ = _tune_sub_kernel(
         kernel, "output_o", o_builder(*shape), OUTPUT_CONFIGS, warmup, rep

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -166,10 +166,15 @@ def _tune_sub_kernel(
     return config, latency
 
 
-def _first_line(exc: Exception) -> str:
-    """Return a one-line summary; compile failures carry a whole nvcc log."""
-    head = str(exc).strip().splitlines()
-    return f"{type(exc).__name__}: {head[0][:200] if head else ''}"
+def _summarize(exc: Exception) -> str:
+    """Return a bounded one-line form; compile failures carry a whole nvcc log.
+
+    Trimmed to a prefix rather than to the first line: tilelang's first line is
+    the same generic sentence for every width, and the diagnostic that tells
+    them apart is below it.
+    """
+    body = " ".join(str(exc).split())
+    return f"{type(exc).__name__}: {body[:400]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:
@@ -273,7 +278,7 @@ def tune_delta_rule_fwd(
         if not compiled:
             raise RuntimeError(
                 f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}: "
-                + "; ".join(f"{label}: {_first_line(exc)}" for label, exc in failures)
+                + "; ".join(f"{label}: {_summarize(exc)}" for label, exc in failures)
             ) from failures[-1][1]
         # Compiled but unmeasured: the untuned width answers if it is one.
         preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -70,19 +70,31 @@ def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     """Return the V-tile width the recurrence runs with when it is not tuned.
 
     Prefers the narrowest buildable tiled width, since tiling is what keeps the
-    recurrence's state within shared memory, and falls back to no tiling when
-    the shape supports none. Short chunks take no tiling — a preference the
-    per-kernel defaults carried without stating a reason, kept here rather than
-    imposed on the sweep, which is free to measure a tiled width and win.
+    recurrence's state within shared memory. Short chunks take no tiling — a
+    preference the per-kernel defaults carried without stating a reason, kept
+    here rather than imposed on the sweep, which is free to measure a tiled
+    width and win.
+
+    The width is drawn from the candidates rather than written out again, so
+    the untuned config stays inside the set ``delta_rule_fwd_autotune_configs``
+    declares. A shape with no buildable width has no default to give.
 
     Args:
         dim_v: Value dimension.
         chunk_size: Chunk length.
+
+    Raises:
+        ValueError: if no V-tile width is buildable at *dim_v*.
     """
-    if chunk_size < TILED_DEFAULT_MIN_CHUNK_SIZE:
-        return 0
-    tiled = [block_v for block_v in h_block_v_candidates(dim_v) if block_v]
-    return min(tiled) if tiled else 0
+    candidates = h_block_v_candidates(dim_v)
+    if not candidates:
+        raise ValueError(
+            f"no buildable recurrence V-tile width for dim_v={dim_v}; "
+            f"widths are {H_BLOCK_V_WIDTHS} and none satisfies resolve_block_v")
+    tiled = [block_v for block_v in candidates if block_v]
+    if tiled and chunk_size >= TILED_DEFAULT_MIN_CHUNK_SIZE:
+        return min(tiled)
+    return 0 if 0 in candidates else min(tiled)
 
 
 def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -172,11 +172,11 @@ def _summarize(exc: Exception) -> str:
     Which width failed is carried by the label beside this, not by the text:
     tilelang reports every failed sweep with the same sentence. The text is
     kept for everything else raised here, bounded because it may be a whole
-    compiler log. Leading blank text is stripped before the slice that keeps a
-    megabyte out of the collapse, so a padded preamble cannot eat the slice and
-    leave nothing behind; the budget itself is applied last.
+    compiler log. Collapsed whole and bounded last: every attempt to bound it
+    earlier — to a line, to a prefix — cost the diagnostic on some input, and
+    the text is already in memory by the time this is called.
     """
-    return f"{type(exc).__name__}: {' '.join(str(exc).lstrip()[:20000].split())[:200]}"
+    return f"{type(exc).__name__}: {' '.join(str(exc).split())[:200]}"
 
 
 def _tuned_value(config: Optional[Dict[str, int]], key: str, fallback: Any) -> Any:

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -49,12 +49,9 @@ TILED_DEFAULT_MIN_CHUNK_SIZE: int = 64
 def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
     """Return the recurrence V-tile widths buildable at this value dimension.
 
-    Whether a width is buildable is ``resolve_block_v``'s question — minimum
-    gemm N extent and divisibility — so ask it rather than restate its rules
-    here, which is what keeps the candidate set from drifting from what the
-    recurrence will accept. Widths resolving to the same tile are one
-    candidate: at ``dim_v == 32`` both 0 and 32 give a 32-column tile and the
-    same generated kernel, so offering both would build and time it twice.
+    Buildability is ``resolve_block_v``'s question, so ask it rather than
+    restate it. Widths resolving to the same tile are one candidate: at
+    ``dim_v == 32`` both 0 and 32 give a 32-column tile and the same kernel.
 
     Args:
         dim_v: Value dimension.
@@ -109,17 +106,15 @@ def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:
 
     The three sub-kernels are tuned independently, so the reachable set is their
     product. Declaring it is what makes ``init_config(tune=True)`` reach
-    ``autotune`` instead of falling back to ``default_config``, and it gives a
-    test a set to check the selected config against. Chunk length does not enter:
-    it steers the untuned default, not what the sweep may build.
+    ``autotune`` at all. Chunk length does not enter: it steers the untuned
+    default, not what the sweep may build.
 
     Args:
         dim_v: Value dimension.
 
     Raises:
-        ValueError: if no V-tile width is buildable at *dim_v*, so the shape is
-            refused here rather than declaring an empty set that reads as
-            "tunable, with nothing to try".
+        ValueError: if no V-tile width is buildable at *dim_v*. An empty set
+            would read as "tunable, with nothing to try".
     """
     return [
         {
@@ -149,9 +144,10 @@ def _tune_sub_kernel(
 ) -> Tuple[Optional[Dict[str, int]], Optional[float]]:
     """Sweep one sub-kernel and return its ``(winning config, latency)``.
 
-    Either element is ``None`` when the autotuner returns without a result.
-    That is not how it reports every candidate failing to compile — it raises
-    for that, so a caller sweeping several variants must catch, not test.
+    Either element is ``None`` when the autotuner skipped the sweep because the
+    seeded parameters read as already tuned — the case ``do_not_specialize``
+    exists to prevent. It is not how every candidate failing to compile is
+    reported: that raises, so a caller sweeping variants must catch, not test.
     """
     print(f"Autotuning {label} ({len(configs)} configs)...")
     # supply_prog=None, not the kernel's: a whole-kernel supplier is written
@@ -191,8 +187,12 @@ def tune_delta_rule_fwd(
     autotuner cannot sweep it as a config key: each width is built and tuned
     separately, and the widths are then compared on the autotuner's own measured
     latency. A launch parameter the autotuner cannot tune keeps its
-    ``default_config`` value. The width is only kept from a sweep that measured
-    it; when every width failed, the failure is raised rather than answered.
+    ``default_config`` value. A width is kept only if its sweep returned, since
+    the autotuner raises when none of a width's candidates compile; when every
+    width failed, the failures are raised rather than answered. A failure that
+    is not the width's own — a device fault mid-sweep — is indistinguishable
+    from here and is attributed to that width, so it only surfaces if no width
+    survives.
 
     Args:
         kernel: The forward kernel being tuned. Supplies the shape, the default
@@ -239,7 +239,10 @@ def tune_delta_rule_fwd(
 
     h_config: Optional[Dict[str, int]] = None
     h_block_v: Optional[int] = None
-    sweep_error: Optional[Exception] = None
+    #: Widths whose sweep returned. The autotuner raises when no candidate of a
+    #: width compiles, so returning at all is the evidence that this one does.
+    compiled: List[int] = []
+    failures: List[Tuple[str, Exception]] = []
     best_latency = float("inf")
     for block_v in candidates:
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
@@ -248,32 +251,29 @@ def tune_delta_rule_fwd(
                 kernel, label, h_builder(*shape, block_v=block_v),
                 PIPELINE_CONFIGS, warmup, rep)
         except Exception as exc:  # noqa: BLE001 - one width must not sink the rest
-            # The whole attempt is guarded, not just the builder: the builder
-            # only wraps the kernel, and the compile happens inside the
+            # The builder only wraps the kernel; the compile is inside the
             # autotuner, which raises when no candidate of this width survives.
-            # A failure that is not width-specific is not lost — it is re-raised
-            # below if no width tunes.
-            sweep_error = exc
+            failures.append((label, exc))
             warnings.warn(  # noqa: B028
                 f"{label} unavailable, dropping it from the sweep: "
                 f"{type(exc).__name__}: {exc}")
             continue
+        compiled.append(block_v)
         if config is None or latency is None:
             continue
         if latency < best_latency:
             h_config, h_block_v, best_latency = config, block_v, latency
 
     if h_block_v is None:
-        if sweep_error is not None:
-            # Every width was tried and none tuned, so the last failure is the
-            # answer. Choosing a width here would bury it under a config that
-            # reads as tuned.
+        if not compiled:
             raise RuntimeError(
-                f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}") from sweep_error
-        # Nothing failed and nothing measured: the autotuner returned without a
-        # result, the same case a launch parameter meets, so the untuned width
-        # answers it.
-        h_block_v = default_h_block_v(kernel.dim_v, kernel.chunk_size)
+                f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}: "
+                + "; ".join(f"{label}: {type(exc).__name__}: {exc}" for label, exc in failures)
+            ) from failures[-1][1]
+        # Some width compiled but none was measured. The untuned width answers,
+        # as it does for a launch parameter, but only if it was one of them.
+        preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
+        h_block_v = preferred if preferred in compiled else compiled[0]
 
     o_config, _ = _tune_sub_kernel(
         kernel, "output_o", o_builder(*shape), OUTPUT_CONFIGS, warmup, rep

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -46,11 +46,15 @@ TILED_DEFAULT_MIN_CHUNK_SIZE: int = 64
 
 
 def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
-    """Return the recurrence V-tile widths buildable at this value dimension.
+    """Return the recurrence V-tile widths worth offering at this dimension.
 
-    Buildability is ``resolve_block_v``'s question, so ask it rather than
-    restate it. Widths resolving to the same tile are one candidate: at
-    ``dim_v == 32`` both 0 and 32 give a 32-column tile and the same kernel.
+    Admissibility is ``resolve_block_v``'s question — gemm N extent and
+    divisibility — so ask it rather than restate it. It is not the whole of
+    buildability: whether a width compiles also depends on the thread count and
+    the layout the recurrence lands on, known only once it is built, which is
+    why the sweep drops a width that fails rather than trusting this. Widths
+    resolving to the same tile are one candidate: at ``dim_v == 32`` both 0 and
+    32 give a 32-column tile and the same kernel.
 
     Args:
         dim_v: Value dimension.
@@ -70,11 +74,11 @@ def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
 
 
 def _require_h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
-    """Return the buildable widths, so both callers refuse the same shapes."""
+    """Return the admissible widths, so both callers refuse the same shapes."""
     candidates = h_block_v_candidates(dim_v)
     if not candidates:
         raise ValueError(
-            f"no buildable recurrence V-tile width for dim_v={dim_v}; "
+            f"no admissible recurrence V-tile width for dim_v={dim_v}; "
             f"widths are {H_BLOCK_V_WIDTHS} and none satisfies resolve_block_v")
     return candidates
 
@@ -82,7 +86,7 @@ def _require_h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
 def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     """Return the V-tile width the recurrence runs with when it is not tuned.
 
-    The narrowest buildable tiled width, since tiling keeps the recurrence's
+    The narrowest admissible tiled width, since tiling keeps the recurrence's
     state in shared memory; short chunks take none. Drawn from the candidates
     so the untuned config stays inside the declared set.
 
@@ -91,7 +95,7 @@ def default_h_block_v(dim_v: int, chunk_size: int) -> int:
         chunk_size: Chunk length.
 
     Raises:
-        ValueError: if no V-tile width is buildable at *dim_v*.
+        ValueError: if no V-tile width is admissible at *dim_v*.
     """
     candidates = _require_h_block_v_candidates(dim_v)
     tiled = [block_v for block_v in candidates if block_v]
@@ -112,7 +116,7 @@ def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:
         dim_v: Value dimension.
 
     Raises:
-        ValueError: if no V-tile width is buildable at *dim_v*. An empty set
+        ValueError: if no V-tile width is admissible at *dim_v*. An empty set
             would read as "tunable, with nothing to try".
     """
     return [
@@ -171,8 +175,8 @@ def _tune_sub_kernel(
         # attribute this comparison rests on has gone, and every width would
         # silently tie.
         warnings.warn(  # noqa: B028
-            f"{label} tuned to {config} but reported no latency; "
-            "the V-tile widths cannot be compared")
+            f"{label} tuned to {config} but reported no latency, "
+            "so this sweep's result cannot be compared against any other")
     print(f"  Best: {config}")
     return config, latency
 
@@ -233,7 +237,7 @@ def tune_delta_rule_fwd(
         ``delta_rule_fwd_autotune_configs(kernel.dim_v)``.
 
     Raises:
-        ValueError: if no V-tile width is buildable at this shape.
+        ValueError: if no V-tile width is admissible at this shape.
         RuntimeError: if no width compiled, listing every failure and chaining
             the last, since the sweep then has no width to name.
     """
@@ -292,7 +296,10 @@ def tune_delta_rule_fwd(
                 f"no recurrence V-tile width tuned for dim_v={kernel.dim_v}: "
                 + "; ".join(f"{label}: {_summarize(exc)}" for label, exc in failures)
             ) from failures[-1][1]
-        # Compiled but unmeasured: the untuned width answers if it is one.
+        # Compiled but unmeasured: the untuned width answers if it is one. Its
+        # launch parameters come from the default, a pair this sweep never built
+        # together — the width compiles, that combination is unverified, and
+        # nothing here can do better without a measurement.
         preferred = default_h_block_v(kernel.dim_v, kernel.chunk_size)
         h_block_v = preferred if preferred in compiled else compiled[0]
 

--- a/tileops/kernels/linear_attn_autotune.py
+++ b/tileops/kernels/linear_attn_autotune.py
@@ -9,11 +9,13 @@ merges the winners into the single flat config the wrapped kernel reads.
 import itertools
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
+from tileops.kernels.v_tile import resolve_block_v
+
 __all__ = [
     "H_BLOCK_V_WIDTHS",
-    "MIN_TILED_CHUNK_SIZE",
     "OUTPUT_CONFIGS",
     "PIPELINE_CONFIGS",
+    "TILED_DEFAULT_MIN_CHUNK_SIZE",
     "default_h_block_v",
     "delta_rule_fwd_autotune_configs",
     "h_block_v_candidates",
@@ -36,57 +38,64 @@ OUTPUT_CONFIGS: Tuple[Dict[str, int], ...] = tuple(
 #: 16 is absent because it loses too much precision in fp16.
 H_BLOCK_V_WIDTHS: Tuple[int, ...] = (0, 32)
 
-#: Smallest chunk size for which a tiled recurrence is offered. Below it the
-#: kernels only build the untiled recurrence, so the sweep must not select a
-#: tiled width the kernel cannot run.
-MIN_TILED_CHUNK_SIZE: int = 64
+#: Chunk length at or above which the untuned recurrence prefers a tiled width.
+#: Carried over from the per-kernel defaults this module replaced, which stated
+#: no reason for it. No builder enforces it, so it stays a default preference
+#: and does not narrow what the sweep may try.
+TILED_DEFAULT_MIN_CHUNK_SIZE: int = 64
 
 
-def h_block_v_candidates(dim_v: int, chunk_size: int) -> Tuple[int, ...]:
-    """Return the recurrence V-tile widths buildable at this shape.
+def h_block_v_candidates(dim_v: int) -> Tuple[int, ...]:
+    """Return the recurrence V-tile widths buildable at this value dimension.
+
+    Whether a width is buildable is ``resolve_block_v``'s question — minimum
+    gemm N extent and divisibility — so ask it rather than restate its rules
+    here, which is what keeps the candidate set from drifting from what the
+    recurrence will accept.
 
     Args:
-        dim_v: Value dimension; a tile width must divide it.
-        chunk_size: Chunk length; tiled widths need ``MIN_TILED_CHUNK_SIZE``.
+        dim_v: Value dimension.
     """
-    return tuple(
-        block_v
-        for block_v in H_BLOCK_V_WIDTHS
-        if dim_v % (block_v or dim_v) == 0
-        and (block_v == 0 or chunk_size >= MIN_TILED_CHUNK_SIZE)
-    )
+    buildable = []
+    for block_v in H_BLOCK_V_WIDTHS:
+        try:
+            resolve_block_v(dim_v, block_v)
+        except ValueError:
+            continue
+        buildable.append(block_v)
+    return tuple(buildable)
 
 
 def default_h_block_v(dim_v: int, chunk_size: int) -> int:
     """Return the V-tile width the recurrence runs with when it is not tuned.
 
-    Prefers the narrowest tiled width the shape allows, since tiling is what
-    keeps the recurrence's state within shared memory, and falls back to no
-    tiling when the shape supports no tiled width. Sharing
-    ``h_block_v_candidates`` with the sweep is what keeps the untuned width and
-    the tuned candidates from disagreeing: a width that divides ``dim_v`` for
-    neither is one the recurrence would build with a V grid too short to cover
-    every column.
+    Prefers the narrowest buildable tiled width, since tiling is what keeps the
+    recurrence's state within shared memory, and falls back to no tiling when
+    the shape supports none. Short chunks take no tiling — a preference the
+    per-kernel defaults carried without stating a reason, kept here rather than
+    imposed on the sweep, which is free to measure a tiled width and win.
 
     Args:
         dim_v: Value dimension.
         chunk_size: Chunk length.
     """
-    tiled = [block_v for block_v in h_block_v_candidates(dim_v, chunk_size) if block_v]
+    if chunk_size < TILED_DEFAULT_MIN_CHUNK_SIZE:
+        return 0
+    tiled = [block_v for block_v in h_block_v_candidates(dim_v) if block_v]
     return min(tiled) if tiled else 0
 
 
-def delta_rule_fwd_autotune_configs(dim_v: int, chunk_size: int) -> List[Dict[str, int]]:
-    """Return every merged config the sweep can select at this shape.
+def delta_rule_fwd_autotune_configs(dim_v: int) -> List[Dict[str, int]]:
+    """Return every merged config the sweep can select at this value dimension.
 
     The three sub-kernels are tuned independently, so the reachable set is their
     product. Declaring it is what makes ``init_config(tune=True)`` reach
     ``autotune`` instead of falling back to ``default_config``, and it gives a
-    test a set to check the selected config against.
+    test a set to check the selected config against. Chunk length does not enter:
+    it steers the untuned default, not what the sweep may build.
 
     Args:
         dim_v: Value dimension.
-        chunk_size: Chunk length.
     """
     return [
         {
@@ -100,7 +109,7 @@ def delta_rule_fwd_autotune_configs(dim_v: int, chunk_size: int) -> List[Dict[st
         for fused, recurrence, block_v, output in itertools.product(
             PIPELINE_CONFIGS,
             PIPELINE_CONFIGS,
-            h_block_v_candidates(dim_v, chunk_size),
+            h_block_v_candidates(dim_v),
             OUTPUT_CONFIGS,
         )
     ]
@@ -165,7 +174,7 @@ def tune_delta_rule_fwd(
     Returns:
         A config with the flat ``fused_`` / ``h_`` / ``o_`` keys the wrapped
         kernel reads. It is always a member of
-        ``delta_rule_fwd_autotune_configs(kernel.dim_v, kernel.chunk_size)``.
+        ``delta_rule_fwd_autotune_configs(kernel.dim_v)``.
     """
     shape = (
         kernel.batch,
@@ -194,7 +203,7 @@ def tune_delta_rule_fwd(
     # let an untuned width the sweep never offers escape through the fallback.
     h_block_v = default_h_block_v(kernel.dim_v, kernel.chunk_size)
     best_latency = float("inf")
-    for block_v in h_block_v_candidates(kernel.dim_v, kernel.chunk_size):
+    for block_v in h_block_v_candidates(kernel.dim_v):
         label = f"h_recurrence (block_v={block_v})" if block_v else "h_recurrence (no V tiling)"
         config, latency = _tune_sub_kernel(
             kernel,


### PR DESCRIPTION
Closes #1822

## Summary

`DeltaNetFwdKernel` and `GatedDeltaNetFwdKernel` each carried an 81-line `autotune` override differing by a comment and a print label. Neither declared `autotune_configs`, so `init_config(tune=True)` warned and fell back — both overrides were dead code.

- One shared sweep, `linear_attn_autotune.tune_delta_rule_fwd`. The per-JIT seed / `do_not_specialize` / decorate step moves to `Kernel.tune_jit_kernel`, which the base sweep uses too.
- **Declaring `autotune_configs` switches the path on**: `tune=True` sweeps for the first time. Not a pure refactor.
- One owner per rule. Candidates ask `resolve_block_v` rather than restating divisibility, and are distinct by resolved width; the untuned width is drawn from those candidates; the sweep and the default refuse the same shapes.

Correctness fixes the switch-on exposed:

- The V-tile comparison re-benchmarked the tuned kernel with no arguments (`Kernel expected 4 inputs, but 0 are provided`) — the measurement is already on `.latency`.
- `default_config` chose an unbuildable width: at `dim_v=48` it tiled 48 into one 32-column tile and the output projection read 16 columns uninitialized. Silent on DeltaNet, whose recurrence lacked the `resolve_block_v` guard its gated twin has.
- A width failing to compile aborted the whole sweep, discarding a width that worked.

`reduction/_primitives.tune_by_forward` was not reused: it times `kernel.forward` per candidate, while this sweep tunes three JIT sub-kernels and compares a build-time V-tile width outside the autotuner.

## Test plan

- [x] pre-commit passed
- [x] `test_linear_attn_autotune.py`, `test_v_tile.py`, `test_deltanet_fwd.py`, `test_gated_deltanet_fwd.py` — 42 passed
- [x] `test_reduce.py` — 171 passed (the other `Kernel.autotune` consumer)
- [x] `tune=True` covered on both kernels and executed end to end on device
- [x] Selected config identical before and after for a fixed shape and seed

## Regression

- Injected-latency replay of the old selection algorithm: 500/500 identical configs (`B=2, H=2, S=128, chunk=64, dim_k=64, dim_v=64, bf16`, seed 42).
- Candidate sets match the pre-refactor sweep at every shape measured, except `dim_v=8`, which correctly reports none where the hand-written check claimed `(0,)`.
- 22 mutations of the sweep, the width rules and the guards: each fails only its own test.

## Notes for review

- `tune=True` now costs real time in the `full` job: the two tuned params sweep 15 kernel variants each instead of returning instantly (measured 5.9s for both). No `benchmarks/` param passes it.
- `default_config` raises for `dim_v` below the gemm N minimum, refusing such a shape at construction rather than at build. That bound is upstream's, chosen to reject rather than clamp; no manifest workload reaches it.

## Test node delta

```
tests/kernels + tests/ops (deltanet, gated)     82     113      +31   (+37.8%)
```

The sweep had no coverage before because it could not run. Nodes cover the sweep contract (every candidate tried, fastest wins, a failed width never returned, selected config always declared), the V-tile width rules, and both rejection paths on both recurrence builders.
