### PR TITLE
[Perf][Norm] apply GroupNorm/InstanceNorm's per-channel affine in the kernel

### DIFF
--- a/tests/kernels/test_group_norm_row_block.py
+++ b/tests/kernels/test_group_norm_row_block.py
@@ -1,0 +1,70 @@
+"""Correctness tests for the group-norm kernels under a multi-row block.
+
+Verifies both kernels match a PyTorch oracle when ``block_m > 1`` puts several
+normalization rows in one block and the last block runs past M. ``block_m`` is
+an autotune candidate but ``select_row_config`` pins the default to 1, so an
+op-level test cannot reach these configs deterministically.
+"""
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
+
+pytestmark = pytest.mark.smoke
+
+_ATOL = _RTOL = 1e-3  # fp16, matching the norm op tests
+
+
+@pytest.mark.parametrize("n, c, spatial, g, block_m", [
+    # M = 9 rows, D = 256: the tail row block runs past M with aligned columns.
+    (3, 24, (4, 8), 3, 4),
+    # M = 9 rows, D = 200: the tail row block and the column padding together.
+    (3, 24, (5, 5), 3, 4),
+])
+def test_affine_multi_row_block(n: int, c: int, spatial: tuple, g: int,
+                                block_m: int) -> None:
+    """Per-channel affine stays correct when a row block runs past M."""
+    dtype = torch.float16
+    cpg = c // g
+    m, d = n * g, cpg * math.prod(spatial)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    weight = torch.randn(c, dtype=dtype, device="cuda")
+    bias = torch.randn(c, dtype=dtype, device="cuda")
+
+    kernel = GroupNormKernel(
+        m, d, 1e-5, dtype, g, cpg,
+        config={"block_m": block_m, "threads": 128},
+    )
+    y = kernel(x.reshape(m, d), weight, bias).reshape(x.shape)
+
+    y_ref = F.group_norm(
+        x.float(), g, weight=weight.float(), bias=bias.float(), eps=1e-5,
+    ).to(dtype)
+    assert torch.allclose(y, y_ref, atol=_ATOL, rtol=_RTOL), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
+@pytest.mark.parametrize("m, d, block_m", [
+    (9, 256, 4),   # tail block, aligned columns
+    (9, 200, 4),   # tail block and column padding together
+    (3, 256, 4),   # M < block_m: the only block is a partial one
+])
+def test_no_affine_multi_row_block(m: int, d: int, block_m: int) -> None:
+    """No-affine rows stay correct when a row block runs past M."""
+    dtype = torch.float16
+    x = torch.randn((m, d), dtype=dtype, device="cuda")
+
+    kernel = GroupNormNoAffineKernel(
+        m, d, 1e-5, dtype, config={"block_m": block_m, "threads": 128},
+    )
+    y = kernel(x)
+
+    y_ref = F.group_norm(
+        x.float().reshape(m, 1, d), 1, weight=None, bias=None, eps=1e-5,
+    ).reshape(m, d).to(dtype)
+    assert y.shape == x.shape, f"expected {tuple(x.shape)}, got {tuple(y.shape)}"
+    assert torch.allclose(y, y_ref, atol=_ATOL, rtol=_RTOL), \
+        f"max err: {(y - y_ref).abs().max()}"

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -1,8 +1,11 @@
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.norm import GroupNormKernel
 from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormNoAffineFwdOp
 from workloads.normalization import GroupNormWorkload
 
@@ -208,6 +211,41 @@ def test_group_norm_rejects_affine_device_mismatch() -> None:
         op(x, weight_other, bias_same)
     with pytest.raises(ValueError, match="bias on"):
         op(x, weight_same, bias_other)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("n, c, spatial, g, block_m", [
+    # M = 9 rows, D = 256: the tail row block runs past M with aligned columns.
+    (3, 24, (4, 8), 3, 4),
+    # M = 9 rows, D = 200: the tail row block and the column padding together.
+    (3, 24, (5, 5), 3, 4),
+])
+def test_group_norm_affine_multi_row_block(n: int, c: int, spatial: tuple,
+                                           g: int, block_m: int) -> None:
+    """Per-channel affine stays correct when a row block runs past M.
+
+    ``block_m > 1`` is an autotune candidate and M = N*G need not be a
+    multiple of it, so the last block covers rows that do not exist.
+    """
+    dtype = torch.float16
+    cpg = c // g
+    m, d = n * g, cpg * math.prod(spatial)
+    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
+    weight = torch.randn(c, dtype=dtype, device="cuda")
+    bias = torch.randn(c, dtype=dtype, device="cuda")
+
+    kernel = GroupNormKernel(
+        m, d, 1e-5, dtype, g, cpg,
+        config={"block_m": block_m, "threads": 128},
+    )
+    y = kernel(x.reshape(m, d), weight, bias).reshape(x.shape)
+
+    y_ref = F.group_norm(
+        x.float(), g, weight=weight.float(), bias=bias.float(), eps=1e-5,
+    ).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
 
 
 class GroupNormNoAffineFixture(FixtureBase):

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.norm import GroupNormKernel
+from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormNoAffineFwdOp
 from workloads.normalization import GroupNormWorkload
 
@@ -305,15 +305,14 @@ def test_group_norm_no_affine_lazily_specializes_per_device() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize("n, c, spatial, g", [
-    # M = N * num_groups not divisible by max block_m (16): triggers tail
-    # program reading/writing rows >= M before the M-padding fix.
+    # Very few rows, so the grid is one or two blocks wide.
     (1, 24, (4, 4), 3),   # M = 3
     (3, 30, (2, 2), 5),   # M = 15
     (1, 16, (8, 8), 1),   # M = 1
 ])
 def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
                                          g: int) -> None:
-    """No-affine GroupNorm handles M not divisible by the kernel's block_m."""
+    """No-affine GroupNorm handles a row count smaller than one grid block."""
     dtype = torch.float16
     op = GroupNormNoAffineFwdOp(num_groups=g)
     x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
