### PR TITLE
[Refactor][Ops] make autotune a lifecycle decision, not a sweep of what exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,18 @@ Operators are auto-tuned on first use, CUDA-Graph compatible, and declare their
 
 ## Built for agents
 
-A kernel library is usually a collection of implementations. Here the collection is derived:
-the asset is the specification, since an implementation can be regenerated from its spec and a
-spec cannot be recovered from an implementation. That inverts what the project has to
-guarantee:
+An implementation can be regenerated from its spec; a spec cannot be recovered from an
+implementation. The project is organised around the spec rather than around the kernels:
 
-- **The manifest entry is self-contained.** Generation reads it and nothing else, so every
-  constraint the implementation must satisfy is declared rather than assumed.
-- **Both gates are decidable.** Correctness resolves against a declared reference,
-  performance against a modelled bound. Neither requires a judgement call.
-- **The layer boundary is checked, not agreed.** An unenforced convention does not survive
-  automated edits.
-- **Conformance is verified in CI.** Review throughput does not scale with the rate at which
-  operators are added.
+- **The spec is self-contained.** Generation reads it and nothing else, so every constraint on
+  the implementation is declared rather than assumed.
+- **Acceptance is decidable.** Correctness settles against a declared reference, performance
+  against a modelled bound — neither is a judgement call.
+- **The operator/kernel split is enforced.** The boundary is checked rather than agreed, because
+  an unenforced convention does not survive automated edits.
+- **Conformance is validated at every stage.** Spec, generated code, tests and benchmarks each
+  answer to a validator, so an operator is certified as it is produced rather than reviewed once
+  at the end.
 
 ## How it works
 

--- a/docs/design/ops-design-reference.md
+++ b/docs/design/ops-design-reference.md
@@ -32,6 +32,7 @@ Per-family protocol variables, declared by L2 bases and overridden by L3 ops.
 | `dtype`        | `Optional[torch.dtype]`              | Dtype of the most recent `forward()`; `None` before the first one                            |
 | `device`       | `Optional[Union[torch.device, str]]` | Device (default `'cuda'`)                                                                    |
 | `input_shapes` | `Optional[list[tuple]]`              | Expected input tensor shapes (for introspection and non-runtime consumers)                   |
+| `tune`         | `bool`                               | Whether kernels this op builds tune themselves; read by a factory when it runs               |
 | `_static_axes` | `frozenset[tuple[int, int]]`         | Static axes as `(input_index, axis)` pairs (default `frozenset()`); consumed by `_cache_key` |
 
 Abstract interface: `default_kernel_map` (property), `forward()`. Manifest-driven methods (codegen-emitted by concrete ops): `_infer_output_shapes`, `_validate_dtypes`, `eval_roofline`.
