### PR TITLE
[CI][Nightly] tell a stuck benchmark file apart from an expensive one

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -119,6 +119,9 @@ jobs:
           # One pytest process per bench file: a native hang / segfault / OOM
           # kill costs only that file's results. py-spy captures the stack of
           # a hung child before the runner kills it.
+          # --stall-timeout bounds silence, not runtime. A file killed mid-run
+          # never writes its kernels to the persistent cache, so capping total
+          # runtime would keep the same files cold every night.
           set -o pipefail
           # Best-effort: on a network failure the run proceeds without stack
           # dumps (the runner records the absence) instead of dying here.
@@ -126,7 +129,7 @@ jobs:
             || echo "::warning::py-spy install failed; hang stack dumps disabled"
           python3 scripts/ci/run_benchmarks.py benchmarks/ops \
             --junit-xml bench_results.xml \
-            --timeout-per-file 900 \
+            --stall-timeout 900 \
             --dump-dir bench_stack_dumps | tee tileops_benchmarks.log
 
           if [ -f profile_run.log ]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,10 @@ jobs:
   # =========================================================================
   benchmark:
     if: ${{ github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
-    timeout-minutes: 150
+    # Sized for a cold cache: a measured 59-file sweep on an idle H200 takes
+    # 5h07m with nothing cached, and minutes once it is. Must exceed
+    # --total-budget below so the runner, not GitHub, ends the sweep.
+    timeout-minutes: 380
     runs-on: [self-hosted, tile-ops, nightly]
     env:
       # Keep the long benchmark suite from fragmenting CUDA allocator segments
@@ -130,6 +133,7 @@ jobs:
           python3 scripts/ci/run_benchmarks.py benchmarks/ops \
             --junit-xml bench_results.xml \
             --stall-timeout 900 \
+            --total-budget 21600 \
             --dump-dir bench_stack_dumps | tee tileops_benchmarks.log
 
           if [ -f profile_run.log ]; then

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -191,7 +191,7 @@ def test_comparison_bench(
     bm = BinaryBenchmark(test)
     inputs = test.gen_inputs()
 
-    op = _CMP_OPS[op_name](a_shape=shape, b_shape=shape, dtype=dtype)
+    op = _CMP_OPS[op_name](a_shape=shape, b_shape=shape)
     result = bm.profile(op, *inputs)
     BenchmarkReport.record(op, locals(), result, tag="tileops")
 

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -102,7 +102,7 @@ def test_moe_experts_nopad_bench(
 
     kwargs = dict(
         num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
-        hidden_size=hidden_size, ffn_size=ffn_size, dtype=dtype,
+        hidden_size=hidden_size, ffn_size=ffn_size,
     )
     output = torch.empty(num_tokens, hidden_size, dtype=dtype, device="cuda")
     ws1 = torch.empty(0, dtype=dtype, device="cuda")

--- a/benchmarks/ops/bench_moe_fused_activation.py
+++ b/benchmarks/ops/bench_moe_fused_activation.py
@@ -145,7 +145,7 @@ def test_moe_fused_activation_bench(regime: str, num_tokens: int) -> None:
 
     kwargs = dict(
         num_tokens=num_tokens, num_experts=NUM_EXPERTS, top_k=TOP_K,
-        hidden_size=HIDDEN_SIZE, ffn_size=FFN_SIZE, dtype=DTYPE,
+        hidden_size=HIDDEN_SIZE, ffn_size=FFN_SIZE,
         activation=ACTIVATION,
     )
 

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -119,7 +119,7 @@ def _run_bench(
         num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
         hidden_size=hidden_size, ffn_size=ffn_size,
         scoring_func=scoring_func, renormalize=renormalize,
-        routed_scaling_factor=routed_scaling_factor, dtype=dtype,
+        routed_scaling_factor=routed_scaling_factor,
     )
 
     if with_correction_bias:

--- a/benchmarks/tests/test_run_benchmarks.py
+++ b/benchmarks/tests/test_run_benchmarks.py
@@ -31,7 +31,7 @@ def _write_bench_dir(tmp_path: Path, files: dict[str, str]) -> Path:
 
 
 def _run_runner(
-    tmp_path: Path, bench_dir: Path, timeout_per_file: str, extra: list | None = None
+    tmp_path: Path, bench_dir: Path, stall_timeout: str, extra: list | None = None
 ) -> tuple:
     out_xml = tmp_path / "bench_results.xml"
     dump_dir = tmp_path / "dumps"
@@ -42,8 +42,8 @@ def _run_runner(
             str(bench_dir),
             "--junit-xml",
             str(out_xml),
-            "--timeout-per-file",
-            timeout_per_file,
+            "--stall-timeout",
+            stall_timeout,
             "--dump-dir",
             str(dump_dir),
             *(extra or []),
@@ -72,7 +72,7 @@ def test_native_crash_loses_only_the_crashing_file(tmp_path):
             "bench_ok.py": "def test_ok():\n    pass\n",
         },
     )
-    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, timeout_per_file="120")
+    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, stall_timeout="120")
 
     assert proc.returncode == 1, proc.stdout + proc.stderr
     cases = _cases(out_xml)
@@ -93,7 +93,7 @@ def test_hung_file_is_killed_dumped_and_reported(tmp_path):
         },
     )
     # Above the child's post-release startup, far below the sleep.
