### PR TITLE
[Refactor][Reduction] drop the host-side padding path from the op layer

### DIFF
--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -77,7 +77,6 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
     _op_kind = "argmax"
     _kernel_key = "argreduce"
     _kernel_cls = ArgreduceKernel
-    _kernel_handles_padding = True
 
     def __init__(
         self,
@@ -106,9 +105,6 @@ class ArgmaxFwdOp(_ArgreduceOpBase):
             f"got {type(self.dim).__name__}: {self.dim!r}"
         )
 
-    def _pad_value(self) -> float:
-        """Pad with -inf so padded positions never win argmax."""
-        return float("-inf")
 
 
 
@@ -132,7 +128,6 @@ class ArgminFwdOp(_ArgreduceOpBase):
     _op_kind = "argmin"
     _kernel_key = "argreduce"
     _kernel_cls = ArgreduceKernel
-    _kernel_handles_padding = True
 
     def __init__(
         self,
@@ -160,7 +155,3 @@ class ArgminFwdOp(_ArgreduceOpBase):
             f"ArgminFwdOp only supports scalar dim (int) or None, "
             f"got {type(self.dim).__name__}: {self.dim!r}"
         )
-
-    def _pad_value(self) -> float:
-        """Pad with +inf so padded positions never win argmin."""
-        return float("inf")

--- a/tileops/ops/reduction/logical_reduce.py
+++ b/tileops/ops/reduction/logical_reduce.py
@@ -24,8 +24,6 @@ class AllFwdOp(_ReduceOpBase):
     are derived from the input tensor at forward time, and kernels are
     cached by ``(M, N)`` to avoid rebuilds.
 
-    Padded positions use 1 (True), which is neutral for AND/all.
-
     Supports any numeric dtype including torch.bool, int32, int64, and complex
     types. Inputs with unsupported TileLang storage dtypes (bool, int32, int64,
     complex64, complex128) are pre-converted to float32 in forward().
@@ -45,7 +43,6 @@ class AllFwdOp(_ReduceOpBase):
     _op_kind = "all"
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
-    _kernel_handles_padding = True
     _empty_dim_policy: EmptyDimPolicy = "noop"
 
     def __init__(
@@ -71,9 +68,6 @@ class AllFwdOp(_ReduceOpBase):
             kernel_map=kernel_map, tune=tune,
         )
 
-    def _pad_value(self) -> float:
-        """Pad with 1 (True), neutral for AND/all."""
-        return 1.0
 
     def _noop_output_dtype(self) -> torch.dtype:
         """All returns bool per manifest contract."""
@@ -94,8 +88,6 @@ class AnyFwdOp(_ReduceOpBase):
     are derived from the input tensor at forward time, and kernels are
     cached by ``(M, N)`` to avoid rebuilds.
 
-    Padded positions use 0 (False), which is neutral for OR/any.
-
     Supports any numeric dtype including torch.bool, int32, int64, and complex
     types. Inputs with unsupported TileLang storage dtypes (bool, int32, int64,
     complex64, complex128) are pre-converted to float32 in forward().
@@ -115,7 +107,6 @@ class AnyFwdOp(_ReduceOpBase):
     _op_kind = "any"
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
-    _kernel_handles_padding = True
     _empty_dim_policy: EmptyDimPolicy = "noop"
 
     def __init__(
@@ -141,9 +132,6 @@ class AnyFwdOp(_ReduceOpBase):
             kernel_map=kernel_map, tune=tune,
         )
 
-    def _pad_value(self) -> float:
-        """Pad with 0 (False), neutral for OR/any."""
-        return 0.0
 
     def _noop_output_dtype(self) -> torch.dtype:
         """Any returns bool per manifest contract."""
@@ -164,8 +152,6 @@ class CountNonzeroFwdOp(_ReduceOpBase):
     derived from the input tensor at forward time, and kernels are cached
     by ``(M, N)`` to avoid rebuilds.
 
-    Padded positions use 0, which is neutral for sum/count.
-
     Note: No ``keepdim`` parameter -- the reduction dimension is always
     removed, matching ``torch.count_nonzero`` semantics.
 
@@ -185,7 +171,6 @@ class CountNonzeroFwdOp(_ReduceOpBase):
     _kernel_key = "logical_reduce"
     _kernel_cls = LogicalReduceKernel
     _empty_dim_policy: EmptyDimPolicy = "full"
-    _kernel_handles_padding = True
 
     def __init__(
         self,
@@ -200,9 +185,6 @@ class CountNonzeroFwdOp(_ReduceOpBase):
             kernel_map=kernel_map, tune=tune,
         )
 
