### PR TITLE
[Fix][CI] copy workloads into the packaging smoke test's temp dir

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -435,8 +435,13 @@ jobs:
           echo "=== Install built wheel ==="
           python3 -m pip install dist/*.whl
 
+          # The smoke test runs outside the checkout so `tileops` resolves to the
+          # installed wheel. Every repo-root tree the suite imports must therefore
+          # be copied in: `tests` and the `workloads` reference implementations it
+          # builds fixtures from. Neither ships in the wheel, by design.
           TMP_TEST_DIR="$(mktemp -d "${RUNNER_TEMP}/packaging-test.XXXXXX")"
           cp -r tests "${TMP_TEST_DIR}/tests"
+          cp -r workloads "${TMP_TEST_DIR}/workloads"
           cp pyproject.toml "${TMP_TEST_DIR}/"
           cd "${TMP_TEST_DIR}"
 


### PR DESCRIPTION
## What

- Copy `workloads/` into the packaging smoke test's temp dir, next to `tests/`.

## Why

- The nightly `packaging` job runs the `packaging`-marked tests from a temp dir so `tileops` resolves to the installed wheel. It copied in only `tests/` and `pyproject.toml`.
- `tests/test_base.py` imports `workloads.workload_base`. Under the flat layout that resolved from the wheel, which shipped every top-level directory; the `src/` move correctly stopped shipping `workloads/`, so collection now dies with `ModuleNotFoundError: No module named 'workloads'` before any test runs.
- `workloads/` is fixture reference code and should not ship — the temp dir is where it belongs.
- No other repo-root tree is needed at collection time; nothing under `src/tileops/` imports `workloads`.
