### PR TITLE
[Bench] Use contract-matching native PyTorch baselines

### DIFF
--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -3,12 +3,10 @@
 Compares TileOPs vs PyTorch cuDNN batch norm on common ResNet-style shapes.
 """
 
-import math
-
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, backward_of
+from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.normalization import BatchNormBwdWorkload, BatchNormFwdWorkload
@@ -16,54 +14,32 @@ from workloads.normalization import BatchNormBwdWorkload, BatchNormFwdWorkload
 _FWD_OP_NAME = "BatchNormFwdOp"
 _BWD_OP_NAME = "BatchNormBwdOp"
 
-# Benchmark classes
 
-
-# Benchmark helpers
-
-
-def _make_inputs(N, C, spatial, dtype, device="cuda"):
-    shape = (N, C, *spatial)
-    x = torch.randn(*shape, device=device, dtype=dtype)
-    weight = torch.randn(C, device=device, dtype=torch.float32)
-    bias = torch.randn(C, device=device, dtype=torch.float32)
-    running_mean = torch.zeros(C, device=device, dtype=torch.float32)
-    running_var = torch.ones(C, device=device, dtype=torch.float32)
-    return x, weight, bias, running_mean, running_var
-
-
-def _make_bwd_inputs(N, C, spatial, dtype, device="cuda"):
-    x, weight, bias, running_mean, running_var = _make_inputs(N, C, spatial, dtype, device)
-    grad_out = torch.randn_like(x)
-    L = N * math.prod(spatial) if spatial else N
-    x_cl = x.float().permute(1, 0, *range(2, x.ndim)).reshape(C, L).contiguous()
-    mean = x_cl.mean(dim=1)
-    var = x_cl.var(dim=1, unbiased=False)
-    rstd = 1.0 / torch.sqrt(var + 1e-5)
-    return grad_out, x, weight, mean, rstd
-
-
-def _torch_bn_fwd(x, weight, bias, running_mean, running_var):
+def _torch_bn_fwd(x, running_mean, running_var, weight, bias, *, training):
     return torch.nn.functional.batch_norm(
-        x.float(),
-        running_mean.clone(),
-        running_var.clone(),
-        weight.float(),
-        bias.float(),
-        training=True,
+        x,
+        running_mean,
+        running_var,
+        weight,
+        bias,
+        training=training,
     )
 
 
 def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
-    """PyTorch reference backward, driven on this thread. Recomputes the forward."""
-    with torch.enable_grad():
-        x32 = x.float().requires_grad_(True)
-        w32 = weight.float().requires_grad_(True)
-        b32 = torch.zeros(x.shape[1], device=x.device, dtype=torch.float32, requires_grad=True)
-        rm = torch.zeros(x.shape[1], device=x.device, dtype=torch.float32)
-        rv = torch.ones(x.shape[1], device=x.device, dtype=torch.float32)
-        y = torch.nn.functional.batch_norm(x32, rm, rv, w32, b32, training=True, eps=1e-5)
-    return backward_of(y)(grad_out.float())
+    """Run ATen BatchNorm backward with the contract's saved statistics."""
+    return torch.ops.aten.native_batch_norm_backward.default(
+        grad_out,
+        x,
+        weight,
+        None,
+        None,
+        mean,
+        rstd,
+        True,
+        1e-5,
+        [True, True, True],
+    )
 
 
 # Manifest-driven params
@@ -100,22 +76,28 @@ def _manifest_bwd_params():
 
 @pytest.mark.parametrize("N, C, spatial, dtype, training, tune", _manifest_fwd_params())
 def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
-    x, weight, bias, running_mean, running_var = _make_inputs(N, C, spatial, dtype)
+    test = BatchNormFwdWorkload(N, C, spatial, dtype, training)
+    x, weight, bias, running_mean, running_var = test.gen_inputs()
     # Manifest input order: (x, running_mean, running_var, weight, bias).
     inputs = (x, running_mean, running_var, weight, bias)
 
     op = BatchNormFwdOp(training=training, tune=tune)
-
-    test = BatchNormFwdWorkload(N, C, spatial, dtype, training)
     bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
 