-    def _pad_value(self) -> float:
-        """Pad with 0, neutral for sum/count."""
-        return 0.0
 
     def _noop_output_dtype(self) -> torch.dtype:
         """count_nonzero returns int64 per manifest contract.

--- a/tileops/ops/reduction/reduce.py
+++ b/tileops/ops/reduction/reduce.py
@@ -6,11 +6,8 @@ for multi-dim reduction. Constructor ``dim`` defaults to ``None`` (full
 reduction) for the ten ops whose manifest declares ``default: null``;
 ``ProdFwdOp`` preserves ``dim=-1``.
 The Op layer validates inputs, reshapes to 2D (M, N), and calls the kernel.
-For simple, Welford, logical reduce, and vector norm ops, alignment padding is
-handled inside the kernel via masked loads with identity-element fills,
-eliminating host-side ``F.pad`` from the forward path. Other ops that inherit
-``_ReduceOpBase`` continue to use host-side padding until their kernels are
-converted.
+Alignment padding belongs to the kernel, which masks its loads and fills with
+the reduction's identity element; the Op layer never pads.
 Kernels are cached by ``(M, N)`` so that the same op instance can handle
 varying shapes.
 """
@@ -20,10 +17,8 @@ from math import prod
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.reduction._primitives import DEFAULT_ALIGNMENT, align_up
 from tileops.kernels.reduction.reduce import ReduceKernel
 
 from ..op_base import Op
@@ -60,7 +55,7 @@ class _ReduceOpBase(Op):
 
     Consolidates shared init params (dtype, dim, keepdim, tune), initializes
     and owns an internal kernel cache, and handles input preparation
-    (validate, transpose, reshape to 2D, pad) and output reshaping.
+    (validate, transpose, reshape to 2D) and output reshaping.
     Subclasses declare ``_op_kind``, ``_kernel_key``, ``_kernel_cls``, and
     override hooks as needed.  ``forward()`` is provided by this base class;
     only ops with non-standard returns (e.g. ``VarMeanFwdOp``) need to
@@ -71,7 +66,6 @@ class _ReduceOpBase(Op):
     - ``_kernel_key``: kernel map key (default ``"reduce"``).
     - ``_kernel_cls``: kernel class (default ``ReduceKernel``).
     - ``_validate_dim()``: validate ``dim`` at init (default: accept int/list/None).
-    - ``_pad_value()``: identity element for alignment padding (default ``0.0``).
     - ``_build_kernel_kwargs()``: extra kwargs for kernel constructor.
     - ``_pre_kernel(x)``: transform 2D input before kernel call (default identity).
       Returns ``(x, context)`` where *context* is passed to ``_post_kernel``.
@@ -81,7 +75,6 @@ class _ReduceOpBase(Op):
     _op_kind: str = ""  # overridden by subclasses
     _kernel_key: str = "reduce"  # overridden by subclasses for different kernel families
     _kernel_cls: type = ReduceKernel  # overridden by subclasses for different kernel classes
-    _kernel_handles_padding: bool = False  # True when kernel accepts (M, N) with masked loads
     _empty_dim_policy: EmptyDimPolicy = "reject"
 
     def __init__(
@@ -147,17 +140,6 @@ class _ReduceOpBase(Op):
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {self._kernel_key: self._kernel_cls}
-
-    # Pad value (subclasses may override; used only when
-    # _kernel_handles_padding is False)
-
-    def _pad_value(self) -> float:
-        """Return the identity element used when padding to alignment.
-
-        Only used when ``_kernel_handles_padding`` is ``False`` (i.e. the
-        kernel expects pre-padded input from the Op layer).
-        """
-        return 0.0
 
     # Extra kernel kwargs (subclasses may override)
 
@@ -409,21 +391,16 @@ class _ReduceOpBase(Op):
             ),
         )
 
-    # Input preparation (validate → transpose → reshape → pad)
+    # Input preparation (validate → transpose → reshape)
 
     def _prepare_input(
         self, x: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Size, object, object]:
-        """Validate, derive M/N, transpose, reshape to 2D, optionally pad.
+        """Validate, derive M/N, transpose, and reshape to 2D.
 
         Returns ``(x_2d, orig_shape, dim_info, kernel)`` where
         *dim_info* is either an ``int`` (single-dim) or ``list[int]``
         (multi-dim).
