### PR TITLE
[Fix][foundry][Mamba] Align Mamba2 primary contract evidence

### DIFF
--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -6,18 +6,22 @@ the official mamba_ssm library (Triton baseline), with a PyTorch fallback.
 
 Run:
     pytest benchmarks/ops/bench_mamba2_e2e.py -m smoke
-    pytest benchmarks/ops/bench_mamba2_e2e.py -m full --benchmark-json=results.json
+    pytest benchmarks/ops/bench_mamba2_e2e.py -m full
 """
 
 from typing import Optional
 
 import pytest
 import torch
-import torch.nn.functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase
 from tileops.ops.mamba2_fwd import Mamba2FwdOp
-from workloads.mamba2_e2e import Mamba2FwdFixture, Mamba2FwdWorkload
+from workloads.mamba2_e2e import (
+    Mamba2FwdFixture,
+    Mamba2FwdWorkload,
+    Mamba2PrimaryWorkload,
+    mamba2_fwd_ref,
+)
 
 # Optional mamba_ssm Triton baseline
 try:
@@ -26,99 +30,6 @@ try:
     )
 except ImportError:
     _mamba_chunk_scan_combined = None
-
-
-def mamba2_fwd_ref(
-    x: torch.Tensor,
-    dt: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    dt_bias: torch.Tensor | None,
-    chunk_size: int,
-    dt_softplus: bool,
-) -> torch.Tensor:
-    """Pure-PyTorch baseline for the Mamba-2 State-Space Dual (SSD) forward pass.
-
-    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
-      out[l,p] = exp(dA[l]) * C[l] @ prev_state
-               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
-
-    Inputs:
-        x:           (B, S, H, P)     dtype
-        dt:          (B, S, H)        float32
-        A:           (H,)             float32  (log-space, <= 0)
-        B:           (B, S, G, N)     dtype
-        C:           (B, S, G, N)     dtype
-        dt_bias:     (H,)             float32, optional
-        chunk_size:  int
-        dt_softplus: bool
-
-    Returns:
-        y: (B, S, H, P)  float32
-    """
-    b, S, h, p = x.shape
-    n = B.shape[-1]
-    g = B.shape[2]
-    hpg = h // g
-    Q = chunk_size
-    num_chunks = S // Q
-
-    # Step 1: DaCumsum
-    dt_val = dt.float()
-    if dt_bias is not None:
-        dt_val = dt_val + dt_bias.float()
-    if dt_softplus:
-        dt_val = F.softplus(dt_val)
-    dt_val = torch.clamp(dt_val, min=0.0)
-    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)
-    dA = dt_chunked * A.float().view(1, h, 1, 1)
-    dA_cumsum = dA.cumsum(dim=-1)
-
-    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned.
-    B_c = B.float().reshape(b, num_chunks, Q, g, n)
-    C_c = C.float().reshape(b, num_chunks, Q, g, n)
-    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)
-    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
-    cb = cb * mask.view(1, 1, 1, Q, Q)
-
-    # Step 3: SSDChunkState
-    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)
-    decay_c = decay.permute(0, 2, 3, 1)
-    dt_c = dt_chunked.permute(0, 2, 3, 1)
-    x_c = x.float().reshape(b, num_chunks, Q, h, p)
-    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-    wx = x_c * (decay_c * dt_c).unsqueeze(-1)
-    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)
-
-    # Step 4: SSDStatePassing
-    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])
-    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
-    prev_states_list = []
-    for ci in range(num_chunks):
-        prev_states_list.append(s.unsqueeze(1))
-        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
-        s = scale * s + chunk_states[:, ci]
-    prev_states = torch.cat(prev_states_list, dim=1)
-
-    # Step 5: SSDChunkScan
-    dA_c = dA_cumsum.permute(0, 2, 3, 1)
-    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-
-    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
-    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
-
-    dA_l = dA_cumsum.unsqueeze(-1)
-    dA_s = dA_cumsum.unsqueeze(-2)
-    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
-        ~mask.view(1, 1, 1, Q, Q), 0.0
-    ).permute(0, 2, 1, 3, 4)
-    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]
-    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)
-    wx_t = x_c.permute(0, 1, 3, 2, 4)
-    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
-
-    return (y_hist + y_intra).reshape(b, S, h, p)
 
 
 # FLOPS / memory calculators
@@ -207,8 +118,88 @@ def test_mamba2_fwd_bench(batch, seqlen, n_heads, d_head, d_state, n_groups,
         functors["mamba"] = (_mamba_wrapper, (x, dt, A, B, C, ))
     else:
         def _torch_wrapper(x, dt, A, B, C):
-            return mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus)
+            return mamba2_fwd_ref(
+                x, dt, A, B, C, dt_bias, chunk_size, dt_softplus
+            )[0]
 
         functors["torch-ref"] = (_torch_wrapper, (x, dt, A, B, C, ))
 
     bm.compare(functors, x, dt, A, B, C, dt_bias, record_as=op, params=locals())
+
+
+@pytest.mark.parametrize(
+    "batch,seqlen,n_heads,d_head,d_state,n_groups,dtype,label",
+    [
+        pytest.param(
+            1, 256, 4, 64, 32, 1, torch.float16,
+            "primary-smoke-fp16",
+            id="primary-smoke-fp16",
+            marks=pytest.mark.smoke,
+        ),
+        pytest.param(
+            1, 256, 4, 64, 32, 1, torch.bfloat16,
+            "primary-smoke-bf16",
+            id="primary-smoke-bf16",
+            marks=pytest.mark.smoke,
+        ),
+        pytest.param(
+            1, 2048, 80, 64, 128, 1, torch.bfloat16,
+            "mamba2-2p7b-b1-s2k",
+            id="mamba2-2p7b-b1-s2k",
+            marks=pytest.mark.full,
+        ),
+        pytest.param(
+            1, 8192, 64, 64, 128, 1, torch.float16,
+            "mamba2-1p3b-b1-s8k",
+            id="mamba2-1p3b-b1-s8k",
+            marks=pytest.mark.full,
+        ),
+    ],
+)
+def test_mamba2_primary_manifest_bench(
+    batch, seqlen, n_heads, d_head, d_state, n_groups, dtype, label
+):
+    """Measure the exact two-output, no-bias primary manifest contract."""
+    if _mamba_chunk_scan_combined is None:
+        pytest.skip("mamba_ssm is required for the primary performance baseline")
+
+    workload = Mamba2PrimaryWorkload(
+        batch, seqlen, n_heads, d_head, d_state, n_groups,
+        dtype, chunk_size=256, dt_softplus=True,
+    )
+    benchmark = Mamba2FwdBenchmark(workload)
+    inputs = workload.gen_inputs()
+    op = Mamba2FwdOp(
+        chunk_size=256,
+        dt_softplus=True,
+        has_initial_states=False,
+    )
+
+    def tileops_primary(x, dt, A, B, C):
+        return op.forward(
+            x, dt, A, B, C,
+            dt_bias=None,
+            initial_states=None,
+            return_final_states=True,
+        )
+
+    def official_primary(x, dt, A, B, C):
+        native_y, native_final = _mamba_chunk_scan_combined(
+            x, dt, A, B, C,
+            256,
+            dt_bias=None,
+            initial_states=None,
+            dt_softplus=True,
+            return_final_states=True,
+        )
+        return native_y.float(), native_final.float()
+
+    benchmark.compare(
+        {
+            "tileops-primary": tileops_primary,
+            "mamba-primary": official_primary,
+        },
+        *inputs,
+        record_as=op,
+        params=locals(),
+    )

--- a/src/tileops/ops/mamba2_fwd.py
+++ b/src/tileops/ops/mamba2_fwd.py
@@ -73,7 +73,7 @@ class Mamba2FwdOp:
         self._heads_per_group = None
         self.tune = tune
 
-        self._da_cumsum_ops: dict[torch.dtype, DaCumsumFwdOp] = {}
+        self._da_cumsum_ops: dict[tuple[torch.dtype, bool], DaCumsumFwdOp] = {}
         self._chunk_state_op = SSDChunkStateFwdOp(
             has_seq_idx=False,
             tune=tune,
@@ -96,16 +96,19 @@ class Mamba2FwdOp:
         self._zero_init_flat: Optional[torch.Tensor] = None
         self._zero_seq_idx: Optional[torch.Tensor]   = None
 
-    def _get_da_cumsum_op(self, dtype: torch.dtype) -> DaCumsumFwdOp:
-        if dtype not in self._da_cumsum_ops:
-            self._da_cumsum_ops[dtype] = DaCumsumFwdOp(
+    def _get_da_cumsum_op(
+        self, dtype: torch.dtype, has_dt_bias: bool
+    ) -> DaCumsumFwdOp:
+        key = (dtype, has_dt_bias)
+        if key not in self._da_cumsum_ops:
+            self._da_cumsum_ops[key] = DaCumsumFwdOp(
                 chunk_len=self.chunk_size,
                 dtype=dtype,
                 dt_softplus=self.dt_softplus,
-                has_dt_bias=True,
+                has_dt_bias=has_dt_bias,
                 tune=self.tune,
             )
-        return self._da_cumsum_ops[dtype]
+        return self._da_cumsum_ops[key]
 
     def _get_cb_producer_op(
         self,
@@ -220,10 +223,13 @@ class Mamba2FwdOp:
         ):
             self._zero_seq_idx = torch.zeros(seq_idx_shape, dtype=torch.int32, device=dev)
         # ── 1. DaCumsum ──────────────────────────────────────────────────────
-        if dt_bias is None:
+        has_dt_bias = dt_bias is not None
+        if not has_dt_bias:
             dt_bias = self._zero_dt_bias
 
-        dt_out, dA_cumsum = self._get_da_cumsum_op(x.dtype).forward(dt, A, dt_bias)
+        dt_out, dA_cumsum = self._get_da_cumsum_op(
+            x.dtype, has_dt_bias
+        ).forward(dt, A, dt_bias)
         # dt_out:    (B, H, C, Q)  dtype
         # dA_cumsum: (B, H, C, Q)  float32
 

--- a/tests/ops/test_mamba.py
+++ b/tests/ops/test_mamba.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import torch.nn.functional as F
 
 from tests.test_base import TestBase, allclose_compare
 from tileops.ops.cb_producer import CBProducerOp
@@ -23,6 +22,11 @@ from workloads.mamba import (
     SSDStatePassingFwdWorkload,
     da_cumsum_fwd_ref,
     ssd_chunk_state_fwd_ref,
+)
+from workloads.mamba2_e2e import (
+    Mamba2PrimaryWorkload,
+    mamba2_direct_ref,
+    mamba2_fwd_ref,
 )
 
 
@@ -277,127 +281,157 @@ def test_ssd_decode(batch, n_heads, d_head, d_state, n_groups, dtype, tune):
     allclose_compare(state, state_ref, atol=atol, rtol=rtol)
 
 
-def mamba2_fwd_ref(
-    x: torch.Tensor,
-    dt: torch.Tensor,
-    A: torch.Tensor,
-    B: torch.Tensor,
-    C: torch.Tensor,
-    dt_bias: torch.Tensor | None,
-    chunk_size: int,
-    dt_softplus: bool,
-) -> torch.Tensor:
-    """Pure-PyTorch reference for the Mamba-2 State-Space Dual (SSD) forward pass.
+@pytest.mark.smoke
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_mamba2_primary_matches_direct_recurrence_across_chunk_boundary(dtype):
+    """The no-bias path returns post-update y and final state across a boundary."""
+    torch.manual_seed(42)
+    workload = Mamba2PrimaryWorkload(
+        1, 512, 4, 64, 32, 2, dtype,
+        chunk_size=256,
+        dt_softplus=True,
+    )
+    inputs = workload.gen_inputs()
+    op = Mamba2FwdOp(chunk_size=256, dt_softplus=True, has_initial_states=False)
+    actual = op.forward(*inputs, return_final_states=True)
+    expected = mamba2_direct_ref(*inputs)
 
