### PR TITLE
[Perf][foundry][MoE] Reduce sparse fused-MoE launch waste on H200

### DIFF
--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -1,8 +1,8 @@
 """Benchmark for FusedMoEExpertsNopadPersistent3WGFwdOp.
 
 Measures the permute + grouped-GEMM + unpermute pipeline without routing.
-The nopad (3WG persistent kernel) layout is benchmarked
-against vLLM Triton fused_experts and vLLM CUTLASS fused_experts (when available).
+The fused-activation nopad path is compared in one drift-balanced run with the
+base default pipeline and vLLM Triton fused_experts.
 
 Workloads match the manifest entries (shared workload set):
 
@@ -13,17 +13,17 @@ Workloads match the manifest entries (shared workload set):
   DeepSeek-V3      4096  7168  2048  256   8   (prefill)
 
 Baselines:
-  - tileops-nopad-3wg: FusedMoEExpertsNopadPersistent3WGFwdOp (default 3WG kernel)
-  - vllm-triton:       vLLM Triton fused_experts (default backend)
-  - vllm-cutlass:      vLLM CUTLASS fused_experts (when importable)
-  - torch-ref:         per-expert GEMM loop with index_add_ (fallback)
-"""
+  - base-incumbent: default unfused FusedMoEExpertsNopadPersistent3WGFwdOp
+  - vllm-triton:   vLLM Triton fused_experts (default backend)
+  - torch-ref:     workload FP32 oracle (only when vLLM is unavailable)
 