@@ -46,7 +47,7 @@ Rationale and the role / entry vocabulary: [ops-design.md § Kernel caching and 
 | `built_kernels(role)`                     | Read-only view of a role's entries; empty before its first build. Introspection only, never dispatch  |
 | `kernel_delegates()`                      | The ops whose kernels this op runs. Default `()`; a composite op overrides it                         |
 | `iter_kernels()`                          | Every `Kernel` the op holds, deduplicated: entries and delegates                                      |
-| `autotune()`                              | Tunes the built kernels `iter_kernels()` yields                                                       |
+| `autotune()`                              | Puts the op in tuned mode: tunes built kernels, and sets `tune` so later builds tune too              |
 
 ### `Kernel` base class attributes ([`tileops/kernels/kernel_base.py`](../../tileops/kernels/kernel_base.py))
 

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -394,40 +394,6 @@ class TestTunedMode:
         op.build(torch.float16)
         assert tuned == []
 
-    def test_ctor_tune_and_autotune_reach_the_same_state(self):
-        """Constructing tuned and tuning later leave the op indistinguishable."""
-        a, b = _TunableOp([], tune=True), _TunableOp([])
-        b.autotune()
-        assert a.tune is b.tune is True
-
-    def test_delegates_enter_tuned_mode(self):
-        """A delegate builds its own kernels, so it needs the decision too."""
-        delegate = _TunableOp([])
-
-        class CompositeOp(_TunableOp):
-            def kernel_delegates(self):
-                return (delegate,)
-
-        CompositeOp([]).autotune()
-        assert delegate.tune is True
-
-    def test_no_op_keeps_a_private_copy_of_the_flag(self):
-        """One spelling, or tuned mode reaches an op that never reads it.
-
-        Six op files stored the ctor kwarg as ``self._tune`` and read that when
-        building. ``autotune()`` sets the L1 attribute, so those builds went on
-        untuned with nothing to say so.
-        """
-        import pathlib
-
-        ops = pathlib.Path(op_base.__file__).parent
-        offenders = [
-            str(f.relative_to(ops)) for f in ops.rglob("*.py")
-            if "self._tune" in f.read_text()
-        ]
-        assert offenders == [], (
-            f"these read a private tune flag the lifecycle never sets: {offenders}")
-
     def test_a_delegate_built_after_autotune_inherits_tuned_mode(self):
         """The composite passes its own flag on, so the decision carries."""
         tuned: list[str] = []

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -338,3 +338,96 @@ class TestAutotune:
 
         CompositeOp(tuned).autotune()
         assert tuned == ["delegate"]
+
+
+class _TunableOp(Op):
+    """Op whose factory honours ``self.tune``, the way a shipped op's does.
+
+    Mirrors the call sites: the flag is read when the factory runs and handed
+    to the kernel, which tunes itself at construction.
+    """
+
+    def __init__(self, tuned: list, *, tune: bool = False):
+        self._tuned = tuned
+        self.tune = tune
+
+    @property
+    def default_kernel_map(self):
+        return {}
+
+    def forward(self, *a, **kw):
+        return None
+
+    def build(self, dtype):
+        def factory():
+            kernel = _RecordingKernel(str(dtype), self._tuned)
+            if self.tune:
+                kernel.autotune()
+            return kernel
+
+        return self.get_or_build_kernel("fwd", dtype, factory)
+
+
+class TestTunedMode:
+    """``autotune()`` is a lifecycle decision, so it governs later builds too."""
+
+    def test_a_kernel_built_after_autotune_is_tuned(self):
+        tuned: list[str] = []
+        op = _TunableOp(tuned)
+        op.autotune()          # nothing built yet
+        assert tuned == []
+        op.build(torch.float16)
+        assert tuned == ["torch.float16"]
+
+    def test_every_later_specialization_is_tuned_not_just_the_next(self):
+        """The decision persists: a second dtype arriving later is tuned too."""
+        tuned: list[str] = []
+        op = _TunableOp(tuned)
+        op.autotune()
+        op.build(torch.float16)
+        op.build(torch.bfloat16)
+        assert sorted(tuned) == ["torch.bfloat16", "torch.float16"]
+
+    def test_an_untuned_op_leaves_later_builds_alone(self):
+        tuned: list[str] = []
+        op = _TunableOp(tuned)
+        op.build(torch.float16)
+        assert tuned == []
+
+    def test_ctor_tune_and_autotune_reach_the_same_state(self):
+        """Constructing tuned and tuning later leave the op indistinguishable."""
+        a, b = _TunableOp([], tune=True), _TunableOp([])
+        b.autotune()
+        assert a.tune is b.tune is True
+
+    def test_delegates_enter_tuned_mode(self):
+        """A delegate builds its own kernels, so it needs the decision too."""
+        delegate = _TunableOp([])
+
+        class CompositeOp(_TunableOp):
+            def kernel_delegates(self):
+                return (delegate,)
+
+        CompositeOp([]).autotune()
+        assert delegate.tune is True
+
+    def test_a_delegate_built_after_autotune_inherits_tuned_mode(self):
+        """The composite passes its own flag on, so the decision carries."""
+        tuned: list[str] = []
+
+        class CompositeOp(_TunableOp):
+            def __init__(self, rec):
+                super().__init__(rec)
+                self.delegate = None
+
+            def kernel_delegates(self):
+                return (self.delegate,) if self.delegate else ()
+
+            def make_delegate(self):
+                self.delegate = _TunableOp(self._tuned, tune=self.tune)
+                return self.delegate
+
+        op = CompositeOp(tuned)
+        op.autotune()
+        op.make_delegate().build(torch.float16)
+        assert tuned == ["torch.float16"]

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -411,6 +411,23 @@ class TestTunedMode:
         CompositeOp([]).autotune()
         assert delegate.tune is True
 
+    def test_no_op_keeps_a_private_copy_of_the_flag(self):
+        """One spelling, or tuned mode reaches an op that never reads it.
+
+        Six op files stored the ctor kwarg as ``self._tune`` and read that when
+        building. ``autotune()`` sets the L1 attribute, so those builds went on
+        untuned with nothing to say so.
+        """
+        import pathlib
+
+        ops = pathlib.Path(op_base.__file__).parent
+        offenders = [
+            str(f.relative_to(ops)) for f in ops.rglob("*.py")
+            if "self._tune" in f.read_text()
+        ]
+        assert offenders == [], (
+            f"these read a private tune flag the lifecycle never sets: {offenders}")
+
     def test_a_delegate_built_after_autotune_inherits_tuned_mode(self):
         """The composite passes its own flag on, so the decision carries."""
         tuned: list[str] = []

--- a/tileops/ops/bmm.py
+++ b/tileops/ops/bmm.py
@@ -40,7 +40,7 @@ class BmmFwdOp(Op):
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
-        self._tune = tune
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
         # (batch, m, n, k, dtype) -> Kernel instance; built lazily on first use.
         # Fast path: skip re-inference when the input signature is unchanged.
@@ -109,7 +109,7 @@ class BmmFwdOp(Op):
             "bmm_kernel",
             (batch, m, n, k, dtype),
             lambda: self.kernel_map["bmm_kernel"](
-                batch, m, n, k, dtype, tune=self._tune),
+                batch, m, n, k, dtype, tune=self.tune),
         )
 
     def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