-
-        When ``_kernel_handles_padding`` is ``True``, the raw ``(M, N)``
-        tensor is passed through -- the kernel handles alignment internally
-        via masked loads.  Otherwise, host-side ``F.pad`` is applied for
-        backward compatibility with kernels that expect ``(M, N_padded)``.
         """
         self._validate_input_tensor(x)
 
@@ -440,12 +417,6 @@ class _ReduceOpBase(Op):
             self._last_roofline_mn = (M, N)
             x = x.reshape(M, N)
             kernel = self._get_or_create_kernel(M, N, x.dtype)
-            if not self._kernel_handles_padding:
-                N_padded = align_up(N, DEFAULT_ALIGNMENT)
-                if N_padded != N:
-                    pv = self._pad_value()
-                    pad = (0, N_padded - N)
-                    x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
             return x, orig_shape, dims, kernel
 
         # --- single-dim path ---
@@ -466,14 +437,6 @@ class _ReduceOpBase(Op):
         x = x.contiguous().reshape(M, N)
 
         kernel = self._get_or_create_kernel(M, N, x.dtype)
-
-        if not self._kernel_handles_padding:
-            N_padded = align_up(N, DEFAULT_ALIGNMENT)
-            if N_padded != N:
-                pv = self._pad_value()
-                pad = (0, N_padded - N)
-                x = F.pad(x, pad) if pv == 0.0 else F.pad(x, pad, value=pv)
-
         return x, orig_shape, dim, kernel
 
     # Output reshape
@@ -506,9 +469,7 @@ class _SimpleReduceOp(_ReduceOpBase):
     """Base for single-output reduce ops (sum, mean, amin, amax, prod).
 
     M and N are derived from the input tensor at forward time, and kernels
-    are cached by ``(M, N)`` to avoid rebuilds. Alignment padding is handled
-    inside the kernel via masked loads with identity-element fills, so no
-    host-side ``F.pad`` is needed.
+    are cached by ``(M, N)`` to avoid rebuilds.
 
     The ``dim`` default follows each op's manifest entry: ``sum``, ``mean``,
     ``amin``, and ``amax`` default to ``None`` (full reduction); ``prod``
@@ -523,7 +484,6 @@ class _SimpleReduceOp(_ReduceOpBase):
         tune: Whether to autotune (default False).
     """
 
-    _kernel_handles_padding = True
 
 
 class SumFwdOp(_SimpleReduceOp):
@@ -604,9 +564,6 @@ class _WelfordReduceOp(_ReduceOpBase):
     M and N are derived from the input tensor at forward time, and kernels
     are cached by ``(M, N)`` to avoid rebuilds.
 
-    Alignment padding is handled inside the kernel via masked loads,
-    so no host-side ``F.pad`` is needed.
-
     Args:
         dim: Reduction dimension (default ``None``, i.e. full reduction).
             Accepts ``int``, ``list[int]``, or ``tuple[int, ...]`` for
@@ -617,7 +574,6 @@ class _WelfordReduceOp(_ReduceOpBase):
         tune: Whether to autotune (default False).
     """
 
-    _kernel_handles_padding = True
     _empty_dim_policy: EmptyDimPolicy = "full"
 
     def __init__(

--- a/tileops/ops/reduction/vector_norm.py
+++ b/tileops/ops/reduction/vector_norm.py
@@ -36,7 +36,6 @@ class L1NormFwdOp(_ReduceOpBase):
     _op_kind = "l1"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
-    _kernel_handles_padding = True
     _required_ord: Union[int, float] = 1
     _empty_dim_policy: EmptyDimPolicy = "full"
 
@@ -84,7 +83,6 @@ class L2NormFwdOp(_ReduceOpBase):
     _op_kind = "l2"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
-    _kernel_handles_padding = True
     _required_ord: Union[int, float] = 2
     _empty_dim_policy: EmptyDimPolicy = "full"
 
@@ -135,7 +133,6 @@ class InfNormFwdOp(_ReduceOpBase):
     _op_kind = "inf"
     _kernel_key = "vector_norm"
     _kernel_cls = VectorNormKernel
-    _kernel_handles_padding = True
     _required_ord: Union[int, float] = inf
     _empty_dim_policy: EmptyDimPolicy = "full"
 


### PR DESCRIPTION
## Summary

`_ReduceOpBase._kernel_handles_padding` chose between the op padding to alignment and the kernel
masking its own loads. Every concrete op resolves it to true, and nothing outside
`tileops/ops/reduction/` subclasses the base, so the false branch and the five `_pad_value`
overrides feeding it were unreachable.

Delete the switch, both `F.pad` blocks, the base `_pad_value()` and its overrides, and the imports
they needed. Alignment stays where it already happens: the kernels mask and fill with the
reduction's identity. Runtime behaviour is unchanged — the deleted branch never ran.

## Test plan

- [x] `pytest tests/ops/test_{reduce,argreduce,logical_reduce,vector_norm}.py
      tests/ops/test_welford_non_aligned.py` — 579 passed
- [x] Unaligned `N=257` on GPU across all four families and dtypes, against the reference
- [x] Kernel-side check that masking is real rather than trusting the flag that claimed it
- [x] Class-hierarchy resolution confirming no concrete op reached the false branch

## Note

`gqa.py` / `mha.py` still pad K/V to a compile-time capacity — a live path, not dead code, tracked
in #1863.
