### PR TITLE
[CI][Runner] Bump the bundled Actions runner to 2.336.0

### DIFF
--- a/.github/runner/Dockerfile
+++ b/.github/runner/Dockerfile
@@ -189,7 +189,7 @@ ENV AGENT_TOOLSDIRECTORY=/home/ci-runner/runner/_work/_tool \
     TRITON_CACHE_DIR=/ci-cache/triton \
     PIP_CACHE_DIR=/ci-cache/pip \
     PIP_NO_CACHE_DIR=0
-ARG RUNNER_VERSION=2.334.0
+ARG RUNNER_VERSION=2.336.0
 # The /ci-cache chown below serves only the unmounted image-verification path
 # (`docker run <image> python ...`, see README): ci-runner writes the root-created cache dirs
 # directly. In the mounted CI path the host bind-mount shadows these dirs, so the chown is a

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -108,7 +108,7 @@ Cache env vars (`TILELANG_CACHE_DIR`, `TRITON_CACHE_DIR`, `PIP_CACHE_DIR`, …) 
 | `MAX_JOBS`         | `64`                                       | Parallelism for the tilelang / FA2 / FA3 source builds.                   |
 | `NVCC_THREADS`     | `4`                                        | Per-`nvcc` threads.                                                       |
 | `DEEPGEMM_GIT_SHA` | `c9f8b34dcdacc20aa746b786f983492c51072870` | DeepGEMM commit for the grouped-GEMM benchmark baseline (`v2.1.1.post3`). |
-| `RUNNER_VERSION`   | `2.334.0`                                  | GitHub Actions runner version baked into `final`.                         |
+| `RUNNER_VERSION`   | `2.336.0`                                  | GitHub Actions runner version baked into `final`.                         |
 
 ### Stages (`--target`)
 


### PR DESCRIPTION
GitHub deprecated runner v2.334.0 on 2026-08-10 and stopped dispatching jobs to it, so both self-hosted runners crash-looped. The version is baked into the image, so the per-job ephemeral rebuild doesn't help.

Bump the default to 2.336.0. The live image is already rebuilt and both runners are back online.