-    proc, out_xml, dump_dir = _run_runner(tmp_path, bench_dir, timeout_per_file="10")
+    proc, out_xml, dump_dir = _run_runner(tmp_path, bench_dir, stall_timeout="10")
 
     assert proc.returncode == 1, proc.stdout + proc.stderr
     cases = _cases(out_xml)
@@ -101,7 +101,8 @@ def test_hung_file_is_killed_dumped_and_reported(tmp_path):
 
     errors = [err for tc in cases.values() if (err := tc.find("error")) is not None]
     assert len(errors) == 1
-    assert "timed out" in errors[0].attrib["message"]
+    # The message names the test it stopped in, not just the file.
+    assert "test_hang" in errors[0].attrib["message"]
 
     dumps = list(dump_dir.glob("*.txt"))
     assert len(dumps) == 1
@@ -129,7 +130,7 @@ def test_fragments_and_profile_logs_merge(tmp_path):
             "bench_import_abort.py": "import os\nos.abort()\n",
         },
     )
-    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, timeout_per_file="120")
+    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, stall_timeout="120")
 
     assert proc.returncode == 1, proc.stdout + proc.stderr
     cases = _cases(out_xml)
@@ -167,7 +168,7 @@ def test_teardown_crash_is_reported(tmp_path):
             ),
         },
     )
-    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, timeout_per_file="120")
+    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, stall_timeout="120")
 
     assert proc.returncode == 1, proc.stdout + proc.stderr
     assert "died in teardown" in proc.stdout
@@ -191,7 +192,7 @@ def test_teardown_deadline_enforced_during_next_file(tmp_path):
         },
     )
     proc, out_xml, _ = _run_runner(
-        tmp_path, bench_dir, timeout_per_file="120",
+        tmp_path, bench_dir, stall_timeout="120",
         extra=["--teardown-timeout", "2", "--prewarm", "0"],
     )
 
@@ -200,3 +201,58 @@ def test_teardown_deadline_enforced_during_next_file(tmp_path):
     assert "stuck in teardown" in out
     assert out.index("stuck in teardown") < out.index("bench_b_next.py finished")
     assert any("bench_a_slow_teardown" in k for k in _cases(out_xml))
+
+
+@pytest.mark.smoke
+def test_slow_file_outlives_the_stall_timeout(tmp_path):
+    """The deadline measures silence, not total runtime."""
+    bench_dir = _write_bench_dir(
+        tmp_path,
+        {
+            "bench_slow.py": (
+                "import time\n"
+                "def test_a():\n    time.sleep(1.2)\n"
+                "def test_b():\n    time.sleep(1.2)\n"
+                "def test_c():\n    time.sleep(1.2)\n"
+                "def test_d():\n    time.sleep(1.2)\n"
+            ),
+        },
+    )
+    proc, out_xml, _ = _run_runner(tmp_path, bench_dir, stall_timeout="3")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert len(_cases(out_xml)) == 4
+
+
+@pytest.mark.smoke
+def test_failure_report_survives_the_child_stdout_buffer(tmp_path):
+    """pytest's FAILURES section reaches the log, so a bench F has a reason."""
+    bench_dir = _write_bench_dir(
+        tmp_path,
+        {"bench_fail.py": "def test_boom():\n    assert 0, 'explosive-marker'\n"},
+    )
+    proc, _, _ = _run_runner(tmp_path, bench_dir, stall_timeout="120")
+
+    assert proc.returncode == 1
+    assert "explosive-marker" in proc.stdout
+
+
+@pytest.mark.smoke
+def test_spent_budget_reports_the_files_it_never_reached(tmp_path):
+    """A spent budget stops the sweep with the report intact and the gap named."""
+    bench_dir = _write_bench_dir(
+        tmp_path,
+        {
+            "bench_a_slow.py": "import time\n\ndef test_slow():\n    time.sleep(6)\n",
+            "bench_z_never.py": "def test_never():\n    pass\n",
+        },
+    )
+    proc, out_xml, _ = _run_runner(
+        tmp_path, bench_dir, stall_timeout="120",
+        extra=["--total-budget", "2", "--prewarm", "0"],
+    )
+
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "not benchmarked" in proc.stdout
+    skipped = ET.parse(out_xml).getroot().findall(".//skipped")
+    assert any("bench_z_never.py" in s.get("message", "") for s in skipped)