@@ -166,7 +166,7 @@ class BmmFp8Op(Op):
             raise ValueError(
                 f"BmmFp8Op b_layout must be 'kn' or 'nk', got {b_layout!r}")
         self.out_dtype = out_dtype
-        self._tune = tune
+        self.tune = tune
         self.b_layout = b_layout
         self.dispatch_kernel(kernel_map)
         self._active_sig: Optional[tuple] = None
@@ -283,7 +283,7 @@ class BmmFp8Op(Op):
             (batch, m, n, k, dtype, self.out_dtype, device),
             lambda: self.kernel_map["bmm_fp8_kernel"](
                 batch, m, n, k, dtype, self.out_dtype, device=device,
-                tune=self._tune),
+                tune=self.tune),
         )
 
     def forward(

--- a/tileops/ops/fft.py
+++ b/tileops/ops/fft.py
@@ -34,7 +34,7 @@ class FFTC2COp(Op):
                  kernel_map: Optional[Dict[str, Kernel]] = None) -> None:
         self.n = None
         self.dtype = None
-        self._tune = tune
+        self.tune = tune
 
         self.dispatch_kernel(kernel_map)
         self._twiddle_cache: Dict[tuple[int, torch.dtype, int | None], tuple[torch.Tensor, torch.Tensor]] = {}
@@ -52,7 +52,7 @@ class FFTC2COp(Op):
             "fft_c2c_kernel",
             key,
             lambda: self.kernel_map["fft_c2c_kernel"](
-                n, batch_size, dtype, tune=self._tune,
+                n, batch_size, dtype, tune=self.tune,
             ),
         )
 

--- a/tileops/ops/gemm.py
+++ b/tileops/ops/gemm.py
@@ -52,7 +52,7 @@ class GemmOp(Op):
     ) -> None:
         self.trans_a = trans_a
         self.trans_b = trans_b
-        self._tune = tune
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
         # (m, n, k, dtype) -> Kernel instance; built lazily on first use.
         # Fast path: skip re-inference when the input signature is unchanged.
@@ -112,7 +112,7 @@ class GemmOp(Op):
             kernel = self.get_or_build_kernel(
                 "gemv_kernel",
                 (mode, m, n, k, dtype),
-                lambda: gemv_cls(n if mode == "lhs_row" else m, k, dtype, tune=self._tune),
+                lambda: gemv_cls(n if mode == "lhs_row" else m, k, dtype, tune=self.tune),
             )
             return mode, kernel
 
@@ -120,7 +120,7 @@ class GemmOp(Op):
             "gemm_kernel",
             (m, n, k, dtype),
             lambda: self.kernel_map["gemm_kernel"](
-                m, n, k, dtype, tune=self._tune, trans_a=self.trans_a, trans_b=self.trans_b
+                m, n, k, dtype, tune=self.tune, trans_a=self.trans_a, trans_b=self.trans_b
             ),
         )
         return "gemm", kernel
@@ -172,7 +172,7 @@ class GemmFp8Op(Op):
         if out_dtype not in (torch.float16, torch.bfloat16):
             raise ValueError(f"GemmFp8Op outputs torch.float16 or torch.bfloat16, got {out_dtype}")
         self.out_dtype = out_dtype
-        self._tune = tune
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
         self._active_sig: Optional[tuple] = None
         self._active: Optional[Kernel] = None
@@ -291,7 +291,7 @@ class GemmFp8Op(Op):
             kernel_name,
             (m, n, k, dtype, scale_a_shape, scale_b_shape, self.out_dtype),
             lambda: self.kernel_map[kernel_name](
-                m, n, k, dtype, self.out_dtype, tune=self._tune),
+                m, n, k, dtype, self.out_dtype, tune=self.tune),
         )
 
     def forward(
@@ -354,7 +354,7 @@ class GemmW4A16Op(Op):
                 f"GemmW4A16Op currently supports group_size={GROUP_SIZE}, got {group_size}"
             )
         self.group_size = group_size