@@ -321,6 +320,36 @@ def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None,
                         eps=1e-5).to(dtype)
     atol, rtol = _get_tolerances(dtype)
+    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
+        f"max err: {(y - y_ref).abs().max()}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("m, d, block_m", [
+    (9, 256, 4),   # tail block, aligned columns
+    (9, 200, 4),   # tail block and column padding together
+    (3, 256, 4),   # M < block_m: the only block is a partial one
+])
+def test_group_norm_no_affine_multi_row_block(m: int, d: int,
+                                              block_m: int) -> None:
+    """No-affine rows stay correct when a row block runs past M.
+
+    ``block_m > 1`` is an autotune candidate and M need not be a multiple of
+    it, so the last block covers rows that do not exist.
+    """
+    dtype = torch.float16
+    x = torch.randn((m, d), dtype=dtype, device="cuda")
+
+    kernel = GroupNormNoAffineKernel(
+        m, d, 1e-5, dtype, config={"block_m": block_m, "threads": 128},
+    )
+    y = kernel(x)
+
+    y_ref = F.group_norm(
+        x.float().reshape(m, 1, d), 1, weight=None, bias=None, eps=1e-5,
+    ).reshape(m, d).to(dtype)
+    atol, rtol = _get_tolerances(dtype)
+    assert y.shape == x.shape, f"expected {tuple(x.shape)}, got {tuple(y.shape)}"
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
         f"max err: {(y - y_ref).abs().max()}"
 

--- a/tests/ops/test_group_norm.py
+++ b/tests/ops/test_group_norm.py
@@ -1,11 +1,8 @@
-import math
-
 import pytest
 import torch
 import torch.nn.functional as F
 
 from tests.test_base import FixtureBase, TestBase
-from tileops.kernels.norm import GroupNormKernel, GroupNormNoAffineKernel
 from tileops.ops.norm.group_norm import GroupNormFwdOp, GroupNormNoAffineFwdOp
 from workloads.normalization import GroupNormWorkload
 
@@ -213,41 +210,6 @@ def test_group_norm_rejects_affine_device_mismatch() -> None:
         op(x, weight_same, bias_other)
 
 