-    Computes the same result as mamba_chunk_scan_combined from mamba_ssm:
-      out[l,p] = exp(dA[l]) * C[l] @ prev_state
-               + sum_{s<=l} (C[l]@B[s]) * exp(dA[l]-dA[s]) * dt[s] * x[s,p]
-
-    Inputs:
-        x:           (B, S, H, P)     dtype
-        dt:          (B, S, H)        float32
-        A:           (H,)             float32  (log-space, <= 0)
-        B:           (B, S, G, N)     dtype
-        C:           (B, S, G, N)     dtype
-        dt_bias:     (H,)             float32, optional
-        chunk_size:  int
-        dt_softplus: bool
-
-    Returns:
-        y: (B, S, H, P)  float32
-    """
-    b, S, h, p = x.shape
-    n = B.shape[-1]
-    g = B.shape[2]
-    hpg = h // g
-    Q = chunk_size
-    num_chunks = S // Q
-
-    # Step 1: DaCumsum
-    dt_val = dt.float()
-    if dt_bias is not None:
-        dt_val = dt_val + dt_bias.float()
-    if dt_softplus:
-        dt_val = F.softplus(dt_val)
-    dt_val = torch.clamp(dt_val, min=0.0)
-    dt_chunked = dt_val.reshape(b, num_chunks, Q, h).permute(0, 3, 1, 2)
-    dA = dt_chunked * A.float().view(1, h, 1, 1)
-    dA_cumsum = dA.cumsum(dim=-1)
-
-    # Step 2: CB = C[l] @ B[s]^T per chunk, lower-triangular, group-owned.
-    B_c = B.float().reshape(b, num_chunks, Q, g, n)
-    C_c = C.float().reshape(b, num_chunks, Q, g, n)
-    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_c, B_c)
-    mask = torch.ones(Q, Q, device=x.device, dtype=torch.bool).tril()
-    cb = cb * mask.view(1, 1, 1, Q, Q)
-
-    # Step 3: SSDChunkState
-    decay = torch.exp(dA_cumsum[:, :, :, -1:] - dA_cumsum)
-    decay_c = decay.permute(0, 2, 3, 1)
-    dt_c = dt_chunked.permute(0, 2, 3, 1)
-    x_c = x.float().reshape(b, num_chunks, Q, h, p)
-    B_heads = B_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-    wx = x_c * (decay_c * dt_c).unsqueeze(-1)
-    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", wx, B_heads)
-
-    # Step 4: SSDStatePassing
-    exp_dA_chunk = torch.exp(dA_cumsum[:, :, :, -1])
-    s = torch.zeros(b, h, p, n, device=x.device, dtype=torch.float32)
-    prev_states_list = []
-    for ci in range(num_chunks):
-        prev_states_list.append(s.unsqueeze(1))
-        scale = exp_dA_chunk[:, :, ci].view(b, h, 1, 1)
-        s = scale * s + chunk_states[:, ci]
-    prev_states = torch.cat(prev_states_list, dim=1)
-
-    # Step 5: SSDChunkScan
-    dA_c = dA_cumsum.permute(0, 2, 3, 1)
-    C_heads = C_c[:, :, :, torch.arange(h, device=x.device) // hpg, :]
-
-    y_hist = torch.einsum("bcqhn,bchpn->bcqhp", C_heads, prev_states.float())
-    y_hist = y_hist * torch.exp(dA_c).unsqueeze(-1)
-
-    dA_l = dA_cumsum.unsqueeze(-1)
-    dA_s = dA_cumsum.unsqueeze(-2)
-    decay_ls = torch.exp(dA_l - dA_s).masked_fill(
-        ~mask.view(1, 1, 1, Q, Q), 0.0
-    ).permute(0, 2, 1, 3, 4)
-    cb_heads = cb[:, :, torch.arange(h, device=x.device) // hpg, :, :]
-    lcb = cb_heads * decay_ls * dt_c.permute(0, 1, 3, 2).unsqueeze(-2)
-    wx_t = x_c.permute(0, 1, 3, 2, 4)
-    y_intra = torch.einsum("bchls,bchsp->bchlp", lcb, wx_t).permute(0, 1, 3, 2, 4)
-
-    return (y_hist + y_intra).reshape(b, S, h, p)
+    atol = 1e-2 if dtype == torch.float16 else 2e-2
+    assert actual[0].shape == (1, 512, 4, 64)
+    assert actual[1].shape == (1, 4, 64, 32)
+    assert actual[0].dtype == torch.float32
+    assert actual[1].dtype == torch.float32
+    allclose_compare(actual[0], expected[0], atol=atol, rtol=1e-3)
+    allclose_compare(actual[1], expected[1], atol=atol, rtol=1e-3)
+    assert next(iter(op._da_cumsum_ops.values())).has_dt_bias is False
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("batch,seqlen,n_heads,d_head,d_state,n_groups,chunk_size", [
-    (1, 256,  4, 64, 32,  1, 256),
-    (2, 512,  8, 64, 64,  2, 256),
-    (1, 512,  4, 64, 128, 1, 256),   # d_state=16 not supported by SSDChunkScanFwdKernel
-])
-def test_mamba2_fwd_e2e(batch, seqlen, n_heads, d_head, d_state, n_groups, chunk_size, dtype):
-    """Mamba2FwdOp output must match the pure-PyTorch reference within tolerance."""
-    dev = "cuda"
-    torch.manual_seed(42)
-    x       = torch.randn(batch, seqlen, n_heads, d_head,   dtype=dtype,          device=dev) * 0.1
-    dt_raw  = torch.randn(batch, seqlen, n_heads,           dtype=torch.float32,  device=dev) * 0.5
-    A       = -torch.rand(n_heads,                          dtype=torch.float32,  device=dev)
-    B       = torch.randn(batch, seqlen, n_groups, d_state, dtype=dtype,          device=dev) * 0.1
-    C       = torch.randn(batch, seqlen, n_groups, d_state, dtype=dtype,          device=dev) * 0.1
-    dt_bias = torch.randn(n_heads,                          dtype=torch.float32,  device=dev) * 0.1
-
-    op = Mamba2FwdOp(
-        chunk_size=chunk_size,
+@pytest.mark.parametrize("with_bias,with_initial", [(True, False), (False, True)])
+def test_mamba2_optional_variants_regressions(with_bias, with_initial):
+    """Primary specialization must preserve bias and initial-state variants."""
+    torch.manual_seed(43)
+    workload = Mamba2PrimaryWorkload(
+        1, 512, 4, 64, 32, 1, torch.float16,
+        chunk_size=256,
         dt_softplus=True,
-        has_initial_states=False,
     )
-    y_op, _ = op.forward(x, dt_raw, A, B, C, dt_bias=dt_bias)
-    y_ref   = mamba2_fwd_ref(x, dt_raw, A, B, C, dt_bias, chunk_size, dt_softplus=True)
+    inputs = workload.gen_inputs()
+    bias = torch.randn(4, device="cuda", dtype=torch.float32) * 0.1 if with_bias else None
+    initial = (
+        torch.randn(1, 4, 64, 32, device="cuda", dtype=torch.float32) * 0.1
+        if with_initial else None
+    )
+    op = Mamba2FwdOp(
+        chunk_size=256,
+        dt_softplus=True,
+        has_initial_states=with_initial,
+    )
+    actual = op.forward(
+        *inputs,
+        dt_bias=bias,
+        initial_states=initial,
+        return_final_states=True,
+    )
+    expected = mamba2_fwd_ref(
+        *inputs, bias, 256, True, initial_states=initial
+    )
+    allclose_compare(actual[0], expected[0], atol=1e-2, rtol=1e-3)
+    allclose_compare(actual[1], expected[1], atol=1e-2, rtol=1e-3)
+    assert next(iter(op._da_cumsum_ops.values())).has_dt_bias is with_bias
+
+
+@pytest.mark.smoke
+def test_mamba2_bias_dispatch_cache_is_call_sensitive():
+    """One reusable op keeps distinct kernels for biased and unbiased calls."""
+    torch.manual_seed(45)
+    workload = Mamba2PrimaryWorkload(
+        1, 256, 4, 64, 32, 1, torch.float16,
+        chunk_size=256,
+        dt_softplus=True,
+    )
+    inputs = workload.gen_inputs()
+    bias = torch.randn(4, device="cuda", dtype=torch.float32) * 0.1
+    op = Mamba2FwdOp(chunk_size=256, dt_softplus=True, has_initial_states=False)
+
+    unbiased_y, unbiased_final = op.forward(*inputs)
+    biased_y, biased_final = op.forward(*inputs, dt_bias=bias)
+    unbiased_again_y, _ = op.forward(*inputs)
+
+    assert unbiased_final is None
+    assert biased_final is None
+    assert set(op._da_cumsum_ops) == {
+        (torch.float16, False),
+        (torch.float16, True),
+    }
+    assert torch.equal(unbiased_y, unbiased_again_y)
+    assert not torch.equal(unbiased_y, biased_y)
+
+
+@pytest.mark.parametrize(
+    "batch,seqlen,n_heads,d_head,d_state,n_groups,dtype",
+    [
+        pytest.param(
+            1, 512, 4, 64, 32, 2, torch.float16,
+            id="smoke-fp16",
+            marks=pytest.mark.smoke,
+        ),
+        pytest.param(
+            1, 512, 4, 64, 32, 2, torch.bfloat16,
+            id="smoke-bf16",
+            marks=pytest.mark.smoke,
+        ),
+        pytest.param(
+            1, 2048, 80, 64, 128, 1, torch.bfloat16,
+            id="mamba2-2p7b-b1-s2k",
+            marks=pytest.mark.full,
+        ),
+        pytest.param(
+            1, 8192, 64, 64, 128, 1, torch.float16,
+            id="mamba2-1p3b-b1-s8k",
+            marks=pytest.mark.full,
+        ),
+    ],
+)
+def test_mamba2_primary_manifest_outputs(
+    batch, seqlen, n_heads, d_head, d_state, n_groups, dtype
+):
+    """Both manifest outputs agree with independent PyTorch and official Mamba."""
+    ssd_combined = pytest.importorskip("mamba_ssm.ops.triton.ssd_combined")
+    torch.manual_seed(44)
+    workload = Mamba2PrimaryWorkload(
+        batch, seqlen, n_heads, d_head, d_state, n_groups, dtype,
+        chunk_size=256,
+        dt_softplus=True,
+    )
+    inputs = workload.gen_inputs()
+    op = Mamba2FwdOp(chunk_size=256, dt_softplus=True, has_initial_states=False)
+    actual = op.forward(*inputs, return_final_states=True)
+    independent = workload.ref_program(*inputs)
+    official_y, official_final = ssd_combined.mamba_chunk_scan_combined(
+        *inputs,
+        256,
+        dt_bias=None,
+        initial_states=None,
+        dt_softplus=True,
+        return_final_states=True,
+    )
+    official = official_y.float(), official_final.float()
 
     atol = 1e-2 if dtype == torch.float16 else 2e-2
-    allclose_compare(y_op.float(), y_ref.float(), atol=atol, rtol=1e-3)
+    for output, ref, baseline in zip(actual, independent, official, strict=True):
+        assert output.dtype == torch.float32
+        allclose_compare(output, ref, atol=atol, rtol=1e-3)
+        allclose_compare(output, baseline, atol=atol, rtol=1e-3)
+
+    assert actual[0].shape == (batch, seqlen, n_heads, d_head)
+    assert actual[1].shape == (batch, n_heads, d_head, d_state)
+    assert op._chunk_state_op.kernel.config == {
+        "block_n": min(128, d_state),
+        "block_p": 64,
+        "block_l": 32,
+        "threads": 128,
+    }
 
 
 if __name__ == "__main__":

--- a/workloads/mamba2_e2e.py
+++ b/workloads/mamba2_e2e.py
@@ -5,6 +5,7 @@ Covers model-scale configurations (130M–2.7B) and workload types
 """
 
 import torch