--- a/scripts/ci/run_benchmarks.py
+++ b/scripts/ci/run_benchmarks.py
@@ -5,6 +5,11 @@ A native failure (hang, segfault, OOM kill) costs one file: other fragments
 survive into the merged report and a hung child leaves a py-spy stack dump.
 Upcoming children import while the current file owns the GPU, hiding startup
 cost. This parent must never import torch: children need fresh processes.
+
+Two limits, because a stuck file and an expensive one call for opposite
+responses. ``--stall-timeout`` kills a child that stopped starting tests,
+however long its individual tests take. ``--total-budget`` stops launching
+files and writes the report, killing nothing for being slow.
 """
 
 from __future__ import annotations
@@ -33,21 +38,33 @@ TEARDOWN_TIMEOUT_S = 120
 # the GPU, so it must stay GPU-silent; CUDA init happens after the stdin
 # grant. TILEOPS_COLLECT_STATUS holds "started", then the collect exit code,
 # so a child that dies mid-collect stays distinguishable from a clean one.
+# TILEOPS_HEARTBEAT is rewritten at every test start: its mtime is the
+# parent's progress signal, its contents name the test to blame for a stall.
+# stdout is a file, so it is block-buffered; without the flush the parent
+# prints the log while pytest's FAILURES section is still in the buffer.
 # The run exit code leaves via the pipe before interpreter teardown.
 _CHILD = """\
 import ctypes, os, sys
 
 status = os.environ["TILEOPS_COLLECT_STATUS"]
 open(status, "w").write("started")
+beat = os.environ["TILEOPS_HEARTBEAT"]
 
 ctypes.CDLL(None).prctl(0x59616D61, os.getppid(), 0, 0, 0)
 
 import pytest
 
+class Heartbeat:
+    def pytest_runtest_logstart(self, nodeid, location):
+        with open(beat, "w") as fh:
+            fh.write(nodeid)
+
 rc_collect = int(pytest.main(["--collect-only", "-q", sys.argv[3]]))
 open(status, "w").write(str(rc_collect))
 sys.stdin.readline()
