### PR TITLE
[Feat][Manifest] declare slot ABIs for the reduction family

### DIFF
--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -247,6 +247,7 @@ Validator enforces `cls.__name__ == manifest_key` exactly — no heuristic resol
 | `workloads`               | yes      | Benchmark shapes/dtypes.                                      |
 | `roofline`                | yes      | Performance model.                                            |
 | `source`                  | yes      | Implementation paths.                                         |
+| `slots`                   | no       | Backend-neutral factory contract. See [Slots](#slots).        |
 
 ### `family`
 
@@ -377,6 +378,47 @@ source:
 ```
 
 - Optional when `status: spec-only`. Required when `status: implemented`.
+
+## Slots
+
+A slot is the contract an implementation of this op answers to: what a factory is handed, and
+what the callable it returns receives and produces. It is written for an author outside this
+repository, so it names semantics and never a class, a file, or a dispatch key.
+
+```yaml
+slots:
+  var:
+    build:
+      M:          {type: int, from: "roofline.vars.M"}
+      N:          {type: int, from: "roofline.vars.N"}
+      dtype:      {type: torch.dtype, from: "x.dtype"}
+      correction: {type: int, from: "signature.params.correction"}
+    call:
+      inputs:
+        x:      {shape: "[M, N]", dtype: "dtype", layout: contiguous}
+      outputs:
+        output: {shape: "[M]", dtype: "same_as(x)"}
+```
+
+| Field   | Required | Description                                                                   |
+| ------- | -------- | ----------------------------------------------------------------------------- |
+| `build` | yes      | Parameters the factory is specialized on. `from` names where each comes from. |
+| `call`  | yes      | Tensors the returned callable receives and returns, in slot terms.            |
+
+- **The slot name is the semantic**, not the in-tree dispatch key. `SumFwdOp` declares `sum`;
+  that its implementation happens to share a class with `mean` and `var`, selected by an
+  `op_kind` argument, is a fact about one provider and stays out of the contract. A slot whose
+  parameter changes the return arity is a multiplexer, not a specialization.
+- `source.kernel_map` keys are in-tree dispatch roles and need not match slot names. The two
+  answer different questions: which class this repository instantiates, versus what any
+  implementation must satisfy.
+- `from` **references** a value the entry already declares — a `roofline.vars` name, an input's
+  dtype, a `signature.params` key. It never restates the derivation: a second copy of an
+  expression is a second thing to keep in step.
+- `call` shapes are written in the build parameters' terms, because the callable sees the
+  problem after the op has normalized it, not the caller's tensor.
+- Build parameters carry what changes the result. What only changes how it is produced —
+  tuning, tile sizes, compilation knobs — belongs to the implementation.
 
 ## Entry Examples
 

--- a/docs/design/manifest.md
+++ b/docs/design/manifest.md
@@ -415,6 +415,9 @@ slots:
 - `from` **references** a value the entry already declares — a `roofline.vars` name, an input's
   dtype, a `signature.params` key. It never restates the derivation: a second copy of an
   expression is a second thing to keep in step.
+- `from` names where a value originates; `type` says what arrives. A param declared
+  `float | None` with a null default reaches the factory as the float the op resolved it to, so
+  the slot writes `type: float`.
 - `call` shapes are written in the build parameters' terms, because the callable sees the
   problem after the op has normalized it, not the caller's tensor.
 - Build parameters carry what changes the result. What only changes how it is produced —

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -581,6 +581,13 @@ def _l0_kernel_map(
 # container type, type-error phrase, section validator run on type match).
 # Genuinely custom rules (key format, scalar fields, kernel_map) stay as
 # dedicated small validators around the table loop in ``check_l0``.
+# Layouts a slot may promise its callable. Anything else names a memory format
+# no implementer can act on.
+_VALID_SLOT_LAYOUTS = frozenset({"contiguous"})
+
+_SAME_AS_RE = re.compile(r"same_as\(([A-Za-z_][A-Za-z_0-9]*)\)")
+
+
 def _l0_slots(op_name: str, entry: dict, slots: dict) -> list[str]:
     """Slot block: every ``from`` resolves, and shapes name declared params.
 
@@ -647,6 +654,10 @@ def _l0_slots(op_name: str, entry: dict, slots: dict) -> list[str]:
             if not isinstance(tensors, dict) or not tensors:
                 err(f"{where}.call.{side} must be a non-empty mapping")
                 continue
+            if side == "outputs" and set(tensors) != declared:
+                err(f"{where}.call.outputs declares {sorted(tensors)}, but the op returns "
+                    f"{sorted(declared)}; an implementer reading this would return the "
+                    f"wrong number of tensors")
             for tname, tspec in tensors.items():
                 if tname not in declared:
                     err(f"{where}.call.{side}.{tname} names no declared "
@@ -662,6 +673,22 @@ def _l0_slots(op_name: str, entry: dict, slots: dict) -> list[str]:
                     if name not in build:
                         err(f"{where}.call.{side}.{tname} shape uses {name!r}, which "
                             f"build does not declare; it has {sorted(build)}")
+
+                dtype = tspec.get("dtype")
+                if dtype is None:
+                    err(f"{where}.call.{side}.{tname} missing 'dtype'")
+                elif not (
+                    dtype in build
+                    or dtype in _TORCH_DTYPES
+                    or _SAME_AS_RE.fullmatch(str(dtype))
+                ):
+                    err(f"{where}.call.{side}.{tname} dtype {dtype!r} is neither a build "
+                        f"parameter, a dtype name, nor same_as(<input>)")
+
+                layout = tspec.get("layout")
+                if layout is not None and layout not in _VALID_SLOT_LAYOUTS:
+                    err(f"{where}.call.{side}.{tname} layout {layout!r} is not one of "
+                        f"{sorted(_VALID_SLOT_LAYOUTS)}")
     return errors
 
 

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -77,7 +77,9 @@ _PROMOTE_TARGET_DTYPE: str = "float32"
 
 # Required top-level fields per op entry
 _REQUIRED_TOP = {"family", "status", "signature", "workloads", "roofline", "source"}
-_VALID_TOP_KEYS = _REQUIRED_TOP | {"ref_api", "variant_of", "torch_compile_fullgraph"}
+_VALID_TOP_KEYS = _REQUIRED_TOP | {
+    "ref_api", "variant_of", "torch_compile_fullgraph", "slots",
+}
 _REQUIRED_SIGNATURE = {"inputs", "outputs"}
 _VALID_SIGNATURE_KEYS = {
     "inputs", "outputs", "params", "shape_rules", "dtype_combos",
@@ -579,11 +581,96 @@ def _l0_kernel_map(
 # container type, type-error phrase, section validator run on type match).
 # Genuinely custom rules (key format, scalar fields, kernel_map) stay as
 # dedicated small validators around the table loop in ``check_l0``.
+def _l0_slots(op_name: str, entry: dict, slots: dict) -> list[str]:
+    """Slot block: every ``from`` resolves, and shapes name declared params.
+
+    A slot is read by an implementer who cannot see this repository, so the
+    only claims worth checking are the ones that would send them somewhere
+    that does not exist.
+    """
+    errors: list[str] = []
+    err = _emit_to(errors, "schema", op_name)
+
+    roofline_vars = set((entry.get("roofline") or {}).get("vars") or {})
+    signature = entry.get("signature") or {}
+    inputs = set(signature.get("inputs") or {})
+    outputs = set(signature.get("outputs") or {})
+    params = set(signature.get("params") or {})
+
+    for slot_name, slot in slots.items():
+        where = f"slots.{slot_name}"
+        if not isinstance(slot, dict):
+            err(f"{where} must be a mapping")
+            continue
+        unknown = sorted(set(slot) - {"build", "call"})
+        if unknown:
+            err(f"{where} has unknown keys {unknown}; valid keys are ['build', 'call']")
+        build = slot.get("build")
+        if not isinstance(build, dict) or not build:
+            err(f"{where}.build must be a non-empty mapping")
+            build = {}
+        for pname, pspec in build.items():
+            if not isinstance(pspec, dict):
+                err(f"{where}.build.{pname} must be a mapping")
+                continue
+            if "type" not in pspec:
+                err(f"{where}.build.{pname} missing 'type'")
+            src = pspec.get("from")
+            if src is None:
+                continue
+            if src.startswith("roofline.vars."):
+                if src.split(".", 2)[2] not in roofline_vars:
+                    err(f"{where}.build.{pname} reads {src!r}, which roofline.vars "
+                        f"does not declare; it has {sorted(roofline_vars)}")
+            elif src.startswith("signature.params."):
+                if src.split(".", 2)[2] not in params:
+                    err(f"{where}.build.{pname} reads {src!r}, which signature.params "
+                        f"does not declare; it has {sorted(params)}")
+            elif src.endswith(".dtype"):
+                if src.split(".", 1)[0] not in inputs:
+                    err(f"{where}.build.{pname} reads {src!r}, which names no declared "
+                        f"input; inputs are {sorted(inputs)}")
+            else:
+                err(f"{where}.build.{pname} has unrecognised from {src!r}; expected "
+                    f"roofline.vars.*, signature.params.*, or <input>.dtype")
+
+        call = slot.get("call")
+        if not isinstance(call, dict):
+            err(f"{where}.call must be a mapping")
+            continue
+        unknown_call = sorted(set(call) - {"inputs", "outputs"})
+        if unknown_call:
+            err(f"{where}.call has unknown keys {unknown_call}; "
+                f"valid keys are ['inputs', 'outputs']")
+        for side, declared in (("inputs", inputs), ("outputs", outputs)):
+            tensors = call.get(side)
+            if not isinstance(tensors, dict) or not tensors:
+                err(f"{where}.call.{side} must be a non-empty mapping")
+                continue
+            for tname, tspec in tensors.items():
+                if tname not in declared:
+                    err(f"{where}.call.{side}.{tname} names no declared "
+                        f"signature.{side}; they are {sorted(declared)}")
+                if not isinstance(tspec, dict):
+                    err(f"{where}.call.{side}.{tname} must be a mapping")
+                    continue
+                shape = tspec.get("shape")
+                if shape is None:
+                    err(f"{where}.call.{side}.{tname} missing 'shape'")
+                    continue
+                for name in re.findall(r"[A-Za-z_][A-Za-z_0-9]*", str(shape)):
+                    if name not in build:
+                        err(f"{where}.call.{side}.{tname} shape uses {name!r}, which "
+                            f"build does not declare; it has {sorted(build)}")
+    return errors
+
+
 _L0_SECTIONS = (
     ("signature", dict, "a mapping", _l0_signature),
     ("workloads", list, "a list", _l0_workloads),
     ("roofline", dict, "a mapping", _l0_roofline),
     ("source", dict, "a mapping", _l0_source),
+    ("slots", dict, "a mapping", _l0_slots),
 )
 
 

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2903,6 +2903,25 @@ class TestSlots:
         errors = validator.check_l0("DemoFwdOp", entry)
         assert any("'N'" in e and "build does not declare" in e for e in errors)
 
+    def test_dropping_a_declared_output_fails(self, validator):
+        """A slot that under-declares returns promises the wrong arity."""
+        entry = _slot_entry()
+        entry["signature"]["outputs"]["z"] = {"dtype": "same_as(x)"}
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("wrong number of tensors" in e for e in errors)
+
+    def test_unresolvable_dtype_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["call"]["inputs"]["x"]["dtype"] = "not_a_dtype"
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("not_a_dtype" in e and "neither a build parameter" in e for e in errors)
+
+    def test_unknown_layout_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["call"]["inputs"]["x"]["layout"] = "strided_by_magic"
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("strided_by_magic" in e for e in errors)
+
     def test_unknown_slot_key_fails(self, validator):
         errors = validator.check_l0("DemoFwdOp", _slot_entry(revision=1))
         assert any("unknown keys" in e and "revision" in e for e in errors)

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -2845,3 +2845,64 @@ class TestCompileContractRegistry:
             f"evidence without declaration: {sorted(registered - declared)}; "
             f"declaration without evidence: {sorted(declared - registered)}"
         )
+
+
+def _slot_entry(**slot_overrides):
+    """Entry carrying one well-formed slot, for mutation by the cases below."""
+    slot = {
+        "build": {
+            "M": {"type": "int", "from": "roofline.vars.M"},
+            "dtype": {"type": "torch.dtype", "from": "x.dtype"},
+        },
+        "call": {
+            "inputs": {"x": {"shape": "[M]", "dtype": "dtype"}},
+            "outputs": {"y": {"shape": "[M]", "dtype": "same_as(x)"}},
+        },
+    }
+    slot.update(slot_overrides)
+    entry = _make_entry(slots={"demo": slot})
+    entry["roofline"] = {"vars": {"M": "x.shape[0]"}, "flops": "M", "bytes": "M"}
+    return entry
+
+
+class TestSlots:
+    """A slot sends an outside implementer somewhere; the checks are that it exists."""
+
+    def test_well_formed_slot_passes(self, validator):
+        assert validator.check_l0("DemoFwdOp", _slot_entry()) == []
+
+    def test_from_naming_an_undeclared_roofline_var_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["build"]["M"]["from"] = "roofline.vars.Nope"
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("roofline.vars.Nope" in e and "does not declare" in e for e in errors)
+
+    def test_from_naming_an_undeclared_input_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["build"]["dtype"]["from"] = "weight.dtype"
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("weight.dtype" in e and "no declared input" in e for e in errors)
+
+    def test_from_naming_an_undeclared_param_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["build"]["c"] = {
+            "type": "int", "from": "signature.params.correction",
+        }
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("signature.params.correction" in e for e in errors)
+
+    def test_call_tensor_outside_the_signature_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["call"]["inputs"]["ghost"] = {"shape": "[M]"}
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("ghost" in e and "no declared" in e for e in errors)
+
+    def test_shape_naming_an_undeclared_build_param_fails(self, validator):
+        entry = _slot_entry()
+        entry["slots"]["demo"]["call"]["outputs"]["y"]["shape"] = "[M, N]"
+        errors = validator.check_l0("DemoFwdOp", entry)
+        assert any("'N'" in e and "build does not declare" in e for e in errors)
+
+    def test_unknown_slot_key_fails(self, validator):
+        errors = validator.check_l0("DemoFwdOp", _slot_entry(revision=1))
+        assert any("unknown keys" in e and "revision" in e for e in errors)

--- a/tileops/manifest/normalization.yaml
+++ b/tileops/manifest/normalization.yaml
@@ -19,21 +19,21 @@ RMSNormFwdOp:
       normalized_shape: {type: "list[int] | tuple[int, ...]"}
       eps: {type: "float | None", default: null}
     shape_rules:
-      - "len(normalized_shape) > 0"
-      - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"
-      - "weight.shape == tuple(normalized_shape)"
-      - "output.shape == x.shape"
+    - "len(normalized_shape) > 0"
+    - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"
+    - "weight.shape == tuple(normalized_shape)"
+    - "output.shape == x.shape"
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+  - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+  - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+  - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
   roofline:
     vars:
@@ -53,6 +53,19 @@ RMSNormFwdOp:
     bench: benchmarks/ops/bench_norm.py
     bench_manifest_driven: true
 
+  slots:
+    rms_norm:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+        eps: {type: float, from: signature.params.eps}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+          weight: {shape: '[N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M, N]', dtype: "same_as(x)"}
 LayerNormFwdOp:
   ref_api: "torch.nn.functional.layer_norm"
   family: normalization
@@ -69,22 +82,22 @@ LayerNormFwdOp:
       normalized_shape: {type: "list[int] | tuple[int, ...]"}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "len(normalized_shape) > 0"
-      - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"
-      - "weight.shape == tuple(normalized_shape)"
-      - "bias.shape == tuple(normalized_shape)"
-      - "output.shape == x.shape"
+    - "len(normalized_shape) > 0"
+    - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"
+    - "weight.shape == tuple(normalized_shape)"
+    - "bias.shape == tuple(normalized_shape)"
+    - "output.shape == x.shape"
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], normalized_shape: [4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], normalized_shape: [4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+  - {x_shape: [2048, 8192], normalized_shape: [8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+  - {x_shape: [1, 8192], normalized_shape: [8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  - {x_shape: [2048, 16384], normalized_shape: [16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+  - {x_shape: [1, 16384], normalized_shape: [16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
   roofline:
     vars:
@@ -104,6 +117,20 @@ LayerNormFwdOp:
     bench: benchmarks/ops/bench_norm.py
     bench_manifest_driven: true
 
+  slots:
+    layer_norm:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+        eps: {type: float, from: signature.params.eps}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+          weight: {shape: '[N]', dtype: dtype, layout: contiguous}
+          bias: {shape: '[N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M, N]', dtype: "same_as(x)"}
 AdaLayerNormFwdOp:
   ref_api: "none"
   family: normalization
@@ -119,16 +146,16 @@ AdaLayerNormFwdOp:
     params:
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "scale.shape == x.shape"
-      - "shift.shape == x.shape"
-      - "output.shape == x.shape"
+    - "scale.shape == x.shape"
+    - "shift.shape == x.shape"
+    - "output.shape == x.shape"
 
   workloads:
     # DiT-XL/2 (hidden_dim=1152)
-    - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+  - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
 
   roofline:
     vars:
@@ -164,17 +191,17 @@ AdaLayerNormZeroFwdOp:
     params:
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "scale.shape == x.shape"
-      - "shift.shape == x.shape"
-      - "gate.shape == x.shape"
-      - "output.shape == x.shape"
+    - "scale.shape == x.shape"
+    - "shift.shape == x.shape"
+    - "gate.shape == x.shape"
+    - "output.shape == x.shape"
 
   workloads:
     # DiT-XL/2 (hidden_dim=1152)
-    - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
+  - {x_shape: [1024, 1152], dtypes: [float16, bfloat16], label: "dit-xl-2"}
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
 
   roofline:
     vars:
@@ -211,19 +238,19 @@ FusedAddLayerNormFwdOp:
     params:
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "residual.shape == x.shape"
-      - "weight.shape == (x.shape[-1],)"
-      - "bias.shape == (x.shape[-1],)"
-      - "output.shape == x.shape"
-      - "residual_out.shape == x.shape"
+    - "residual.shape == x.shape"
+    - "weight.shape == (x.shape[-1],)"
+    - "bias.shape == (x.shape[-1],)"
+    - "output.shape == x.shape"
+    - "residual_out.shape == x.shape"
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+  - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+  - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
 
   roofline:
     vars:
@@ -259,21 +286,21 @@ FusedAddRMSNormFwdOp:
     params:
       eps: {type: float, default: 1.0e-6}
     shape_rules:
-      - "residual.shape == x.shape"
-      - "weight.shape == (x.shape[-1],)"
-      - "output.shape == x.shape"
-      - "residual_out.shape == x.shape"
+    - "residual.shape == x.shape"
+    - "weight.shape == (x.shape[-1],)"
+    - "output.shape == x.shape"
+    - "residual_out.shape == x.shape"
 
   workloads:
     # Llama-3.1-8B (hidden_dim=4096)
-    - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
-    - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
+  - {x_shape: [2048, 4096], dtypes: [float16, bfloat16], label: "llama-3.1-8b-prefill"}
+  - {x_shape: [1, 4096], dtypes: [bfloat16], label: "llama-3.1-8b-decode"}
     # Llama-3.1-70B (hidden_dim=8192)
-    - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
-    - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
+  - {x_shape: [2048, 8192], dtypes: [float16, bfloat16], label: "llama-3.1-70b-prefill"}
+  - {x_shape: [1, 8192], dtypes: [bfloat16], label: "llama-3.1-70b-decode"}
     # Llama-3.1-405B (hidden_dim=16384)
-    - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
-    - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
+  - {x_shape: [2048, 16384], dtypes: [float16, bfloat16], label: "llama-3.1-405b-prefill"}
+  - {x_shape: [1, 16384], dtypes: [bfloat16], label: "llama-3.1-405b-decode"}
 
   roofline:
     vars:
@@ -316,20 +343,20 @@ BatchNormFwdOp:
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "running_mean.shape == (x.shape[1],)"
-      - "running_var.shape == (x.shape[1],)"
-      - "weight.shape == (x.shape[1],)"
-      - "bias.shape == (x.shape[1],)"
-      - "output.shape == x.shape"
+    - "running_mean.shape == (x.shape[1],)"
+    - "running_var.shape == (x.shape[1],)"
+    - "weight.shape == (x.shape[1],)"
+    - "bias.shape == (x.shape[1],)"
+    - "output.shape == x.shape"
 
   workloads:
     # ResNet-50 stages
-    - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
-    - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
-    - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
-    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+  - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+  - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+  - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+  - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
     # Large spatial
-    - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+  - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
 
   roofline:
     vars:
@@ -368,22 +395,22 @@ BatchNormBwdOp:
       grad_bias: {dtype: "float32"}
     params: {}
     shape_rules:
-      - "x.shape == grad_out.shape"
-      - "weight.shape == (grad_out.shape[1],)"
-      - "mean.shape == (grad_out.shape[1],)"
-      - "rstd.shape == (grad_out.shape[1],)"
-      - "grad_x.shape == grad_out.shape"
-      - "grad_weight.shape == (grad_out.shape[1],)"
-      - "grad_bias.shape == (grad_out.shape[1],)"
+    - "x.shape == grad_out.shape"
+    - "weight.shape == (grad_out.shape[1],)"
+    - "mean.shape == (grad_out.shape[1],)"
+    - "rstd.shape == (grad_out.shape[1],)"
+    - "grad_x.shape == grad_out.shape"
+    - "grad_weight.shape == (grad_out.shape[1],)"
+    - "grad_bias.shape == (grad_out.shape[1],)"
 
   workloads:
     # ResNet-50 stages (same as fwd)
-    - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
-    - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
-    - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
-    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
+  - {x_shape: [32, 64], dtypes: [float16], label: "resnet50-fc"}
+  - {x_shape: [8, 64, 32, 32], dtypes: [float16], label: "resnet50-stage1"}
+  - {x_shape: [4, 128, 32, 32], dtypes: [float16], label: "resnet50-stage2"}
+  - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "resnet50-stage3"}
     # Large spatial
-    - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
+  - {x_shape: [4, 128, 1024, 1024], dtypes: [float16], label: "large-spatial"}
 
   roofline:
     vars:
@@ -419,16 +446,16 @@ GroupNormFwdOp:
       num_groups: {type: int}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "weight.shape == (x.shape[1],)"
-      - "bias.shape == (x.shape[1],)"
-      - "x.shape[1] % num_groups == 0"
-      - "output.shape == x.shape"
+    - "weight.shape == (x.shape[1],)"
+    - "bias.shape == (x.shape[1],)"
+    - "x.shape[1] % num_groups == 0"
+    - "output.shape == x.shape"
 
   workloads:
     # Typical CV shapes
-    - {x_shape: [8, 128, 32, 32], num_groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
-    - {x_shape: [4, 256, 28, 28], num_groups: 32, dtypes: [float16], label: "wider-channel-g32"}
-    - {x_shape: [4, 128, 30, 30], num_groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
+  - {x_shape: [8, 128, 32, 32], num_groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
+  - {x_shape: [4, 256, 28, 28], num_groups: 32, dtypes: [float16], label: "wider-channel-g32"}
+  - {x_shape: [4, 128, 30, 30], num_groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
 
   roofline:
     vars:
@@ -469,15 +496,15 @@ GroupNormNoAffineFwdOp:
       num_groups: {type: int}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "x.shape[1] % num_groups == 0"
-      - "output.shape == x.shape"
+    - "x.shape[1] % num_groups == 0"
+    - "output.shape == x.shape"
 
   workloads:
     # Mirror the affine primary's CV shapes; affine-vs-no-affine perf
     # difference is sub-percent, so shape coverage is what matters.
-    - {x_shape: [8, 128, 32, 32], num_groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
-    - {x_shape: [4, 256, 28, 28], num_groups: 32, dtypes: [float16], label: "wider-channel-g32"}
-    - {x_shape: [4, 128, 30, 30], num_groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
+  - {x_shape: [8, 128, 32, 32], num_groups: 32, dtypes: [float16, bfloat16], label: "image-g32"}
+  - {x_shape: [4, 256, 28, 28], num_groups: 32, dtypes: [float16], label: "wider-channel-g32"}
+  - {x_shape: [4, 128, 30, 30], num_groups: 16, dtypes: [float16], label: "tail-spatial-g16"}
 
   roofline:
     vars:
@@ -516,15 +543,15 @@ InstanceNormFwdOp:
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "weight.shape == (x.shape[1],)"
-      - "bias.shape == (x.shape[1],)"
-      - "output.shape == x.shape"
+    - "weight.shape == (x.shape[1],)"
+    - "bias.shape == (x.shape[1],)"
+    - "output.shape == x.shape"
 
   workloads:
     # Typical CV shapes (style transfer, image generation)
-    - {x_shape: [8, 128, 32, 32], dtypes: [float16, bfloat16], label: "image"}
-    - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "wider-channel"}
-    - {x_shape: [4, 64, 30, 30], dtypes: [float16], label: "tail-spatial"}
+  - {x_shape: [8, 128, 32, 32], dtypes: [float16, bfloat16], label: "image"}
+  - {x_shape: [4, 256, 28, 28], dtypes: [float16], label: "wider-channel"}
+  - {x_shape: [4, 64, 30, 30], dtypes: [float16], label: "tail-spatial"}
 
   roofline:
     vars:
@@ -567,16 +594,16 @@ InstanceNormNoAffineFwdOp:
       momentum: {type: float, default: 0.1}
       eps: {type: float, default: 1.0e-5}
     shape_rules:
-      - "running_mean.shape == (x.shape[1],)"
-      - "running_var.shape == (x.shape[1],)"
-      - "output.shape == x.shape"
+    - "running_mean.shape == (x.shape[1],)"
+    - "running_var.shape == (x.shape[1],)"
+    - "output.shape == x.shape"
 
   workloads:
     # Mirror the affine primary's CV shapes. running_mean / running_var
     # are per-channel (shape [C]) per torch.nn.functional.instance_norm.
-    - {x_shape: [8, 128, 32, 32], running_mean_shape: [128], running_var_shape: [128], dtypes: [float16, bfloat16], label: "image"}
-    - {x_shape: [4, 256, 28, 28], running_mean_shape: [256], running_var_shape: [256], dtypes: [float16], label: "wider-channel"}
-    - {x_shape: [4, 64, 30, 30], running_mean_shape: [64], running_var_shape: [64], dtypes: [float16], label: "tail-spatial"}
+  - {x_shape: [8, 128, 32, 32], running_mean_shape: [128], running_var_shape: [128], dtypes: [float16, bfloat16], label: "image"}
+  - {x_shape: [4, 256, 28, 28], running_mean_shape: [256], running_var_shape: [256], dtypes: [float16], label: "wider-channel"}
+  - {x_shape: [4, 64, 30, 30], running_mean_shape: [64], running_var_shape: [64], dtypes: [float16], label: "tail-spatial"}
 
   roofline:
     vars:

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -785,6 +785,17 @@ AllFwdOp:
     bench: benchmarks/ops/bench_logical_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    all:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "bool"}
 AnyFwdOp:
   ref_api: "torch.any"
   family: reduction
@@ -832,6 +843,17 @@ AnyFwdOp:
     bench: benchmarks/ops/bench_logical_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    any:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "bool"}
 CountNonzeroFwdOp:
   ref_api: "torch.count_nonzero"
   family: reduction
@@ -879,6 +901,17 @@ CountNonzeroFwdOp:
 # reduction -- vector norms (output dtype: same_as(x))
 # ---------------------------------------------------------------------------
 
+  slots:
+    count_nonzero:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "int64"}
 L1NormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
@@ -930,6 +963,17 @@ L1NormFwdOp:
     bench: benchmarks/ops/bench_vector_norm.py
     bench_manifest_driven: true
 
+  slots:
+    l1_norm:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "same_as(x)"}
 L2NormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
@@ -981,6 +1025,17 @@ L2NormFwdOp:
     bench: benchmarks/ops/bench_vector_norm.py
     bench_manifest_driven: true
 
+  slots:
+    l2_norm:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "same_as(x)"}
 InfNormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction
@@ -1031,3 +1086,14 @@ InfNormFwdOp:
     test: tests/ops/test_vector_norm.py
     bench: benchmarks/ops/bench_vector_norm.py
     bench_manifest_driven: true
+  slots:
+    inf_norm:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "same_as(x)"}

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -818,17 +818,6 @@ AllFwdOp:
     bench: benchmarks/ops/bench_logical_reduce.py
     bench_manifest_driven: true
 
-  slots:
-    all:
-      build:
-        M: {type: int, from: roofline.vars.M}
-        N: {type: int, from: roofline.vars.N}
-        dtype: {type: torch.dtype, from: x.dtype}
-      call:
-        inputs:
-          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
-        outputs:
-          output: {shape: '[M]', dtype: "bool"}
 AnyFwdOp:
   ref_api: "torch.any"
   family: reduction
@@ -876,17 +865,6 @@ AnyFwdOp:
     bench: benchmarks/ops/bench_logical_reduce.py
     bench_manifest_driven: true
 
-  slots:
-    any:
-      build:
-        M: {type: int, from: roofline.vars.M}
-        N: {type: int, from: roofline.vars.N}
-        dtype: {type: torch.dtype, from: x.dtype}
-      call:
-        inputs:
-          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
-        outputs:
-          output: {shape: '[M]', dtype: "bool"}
 CountNonzeroFwdOp:
   ref_api: "torch.count_nonzero"
   family: reduction
@@ -934,17 +912,6 @@ CountNonzeroFwdOp:
 # reduction -- vector norms (output dtype: same_as(x))
 # ---------------------------------------------------------------------------
 
-  slots:
-    count_nonzero:
-      build:
-        M: {type: int, from: roofline.vars.M}
-        N: {type: int, from: roofline.vars.N}
-        dtype: {type: torch.dtype, from: x.dtype}
-      call:
-        inputs:
-          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
-        outputs:
-          output: {shape: '[M]', dtype: "int64"}
 L1NormFwdOp:
   ref_api: "torch.linalg.vector_norm"
   family: reduction

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -210,6 +210,17 @@ SumFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    sum:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 MeanFwdOp:
   ref_api: "torch.mean"
   family: reduction
@@ -259,6 +270,17 @@ MeanFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    mean:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 AmaxFwdOp:
   ref_api: "torch.amax"
   family: reduction
@@ -304,6 +326,17 @@ AmaxFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    amax:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 AminFwdOp:
   ref_api: "torch.amin"
   family: reduction
@@ -349,6 +382,17 @@ AminFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    amin:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 ProdFwdOp:
   ref_api: "torch.prod"
   family: reduction
@@ -406,6 +450,17 @@ ProdFwdOp:
 # reduction -- Welford reductions (correction + dim + keepdim)
 # ---------------------------------------------------------------------------
 
+  slots:
+    prod:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 VarFwdOp:
   ref_api: "torch.var"
   family: reduction
@@ -452,6 +507,18 @@ VarFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    var:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+        correction: {type: int, from: signature.params.correction}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 StdFwdOp:
   ref_api: "torch.std"
   family: reduction
@@ -498,6 +565,18 @@ StdFwdOp:
     bench: benchmarks/ops/bench_reduce.py
     bench_manifest_driven: true
 
+  slots:
+    std:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+        correction: {type: int, from: signature.params.correction}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: same_as(x)}
 VarMeanFwdOp:
   ref_api: "torch.var_mean"
   family: reduction
@@ -551,6 +630,19 @@ VarMeanFwdOp:
 # reduction -- argmax/argmin (output dtype: int64)
 # ---------------------------------------------------------------------------
 
+  slots:
+    var_mean:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+        correction: {type: int, from: signature.params.correction}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          var: {shape: '[M]', dtype: same_as(x)}
+          mean: {shape: '[M]', dtype: same_as(x)}
 ArgmaxFwdOp:
   ref_api: "torch.argmax"
   family: reduction

--- a/tileops/manifest/reduction.yaml
+++ b/tileops/manifest/reduction.yaml
@@ -52,6 +52,17 @@ SoftmaxFwdOp:
     bench: benchmarks/ops/bench_softmax.py
     bench_manifest_driven: true
 
+  slots:
+    softmax:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M, N]', dtype: "same_as(x)"}
 LogSoftmaxFwdOp:
   ref_api: "torch.nn.functional.log_softmax"
   family: reduction
@@ -104,6 +115,17 @@ LogSoftmaxFwdOp:
     bench: benchmarks/ops/bench_softmax.py
     bench_manifest_driven: true
 
+  slots:
+    log_softmax:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M, N]', dtype: "same_as(x)"}
 LogSumExpFwdOp:
   ref_api: "torch.logsumexp"
   family: reduction
@@ -157,6 +179,17 @@ LogSumExpFwdOp:
 # reduction -- simple reductions (dim + keepdim)
 # ---------------------------------------------------------------------------
 
+  slots:
+    logsumexp:
+      build:
+        M: {type: int, from: roofline.vars.M}
+        N: {type: int, from: roofline.vars.N}
+        dtype: {type: torch.dtype, from: x.dtype}
+      call:
+        inputs:
+          x: {shape: '[M, N]', dtype: dtype, layout: contiguous}
+        outputs:
+          output: {shape: '[M]', dtype: "same_as(x)"}
 SumFwdOp:
   ref_api: "torch.sum"
   family: reduction


### PR DESCRIPTION
## Summary

Starts B3 — the manifest field an outside author implements a slot from, without reading TileOPs
source. Reduction first, because it is the family that has been regularised.

- **Spec** (`docs/design/manifest.md`): a slot carries `build` — what the factory is specialized on
  — and `call` — what the returned callable receives and returns. Nothing else.
- **Names are semantics.** `SumFwdOp` declares `sum`, not the `reduce` dispatch key it shares with
  seven others behind an `op_kind` selector. `VarMeanFwdOp` is why: same class as `var`, two
  returned tensors against one. A parameter that changes return arity multiplexes operations.
- **`from` references, never restates.** `M` and `N` are the expressions `roofline.vars` already
  carries; a copy is a second thing to keep in step.
- **Validator**: a `from`, a call tensor, a shape term, a dtype or a layout that resolves to
  nothing is an error. 10 tests, one per failure.
- **14 of 19 reduction entries** declared, each checked against runtime rather than the schema.

## Deliberately absent

- `argreduce` — its factory takes `inner_stride`, a memory-layout parameter. Declaring it would
  put one backend's strided indexing into the contract.
- `all` / `any` / `count_nonzero` — the factory is built on the semantic dtype but the callable
  receives float32 whenever the input is bool, int32, int64 or complex. The storage dtype varies
  with the input, so no fixed value states it.

Both are the same shape of problem: a build fact that cannot be stated from what the entry
declares. Recorded here rather than papered over with an expression.

## Not declared yet

`revision`, `mutates`, `aliases`, `accepts_noncontiguous`, `provider_options`. Nothing consumes
them and the validator cannot fail on them, so they would be promises no one reads.

## Test plan

- [x] `pytest tests/test_validate_manifest.py` — 132 passed
- [x] `pytest tests/ops/test_{reduce,logical_reduce,vector_norm}.py` — 533 passed
- [x] `validate_manifest.py --strict` clean
- [x] Every declared slot built through its op on GPU; arity, shape and dtype compared against
      what the kernel actually returns