-    spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
+    spatial = str(spatial)  # stringify tuple so it survives report parameter filtering
+
+    def baseline_fn(x, running_mean, running_var, weight, bias):
+        return _torch_bn_fwd(
+            x,
+            running_mean,
+            running_var,
+            weight,
+            bias,
+            training=training,
+        )
 
     bm.compare(
-        {
-            "tileops": lambda *a: op(*a),
-            "torch-cudnn": lambda x, rm, rv, w, b: _torch_bn_fwd(x, w, b, rm, rv),
-        },
+        {"tileops": op, "torch-cudnn": baseline_fn},
         *inputs,
         record_as=op,
         params=locals(),
@@ -124,15 +106,17 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
 
 @pytest.mark.parametrize("N, C, spatial, dtype", _manifest_bwd_params())
 def test_batch_norm_bwd_bench(N, C, spatial, dtype):
-    inputs = _make_bwd_inputs(N, C, spatial, dtype)
+    test = BatchNormBwdWorkload(N, C, spatial, dtype)
+    inputs = test.gen_inputs()
 
     op = BatchNormBwdOp()
-
-    test = BatchNormBwdWorkload(N, C, spatial, dtype)
     bm = ManifestBenchmark(_BWD_OP_NAME, op, test)
 
-    spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
+    spatial = str(spatial)  # stringify tuple so it survives report parameter filtering
 
     bm.compare(
-        {"tileops": op, "torch-autograd": _torch_bn_bwd}, *inputs, record_as=op, params=locals()
+        {"tileops": op, "torch-aten": _torch_bn_bwd},
+        *inputs,
+        record_as=op,
+        params=locals(),
     )

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -8,11 +8,7 @@ Workload shapes and roofline formulas are loaded from the ops manifest
 import pytest
 import torch
 
-from benchmarks.benchmark_base import (
-    BenchmarkReport,
-    ManifestBenchmark,
-    workloads_to_params,
-)
+from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from workloads.reduction import CumulativeWorkload
 
 _CUMSUM_OP = "CumsumFwdOp"
@@ -41,6 +37,14 @@ class CumulativeBenchmarkWorkload(CumulativeWorkload):
         raise ValueError(f"Unknown op_kind: {self.op_kind}")
 
 
+def _torch_cumsum(x: torch.Tensor) -> torch.Tensor:
+    return torch.cumsum(x, dim=-1)
+
+
+def _torch_cumprod(x: torch.Tensor) -> torch.Tensor:
+    return torch.cumprod(x, dim=-1)
+
+
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMSUM_OP))
 def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     test = CumulativeBenchmarkWorkload(shape, dtype, "cumsum")