+import torch.nn.functional as F
 
 from workloads.workload_base import FixtureBase, WorkloadBase
 
@@ -19,6 +20,139 @@ MAMBA2_MODELS = {
     "1.3b": (80,   64, 128, 1),
     "2.7b": (128,  64, 128, 1),
 }
+
+
+def mamba2_fwd_ref(
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    dt_bias: torch.Tensor | None,
+    chunk_size: int,
+    dt_softplus: bool,
+    initial_states: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent PyTorch SSD factorization returning both FP32 outputs."""
+    batch, seqlen, n_heads, d_head = x.shape
+    d_state = B.shape[-1]
+    n_groups = B.shape[2]
+    heads_per_group = n_heads // n_groups
+    num_chunks = seqlen // chunk_size
+
+    dt_value = dt.float()
+    if dt_bias is not None:
+        dt_value = dt_value + dt_bias.float()
+    if dt_softplus:
+        dt_value = F.softplus(dt_value)
+    dt_value = torch.clamp(dt_value, min=0.0)
+    dt_chunked = dt_value.reshape(
+        batch, num_chunks, chunk_size, n_heads
+    ).permute(0, 3, 1, 2)
+    dA_cumsum = (
+        dt_chunked * A.float().view(1, n_heads, 1, 1)
+    ).cumsum(dim=-1)
+
+    B_chunked = B.float().reshape(
+        batch, num_chunks, chunk_size, n_groups, d_state
+    )
+    C_chunked = C.float().reshape(
+        batch, num_chunks, chunk_size, n_groups, d_state
+    )
+    cb = torch.einsum("bcqgn,bcsgn->bcgqs", C_chunked, B_chunked)
+    mask = torch.ones(
+        chunk_size, chunk_size, device=x.device, dtype=torch.bool
+    ).tril()
+    cb = cb * mask.view(1, 1, 1, chunk_size, chunk_size)
+
+    decay = torch.exp(dA_cumsum[..., -1:] - dA_cumsum)
+    decay_chunked = decay.permute(0, 2, 3, 1)
+    dt_by_chunk = dt_chunked.permute(0, 2, 3, 1)
+    x_chunked = x.float().reshape(
+        batch, num_chunks, chunk_size, n_heads, d_head
+    )
+    head_groups = torch.arange(n_heads, device=x.device) // heads_per_group
+    B_heads = B_chunked[:, :, :, head_groups, :]
+    weighted_x = x_chunked * (decay_chunked * dt_by_chunk).unsqueeze(-1)
+    chunk_states = torch.einsum("bcqhp,bcqhn->bchpn", weighted_x, B_heads)
+
+    exp_dA_chunk = torch.exp(dA_cumsum[..., -1])
+    if initial_states is None:
+        state = torch.zeros(
+            batch, n_heads, d_head, d_state,
+            device=x.device,
+            dtype=torch.float32,
+        )
+    else:
+        state = initial_states.float()
+    prev_states = []
+    for chunk_idx in range(num_chunks):
+        prev_states.append(state.unsqueeze(1))
+        scale = exp_dA_chunk[:, :, chunk_idx].view(batch, n_heads, 1, 1)
+        state = scale * state + chunk_states[:, chunk_idx]
+    prev_states_tensor = torch.cat(prev_states, dim=1)
+
+    dA_by_chunk = dA_cumsum.permute(0, 2, 3, 1)
+    C_heads = C_chunked[:, :, :, head_groups, :]
+    y_history = torch.einsum(
+        "bcqhn,bchpn->bcqhp", C_heads, prev_states_tensor
+    )
+    y_history = y_history * torch.exp(dA_by_chunk).unsqueeze(-1)
+
+    decay_ls = torch.exp(
+        dA_cumsum.unsqueeze(-1) - dA_cumsum.unsqueeze(-2)
+    ).masked_fill(
+        ~mask.view(1, 1, 1, chunk_size, chunk_size), 0.0
+    ).permute(0, 2, 1, 3, 4)
+    cb_heads = cb[:, :, head_groups, :, :]
+    local_cb = (
+        cb_heads
+        * decay_ls
+        * dt_by_chunk.permute(0, 1, 3, 2).unsqueeze(-2)
+    )
+    x_by_head = x_chunked.permute(0, 1, 3, 2, 4)
+    y_intra = torch.einsum(
+        "bchls,bchsp->bchlp", local_cb, x_by_head
+    ).permute(0, 1, 3, 2, 4)
+
+    y = (y_history + y_intra).reshape(batch, seqlen, n_heads, d_head)
+    return y.float(), state.float()
+
+
+def mamba2_direct_ref(
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Literal token-ordered primary recurrence for small diagnostic cases."""
+    batch, seqlen, n_heads, d_head = x.shape
+    d_state = B.shape[-1]
+    heads_per_group = n_heads // B.shape[2]
+    head_groups = torch.arange(n_heads, device=x.device) // heads_per_group
+    state = torch.zeros(
+        batch, n_heads, d_head, d_state,
+        device=x.device,
+        dtype=torch.float32,
+    )
+    outputs = []
+    delta = F.softplus(dt.float()).clamp(min=0.0)
+    for token in range(seqlen):
+        delta_t = delta[:, token]
+        B_heads = B[:, token, head_groups].float()
+        C_heads = C[:, token, head_groups].float()
+        update = (
+            delta_t[:, :, None, None]
+            * x[:, token].float()[..., None]
+            * B_heads[:, :, None, :]
+        )
+        decay = torch.exp(delta_t * A.float())[..., None, None]
+        state = decay * state + update
+        outputs.append(
+            (state * C_heads[:, :, None, :]).sum(dim=-1).unsqueeze(1)
+        )
+    return torch.cat(outputs, dim=1), state
 
 # ---------------------------------------------------------------------------
 # Fixture
@@ -138,3 +272,20 @@ class Mamba2FwdWorkload(WorkloadBase):
         dt_bias = torch.randn(h,           dtype=torch.float32, device=dev) * 0.1
 
         return x, dt_raw, A, B, C, dt_bias
+
+    def ref_program(self, x, dt, A, B, C, dt_bias):
+        return mamba2_fwd_ref(
+            x, dt, A, B, C, dt_bias, self.chunk_size, self.dt_softplus
+        )[0]
+
+
+class Mamba2PrimaryWorkload(Mamba2FwdWorkload):
+    """The manifest contract: no bias or initial state, two FP32 outputs."""
+
+    def gen_inputs(self):
+        return super().gen_inputs()[:5]
+
+    def ref_program(self, x, dt, A, B, C):
+        return mamba2_fwd_ref(
+            x, dt, A, B, C, None, self.chunk_size, self.dt_softplus
+        )


### PR DESCRIPTION
## Summary

- Route an absent dt_bias through the existing unbiased dA-cumsum specialization and cache biased and unbiased variants independently.
- Make the shared workload and benchmark own the exact no-bias, two-output primary Mamba2 contract.
- Keep the change classified as a contract fix; it does not deliver a new performance kernel or a measurable improvement over the TileOPs incumbent.

## TileFoundry Description

```python
@module(
    entry="mamba2_step",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132), Topology("thread", 512)),
)
class Mamba2Step:
    @func
    def mamba2_step(
        state: Tensor[(BATCH, HEADS, HEAD_DIM, STATE_DIM), "f32"],
        x_t: Tensor[(BATCH, HEADS, HEAD_DIM), DTYPE],
        dt_t: Tensor[(BATCH, HEADS), "f32"],
        A: Tensor[(HEADS,), "f32"],
        B_t: Tensor[(BATCH, GROUPS, STATE_DIM), DTYPE],
        C_t: Tensor[(BATCH, GROUPS, STATE_DIM), DTYPE],
    ):
        delta = tf.clamp(tf.softplus(dt_t), min_val=0.0, max_val=MAX_DT)
        decay = tf.exp(delta * tf.reshape(A, new_shape=(1, HEADS)))
        B_heads = tf.repeat_interleave(B_t, repeats=HEADS, axis=1)
        C_heads = tf.repeat_interleave(C_t, repeats=HEADS, axis=1)
        update = (
            tf.reshape(delta, new_shape=(BATCH, HEADS, 1, 1))
            * tf.reshape(tf.cast(x_t, dtype="f32"), new_shape=(BATCH, HEADS, HEAD_DIM, 1))
            * tf.reshape(
                tf.cast(B_heads, dtype="f32"),
                new_shape=(BATCH, HEADS, 1, STATE_DIM),
            )
        )
        next_state = (
            tf.reshape(decay, new_shape=(BATCH, HEADS, 1, 1)) * state + update
        )
        y_t = tf.reduce(
            next_state
            * tf.reshape(
                tf.cast(C_heads, dtype="f32"),
                new_shape=(BATCH, HEADS, 1, STATE_DIM),
            ),
            axes=(-1,),
            keepdim=False,
            kind="sum",
        )
        return y_t, next_state
```

## Performance

Operator: `Mamba2FwdOp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev |
| digest | sha256:2590888968a870216e1ea076829b909e62e9053608f6a65d5ab5ecd7eb5561f7 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| mamba_ssm | 2.3.2.post1 |
| timer | native CUPTI |

Method: Candidate, reconstructed incumbent, and mamba_ssm ran in one process on the same GPU and inputs with identical precision and two-output work, rotated implementation order, L2 reset/input shifting, and three repeated trials. Compilation was excluded, output casts required by the contract remained inside timing, and CUPTI failure was fail-closed.

| Workload | B | S | H | P | N | G | Q | Dtype | TileFoundry candidate (ms) | TileOPs incumbent (ms) | mamba_ssm 2.3.2.post1 (ms) | TileOPs incumbent / candidate | mamba_ssm 2.3.2.post1 / candidate |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| mamba2-2p7b-b1-s2k | 1 | 2048 | 80 | 64 | 128 | 1 | 256 | bfloat16 | 0.723347 | 0.706002 | 0.782755 | 0.9760x | 1.0821x |
| mamba2-1p3b-b1-s8k | 1 | 8192 | 64 | 64 | 128 | 1 | 256 | float16 | 0.820499 | 0.824755 | 0.924323 | 1.0052x | 1.1265x |
| geometric mean |  |  |  |  |  |  |  |  | 0.770393 | 0.763072 | 0.850599 | 0.9905x | 1.1041x |

## Result And Limitations

**measured SOTA**

- Classification is measured SOTA only against the runnable same-contract external baseline: the candidate is faster than mamba_ssm on both primary workloads and by 1.1041x in geometric mean.
- The candidate is 2.46% slower than the TileOPs incumbent on the 2K row, 0.52% faster on the 8K row, and 0.96% slower in geometric mean; this is not an incumbent improvement.
- Across the three trial medians, candidate ranges were 0.78% and 4.15%, incumbent ranges were 26.63% and 3.11%, and mamba_ssm ranges were 2.33% and 5.36% for the 2K and 8K rows respectively; the highly variable 2K incumbent prevents a stable per-row regression claim.
- The TileFoundry module captures one recurrence step because dynamic loop-token indexing and output insertion cannot yet express the full ordered scan; the shipped fix reuses existing TileOps kernels rather than claiming that module as a new performance kernel.
- The measured-SOTA classification is specific to this CUDA 13.2 stack and mamba_ssm 2.3.2.post1.