-rc = int(pytest.main(sys.argv[2:]))
+open(beat, "w").write("")
+rc = int(pytest.main(sys.argv[2:], plugins=[Heartbeat()]))
+sys.stdout.flush()
 os.write(int(sys.argv[1]), str(rc).encode())
 sys.exit(rc)
 """
@@ -55,7 +72,14 @@ sys.exit(rc)
 class Child:
     """One bench child process plus its status pipe."""
 
-    def __init__(self, code: str, argv: list[str], log_path: Path, status_path: Path):
+    def __init__(
+        self,
+        code: str,
+        argv: list[str],
+        log_path: Path,
+        status_path: Path,
+        beat_path: Path,
+    ):
         read_fd, write_fd = os.pipe()
         log_fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
         try:
@@ -66,12 +90,25 @@ class Child:
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
                 pass_fds=(write_fd,),
-                env={**os.environ, "TILEOPS_COLLECT_STATUS": str(status_path)},
+                env={
+                    **os.environ,
+                    "TILEOPS_COLLECT_STATUS": str(status_path),
+                    "TILEOPS_HEARTBEAT": str(beat_path),
+                },
             )
         finally:
             os.close(log_fd)
             os.close(write_fd)
         self.status_fd = read_fd
+        self.beat_path = beat_path
+
+    def beat(self) -> tuple[float, str]:
+        """Return (mtime, running nodeid) of the heartbeat; (0.0, "") if absent."""
+        try:
+            mtime = self.beat_path.stat().st_mtime
+            return mtime, self.beat_path.read_text(errors="replace").strip()
+        except OSError:
+            return 0.0, ""
 
     def release(self) -> None:
         """Unblock the child waiting on stdin; a child already dead is fine."""
@@ -194,6 +231,18 @@ def _discover_bench_files(targets: list[str]) -> list[str]:
     return list(files)
 
 
+def _unrun_suite(rel: str) -> ET.Element:
+    """Build a one-entry junit testsuite marking a file the budget never reached."""
+    suite = ET.Element(
+        "testsuite",
+        {"name": "pytest", "tests": "1", "errors": "0", "failures": "0", "skipped": "1"},
+    )
+    classname = rel[: -len(".py")].replace(os.sep, ".")
+    case = ET.SubElement(suite, "testcase", {"classname": classname, "name": "whole_file"})
+    ET.SubElement(case, "skipped", {"message": f"{rel}: not run, sweep budget spent"})
+    return suite
+
+
 def _synthetic_suite(bench_file: str, message: str, log_tail: str) -> ET.Element:
     """Build a one-entry junit testsuite standing in for a dead child's results."""
     suite = ET.Element(
@@ -243,10 +292,24 @@ def main() -> int:
     )
     parser.add_argument("--junit-xml", required=True, help="merged junit report path")
     parser.add_argument(
-        "--timeout-per-file",
+        "--stall-timeout",
         type=float,
-        default=1800.0,
-        help="seconds before a bench file's process is dumped and killed",
+        default=900.0,
+        help=(
+            "seconds a bench file may spend without starting a new test before "
+            "its process is dumped and killed; this catches a hung or wedged "
+            "child, and is not a cap on how long a file may legitimately run"
+        ),
+    )
+    parser.add_argument(
+        "--total-budget",
+        type=float,
+        default=None,
+        help=(
+            "seconds the whole sweep may run; the runner stops launching files "
+            "once it is spent and reports the rest as not run, so the report is "
+            "written instead of the CI job being cancelled mid-sweep"
+        ),
     )
     parser.add_argument("--dump-dir", default="bench_stack_dumps", help="stack dump directory")
     parser.add_argument(
@@ -287,7 +350,11 @@ def main() -> int:
             fragment = work_dir / f"{index:03d}.xml"
             argv = ["-q", bench_files[index], f"--junit-xml={fragment}"]
             return Child(
-                _CHILD, argv, work_dir / f"{index:03d}.log", work_dir / f"{index:03d}.collect"
+                _CHILD,
+                argv,
+                work_dir / f"{index:03d}.log",
+                work_dir / f"{index:03d}.collect",
+                work_dir / f"{index:03d}.beat",
             )
 
         pending: deque[Child] = deque()
@@ -300,9 +367,20 @@ def main() -> int:
                 pending.append(spawn_at(spawned))
                 spawned += 1
 
+        run_deadline = (
+            time.monotonic() + args.total_budget if args.total_budget is not None else None
+        )
+        unrun: list[str] = []
+
+        def budget_spent() -> bool:
+            return run_deadline is not None and time.monotonic() >= run_deadline
+
         top_up()
         try:
             for index, bench_file in enumerate(bench_files):
+                if budget_spent():
+                    unrun.extend(os.path.relpath(f) for f in bench_files[index:])
+                    break
                 child = pending.popleft()
                 top_up()
                 rel = os.path.relpath(bench_file)
@@ -313,26 +391,55 @@ def main() -> int:
                 start = time.monotonic()
                 child.release()
                 # Poll in short steps so lingering teardown deadlines are
-                # enforced while this file runs, not after it.
-                file_deadline = start + args.timeout_per_file
+                # enforced while this file runs, not after it. The deadline
+                # tracks the last test start, not the file start: a file of
+                # many slow tests is progressing, not stuck.
+                stall_deadline = start + args.stall_timeout
+                last_beat = 0.0
+                out_of_budget = False
                 while True:
-                    rc = child.wait_result(min(1.0, max(0.0, file_deadline - time.monotonic())))
+                    limit = stall_deadline if run_deadline is None else min(
+                        stall_deadline, run_deadline
+                    )
+                    rc = child.wait_result(min(1.0, max(0.0, limit - time.monotonic())))
                     note_anomalies(_reap_lingering(lingering, block=False))
-                    if rc is not None or time.monotonic() >= file_deadline:
+                    if rc is not None:
+                        break
+                    beat_mtime, _ = child.beat()
+                    if beat_mtime > last_beat:
+                        last_beat = beat_mtime
+                        stall_deadline = time.monotonic() + args.stall_timeout
+                    if time.monotonic() >= stall_deadline:
+                        break
+                    if budget_spent():
+                        out_of_budget = True
                         break
                 elapsed = time.monotonic() - start
 
+                if out_of_budget:
+                    child.kill()
+                    sys.stdout.write(log_path.read_text(errors="replace"))
+                    print(
+                        f"BUDGET: {rel}: stopped after {elapsed:.0f}s; "
+                        f"the {args.total_budget:.0f}s sweep budget is spent",
+                        flush=True,
+                    )
+                    unrun.extend(os.path.relpath(f) for f in bench_files[index:])
+                    break
+
                 if rc is None:
+                    _, stalled_on = child.beat()
                     dump_dir.mkdir(parents=True, exist_ok=True)
                     dump_path = dump_dir / f"{Path(bench_file).stem}.txt"
                     _dump_stack(child.proc.pid, dump_path)
                     child.kill()
                     sys.stdout.write(log_path.read_text(errors="replace"))
+                    where = stalled_on or "startup (no test reached)"
                     message = (
-                        f"timed out after {args.timeout_per_file:.0f}s; "
+                        f"no test started for {args.stall_timeout:.0f}s at {where}; "
                         f"killed, stack dump at {dump_path}"
                     )
-                    print(f"TIMEOUT: {rel}: {message}", flush=True)
+                    print(f"STALLED: {rel}: {message}", flush=True)
                     suites.append(_synthetic_suite(bench_file, message, _log_tail(log_path)))
                     failed.append(rel)
                 else:
@@ -369,6 +476,10 @@ def main() -> int:
                 leftover.kill()
             note_anomalies(_reap_lingering(lingering, block=True))
 
+    # Absent from the sweep, not passing: the report must show the gap.
+    for rel in unrun:
+        suites.append(_unrun_suite(rel))
+
     merged = ET.Element("testsuites")
     merged.extend(suites)
     ET.ElementTree(merged).write(args.junit_xml, encoding="utf-8", xml_declaration=True)
@@ -390,10 +501,25 @@ def main() -> int:
             flush=True,
         )
 
