### PR TITLE
[Perf][Attention] Optimize FP8 GQA prefill pipeline

### DIFF
--- a/src/tileops/kernels/attention/_fp8_gqa_helper.h
+++ b/src/tileops/kernels/attention/_fp8_gqa_helper.h
@@ -234,6 +234,18 @@ __device__ __forceinline__ void fp8_acc_to_fa3_p_regs_64x224_no_cute(
     p_regs[r] = fp8_pack4_fa3_p_bytes(acc_s, r * 4);
   }
 }
+__device__ __forceinline__ void fp8_partial_row_sum_raw_acc_64x224(
+    float* acc_s, float* row_sum) {
+#pragma unroll
+  for (int i = 0; i < 2; ++i) {
+    float sum = 0.0f;
+#pragma unroll
+    for (int rv = 0; rv < 56; ++rv) {
+      sum += acc_s[((rv % 28) * 4) + (i * 2) + (rv / 28)];
+    }
+    row_sum[i] = sum;
+  }
+}
 __device__ __forceinline__ void fp8_producer_barrier_128() {
   asm volatile("bar.sync 15, 128;\n" ::: "memory");
 }
@@ -286,8 +298,8 @@ __device__ __forceinline__ void fp8_transpose_v_128x224_fa3_src_ldsm_stsm_barrie
   }
 }
 template <typename FP8T>
