### PR TITLE
[Perf][GEMM] Dispatch W4A16 M=1 to optimized decode kernel

### DIFF
--- a/src/tileops/kernels/gemm_w4a16.py
+++ b/src/tileops/kernels/gemm_w4a16.py
@@ -5,12 +5,462 @@ import tilelang
 import tilelang.language as T
 import torch
 
+from tileops.kernels.gemm_call import GemmCall
 from tileops.kernels.kernel_base import Kernel
-from tileops.kernels.quantize_utils import _tir_packed_to_unsigned_convert
+from tileops.kernels.quantize_utils import (
+    UINT4_TO_FP16_LOP3_SOURCE,
+    _tir_packed_to_unsigned_convert,
+)
 
 GROUP_SIZE = 128
 
-__all__ = ["GemmW4A16Kernel"]
+__all__ = ["GemmW4A16DecodeKernel", "GemmW4A16Kernel"]
+
+
+def _plain_packed_activation_index(index):
+    """Map LOP3 output lanes back to the public low/high-nibble order."""
+    chunk = index // 8 * 8
+    within = index % 8
+    return chunk + within // 2 + (within % 2) * 4
+
+
+def _decode_schedule_index(index, size: int, mode: int):
+    """Compile-time traversal orders retained from the decode AKO campaign."""
+    if mode == 0:
+        return index
+    if mode == 5:
+        bits = (size - 1).bit_length()
+        result = index & 1
+        for bit in range(1, bits):
+            result = (result << 1) | ((index >> bit) & 1)
+        return result
+    if mode == 7:
+        reverse = size - 1 - index
+        return reverse ^ (reverse >> 1)
+    raise ValueError(f"unsupported decode schedule mode {mode}")
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_w4a16_decode_direct_kernel(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    group_size: int = GROUP_SIZE,
+) -> Callable:
+    """M=1 register-dequant GEMV over the public packed-weight layout."""
+    if m != 1:
+        raise ValueError(f"W4A16 decode requires M=1, got {m}")
+    if dtype != "float16":
+        raise ValueError(f"W4A16 decode requires float16, got {dtype}")
+    if k % 256 != 0:
+        raise ValueError(f"W4A16 decode requires K divisible by 256, got {k}")
+
+    @tilelang.jit(out_idx=[-1], compile_flags=["-O3", "-DENABLE_BF16"])
+    def build(
+        n_partition: int = 1,
+        split_k_warps: int = 1,
+        outputs_per_warp: int = 1,
+    ) -> Callable:
+        reduce_threads = 32
+        values_per_thread = 8
+        packed_per_thread = values_per_thread // 2
+        block_k = reduce_threads * values_per_thread
+        split_block_k = block_k * split_k_warps
+        total_threads = reduce_threads * n_partition * split_k_warps
+
+        if split_k_warps not in (1, 2, 4, 8):
+            raise ValueError("split_k_warps must be 1, 2, 4, or 8")
+        if outputs_per_warp not in (1, 2, 4, 8):
+            raise ValueError("outputs_per_warp must be 1, 2, 4, or 8")
+        if total_threads > 1024:
+            raise ValueError(f"decode launch requests {total_threads} threads")
+        if k % split_block_k != 0:
+            raise ValueError(f"K={k} must be divisible by {split_block_k}")
+
+        @T.prim_func
+        def main(
+            activation: T.Tensor((m, k), dtype),  # type: ignore
+            packed_weight: T.Tensor((n, k // 2), "uint8"),  # type: ignore
+            weight_scale: T.Tensor((n, k // group_size), "float32"),  # type: ignore
+            weight_zero: T.Tensor((n, k // group_size), "uint8"),  # type: ignore
+            output: T.Tensor((m, n), dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(
+                T.ceildiv(n, n_partition * outputs_per_warp),
+                threads=(reduce_threads, n_partition * split_k_warps),
+            ) as bx:
+                activation_local = T.alloc_local((values_per_thread,), dtype)
+                packed_local = T.alloc_local((packed_per_thread,), "uint8")
+                decoded_local = T.alloc_local((values_per_thread,), dtype)
+                accumulator = T.alloc_local((outputs_per_warp,), "float32")
+                reduced = T.alloc_local((outputs_per_warp,), "float32")
+                scale_local = T.alloc_local((1,), dtype)
+                zero_local = T.alloc_local((1,), dtype)
+                partials = T.alloc_shared((n_partition, outputs_per_warp, split_k_warps), "float32")
+
+                lane = T.thread_binding(0, reduce_threads, thread="threadIdx.x")
+                warp_slot = T.thread_binding(
+                    0,
+                    n_partition * split_k_warps,
+                    thread="threadIdx.y",
+                )
+                n_slot = warp_slot // split_k_warps
+                k_partition = warp_slot % split_k_warps
+                output_col_base = bx * n_partition * outputs_per_warp + n_slot * outputs_per_warp
+
+                T.import_source(UINT4_TO_FP16_LOP3_SOURCE)
+                T.clear(accumulator)
+
+                for ko in T.serial(k // split_block_k):
+                    logical_k = (
+                        ko * split_k_warps + k_partition
+                    ) * block_k + lane * values_per_thread
+                    for v in T.vectorized(values_per_thread):
+                        activation_local[v] = activation[0, logical_k + v]
+
+                    for output_slot in T.serial(outputs_per_warp):
+                        output_col = output_col_base + output_slot
+                        for v in T.vectorized(packed_per_thread):
+                            packed_local[v] = T.if_then_else(
+                                output_col < n,
+                                packed_weight[output_col, logical_k // 2 + v],
+                                T.cast(0, "uint8"),
+                            )
+                        T.call_extern(
+                            "decode_i4u_to_f16",
+                            T.access_ptr(packed_local[0], "r", packed_per_thread),
+                            T.access_ptr(decoded_local[0], "w", values_per_thread),
+                            dtype=dtype,
+                        )
+                        scale_local[0] = T.if_then_else(
+                            output_col < n,
+                            T.cast(weight_scale[output_col, logical_k // group_size], dtype),
+                            T.cast(0, dtype),
+                        )
+                        zero_local[0] = T.if_then_else(
+                            output_col < n,
+                            T.cast(weight_zero[output_col, logical_k // group_size], dtype),
+                            T.cast(0, dtype),
+                        )
+                        for v in T.serial(values_per_thread):
+                            activation_v = _plain_packed_activation_index(v)
+                            accumulator[output_slot] += T.cast(
+                                activation_local[activation_v], "float32"
+                            ) * T.cast(
+                                (decoded_local[v] - zero_local[0]) * scale_local[0],
+                                "float32",
+                            )
+
+                for output_slot in T.serial(outputs_per_warp):
+                    for step in T.serial(5):
+                        accumulator[output_slot] += T.shfl_down(
+                            accumulator[output_slot], 16 >> step, width=reduce_threads
+                        )
+
+                if split_k_warps == 1:
+                    if lane == 0:
+                        for output_slot in T.serial(outputs_per_warp):
+                            output_col = output_col_base + output_slot
+                            if output_col < n:
+                                output[0, output_col] = accumulator[output_slot]
+                else:
+                    if lane == 0:
+                        for output_slot in T.serial(outputs_per_warp):
+                            partials[n_slot, output_slot, k_partition] = accumulator[output_slot]
+                    T.sync_threads(barrier_id=1, arrive_count=total_threads)
+                    if lane == 0 and k_partition == 0:
+                        for output_slot in T.serial(outputs_per_warp):
+                            output_col = output_col_base + output_slot
+                            reduced[output_slot] = T.cast(0, "float32")
+                            for part in T.serial(split_k_warps):
+                                reduced[output_slot] += partials[n_slot, output_slot, part]
+                            if output_col < n:
+                                output[0, output_col] = reduced[output_slot]
+
+        return main
+
+    return build
+
+
+@functools.lru_cache(maxsize=32)
+def _gemm_w4a16_decode_tma_kernel(
+    m: int,
+    n: int,
+    k: int,
+    dtype: str,
+    group_size: int = GROUP_SIZE,
+) -> Callable:
+    """M=1 N64 pipeline: TMA packed W4, register decode, CTA split-K."""
+    if m != 1 or dtype != "float16":
+        raise ValueError("W4A16 TMA decode requires M=1 and float16")
+    if n % 64 != 0 or k % 1024 != 0:
+        raise ValueError("W4A16 TMA decode requires N%64==0 and K%1024==0")
+
+    @tilelang.jit(
+        out_idx=[-1],
+        pass_configs={"tl.disable_warp_specialized": True},
+        compile_flags=["-O3", "-DENABLE_BF16"],
+    )
+    def build(
+        num_stages: int = 3,
+        cache_activation_fp32: bool = False,
+        long_k_schedule: bool = False,
+        consumer_max_nreg: int = 112,
+    ) -> Callable:
+        block_n = 64
+        block_k = 512
+        split_k_warps = 2
+        outputs_per_warp = 8
+        producer_threads = 128
+        consumer_threads = 512
+        threads = producer_threads + consumer_threads
+        reduce_threads = 32
+        consumer_warps = consumer_threads // reduce_threads
+        output_warps = consumer_warps // split_k_warps
+        values_per_thread = block_k // reduce_threads
+        packed_per_thread = values_per_thread // 2
+        groups_per_partition = block_k // group_size
+        super_block_k = block_k * split_k_warps
+        super_tiles = k // super_block_k
+        output_mode = 7 if long_k_schedule else 0
+        value_mode = 5 if long_k_schedule else 0
+        release_after_activation = long_k_schedule
+
+        if num_stages not in (2, 3, 4):
+            raise ValueError("num_stages must be 2, 3, or 4")
+        if consumer_max_nreg not in (96, 104, 112):
+            raise ValueError("consumer_max_nreg must be 96, 104, or 112")
+
+        @T.prim_func
+        def main(
+            activation: T.Tensor((m, k), dtype),  # type: ignore
+            packed_weight: T.Tensor((n, k // 2), "uint8"),  # type: ignore
+            weight_scale: T.Tensor((n, k // group_size), "float32"),  # type: ignore
+            weight_zero: T.Tensor((n, k // group_size), "uint8"),  # type: ignore
+            output: T.Tensor((m, n), dtype),  # type: ignore
+        ) -> None:
+            with T.Kernel(n // block_n, threads=threads) as bx:
+                activation_shared = T.alloc_shared((num_stages, split_k_warps, block_k), dtype)
+                packed_shared = T.alloc_shared(
+                    (num_stages, split_k_warps, block_n, block_k // 2),
+                    "uint8",
+                )
+                scale_shared = T.alloc_shared(
+                    (
+                        num_stages,
+                        block_n,
+                        split_k_warps * groups_per_partition,
+                    ),
+                    "float32",
+                )
+                zero_shared = T.alloc_shared(
+                    (
+                        num_stages,
+                        block_n,
+                        split_k_warps * groups_per_partition,
+                    ),
+                    "uint8",
+                )
+                partials = T.alloc_shared(
+                    (output_warps, outputs_per_warp, split_k_warps), "float32"
+                )
+
+                activation_local = T.alloc_local((values_per_thread,), dtype)
+                activation_float = T.alloc_local((values_per_thread,), "float32")
+                packed_local = T.alloc_local((outputs_per_warp, packed_per_thread), "uint8")
+                decoded_local = T.alloc_local((values_per_thread,), dtype)
+                accumulator = T.alloc_local((outputs_per_warp,), "float32")
+                raw_partial = T.alloc_local((outputs_per_warp,), "float32")
+                activation_sum = T.alloc_local((1,), "float32")
+                output_sum = T.alloc_local((1,), "float32")
+                scale_local = T.alloc_local((outputs_per_warp,), "float32")
+                zero_local = T.alloc_local((outputs_per_warp,), "float32")
+
+                ready = T.alloc_barrier([producer_threads] * num_stages)
+                empty = T.alloc_barrier([consumer_threads] * num_stages)
+                producer_iteration = T.alloc_var("int32", init=0)
+                consumer_iteration = T.alloc_var("int32", init=0)
+                tx = T.get_thread_binding()
+                n_start = bx * block_n
+
+                T.import_source(UINT4_TO_FP16_LOP3_SOURCE)
+
+                if tx < producer_threads:
+                    T.dec_max_nreg(24)
+                    for ko in T.serial(super_tiles):
+                        stage = producer_iteration % num_stages
+                        phase = (producer_iteration // num_stages) % 2
+                        k_start = ko * super_block_k
+                        for stage_index in range(num_stages):
+                            if stage == stage_index:
+                                T.barrier_wait(empty[stage_index], phase ^ 1)
+                                T.fence_proxy_async()
+                                for part, value in T.Parallel(split_k_warps, block_k):
+                                    activation_shared[stage_index, part, value] = activation[
+                                        0, k_start + part * block_k + value
+                                    ]
+                                for part in range(split_k_warps):
+                                    part_k_start = k_start + part * block_k
+                                    T.tma_copy(
+                                        packed_weight[
+                                            n_start : n_start + block_n,
+                                            part_k_start // 2 : (part_k_start + block_k) // 2,
+                                        ],
+                                        packed_shared[stage_index, part, :, :],
+                                        barrier=ready[stage_index],
+                                    )
+                                T.tma_copy(
+                                    weight_scale[
+                                        n_start : n_start + block_n,
+                                        k_start // group_size : (k_start + super_block_k)
+                                        // group_size,
+                                    ],
+                                    scale_shared[stage_index, :, :],
+                                    barrier=ready[stage_index],
+                                )
+                                T.copy(
+                                    weight_zero[
+                                        n_start : n_start + block_n,
+                                        k_start // group_size : (k_start + super_block_k)
+                                        // group_size,
+                                    ],
+                                    zero_shared[stage_index, :, :],
+                                )
+                                T.barrier_arrive(ready[stage_index])
+                        producer_iteration = producer_iteration + 1
+                else:
+                    T.inc_max_nreg(consumer_max_nreg)
+                    consumer_thread = tx - producer_threads
+                    warp_id = consumer_thread // reduce_threads
+                    lane = consumer_thread % reduce_threads
+                    output_warp = warp_id // split_k_warps
+                    k_partition = warp_id % split_k_warps
+                    output_col_base = n_start + output_warp * outputs_per_warp
+                    T.clear(accumulator)
+
+                    for _ko in T.serial(super_tiles):
+                        stage = consumer_iteration % num_stages
+                        phase = (consumer_iteration // num_stages) % 2
+                        for stage_index in range(num_stages):
+                            if stage == stage_index:
+                                T.barrier_wait(ready[stage_index], phase)
+                                for value in T.vectorized(values_per_thread):
+                                    activation_local[value] = activation_shared[
+                                        stage_index,
+                                        k_partition,
+                                        lane * values_per_thread + value,
+                                    ]
+
+                                group_in_partition = (lane * values_per_thread) // group_size
+                                for output_iter in T.serial(outputs_per_warp):
+                                    output_slot = _decode_schedule_index(
+                                        output_iter, outputs_per_warp, output_mode
+                                    )
+                                    output_col_local = output_warp * outputs_per_warp + output_slot
+                                    for value in T.vectorized(packed_per_thread):
+                                        packed_local[output_slot, value] = packed_shared[
+                                            stage_index,
+                                            k_partition,
+                                            output_col_local,
+                                            lane * packed_per_thread + value,
+                                        ]
+                                    scale_local[output_slot] = scale_shared[
+                                        stage_index,
+                                        output_col_local,
+                                        k_partition * groups_per_partition + group_in_partition,
+                                    ]
+                                    zero_local[output_slot] = T.cast(
+                                        zero_shared[
+                                            stage_index,
+                                            output_col_local,
+                                            k_partition * groups_per_partition + group_in_partition,
+                                        ],
+                                        "float32",
+                                    )
+
+                                if not release_after_activation:
+                                    T.barrier_arrive(empty[stage_index])
+
+                                activation_sum[0] = T.cast(0, "float32")
+                                for value_iter in T.serial(values_per_thread):
+                                    value = _decode_schedule_index(
+                                        value_iter, values_per_thread, value_mode
+                                    )
+                                    if cache_activation_fp32:
+                                        activation_float[value] = T.cast(
+                                            activation_local[value], "float32"
+                                        )
+                                        activation_sum[0] += activation_float[value]
+                                    else:
+                                        activation_sum[0] += T.cast(
+                                            activation_local[value], "float32"
+                                        )
+
+                                if release_after_activation:
+                                    T.barrier_arrive(empty[stage_index])
+
+                                for output_iter in T.serial(outputs_per_warp):
+                                    output_slot = _decode_schedule_index(
+                                        output_iter, outputs_per_warp, output_mode
+                                    )
+                                    for chunk in T.serial(values_per_thread // 8):
+                                        T.call_extern(
+                                            "decode_i4u_to_f16",
+                                            T.access_ptr(
+                                                packed_local[output_slot, chunk * 4],
+                                                "r",
+                                                4,
+                                            ),
+                                            T.access_ptr(decoded_local[chunk * 8], "w", 8),
+                                            dtype=dtype,
+                                        )
+
+                                    raw_partial[output_slot] = T.cast(0, "float32")
+                                    for value_iter in T.serial(values_per_thread):
+                                        decoded_index = _decode_schedule_index(
+                                            value_iter, values_per_thread, value_mode
+                                        )
+                                        activation_index = _plain_packed_activation_index(
+                                            decoded_index
+                                        )
+                                        raw_partial[output_slot] += (
+                                            activation_float[activation_index]
+                                            if cache_activation_fp32
+                                            else T.cast(
+                                                activation_local[activation_index],
+                                                "float32",
+                                            )
+                                        ) * T.cast(decoded_local[decoded_index], "float32")
+                                    accumulator[output_slot] += (
+                                        raw_partial[output_slot]
+                                        - zero_local[output_slot] * activation_sum[0]
+                                    ) * scale_local[output_slot]
+                        consumer_iteration = consumer_iteration + 1
+
+                    for output_slot in T.serial(outputs_per_warp):
+                        for step in T.serial(5):
+                            accumulator[output_slot] += T.shfl_down(
+                                accumulator[output_slot],
+                                16 >> step,
+                                width=reduce_threads,
+                            )
+                        if lane == 0:
+                            partials[output_warp, output_slot, k_partition] = accumulator[
+                                output_slot
+                            ]
+
+                    T.sync_threads(barrier_id=1, arrive_count=consumer_threads)
+                    if lane == 0 and k_partition == 0:
+                        for output_slot in T.serial(outputs_per_warp):
+                            output_sum[0] = T.cast(0, "float32")
+                            for part in T.serial(split_k_warps):
+                                output_sum[0] += partials[output_warp, output_slot, part]
+                            output[0, output_col_base + output_slot] = output_sum[0]
+
+        return main
+
+    return build
 
 
 @functools.lru_cache(maxsize=32)
@@ -211,4 +661,70 @@ class GemmW4A16Kernel(Kernel):
         compiled = _gemm_w4a16_kernel(self.m, self.n, self.k, self.dtype_str, self.group_size)(
             **self.config
         )
+        return compiled(activation, packed_weight, weight_scale, weight_zero)
+
+
+class GemmW4A16DecodeKernel(Kernel):
+    """Hopper M=1 W4A16 path with register decode and CTA-local split-K."""
+
+    supported_archs = [90]
+
+    @classmethod
+    def applies(cls, call: GemmCall) -> bool:
+        return call.m == 1 and call.dtype == torch.float16 and call.k % 256 == 0
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        dtype: torch.dtype,
+        config: Optional[dict] = None,
+        tune: bool = False,
+        group_size: int = GROUP_SIZE,
+    ) -> None:
+        super().__init__()
+        self.m = m
+        self.n = n
+        self.k = k
+        self.dtype = dtype
+        self.group_size = group_size
+        self.use_tma = n % 64 == 0 and k % 1024 == 0
+        self.kernel = (
+            _gemm_w4a16_decode_tma_kernel(m, n, k, self.dtype_str, group_size)
+            if self.use_tma
+            else _gemm_w4a16_decode_direct_kernel(m, n, k, self.dtype_str, group_size)
+        )
+        self.init_config(config, tune)
+
+    @property
+    def default_config(self) -> dict:
+        if self.use_tma:
+            return {
+                "num_stages": 4 if self.k <= 8192 else 3,
+                "cache_activation_fp32": self.k == 16384,
+                "long_k_schedule": self.k >= 65536,
+                "consumer_max_nreg": 104 if self.k <= 32768 else 112,
+            }
+        split_k_warps = next(split for split in (8, 4, 2, 1) if self.k % (256 * split) == 0)
+        outputs_per_warp = 4 if self.k >= 8192 else 1
+        return {
+            "n_partition": 4 // outputs_per_warp,
+            "split_k_warps": split_k_warps,
+            "outputs_per_warp": outputs_per_warp,
+        }
+
+    def forward(
+        self,
+        activation: torch.Tensor,
+        packed_weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        weight_zero: torch.Tensor,
+    ) -> torch.Tensor:
+        factory = (
+            _gemm_w4a16_decode_tma_kernel
+            if self.use_tma
+            else _gemm_w4a16_decode_direct_kernel
+        )
+        compiled = factory(self.m, self.n, self.k, self.dtype_str, self.group_size)(**self.config)
         return compiled(activation, packed_weight, weight_scale, weight_zero)

--- a/src/tileops/kernels/gemm_w4a16.py
+++ b/src/tileops/kernels/gemm_w4a16.py
@@ -722,9 +722,7 @@ class GemmW4A16DecodeKernel(Kernel):
         weight_zero: torch.Tensor,
     ) -> torch.Tensor:
         factory = (
-            _gemm_w4a16_decode_tma_kernel
-            if self.use_tma
-            else _gemm_w4a16_decode_direct_kernel
+            _gemm_w4a16_decode_tma_kernel if self.use_tma else _gemm_w4a16_decode_direct_kernel
         )
         compiled = factory(self.m, self.n, self.k, self.dtype_str, self.group_size)(**self.config)
         return compiled(activation, packed_weight, weight_scale, weight_zero)

--- a/src/tileops/kernels/quantize_utils.py
+++ b/src/tileops/kernels/quantize_utils.py
@@ -12,7 +12,34 @@ try:
 except ImportError:
     from tvm import tir
 
-__all__ = ["_tir_packed_to_unsigned_convert"]
+__all__ = ["UINT4_TO_FP16_LOP3_SOURCE", "_tir_packed_to_unsigned_convert"]
+
+
+# Vendored from tile-ai/tilelang's former ``tilelang.quantize.lop3`` module at
+# the same commit documented above.  Newer TileLang releases removed that
+# Python package, but W4 decode still needs the four-instruction LOP3 sequence
+# rather than eight scalar shifts and casts.
+UINT4_TO_FP16_LOP3_SOURCE = r"""
+template <typename T1, typename T2>
+__device__ __forceinline__ void decode_i4u_to_f16(
+    T1* packed, T2* decoded, const int N = 8) {
+  uint* half2 = reinterpret_cast<uint*>(decoded);
+  constexpr uint kLut = (0xf0 & 0xcc) | 0xaa;
+  constexpr uint kBottomMask = 0x000f000f;
+  constexpr uint kFp16Magic = 0x64006400;
+  const uint values = *reinterpret_cast<uint*>(packed);
+#pragma unroll
+  for (int i = 0; i < N / 2; ++i) {
+    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(half2[i])
+                 : "r"(values >> (4 * i)), "n"(kBottomMask),
+                   "n"(kFp16Magic), "n"(kLut));
+    asm volatile("sub.f16x2 %0, %1, %2;\n"
+                 : "=r"(half2[i])
+                 : "r"(half2[i]), "r"(kFp16Magic));
+  }
+}
+"""
 
 
 def _tir_packed_to_unsigned_convert(storage_type="uint", storage_nbit=8):

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -151,7 +151,6 @@ GemmW4A16FwdOp:
     bench: benchmarks/ops/bench_gemm.py
     bench_manifest_driven: true
     kernel_map:
-      gemm_w4a16_decode_kernel: GemmW4A16DecodeKernel
       gemm_w4a16_kernel: GemmW4A16Kernel
       gemm_w4a16_decode_kernel: GemmW4A16DecodeKernel
 

--- a/src/tileops/manifest/gemm.yaml
+++ b/src/tileops/manifest/gemm.yaml
@@ -151,6 +151,7 @@ GemmW4A16FwdOp:
     bench: benchmarks/ops/bench_gemm.py
     bench_manifest_driven: true
     kernel_map:
+      gemm_w4a16_decode_kernel: GemmW4A16DecodeKernel
       gemm_w4a16_kernel: GemmW4A16Kernel
       gemm_w4a16_decode_kernel: GemmW4A16DecodeKernel
 

--- a/src/tileops/ops/gemm.py
+++ b/src/tileops/ops/gemm.py
@@ -9,8 +9,11 @@ from tileops.kernels.gemm import (
     GemvKernel,
 )
 from tileops.kernels.gemm_call import GemmCall
-from tileops.kernels.gemm_w4a16 import GROUP_SIZE, GemmW4A16Kernel
-from tileops.kernels.gemm_w4a16_decode import GemmW4A16DecodeKernel
+from tileops.kernels.gemm_w4a16 import (
+    GROUP_SIZE,
+    GemmW4A16DecodeKernel,
+    GemmW4A16Kernel,
+)
 from tileops.kernels.kernel_base import Kernel
 
 from .op_base import Op
@@ -365,8 +368,8 @@ class GemmW4A16FwdOp(Op):
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {
-            "gemm_w4a16_kernel": GemmW4A16Kernel,
             "gemm_w4a16_decode_kernel": GemmW4A16DecodeKernel,
+            "gemm_w4a16_kernel": GemmW4A16Kernel,
         }
 
     def _validate_dtypes(
@@ -454,12 +457,14 @@ class GemmW4A16FwdOp(Op):
         k: int,
         dtype: torch.dtype,
     ) -> Kernel:
-        call = GemmCall(m=m, n=n, k=k, dtype=dtype, trans_b=True)
-        key_name = self.select_kernel_key(("gemm_w4a16_decode_kernel", "gemm_w4a16_kernel"), call)
+        call = GemmCall(m=m, n=n, k=k, dtype=dtype, trans_a=False, trans_b=True)
+        kernel_name = self.select_kernel_key(
+            ("gemm_w4a16_decode_kernel", "gemm_w4a16_kernel"), call
+        )
         return self.get_or_build_kernel(
-            key_name,
+            kernel_name,
             key=(m, n, k, dtype, self.group_size),
-            build=lambda: self.kernel_map[key_name](
+            build=lambda: self.kernel_map[kernel_name](
                 m, n, k, dtype, tune=self.tune, group_size=self.group_size
             ),
         )

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -314,8 +314,16 @@ class GemmW4A16Fixture(FixtureBase):
                     512,
                     512,
                     torch.float16,
-                    marks=pytest.mark.smoke,
-                    id="smoke-w4a16-m1",
+                    marks=pytest.mark.full,
+                    id="full-w4a16-m1-direct",
+                ),
+                pytest.param(
+                    1,
+                    64,
+                    1024,
+                    torch.float16,
+                    marks=pytest.mark.full,
+                    id="full-w4a16-m1-tma",
                 ),
                 pytest.param(
                     16,
@@ -372,8 +380,10 @@ def test_gemm_w4a16(m: int, n: int, k: int, dtype: torch.dtype) -> None:
     test = GemmW4A16Test(m, n, k, dtype)
     op = GemmW4A16FwdOp()
     test.check(op, *test.gen_inputs(), atol=7e-2, rtol=5e-2)
-    expected = "GemmW4A16DecodeKernel" if m == 1 else "GemmW4A16Kernel"
-    assert op.kernel.__class__.__name__ == expected
+    expected_kernel = "GemmW4A16DecodeKernel" if m == 1 else "GemmW4A16Kernel"
+    assert op.kernel.__class__.__name__ == expected_kernel
+    if m == 1:
+        assert op.kernel.use_tma == (n % 64 == 0 and k % 1024 == 0)
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
## Summary

- dispatch Hopper FP16 W4A16 calls with M=1 to a dedicated decode kernel
- use register LOP3 decode with CTA-local split-K, plus a TMA producer/consumer path for aligned decode shapes
- preserve the existing packed-weight contract and keep the original GEMM kernel as the general fallback
- register both kernels in the manifest and test direct, TMA, and fallback dispatch

Follow-up to #1739: that PR merged the functional W4A16 MVP, but M=1 decode was still routed through the general M=64 GEMM schedule.

## H200 results

Measured twice with the native-CUPTI phase-isolated-v3 protocol from #1838 (50 repeats, median):

| M, N, K | Current TileOps | This PR | Marlin | This PR / current |
|---|---:|---:|---:|---:|
| 1, 8192, 8192 | 0.1004 ms | 0.0211 ms | 0.0203 ms | 4.76x |
| 1, 8192, 16384 | 0.1995 ms | 0.0387 ms | 0.0381 ms | 5.16x |
| 1, 7168, 20480 | 0.2429 ms | 0.0447 ms | 0.0406 ms | 5.43x |
| 1, 8192, 81920 | 0.9687 ms | 0.1599 ms | 0.1384 ms | 6.06x |

The second run reproduced 0.0211 / 0.0387 / 0.0447 / 0.1599 ms; the first was 0.0211 / 0.0387 / 0.0447 / 0.1613 ms.

## Validation

- W4A16 correctness and dispatch: 5 passed
- manifest and registry validation: 129 passed
- lint and diff checks passed