### PR TITLE
[Fix][Ops] stop reusing compile-boundary instance keys

### DIFF
--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -414,3 +414,21 @@ class TestTunedMode:
         op.autotune()
         op.make_delegate().build(torch.float16)
         assert tuned == ["torch.float16"]
+
+
+class TestInstanceKeys:
+    def test_a_collected_instances_key_is_never_handed_out_again(self):
+        """An op reaching a used key inherits that op's compiled shapes."""
+        import gc
+
+        class _Dummy:
+            pass
+
+        keys = set()
+        for _ in range(50):
+            op = _Dummy()
+            keys.add(op_base.register_instance(op))
+            del op
+            gc.collect()
+
+        assert len(keys) == 50

--- a/tileops/ops/compile_boundary.py
+++ b/tileops/ops/compile_boundary.py
@@ -10,16 +10,22 @@ time; weak references keep the registry from extending lifetimes. Keys
 are strings because dynamo treats string custom-op arguments as static
 constants — an ``int`` key is generalized to an unhashable ``SymInt``
 once a second instance compiles through the same frame.
+
+Being a constant is also why keys must never repeat: inductor bakes the
+fake's output shape into the artifact, so an op reaching a used key
+inherits the first one's shapes. ``id()`` is an address and gets reissued.
 """
 
+import itertools
 import weakref
 
 _OP_REGISTRY: "weakref.WeakValueDictionary[str, object]" = weakref.WeakValueDictionary()
+_KEY_COUNTER = itertools.count()
 
 
 def register_instance(op: object) -> str:
     """Register ``op`` and return the key its dispatch custom op passes back."""
-    key = str(id(op))
+    key = f"op{next(_KEY_COUNTER)}"
     _OP_REGISTRY[key] = op
     return key
 


### PR DESCRIPTION
## The bug

`register_instance` keyed each op by `str(id(op))`. An `id` is an address, and CPython hands the same one out as soon as the previous op is collected:

```
50 register/collect cycles -> 2 distinct keys
```

The key reaches dynamo as a guarded static constant (that is why it is a string), and inductor bakes the fake's output shape into the compiled artifact. A second op arriving at a key the first one used passes the guard and inherits the first one's shapes.

[gpu-smoke on main](https://github.com/tile-ai/TileOPs/actions/runs/31306856776/job/93228520572) caught it on `avg_pool1d`: a stale artifact built for a stride-1 pool asserted a length-32 output against the length-16 one the kernel produced.

```
AssertionError: expected size 16==32 at dim=2
Error in op: torch.ops.top.pool_fwd.default
```

The test passes in isolation and passes with the whole `test_pool.py` file — it needs a preceding op to be collected at the right moment, which is why it surfaces and disappears with unrelated changes.

## Exposure

Six op families route through this boundary. What matters is whether the fake derives its output from the input tensors or from construction parameters:

| Family | Fake derives output from | Exposed |
|---|---|---|
| `pool_fwd`, `pool_fwd_with_indices` | `op._infer_output_shapes()` — kernel_size / stride / padding | yes, this is what fired |
| `mha_fwd` | `op._infer_output_shapes(q, k, v)` | yes |
| `rope_*` | `torch.empty_like(x)` | no |
| `dropout` | `torch.empty_like(x)` | no |
| `batch_norm` fwd/bwd | `empty_like`, `weight.shape` | no |
| `elementwise_*` (12 registrations) | `broadcast_shapes`, `x.shape` | no |

`mha` was never hit only because it needs two instances with differing output shapes to land on the same address; it was not safe.

## The fix

Key by a counter that never repeats. That closes the class instead of patching each fake, and keeps a future fake that reads op state from silently inheriting the same defect.

## Testing

`tests/test_op_base.py::TestInstanceKeys` asserts 50 register/collect cycles yield 50 distinct keys. It fails on the current code (2 keys) and passes with the fix.

Everything below ran in `ghcr.io/tile-ai/tileops-runner:afcebed1-torch2.10-dev`, the CI-identical image:

- every family reaching the boundary — `test_op_base.py`, `test_pool.py`, `test_rope.py`, `test_dropout.py`, `test_batch_norm.py`, `tests/ops/attention` at `-m "smoke or full"`: **596 passed**
- `test_elementwise_compile.py::test_unary_float_compile`: **23 passed**