-    if failed:
-        print(f"\n{len(failed)} benchmark file(s) failed:", flush=True)
-        for rel in failed:
+    if unrun:
+        print(
+            f"\nthe {args.total_budget:.0f}s sweep budget ran out with "
+            f"{len(unrun)} of {len(bench_files)} file(s) not benchmarked:",
+            flush=True,
+        )
+        for rel in unrun:
             print(f"  {rel}", flush=True)
+        print(
+            "  Coverage is the contract: either the sweep gets cheaper or the"
+            " budget grows. Results for the files that did run are in the report.",
+            flush=True,
+        )
+
+    if failed or unrun:
+        if failed:
+            print(f"\n{len(failed)} benchmark file(s) failed:", flush=True)
+            for rel in failed:
+                print(f"  {rel}", flush=True)
         return 1
     print("\nall benchmark files passed", flush=True)
     return 0

--- a/tests/ops/test_argreduce.py
+++ b/tests/ops/test_argreduce.py
@@ -644,6 +644,25 @@ def test_argreduce_strided_axis_crossover(shape, dim, expect_strided) -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.parametrize("op_cls_name", ["ArgmaxFwdOp", "ArgminFwdOp"])
+def test_strided_axis_forward_binds_roofline_state(op_cls_name: str) -> None:
+    """The strided-axis path owes ``eval_roofline()`` the same state as the base.
+
+    Reading a short non-last axis in place skips the transpose, and with it
+    the shared validation that binds ``dtype``.
+    """
+    import tileops.ops.reduction.argreduce as argreduce
+
+    op = getattr(argreduce, op_cls_name)(dim=0)
+    x = torch.randn(4, 128, 4096, device="cuda", dtype=torch.float16)
+    _call(op, x)
+
+    flops, mem_bytes = op.eval_roofline()
+    assert flops > 0 and mem_bytes > 0
+    assert op.dtype is torch.float16
+
+
+@pytest.mark.smoke
 @pytest.mark.parametrize("m, n, inner_stride, strategy", [
     (4, 1024, 1, "warp"),
     (4, 8192, 1, "cta"),

--- a/tileops/ops/reduction/argreduce.py
+++ b/tileops/ops/reduction/argreduce.py
@@ -36,6 +36,8 @@ class _ArgreduceOpBase(_ReduceOpBase):
     def _prepare_input(
         self, x: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Size, Union[int, list], object]:
+        # Binds self.dtype, which the strided path below never reaches.
+        self._validate_input_tensor(x)
         if self.dim is None or not x.is_contiguous():
             return super()._prepare_input(x)
         if self.dim < -x.ndim or self.dim >= x.ndim:


### PR DESCRIPTION
Closes #1813.

## Why

The nightly benchmark job ([run 31272374766](https://github.com/tile-ai/TileOPs/actions/runs/31272374766)) was cancelled at its 150-minute limit having run 34 of 59 files. Because GitHub cancelled it, `bench_results.xml` was never written and `publish-bench-data` skipped — 149 minutes of exclusive GPU time produced no data at all.

`run_benchmarks.py` had one knob, `--timeout-per-file`, doing two jobs: it bounds a native failure, and it also kills a file for being expensive. Three files reached the 900s cap while running normally. Given the full time they need, none is anywhere near a hang:

| File | Full cold-cache run | Slowest single test | Under the cap |
|---|---|---|---|
| `bench_convolution.py` | 3838s | 100s | killed, 11 of 57 tests |
| `bench_gqa.py` | 1153s | 76s | killed, 27 of 34 tests |
| `bench_gated_deltanet_prefill.py` | 1129s | 98s | killed, 20 of 26 tests |

The cap was also self-perpetuating. `bench_convolution.py` spends 92% of its runtime autotuning (3838s tuned, 324s untuned), and tilelang caches autotune results across processes — the same tuned conv2d subset takes **1035s cold and 8s warm**. A file killed mid-tune writes nothing, so it arrived cold every night and hit the cap again. The benchmarks do not need to get cheaper; they need to be allowed to finish once.

## The change

Two limits with separate jobs replace the one.

- **`--stall-timeout`** measures time since the child last *started a test* — a pytest plugin rewrites a heartbeat file, the parent stats its mtime in the poll loop it already runs. A hang is caught as fast as before, and the kill message names the test.
- **`--total-budget`** stops launching files, writes the merged report, and records what it never reached as skipped, instead of letting CI cancel the job and discard everything.

Sized from a measured full sweep: 59 files, cold cache, idle H200, **18438s (5h07m)**; median file 86s, p90 673s. `--total-budget 21600` covers it with margin and `timeout-minutes 380` stays above the budget.

## Defects the same investigation exposed

**Failure output was being lost.** The child wrote its exit code to the status pipe before flushing stdout. Redirected to a file, stdout is block-buffered, so the parent printed the log while pytest's `FAILURES` section was still in the buffer — nightly reported failures with no reason attached to any of them.

**20 benchmark failures, none of which had a visible cause.** Four bench files (`bench_binary_elementwise`, `bench_fused_moe_experts`, `bench_moe_fused_moe`, `bench_moe_fused_activation`) passed `dtype=` to constructors that bind dtype per call. The last two are in the region the cancelled nightly never reached, and only turned up in the full sweep.

**One op bug.** `_ArgreduceOpBase._prepare_input` skipped the shared input validation on its strided fast path, so the op returned a correct result and then failed `eval_roofline()` for an unbound dtype, with device and rank unchecked.

## Testing

Verified in `ghcr.io/tile-ai/tileops-runner:afcebed1-torch2.10-dev`, the CI-identical image:

- `benchmarks/tests/test_run_benchmarks.py` — 8 passed, covering the flag rename plus the three cases the split introduces
- the five formerly-failing bench files plus `tests/ops/test_argreduce.py` — 196 passed, was 20 failed (two runs: 188 before the sweep surfaced the last two files, 8 after)
- full 59-file sweep under the new runner — no stalls, no crashes, every file completed