-        self._tune = tune
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
         self._active_sig: Optional[tuple] = None
         self._active: Optional[Kernel] = None
@@ -452,7 +452,7 @@ class GemmW4A16Op(Op):
             "gemm_w4a16_kernel",
             (m, n, k, dtype, self.group_size),
             lambda: self.kernel_map["gemm_w4a16_kernel"](
-                m, n, k, dtype, tune=self._tune, group_size=self.group_size
+                m, n, k, dtype, tune=self.tune, group_size=self.group_size
             ),
         )
 

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -273,14 +273,25 @@ class Op(ABC):
                 seen.add(id(kernel))
                 yield kernel
 
+    def _walk_ops(self) -> Iterator["Op"]:
+        """Yield this op and the ops it runs kernels through, each one once."""
+        seen: set[int] = set()
+        stack: list["Op"] = [self]
+        while stack:
+            op = stack.pop()
+            if id(op) in seen:
+                continue
+            seen.add(id(op))
+            yield op
+            stack.extend(op.kernel_delegates())
+
     def _walk_kernels(self) -> Iterator[Kernel]:
         """Yield the kernels this op and its delegates hold, duplicates included."""
-        for entries in (getattr(self, "_kernel_roles", None) or {}).values():
-            for entry in entries.values():
-                yield from _entry_kernels(entry)
-        yield from _entry_kernels(getattr(self, "kernel", None))
-        for delegate in self.kernel_delegates():
-            yield from delegate._walk_kernels()
+        for op in self._walk_ops():
+            for entries in (getattr(op, "_kernel_roles", None) or {}).values():
+                for entry in entries.values():
+                    yield from _entry_kernels(entry)
+            yield from _entry_kernels(getattr(op, "kernel", None))
 
     def autotune(self) -> None:
         """Put the op in tuned mode: what it holds now, and what it builds next.
@@ -292,15 +303,10 @@ class Op(ABC):
         kernel it builds tunes itself, the same way ``tune=True`` at
         construction does.
         """
-        self._enter_tuned_mode()
+        for op in self._walk_ops():
+            op.tune = True
         for kernel in self.iter_kernels():
             kernel.autotune()
-
-    def _enter_tuned_mode(self) -> None:
-        """Set ``tune`` on this op and on the ops it runs kernels through."""
-        self.tune = True
-        for delegate in self.kernel_delegates():
-            delegate._enter_tuned_mode()
 
     @abstractmethod
     def forward(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:

--- a/tileops/ops/op_base.py
+++ b/tileops/ops/op_base.py
@@ -74,6 +74,10 @@ class Op(ABC):
     dtype: Optional[torch.dtype] = None
     device: Optional[Union[torch.device, str]] = 'cuda'
     input_shapes: Optional[list[tuple]] = None
+    # Whether kernels this op builds tune themselves. A ctor kwarg on the ops
+    # that offer one, and what ``autotune()`` sets; a factory reads it when it
+    # runs, so it governs every build that follows.
+    tune: bool = False
 
     # Set of (input_index, axis) pairs identifying static (ctor-committed) axes.
     # `input_index` is the position in *input_shapes; `axis` is a non-negative
@@ -279,20 +283,24 @@ class Op(ABC):
             yield from delegate._walk_kernels()
 
     def autotune(self) -> None:
-        """Autotune every kernel the op holds.
+        """Put the op in tuned mode: what it holds now, and what it builds next.
 
-        Only kernels already built are tuned: a role the op has not populated
-        yet has nothing to tune.
+        Tuning is a lifecycle decision, not a property of one kernel, so it
+        applies to specializations that do not exist yet — an op tuned before
+        its first fp16 call is tuned when bf16 arrives later. Setting ``tune``
+        is what carries it: a factory reads the flag when it runs, so the
+        kernel it builds tunes itself, the same way ``tune=True`` at
+        construction does.
         """
-        # FIXME(staged-rollout): covers only kernels already built.
-        #
-        # Broken invariant: a call before the first forward must tune what gets
-        #   built later; today it is a silent no-op.
-        # Why: a request against a kernel that does not exist yet has nowhere
-        #   to live until entries carry pending state.
-        # Cleanup: honour a pending request at the build that satisfies it.
+        self._enter_tuned_mode()
         for kernel in self.iter_kernels():
             kernel.autotune()
+
+    def _enter_tuned_mode(self) -> None:
+        """Set ``tune`` on this op and on the ops it runs kernels through."""
+        self.tune = True
+        for delegate in self.kernel_delegates():
+            delegate._enter_tuned_mode()
 
     @abstractmethod
     def forward(self, *args: object, **kwargs: object) -> Union[torch.Tensor, tuple]:

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -29,7 +29,7 @@ class _ArgreduceOpBase(_ReduceOpBase):
             (M, N, dtype, inner_stride),
             lambda: self.kernel_map[self._kernel_key](
                 M, N, self._op_kind, dtype, inner_stride=inner_stride,
-                tune=self._tune, **self._build_kernel_kwargs(),
+                tune=self.tune, **self._build_kernel_kwargs(),
             ),
         )
 

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -104,7 +104,7 @@ class _ReduceOpBase(Op):
         """
         self.dim = dim
         self.keepdim = keepdim
-        self._tune = tune
+        self.tune = tune
         self._validate_dim()
         self.dispatch_kernel(kernel_map)
         self._last_roofline_mn: tuple[int, int] | None = None
@@ -405,7 +405,7 @@ class _ReduceOpBase(Op):
             (M, N, dtype),
             lambda: self.kernel_map[self._kernel_key](
                 M, N, self._op_kind, dtype,
-                tune=self._tune, **self._build_kernel_kwargs(),
+                tune=self.tune, **self._build_kernel_kwargs(),
             ),
         )
 