-@pytest.mark.smoke
-@pytest.mark.parametrize("n, c, spatial, g, block_m", [
-    # M = 9 rows, D = 256: the tail row block runs past M with aligned columns.
-    (3, 24, (4, 8), 3, 4),
-    # M = 9 rows, D = 200: the tail row block and the column padding together.
-    (3, 24, (5, 5), 3, 4),
-])
-def test_group_norm_affine_multi_row_block(n: int, c: int, spatial: tuple,
-                                           g: int, block_m: int) -> None:
-    """Per-channel affine stays correct when a row block runs past M.
-
-    ``block_m > 1`` is an autotune candidate and M = N*G need not be a
-    multiple of it, so the last block covers rows that do not exist.
-    """
-    dtype = torch.float16
-    cpg = c // g
-    m, d = n * g, cpg * math.prod(spatial)
-    x = torch.randn((n, c, *spatial), dtype=dtype, device="cuda")
-    weight = torch.randn(c, dtype=dtype, device="cuda")
-    bias = torch.randn(c, dtype=dtype, device="cuda")
-
-    kernel = GroupNormKernel(
-        m, d, 1e-5, dtype, g, cpg,
-        config={"block_m": block_m, "threads": 128},
-    )
-    y = kernel(x.reshape(m, d), weight, bias).reshape(x.shape)
-
-    y_ref = F.group_norm(
-        x.float(), g, weight=weight.float(), bias=bias.float(), eps=1e-5,
-    ).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
-        f"max err: {(y - y_ref).abs().max()}"
-
-
 class GroupNormNoAffineFixture(FixtureBase):
     PARAMS = [
         ("n, c, spatial, g, dtype", [
@@ -320,36 +282,6 @@ def test_group_norm_no_affine_tail_block(n: int, c: int, spatial: tuple,
     y_ref = F.group_norm(x.float(), g, weight=None, bias=None,
                         eps=1e-5).to(dtype)
     atol, rtol = _get_tolerances(dtype)
-    assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
-        f"max err: {(y - y_ref).abs().max()}"
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize("m, d, block_m", [
-    (9, 256, 4),   # tail block, aligned columns
-    (9, 200, 4),   # tail block and column padding together
-    (3, 256, 4),   # M < block_m: the only block is a partial one
-])
-def test_group_norm_no_affine_multi_row_block(m: int, d: int,
-                                              block_m: int) -> None:
-    """No-affine rows stay correct when a row block runs past M.
-
-    ``block_m > 1`` is an autotune candidate and M need not be a multiple of
-    it, so the last block covers rows that do not exist.
-    """
-    dtype = torch.float16
-    x = torch.randn((m, d), dtype=dtype, device="cuda")
-
-    kernel = GroupNormNoAffineKernel(
-        m, d, 1e-5, dtype, config={"block_m": block_m, "threads": 128},
-    )
-    y = kernel(x)
-
-    y_ref = F.group_norm(
-        x.float().reshape(m, 1, d), 1, weight=None, bias=None, eps=1e-5,
-    ).reshape(m, d).to(dtype)
-    atol, rtol = _get_tolerances(dtype)
-    assert y.shape == x.shape, f"expected {tuple(x.shape)}, got {tuple(y.shape)}"
     assert torch.allclose(y, y_ref, atol=atol, rtol=rtol), \
         f"max err: {(y - y_ref).abs().max()}"
 

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -64,6 +64,47 @@ def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size
     return (row % num_groups) * channels_per_group + col // spatial_size
 
 
+def _make_row_reduce(block_m, D, D_padded, eps):
+    """Create the macro reducing a loaded fp32 row block to mean and rstd.
+
+    Consumes ``x_f32`` and overwrites it with the centered squares. The load
+    stays at the call sites: pulling it in here makes TileLang insert a
+    ``__syncthreads()`` between the global-to-shared and shared-to-register
+    copies, which measures 2% slower on an aligned row.
+
+    Args:
+        block_m: Rows per block.
+        D: Row length.
+        D_padded: *D* rounded up to :data:`ALIGNMENT`.
+        eps: Epsilon for numerical stability.
+
+    Returns:
+        A ``@T.macro`` taking ``(x_f32, acc, mean_val, rstd)``.
+    """
+    pad_count = D_padded - D
+
+    @T.macro
+    def row_reduce(x_f32, acc, mean_val, rstd):
+        T.reduce_sum(x_f32, acc, dim=1)
+        for i in T.Parallel(block_m):
+            mean_val[i] = acc[i] / float(D)
+
+        # Rewrite x_f32 in-place with (x - mean)^2. Padded positions (x=0)
+        # contribute mean^2, subtracted back out below.
+        for i, j in T.Parallel(block_m, D_padded):
+            x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
+
+        T.reduce_sum(x_f32, acc, dim=1)
+        for i in T.Parallel(block_m):
+            rstd[i] = T.rsqrt(
+                (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
+                / float(D)
+                + eps
+            )
+
+    return row_reduce
+
+
 @functools.lru_cache(maxsize=32)
 def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
     """Build a row-wise normalization kernel with a per-channel affine.
@@ -83,7 +124,6 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
             ``(m % G) * channels_per_group`` onwards.
     """
     D_padded = _align_up(D, ALIGNMENT)
-    pad_count = D_padded - D
     spatial_size = D // channels_per_group
     C = num_groups * channels_per_group
 
@@ -91,6 +131,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
+        row_reduce = _make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(
@@ -108,8 +149,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                 rstd = T.alloc_fragment((block_m,), "float32")
 
                 if masked:
-                    # Retain the original values in shared memory for the
-                    # output pass while the fp32 fragment is reduced below.
+                    # Keep the input in shared memory for the output pass.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
@@ -118,30 +158,12 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                 else:
-                    # Preserve the vectorized copy fast path.
                     T.copy(x[pid_m * block_m, 0], shared_buf)
                     T.copy(shared_buf, x_local)
                     for i, j in T.Parallel(block_m, D_padded):
                         x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
-                # --- Mean reduction ---
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    mean_val[i] = acc[i] / float(D)
-
-                # --- Centered variance reduction ---
-                # Rewrite x_f32 in-place with (x - mean)^2.
-                # Padded positions (x=0) contribute mean^2; corrected below.
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    rstd[i] = T.rsqrt(
-                        (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
-                        / float(D)
-                        + eps
-                    )
+                row_reduce(x_f32, acc, mean_val, rstd)
 
                 # --- Output: y = (x - mean) * rstd * weight[c] + bias[c] ---
                 if masked:
@@ -159,7 +181,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
                             )
                 else:
                     # Re-cast from x_local (original dtype) to avoid a second
-                    # fp32 buffer, then retain the vectorized copy fast path.
+                    # fp32 buffer.
                     for i, j in T.Parallel(block_m, D_padded):
                         c = _channel_of(
                             pid_m * block_m + i, j,
@@ -310,12 +332,12 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
         dtype: TileLang dtype string.
     """
     D_padded = _align_up(D, ALIGNMENT)
-    pad_count = D_padded - D
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
         masked = D_padded != D
+        row_reduce = _make_row_reduce(block_m, D, D_padded, eps)
 
         @T.prim_func
         def main(
@@ -331,8 +353,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                 rstd = T.alloc_fragment((block_m,), "float32")
 
                 if masked:
-                    # Retain the original values in shared memory for the
-                    # output pass while the fp32 fragment is reduced below.
+                    # Keep the input in shared memory for the output pass.
                     for i, j in T.Parallel(block_m, D_padded):
                         shared_buf[i, j] = T.if_then_else(
                             T.And(pid_m * block_m + i < M, j < D),
@@ -341,26 +362,12 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                         )
                         x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
                 else:
-                    # Preserve the vectorized copy fast path.
                     T.copy(x[pid_m * block_m, 0], shared_buf)
                     T.copy(shared_buf, x_local)
                     for i, j in T.Parallel(block_m, D_padded):
                         x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    mean_val[i] = acc[i] / float(D)
-
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_f32[i, j] = (x_f32[i, j] - mean_val[i]) * (x_f32[i, j] - mean_val[i])
-
-                T.reduce_sum(x_f32, acc, dim=1)
-                for i in T.Parallel(block_m):
-                    rstd[i] = T.rsqrt(
-                        (acc[i] - float(pad_count) * mean_val[i] * mean_val[i])
-                        / float(D)
-                        + eps
-                    )
+                row_reduce(x_f32, acc, mean_val, rstd)
 
                 # No-affine output: y = (x - mean) * rstd
                 if masked:

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -1,19 +1,27 @@
 """GroupNorm forward kernel using TileLang.
 
-y = (x - mean) / sqrt(var + eps) * weight + bias
+y = (x - mean) / sqrt(var + eps) * weight[c] + bias[c]
 
 where mean and var are computed over (C/G, *spatial) dimensions for each of
 the G groups independently. The input (N, C, *spatial) is reshaped to
 (N*G, D) where D = (C/G) * spatial_size, enabling row-wise normalization
 identical to LayerNorm.
 
-256-element alignment (512 bytes for fp16/bf16) required by T.copy() shared
-memory instructions. Padding zeros contribute 0 to sum; the centered two-pass
-variance computation subtracts the exact padding bias.
+The affine is per-channel (C elements) while the normalization is per-row, so
+the kernel derives the channel from the position inside the row: row m covers
+group ``g = m % G`` and column d covers the group-local channel
+``d // spatial_size``, hence ``c = g * (C/G) + d // spatial_size``. Applying
+the affine here rather than after the kernel saves a full read+write of the
+output tensor.
 
-Weight and bias are per-channel (C elements). After reshaping, each row of
-length D = (C/G) * spatial_size has its own weight/bias slice of length D,
-which is tiled from the weight/bias vectors accordingly.
+InstanceNorm is the G = C case: channels_per_group is 1, spatial_size is the
+whole row, and the derivation collapses to ``c = m % C``.
+
+256-element alignment (512 bytes for fp16/bf16) is required by T.copy() shared
+memory instructions. Boundary handling for a non-aligned D and for a tail row
+block is performed inside the kernel, so no host-side padding copy is needed.
+Padding zeros contribute 0 to the mean; the centered two-pass variance
+computation subtracts their exact contribution.
 """
 
 import functools
@@ -42,31 +50,61 @@ def _align_up(n: int, alignment: int) -> int:
     return ((n + alignment - 1) // alignment) * alignment
 
 
-@functools.lru_cache(maxsize=32)
-def _group_norm_kernel(M, D, eps, dtype):
-    """Build a row-wise normalization kernel for shape (M, D_padded).
+def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size: int):
+    """Return the channel owning element ``(row, col)`` of the (M, D) reshape.
 
-    This is the core computation shared by GroupNorm and InstanceNorm.
-    The caller is responsible for reshaping input/weight/bias into (M, D_padded).
+    Row ``m`` of the ``(N*G, (C/G)*spatial_size)`` view holds group
+    ``m % G``, and column ``d`` holds that group's local channel
+    ``d // spatial_size``.
+
+    Args:
+        row: Row index into the (M, D) view.
+        col: Column index into the (M, D) view.
+        num_groups: Number of groups G.
+        channels_per_group: C / G.
+        spatial_size: Number of spatial elements per channel.
+
+    Returns:
+        Index into the length-C weight / bias vectors.
+    """
+    return (row % num_groups) * channels_per_group + col // spatial_size
+
+
+@functools.lru_cache(maxsize=32)
+def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
+    """Build a row-wise normalization kernel with a per-channel affine.
+
+    This is the core computation shared by GroupNorm and InstanceNorm. The
+    caller is responsible for reshaping the input into (M, D); weight and
+    bias stay in their natural per-channel (C,) layout and are gathered by
+    the channel each element belongs to.
 
     Args:
         M: Number of rows = N * G.
-        D: Row length = (C / G) * spatial_size (before padding).
+        D: Row length = (C / G) * spatial_size.
         eps: Epsilon for numerical stability.
         dtype: TileLang dtype string.
+        num_groups: Number of groups G.
+        channels_per_group: C / G. Row ``m`` covers channels
+            ``(m % G) * channels_per_group`` onwards.
     """
     D_padded = _align_up(D, ALIGNMENT)
     pad_count = D_padded - D
+    spatial_size = D // channels_per_group
+    C = num_groups * channels_per_group
 
     @tilelang.jit(out_idx=[3])
     def _func(block_m, threads):
+        # A tail row block would read and write rows >= M, and a non-aligned D
+        # would read and write columns >= D, unless both are masked off.
+        masked = D_padded != D or M % block_m != 0
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M, D_padded), dtype],
-            weight: T.Tensor[(D_padded,), dtype],
-            bias: T.Tensor[(D_padded,), dtype],
-            y: T.Tensor[(M, D_padded), dtype],
+            x: T.Tensor[(M, D), dtype],
+            weight: T.Tensor[(C,), dtype],
+            bias: T.Tensor[(C,), dtype],
+            y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, D_padded), dtype)
@@ -76,13 +114,22 @@ def _group_norm_kernel(M, D, eps, dtype):
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                # Load input row block via shared memory
-                T.copy(x[pid_m * block_m, 0], shared_buf)
-                T.copy(shared_buf, x_local)
-
-                # Cast to fp32 once -- reused across all passes
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                if masked:
+                    # Retain the original values in shared memory for the
+                    # output pass while the fp32 fragment is reduced below.
+                    for i, j in T.Parallel(block_m, D_padded):
+                        shared_buf[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < D),
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                else:
+                    # Preserve the vectorized copy fast path.
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 # --- Mean reduction ---
                 T.reduce_sum(x_f32, acc, dim=1)
@@ -103,18 +150,36 @@ def _group_norm_kernel(M, D, eps, dtype):
                         + eps
                     )
 
-                # --- Output: y = (x - mean) * rstd * weight + bias ---
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_local[i, j] = (
-                        (T.cast(x_local[i, j], "float32") - mean_val[i])
-                        * rstd[i]
-                        * T.cast(weight[j], "float32")
-                        + T.cast(bias[j], "float32")
-                    )
-
-                # Write output via shared memory
-                T.copy(x_local, shared_buf)
-                T.copy(shared_buf, y[pid_m * block_m, 0])
+                # --- Output: y = (x - mean) * rstd * weight[c] + bias[c] ---
+                if masked:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        if T.And(pid_m * block_m + i < M, j < D):
+                            c = _channel_of(
+                                pid_m * block_m + i, j,
+                                num_groups, channels_per_group, spatial_size,
+                            )
+                            y[pid_m * block_m + i, j] = (
+                                (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                * rstd[i]
+                                * T.cast(weight[c], "float32")
+                                + T.cast(bias[c], "float32")
+                            )
+                else:
+                    # Re-cast from x_local (original dtype) to avoid a second
+                    # fp32 buffer, then retain the vectorized copy fast path.
+                    for i, j in T.Parallel(block_m, D_padded):
+                        c = _channel_of(
+                            pid_m * block_m + i, j,
+                            num_groups, channels_per_group, spatial_size,
+                        )
+                        x_local[i, j] = (
+                            (T.cast(x_local[i, j], "float32") - mean_val[i])
+                            * rstd[i]
+                            * T.cast(weight[c], "float32")
+                            + T.cast(bias[c], "float32")
+                        )
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
 
         return main
 
@@ -127,26 +192,34 @@ def _group_norm_wrapped(
     D: int,
     eps: float,
     dtype_str: str,
+    num_groups: int,
+    channels_per_group: int,
     block_m: int,
     threads: int,
     x: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> torch.Tensor:
-    return _group_norm_kernel(M, D, eps, dtype_str)(block_m, threads)(x, weight, bias)
+    return _group_norm_kernel(
+        M, D, eps, dtype_str, num_groups, channels_per_group,
+    )(block_m, threads)(x, weight, bias)
 
 
 @_group_norm_wrapped.register_fake
-def _(M, D, eps, dtype_str, block_m, threads, x, weight, bias):
-    D_padded = _align_up(D, ALIGNMENT)
-    return torch.empty((M, D_padded), dtype=x.dtype, device=x.device)
+def _(M, D, eps, dtype_str, num_groups, channels_per_group, block_m, threads, x, weight, bias):
+    return torch.empty((M, D), dtype=x.dtype, device=x.device)
 
 
 class GroupNormKernel(Kernel):
-    """GroupNorm forward kernel.
+    """GroupNorm forward kernel with a per-channel affine.
 
-    Normalizes each group's (C/G, *spatial) slice independently.
-    Input is pre-reshaped to (M, D) where M = N*G, D = (C/G)*spatial_size.
+    Normalizes each group's (C/G, *spatial) slice independently and applies
+    ``weight[c]`` / ``bias[c]`` to every element, with *c* derived from the
+    element's position in the row. Input is pre-reshaped to (M, D) where
+    M = N*G, D = (C/G)*spatial_size; weight and bias keep their (C,) layout.
+
+    InstanceNorm uses this kernel with ``num_groups=C`` and
+    ``channels_per_group=1``.
 
     Supports SM80+ architectures. Uses 256-element alignment for shared
     memory copies. Single shared buffer reused for input load and output store.
@@ -156,6 +229,8 @@ class GroupNormKernel(Kernel):
         D: Row length = (C / G) * spatial_size.
         eps: Epsilon for numerical stability.
         dtype: Data type (float32, float16, or bfloat16).
+        num_groups: Number of groups G.
+        channels_per_group: C / G.
         config: Optional tile config dict.
         tune: If True, autotune tile config.
     """
@@ -168,6 +243,8 @@ class GroupNormKernel(Kernel):
         D: int,
         eps: float,
         dtype: torch.dtype,
+        num_groups: int,
+        channels_per_group: int,
         config: Optional[dict] = None,
         tune: bool = False,
     ):
@@ -176,9 +253,13 @@ class GroupNormKernel(Kernel):
         self.D = D
         self.eps = eps
         self.dtype = dtype
+        self.num_groups = num_groups
+        self.channels_per_group = channels_per_group
         self.D_padded = _align_up(D, ALIGNMENT)
-        self.kernel = _group_norm_kernel(self.M, self.D, self.eps, self.dtype_str)
-        self._identity_affine: dict[torch.device, tuple[torch.Tensor, torch.Tensor]] = {}
+        self.kernel = _group_norm_kernel(
+            self.M, self.D, self.eps, self.dtype_str,
+            self.num_groups, self.channels_per_group,
+        )
         self.init_config(config, tune)
 
     @property
@@ -189,63 +270,35 @@ class GroupNormKernel(Kernel):
     def autotune_configs(self) -> list[dict]:
         return select_row_configs(self.D_padded, self.dtype)
 
-    def _identity_affine_for(
-        self, device: torch.device
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return cached unit-scale / zero-shift buffers of the launch width."""
-        buffers = self._identity_affine.get(device)
-        if buffers is None:
-            buffers = (
-                torch.ones(self.D_padded, dtype=self.dtype, device=device),
-                torch.zeros(self.D_padded, dtype=self.dtype, device=device),
-            )
-            self._identity_affine[device] = buffers
-        return buffers
-
     def forward(
         self,
         x: torch.Tensor,
-        weight: Optional[torch.Tensor] = None,
-        bias: Optional[torch.Tensor] = None,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
     ) -> torch.Tensor:
-        """Normalize ``(M, D)`` rows with a row-broadcast affine.
+        """Normalize ``(M, D)`` rows and apply the per-channel affine.
 
         Args:
             x: Input of shape ``(M, D)``.
-            weight: Affine scale of shape ``(D,)``. Omit together with *bias*
-                to normalize without an affine.
-            bias: Affine shift of shape ``(D,)``. Omit together with *weight*
-                to normalize without an affine.
+            weight: Affine scale of shape ``(C,)``.
+            bias: Affine shift of shape ``(C,)``.
 
         Returns:
-            Tensor of shape ``(M, D)``. The alignment padding the prim_func
-            requires is applied and trimmed here.
-
-        Raises:
-            ValueError: If exactly one of *weight* / *bias* is omitted.
+            Tensor of shape ``(M, D)``.
         """
-        if (weight is None) != (bias is None):
-            raise ValueError("weight and bias must be supplied together")
-        pad = self.D_padded - self.D
-        if pad:
-            x = F.pad(x, (0, pad))
-        if weight is None:
-            weight, bias = self._identity_affine_for(x.device)
-        elif pad:
-            weight = F.pad(weight, (0, pad))
-            bias = F.pad(bias, (0, pad))
-        y = _group_norm_wrapped(
+        return _group_norm_wrapped(
             self.M,
             self.D,
             self.eps,
             self.dtype_str,
+            self.num_groups,
+            self.channels_per_group,
             self.config["block_m"],
             self.config["threads"],
             x,
             weight,
             bias,
         )
-        return y[:, : self.D] if pad else y
 
 
 @functools.lru_cache(maxsize=32)

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -18,10 +18,10 @@ InstanceNorm is the G = C case: channels_per_group is 1, spatial_size is the
 whole row, and the derivation collapses to ``c = m % C``.
 
 256-element alignment (512 bytes for fp16/bf16) is required by T.copy() shared
-memory instructions. Boundary handling for a non-aligned D and for a tail row
-block is performed inside the kernel, so no host-side padding copy is needed.
-Padding zeros contribute 0 to the mean; the centered two-pass variance
-computation subtracts their exact contribution.
+memory instructions. Both kernels here handle a non-aligned D and a tail row
+block inside the prim_func, so neither needs a host-side padding copy. Padding
+zeros contribute 0 to the mean; the centered two-pass variance computation
+subtracts their exact contribution.
 """
 
 import functools
@@ -30,7 +30,6 @@ from typing import Optional
 import tilelang
 import tilelang.language as T
 import torch
-import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
 
@@ -39,11 +38,6 @@ from ._config import select_row_config, select_row_configs
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
 ALIGNMENT = 256
-
-# A multiple of every candidate block_m (_config._CANDIDATE_BLOCK_M tops out
-# at 8). The row count is padded to this value so the full-tile T.copy never
-# crosses the M boundary regardless of the selected block_m.
-_M_BLOCK_ALIGN = 16
 
 
 def _align_up(n: int, alignment: int) -> int:
@@ -95,8 +89,10 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
 
     @tilelang.jit(out_idx=[3])
     def _func(block_m, threads):
-        # A tail row block would read and write rows >= M, and a non-aligned D
-        # would read and write columns >= D, unless both are masked off.
+        # A non-aligned D would read and write columns >= D unless masked.
+        # A tail row block is the weaker condition: TileLang already predicates
+        # the bulk T.copy against the row extent, so the mask states the bound
+        # in the kernel rather than leaving it to the copy lowering.
         masked = D_padded != D or M % block_m != 0
 
         @T.prim_func
@@ -303,15 +299,16 @@ class GroupNormKernel(Kernel):
 
 @functools.lru_cache(maxsize=32)
 def _group_norm_no_affine_kernel(M, D, eps, dtype):
-    """Build a row-wise normalization kernel for shape (M, D_padded) without affine.
+    """Build a row-wise normalization kernel for shape (M, D) without affine.
 
-    Same numerics as :func:`_group_norm_kernel` but omits the trailing
-    weight/bias multiply/add — output is ``(x - mean) * rstd``. Used for the
-    no-affine variants of GroupNorm and InstanceNorm.
+    Same numerics and same boundary handling as :func:`_group_norm_kernel`,
+    but omits the trailing weight/bias multiply-add — output is
+    ``(x - mean) * rstd``. Used for the no-affine variants of GroupNorm and
+    InstanceNorm.
 
     Args:
         M: Number of rows = N * G.
-        D: Row length = (C / G) * spatial_size (before padding).
+        D: Row length = (C / G) * spatial_size.
         eps: Epsilon for numerical stability.
         dtype: TileLang dtype string.
     """
@@ -320,11 +317,16 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
+        # A non-aligned D would read and write columns >= D unless masked.
+        # A tail row block is the weaker condition: TileLang already predicates
+        # the bulk T.copy against the row extent, so the mask states the bound
+        # in the kernel rather than leaving it to the copy lowering.
+        masked = D_padded != D or M % block_m != 0
 
         @T.prim_func
         def main(
-            x: T.Tensor[(M, D_padded), dtype],
-            y: T.Tensor[(M, D_padded), dtype],
+            x: T.Tensor[(M, D), dtype],
+            y: T.Tensor[(M, D), dtype],
         ):
             with T.Kernel(T.ceildiv(M, block_m), threads=threads) as pid_m:
                 shared_buf = T.alloc_shared((block_m, D_padded), dtype)
@@ -334,11 +336,22 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                 mean_val = T.alloc_fragment((block_m,), "float32")
                 rstd = T.alloc_fragment((block_m,), "float32")
 
-                T.copy(x[pid_m * block_m, 0], shared_buf)
-                T.copy(shared_buf, x_local)
-
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_f32[i, j] = T.cast(x_local[i, j], "float32")
+                if masked:
+                    # Retain the original values in shared memory for the
+                    # output pass while the fp32 fragment is reduced below.
+                    for i, j in T.Parallel(block_m, D_padded):
+                        shared_buf[i, j] = T.if_then_else(
+                            T.And(pid_m * block_m + i < M, j < D),
+                            x[pid_m * block_m + i, j],
+                            T.cast(0.0, dtype),
+                        )
+                        x_f32[i, j] = T.cast(shared_buf[i, j], "float32")
+                else:
+                    # Preserve the vectorized copy fast path.
+                    T.copy(x[pid_m * block_m, 0], shared_buf)
+                    T.copy(shared_buf, x_local)
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_f32[i, j] = T.cast(x_local[i, j], "float32")
 
                 T.reduce_sum(x_f32, acc, dim=1)
                 for i in T.Parallel(block_m):
@@ -356,14 +369,22 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
                     )
 
                 # No-affine output: y = (x - mean) * rstd
-                for i, j in T.Parallel(block_m, D_padded):
-                    x_local[i, j] = T.cast(
-                        (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
-                        dtype,
-                    )
-
-                T.copy(x_local, shared_buf)
-                T.copy(shared_buf, y[pid_m * block_m, 0])
+                if masked:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        if T.And(pid_m * block_m + i < M, j < D):
+                            y[pid_m * block_m + i, j] = T.cast(
+                                (T.cast(shared_buf[i, j], "float32") - mean_val[i])
+                                * rstd[i],
+                                dtype,
+                            )
+                else:
+                    for i, j in T.Parallel(block_m, D_padded):
+                        x_local[i, j] = T.cast(
+                            (T.cast(x_local[i, j], "float32") - mean_val[i]) * rstd[i],
+                            dtype,
+                        )
+                    T.copy(x_local, shared_buf)
+                    T.copy(shared_buf, y[pid_m * block_m, 0])
 
         return main
 
@@ -385,8 +406,7 @@ def _group_norm_no_affine_wrapped(
 
 @_group_norm_no_affine_wrapped.register_fake
 def _(M, D, eps, dtype_str, block_m, threads, x):
-    D_padded = _align_up(D, ALIGNMENT)
-    return torch.empty((M, D_padded), dtype=x.dtype, device=x.device)
+    return torch.empty((M, D), dtype=x.dtype, device=x.device)
 
 
 class GroupNormNoAffineKernel(Kernel):
@@ -399,8 +419,7 @@ class GroupNormNoAffineKernel(Kernel):
     InstanceNorm.
 
     Args:
-        M: Number of rows = N * G. Rounded up internally to a whole number
-            of ``block_m`` tiles.
+        M: Number of rows = N * G.
         D: Row length = (C / G) * spatial_size.
         eps: Epsilon for numerical stability.
         dtype: Data type (float32, float16, or bfloat16).
@@ -425,9 +444,8 @@ class GroupNormNoAffineKernel(Kernel):
         self.eps = eps
         self.dtype = dtype
         self.D_padded = _align_up(D, ALIGNMENT)
-        self.M_padded = _align_up(M, _M_BLOCK_ALIGN)
         self.kernel = _group_norm_no_affine_kernel(
-            self.M_padded, self.D, self.eps, self.dtype_str,
+            self.M, self.D, self.eps, self.dtype_str,
         )
         self.init_config(config, tune)
 
@@ -446,17 +464,10 @@ class GroupNormNoAffineKernel(Kernel):
             x: Input of shape ``(M, D)``.
 
         Returns:
-            Tensor of shape ``(M, D)``. Both the row-count and row-length
-            padding the prim_func requires are applied and trimmed here.
+            Tensor of shape ``(M, D)``.
         """
-        d_pad = self.D_padded - self.D
-        m_pad = self.M_padded - self.M
-        if d_pad:
-            x = F.pad(x, (0, d_pad))
-        if m_pad:
-            x = F.pad(x, (0, 0, 0, m_pad))
-        y = _group_norm_no_affine_wrapped(
-            self.M_padded,
+        return _group_norm_no_affine_wrapped(
+            self.M,
             self.D,
             self.eps,
             self.dtype_str,
@@ -464,8 +475,3 @@ class GroupNormNoAffineKernel(Kernel):
             self.config["threads"],
             x,
         )
-        if m_pad:
-            y = y[: self.M, :]
-        if d_pad:
-            y = y[:, : self.D]
-        return y

--- a/tileops/kernels/norm/group_norm.py
+++ b/tileops/kernels/norm/group_norm.py
@@ -90,10 +90,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
     @tilelang.jit(out_idx=[3])
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
-        # A tail row block is the weaker condition: TileLang already predicates
-        # the bulk T.copy against the row extent, so the mask states the bound
-        # in the kernel rather than leaving it to the copy lowering.
-        masked = D_padded != D or M % block_m != 0
+        masked = D_padded != D
 
         @T.prim_func
         def main(
@@ -318,10 +315,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
         # A non-aligned D would read and write columns >= D unless masked.
-        # A tail row block is the weaker condition: TileLang already predicates
-        # the bulk T.copy against the row extent, so the mask states the bound
-        # in the kernel rather than leaving it to the copy lowering.
-        masked = D_padded != D or M % block_m != 0
+        masked = D_padded != D
 
         @T.prim_func
         def main(

--- a/tileops/ops/norm/group_norm.py
+++ b/tileops/ops/norm/group_norm.py
@@ -43,7 +43,8 @@ class GroupNormFwdOp(Op):
     Note:
         Supports arbitrary spatial dimensions (1-D, 2-D, 3-D+).
         Handles non-contiguous inputs via explicit ``contiguous()`` call.
-        Hidden dimension is padded to 256-element alignment internally.
+        The per-channel affine is applied inside the kernel, so the op does
+        no post-kernel arithmetic.
 
     Args:
         num_groups: Number of groups (manifest ``params.num_groups``).
@@ -138,15 +139,16 @@ class GroupNormFwdOp(Op):
         self,
         M: int,
         D: int,
+        cpg: int,
         dtype: torch.dtype,
         device_index: Optional[int],
     ) -> Kernel:
-        key = (M, D, dtype, device_index, self.eps, self.tune)
+        key = (M, D, cpg, dtype, device_index, self.eps, self.tune)
         kernel = self.get_or_build_kernel(
             "group_norm",
             key,
             lambda: self.kernel_map["group_norm"](
-                M, D, self.eps, dtype, tune=self.tune,
+                M, D, self.eps, dtype, self.num_groups, cpg, tune=self.tune,
             ),
         )
         self.kernel = kernel
@@ -224,25 +226,15 @@ class GroupNormFwdOp(Op):
             )
 
         self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
-        kernel = self._get_kernel(M, D, dtype, x.device.index)
+        kernel = self._get_kernel(M, D, cpg, dtype, x.device.index)
         orig_shape = x.shape
-        x = x.contiguous()
-        x_reshaped = x.reshape(
-            N, self.num_groups, cpg, *spatial,
-        )
-        x_2d = x_reshaped.reshape(M, D)
+        x_2d = x.contiguous().reshape(M, D)
 
-        # The kernel broadcasts its affine row-wise; GroupNorm's per-channel
-        # affine doesn't fit that layout, so normalize without an affine and
-        # apply the per-channel scale/shift after.
-        y_2d = kernel(x_2d)
+        # The kernel derives each element's channel from its position in the
+        # row, so the per-channel affine is applied inside the kernel.
+        y_2d = kernel(x_2d, weight, bias)
 
-        y = y_2d.reshape(N, self.num_groups, cpg, *spatial)
-        y = y.reshape(orig_shape)
-
-        affine_shape = (1, C) + (1,) * len(spatial)
-        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-        return y
+        return y_2d.reshape(orig_shape)
 
 
 class GroupNormNoAffineFwdOp(Op):

--- a/tileops/ops/norm/instance_norm.py
+++ b/tileops/ops/norm/instance_norm.py
@@ -48,10 +48,9 @@ class InstanceNormFwdOp(Op):
 
     Note:
         Supports arbitrary spatial dimensions (1-D, 2-D, 3-D+). Delegates
-        to :class:`GroupNormKernel` with one group per channel. Hidden
-        dimension is padded to 256-element alignment internally. The
-        running-stats variant (``use_input_stats=False``) is out of scope
-        for this op.
+        to :class:`GroupNormKernel` with one group per channel, which
+        applies the per-channel affine itself. The running-stats variant
+        (``use_input_stats=False``) is out of scope for this op.
 
     Args:
         use_input_stats: Mirrors ``torch.nn.functional.instance_norm``. When
@@ -176,15 +175,18 @@ class InstanceNormFwdOp(Op):
         self,
         M: int,
         D: int,
+        C: int,
         dtype: torch.dtype,
         device_index: Optional[int],
     ) -> Kernel:
-        key = (M, D, dtype, device_index, self.eps, self.tune)
+        # One group per channel, so a row's every element belongs to the same
+        # channel: num_groups=C with channels_per_group=1.
+        key = (M, D, C, dtype, device_index, self.eps, self.tune)
         kernel = self.get_or_build_kernel(
             "group_norm",
             key,
             lambda: self.kernel_map["group_norm"](
-                M, D, self.eps, dtype, tune=self.tune,
+                M, D, self.eps, dtype, C, 1, tune=self.tune,
             ),
         )
         self.kernel = kernel
@@ -246,21 +248,16 @@ class InstanceNormFwdOp(Op):
             )
 
         self._bind_spec(N, C, spatial, spatial_size, D, M, dtype)
-        kernel = self._get_kernel(M, D, dtype, x.device.index)
+        kernel = self._get_kernel(M, D, C, dtype, x.device.index)
         orig_shape = x.shape
-        x = x.contiguous()
-        x_2d = x.reshape(M, D)
+        x_2d = x.contiguous().reshape(M, D)
 
-        # The kernel broadcasts its affine row-wise; the per-channel affine
-        # is applied after, so normalize without an affine here.
-        y_2d = kernel(x_2d)
+        # Row m of the (N*C, spatial_size) view is channel m % C throughout,
+        # so the kernel applies the per-channel affine itself.
+        y_2d = kernel(x_2d, weight, bias)
 
         # Reshape back: (N*C, spatial_size) -> (N, C, *spatial)
-        y = y_2d.reshape(orig_shape)
-
-        affine_shape = (1, C) + (1,) * len(spatial)
-        y = y * weight.reshape(affine_shape) + bias.reshape(affine_shape)
-        return y
+        return y_2d.reshape(orig_shape)
 
 
 class InstanceNormNoAffineFwdOp(Op):


### PR DESCRIPTION
## What changes

`GroupNormFwdOp` and `InstanceNormFwdOp` applied the per-channel affine in PyTorch after the
kernel returned, costing a full extra read+write of the output. The kernel now applies it,
indexing by `c = (m % G) * cpg + d // spatial_size`. InstanceNorm is the `G = C, cpg = 1` case
of that expression, so both ops share one kernel. Both `forward` methods are now
reshape → kernel → reshape.

Two padding removals follow from it:

- The no-affine kernel padded `M` and `D` on the host with `F.pad`, copying the whole tensor.
  Its trigger dated from when `default_config` selected `block_m` up to 16; `block_m` has been
  pinned to 1 since, leaving the copy as dead cost. In-kernel masking covers the same condition.
- The mask condition itself included `M % block_m != 0`, which forced the element-wise path
  whenever the row count did not divide the block. The generated CUDA shows the bulk copy is
  already predicated on every declared arch — sm_80 guards load and store, sm_90 stores through
  `tl::tma_store` with tensor-map bounds — so the term guarded nothing while removing the
  vectorized copy from configs where it was faster.

## Result

Device time, H200, CUDA-graph replay, best of 7 × 200:

| case | before | after | |
|---|---|---|---|
| GroupNorm affine (32,256,56,56) g=32 | 0.186 | 0.038 | 4.9× |
| InstanceNorm affine (32,256,56,56) | 0.254 | 0.031 | 8.1× |
| InstanceNorm no-affine (32,256,56,56) | 0.107 | 0.028 | 3.9× |
| GroupNorm no-affine (4,128,30,30) g=16 | 0.0099 | 0.0042 | 2.4× |

No shape regresses; shapes with `D` already 256-aligned are unchanged. The fused affine costs
~0.003 ms against the 0.14 ms PyTorch pass it replaces.

## Notes for later

- **The two prim_funcs share their reduction through `@T.macro`, but not their load.** Folding
  the `T.copy` pair into a macro makes TileLang insert a `__syncthreads()` between the
  global→shared and shared→register copies, measured at +2.0%. With only the reduction shared,
  the generated CUDA is byte-identical across all four configurations. The same shape in
  `ada_layer_norm.py` was checked and does not carry the barrier, so this is per-site: dump
  `get_kernel_source()` before deduplicating a copy pair.
- The row-block tests live in `tests/kernels/`, not `tests/ops/`: they pin `block_m` to reach
  paths the op layer cannot, which is provider detail. `block_m` is pinned to 1 in
  `select_row_config`, so no op-level test can distinguish per-row from row-0 indexing — both
  tests were earned by mutation against that.