-import warnings
+vLLM 0.19.1's CUTLASS MoE module exposes quantized FP8/FP4 paths, not a
+matching BF16 entry point, so it is intentionally not reported as an
+equivalent baseline.
+"""
 
 import pytest
 import torch
-import torch.nn.functional as F
 
 try:
     from vllm.model_executor.layers.fused_moe.fused_moe import (
@@ -33,27 +33,8 @@ try:
 except ImportError:
     _VLLM_TRITON_AVAILABLE = False
 
-try:
-    from vllm.model_executor.layers.fused_moe.cutlass_moe import (
-        cutlass_moe_fp16 as _vllm_cutlass_moe,
-    )
-    _VLLM_CUTLASS_AVAILABLE = True
-except ImportError:
-    try:
-        from vllm.model_executor.layers.fused_moe.cutlass_moe import (
-            cutlass_moe as _vllm_cutlass_moe,
-        )
-        _VLLM_CUTLASS_AVAILABLE = True
-    except ImportError as _cutlass_import_err:
-        _VLLM_CUTLASS_AVAILABLE = False
-        warnings.warn(
-            f"vLLM CUTLASS MoE baseline unavailable ({_cutlass_import_err}); "
-            "the vllm-cutlass column will be omitted from results.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import ManifestBenchmark
+from tileops.kernels.moe import MoeGroupedGemmPersistent3WGFusedActKernel
 from tileops.manifest import load_workloads
 from tileops.ops.moe import (
     FusedMoEExpertsNopadPersistent3WGFwdOp,
@@ -104,72 +85,63 @@ def test_moe_experts_nopad_bench(
         num_tokens=num_tokens, num_experts=num_experts, top_k=top_k,
         hidden_size=hidden_size, ffn_size=ffn_size,
     )
-    output = torch.empty(num_tokens, hidden_size, dtype=dtype, device="cuda")
+    candidate_output = torch.empty(
+        num_tokens, hidden_size, dtype=dtype, device="cuda"
+    )
+    incumbent_output = torch.empty_like(candidate_output)
     ws1 = torch.empty(0, dtype=dtype, device="cuda")
     ws2 = torch.empty(0, dtype=dtype, device="cuda")
 
-    # -- TileOPs nopad (3WG persistent) --------------------------------------
-    nopad = FusedMoEExpertsNopadPersistent3WGFwdOp(**kwargs)
-    bm = ManifestBenchmark(_OP_NAME, nopad, test)
+    candidate = FusedMoEExpertsNopadPersistent3WGFwdOp(
+        **kwargs,
+        use_fused_activation=True,
+    )
+    incumbent = FusedMoEExpertsNopadPersistent3WGFwdOp(**kwargs)
+    bm = ManifestBenchmark(_OP_NAME, candidate, test)
 
-    def _nopad_fn(hidden, w1, w2, topk_weights, topk_ids):
-        nopad.forward(
-            output, hidden, w1, w2, topk_weights, topk_ids,
+    def _candidate_fn(hidden, w1, w2, topk_weights, topk_ids):
+        candidate.forward(
+            candidate_output, hidden, w1, w2, topk_weights, topk_ids,
             expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=num_experts,
         )
-        return output
+        return candidate_output
 
-    _nopad_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup / JIT compile
+    def _incumbent_fn(hidden, w1, w2, topk_weights, topk_ids):
+        incumbent.forward(
+            incumbent_output, hidden, w1, w2, topk_weights, topk_ids,
+            expert_map=None, workspace1=ws1, workspace2=ws2, num_experts=num_experts,
+        )
+        return incumbent_output
+
+    implementations = {
+        "tileops-fused-act": _candidate_fn,
+        "base-incumbent": _incumbent_fn,
+    }
+    if _VLLM_TRITON_AVAILABLE:
+        implementations["vllm-triton"] = _vllm_fused_experts
+    else:
+        implementations["torch-ref"] = test.ref_program
+
+    # Compile all paths before timing. The class assertion prevents a measured
+    # row from being silently attributed to the fused path after a fallback.
+    for fn in implementations.values():
+        fn(hidden, w1, w2, topk_weights, topk_ids)
+    fused_kernels = candidate._gemm_gate_up.built_kernels(
+        "moe_grouped_gemm_fused_act_kernel"
+    )
+    assert fused_kernels and all(
+        isinstance(kernel, MoeGroupedGemmPersistent3WGFusedActKernel)
+        for kernel in fused_kernels.values()
+    )
     torch.cuda.synchronize()
 
-    functors = {"tileops-nopad-3wg": _nopad_fn}
+    bm.compare(
+        implementations,
+        hidden, w1, w2, topk_weights, topk_ids,
+        record_as=candidate,
+        params=locals(),
+    )
 
-    # -- vLLM Triton baseline -------------------------------------------------
-    if _VLLM_TRITON_AVAILABLE:
-        def _vllm_triton_fn(hidden, w1, w2, topk_weights, topk_ids):
-            return _vllm_fused_experts(hidden, w1, w2, topk_weights, topk_ids)
 
-        _vllm_triton_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
-        torch.cuda.synchronize()
-
-        functors["vllm-triton"] = _vllm_triton_fn
-
-    # -- vLLM CUTLASS baseline ------------------------------------------------
-    if _VLLM_CUTLASS_AVAILABLE:
-        try:
-            def _vllm_cutlass_fn(hidden, w1, w2, topk_weights, topk_ids):
-                return _vllm_cutlass_moe(hidden, w1, w2, topk_weights, topk_ids)
-
-            _vllm_cutlass_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
-            torch.cuda.synchronize()
-
-            functors["vllm-cutlass"] = _vllm_cutlass_fn
-        except Exception as e:
-            print(f"[vllm-cutlass] skipped: {e}")
-
-    # -- Torch fallback -------------------------------------------------------
-    if not _VLLM_TRITON_AVAILABLE:
-        output_buf = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device=hidden.device)
-        ids_i64 = topk_ids.to(torch.int64)
-
-        def _torch_fn(hidden, w1, w2, topk_weights, topk_ids):
-            output_buf.zero_()
-            for e in range(num_experts):
-                mask = (ids_i64 == e)
-                if not mask.any():
-                    continue
-                t_idx, k_idx = mask.nonzero(as_tuple=True)
-                h = hidden[t_idx].float()
-                gate_up = h @ w1[e].float().t()
-                ffn_dim = w1.shape[1] // 2
-                act = F.silu(gate_up[:, :ffn_dim]) * gate_up[:, ffn_dim:]
-                down = act @ w2[e].float().t()
-                output_buf.index_add_(0, t_idx, down * topk_weights[t_idx, k_idx].float().unsqueeze(-1))
-            return output_buf.to(hidden.dtype)
-
-        _torch_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
-        torch.cuda.synchronize()
-
-        functors["torch-ref"] = _torch_fn
-
-    bm.compare(functors, hidden, w1, w2, topk_weights, topk_ids, record_as=nopad, params=locals())
+if __name__ == "__main__":
+    pytest.main([__file__, "-vvs"])

--- a/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
+++ b/src/tileops/kernels/moe/moe_grouped_gemm_persistent_3wg_fused_act.py
@@ -29,6 +29,11 @@ _DEFAULT_CONFIG = {
     "num_stages": 3, "threads": 384, "group_size_m": 1,
 }
 
+_SPARSE_EXPERT_CONFIG = {
+    "block_m": 64, "block_n": 128, "block_k": 64,
+    "num_stages": 2, "threads": 384, "group_size_m": 1,
+}
+
 
 def _act_expr(name):
     """Return a fn(g_fp32) -> activated fp32 TIR expr (compile-time specialized)."""
@@ -68,6 +73,10 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
 
     @property
     def default_config(self) -> dict:
+        # With at most 16 routed rows per expert, BM64 avoids enough empty work
+        # to offset the cooperative BM128 template's stronger weight reuse.
+        if self.numel <= 16 * self.num_experts:
+            return dict(_SPARSE_EXPERT_CONFIG)
         return dict(_DEFAULT_CONFIG)
 
     @property
@@ -141,7 +150,10 @@ class MoeGroupedGemmPersistent3WGFusedActKernel(Kernel):
             print("Autotune failed for all configs, using default.")
 
     def forward(self, A, B, true_sizes, true_offsets):
-        C = torch.zeros(self.numel, self.N, dtype=self.dtype, device=A.device)
+        # Every locally routed row is fully written, including the predicated
+        # tail-M path. EP-only unused tail rows are excluded by true_sizes and
+        # fwd_idx, so no downstream consumer observes an unwritten element.
+        C = torch.empty(self.numel, self.N, dtype=self.dtype, device=A.device)
         bm, bn, bk = self.config["block_m"], self.config["block_n"], self.config["block_k"]
         if self.K % bk != 0:
             raise ValueError(f"K-aligned only: K={self.K}, block_k={bk}")

--- a/tests/ops/test_fused_moe_experts.py
+++ b/tests/ops/test_fused_moe_experts.py
@@ -17,26 +17,16 @@ from tileops.ops.moe.routed_expert.fused_routed_expert import (
 from tileops.ops.moe.routed_expert.moe_grouped_gemm_nopad_fused_act import (
     MoeGroupedGemmNopad3WGFusedActFwdOp,
 )
+from workloads.moe import MoeExpertsWorkload
 
 
-def _torch_ref_moe(hidden, w1, w2, topk_weights, topk_ids):
-    """Per-expert PyTorch reference: ground-truth MoE FFN."""
+def _workload_ref_moe(hidden, w1, w2, topk_weights, topk_ids):
     T, H = hidden.shape
     E, twoF, _ = w1.shape
-    F_dim = twoF // 2
-    output = torch.zeros(T, H, dtype=torch.float32, device=hidden.device)
-    ids_i64 = topk_ids.to(torch.int64)
-    for e in range(E):
-        mask = (ids_i64 == e)
-        if not mask.any():
-            continue
-        t_idx, k_idx = mask.nonzero(as_tuple=True)
-        h = hidden[t_idx].float()
-        gate_up = h @ w1[e].float().t()
-        act = F.silu(gate_up[:, :F_dim]) * gate_up[:, F_dim:]
-        down = act @ w2[e].float().t()
-        output.index_add_(0, t_idx, down * topk_weights[t_idx, k_idx].float().unsqueeze(-1))
-    return output.to(hidden.dtype)
+    workload = MoeExpertsWorkload(
+        T, E, topk_ids.shape[1], H, twoF // 2, hidden.dtype
+    )
+    return workload.ref_program(hidden, w1, w2, topk_weights, topk_ids)
 
 
 def _torch_ref_moe_activation(hidden, w1, w2, topk_weights, topk_ids, activation="silu_and_mul"):
@@ -199,7 +189,9 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
             hidden_size=d["H"], ffn_size=d["F"],
         )
 
-        ref_out = _torch_ref_moe(d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"])
+        ref_out = _workload_ref_moe(
+            d["hidden"], d["w1"], d["w2"], d["weights"], d["ids"]
+        )
 
         output = torch.empty(d["T"], d["H"], dtype=d["dtype"], device="cuda")
         ws1 = torch.empty(0, dtype=d["dtype"], device="cuda")
@@ -240,7 +232,7 @@ class TestFusedMoEExpertsNopadPersistent3WGFwdOp:
             for rec in caplog.records
         ), f"expected fallback warning, got: {[rec.message for rec in caplog.records]}"
 
-        ref_out = _torch_ref_moe(hidden, w1, w2, weights, ids)
+        ref_out = _workload_ref_moe(hidden, w1, w2, weights, ids)
         output = torch.empty(T, H, dtype=dtype, device="cuda")
         ws1 = torch.empty(0, dtype=dtype, device="cuda")
         ws2 = torch.empty(0, dtype=dtype, device="cuda")
@@ -584,3 +576,35 @@ def test_fused_act_fwd_op_shape_and_values():
         gu = A[o:o+n].float() @ B[e].float().t()
         exp[o:o+n] = (F.silu(gu[:, :ffn]) * gu[:, ffn:]).to(torch.bfloat16)
     torch.testing.assert_close(out, exp, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.smoke
+def test_fused_act_sparse_experts_tail_and_empty_groups():
+    """The sparse-expert config writes every row across empty groups and an M tail."""
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Requires SM90")
+    numel, E, ffn, K = 130, 64, 128, 64
+    sizes = torch.zeros(E, dtype=torch.int32, device="cuda")
+    sizes[0], sizes[7], sizes[-1] = 65, 1, 64
+    offsets = torch.zeros(E, dtype=torch.int32, device="cuda")
+    offsets[1:] = torch.cumsum(sizes[:-1], dim=0)
+    A = torch.randn(numel, K, dtype=torch.bfloat16, device="cuda") * 0.02
+    B = torch.randn(E, 2 * ffn, K, dtype=torch.bfloat16, device="cuda") * 0.02
+
+    op = MoeGroupedGemmNopad3WGFusedActFwdOp(
+        numel=numel, num_experts=E, ffn=ffn, k=K,
+        activation="silu_and_mul",
+    )
+    out = op(A, B, sizes, offsets)
+    kernels = op.built_kernels("moe_grouped_gemm_fused_act_kernel")
+    assert kernels and all(kernel.config["block_m"] == 64 for kernel in kernels.values())
+
+    expected = torch.empty_like(out)
+    for expert in (0, 7, E - 1):
+        count, offset = int(sizes[expert]), int(offsets[expert])
+        gate_up = A[offset:offset + count].float() @ B[expert].float().t()
+        expected[offset:offset + count] = (
+            F.silu(gate_up[:, :ffn]) * gate_up[:, ffn:]
+        ).to(torch.bfloat16)
+    assert torch.isfinite(out.float()).all()
+    torch.testing.assert_close(out, expected, rtol=2e-2, atol=2e-2)

--- a/workloads/moe.py
+++ b/workloads/moe.py
@@ -287,6 +287,33 @@ class MoeExpertsWorkload(WorkloadBase):
         topk_ids = torch.randint(0, self.num_experts, (self.num_tokens, self.top_k), dtype=torch.int32, device=dev)
         return hidden, w1, w2, topk_weights, topk_ids
 
+    def ref_program(self, hidden, w1, w2, topk_weights, topk_ids):
+        """FP32 per-expert oracle for the routed SwiGLU expert block."""
+        output = torch.zeros(
+            self.num_tokens,
+            self.hidden_size,
+            dtype=torch.float32,
+            device=hidden.device,
+        )
+        ids_i64 = topk_ids.to(torch.int64)
+        for expert in range(self.num_experts):
+            mask = ids_i64 == expert
+            if not mask.any():
+                continue
+            token_idx, route_idx = mask.nonzero(as_tuple=True)
+            gate_up = hidden[token_idx].float() @ w1[expert].float().t()
+            inner = (
+                torch.nn.functional.silu(gate_up[:, : self.ffn_size])
+                * gate_up[:, self.ffn_size :]
+            )
+            down = inner @ w2[expert].float().t()
+            output.index_add_(
+                0,
+                token_idx,
+                down * topk_weights[token_idx, route_idx].float().unsqueeze(-1),
+            )
+        return output.to(hidden.dtype)
+
 
 class MoeFusedActivationWorkload(WorkloadBase):
     """Workload descriptor for fused vs unfused activation benchmark."""


### PR DESCRIPTION
## Summary

- Select the lower-waste BM64/stage2 fused gate/up template for sparse routed rows.
- Remove one redundant output clear while preserving the public fallback, activation, and expert-parallel behavior.
- Compare the candidate, exact TileOPs incumbent, and vLLM Triton on every primary manifest workload.

## TileFoundry Description

```python
@module(
    entry="routed_experts",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132), Topology("thread", 256)),
)
class RoutedExperts:
    @func
    def routed_experts(
        hidden: Tensor[(T, H), DT],
        topk_weights: Tensor[(T, K), "f32"],
        topk_ids: Tensor[(T, K), "i32"],
        w_gate_up: ConstTensor[(E, 2 * F, H), DT],
        w_down: ConstTensor[(E, H, F), DT],
    ) -> Tensor[(T, H), DT]:
        flat_ids = tf.reshape(topk_ids, new_shape=(T * K,))
        selected_in = tf.reshape(
            tf.index_select(w_gate_up, flat_ids, dim=0),
            new_shape=(T, K, 2 * F, H),
        )
        both = tf.reshape(
            tf.matmul(selected_in, tf.reshape(hidden, new_shape=(T, 1, H, 1))),
            new_shape=(T, K, 2 * F),
        )
        inner = tf.silu(both[:, :, :F]) * both[:, :, F:]
        selected_down = tf.reshape(
            tf.index_select(w_down, flat_ids, dim=0),
            new_shape=(T, K, H, F),
        )
        down = tf.reshape(
            tf.matmul(selected_down, tf.reshape(inner, new_shape=(T, K, F, 1))),
            new_shape=(T, K, H),
        )
        weighted = tf.cast(down, dtype="f32") * tf.reshape(
            topk_weights, new_shape=(T, K, 1)
        )
        mixed = tf.reduce(weighted, axes=(1,), keepdim=False, kind="sum")
        scaled = mixed * tf.full_like(mixed, value=ROUTED_SCALING_FACTOR)
        return tf.cast(scaled, dtype=DT)
```

## Performance

Operator: `FusedMoEExpertsNopadPersistent3WGFwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev |
| digest | sha256:2590888968a870216e1ea076829b909e62e9053608f6a65d5ab5ecd7eb5561f7 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| vllm | 0.27.1 |
| timer | native CUPTI |

Method: Candidate, incumbent, and vLLM ran in one process on common inputs with identical BF16 work, L2 reset/input rotation, adaptive repeats, and forward/reverse drift balancing. Compilation was excluded and CUPTI failure was fail-closed.

| Workload | T | E | K | H | F | Dtype | TileFoundry candidate (ms) | TileOPs incumbent (ms) | vLLM Triton (ms) | TileOPs incumbent / candidate | vLLM Triton / candidate |
| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| qwen3-235b-decode | 512 | 128 | 8 | 7168 | 2048 | bfloat16 | 3.0439 | 3.1617 | 2.9422 | 1.0387x | 0.9666x |
| qwen3-235b-prefill | 4096 | 128 | 8 | 7168 | 2048 | bfloat16 | 6.0151 | 5.7425 | 6.7984 | 0.9547x | 1.1302x |
| deepseek-v3-decode | 512 | 256 | 8 | 7168 | 2048 | bfloat16 | 5.8042 | 6.1058 | 5.5988 | 1.0520x | 0.9646x |
| deepseek-v3-prefill | 4096 | 256 | 8 | 7168 | 2048 | bfloat16 | 8.21 | 8.1078 | 8.5403 | 0.9876x | 1.0402x |
| geometric mean |  |  |  |  |  |  | 5.43488 | 5.47541 | 5.56111 | 1.0075x | 1.0232x |

## Result And Limitations

**improvement without SOTA**

- Classification is improvement without SOTA: the candidate geometric mean is lower than incumbent and vLLM, but both decode rows remain slower than vLLM and both prefill rows remain slower than the incumbent.
- The public default remains unchanged; the specialization only applies where its measured contract holds.
- A general runtime vector IndexSelect lowering remains a demonstrated TileFoundry gap and is not hidden by the PR.