@@ -49,7 +53,12 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumsum")
     bm = ManifestBenchmark(_CUMSUM_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch": _torch_cumsum},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
@@ -60,4 +69,9 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
     op = _make_op(shape, dtype, "cumprod")
     bm = ManifestBenchmark(_CUMPROD_OP, op, test)
 
-    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
+    bm.compare(
+        {"tileops": op, "torch": _torch_cumprod},
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops.norm.fused_add_layer_norm import FusedAddLayerNormFwdOp
 from tileops.ops.norm.fused_add_rms_norm import FusedAddRMSNormFwdOp
@@ -18,6 +18,10 @@ from workloads.normalization import (
 )
 
 _RMS_OP_NAME = "RMSNormFwdOp"
+
+
+def _torch_rms_norm(x, weight, *, normalized_shape, eps):
+    return F.rms_norm(x, normalized_shape, weight=weight, eps=eps)
 
 
 def _rms_params():
@@ -40,8 +44,14 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
     op = RMSNormFwdOp(normalized_shape=(n,), tune=tune)
     bm = ManifestBenchmark(_RMS_OP_NAME, op, test)
 
+    def baseline_fn(x, weight):
+        return _torch_rms_norm(x, weight, normalized_shape=(n,), eps=test.eps)
+
     bm.compare(
-        {"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals()
+        {"tileops": op, "torch": baseline_fn},
+        *inputs,
+        record_as=op,
+        params=locals(),
     )
 
 

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -7,7 +7,7 @@ Workload shapes and roofline formulas are loaded from the ops manifest (src/tile
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.reduce import (
     AmaxFwdOp,
     AminFwdOp,
@@ -41,6 +41,30 @@ _VAR_OP = "VarFwdOp"
 _VAR_MEAN_OP = "VarMeanFwdOp"
 
 
+def _torch_sum(x, *, dim, keepdim):
+    return torch.sum(x, dim=dim, keepdim=keepdim)
+
+
+def _torch_mean(x, *, dim, keepdim):
+    return torch.mean(x, dim=dim, keepdim=keepdim)
+
+
+def _torch_prod(x):
+    return torch.prod(x, dim=-1)
+
+
+def _torch_std(x, *, dim, keepdim):
+    return torch.std(x, dim=dim, keepdim=keepdim, correction=1)
+
+
+def _torch_var(x, *, dim, keepdim):
+    return torch.var(x, dim=dim, keepdim=keepdim, correction=1)
+
+
+def _torch_var_mean(x, *, dim, keepdim):
+    return torch.var_mean(x, dim=dim, keepdim=keepdim, correction=1)
+
+
 # Sum benchmarks
 
 
@@ -59,7 +83,7 @@ def test_sum_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return x.float().sum(dim=dim, keepdim=keepdim).to(x.dtype)
+        return _torch_sum(x, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -87,7 +111,7 @@ def test_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
+        return _torch_mean(x, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -163,12 +187,8 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = ProdFwdOp()
     bm = ManifestBenchmark(_PROD_OP, op, test)
-
-    def baseline_fn(x):
-        return x.float().prod(dim=-1).to(x.dtype)
-
     try:
-        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
+        bm.compare({"tileops": op, "torch": _torch_prod}, *inputs, record_as=op, params=locals())
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
@@ -193,7 +213,7 @@ def test_std_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return x.float().std(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
+        return _torch_std(x, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -221,7 +241,7 @@ def test_var_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> None:
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return x.float().var(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
+        return _torch_var(x, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -249,9 +269,7 @@ def test_var_mean_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        v = x.float().var(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
-        m = x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
-        return (v, m)
+        return _torch_var_mean(x, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -7,7 +7,7 @@ Workload shapes and roofline formulas are loaded from the ops manifest (src/tile
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, workloads_to_params
+from benchmarks.benchmark_base import ManifestBenchmark, workloads_to_params
 from tileops.ops.reduction.vector_norm import InfNormFwdOp, L1NormFwdOp, L2NormFwdOp
 from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
 
@@ -16,6 +16,10 @@ from workloads.reduction import InfNormWorkload, L1NormWorkload, L2NormWorkload
 _L1_NORM_OP = "L1NormFwdOp"
 _L2_NORM_OP = "L2NormFwdOp"
 _INF_NORM_OP = "InfNormFwdOp"
+
+
+def _torch_vector_norm(x, *, ord, dim, keepdim):
+    return torch.linalg.vector_norm(x, ord=ord, dim=dim, keepdim=keepdim)
 
 
 # L1 Norm benchmarks
@@ -36,12 +40,7 @@ def test_l1_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(
-            x.float(),
-            ord=1,
-            dim=dim,
-            keepdim=keepdim,
-        ).to(x.dtype)
+        return _torch_vector_norm(x, ord=1, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -69,12 +68,7 @@ def test_l2_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> Non
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(
-            x.float(),
-            ord=2,
-            dim=dim,
-            keepdim=keepdim,
-        ).to(x.dtype)
+        return _torch_vector_norm(x, ord=2, dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
@@ -102,12 +96,7 @@ def test_inf_norm_bench(shape: tuple, dtype: torch.dtype, op_params: dict) -> No
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
-        return torch.linalg.vector_norm(
-            x.float(),
-            ord=float("inf"),
-            dim=dim,
-            keepdim=keepdim,
-        ).to(x.dtype)
+        return _torch_vector_norm(x, ord=float("inf"), dim=dim, keepdim=keepdim)
 
     try:
         bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())

--- a/benchmarks/tests/test_native_baselines.py
+++ b/benchmarks/tests/test_native_baselines.py
@@ -38,17 +38,18 @@ def test_reduction_baselines_preserve_contract_dtype(dtype):
     cases = [
         (_torch_sum(x, dim=dim, keepdim=keepdim), x.float().sum(dim, keepdim=True)),
         (_torch_mean(x, dim=dim, keepdim=keepdim), x.float().mean(dim, keepdim=True)),
-        (_torch_std(x, dim=dim, keepdim=keepdim),
-         x.float().std(dim, keepdim=True, correction=1)),
-        (_torch_var(x, dim=dim, keepdim=keepdim),
-         x.float().var(dim, keepdim=True, correction=1)),
+        (_torch_std(x, dim=dim, keepdim=keepdim), x.float().std(dim, keepdim=True, correction=1)),
+        (_torch_var(x, dim=dim, keepdim=keepdim), x.float().var(dim, keepdim=True, correction=1)),
     ]
     for actual, expected in cases:
         _assert_contract_output(actual, expected.to(dtype), dtype)
 
     actual_var, actual_mean = _torch_var_mean(x, dim=dim, keepdim=keepdim)
     expected_var, expected_mean = torch.var_mean(
-        x.float(), dim=dim, keepdim=keepdim, correction=1,
+        x.float(),
+        dim=dim,
+        keepdim=keepdim,
+        correction=1,
     )
     _assert_contract_output(actual_var, expected_var.to(dtype), dtype)
     _assert_contract_output(actual_mean, expected_mean.to(dtype), dtype)
@@ -107,10 +108,20 @@ def test_batch_norm_forward_uses_contract_inputs_and_updates_state(dtype):
     ref_var = running_var.clone()
 
     actual = _torch_bn_fwd(
-        x, running_mean, running_var, weight, bias, training=True,
+        x,
+        running_mean,
+        running_var,
+        weight,
+        bias,
+        training=True,
     )
     expected, expected_mean, expected_var = batch_norm_fwd_ref(
-        x, weight, bias, ref_mean, ref_var, training=True,
+        x,
+        weight,
+        bias,
+        ref_mean,
+        ref_var,
+        training=True,
     )
 
     _assert_contract_output(actual, expected, dtype)
@@ -133,5 +144,8 @@ def test_batch_norm_backward_consumes_saved_statistics(dtype):
         assert actual_tensor.shape == expected_tensor.shape
         assert actual_tensor.dtype == expected_tensor.dtype
         assert torch.allclose(
-            actual_tensor.float(), expected_tensor.float(), atol=2e-2, rtol=2e-2,
+            actual_tensor.float(),
+            expected_tensor.float(),
+            atol=2e-2,
+            rtol=2e-2,
         )

--- a/benchmarks/tests/test_native_baselines.py
+++ b/benchmarks/tests/test_native_baselines.py
@@ -1,0 +1,137 @@
+"""Contract tests for the native framework performance baselines."""
+
+import pytest
+import torch
+
+from benchmarks.ops.bench_batch_norm import _torch_bn_bwd, _torch_bn_fwd
+from benchmarks.ops.bench_cumulative import _torch_cumprod, _torch_cumsum
+from benchmarks.ops.bench_norm import _torch_rms_norm
+from benchmarks.ops.bench_reduce import (
+    _torch_mean,
+    _torch_prod,
+    _torch_std,
+    _torch_sum,
+    _torch_var,
+    _torch_var_mean,
+)
+from benchmarks.ops.bench_vector_norm import _torch_vector_norm
+from workloads.normalization import (
+    BatchNormBwdWorkload,
+    batch_norm_fwd_ref,
+)
+
+
+def _assert_contract_output(actual, expected, dtype):
+    assert actual.dtype == dtype
+    assert actual.shape == expected.shape
+    assert torch.allclose(actual.float(), expected.float(), atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_reduction_baselines_preserve_contract_dtype(dtype):
+    x = torch.randn(8, 64, device="cuda", dtype=dtype)
+    dim = -1
+    keepdim = True
+
+    cases = [
+        (_torch_sum(x, dim=dim, keepdim=keepdim), x.float().sum(dim, keepdim=True)),
+        (_torch_mean(x, dim=dim, keepdim=keepdim), x.float().mean(dim, keepdim=True)),
+        (_torch_std(x, dim=dim, keepdim=keepdim),
+         x.float().std(dim, keepdim=True, correction=1)),
+        (_torch_var(x, dim=dim, keepdim=keepdim),
+         x.float().var(dim, keepdim=True, correction=1)),
+    ]
+    for actual, expected in cases:
+        _assert_contract_output(actual, expected.to(dtype), dtype)
+
+    actual_var, actual_mean = _torch_var_mean(x, dim=dim, keepdim=keepdim)
+    expected_var, expected_mean = torch.var_mean(
+        x.float(), dim=dim, keepdim=keepdim, correction=1,
+    )
+    _assert_contract_output(actual_var, expected_var.to(dtype), dtype)
+    _assert_contract_output(actual_mean, expected_mean.to(dtype), dtype)
+
+    prod_input = torch.rand(8, 64, device="cuda", dtype=dtype) * 0.01 + 0.99
+    _assert_contract_output(
+        _torch_prod(prod_input),
+        prod_input.float().prod(dim=-1).to(dtype),
+        dtype,
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_norm_and_cumulative_baselines_preserve_contract_dtype(dtype):
+    x = torch.randn(8, 64, device="cuda", dtype=dtype)
+    weight = torch.randn(64, device="cuda", dtype=dtype)
+
+    for order in (1, 2, float("inf")):
+        actual = _torch_vector_norm(x, ord=order, dim=-1, keepdim=False)
+        expected = torch.linalg.vector_norm(x.float(), ord=order, dim=-1).to(dtype)
+        _assert_contract_output(actual, expected, dtype)
+
+    actual_rms = _torch_rms_norm(x, weight, normalized_shape=(64,), eps=1e-5)
+    rms = torch.sqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + 1e-5)
+    expected_rms = (x.float() / rms * weight.float()).to(dtype)
+    _assert_contract_output(actual_rms, expected_rms, dtype)
+
+    cumulative_input = torch.randn(8, 64, device="cuda", dtype=dtype) * 0.01
+    _assert_contract_output(
+        _torch_cumsum(cumulative_input),
+        cumulative_input.float().cumsum(dim=-1).to(dtype),
+        dtype,
+    )
+
+    product_input = cumulative_input + 0.99
+    _assert_contract_output(
+        _torch_cumprod(product_input),
+        product_input.float().cumprod(dim=-1).to(dtype),
+        dtype,
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_batch_norm_forward_uses_contract_inputs_and_updates_state(dtype):
+    n, c, spatial = 4, 8, (4, 4)
+    x = torch.randn(n, c, *spatial, device="cuda", dtype=dtype)
+    weight = torch.randn(c, device="cuda", dtype=torch.float32)
+    bias = torch.randn(c, device="cuda", dtype=torch.float32)
+    running_mean = torch.zeros(c, device="cuda", dtype=torch.float32)
+    running_var = torch.ones(c, device="cuda", dtype=torch.float32)
+    ref_mean = running_mean.clone()
+    ref_var = running_var.clone()
+
+    actual = _torch_bn_fwd(
+        x, running_mean, running_var, weight, bias, training=True,
+    )
+    expected, expected_mean, expected_var = batch_norm_fwd_ref(
+        x, weight, bias, ref_mean, ref_var, training=True,
+    )
+
+    _assert_contract_output(actual, expected, dtype)
+    assert torch.allclose(running_mean, expected_mean, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(running_var, expected_var, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_batch_norm_backward_consumes_saved_statistics(dtype):
+    workload = BatchNormBwdWorkload(4, 8, (4, 4), dtype)
+    inputs = workload.gen_inputs()
+
+    actual = _torch_bn_bwd(*inputs)
+    expected = workload.ref_program(*inputs)
+
+    assert len(actual) == len(expected) == 3
+    for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+        assert actual_tensor.shape == expected_tensor.shape
+        assert actual_tensor.dtype == expected_tensor.dtype
+        assert torch.allclose(
+            actual_tensor.float(), expected_tensor.float(), atol=2e-2, rtol=2e-2,
+        )


### PR DESCRIPTION
Closes #1881

## Summary

- time direct, contract-dtype PyTorch APIs for reductions, vector norms,
  cumulative ops, and RMSNorm instead of explicit FP32 materialization or
  decomposed calls;
- use `F.batch_norm` without timed state clones and
  `aten.native_batch_norm_backward` with the supplied saved statistics;
- retain the existing high-precision correctness references and keep the
  manifest/report schemas unchanged;
- add focused FP16/BF16 tests for values, dtypes, tuple outputs, and BatchNorm
  running/saved-stat semantics.

## Validation

- `ruff check` on all changed files;
- H200: all 62 affected parameterized benchmark cases passed;
- H200: 8/8 focused contract tests passed;
- PR #1838 native-CUPTI A/B: 62/62 cases passed, with 124/124 records using
  50 samples, zero dropped records, and no CUDA Event fallback.