-__device__ __forceinline__ void fp8_pv_ptx_unit_accumulate_fa3_raw_64x128x224(
-    float* acc_s, FP8T* v_tc_smem, int flags, float* ss, float v_scale, float* acc_o) {
+__device__ __forceinline__ void fp8_pv_ptx_unit_begin_accumulate_fa3_raw_64x128x224(
+    float* acc_s, FP8T* v_tc_smem, float* acc_o) {
   using namespace cute;
   using Element = cutlass::float_e4m3_t;
   using ElementAccum = float;
@@ -301,17 +313,10 @@ __device__ __forceinline__ void fp8_pv_ptx_unit_accumulate_fa3_raw_64x128x224(
 
   int const tid = static_cast<int>(threadIdx.x) & 127;
   uint32_t p_regs[28];
-  float delta_storage[64];
-  float* delta = delta_storage;
   TiledMmaPV tiled_mma_pv;
   auto thr_mma = tiled_mma_pv.get_slice(tid);
   Tensor sV = make_tensor(make_smem_ptr(v_tc_smem), typename VConfig::SmemLayoutVtMma{});
   Tensor tOrV = thr_mma.partition_fragment_B(sV)(_, _, _, _0{});
-
-#pragma unroll
-  for (int i = 0; i < 64; ++i) {
-    delta[i] = 0.0f;
-  }
 
   fp8_acc_to_fa3_p_regs_64x224_no_cute(acc_s, p_regs);
 
@@ -323,39 +328,133 @@ __device__ __forceinline__ void fp8_pv_ptx_unit_accumulate_fa3_raw_64x128x224(
              64, 128, 32, false, false>(
         p_regs + ki * 4,
         uint64_t(desc_b),
-        reinterpret_cast<uint32_t*>(delta),
-        ki != 0);
+        reinterpret_cast<uint32_t*>(acc_o),
+        true);
   }
   asm volatile("wgmma.commit_group.sync.aligned;\n" ::: "memory");
-  asm volatile("wgmma.wait_group.sync.aligned 0;\n" ::: "memory");
-  asm volatile("wgmma.fence.sync.aligned;\n" ::: "memory");
+}
+__device__ __forceinline__ void fp8_fa3_raw_acc_rescale_keep_ptx_layout_64x128(
+    float* acc_o, float* ss) {
+  using namespace cute;
+  using Element = cutlass::float_e4m3_t;
+  using ElementAccum = float;
+  using TileShapePV = Shape<_64, _128, _128>;
+  using AtomLayout = Layout<Shape<_1, _1, _1>>;
+  using MmaPV = decltype(GMMA::rs_op_selector<Element, Element, ElementAccum,
+                                              TileShapePV, GMMA::Major::K,
+                                              GMMA::Major::K>());
+  using TiledMmaPV = decltype(make_tiled_mma(MmaPV{}, AtomLayout{}));
 
+  int const tid = static_cast<int>(threadIdx.x) & 127;
+  TiledMmaPV tiled_mma_pv;
+  auto thr_mma = tiled_mma_pv.get_slice(tid);
   Tensor tOrO_template = partition_fragment_C(tiled_mma_pv, Shape<_64, _128>{});
-  Tensor tDelta = make_tensor(delta, tOrO_template.layout());
   Tensor tAccO = make_tensor(acc_o, tOrO_template.layout());
   Tensor cO = make_identity_tensor(Shape<_64, _128>{});
   Tensor tOcO = thr_mma.partition_C(cO);
-
-  if ((flags & 2) == 0) {
-    fp8_gqa_detail::permute_output_fp8(tDelta);
-  }
-
-  Tensor tDelta_rowcol = make_tensor(
-      tDelta.data(), fp8_gqa_detail::convert_layout_acc_rowcol(tDelta.layout()));
-  Tensor tAccO_rowcol = make_tensor(
-      tAccO.data(), fp8_gqa_detail::convert_layout_acc_rowcol(tAccO.layout()));
-  Tensor tOcO_rowcol = make_tensor(
-      tOcO.data(), fp8_gqa_detail::convert_layout_acc_rowcol(tOcO.layout()));
+  Tensor frag = group_modes<1, 3>(tAccO);
+  Tensor frag_coord = group_modes<1, 3>(tOcO);
 
 #pragma unroll
-  for (int m = 0; m < size<0>(tDelta_rowcol); ++m) {
+  for (int mi = 0; mi < size<1>(frag); ++mi) {
 #pragma unroll
-  for (int n = 0; n < size<1>(tDelta_rowcol); ++n) {
-    auto coord = tOcO_rowcol(m, n);
-    int const row = int(get<0>(coord));
-    tAccO_rowcol(m, n) = tAccO_rowcol(m, n) * ss[row] + tDelta_rowcol(m, n) * v_scale;
+  for (int x0 = 0; x0 < size<0, 0>(frag); ++x0) {
+#pragma unroll
+  for (int j = 0; j < size<0, 1>(frag); ++j) {
+#pragma unroll
+  for (int x2 = 0; x2 < size<0, 2>(frag); ++x2) {
+    bool const swapped =
+        (x0 == 1 && ((x2 & 1) == 0)) || (x0 == 0 && ((x2 & 1) == 1));
+    if (!swapped) {
+      auto coord = frag_coord(make_coord(x0, j, x2), mi);
+      int const row = int(get<0>(coord));
+      frag(make_coord(x0, j, x2), mi) *= ss[row];
+    }
   }
   }
+  }
+  }
+
+#pragma unroll
+  for (int mi = 0; mi < size<1>(frag); ++mi) {
+#pragma unroll
+  for (int j = 0; j < size<0, 1>(frag); ++j) {
+#pragma unroll
+  for (int i = 0; i < size<0, 2>(frag) / 2; ++i) {
+    auto coord_a = frag_coord(make_coord(_1{}, j, 2 * i), mi);
+    auto coord_b = frag_coord(make_coord(_0{}, j, 2 * i + 1), mi);
+    int const row_a = int(get<0>(coord_a));
+    int const row_b = int(get<0>(coord_b));
+    frag(make_coord(_1{}, j, 2 * i), mi) *= ss[row_b];
+    frag(make_coord(_0{}, j, 2 * i + 1), mi) *= ss[row_a];
+  }
+  }
+  }
+}
+__device__ __forceinline__ void fp8_fa3_raw_acc_permute_to_canonical_64x128(
+    float* acc_o) {
+  using namespace cute;
+  using Element = cutlass::float_e4m3_t;
+  using ElementAccum = float;
+  using TileShapePV = Shape<_64, _128, _128>;
+  using AtomLayout = Layout<Shape<_1, _1, _1>>;
+  using MmaPV = decltype(GMMA::rs_op_selector<Element, Element, ElementAccum,
+                                              TileShapePV, GMMA::Major::K,
+                                              GMMA::Major::K>());
+  using TiledMmaPV = decltype(make_tiled_mma(MmaPV{}, AtomLayout{}));
+
+  TiledMmaPV tiled_mma_pv;
+  Tensor tOrO_template = partition_fragment_C(tiled_mma_pv, Shape<_64, _128>{});
+  Tensor tAccO = make_tensor(acc_o, tOrO_template.layout());
+  fp8_gqa_detail::permute_output_fp8(tAccO);
+}
+__device__ __forceinline__ void fp8_fa3_raw_acc_scale_64x128(
+    float* acc_o, float scale) {
+#pragma unroll
+  for (int i = 0; i < 64; ++i) {
+    acc_o[i] *= scale;
+  }
+}
+template <typename FP8T>
+__device__ __forceinline__ void fp8_qk_cute_grouped_fa3_raw_64x224x128(
+    FP8T* q_tc_smem, FP8T* k_tc_smem, float* acc_s) {
+  using namespace cute;
+  using Element = cutlass::float_e4m3_t;
+  using ElementAccum = float;
+  using TileShapeQK = Shape<_64, Int<224>, _128>;
+  using AtomLayout = Layout<Shape<_1, _1, _1>>;
+  using MmaQK = decltype(GMMA::ss_op_selector<Element, Element, ElementAccum, TileShapeQK>());
+  using TiledMmaQK = decltype(make_tiled_mma(MmaQK{}, AtomLayout{}));
+  using SmemLayoutAtomQ =
+      decltype(cutlass::gemm::collective::detail::ss_smem_selector<
+               GMMA::Major::K, Element, _64, _128>());
+  using SmemLayoutQ = decltype(tile_to_shape(SmemLayoutAtomQ{}, Shape<_64, _128>{}));
+  using SmemLayoutAtomK =
+      decltype(cutlass::gemm::collective::detail::ss_smem_selector<
+               GMMA::Major::K, Element, Int<224>, _128>());
+  using SmemLayoutK = decltype(tile_to_shape(
+      SmemLayoutAtomK{}, Shape<Int<224>, _128, _1>{}));
+
+  TiledMmaQK tiled_mma_qk;
+  auto thr_mma = tiled_mma_qk.get_slice(static_cast<int>(threadIdx.x) & 127);
+  Tensor sQ = make_tensor(make_smem_ptr(q_tc_smem), SmemLayoutQ{});
+  Tensor sK = make_tensor(make_smem_ptr(k_tc_smem), SmemLayoutK{});
+  Tensor tSrQ = thr_mma.partition_fragment_A(sQ);
+  Tensor tSrK = thr_mma.partition_fragment_B(sK)(_, _, _, _0{});
+  Tensor tSrS_template = partition_fragment_C(tiled_mma_qk, Shape<_64, Int<224>>{});
+  Tensor tSrS = make_tensor(acc_s, tSrS_template.layout());
+
+  warpgroup_fence_operand(tSrS);
+  warpgroup_arrive();
+  tiled_mma_qk.accumulate_ = GMMA::ScaleOut::Zero;
+
+#pragma unroll
+  for (int ki = 0; ki < size<2>(tSrQ); ++ki) {
+    cute::gemm(tiled_mma_qk, tSrQ(_, _, ki), tSrK(_, _, ki), tSrS);
+    tiled_mma_qk.accumulate_ = GMMA::ScaleOut::One;
+  }
+
+  warpgroup_commit_batch();
 }
 __device__ __forceinline__ void fp8_zero_raw_acc_64(float* acc) {
 #pragma unroll
@@ -429,29 +528,34 @@ __device__ __forceinline__ void fp8_fa3_raw_acc_store_smem_cute_64x128(
   cute::copy(smem_tiled_copy_O, taccOrO, taccOsO);
 }
 template <typename OutT>
+__device__ __forceinline__ void fp8_fa3_raw_acc_finalize_store_smem_cute_64x128(
+    float* acc_o, float* ls, int flags, float scale, OutT* o_smem) {
+  fp8_fa3_raw_acc_permute_to_canonical_64x128(acc_o);
+  fp8_fa3_raw_acc_scale_64x128(acc_o, scale);
+  fp8_fa3_raw_acc_store_smem_cute_64x128(acc_o, ls, flags, o_smem);
+}
+template <typename OutT>
 __device__ __forceinline__ void fp8_fa3_o_smem_store_global_cute_64x128(
     OutT* o_smem, OutT* output, int output_row_stride) {
   using namespace cute;
   using StoreConfig = FP8Fa3OutputStore64x128<OutT>;
+  using GmemLayoutAtom = Layout<Shape<_16, _8>, Stride<_8, _1>>;
+  using GmemTiledCopyO = decltype(make_tiled_copy(
+      Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, OutT>{},
+      GmemLayoutAtom{}, Layout<Shape<_1, _8>>{}));
 
   int const tid = static_cast<int>(threadIdx.x) & 127;
-  int const row_lane = tid >> 3;
-  int const col_lane = tid & 7;
-  typename StoreConfig::SmemLayoutO smem_layout;
-
-#pragma unroll
-  for (int row = row_lane; row < 64; row += 16) {
-#pragma unroll
-    for (int col_block = 0; col_block < 128; col_block += 64) {
-      int const col = col_block + col_lane * 8;
-      uint4 vec;
-      OutT* vec_out = reinterpret_cast<OutT*>(&vec);
-#pragma unroll
-      for (int i = 0; i < 8; ++i) {
-        vec_out[i] = o_smem[int(smem_layout(make_coord(row, col + i)))];
-      }
-      *reinterpret_cast<uint4*>(output + row * output_row_stride + col) = vec;
-    }
-  }
+  Tensor sO = make_tensor(
+      make_smem_ptr(o_smem), typename StoreConfig::SmemLayoutO{});
+  Tensor gO = make_tensor(
+      make_gmem_ptr(output),
+      make_layout(Shape<_64, _128>{}, make_stride(output_row_stride, _1{})));
+  GmemTiledCopyO gmem_tiled_copy_O;
+  auto gmem_thr_copy_O = gmem_tiled_copy_O.get_thread_slice(tid);
+  Tensor tOsO = gmem_thr_copy_O.partition_S(sO);
+  Tensor tOgO = gmem_thr_copy_O.partition_D(gO);
+  Tensor tOrO = make_fragment_like(tOsO);
+  cute::copy(gmem_tiled_copy_O, tOsO, tOrO);
+  cute::copy(gmem_tiled_copy_O, tOrO, tOgO);
 }
 }  // namespace tl

--- a/src/tileops/kernels/attention/gqa_fwd_fp8.py
+++ b/src/tileops/kernels/attention/gqa_fwd_fp8.py
@@ -24,6 +24,43 @@ TMA_OOB_FILL_NONE = 0
 _FP8_GQA_HELPER_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "_fp8_gqa_helper.h"))
 
 
+def _make_fa3_pv_acc_fragment(dim: int, thread_offset: int) -> tilelang.layout.Fragment:
+    col_phase = dim // 8
+
+    def forward_fn(i, j):
+        rv = j // 4
+        thread = thread_offset + (i // 16) * 32 + (i % 8) * 4 + (j % 4)
+        index = (rv % col_phase) * 4 + ((i % 16) // 8) * 2 + rv // col_phase
+        return thread, index
+
+    if dim != 128:
+        raise ValueError("FA3 PV accumulator fragment annotation requires dim == 128.")
+    return tilelang.layout.Fragment([64, dim], forward_fn=forward_fn)
+
+
+def _make_fa3_qk_acc_fragment(block_n: int, thread_offset: int) -> tilelang.layout.Fragment:
+    col_phase = block_n // 8
+
+    def forward_fn(i, j):
+        rv = j // 4
+        thread = thread_offset + (i // 16) * 32 + (i % 8) * 4 + (j % 4)
+        index = (rv % col_phase) * 4 + ((i % 16) // 8) * 2 + rv // col_phase
+        return thread, index
+
+    if block_n != 224:
+        raise ValueError("FA3 QK accumulator fragment annotation requires block_n == 224.")
+    return tilelang.layout.Fragment([64, block_n], forward_fn=forward_fn)
+
+
+def _make_fa3_qk_row_fragment(thread_offset: int) -> tilelang.layout.Fragment:
+    def forward_fn(i, rep):
+        thread = thread_offset + (i // 16) * 32 + (i % 8) * 4 + rep
+        index = (i % 16) // 8
+        return thread, index
+
+    return tilelang.layout.Fragment([64], forward_fn=forward_fn, replicate=4)
+
+
 @functools.lru_cache(maxsize=32)
 def _gqa_fwd_fp8_bn224_tma_v_kernel(
     batch: int, heads: int, heads_kv: int, seq_len: int, dim: int, out_dtype: str
@@ -48,8 +85,38 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
     accum_dtype = "float"
     fp8_dtype = "float8_e4m3fn"
     scale = make_log2e_scale(dim)
-    scale_block = 128
-    scale_blocks = (seq_len + scale_block - 1) // scale_block
+    defer_row_sum = (seq_len + 223) // 224 < 32
+
+    @T.macro
+    def online_softmax_with_partial_sum(
+        acc_s,
+        scores_max,
+        scores_max_prev,
+        scores_scale,
+        scores_sum,
+        logsum,
+        score_scale,
+    ):
+        score_scale_softmax = score_scale * scale
+        T.copy(scores_max, scores_max_prev)
+        T.fill(scores_max, -T.infinity(accum_dtype))
+        T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+        for i in T.Parallel(half_m):
+            scores_max[i] *= score_scale
+        for i in T.Parallel(half_m):
+            scores_scale[i] = T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale)
+        for i, j in T.Parallel(half_m, 224):
+            acc_s[i, j] = T.exp2(acc_s[i, j] * score_scale_softmax - scores_max[i] * scale)
+        # Accumulate lane-local row sums here; the quad reduction is deferred
+        # until finalization instead of running once per K/V tile.
+        T.call_extern(
+            "handle",
+            "tl::fp8_partial_row_sum_raw_acc_64x224",
+            acc_s.data,
+            scores_sum.data,
+        )
+        for i in T.Parallel(half_m):
+            logsum[i] = logsum[i] * scores_scale[i] + scores_sum[i]
 
     @tilelang.jit(
         out_idx=[6, 7],
@@ -60,6 +127,7 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
         compile_flags=[
             "-O3",
             "-DENABLE_BF16",
+            "-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED",
             "-include",
             _FP8_GQA_HELPER_PATH,
         ],
@@ -67,11 +135,17 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
     def func():
         q_shape = (batch, seq_len, heads, dim)
         kv_shape = (batch, seq_len, heads_kv, dim)
-        q_scale_shape = (batch, heads, scale_blocks)
-        kv_scale_shape = (batch, heads_kv, scale_blocks)
-        online_softmax_1 = make_online_softmax_with_score_scale(scale, accum_dtype, half_m, 224)
-        online_softmax_2 = make_online_softmax_with_score_scale(scale, accum_dtype, half_m, 224)
-        pv_accumulate_helper = "tl::fp8_pv_ptx_unit_accumulate_fa3_raw_64x128x224"
+        descale_shape = (batch, heads_kv)
+        # The 32-tile S7168 producer/consumer schedule still needs the original
+        # per-tile quad reduction. Shorter schedules use the deferred reduction
+        # without changing the public dispatch contract.
+        if not defer_row_sum:
+            online_softmax_1 = make_online_softmax_with_score_scale(scale, accum_dtype, half_m, 224)
+            online_softmax_2 = make_online_softmax_with_score_scale(scale, accum_dtype, half_m, 224)
+        else:
+            online_softmax_1 = online_softmax_with_partial_sum
+            online_softmax_2 = online_softmax_with_partial_sum
+        pv_begin_accumulate_helper = "tl::fp8_pv_ptx_unit_begin_accumulate_fa3_raw_64x128x224"
         v_inplace_transform_helper = (
             "tl::fp8_transpose_v_128x224_fa3_src_ldsm_stsm_barrier_each_iter"
         )
@@ -81,9 +155,9 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
             q: T.Tensor(q_shape, fp8_dtype),
             k: T.Tensor(kv_shape, fp8_dtype),
             v: T.Tensor(kv_shape, fp8_dtype),
-            q_scale: T.Tensor(q_scale_shape, accum_dtype),
-            k_scale: T.Tensor(kv_scale_shape, accum_dtype),
-            v_scale: T.Tensor(kv_scale_shape, accum_dtype),
+            q_descale: T.Tensor(descale_shape, accum_dtype),
+            k_descale: T.Tensor(descale_shape, accum_dtype),
+            v_descale: T.Tensor(descale_shape, accum_dtype),
             output: T.Tensor(q_shape, out_dtype),
             lse: T.Tensor([batch, heads, seq_len], accum_dtype),
         ) -> None:
@@ -102,8 +176,9 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                 ss_shared_2 = T.alloc_shared([half_m], accum_dtype)
                 ls_shared_1 = T.alloc_shared([half_m], accum_dtype)
                 ls_shared_2 = T.alloc_shared([half_m], accum_dtype)
-                acc_o_layout_seed_1 = T.alloc_shared([half_m, dim], out_dtype)
-                acc_o_layout_seed_2 = T.alloc_shared([half_m, dim], out_dtype)
+                # Valid sequence lengths make loop_range a multiple of four, so
+                # K/V phases reset per work item; only the initial V warm-up persists.
+                producer_warm_shared = T.alloc_shared([4], "int32")
                 acc_s_1 = T.alloc_fragment([half_m, 224], accum_dtype)
                 acc_o_1 = T.alloc_fragment([half_m, dim], accum_dtype)
                 sm_1 = T.alloc_fragment([half_m], accum_dtype)
@@ -131,11 +206,26 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                     {
                         q_shared_1: tilelang.layout.make_swizzled_layout(q_shared_1),
                         q_shared_2: tilelang.layout.make_swizzled_layout(q_shared_2),
+                        k_smem_0: tilelang.layout.make_swizzled_layout(k_smem_0),
+                        k_smem_1: tilelang.layout.make_swizzled_layout(k_smem_1),
+                        acc_s_1: _make_fa3_qk_acc_fragment(224, 128),
+                        acc_s_2: _make_fa3_qk_acc_fragment(224, 256),
+                        sm_1: _make_fa3_qk_row_fragment(128),
+                        smp_1: _make_fa3_qk_row_fragment(128),
+                        ss_1: _make_fa3_qk_row_fragment(128),
+                        ssum_1: _make_fa3_qk_row_fragment(128),
+                        ls_1: _make_fa3_qk_row_fragment(128),
+                        sm_2: _make_fa3_qk_row_fragment(256),
+                        smp_2: _make_fa3_qk_row_fragment(256),
+                        ss_2: _make_fa3_qk_row_fragment(256),
+                        ssum_2: _make_fa3_qk_row_fragment(256),
+                        ls_2: _make_fa3_qk_row_fragment(256),
+                        acc_o_1: _make_fa3_pv_acc_fragment(dim, 128),
+                        acc_o_2: _make_fa3_pv_acc_fragment(dim, 256),
                     }
                 )
+                T.clear(producer_warm_shared)
                 T.sync_threads()
-                gi_kp = T.alloc_var("int32", init=0)
-                gi_vp = T.alloc_var("int32", init=0)
                 gi_kc1 = T.alloc_var("int32", init=0)
                 gi_vc1 = T.alloc_var("int32", init=0)
                 gi_kc2 = T.alloc_var("int32", init=0)
@@ -153,14 +243,15 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                     ):
                         head_kv = tile_hkv
                         loop_range = T.ceildiv(seq_len, 224)
+                        producer_warm = T.alloc_var("int32", init=producer_warm_shared[tx // 32])
                         for n_idx in T.Pipelined(loop_range, num_stages=0):
                             if n_idx > 0:
-                                if gi_vp >= 2:
-                                    if gi_vp % 2 == 0:
-                                        T.barrier_wait(v_empty_0, (gi_vp // 2 - 1) % 2)
+                                if producer_warm != 0 or n_idx >= 3:
+                                    if (n_idx - 1) % 2 == 0:
+                                        T.barrier_wait(v_empty_0, ((n_idx - 1) // 2 - 1) % 2)
                                     else:
-                                        T.barrier_wait(v_empty_1, (gi_vp // 2 - 1) % 2)
-                                if gi_vp % 2 == 0:
+                                        T.barrier_wait(v_empty_1, ((n_idx - 1) // 2 - 1) % 2)
+                                if (n_idx - 1) % 2 == 0:
                                     if tx == 0:
                                         T.mbarrier_expect_tx(v_raw_full, dim * 224)
                                         v_desc = T.create_tma_descriptor(
@@ -200,7 +291,7 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                             tile_b,
                                         )
                                     T.barrier_arrive(v_raw_full)
-                                    T.barrier_wait(v_raw_full, gi_vp % 2)
+                                    T.barrier_wait(v_raw_full, (n_idx - 1) % 2)
                                     T.call_extern(
                                         "handle",
                                         v_inplace_transform_helper,
@@ -247,20 +338,19 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                             tile_b,
                                         )
                                     T.barrier_arrive(v_raw_full)
-                                    T.barrier_wait(v_raw_full, gi_vp % 2)
+                                    T.barrier_wait(v_raw_full, (n_idx - 1) % 2)
                                     T.call_extern(
                                         "handle",
                                         v_inplace_transform_helper,
                                         v_vt_smem_1.access_ptr("rw"),
                                         v_vt_smem_1.access_ptr("rw"),
                                     )
-                                if gi_vp % 2 == 0:
+                                if (n_idx - 1) % 2 == 0:
                                     T.barrier_arrive(v_full_0)
                                 else:
                                     T.barrier_arrive(v_full_1)
-                                gi_vp = gi_vp + 1
-                            T.barrier_wait(k_empty, (gi_kp + 1) % 2)
-                            if gi_kp % 2 == 0:
+                            T.barrier_wait(k_empty, (n_idx + 1) % 2)
+                            if n_idx % 2 == 0:
                                 T.tma_copy(
                                     k[tile_b, n_idx * 224 : (n_idx + 1) * 224, head_kv, :],
                                     k_smem_0,
@@ -273,13 +363,12 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                     barrier=k_full,
                                 )
                             T.barrier_arrive(k_full)
-                            gi_kp = gi_kp + 1
-                        if gi_vp >= 2:
-                            if gi_vp % 2 == 0:
-                                T.barrier_wait(v_empty_0, (gi_vp // 2 - 1) % 2)
+                        if producer_warm != 0 or loop_range - 1 >= 2:
+                            if (loop_range - 1) % 2 == 0:
+                                T.barrier_wait(v_empty_0, ((loop_range - 1) // 2 - 1) % 2)
                             else:
-                                T.barrier_wait(v_empty_1, (gi_vp // 2 - 1) % 2)
-                        if gi_vp % 2 == 0:
+                                T.barrier_wait(v_empty_1, ((loop_range - 1) // 2 - 1) % 2)
+                        if (loop_range - 1) % 2 == 0:
                             if tx == 0:
                                 T.mbarrier_expect_tx(v_raw_full, dim * 224)
                                 v_desc_tail = T.create_tma_descriptor(
@@ -319,7 +408,7 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                     tile_b,
                                 )
                             T.barrier_arrive(v_raw_full)
-                            T.barrier_wait(v_raw_full, gi_vp % 2)
+                            T.barrier_wait(v_raw_full, (loop_range - 1) % 2)
                             T.call_extern(
                                 "handle",
                                 v_inplace_transform_helper,
@@ -366,18 +455,20 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                     tile_b,
                                 )
                             T.barrier_arrive(v_raw_full)
-                            T.barrier_wait(v_raw_full, gi_vp % 2)
+                            T.barrier_wait(v_raw_full, (loop_range - 1) % 2)
                             T.call_extern(
                                 "handle",
                                 v_inplace_transform_helper,
                                 v_vt_smem_1.access_ptr("rw"),
                                 v_vt_smem_1.access_ptr("rw"),
                             )
-                        if gi_vp % 2 == 0:
+                        if (loop_range - 1) % 2 == 0:
                             T.barrier_arrive(v_full_0)
                         else:
                             T.barrier_arrive(v_full_1)
-                        gi_vp = gi_vp + 1
+                        producer_warm_shared[tx // 32] = 1
+                        if groups == 8 and defer_row_sum:
+                            T.sync_threads(barrier_id=5, arrive_count=384)
                 elif tx < 256:
                     T.inc_max_nreg(240)
                     for tile_b, tile_hkv, tile_m, tile_g in T.Persistent(
@@ -389,8 +480,12 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         tile_h = tile_hkv * groups + tile_g
                         head_kv = tile_hkv
                         row_base = tile_m * block_m
-                        q_scale_idx = row_base // scale_block
                         loop_range = T.ceildiv(seq_len, 224)
+                        qk_descale = T.alloc_var(
+                            accum_dtype,
+                            init=q_descale[tile_b, head_kv] * k_descale[tile_b, head_kv],
+                        )
+                        value_descale = T.alloc_var(accum_dtype, init=v_descale[tile_b, head_kv])
                         T.tma_copy(
                             q[tile_b, row_base : row_base + half_m, tile_h, :],
                             q_shared_1,
@@ -405,26 +500,33 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         for n_idx in T.Pipelined(loop_range, num_stages=0):
                             T.barrier_wait(k_full, gi_kc1 % 2)
                             if gi_kc1 % 2 == 0:
-                                T.wgmma_gemm(
-                                    q_shared_1,
-                                    k_smem_0,
-                                    acc_s_1,
-                                    transpose_B=True,
-                                    policy=T.GemmWarpPolicy.FullRow,
-                                    clear_accum=True,
+                                T.call_extern(
+                                    "handle",
+                                    "tl::fp8_qk_cute_grouped_fa3_raw_64x224x128",
+                                    q_shared_1.access_ptr("r"),
+                                    k_smem_0.access_ptr("r"),
+                                    acc_s_1.data,
                                 )
                             else:
-                                T.wgmma_gemm(
-                                    q_shared_1,
-                                    k_smem_1,
-                                    acc_s_1,
-                                    transpose_B=True,
-                                    policy=T.GemmWarpPolicy.FullRow,
-                                    clear_accum=True,
+                                T.call_extern(
+                                    "handle",
+                                    "tl::fp8_qk_cute_grouped_fa3_raw_64x224x128",
+                                    q_shared_1.access_ptr("r"),
+                                    k_smem_1.access_ptr("r"),
+                                    acc_s_1.data,
                                 )
+                            if n_idx > 0:
+                                T.wait_wgmma(1)
+                                T.warpgroup_fence_operand(acc_o_1, num_regs=64)
+                                if gi_vc1 % 2 == 0:
+                                    T.barrier_arrive(v_empty_0)
+                                else:
+                                    T.barrier_arrive(v_empty_1)
+                                gi_vc1 = gi_vc1 + 1
                             T.wait_wgmma(0)
                             T.warpgroup_fence_operand(acc_s_1, num_regs=112)
                             T.barrier_arrive(k_empty)
+                            gi_kc1 = gi_kc1 + 1
                             online_softmax_1(
                                 acc_s_1,
                                 sm_1,
@@ -432,10 +534,20 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                 ss_1,
                                 ssum_1,
                                 ls_1,
-                                q_scale[tile_b, tile_h, q_scale_idx]
-                                * k_scale[tile_b, head_kv, n_idx],
+                                qk_descale,
                             )
                             T.copy(ss_1, ss_shared_1)
+                            # The row-scale fragment is compacted through one
+                            # lane per quad before the full consumer warpgroup
+                            # reads it while rescaling the PV accumulator.
+                            if groups == 8 and defer_row_sum:
+                                T.sync_threads(barrier_id=6, arrive_count=128)
+                            T.call_extern(
+                                "handle",
+                                "tl::fp8_fa3_raw_acc_rescale_keep_ptx_layout_64x128",
+                                acc_o_1.data,
+                                ss_shared_1.access_ptr("r"),
+                            )
                             if gi_vc1 % 2 == 0:
                                 T.barrier_wait(v_full_0, (gi_vc1 // 2) % 2)
                             else:
@@ -443,39 +555,40 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                             if gi_vc1 % 2 == 0:
                                 T.call_extern(
                                     "handle",
-                                    pv_accumulate_helper,
+                                    pv_begin_accumulate_helper,
                                     acc_s_1.data,
                                     v_tc_smem_0.access_ptr("r"),
-                                    4,
-                                    ss_shared_1.access_ptr("r"),
-                                    v_scale[tile_b, head_kv, n_idx],
                                     acc_o_1.data,
                                 )
                             else:
                                 T.call_extern(
                                     "handle",
-                                    pv_accumulate_helper,
+                                    pv_begin_accumulate_helper,
                                     acc_s_1.data,
                                     v_tc_smem_1.access_ptr("r"),
-                                    4,
-                                    ss_shared_1.access_ptr("r"),
-                                    v_scale[tile_b, head_kv, n_idx],
                                     acc_o_1.data,
                                 )
-                            if gi_vc1 % 2 == 0:
-                                T.barrier_arrive(v_empty_0)
-                            else:
-                                T.barrier_arrive(v_empty_1)
-                            gi_vc1 = gi_vc1 + 1
-                            gi_kc1 = gi_kc1 + 1
+                        T.wait_wgmma(0)
+                        T.warpgroup_fence_operand(acc_o_1, num_regs=64)
+                        if gi_vc1 % 2 == 0:
+                            T.barrier_arrive(v_empty_0)
+                        else:
+                            T.barrier_arrive(v_empty_1)
+                        gi_vc1 = gi_vc1 + 1
+                        if defer_row_sum:
+                            # Match FA3's reduction schedule: combine the four
+                            # lane partials once after all tiles are consumed.
+                            for i in T.Parallel(half_m):
+                                ls_1[i] = ls_1[i] + T.shfl_xor(ls_1[i], 1)
+                                ls_1[i] = ls_1[i] + T.shfl_xor(ls_1[i], 2)
                         T.copy(ls_1, ls_shared_1)
-                        T.copy(acc_o_1, acc_o_layout_seed_1)
                         T.call_extern(
                             "handle",
-                            "tl::fp8_fa3_raw_acc_store_smem_cute_64x128",
+                            "tl::fp8_fa3_raw_acc_finalize_store_smem_cute_64x128",
                             acc_o_1.data,
                             ls_shared_1.access_ptr("r"),
                             4,
+                            value_descale,
                             o_shared_1.access_ptr("w"),
                         )
                         T.fence_proxy_async()
@@ -490,6 +603,8 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         for i in T.Parallel(half_m):
                             ls_1[i] = T.log2(ls_1[i]) + sm_1[i] * scale
                         T.copy(ls_1, lse[tile_b, tile_h, row_base : row_base + half_m])
+                        if groups == 8 and defer_row_sum:
+                            T.sync_threads(barrier_id=5, arrive_count=384)
                 else:
                     T.inc_max_nreg(240)
                     for tile_b, tile_hkv, tile_m, tile_g in T.Persistent(
@@ -501,8 +616,12 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         tile_h = tile_hkv * groups + tile_g
                         head_kv = tile_hkv
                         row_base = tile_m * block_m
-                        q_scale_idx = row_base // scale_block
                         loop_range = T.ceildiv(seq_len, 224)
+                        qk_descale = T.alloc_var(
+                            accum_dtype,
+                            init=q_descale[tile_b, head_kv] * k_descale[tile_b, head_kv],
+                        )
+                        value_descale = T.alloc_var(accum_dtype, init=v_descale[tile_b, head_kv])
                         T.tma_copy(
                             q[tile_b, row_base + half_m : row_base + block_m, tile_h, :],
                             q_shared_2,
@@ -517,26 +636,33 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         for n_idx in T.Pipelined(loop_range, num_stages=0):
                             T.barrier_wait(k_full, gi_kc2 % 2)
                             if gi_kc2 % 2 == 0:
-                                T.wgmma_gemm(
-                                    q_shared_2,
-                                    k_smem_0,
-                                    acc_s_2,
-                                    transpose_B=True,
-                                    policy=T.GemmWarpPolicy.FullRow,
-                                    clear_accum=True,
+                                T.call_extern(
+                                    "handle",
+                                    "tl::fp8_qk_cute_grouped_fa3_raw_64x224x128",
+                                    q_shared_2.access_ptr("r"),
+                                    k_smem_0.access_ptr("r"),
+                                    acc_s_2.data,
                                 )
                             else:
-                                T.wgmma_gemm(
-                                    q_shared_2,
-                                    k_smem_1,
-                                    acc_s_2,
-                                    transpose_B=True,
-                                    policy=T.GemmWarpPolicy.FullRow,
-                                    clear_accum=True,
+                                T.call_extern(
+                                    "handle",
+                                    "tl::fp8_qk_cute_grouped_fa3_raw_64x224x128",
+                                    q_shared_2.access_ptr("r"),
+                                    k_smem_1.access_ptr("r"),
+                                    acc_s_2.data,
                                 )
+                            if n_idx > 0:
+                                T.wait_wgmma(1)
+                                T.warpgroup_fence_operand(acc_o_2, num_regs=64)
+                                if gi_vc2 % 2 == 0:
+                                    T.barrier_arrive(v_empty_0)
+                                else:
+                                    T.barrier_arrive(v_empty_1)
+                                gi_vc2 = gi_vc2 + 1
                             T.wait_wgmma(0)
                             T.warpgroup_fence_operand(acc_s_2, num_regs=112)
                             T.barrier_arrive(k_empty)
+                            gi_kc2 = gi_kc2 + 1
                             online_softmax_2(
                                 acc_s_2,
                                 sm_2,
@@ -544,10 +670,17 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                                 ss_2,
                                 ssum_2,
                                 ls_2,
-                                q_scale[tile_b, tile_h, q_scale_idx]
-                                * k_scale[tile_b, head_kv, n_idx],
+                                qk_descale,
                             )
                             T.copy(ss_2, ss_shared_2)
+                            if groups == 8 and defer_row_sum:
+                                T.sync_threads(barrier_id=7, arrive_count=128)
+                            T.call_extern(
+                                "handle",
+                                "tl::fp8_fa3_raw_acc_rescale_keep_ptx_layout_64x128",
+                                acc_o_2.data,
+                                ss_shared_2.access_ptr("r"),
+                            )
                             if gi_vc2 % 2 == 0:
                                 T.barrier_wait(v_full_0, (gi_vc2 // 2) % 2)
                             else:
@@ -555,39 +688,40 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                             if gi_vc2 % 2 == 0:
                                 T.call_extern(
                                     "handle",
-                                    pv_accumulate_helper,
+                                    pv_begin_accumulate_helper,
                                     acc_s_2.data,
                                     v_tc_smem_0.access_ptr("r"),
-                                    4,
-                                    ss_shared_2.access_ptr("r"),
-                                    v_scale[tile_b, head_kv, n_idx],
                                     acc_o_2.data,
                                 )
                             else:
                                 T.call_extern(
                                     "handle",
-                                    pv_accumulate_helper,
+                                    pv_begin_accumulate_helper,
                                     acc_s_2.data,
                                     v_tc_smem_1.access_ptr("r"),
-                                    4,
-                                    ss_shared_2.access_ptr("r"),
-                                    v_scale[tile_b, head_kv, n_idx],
                                     acc_o_2.data,
                                 )
-                            if gi_vc2 % 2 == 0:
-                                T.barrier_arrive(v_empty_0)
-                            else:
-                                T.barrier_arrive(v_empty_1)
-                            gi_vc2 = gi_vc2 + 1
-                            gi_kc2 = gi_kc2 + 1
+                        T.wait_wgmma(0)
+                        T.warpgroup_fence_operand(acc_o_2, num_regs=64)
+                        if gi_vc2 % 2 == 0:
+                            T.barrier_arrive(v_empty_0)
+                        else:
+                            T.barrier_arrive(v_empty_1)
+                        gi_vc2 = gi_vc2 + 1
+                        if defer_row_sum:
+                            # Match FA3's reduction schedule: combine the four
+                            # lane partials once after all tiles are consumed.
+                            for i in T.Parallel(half_m):
+                                ls_2[i] = ls_2[i] + T.shfl_xor(ls_2[i], 1)
+                                ls_2[i] = ls_2[i] + T.shfl_xor(ls_2[i], 2)
                         T.copy(ls_2, ls_shared_2)
-                        T.copy(acc_o_2, acc_o_layout_seed_2)
                         T.call_extern(
                             "handle",
-                            "tl::fp8_fa3_raw_acc_store_smem_cute_64x128",
+                            "tl::fp8_fa3_raw_acc_finalize_store_smem_cute_64x128",
                             acc_o_2.data,
                             ls_shared_2.access_ptr("r"),
                             4,
+                            value_descale,
                             o_shared_2.access_ptr("w"),
                         )
                         T.fence_proxy_async()
@@ -602,6 +736,8 @@ def _gqa_fwd_fp8_bn224_tma_v_kernel(
                         for i in T.Parallel(half_m):
                             ls_2[i] = T.log2(ls_2[i]) + sm_2[i] * scale
                         T.copy(ls_2, lse[tile_b, tile_h, row_base + half_m : row_base + block_m])
+                        if groups == 8 and defer_row_sum:
+                            T.sync_threads(barrier_id=5, arrive_count=384)
 
         return main
 
@@ -619,12 +755,12 @@ def _gqa_fwd_fp8_bn224_tma_v_wrapped_kernel(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    q_scale: torch.Tensor,
-    k_scale: torch.Tensor,
-    v_scale: torch.Tensor,
+    q_descale: torch.Tensor,
+    k_descale: torch.Tensor,
+    v_descale: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     return _gqa_fwd_fp8_bn224_tma_v_kernel(batch, heads, heads_kv, seq_len, dim, out_dtype)()(
-        q, k, v, q_scale, k_scale, v_scale
+        q, k, v, q_descale, k_descale, v_descale
     )
 
 
@@ -644,72 +780,35 @@ def _(
     return (fake_o, fake_lse)
 
 
-def _expand_fa3_gqa_descales(
+def _validate_fa3_gqa_descales(
     q_descale: torch.Tensor,
     k_descale: torch.Tensor,
     v_descale: torch.Tensor,
     batch: int,
-    heads: int,
     heads_kv: int,
-    seq_len: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Accept FA3-interface [batch, heads_kv] descales.
-
-    The TileLang kernels below still index scale metadata as
-    q: [batch, heads, scale_blocks] and k/v: [batch, heads_kv, scale_blocks].
-    The public FA3 FP8 GQA binding exposes q/k/v descales as [batch, heads_kv],
-    with q grouped by KV head.  This wrapper broadcasts that 2D contract to the
-    internal per-block layout; direct kernel users may still pass the internal
-    3D layout explicitly.
-    """
-    scale_blocks = (seq_len + 127) // 128
-    group_size = heads // heads_kv
-
-    def _record_stream(x: torch.Tensor) -> torch.Tensor:
-        if x.is_cuda:
-            x.record_stream(torch.cuda.current_stream(x.device))
-        return x
-
-    def _as_float_contiguous(x: torch.Tensor) -> torch.Tensor:
-        return x if x.dtype == torch.float32 and x.is_contiguous() else x.float().contiguous()
-
-    def _expand_q(x: torch.Tensor) -> torch.Tensor:
-        if x.ndim == 3:
-            if tuple(x.shape) != (batch, heads, scale_blocks):
-                raise ValueError(
-                    f"q_descale/q_scale with 3 dimensions must have internal shape ({batch}, {heads}, {scale_blocks}), got {tuple(x.shape)}."
-                )
-            return _record_stream(_as_float_contiguous(x))
-        if x.ndim != 2 or tuple(x.shape) != (batch, heads_kv):
+    device: torch.device,
+) -> None:
+    """Validate the direct FA3 ``[batch, heads_kv]`` descale contract."""
+    expected_shape = (batch, heads_kv)
+    for name, descale in (
+        ("q_scale", q_descale),
+        ("k_scale", k_descale),
+        ("v_scale", v_descale),
+    ):
+        if tuple(descale.shape) != expected_shape:
             raise ValueError(
-                f"q_descale must have FA3 shape ({batch}, {heads_kv}) or internal shape ({batch}, {heads}, {scale_blocks}), got {tuple(x.shape)}."
+                f"{name} must have shape {expected_shape}, got {tuple(descale.shape)}."
             )
-        x = _as_float_contiguous(x).repeat_interleave(group_size, dim=1)
-        return _record_stream(x[:, :, None].expand(batch, heads, scale_blocks).contiguous())
-
-    def _expand_kv(name: str, x: torch.Tensor) -> torch.Tensor:
-        if x.ndim == 3:
-            if tuple(x.shape) != (batch, heads_kv, scale_blocks):
-                raise ValueError(
-                    f"{name} with 3 dimensions must have internal shape ({batch}, {heads_kv}, {scale_blocks}), got {tuple(x.shape)}."
-                )
-            return _record_stream(_as_float_contiguous(x))
-        if x.ndim != 2 or tuple(x.shape) != (batch, heads_kv):
-            raise ValueError(
-                f"{name} must have FA3 shape ({batch}, {heads_kv}) or internal shape ({batch}, {heads_kv}, {scale_blocks}), got {tuple(x.shape)}."
-            )
-        x = _as_float_contiguous(x)
-        return _record_stream(x[:, :, None].expand(batch, heads_kv, scale_blocks).contiguous())
-
-    return (
-        _expand_q(q_descale),
-        _expand_kv("k_descale", k_descale),
-        _expand_kv("v_descale", v_descale),
-    )
+        if descale.dtype != torch.float32:
+            raise ValueError(f"{name} must have dtype torch.float32, got {descale.dtype}.")
+        if descale.device != device:
+            raise ValueError(f"{name} must be on {device}, got {descale.device}.")
+        if not descale.is_contiguous():
+            raise ValueError(f"{name} must be contiguous.")
 
 
 class GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel(PackedPrefillKernel):
-    """BN224 WS FP8 GQA kernel with FA3-compatible 2D descales and TMA-V layout.
+    """BN224 WS FP8 GQA kernel with direct FA3-compatible descales.
 
     Query, key and value are always ``torch.float8_e4m3fn``; the only free dtype
     is the one the kernel writes, so ``dtype`` names the output element type.
@@ -797,13 +896,14 @@ class GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel(PackedPrefillKernel):
             raise ValueError("torch.float8_e4m3fn is required for this kernel.")
         if q.dtype != fp8 or k.dtype != fp8 or v.dtype != fp8:
             raise ValueError(
-                "GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel expects q/k/v to be torch.float8_e4m3fn."
+                "GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel expects q/k/v to be "
+                "torch.float8_e4m3fn."
             )
         if q_scale is None or k_scale is None or v_scale is None:
             raise ValueError("GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel requires q/k/v descales.")
         q_bshd, k_bshd, v_bshd = self._bshd(q, k, v)
-        q_expanded, k_expanded, v_expanded = _expand_fa3_gqa_descales(
-            q_scale, k_scale, v_scale, self.batch, self.heads, self.heads_kv, self.max_seqlen_q
+        _validate_fa3_gqa_descales(
+            q_scale, k_scale, v_scale, self.batch, self.heads_kv, q_bshd.device
         )
         output, _ = _gqa_fwd_fp8_bn224_tma_v_wrapped_kernel(
             self.batch,
@@ -815,8 +915,8 @@ class GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel(PackedPrefillKernel):
             q_bshd,
             k_bshd,
             v_bshd,
-            q_expanded,
-            k_expanded,
-            v_expanded,
+            q_scale,
+            k_scale,
+            v_scale,
         )
         return output.reshape(q.shape)

--- a/tests/ops/attention/test_gqa_fp8.py
+++ b/tests/ops/attention/test_gqa_fp8.py
@@ -236,3 +236,42 @@ def test_gqa_prefill_fp8_tensor_core_matches_dequantized_reference() -> None:
     torch.testing.assert_close(
         out.reshape(batch, seq_len, heads, dim).float(), ref, atol=5e-2, rtol=5e-2
     )
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="torch fp8 is unavailable")
+@pytest.mark.skipif(not _has_sm90(), reason="requires Hopper FP8 WGMMA")
+@pytest.mark.parametrize("seq_len", [6272, 7168, 8064])
+@pytest.mark.smoke
+def test_gqa_prefill_fp8_row_reduction_boundary_is_live_and_repeatable(seq_len: int) -> None:
+    """Exercise 28/32/36 BN224 tiles across the deferred-reduction boundary."""
+    batch, heads, heads_kv, dim = 1, 64, 8, 128
+    fp8 = torch.float8_e4m3fn
+    q_fp8 = torch.zeros((batch, seq_len, heads, dim), device="cuda", dtype=fp8)
+    k_fp8 = torch.zeros((batch, seq_len, heads_kv, dim), device="cuda", dtype=fp8)
+    v_fp8 = torch.full((batch, seq_len, heads_kv, dim), 0.5, device="cuda", dtype=fp8)
+    q_scale = torch.ones((batch, heads_kv), device="cuda", dtype=torch.float32)
+    k_scale = torch.ones_like(q_scale)
+    v_scale = torch.full_like(q_scale, 0.25)
+
+    outputs = [
+        _run_canonical_fp8_prefill(
+            batch=batch,
+            seq_len=seq_len,
+            heads=heads,
+            heads_kv=heads_kv,
+            dim=dim,
+            out_dtype=torch.float16,
+            q_fp8=q_fp8,
+            k_fp8=k_fp8,
+            v_fp8=v_fp8,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+        for _ in range(2)
+    ]
+
+    expected = torch.full_like(outputs[0], 0.125)
+    for output in outputs:
+        torch.testing.assert_close(output, expected, atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(outputs[0], outputs[1], atol=0, rtol=0)


### PR DESCRIPTION
## Summary

- consume FA3-compatible `[batch, heads_kv]` descales directly instead of materializing expanded per-head/per-tile scale tensors
- keep PV accumulation in the WGMMA-native register layout, rescale it in place, and defer the row-sum quad reduction for schedules shorter than 32 BN224 tiles
- retain the proven per-tile reduction path at and beyond the 32-tile liveness boundary
- remove the superseded PV accumulate helper and add repeated-launch coverage around the 28/32/36-tile boundary

## Validation

On an H200 locked to a 1500 MHz SM clock:

- `ruff check`: passed
- `ruff format --check`: passed
- `pytest -q tests/ops/attention/test_gqa_fp8.py`: 11 passed

The long-sequence tests use non-zero values and launch each boundary shape twice.

## Benchmark

Measured with the native-CUPTI V3 protocol: case-scoped trace with 1 ms margins, isolated discovery/timing captures, 10 warmups, 3 discovery iterations, 50 timed repeats summarized by their median, and kernel/MEMCPY/MEMSET activity enabled. All eight cases passed with zero dropped records or attribution errors.

| Shape | Output | TileOps | FA3 | TileOps / FA3 throughput |
|---|---:|---:|---:|---:|
| S=896, H=32 | FP16 | 0.0318 ms | 0.0285 ms | 89.50% |
| S=896, H=32 | BF16 | 0.0312 ms | 0.0285 ms | 91.33% |
| S=1792, H=32 | FP16 | 0.0959 ms | 0.0856 ms | 89.27% |
| S=1792, H=32 | BF16 | 0.0956 ms | 0.0855 ms | 89.47% |
| S=3584, H=64 | FP16 | 0.5975 ms | 0.5300 ms | 88.70% |
| S=3584, H=64 | BF16 | 0.5973 ms | 0.5300 ms | 88.74% |
| S=7168, H=64 | FP16 | 2.3601 ms | 2.0324 ms | 86.11% |
| S=7168, H=64 | BF16 | 2.3572 ms | 2.0348 ms | 86.32% |