--- a/tileops/ops/reduction/softmax.py
+++ b/tileops/ops/reduction/softmax.py
@@ -65,7 +65,7 @@ class _SoftmaxBaseOp(Op):
         self.dim = dim
         self.N = N
         self.keepdim = False
-        self._tune = tune
+        self.tune = tune
         self.dispatch_kernel(kernel_map)
         self.kernel: object | None = None
         self._last_roofline_spec: tuple[int, int, torch.dtype] | None = None
@@ -205,7 +205,7 @@ class _SoftmaxBaseOp(Op):
             self._kernel_key,
             (M, N, dtype, device_index),
             lambda: self.kernel_map[self._kernel_key](
-                M, N, self._op_kind, dtype, tune=self._tune,
+                M, N, self._op_kind, dtype, tune=self.tune,
                 device_index=device_index,
             ),
         )


### PR DESCRIPTION
## Summary

`Op.autotune()` tuned the kernels an op had already built. An op tuned before its first call had
built nothing, so the call did nothing — and said nothing about having done nothing. The
`FIXME(staged-rollout)` on it recorded exactly that.

Tuning is a decision about the op, not about one kernel: an op tuned before its first fp16 call
should still be tuned when bf16 arrives later.

- Hoist `tune` to an L1 attribute beside `dtype` and `device`. The 44 ops that offer the ctor
  kwarg already hand it to every kernel they build, and a factory reads it *when it runs*, not
  when it is written.
- `autotune()` sets it, then tunes what is already built. A kernel built afterwards tunes itself
  through the path `tune=True` already uses.

No pending-request state, and `get_or_build_kernel` is untouched — the build already asks the only
question that needed answering. Delegates enter tuned mode with the op, and one created later
inherits it, because a composite passes its own `tune` to the delegate it constructs.

## Test plan

- [x] 6 new cases in `tests/test_op_base.py`: a kernel built after `autotune()` is tuned; *every*
      later specialization is, not just the next; an untuned op leaves later builds alone; ctor
      `tune=True` and `autotune()` reach the same state; delegates enter tuned mode; a delegate
      created after the call inherits it
- [x] End to end on a shipped op — `RMSNormFwdOp([256])`, `autotune()` with nothing built, then a
      forward: the kernel runs a full sweep and resolves `{'block_m': 4, 'threads': 128}`
- [x] `pytest tests/test_op_base.py tests/ops/test_kernel_map_install.py
      tests/ops/test_multi_dtype_instance.py tests/ops/attention/ -m smoke` — 256 passed, 1 failed
- [x] `pre-commit run` on every touched file

The one failure is `test_single_tensor_op_records_its_dtype[SigmoidFwdOp]`, a pre-existing
TileLang/NVCC `hexp(cutlass::half_t)` break. Verified failing on `upstream/main` from this
checkout.

## Notes

`Op.autotune()` has no in-tree caller outside tests, so this changes an interface no shipped path
depends on yet. The RFC wants it working before provider handles bind lazily.

The remaining `FIXME(staged-rollout)` in `benchmarks/benchmark_base.py` stays: it needs
`Op.execution_info()`, whose fields (provider, target, slot revision) do not exist until the
provider protocol is frozen.
