### PR TITLE
[Bench][Timing] compare implementations in one interleaved call

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -259,24 +259,18 @@ def collect_discovery(
 def collect_repeats(
     run_one: Callable[[int], None],
     n_repeat: int,
-    prepare_one: Callable[[int], None] | None = None,
+    prepare_one: Callable[[int], None],
 ) -> list[dict[str, Any]]:
     """Capture a complete timed trial as one ordered activity-record range."""
     with _phase_session():
         for i in range(n_repeat):
-            if prepare_one is not None:
-                prepare_one(i)
+            prepare_one(i)
             run_one(i)
         return _flush()
 
 
 def _activity_identity(activity: dict) -> str:
     """Return a stable identity for a timed GPU activity."""
-    kind = activity["kind"]
-    if kind == "memcpy":
-        return f"memcpy:{int(activity['copy_kind'])}:{int(activity['bytes'])}"
-    if kind == "memset":
-        return f"memset:{int(activity['bytes'])}:{int(activity['value'])}"
     return f"kernel:{activity['name']}"
 
 
@@ -454,17 +448,12 @@ def _attributed_latency_samples_ms(
 
 
 def _sample_spread_ms(samples: list[float]) -> tuple[float, float] | tuple[None, None]:
-    """Return the 10th and 90th percentile of one op's timed samples.
-
-    The reported latency is a median. Without the spread around it, a stable
-    measurement and one dominated by launch jitter read the same downstream.
-    """
+    """Return the 10th and 90th percentile, so a median carries its spread."""
     if len(samples) < 2:
         return None, None
     ordered = sorted(samples)
     last = len(ordered) - 1
-    # Nearest rank, rounded rather than truncated: truncating collapses both
-    # percentiles onto the minimum for small sample counts.
+    # Rounded, not truncated: truncating collapses both onto the minimum.
     return ordered[round(0.1 * last)], ordered[round(0.9 * last)]
 
 
@@ -540,17 +529,13 @@ def bench_kernel(
     max_iters: int = _MAX_ITERS,
     min_iters: int = _MIN_ITERS,
 ) -> list[float]:
-    """Time *fn* with CUPTI kernel-activity attribution.
+    """Return per-iteration latencies in ms, attributed from CUPTI activity.
 
-    A calibration pass measures one iteration, then warmup and measurement each
-    run for their millisecond budget, so a short op is sampled many times and a
-    long one few. L2 is cleared and inputs rotated before every iteration. Each
-    call spans the earliest to the latest activity of its discovered sequence,
-    keeping inter-kernel gaps. Attribution fails closed unless
+    Calibration sizes the warmup and measurement loops to their millisecond
+    budgets, so a short op is sampled many times and a long one few. L2 is
+    cleared and inputs rotated per iteration; each call spans its discovered
+    activity sequence, gaps included. Fails closed unless
     ``TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1``.
-
-    Returns:
-        Per-iteration latencies in **milliseconds**.
     """
     if not isinstance(args, tuple):
         raise TypeError(
@@ -709,14 +694,7 @@ def _get_env_metadata() -> list[str]:
 
 
 class BenchmarkBase(Generic[W], ABC):
-    """Abstract base class for op benchmarking.
-
-    Generic over workload type so subclasses can declare the exact
-    capability they need.  ``WorkloadBase`` remains the typical in-repo
-    implementation, but the public contract is the type parameter.
-
-    Subclass must implement calculate_flops() and calculate_memory().
-    """
+    """Turns measured latency into the op's roofline-relative metrics."""
 
     def __init__(self, workload: W):
         self.workload = workload
@@ -742,17 +720,13 @@ class BenchmarkBase(Generic[W], ABC):
         params: Optional[dict] = None,
         needs_grad: tuple[str, ...] = (),
     ) -> dict[str, dict]:
-        """Time several implementations against each other and record them all.
+        """Time several implementations forward then reversed, and record them.
 
-        Each implementation is timed twice, once in the given order and once in
-        reverse, so clock and thermal drift across the case lands on all of them
-        equally instead of on whichever ran last.
-
-        A value is either a callable, timed on the shared *inputs*, or a
-        ``(callable, args)`` pair for an implementation that takes its own.
-
-        Tags in *needs_grad* run with autograd enabled. Ops never need it; a
-        baseline does when it builds its graph inside the timed callable.
+        Timing each one twice in opposite orders keeps drift across the case
+        from landing on whichever ran last. A value is a callable timed on
+        *inputs*, or a ``(callable, args)`` pair. Tags in *needs_grad* keep
+        autograd on, which only a baseline that builds its graph inside the
+        timed callable needs.
         """
         plan = {
             tag: value if isinstance(value, tuple) else (value, inputs)
@@ -877,21 +851,10 @@ def workload_field_params(workloads: list, keys: tuple) -> list:
 
 
 class ManifestBenchmark(BenchmarkBase[Any]):
-    """Generic benchmark that reads FLOP/memory counts from an Op instance.
+    """Reads the roofline off ``op.eval_roofline()``, never off the workload.
 
-    Accepts an op name, an instantiated Op, and the workload that produced
-    the inputs.  Roofline numbers come from ``op.eval_roofline()``, so the
-    workload needs no ``shape`` / ``dtype`` metadata — it is retained only
-    for subclasses that read their own fields off it.  Dynamic-shape ops may
-    bind roofline variables during ``forward()``, so this helper calls
-    ``op.eval_roofline()`` only while building a result after profiling has
-    executed the op.
-
-    Usage::
-
-        op = SumFwdOp(dim=0)
-        bm = ManifestBenchmark("SumFwdOp", op, workload)
-        result = bm.profile(op, *inputs)
+    Called lazily while building a result, because a dynamic-shape op binds its
+    roofline variables during ``forward()``.
     """
 
     def __init__(
@@ -973,12 +936,6 @@ class BenchmarkReport:
     def record(op_or_name, params: dict, result: dict, tag: str = "tileops") -> None:
         """Record a benchmark result.
 
-        Args:
-            op_or_name: Op instance or benchmark group name string.
-                If an Op instance, class name and module are extracted automatically.
-            params: Parameter dict (typically from locals())
-            result: Dict with latency_ms, tflops, bandwidth_tbs
-            tag: Label to distinguish implementations (e.g. "tileops", "FA3", "fla")
         """
         if isinstance(op_or_name, str):
             name = op_or_name

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -750,7 +750,16 @@ class BenchmarkBase(Generic[W], ABC):
                     max_iters=_MAX_ITERS // passes,
                     min_iters=max(1, _MIN_ITERS // passes),
                 ))
-            meta[tag] = _capture_bench_meta()
+            pass_meta = _capture_bench_meta()
+            previous = meta.get(tag)
+            if previous is not None and previous["timing"] != pass_meta["timing"]:
+                raise RuntimeError(
+                    f"{tag}: the two passes timed with different methods "
+                    f"({previous['timing']} then {pass_meta['timing']}); pooling "
+                    "them would report one median over two kinds of measurement. "
+                    "Only reachable with TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1."
+                )
+            meta[tag] = pass_meta
         results = {tag: self._build_result(samples[tag], meta[tag]) for tag in tags}
         if record_as is not None:
             for tag in tags:

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -57,8 +57,9 @@ _MIN_ITERS = 10
 _MAX_ITERS = 200
 
 
-def _clamp_iters(raw: float, max_iters: int = _MAX_ITERS) -> int:
-    return max(_MIN_ITERS, min(max_iters, int(raw)))
+def _clamp_iters(raw: float, max_iters: int = _MAX_ITERS,
+                 min_iters: int = _MIN_ITERS) -> int:
+    return max(min_iters, min(max_iters, int(raw)))
 
 # Thread-local storage for conftest hook to pick up per-test bench results.
 # A single test function may call record() multiple times (tileops + baseline).
@@ -537,6 +538,7 @@ def bench_kernel(
     dry_run_ms: float = DRY_RUN_MS,
     repeat_ms: float = REPEAT_MS,
     max_iters: int = _MAX_ITERS,
+    min_iters: int = _MIN_ITERS,
 ) -> list[float]:
     """Time *fn* with CUPTI kernel-activity attribution.
 
@@ -582,8 +584,8 @@ def bench_kernel(
     torch.cuda.synchronize()
     per_iter_ms = max(start.elapsed_time(end) / _CALIBRATION_ITERS, 1e-6)
 
-    n_warmup = _clamp_iters(dry_run_ms / per_iter_ms, max_iters)
-    n_repeat = _clamp_iters(repeat_ms / per_iter_ms, max_iters)
+    n_warmup = _clamp_iters(dry_run_ms / per_iter_ms, max_iters, min_iters)
+    n_repeat = _clamp_iters(repeat_ms / per_iter_ms, max_iters, min_iters)
 
     if args:
         total = 1 + n_warmup + _discovery_repeats() + n_repeat
@@ -732,16 +734,13 @@ class BenchmarkBase(Generic[W], ABC):
         with torch.no_grad():
             return self._build_result(bench_kernel(functor, args=inputs))
 
-    def profile_autograd(self, functor: Any) -> dict:
-        """Profile a zero-arg closure that builds an autograd graph."""
-        return self._build_result(bench_kernel(functor))
-
     def compare(
         self,
         functors: dict[str, Any],
         *inputs: Any,
         record_as: Any = None,
         params: Optional[dict] = None,
+        needs_grad: tuple[str, ...] = (),
     ) -> dict[str, dict]:
         """Time several implementations against each other and record them all.
 
@@ -751,6 +750,9 @@ class BenchmarkBase(Generic[W], ABC):
 
         A value is either a callable, timed on the shared *inputs*, or a
         ``(callable, args)`` pair for an implementation that takes its own.
+
+        Tags in *needs_grad* run with autograd enabled. Ops never need it; a
+        baseline does when it builds its graph inside the timed callable.
         """
         plan = {
             tag: value if isinstance(value, tuple) else (value, inputs)
@@ -765,12 +767,14 @@ class BenchmarkBase(Generic[W], ABC):
         meta: dict[str, dict] = {}
         for tag in order:
             functor, args = plan[tag]
-            with torch.no_grad():
+            grad = contextlib.nullcontext() if tag in needs_grad else torch.no_grad()
+            with grad:
                 samples[tag].extend(bench_kernel(
                     functor, args=args,
                     dry_run_ms=DRY_RUN_MS / passes,
                     repeat_ms=REPEAT_MS / passes,
                     max_iters=_MAX_ITERS // passes,
+                    min_iters=max(1, _MIN_ITERS // passes),
                 ))
             meta[tag] = _capture_bench_meta()
         results = {tag: self._build_result(samples[tag], meta[tag]) for tag in tags}

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -57,8 +57,8 @@ _MIN_ITERS = 10
 _MAX_ITERS = 200
 
 
-def _clamp_iters(raw: float) -> int:
-    return max(_MIN_ITERS, min(_MAX_ITERS, int(raw)))
+def _clamp_iters(raw: float, max_iters: int = _MAX_ITERS) -> int:
+    return max(_MIN_ITERS, min(max_iters, int(raw)))
 
 # Thread-local storage for conftest hook to pick up per-test bench results.
 # A single test function may call record() multiple times (tileops + baseline).
@@ -536,6 +536,7 @@ def bench_kernel(
     args: tuple[Any, ...] = (),
     dry_run_ms: float = DRY_RUN_MS,
     repeat_ms: float = REPEAT_MS,
+    max_iters: int = _MAX_ITERS,
 ) -> list[float]:
     """Time *fn* with CUPTI kernel-activity attribution.
 
@@ -581,8 +582,8 @@ def bench_kernel(
     torch.cuda.synchronize()
     per_iter_ms = max(start.elapsed_time(end) / _CALIBRATION_ITERS, 1e-6)
 
-    n_warmup = _clamp_iters(dry_run_ms / per_iter_ms)
-    n_repeat = _clamp_iters(repeat_ms / per_iter_ms)
+    n_warmup = _clamp_iters(dry_run_ms / per_iter_ms, max_iters)
+    n_repeat = _clamp_iters(repeat_ms / per_iter_ms, max_iters)
 
     if args:
         total = 1 + n_warmup + _discovery_repeats() + n_repeat
@@ -756,12 +757,21 @@ class BenchmarkBase(Generic[W], ABC):
             for tag, value in functors.items()
         }
         tags = list(plan)
+        order = tags + tags[::-1]
+        # Split the budget across the two passes rather than spending it twice:
+        # the point is symmetry, not more samples.
+        passes = 2
         samples: dict[str, list[float]] = {tag: [] for tag in tags}
         meta: dict[str, dict] = {}
-        for tag in tags + tags[::-1]:
+        for tag in order:
             functor, args = plan[tag]
             with torch.no_grad():
-                samples[tag].extend(bench_kernel(functor, args=args))
+                samples[tag].extend(bench_kernel(
+                    functor, args=args,
+                    dry_run_ms=DRY_RUN_MS / passes,
+                    repeat_ms=REPEAT_MS / passes,
+                    max_iters=_MAX_ITERS // passes,
+                ))
             meta[tag] = _capture_bench_meta()
         results = {tag: self._build_result(samples[tag], meta[tag]) for tag in tags}
         if record_as is not None:

--- a/benchmarks/kernels/bench_moe_shared_expert_mlp.py
+++ b/benchmarks/kernels/bench_moe_shared_expert_mlp.py
@@ -45,9 +45,6 @@ def test_shared_mlp_bench(num_tokens, hidden_size, ffn_size, dtype):
     kernel(hidden, w_gate_up, w_down)  # warmup
     torch.cuda.synchronize()
 
-    result = bm.profile(kernel, hidden, w_gate_up, w_down)
-    BenchmarkReport.record(kernel, locals(), result, tag="tileops")
-
     # PyTorch baseline
     def pytorch_fn(hidden, w_gate_up, w_down):
         gate = torch.nn.functional.linear(hidden, w_gate_up[:ffn_size])
@@ -58,8 +55,7 @@ def test_shared_mlp_bench(num_tokens, hidden_size, ffn_size, dtype):
     pytorch_fn(hidden, w_gate_up, w_down)  # warmup
     torch.cuda.synchronize()
 
-    result_torch = bm.profile(pytorch_fn, hidden, w_gate_up, w_down)
-    BenchmarkReport.record(kernel, locals(), result_torch, tag="torch")
+    bm.compare({"tileops": kernel, "torch": pytorch_fn}, hidden, w_gate_up, w_down, record_as=kernel, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_dsa_decode.py
@@ -34,11 +34,8 @@ def test_dsa_decode_bench(batch: int, heads: int, seq_len_q: int, seq_len_kv: in
         batch, heads, seq_len_q, seq_len_kv, dim, dim_tail, topk, stride_kv, heads_kv,
         q_start_index_s, sm_scale=sm_scale, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_deepseek_mla_decode.py
+++ b/benchmarks/ops/attention/bench_deepseek_mla_decode.py
@@ -25,11 +25,8 @@ def test_mla_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int
     op = MultiHeadLatentAttentionDecodeWithKVCacheFwdOp(
         batch, heads, heads_kv, seq_len_kv, dim, dim_pe, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -278,22 +278,20 @@ def test_gqa_fwd_bench(
     op = GroupedQueryAttentionFwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_GQA_FWD_OP, op, test)
     tileops_variant = _tileops_gqa_variant(op, dtype)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag=f"tileops_{tileops_variant}")
+    functors = {f"tileops_{tileops_variant}": op}
 
     fa3_fn = _fa3_gqa_fwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_gqa_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(_torch_gqa_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = _torch_gqa_fwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 # GQA backward benchmark parameters (training only).

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -321,16 +321,15 @@ def test_gqa_bwd_bench(
 
     op = GroupedQueryAttentionBwdOp(batch, heads, heads_kv, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_GQA_BWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_bwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
     else:
-        result_bl = bm.profile(_torch_gqa_bwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = _torch_gqa_bwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
     # No FlashInfer baseline for bwd (FlashInfer has no backward API)
 
 
@@ -383,16 +382,15 @@ def test_gqa_prefill_fwd_bench(
         softcap=softcap,
     )
     bm = ManifestBenchmark(_GQA_PREFILL_FWD_OP, op, test)
-    result = bm.profile(op, *packed_inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
-    result_bl = bm.profile(_torch_gqa_prefill_ref(test), *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    functors["torch-ref"] = (_torch_gqa_prefill_ref(test), (*inputs, ))
 
     fi_fn = _flashinfer_gqa_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = (fi_fn, (*inputs, ))
+
+    bm.compare(functors, *packed_inputs, record_as=op, params=locals())
 
 
 _GQA_PREFILL_VARLEN_FWD_BENCH_PARAMS = [

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -457,11 +457,8 @@ def test_gqa_prefill_varlen_fwd_bench(
         batch, heads, heads_kv, dim, test.max_seqlen_q, test.max_seqlen_kv, causal, tune=tune
     )
     bm = GQAPrefillVarlenFwdBenchmark(test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(_torch_gqa_prefill_varlen_ref(test), *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": _torch_gqa_prefill_varlen_ref(test)}, *inputs, record_as=op, params=locals())
 
 
 def _fp8_paged_cache_inputs(

--- a/benchmarks/ops/attention/bench_gqa_decode.py
+++ b/benchmarks/ops/attention/bench_gqa_decode.py
@@ -134,22 +134,20 @@ def test_gqa_decode_bench(batch: int, heads: int, heads_kv: int, seq_len_kv: int
         tune=tune,
     )
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_decode_fwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_gqa_decode_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_gqa_decode_paged.py
+++ b/benchmarks/ops/attention/bench_gqa_decode_paged.py
@@ -157,22 +157,20 @@ def test_gqa_decode_paged_bench(batch: int, heads: int, heads_kv: int, seqlen_kv
         batch, heads, heads_kv, seqlen_kv, dim, page_size,
         sm_scale=sm_scale, softcap=softcap, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_gqa_decode_paged(test, k, v)
     if fa3_fn is not None:
-        result_fa3 = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fa3, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_gqa_decode_paged(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, bench_kernel
+from benchmarks.benchmark_base import ManifestBenchmark
 from tileops.manifest import load_workloads
 from tileops.ops import GroupedQueryAttentionPrefillFwdOp
 from workloads.gqa_fp8_utils import (
@@ -134,25 +134,11 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
     inputs = _make_inputs(case)
     op(*inputs)
     torch.cuda.synchronize()
-    latency_ms = bench_kernel(op, args=inputs, n_warmup=1, n_repeat=3)
-    flops, bytes_moved = op.eval_roofline()
-    result = {
-        "latency_ms": latency_ms,
-        "tflops": flops / latency_ms * 1e-9 if latency_ms > 0 else 0.0,
-        "gbps": bytes_moved / latency_ms * 1e-6 if latency_ms > 0 else 0.0,
-        "flops": flops,
-        "bytes": bytes_moved,
-    }
-    BenchmarkReport.record(op, {"case": case.label}, result, tag="tileops")
 
+    bm = ManifestBenchmark(_OP_NAME, op, case)
+    functors = {"tileops": op}
     fa3_fn = _fa3_gqa_fp8_fwd(case)
     if fa3_fn is not None:
-        fa3_latency_ms = bench_kernel(fa3_fn, args=inputs, n_warmup=1, n_repeat=3)
-        fa3_result = {
-            "latency_ms": fa3_latency_ms,
-            "tflops": flops / fa3_latency_ms * 1e-9 if fa3_latency_ms > 0 else 0.0,
-            "gbps": bytes_moved / fa3_latency_ms * 1e-6 if fa3_latency_ms > 0 else 0.0,
-            "flops": flops,
-            "bytes": bytes_moved,
-        }
-        BenchmarkReport.record(op, {"case": case.label}, fa3_result, tag="fa3")
+        functors["fa3"] = fa3_fn
+
+    bm.compare(functors, *inputs, record_as=op, params={"case": case.label})

--- a/benchmarks/ops/attention/bench_gqa_sliding_window.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window.py
@@ -141,24 +141,22 @@ def test_gqa_sliding_window_fwd_bench(
     op(*inputs)
     torch.cuda.synchronize()
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # FA3 baseline
     fa3_fn = _fa3_baseline(is_causal, wl, wr)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     # FlashInfer baseline
     fi_fn = _flashinfer_sliding_window_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(_torch_sliding_window_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = _torch_sliding_window_fwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
+++ b/benchmarks/ops/attention/bench_gqa_sliding_window_varlen.py
@@ -181,25 +181,23 @@ def test_gqa_sliding_window_varlen_fwd_bench(
     op(*inputs)
     torch.cuda.synchronize()
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # FA3 baseline
     max_seqlen_k = max(seqlens_k)
     fa3_fn = _fa3_varlen_baseline(max_seqlen_k, is_causal, wl, wr)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     # FlashInfer baseline
     fi_fn = _flashinfer_varlen_sliding_window_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(_torch_sliding_window_varlen_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = _torch_sliding_window_varlen_fwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -112,22 +112,20 @@ def test_mha_fwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
 
     op = MultiHeadAttentionFwdOp(batch, heads, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_MHA_FWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_fwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_mha_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(_torch_mha_fwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = _torch_mha_fwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 _MHA_BWD_BENCH_PARAMS = manifest_params(load_workloads(_MHA_BWD_OP), mha_qkv_args)
@@ -141,16 +139,15 @@ def test_mha_bwd_bench(batch: int, seq_len: int, heads: int, dim: int, causal: b
 
     op = MultiHeadAttentionBwdOp(batch, heads, seq_len, dim, causal, tune=tune)
     bm = ManifestBenchmark(_MHA_BWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_bwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
     else:
-        result_bl = bm.profile(_torch_mha_bwd(test), *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = _torch_mha_bwd(test)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_mha_decode.py
+++ b/benchmarks/ops/attention/bench_mha_decode.py
@@ -63,22 +63,20 @@ def test_mha_decode_bench(b: int, h: int, s_q: int, s_kv: int, d: int, dtype: to
 
     op = MultiHeadAttentionDecodeWithKVCacheFwdOp(b, h, s_q, s_kv, d, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_decode_fwd(test)
     if fa3_fn is not None:
-        result_bl = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_mha_decode_fwd(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-sdpa")
+        functors["torch-sdpa"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/attention/bench_mha_decode_paged.py
+++ b/benchmarks/ops/attention/bench_mha_decode_paged.py
@@ -97,22 +97,20 @@ def test_mha_decode_paged_bench(batch: int, heads: int, seqlen_q: int, seqlen_kv
     op = MultiHeadAttentionDecodePagedWithKVCacheFwdOp(
         batch, heads, seqlen_q, seqlen_kv, dim, page_size, is_causal, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     fa3_fn = _fa3_mha_decode_paged(test, k, v)
     if fa3_fn is not None:
-        result_fa3 = bm.profile(fa3_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fa3, tag="fa3")
+        functors["fa3"] = fa3_fn
 
     fi_fn = _flashinfer_mha_decode_paged(test, *inputs)
     if fi_fn is not None:
-        result_fi = bm.profile(fi_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_fi, tag="flashinfer")
+        functors["flashinfer"] = fi_fn
 
     if fa3_fn is None and fi_fn is None:
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_ada_layer_norm.py
+++ b/benchmarks/ops/bench_ada_layer_norm.py
@@ -31,16 +31,13 @@ def test_ada_layer_norm_bench(m: int, n: int, dtype: torch.dtype) -> None:
 
     op = AdaLayerNormFwdOp()
     bm = ManifestBenchmark(_ADA_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: PyTorch composite F.layer_norm + arithmetic
     def baseline_fn(x, scale, shift):
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return scale * normed + shift
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("m, n, dtype", _to_params(load_workloads(_ADA_ZERO_OP_NAME)))
@@ -50,16 +47,13 @@ def test_ada_layer_norm_zero_bench(m: int, n: int, dtype: torch.dtype) -> None:
 
     op = AdaLayerNormZeroFwdOp()
     bm = ManifestBenchmark(_ADA_ZERO_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: PyTorch composite F.layer_norm + arithmetic + gate
     def baseline_fn(x, scale, shift, gate):
         normed = F.layer_norm(x, (n,), weight=None, bias=None, eps=test.eps)
         return gate * (scale * normed + shift)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_argreduce.py
+++ b/benchmarks/ops/bench_argreduce.py
@@ -27,16 +27,14 @@ def test_argmax_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
 
     op = ArgmaxFwdOp(**extra)
     bm = ManifestBenchmark(_ARGMAX_OP, op, workload)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     dim = extra["dim"]
 
     def baseline_fn(x):
         return x.argmax(dim=dim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op,
+                params={"shape": shape, "dtype": dtype, "dim": dim})
 
 
 # Argmin benchmarks
@@ -49,16 +47,14 @@ def test_argmin_bench(shape: tuple, dtype: torch.dtype, extra: dict) -> None:
 
     op = ArgminFwdOp(**extra)
     bm = ManifestBenchmark(_ARGMIN_OP, op, workload)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     dim = extra["dim"]
 
     def baseline_fn(x):
         return x.argmin(dim=dim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op,
+                params={"shape": shape, "dtype": dtype, "dim": dim})
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -103,14 +103,9 @@ def test_batch_norm_fwd_bench(N, C, spatial, dtype, training, tune):
     test = BatchNormFwdWorkload(N, C, spatial, dtype, training)
     bm = ManifestBenchmark(_FWD_OP_NAME, op, test)
 
-    result = bm.profile(lambda *a: op(*a), *inputs)
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(
-        lambda x, rm, rv, w, b: _torch_bn_fwd(x, w, b, rm, rv), *inputs,
-    )
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-cudnn")
+    bm.compare({"tileops": lambda *a: op(*a), "torch-cudnn": lambda x, rm, rv, w, b: _torch_bn_fwd(x, w, b, rm, rv)}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("N, C, spatial, dtype", _manifest_bwd_params())
@@ -122,12 +117,9 @@ def test_batch_norm_bwd_bench(N, C, spatial, dtype):
     test = BatchNormBwdWorkload(N, C, spatial, dtype)
     bm = ManifestBenchmark(_BWD_OP_NAME, op, test)
 
-    result = bm.profile(op, *inputs)
     spatial = str(spatial)  # stringify tuple so it survives BenchmarkReport.record filtering
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(_torch_bn_bwd, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-autograd")
+    bm.compare({"tileops": op, "torch-autograd": _torch_bn_bwd}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -220,13 +220,12 @@ def test_logical_bench(
     inputs = test.gen_inputs()
 
     op = op_cls(a_shape=shape, b_shape=shape)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # Baseline uses bool tensors
     a_bool, b_bool = inputs[0].bool(), inputs[1].bool()
-    result_bl = bm.profile(baseline_fn, a_bool, b_bool)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    functors["torch"] = (baseline_fn, (a_bool, b_bool, ))
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 # Bitwise ops (3)

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -147,11 +147,8 @@ def test_binary_arith_bench(
     inputs = test.gen_inputs()
 
     op = op_cls(a_shape=shape, b_shape=shape)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 # Comparison ops (6)
@@ -192,11 +189,8 @@ def test_comparison_bench(
     inputs = test.gen_inputs()
 
     op = _CMP_OPS[op_name](a_shape=shape, b_shape=shape)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 # Logical ops (2)
@@ -262,11 +256,8 @@ def test_bitwise_bench(
     inputs = test.gen_inputs()
 
     op = op_cls(a_shape=shape, b_shape=shape)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 # Fused gated ops (2)
@@ -328,10 +319,7 @@ _FUSED_BASELINES = {
 def _profile_fused_gated(bm: ManifestBenchmark, op, test, baseline_key: str,
                          params: dict) -> None:
     inputs = test.gen_inputs()
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, params, result, tag="tileops")
-    result_bl = bm.profile(_FUSED_BASELINES[baseline_key], *inputs)
-    BenchmarkReport.record(op, params, result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": _FUSED_BASELINES[baseline_key]}, *inputs, record_as=op, params=params)
 
 
 @SiluAndMulBenchFixture
@@ -486,11 +474,8 @@ def test_broadcast_bench(
     inputs = test.gen_inputs()
 
     op = op_cls(a_shape=a_shape, b_shape=b_shape)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(f"{op_name}_bcast", locals(), result, tag="tileops")
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(f"{op_name}_bcast", locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=f'{op_name}_bcast', params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_binary_elementwise.py
+++ b/benchmarks/ops/bench_binary_elementwise.py
@@ -408,12 +408,9 @@ def test_fused_gated_strategy_bench(
 
     shape = (M, N)
     kernel = kernel_cls(M=M, N=N, dtype=dtype, config={"strategy": strategy})
-    result = bm.profile(kernel, *inputs)
-    BenchmarkReport.record(f"{op_name}_strategy", locals(), result, tag=f"tileops-{strategy}")
-
     baseline_fn = _FUSED_BASELINES[op_name]
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(f"{op_name}_strategy", locals(), result_bl, tag="torch")
+    bm.compare({f"tileops-{strategy}": kernel, "torch": baseline_fn}, *inputs,
+               record_as=f"{op_name}_strategy", params=locals())
 
 
 # Broadcast benchmark (bias-add pattern)

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -108,24 +108,25 @@ def test_bmm_fp8_bench(
     # Fast path: feed [B, N, K] (K-innermost) via explicit b_layout='nk'.
     op = BmmFp8Op(out_dtype=out_dtype, tune=True, b_layout="nk")
     bm = ManifestBenchmark(_FP8_OP_NAME, op, workload)
-    result = bm.profile(op, a, b_nk, scale_a, scale_b)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {
+        "tileops": (op, (a, b_nk, scale_a, scale_b)),
+        "torch-fp32-ref": (workload.torch_fp32_bmm_ref, (a, b_kn, scale_a, scale_b)),
+    }
 
-    result_bl = bm.profile(workload.torch_fp32_bmm_ref, a, b_kn, scale_a, scale_b)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-fp32-ref")
+    def flashinfer_fn(a_, b_, sa_, sb_):
+        return _flashinfer_bmm_fp8_per_tensor_ref(workload, a_, b_, sa_, sb_)
 
-    flashinfer = pytest.importorskip("flashinfer")
+    # flashinfer is optional and shape-sensitive. Probe it once and drop only
+    # its row when it cannot run; skipping the case would take the op's own
+    # numbers down with it.
     try:
-        result_flashinfer = bm.profile(
-            lambda a_, b_, sa_, sb_: _flashinfer_bmm_fp8_per_tensor_ref(
-                workload, a_, b_, sa_, sb_),
-            a, b_kmajor, scale_a, scale_b,
-        )
-    except RuntimeError as exc:
-        pytest.skip(f"flashinfer bmm_fp8 unavailable for this shape: {exc}")
-    BenchmarkReport.record(
-        op, locals(), result_flashinfer, tag="flashinfer-bmm-fp8",
-    )
+        flashinfer_fn(a, b_kmajor, scale_a, scale_b)
+    except (ImportError, RuntimeError) as exc:
+        print(f"  [skip] flashinfer-bmm-fp8: {exc}")
+    else:
+        functors["flashinfer-bmm-fp8"] = (flashinfer_fn, (a, b_kmajor, scale_a, scale_b))
+
+    bm.compare(functors, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_bmm.py
+++ b/benchmarks/ops/bench_bmm.py
@@ -90,11 +90,8 @@ def test_bmm_bench(batch: int, m: int, n: int, k: int, dtype_str: str) -> None:
 
     # eval_roofline() is read lazily after profiling, by which point
     # forward() has bound the dims.
-    result = bm.profile(op, a, b)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(torch.bmm, a, b)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
+    bm.compare({"tileops": op, "torch-cublas": torch.bmm}, a, b, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("batch, m, n, k, dtype_str", _manifest_fp8_params())

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -198,18 +198,15 @@ def _profile_conv(
         def baseline_with_static_weight(x_i):
             return baseline_fn(x_i, weight, bias)
 
-        result = bm.profile(op_with_static_weight, x)
-        BenchmarkReport.record(op, params, result, tag="tileops")
+        functors = {"tileops": op_with_static_weight}
 
-        result_bl = bm.profile(baseline_with_static_weight, x)
-        BenchmarkReport.record(op, params, result_bl, tag="torch")
+        functors["torch"] = baseline_with_static_weight
         return
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, params, result, tag="tileops")
+    functors["tileops"] = (op, (*inputs, ))
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, params, result_bl, tag="torch")
+    functors["torch"] = (baseline_fn, (*inputs, ))
+    bm.compare(functors, x, record_as=op, params=params)
 
 
 # Conv1d

--- a/benchmarks/ops/bench_convolution.py
+++ b/benchmarks/ops/bench_convolution.py
@@ -198,15 +198,14 @@ def _profile_conv(
         def baseline_with_static_weight(x_i):
             return baseline_fn(x_i, weight, bias)
 
-        functors = {"tileops": op_with_static_weight}
-
-        functors["torch"] = baseline_with_static_weight
+        bm.compare(
+            {"tileops": op_with_static_weight, "torch": baseline_with_static_weight},
+            x, record_as=op, params=params,
+        )
         return
 
-    functors["tileops"] = (op, (*inputs, ))
-
-    functors["torch"] = (baseline_fn, (*inputs, ))
-    bm.compare(functors, x, record_as=op, params=params)
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+               record_as=op, params=params)
 
 
 # Conv1d

--- a/benchmarks/ops/bench_cumulative.py
+++ b/benchmarks/ops/bench_cumulative.py
@@ -47,11 +47,8 @@ def test_cumsum_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = _make_op(shape, dtype, "cumsum")
     bm = ManifestBenchmark(_CUMSUM_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("shape, dtype", workloads_to_params(_CUMPROD_OP))
@@ -61,11 +58,8 @@ def test_cumprod_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = _make_op(shape, dtype, "cumprod")
     bm = ManifestBenchmark(_CUMPROD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -212,8 +212,7 @@ def test_deltanet_vs_fla_fwd(
 
     # --- TileOPs (BHSD) ---
     op = DeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if chunk_delta_rule is not None:
         # --- FLA (BTHK) ---
@@ -224,12 +223,12 @@ def test_deltanet_vs_fla_fwd(
         def fla_fwd():
             return chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
 
-        result_fla = bm.profile(fla_fwd)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_fwd, ())
     else:
         # --- Torch reference baseline ---
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 # Backward benchmark
@@ -287,8 +286,7 @@ def test_deltanet_vs_fla_bwd(
     _o, S_fwd, Aw, Au, w_fwd, u_fwd = fwd_op.forward(q, k, v, beta)
 
     bwd_op = DeltaNetBwdOp(chunk_size=BC, tune=tune)
-    result = bm.profile(bwd_op.forward, do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd)
-    BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
+    functors = {"tileops": bwd_op.forward}
 
     if chunk_delta_rule is not None:
         # --- FLA: bwd only via autograd (BTHK layout) ---
@@ -309,14 +307,14 @@ def test_deltanet_vs_fla_bwd(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile(fla_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_bwd, ())
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return deltanet_autograd_bwd_torch(do, q, k, v, beta, BC)
-        result_bl = bm.profile(torch_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
+        functors["torch"] = (torch_bwd, ())
+
+    bm.compare(functors, do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd, record_as=bwd_op, params=locals())
 
 
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -377,8 +377,7 @@ def test_deltanet_vs_fla_fwdbwd(
         o.backward(do)
         return q.grad, k.grad, v.grad
 
-    result = bm.profile_autograd(tileops_fwdbwd)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": tileops_fwdbwd}
 
     if chunk_delta_rule is not None:
         # --- FLA: fwd+bwd via autograd ---
@@ -395,14 +394,16 @@ def test_deltanet_vs_fla_fwdbwd(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile_autograd(fla_fwdbwd)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = fla_fwdbwd
     else:
         # --- Torch autograd reference baseline ---
         def torch_fwdbwd():
             return deltanet_autograd_bwd_torch(do, q.data, k.data, v.data, beta.data, BC)
-        result_bl = bm.profile_autograd(torch_fwdbwd)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = torch_fwdbwd
+
+    # Every closure builds its graph and calls backward inside the timed call.
+    bm.compare(functors, record_as=op, params=locals(),
+               needs_grad=("tileops", "fla", "torch"))
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_deltanet_recurrence.py
@@ -85,11 +85,8 @@ def test_deltanet_decode_bench(
 
     op = DeltaNetDecodeOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_dropout.py
+++ b/benchmarks/ops/bench_dropout.py
@@ -32,11 +32,8 @@ def test_dropout_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = DropoutOp(p=test.p, seed=42)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, x)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, x)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": test.ref_program}, x, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_elementwise_manifest.py
+++ b/benchmarks/ops/bench_elementwise_manifest.py
@@ -231,10 +231,7 @@ def _record_unary(
     inputs: tuple[torch.Tensor, ...],
     baseline_fn: Callable,
 ) -> None:
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, _manifest_params(bm), result, tag="tileops")
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, _manifest_params(bm), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm))
 
 
 def _record_binary(
@@ -243,10 +240,7 @@ def _record_binary(
     inputs: tuple[torch.Tensor, torch.Tensor],
     baseline_fn: Callable,
 ) -> None:
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, _manifest_params(bm), result, tag="tileops")
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, _manifest_params(bm), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=_manifest_params(bm))
 
 
 _RELU_OP = "ReluFwdOp"
@@ -417,10 +411,7 @@ def test_prelu_manifest_bench(
     x, weight = test.gen_inputs()
     op = PreluFwdOp(shape=input_shape, num_channels=test.num_channels)
     bm = ManifestBenchmark(_PRELU_OP, op, test)
-    result = bm.profile(op, x, weight)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-    result_bl = bm.profile(F.prelu, x, weight)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": F.prelu}, x, weight, record_as=op, params=locals())
 
 
 _MASKED_FILL_OP = "MaskedFillFwdOp"
@@ -441,10 +432,7 @@ def test_masked_fill_tensor_manifest_bench(
     x, mask, value = test.gen_inputs()
     op = MaskedFillFwdOp(input=input_shape, mask=mask_shape, value=value_shape)
     bm = ManifestBenchmark(_MASKED_FILL_OP, op, test)
-    result = bm.profile(op, x, mask, value)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-    result_bl = bm.profile(lambda a, m, v: a.masked_fill(m, v), x, mask, value)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": lambda a, m, v: a.masked_fill(m, v)}, x, mask, value, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -459,10 +447,7 @@ def test_masked_fill_scalar_manifest_bench(
     x, mask = test.gen_inputs()
     op = MaskedFillScalarFwdOp(input=shape, mask=shape, value=-100.0)
     bm = ManifestBenchmark(_MASKED_FILL_SCALAR_OP, op, test)
-    result = bm.profile(op, x, mask)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-    result_bl = bm.profile(lambda a, m: a.masked_fill(m, -100.0), x, mask)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": lambda a, m: a.masked_fill(m, -100.0)}, x, mask, record_as=op, params=locals())
 
 
 _ADD_OP = "AddFwdOp"
@@ -710,10 +695,7 @@ def test_where_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) -> Non
     cond, x, other = test.gen_inputs()
     op = WhereFwdOp(condition=shape, input=shape, other=shape)
     bm = ManifestBenchmark(_WHERE_OP, op, test)
-    result = bm.profile(op, cond, x, other)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-    result_bl = bm.profile(torch.where, cond, x, other)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": torch.where}, cond, x, other, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("shape, dtype", _shape_dtype_params(load_workloads(_LERP_TENSOR_OP)))
@@ -722,10 +704,7 @@ def test_lerp_tensor_manifest_bench(shape: tuple[int, ...], dtype: torch.dtype) 
     x, end, weight = test.gen_inputs()
     op = LerpTensorFwdOp(input=shape, end=shape, weight=shape)
     bm = ManifestBenchmark(_LERP_TENSOR_OP, op, test)
-    result = bm.profile(op, x, end, weight)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-    result_bl = bm.profile(torch.lerp, x, end, weight)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": torch.lerp}, x, end, weight, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_engram.py
+++ b/benchmarks/ops/bench_engram.py
@@ -43,11 +43,8 @@ def test_engram_gate_conv_fwd_bench(M, seq_len, d, dtype):
 
     op = EngramGateConvFwdOp(M, seq_len, d, tune=_TUNE)
     bm = ManifestBenchmark(_ENGRAM_GATE_CONV_FWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 _ENGRAM_GATE_CONV_BWD_OP = "EngramGateConvBwdOp"
@@ -63,15 +60,12 @@ def test_engram_gate_conv_bwd_bench(M, seq_len, d, dtype):
 
     op = EngramGateConvBwdOp(M, seq_len, d, tune=_TUNE)
     bm = ManifestBenchmark(_ENGRAM_GATE_CONV_BWD_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     @torch.enable_grad()
     def ref_with_grad(*args):
         return test.ref_program(*args)
 
-    result_bl = bm.profile(ref_with_grad, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": ref_with_grad}, *inputs, record_as=op, params=locals())
 
 
 _ENGRAM_DECODE_OP = "EngramDecodeOp"
@@ -93,11 +87,8 @@ def test_engram_decode_bench(batch, d_mem, d, max_conv_len, conv_kernel_size, di
         batch, d_mem, d, max_conv_len, conv_kernel_size, dilation, tune=_TUNE,
     )
     bm = ManifestBenchmark(_ENGRAM_DECODE_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_fft.py
+++ b/benchmarks/ops/bench_fft.py
@@ -26,11 +26,8 @@ def test_fft_bench(shape: tuple, dtype: torch.dtype) -> None:
     torch.cuda.synchronize()
 
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-cufft")
+    bm.compare({"tileops": op, "torch-cufft": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_fp8_lightning_indexer.py
+++ b/benchmarks/ops/bench_fp8_lightning_indexer.py
@@ -53,11 +53,8 @@ def test_fp8_lightning_indexer_bench(batch: int, seq_len: int, heads: int, index
 
     op = FP8LightningIndexerOp(clean_logits=clean_logits, config=_CONFIG, tune=_TUNE)
     bm = ManifestBenchmark(_FP8_LIGHTNING_INDEXER_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_fp8_quant.py
+++ b/benchmarks/ops/bench_fp8_quant.py
@@ -37,11 +37,8 @@ def test_fp8_quant_bench(batch: int, seq_len_kv: int, kv_group: int, index_dim: 
 
     op = FP8QuantOp(tune=_TUNE)
     bm = ManifestBenchmark(_FP8_QUANT_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_fused_moe_experts.py
+++ b/benchmarks/ops/bench_fused_moe_experts.py
@@ -122,8 +122,7 @@ def test_moe_experts_nopad_bench(
     _nopad_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(_nopad_fn, hidden, w1, w2, topk_weights, topk_ids)
-    BenchmarkReport.record(nopad, locals(), result, tag="tileops-nopad-3wg")
+    functors = {"tileops-nopad-3wg": _nopad_fn}
 
     # -- vLLM Triton baseline -------------------------------------------------
     if _VLLM_TRITON_AVAILABLE:
@@ -133,8 +132,7 @@ def test_moe_experts_nopad_bench(
         _vllm_triton_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
         torch.cuda.synchronize()
 
-        result_triton = bm.profile(_vllm_triton_fn, hidden, w1, w2, topk_weights, topk_ids)
-        BenchmarkReport.record(nopad, locals(), result_triton, tag="vllm-triton")
+        functors["vllm-triton"] = _vllm_triton_fn
 
     # -- vLLM CUTLASS baseline ------------------------------------------------
     if _VLLM_CUTLASS_AVAILABLE:
@@ -145,8 +143,7 @@ def test_moe_experts_nopad_bench(
             _vllm_cutlass_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
             torch.cuda.synchronize()
 
-            result_cutlass = bm.profile(_vllm_cutlass_fn, hidden, w1, w2, topk_weights, topk_ids)
-            BenchmarkReport.record(nopad, locals(), result_cutlass, tag="vllm-cutlass")
+            functors["vllm-cutlass"] = _vllm_cutlass_fn
         except Exception as e:
             print(f"[vllm-cutlass] skipped: {e}")
 
@@ -173,8 +170,9 @@ def test_moe_experts_nopad_bench(
         _torch_fn(hidden, w1, w2, topk_weights, topk_ids)  # warmup
         torch.cuda.synchronize()
 
-        result_torch = bm.profile(_torch_fn, hidden, w1, w2, topk_weights, topk_ids)
-        BenchmarkReport.record(nopad, locals(), result_torch, tag="torch-ref")
+        functors["torch-ref"] = _torch_fn
+
+    bm.compare(functors, hidden, w1, w2, topk_weights, topk_ids, record_as=nopad, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -236,8 +236,7 @@ def test_gated_deltanet_vs_fla_fwd(
 
     # --- TileOPs (BHSD) ---
     op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if chunk_gated_delta_rule is not None:
         # --- FLA (BTHK) ---
@@ -248,12 +247,12 @@ def test_gated_deltanet_vs_fla_fwd(
         def fla_fwd():
             return chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
 
-        result_fla = bm.profile(fla_fwd)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_fwd, ())
     else:
         # --- Torch reference baseline ---
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 # Backward benchmark
@@ -314,8 +313,7 @@ def test_gated_deltanet_vs_fla_bwd(
     _o, S_fwd, _Aw, _Au = fwd_op.forward(q, k, v, g, beta)
 
     bwd_op = GatedDeltaNetBwdOp(chunk_size=BC, tune=tune)
-    result = bm.profile(bwd_op.forward, do, q, k, v, g, beta, S_fwd)
-    BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
+    functors = {"tileops": bwd_op.forward}
 
     if chunk_gated_delta_rule is not None:
         # --- FLA: bwd only via autograd (BTHK layout) ---
@@ -337,14 +335,14 @@ def test_gated_deltanet_vs_fla_bwd(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile(fla_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_bwd, ())
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return gated_deltanet_autograd_bwd_torch(do, q, k, v, g, beta, BC)
-        result_bl = bm.profile(torch_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
+        functors["torch"] = (torch_bwd, ())
+
+    bm.compare(functors, do, q, k, v, g, beta, S_fwd, record_as=bwd_op, params=locals())
 
 
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -408,8 +408,7 @@ def test_gated_deltanet_vs_fla_fwdbwd(
         o.backward(do, retain_graph=True)
         return q.grad, k.grad, v.grad
 
-    result = bm.profile_autograd(tileops_fwdbwd)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": tileops_fwdbwd}
 
     if chunk_gated_delta_rule is not None:
         # --- FLA: fwd+bwd via autograd ---
@@ -427,14 +426,16 @@ def test_gated_deltanet_vs_fla_fwdbwd(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile_autograd(fla_fwdbwd)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = fla_fwdbwd
     else:
         # --- Torch autograd reference baseline ---
         def torch_fwdbwd():
             return gated_deltanet_autograd_bwd_torch(do, q.data, k.data, v.data, g.data, beta.data, BC)
-        result_bl = bm.profile_autograd(torch_fwdbwd)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = torch_fwdbwd
+
+    # Every closure builds its graph and calls backward inside the timed call.
+    bm.compare(functors, record_as=op, params=locals(),
+               needs_grad=("tileops", "fla", "torch"))
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gated_deltanet_prefill.py
+++ b/benchmarks/ops/bench_gated_deltanet_prefill.py
@@ -196,18 +196,24 @@ def test_gated_deltanet_prefill_fwd_bench(
 
     op = GatedDeltaNetPrefillFwdOp(chunk_size=chunk_size, tune=tune, layout=layout)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-
+    functors = {"tileops": op}
     if fla_fn is not None:
         fla_inputs = convert_gdn_prefill_layout(inputs, layout, "bthd")
-        result_fla = bm.profile(fla_fn, *fla_inputs)
-        result["speedup_vs_fla"] = result_fla["latency_ms"] / result["latency_ms"]
-        BenchmarkReport.record(op, locals(), result, tag="tileops")
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_fn, fla_inputs)
     else:
-        BenchmarkReport.record(op, locals(), result, tag="tileops")
-        result_ref = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
+        functors["torch-ref"] = test.ref_program
+
+    # Recorded by hand: the tileops row carries a derived speedup field.
+    results = bm.compare(functors, *inputs)
+    if fla_fn is not None:
+        results["tileops"]["speedup_vs_fla"] = (
+            results["fla"]["latency_ms"] / results["tileops"]["latency_ms"]
+        )
+        BenchmarkReport.record(op, locals(), results["tileops"], tag="tileops")
+        BenchmarkReport.record(op, locals(), results["fla"], tag="fla")
+    else:
+        BenchmarkReport.record(op, locals(), results["tileops"], tag="tileops")
+        BenchmarkReport.record(op, locals(), results["torch-ref"], tag="torch-ref")
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gated_deltanet_recurrence.py
+++ b/benchmarks/ops/bench_gated_deltanet_recurrence.py
@@ -95,8 +95,7 @@ def test_gated_deltanet_decode_bench(
 
     op = GatedDeltaNetDecodeOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if fused_recurrent_gated_delta_rule is not None:
         # --- FLA: fused_recurrent_gated_delta_rule with T=1 ---
@@ -116,12 +115,12 @@ def test_gated_deltanet_decode_bench(
                 output_final_state=True,
             )
 
-        result_fla = bm.profile(fla_decode)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_decode, ())
     else:
         # --- Torch reference baseline ---
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -284,42 +284,42 @@ def test_gemm_fp8_bench(
     op = GemmFp8Op(out_dtype=out_dtype)
     bm = ManifestBenchmark(_FP8_OP_NAME, op, workload)
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    if scale_mode not in ("per_tensor", "block128"):
+        raise ValueError(f"unsupported FP8 GEMM scale_mode for benchmark: {scale_mode!r}")
 
-    result_bl = bm.profile(workload.torch_scaled_matmul, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-scaled-mm")
+    functors = {"tileops": op, "torch-scaled-mm": workload.torch_scaled_matmul}
 
     if scale_mode == "per_tensor":
         unsupported_reason = _flashinfer_fp8_per_tensor_unsupported_reason(inputs[0].device)
         if unsupported_reason is not None:
             print(f"  [skip] flashinfer-mm-fp8: {unsupported_reason}")
-            return
-        flashinfer = pytest.importorskip("flashinfer")
-        prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(workload, *inputs)
+        else:
+            # Probe once and drop only the flashinfer row when it cannot run;
+            # skipping would take the op's own numbers down with it.
+            try:
+                import flashinfer
+
+                prepared_b, alpha = _prepare_flashinfer_fp8_per_tensor(workload, *inputs)
+
+                def flashinfer_fn(a):
+                    return flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=out_dtype)
+
+                flashinfer_fn(inputs[0])
+            except (ImportError, RuntimeError) as exc:
+                print(f"  [skip] flashinfer-mm-fp8: {str(exc).splitlines()[0]}")
+            else:
+                functors["flashinfer-mm-fp8"] = (flashinfer_fn, (inputs[0],))
+    else:
         try:
-            result_flashinfer = bm.profile(
-                lambda a: flashinfer.mm_fp8(a, prepared_b, alpha, out_dtype=out_dtype),
-                inputs[0],
+            import flashinfer  # noqa: F401
+        except ImportError as exc:
+            print(f"  [skip] flashinfer-fp8-blockscale-sm90: {exc}")
+        else:
+            functors["flashinfer-fp8-blockscale-sm90"] = (
+                lambda *args: _flashinfer_fp8_blockscale_ref(workload, *args), inputs,
             )
-        except RuntimeError as exc:
-            reason = str(exc).splitlines()[0]
-            print(f"  [skip] flashinfer-mm-fp8: {reason}")
-            return
-        BenchmarkReport.record(op, locals(), result_flashinfer, tag="flashinfer-mm-fp8")
-        return
 
-    if scale_mode == "block128":
-        pytest.importorskip("flashinfer")
-        result_flashinfer = bm.profile(
-            lambda *args: _flashinfer_fp8_blockscale_ref(workload, *args), *inputs
-        )
-        BenchmarkReport.record(
-            op, locals(), result_flashinfer, tag="flashinfer-fp8-blockscale-sm90"
-        )
-        return
-
-    raise ValueError(f"unsupported FP8 GEMM scale_mode for benchmark: {scale_mode!r}")
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("m, n, k, group_size, dtype_str", _manifest_w4a16_params())
@@ -337,11 +337,10 @@ def test_gemm_w4a16_bench(
     op = GemmW4A16Op(group_size=group_size)
     bm = ManifestBenchmark(_W4A16_OP_NAME, op, workload)
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    result_bl = bm.profile(workload.torch_dequantized_matmul, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-dequantized-matmul")
+    functors = {
+        "tileops": op,
+        "torch-dequantized-matmul": workload.torch_dequantized_matmul,
+    }
 
     if m == 1:
         for reduce_mode, use_fp32_reduce in (("fp32", True), ("fp16", False)):
@@ -356,8 +355,9 @@ def test_gemm_w4a16_bench(
             if actual.shape != (m, n) or not torch.isfinite(actual).all():
                 raise RuntimeError("Marlin W4A16 baseline smoke check failed")
             torch.cuda.synchronize()
-            result_marlin = bm.profile(marlin, *marlin_inputs)
-            BenchmarkReport.record(op, locals(), result_marlin, tag=f"marlin-{reduce_mode}")
+            functors[f"marlin-{reduce_mode}"] = (marlin, marlin_inputs)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gemm.py
+++ b/benchmarks/ops/bench_gemm.py
@@ -264,11 +264,8 @@ def test_gemm_bench(
 
     # The benchmark framework warms up internally; eval_roofline() is read
     # lazily after profiling, by which point forward() has bound the dims.
-    result = bm.profile(op, a, b)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(workload.torch_matmul, a, b)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-cublas")
+    bm.compare({"tileops": op, "torch-cublas": workload.torch_matmul}, a, b, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("m, n, k, scale_mode, dtype_str", _manifest_fp8_params())

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -211,8 +211,7 @@ def test_gla_bwd_bench(
     dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
 
     bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
-    result = bm.profile(bwd_op.forward, q, k, v, g, h, do, dht)
-    BenchmarkReport.record(bwd_op, locals(), result, tag="tileops")
+    functors = {"tileops": (bwd_op.forward, (q, k, v, g, h, do, dht))}
 
     if chunk_gla is not None:
         # --- FLA: bwd via autograd ---
@@ -231,16 +230,16 @@ def test_gla_bwd_bench(
             o_fla.backward(do_fla, retain_graph=True)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile(fla_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_bwd, ())
     else:
         # --- Torch autograd reference baseline ---
         def torch_bwd():
             return gla_autograd_bwd_torch(do, q, k, v, g, BC, scale=scale)
-        # torch_bwd builds its forward graph inside the timed callable, so it
-        # needs the autograd-enabled path; profile() runs under no_grad.
-        result_bl = bm.profile_autograd(torch_bwd)
-        BenchmarkReport.record(bwd_op, locals(), result_bl, tag="torch")
+
+        functors["torch"] = (torch_bwd, ())
+
+    # Only torch_bwd builds its graph inside the timed call.
+    bm.compare(functors, record_as=bwd_op, params=locals(), needs_grad=("torch",))
 
 
 # Combined fwd+bwd benchmark
@@ -304,8 +303,7 @@ def test_gla_fwdbwd_bench(
         dht = torch.zeros(B, H, K, V, device="cuda", dtype=torch.float32)
         return bwd_op.forward(q, k, v, g, h, do, dht)
 
-    result = bm.profile_autograd(tileops_fwdbwd)
-    BenchmarkReport.record(fwd_op, locals(), result, tag="tileops")
+    functors = {"tileops": tileops_fwdbwd}
 
     if chunk_gla is not None:
         # --- FLA: fwd+bwd via autograd ---
@@ -321,13 +319,16 @@ def test_gla_fwdbwd_bench(
             o.backward(do_fla)
             return q_fla.grad, k_fla.grad, v_fla.grad
 
-        result_fla = bm.profile_autograd(fla_fwdbwd)
-        BenchmarkReport.record(fwd_op, locals(), result_fla, tag="fla")
+        functors["fla"] = fla_fwdbwd
     else:
         def ref_autograd_fwdbwd():
             return gla_autograd_bwd_torch(do, q, k, v, g, BC, scale=scale)
-        result_bl = bm.profile_autograd(ref_autograd_fwdbwd)
-        BenchmarkReport.record(fwd_op, locals(), result_bl, tag="torch")
+
+        functors["torch"] = ref_autograd_fwdbwd
+
+    # Only the baselines build their graph inside the timed call.
+    bm.compare(functors, record_as=fwd_op, params=locals(),
+               needs_grad=("fla", "torch"))
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -136,8 +136,7 @@ def test_gla_fwd_bench(
     # --- TileOPs ---
     scale = dim_k ** -0.5
     op = GLAFwdOp(chunk_size=chunk_size, scale=scale, tune=tune)
-    result = bm.profile(op.forward, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op.forward}
 
     if chunk_gla is not None:
         # --- FLA ---
@@ -146,15 +145,12 @@ def test_gla_fwd_bench(
         def fla_fwd():
             return chunk_gla(q, k, v, g, scale=scale)
 
-        result_fla = bm.profile(fla_fwd)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_fwd, ())
     else:
         # --- Torch reference baseline ---
-        result_bl = bm.profile(
-            lambda q, k, v, g: gla_fwd_chunked_torch(q, k, v, g, chunk_size),
-            *inputs,
-        )
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = lambda q, k, v, g: gla_fwd_chunked_torch(q, k, v, g, chunk_size)
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 # Backward benchmark

--- a/benchmarks/ops/bench_gla_recurrence.py
+++ b/benchmarks/ops/bench_gla_recurrence.py
@@ -104,8 +104,7 @@ def test_gla_decode_bench(
     # --- TileOPs ---
     op = GLADecodeOp(scale=scale, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if fused_recurrent_gla is not None:
         # --- FLA: fused_recurrent_gla with T=1 ---
@@ -122,12 +121,12 @@ def test_gla_decode_bench(
                 output_final_state=True,
             )
 
-        result_fla = bm.profile(fla_decode)
-        BenchmarkReport.record(op, locals(), result_fla, tag="fla")
+        functors["fla"] = (fla_decode, ())
     else:
         # --- Torch reference baseline ---
-        result_bl = bm.profile(test.ref_program, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+        functors["torch"] = test.ref_program
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_group_norm.py
+++ b/benchmarks/ops/bench_group_norm.py
@@ -45,15 +45,12 @@ def test_group_norm_bench(n: int, c: int, spatial: tuple, num_groups: int,
 
     op = GroupNormFwdOp(num_groups=num_groups, tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, x, weight, bias)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: torch.nn.functional.group_norm
     def baseline_fn(x, weight, bias):
         return F.group_norm(x, num_groups, weight=weight, bias=bias, eps=1e-5)
 
-    result_bl = bm.profile(baseline_fn, x, weight, bias)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, x, weight, bias, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("n, c, spatial, num_groups, dtype, tune",
@@ -66,14 +63,11 @@ def test_group_norm_no_affine_bench(n: int, c: int, spatial: tuple,
 
     op = GroupNormNoAffineFwdOp(num_groups=num_groups, tune=tune)
     bm = ManifestBenchmark(_OP_NAME_NO_AFFINE, op, test)
-    result = bm.profile(op, x)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_no_affine(x):
         return F.group_norm(x, num_groups, weight=None, bias=None, eps=1e-5)
 
-    result_bl = bm.profile(baseline_no_affine, x)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_no_affine}, x, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_grouped_gemm.py
+++ b/benchmarks/ops/bench_grouped_gemm.py
@@ -53,11 +53,8 @@ def test_grouped_gemm_bench(batch_sum: int, batch_count: int, N: int, K: int,
 
     op = GroupedGemmOp(transpose_a=transpose_a, transpose_b=transpose_b, tune=_TUNE)
     bm = ManifestBenchmark(_GROUPED_GEMM_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(name, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(name, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=name, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -109,14 +109,11 @@ def test_clamp_tensor_bench(
 
     op = ClampFwdOp(input=input_shape, min=min_shape, max=max_shape)
     bm = ManifestBenchmark(_CLAMP_FWD_OP, op, test)
-    result = bm.profile(op, x, t_min, t_max)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x, t_min, t_max):
         return torch.clamp(x, t_min, t_max)
 
-    result_bl = bm.profile(baseline_fn, x, t_min, t_max)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, x, t_min, t_max, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -136,14 +133,11 @@ def test_clamp_min_bench(
 
     op = ClampMinFwdOp(input=input_shape, min=min_shape)
     bm = ManifestBenchmark(_CLAMP_MIN_OP, op, test)
-    result = bm.profile(op, x, t_min)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x, t_min):
         return torch.maximum(x, t_min)
 
-    result_bl = bm.profile(baseline_fn, x, t_min)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, x, t_min, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -163,14 +157,11 @@ def test_clamp_max_bench(
 
     op = ClampMaxFwdOp(input=input_shape, max=max_shape)
     bm = ManifestBenchmark(_CLAMP_MAX_OP, op, test)
-    result = bm.profile(op, x, t_max)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     def baseline_fn(x, t_max):
         return torch.minimum(x, t_max)
 
-    result_bl = bm.profile(baseline_fn, x, t_max)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, x, t_max, record_as=op, params=locals())
 
 
 # alibi & sinusoidal (generative: no input tensors)
@@ -231,11 +222,7 @@ def test_alibi_bench(seq_len: int, num_heads: int, dtype: torch.dtype) -> None:
     workload = _GenerativeWorkload((num_heads, seq_len, seq_len), dtype)
     bm = ManifestBenchmark(_ALIBI_OP, op, workload)
 
-    result = bm.profile(op)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    result_bl = bm.profile(lambda: _alibi_reference(seq_len, num_heads, dtype))
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": lambda: _alibi_reference(seq_len, num_heads, dtype)}, record_as=op, params=locals())
 
 
 @SinusoidalBenchFixture
@@ -244,11 +231,7 @@ def test_sinusoidal_bench(seq_len: int, d_model: int, dtype: torch.dtype) -> Non
     workload = _GenerativeWorkload((seq_len, d_model), dtype)
     bm = ManifestBenchmark(_SINUSOIDAL_OP, op, workload)
 
-    result = bm.profile(op)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    result_bl = bm.profile(lambda: _sinusoidal_reference(seq_len, d_model, dtype))
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": lambda: _sinusoidal_reference(seq_len, d_model, dtype)}, record_as=op, params=locals())
 
 
 # fp8 benchmarks: representative independent ops with e4m3fn / e5m2
@@ -313,15 +296,12 @@ def test_fp8_unary_independent_bench(
         op = op_cls(input=shape, **extra_kwargs)
     else:
         op = op_cls(N_total=n_total, **extra_kwargs)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(f"{op_name}_fp8", locals(), result, tag="tileops")
 
     # Baseline: PyTorch fp16 compute then cast back to fp8
     def baseline(x):
         return baseline_fn(x.to(torch.float16)).to(dtype)
 
-    result_bl = bm.profile(baseline, *inputs)
-    BenchmarkReport.record(f"{op_name}_fp8", locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline}, *inputs, record_as=f'{op_name}_fp8', params=locals())
 
 
 # fp8 where / masked_fill (selection ops - pass fp8 through directly)

--- a/benchmarks/ops/bench_independent_elementwise.py
+++ b/benchmarks/ops/bench_independent_elementwise.py
@@ -369,14 +369,12 @@ def test_fp8_selection_bench(
         x, mask = test.gen_inputs()
 
         op = MaskedFillScalarFwdOp(input=tuple(shape), mask=tuple(shape), value=-100.0)
-        result = bm.profile(op, x, mask)
-        BenchmarkReport.record(op, locals(), result, tag="tileops")
 
         def baseline(x, mask):
             return x.to(torch.float16).masked_fill(mask, -100.0).to(dtype)
 
-        result_bl = bm.profile(baseline, x, mask)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        bm.compare({"tileops": op, "torch-ref": baseline}, x, mask,
+                   record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -39,15 +39,12 @@ def test_instance_norm_bench(n: int, c: int, spatial: tuple,
 
     op = InstanceNormFwdOp(tune=tune)
     bm = ManifestBenchmark(_OP_NAME, op, test)
-    result = bm.profile(op, x, weight, bias)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: torch.nn.functional.instance_norm
     def baseline_fn(x, weight, bias):
         return F.instance_norm(x, weight=weight, bias=bias, eps=1e-5)
 
-    result_bl = bm.profile(baseline_fn, x, weight, bias)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, x, weight, bias, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize("n, c, spatial, dtype, tune", _NO_AFFINE_PARAMS)

--- a/benchmarks/ops/bench_instance_norm.py
+++ b/benchmarks/ops/bench_instance_norm.py
@@ -59,14 +59,13 @@ def test_instance_norm_no_affine_bench(n: int, c: int, spatial: tuple,
     # use_input_stats=True path; pass placeholders.
     rm = torch.zeros(c, dtype=torch.float32, device="cuda")
     rv = torch.ones(c, dtype=torch.float32, device="cuda")
-    result = bm.profile(op, x, rm, rv)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     def baseline_no_affine(x):
         return F.instance_norm(x, weight=None, bias=None, eps=1e-5)
 
-    result_bl = bm.profile(baseline_no_affine, x)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    functors["torch"] = (baseline_no_affine, (x, ))
+    bm.compare(functors, x, rm, rv, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_logical_reduce.py
+++ b/benchmarks/ops/bench_logical_reduce.py
@@ -34,22 +34,19 @@ def test_any_bench(
     op_params.setdefault("dim", -1)
     op = AnyFwdOp(**op_params)
     bm = ManifestBenchmark(_ANY_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.bool().any(dim=dim, keepdim=keepdim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # All benchmarks
@@ -68,22 +65,19 @@ def test_all_bench(
     op_params.setdefault("dim", -1)
     op = AllFwdOp(**op_params)
     bm = ManifestBenchmark(_ALL_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.bool().all(dim=dim, keepdim=keepdim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # CountNonzero benchmarks
@@ -102,21 +96,18 @@ def test_count_nonzero_bench(
     op_params.setdefault("dim", -1)
     op = CountNonzeroFwdOp(**op_params)
     bm = ManifestBenchmark(_COUNT_NONZERO_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
 
     def baseline_fn(x):
         return torch.count_nonzero(x, dim=dim).to(torch.int64)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mamba.py
+++ b/benchmarks/ops/bench_mamba.py
@@ -118,8 +118,7 @@ def test_da_cumsum_fwd_bench(batch, num_chunks, chunk_len, n_heads, has_dt_bias,
         dtype=dtype,
         tune=tune,
     )
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # ── Mamba-2 Triton baseline ──
     # _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=None, dt_softplus=False, dt_limit=...)
@@ -136,8 +135,7 @@ def test_da_cumsum_fwd_bench(batch, num_chunks, chunk_len, n_heads, has_dt_bias,
                 dt_softplus=dt_softplus,
             )
 
-        result_mamba = bm.profile(mamba_fwd)
-        BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
+        functors["mamba"] = (mamba_fwd, ())
     else:
         def baseline(dt_raw, A, dt_bias):
             return da_cumsum_fwd_ref(
@@ -145,8 +143,9 @@ def test_da_cumsum_fwd_bench(batch, num_chunks, chunk_len, n_heads, has_dt_bias,
                 dt_bias=dt_bias if has_dt_bias else None,
                 dt_softplus=dt_softplus,
             )
-        result_bl = bm.profile(baseline, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = baseline
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 
@@ -304,8 +303,7 @@ def test_ssd_chunk_scan_fwd_bench(
 
     # ── TileOPs kernel ──
     op = SSDChunkScanFwdOp(tune=tune)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # ── Mamba-2 Triton baseline ──
     if _mamba_chunk_scan_fwd is not None:
@@ -315,14 +313,14 @@ def test_ssd_chunk_scan_fwd_bench(
         def mamba_fwd():
             return _mamba_chunk_scan_fwd(cb, x, dt, dA_cumsum, C, prev_states)
 
-        result_mamba = bm.profile(mamba_fwd)
-        BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
+        functors["mamba"] = (mamba_fwd, ())
     else:
         def torch_ref(x, cb, dA_cumsum, C, prev_states, dt):
             return ssd_chunk_scan_fwd_ref(x, cb, dA_cumsum, C, prev_states, dt, n_groups)
 
-        result_bl = bm.profile(torch_ref, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = torch_ref
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 def ssd_chunk_state_fwd_ref(
@@ -442,8 +440,7 @@ def test_ssd_chunk_state_fwd_bench(
     inputs = test.gen_inputs()
 
     op = SSDChunkStateFwdOp(has_seq_idx=has_seq_idx, tune=tune)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if _mamba_chunk_state_fwd is not None:
         x, Bmat, dt, dA_cumsum, seq_idx = inputs
@@ -459,13 +456,13 @@ def test_ssd_chunk_state_fwd_bench(
                 seq_idx=seq_idx,
             )
 
-        result_mamba = bm.profile(mamba_fwd)
-        BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
+        functors["mamba"] = (mamba_fwd, ())
     else:
         def baseline(x, Bmat, dt, dA_cumsum, seq_idx):
             return ssd_chunk_state_fwd_ref(x, Bmat, dt, dA_cumsum, n_groups=n_groups, seq_idx=seq_idx)
-        result_bl = bm.profile(baseline, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = baseline
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 def ssd_state_passing_fwd_ref(
@@ -556,8 +553,7 @@ def test_ssd_state_passing_fwd_bench(
     states, dA_chunk_cumsum, initial_states = inputs
 
     op = SSDStatePassingFwdOp(tune=tune)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     if _mamba_state_passing_fwd is not None:
         def mamba_fwd():
@@ -576,13 +572,13 @@ def test_ssd_state_passing_fwd_bench(
         mamba_fwd()
         torch.cuda.synchronize()
 
-        result_mamba = bm.profile(mamba_fwd)
-        BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
+        functors["mamba"] = (mamba_fwd, ())
     else:
         def baseline(states, dA_chunk_cumsum, initial_states):
             return ssd_state_passing_fwd_ref(states, dA_chunk_cumsum, initial_states)
-        result_bl = bm.profile(baseline, *inputs)
-        BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+        functors["torch-ref"] = baseline
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 def ssd_decode_ref(
@@ -693,11 +689,10 @@ def test_ssd_decode_bench(
     state_bl = state.clone()
 
     op = SSDDecodeOp(tune=tune)
-    result = bm.profile(op, A, dt, x, B_in, C_in, state_for_op)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     def baseline(A, dt, x, B_in, C_in, state):
         return ssd_decode_ref(A, dt, x, B_in, C_in, state)
 
-    result_bl = bm.profile(baseline, A, dt, x, B_in, C_in, state_bl)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    functors["torch-ref"] = (baseline, (A, dt, x, B_in, C_in, state_bl, ))
+    bm.compare(functors, A, dt, x, B_in, C_in, state_for_op, record_as=op, params=locals())

--- a/benchmarks/ops/bench_mamba2_e2e.py
+++ b/benchmarks/ops/bench_mamba2_e2e.py
@@ -189,8 +189,7 @@ def test_mamba2_fwd_bench(batch, seqlen, n_heads, d_head, d_state, n_groups,
     # Pass inputs directly so bench_kernel clones them each iteration,
     # giving accurate per-clone addressing and fair kernel-only timing.
     # Include dt_bias so all three paths see the same input distribution.
-    result = bm.profile(op.forward, x, dt, A, B, C, dt_bias)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op.forward}
 
     # ── Official mamba_ssm Triton baseline ───────────────────────────────────
     # Pass the same 5 tensor inputs so both paths get identical clone treatment.
@@ -205,11 +204,11 @@ def test_mamba2_fwd_bench(batch, seqlen, n_heads, d_head, d_state, n_groups,
                 dt_softplus=dt_softplus,
             )
 
-        result_mamba = bm.profile(_mamba_wrapper, x, dt, A, B, C)
-        BenchmarkReport.record(op, locals(), result_mamba, tag="mamba")
+        functors["mamba"] = (_mamba_wrapper, (x, dt, A, B, C, ))
     else:
         def _torch_wrapper(x, dt, A, B, C):
             return mamba2_fwd_ref(x, dt, A, B, C, dt_bias, chunk_size, dt_softplus)
 
-        result_torch = bm.profile(_torch_wrapper, x, dt, A, B, C)
-        BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+        functors["torch-ref"] = (_torch_wrapper, (x, dt, A, B, C, ))
+
+    bm.compare(functors, x, dt, A, B, C, dt_bias, record_as=op, params=locals())

--- a/benchmarks/ops/bench_mean_pooling.py
+++ b/benchmarks/ops/bench_mean_pooling.py
@@ -91,11 +91,8 @@ def test_mean_pooling_bench(batch_size: int, seq_len: int, heads: int, dim: int,
     inputs = test.gen_inputs()
 
     op = MeanPoolingForwardOp(**params)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_mhc.py
+++ b/benchmarks/ops/bench_mhc.py
@@ -50,11 +50,8 @@ def test_mhc_pre_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype,
 
     op = MHCPreOp(tune=_TUNE)
     bm = ManifestBenchmark(_MHC_PRE_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 _MHC_POST_OP = "MHCPostOp"
@@ -70,11 +67,8 @@ def test_mhc_post_bench(batch: int, n_expand: int, c_x: int, dtype: torch.dtype)
 
     op = MHCPostOp(tune=_TUNE)
     bm = ManifestBenchmark(_MHC_POST_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_fused_activation.py
+++ b/benchmarks/ops/bench_moe_fused_activation.py
@@ -198,26 +198,23 @@ def test_moe_fused_activation_bench(regime: str, num_tokens: int) -> None:
     _run_torch_ref(hidden, w_gate_up, w_down, topk_weights, topk_ids)  # warmup
     torch.cuda.synchronize()
 
-    result_torch = bm.profile(_run_torch_ref, hidden, w_gate_up, w_down, topk_weights, topk_ids)
+    # Recorded by hand: the fused row belongs to a different op.
+    results = bm.compare(
+        {
+            "torch-ref": _run_torch_ref,
+            "tileops-unfused": _run_unfused,
+            "tileops-fused": _run_fused,
+        },
+        hidden, w_gate_up, w_down, topk_weights, topk_ids,
+    )
+    result_torch = results["torch-ref"]
+    result_unfused = results["tileops-unfused"]
+    result_fused = results["tileops-fused"]
     BenchmarkReport.record(op_unfused, locals(), result_torch, tag="torch-ref")
+    BenchmarkReport.record(op_unfused, locals(), result_unfused, tag="tileops-unfused")
+    BenchmarkReport.record(op_fused, locals(), result_fused, tag="tileops-fused")
     ms_torch = result_torch["latency_ms"]
-
-    # ---- Timing: unfused ----------------------------------------------------
-    result_unfused = bm.profile(
-        _run_unfused, hidden, w_gate_up, w_down, topk_weights, topk_ids,
-    )
-    BenchmarkReport.record(
-        op_unfused, locals(), result_unfused, tag="tileops-unfused",
-    )
     ms_unfused = result_unfused["latency_ms"]
-
-    # ---- Timing: fused ------------------------------------------------------
-    result_fused = bm.profile(
-        _run_fused, hidden, w_gate_up, w_down, topk_weights, topk_ids,
-    )
-    BenchmarkReport.record(
-        op_fused, locals(), result_fused, tag="tileops-fused",
-    )
     ms_fused = result_fused["latency_ms"]
 
     # ---- Console summary for this regime ------------------------------------

--- a/benchmarks/ops/bench_moe_fused_moe.py
+++ b/benchmarks/ops/bench_moe_fused_moe.py
@@ -133,8 +133,7 @@ def _run_bench(
     op(*forward_args_tileops)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(op, *forward_args_tileops)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # -- Baseline ----------------------------------------------------------
     # vLLM's ``fused_topk`` has no correction_bias parameter, so routing for
@@ -160,10 +159,7 @@ def _run_bench(
         _vllm_fn(hidden, gating, correction_bias, w_gate_up, w_down)
         torch.cuda.synchronize()
 
-        result_vllm = bm.profile(
-            _vllm_fn, hidden, gating, correction_bias, w_gate_up, w_down,
-        )
-        BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+        functors["vllm"] = (_vllm_fn, (hidden, gating, correction_bias, w_gate_up, w_down, ))
     else:
         # torch-ref baseline: memory-efficient per-expert GEMM loop.
         fk = FusedTopKOp(
@@ -197,10 +193,9 @@ def _run_bench(
         _ref_fn(hidden, gating, correction_bias, w_gate_up, w_down)
         torch.cuda.synchronize()
 
-        result_ref = bm.profile(
-            _ref_fn, hidden, gating, correction_bias, w_gate_up, w_down,
-        )
-        BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
+        functors["torch-ref"] = (_ref_fn, (hidden, gating, correction_bias, w_gate_up, w_down, ))
+
+    bm.compare(functors, *forward_args_tileops, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(

--- a/benchmarks/ops/bench_moe_fused_topk.py
+++ b/benchmarks/ops/bench_moe_fused_topk.py
@@ -100,8 +100,7 @@ def test_fused_topk_bench(
     op(gating_output)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(op, gating_output)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # vLLM baseline (optional)
     has_external = False
@@ -121,8 +120,7 @@ def test_fused_topk_bench(
         _vllm_fn(gating_output)  # warmup
         torch.cuda.synchronize()
 
-        result_vllm = bm.profile(_vllm_fn, gating_output)
-        BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+        functors["vllm"] = _vllm_fn
 
     # Fallback: torch reference baseline (only when no external baselines)
     if not has_external:
@@ -132,5 +130,6 @@ def test_fused_topk_bench(
         _ref_fn(gating_output)  # warmup
         torch.cuda.synchronize()
 
-        result_ref = bm.profile(_ref_fn, gating_output)
-        BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
+        functors["torch-ref"] = _ref_fn
+
+    bm.compare(functors, gating_output, record_as=op, params=locals())

--- a/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
+++ b/benchmarks/ops/bench_moe_grouped_gemm_nopad.py
@@ -56,9 +56,6 @@ def test_moe_grouped_gemm_nopad_bench(
     op(a, b, true_sizes, true_offsets)
     torch.cuda.synchronize()
 
-    result = bm.profile(op, a, b, true_sizes, true_offsets)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     # PyTorch baseline: per-expert NT matmul.
     sizes_l = true_sizes.tolist()
     offsets_l = true_offsets.tolist()
@@ -76,8 +73,7 @@ def test_moe_grouped_gemm_nopad_bench(
     _torch_fn(a, b, true_sizes, true_offsets)  # warmup
     torch.cuda.synchronize()
 
-    result_torch = bm.profile(_torch_fn, a, b, true_sizes, true_offsets)
-    BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": _torch_fn}, a, b, true_sizes, true_offsets, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_permute_align.py
+++ b/benchmarks/ops/bench_moe_permute_align.py
@@ -174,8 +174,7 @@ def test_permute_align_bench(
     op(*inputs)
     torch.cuda.synchronize()
 
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # Triton baseline
     dev = inputs[0].device
@@ -196,8 +195,7 @@ def test_permute_align_bench(
     _triton_fn(*inputs)
     torch.cuda.synchronize()
 
-    result_bl = bm.profile(_triton_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="triton")
+    functors["triton"] = _triton_fn
 
     # sgl-kernel baseline (optional -- only runs when sgl_kernel is installed)
     if _SGL_KERNEL_AVAILABLE:
@@ -217,8 +215,9 @@ def test_permute_align_bench(
         _sgl_fn(*inputs)
         torch.cuda.synchronize()
 
-        result_sgl = bm.profile(_sgl_fn, *inputs)
-        BenchmarkReport.record(op, locals(), result_sgl, tag="sgl-kernel")
+        functors["sgl-kernel"] = _sgl_fn
+
+    bm.compare(functors, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_permute_nopad.py
+++ b/benchmarks/ops/bench_moe_permute_nopad.py
@@ -71,8 +71,7 @@ def test_moe_permute_nopad_bench(
     op(hidden_states, topk_ids)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(op, hidden_states, topk_ids)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # vLLM baseline (optional)
     if _VLLM_AVAILABLE:
@@ -82,8 +81,7 @@ def test_moe_permute_nopad_bench(
         _vllm_fn(hidden_states, topk_ids)  # warmup
         torch.cuda.synchronize()
 
-        result_vllm = bm.profile(_vllm_fn, hidden_states, topk_ids)
-        BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+        functors["vllm"] = _vllm_fn
     else:
         # PyTorch vectorized baseline: counting sort + gather
         numel = total_tokens * top_k
@@ -115,8 +113,9 @@ def test_moe_permute_nopad_bench(
         _torch_fn(hidden_states, topk_ids)  # warmup
         torch.cuda.synchronize()
 
-        result_torch = bm.profile(_torch_fn, hidden_states, topk_ids)
-        BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+        functors["torch-ref"] = _torch_fn
+
+    bm.compare(functors, hidden_states, topk_ids, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_moe_shared_fused_moe.py
+++ b/benchmarks/ops/bench_moe_shared_fused_moe.py
@@ -144,11 +144,7 @@ def test_shared_fused_moe_bench(
         return op(hidden, gating, w_gate_up, w_down, correction_bias,
                   shared_w_gate_up=shared_w_gate_up, shared_w_down=shared_w_down)
 
-    result = bm.profile(
-        _tileops_fn, hidden, gating, w_gate_up, w_down, correction_bias,
-        shared_w_gate_up, shared_w_down,
-    )
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": _tileops_fn}
 
     # ── vLLM baseline (optional) ──────────────────────────────────────────────
     if _VLLM_AVAILABLE:
@@ -181,11 +177,7 @@ def test_shared_fused_moe_bench(
                  shared_w_gate_up, shared_w_down)  # warmup
         torch.cuda.synchronize()
 
-        result_vllm = bm.profile(
-            _vllm_fn, hidden, gating, correction_bias, w_gate_up, w_down,
-            shared_w_gate_up, shared_w_down,
-        )  # all positional — OK
-        BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+        functors["vllm"] = (_vllm_fn, (hidden, gating, correction_bias, w_gate_up, w_down, shared_w_gate_up, shared_w_down, ))
     else:
         # torch-ref: per-expert GEMM loop + manual shared MLP
         fk = FusedTopKOp(
@@ -227,8 +219,6 @@ def test_shared_fused_moe_bench(
                 shared_w_gate_up, shared_w_down)  # warmup
         torch.cuda.synchronize()
 
-        result_ref = bm.profile(
-            _ref_fn, hidden, gating, correction_bias, w_gate_up, w_down,
-            shared_w_gate_up, shared_w_down,
-        )
-        BenchmarkReport.record(op, locals(), result_ref, tag="torch-ref")
+        functors["torch-ref"] = (_ref_fn, (hidden, gating, correction_bias, w_gate_up, w_down, shared_w_gate_up, shared_w_down, ))
+
+    bm.compare(functors, hidden, gating, w_gate_up, w_down, correction_bias, shared_w_gate_up, shared_w_down, record_as=op, params=locals())

--- a/benchmarks/ops/bench_moe_unpermute.py
+++ b/benchmarks/ops/bench_moe_unpermute.py
@@ -68,8 +68,7 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
     op(mm2_pad, fwd_idx, topk_weights)  # warmup / JIT compile
     torch.cuda.synchronize()
 
-    result = bm.profile(op, mm2_pad, fwd_idx, topk_weights)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
+    functors = {"tileops": op}
 
     # vLLM baseline (optional)
     if _VLLM_AVAILABLE:
@@ -87,8 +86,7 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
         _vllm_fn(mm2_pad, fwd_idx, topk_weights)  # warmup
         torch.cuda.synchronize()
 
-        result_vllm = bm.profile(_vllm_fn, mm2_pad, fwd_idx, topk_weights)
-        BenchmarkReport.record(op, locals(), result_vllm, tag="vllm")
+        functors["vllm"] = _vllm_fn
     else:
         # Fallback: PyTorch vectorized baseline (gather + weighted sum)
         fwd_idx_long = fwd_idx.long()
@@ -103,8 +101,9 @@ def test_moe_unpermute_bench(total_tokens: int, top_k: int, hidden_size: int) ->
         _torch_fn(mm2_pad, fwd_idx, topk_weights)  # warmup
         torch.cuda.synchronize()
 
-        result_torch = bm.profile(_torch_fn, mm2_pad, fwd_idx, topk_weights)
-        BenchmarkReport.record(op, locals(), result_torch, tag="torch-ref")
+        functors["torch-ref"] = _torch_fn
+
+    bm.compare(functors, mm2_pad, fwd_idx, topk_weights, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_norm.py
+++ b/benchmarks/ops/bench_norm.py
@@ -40,11 +40,8 @@ def test_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> None:
 
     op = RMSNormFwdOp(normalized_shape=(n,), tune=tune)
     bm = ManifestBenchmark(_RMS_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 _FUSED_RMS_OP_NAME = "FusedAddRMSNormFwdOp"
@@ -77,8 +74,6 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
 
     op = FusedAddRMSNormFwdOp(tune=tune)
     bm = ManifestBenchmark(_FUSED_RMS_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: add + manual rmsnorm (separate ops)
     def baseline_fn(x, residual, weight):
@@ -87,8 +82,7 @@ def test_fused_add_rms_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool
         y = ((add_result.float() / rms) * weight.float()).to(x.dtype)
         return y, add_result
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 _LN_OP_NAME = "LayerNormFwdOp"
@@ -113,15 +107,12 @@ def test_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bool) -> Non
 
     op = LayerNormFwdOp(normalized_shape=(n,), tune=tune)
     bm = ManifestBenchmark(_LN_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline uses torch.nn.functional.layer_norm
     def baseline_fn(x, weight, bias):
         return F.layer_norm(x, (n,), weight=weight, bias=bias, eps=1e-5)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 _FUSED_LN_OP_NAME = "FusedAddLayerNormFwdOp"
@@ -146,16 +137,13 @@ def test_fused_add_layer_norm_bench(m: int, n: int, dtype: torch.dtype, tune: bo
 
     op = FusedAddLayerNormFwdOp(tune=tune)
     bm = ManifestBenchmark(_FUSED_LN_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
     # Baseline: add + F.layer_norm (separate ops)
     def baseline_fn(x, residual, weight, bias):
         add_result = (x.float() + residual.float()).to(x.dtype)
         return F.layer_norm(add_result, (n,), weight=weight, bias=bias, eps=test.eps), add_result
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline_fn}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_pool.py
+++ b/benchmarks/ops/bench_pool.py
@@ -190,11 +190,8 @@ def test_avg_pool1d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_AVG_POOL1D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 def _avg_pool2d_bench_params() -> list:
@@ -275,11 +272,8 @@ def test_avg_pool2d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_AVG_POOL2D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 def _avg_pool3d_bench_params() -> list:
@@ -363,11 +357,8 @@ def test_avg_pool3d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_AVG_POOL3D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 def _max_pool2d_bench_params_from_workloads(workloads: list[dict]) -> list:
@@ -451,11 +442,8 @@ def test_max_pool2d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL2D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -499,11 +487,8 @@ def test_max_pool2d_indices_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL2D_INDICES_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 def _max_pool1d_bench_params_from_workloads(workloads: list[dict]) -> list:
@@ -587,11 +572,8 @@ def test_max_pool1d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL1D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -633,11 +615,8 @@ def test_max_pool1d_indices_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL1D_INDICES_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 def _max_pool3d_bench_params_from_workloads(workloads: list[dict]) -> list:
@@ -727,11 +706,8 @@ def test_max_pool3d_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL3D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -777,11 +753,8 @@ def test_max_pool3d_indices_bench(
         tune=tune,
     )
     bm = ManifestBenchmark(_MAX_POOL3D_INDICES_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 class AdaptiveAvgPool2dBenchmarkWorkload(AdaptivePool2dWorkload):
@@ -845,11 +818,8 @@ def test_adaptive_avg_pool2d_bench(
 
     op = AdaptiveAvgPool2dFwdOp(output_size=output_size, tune=tune)
     bm = ManifestBenchmark(_ADAPTIVE_AVG_POOL2D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -870,11 +840,8 @@ def test_adaptive_max_pool2d_bench(
 
     op = AdaptiveMaxPool2dFwdOp(output_size=output_size, tune=tune)
     bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 @pytest.mark.parametrize(
@@ -897,8 +864,5 @@ def test_adaptive_max_pool2d_indices_bench(
 
     op = AdaptiveMaxPool2dIndicesFwdOp(output_size=output_size, tune=tune)
     bm = ManifestBenchmark(_ADAPTIVE_MAX_POOL2D_INDICES_OP_NAME, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": test.ref_program}, *inputs, record_as=op, params=locals())

--- a/benchmarks/ops/bench_reduce.py
+++ b/benchmarks/ops/bench_reduce.py
@@ -57,22 +57,19 @@ def test_sum_bench(
     op_params.setdefault("dim", -1)  # baseline below reduces dim=-1
     op = SumFwdOp(**op_params)
     bm = ManifestBenchmark(_SUM_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params.get("dim", -1)
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.float().sum(dim=dim, keepdim=keepdim).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Mean benchmarks
@@ -91,22 +88,19 @@ def test_mean_bench(
     op_params.setdefault("dim", -1)  # baseline below mirrors the op's dim
     op = MeanFwdOp(**op_params)
     bm = ManifestBenchmark(_MEAN_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Amax benchmarks
@@ -125,22 +119,19 @@ def test_amax_bench(
     op_params.setdefault("dim", -1)
     op = AmaxFwdOp(**op_params)
     bm = ManifestBenchmark(_AMAX_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.amax(dim=dim, keepdim=keepdim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Amin benchmarks
@@ -159,22 +150,19 @@ def test_amin_bench(
     op_params.setdefault("dim", -1)
     op = AminFwdOp(**op_params)
     bm = ManifestBenchmark(_AMIN_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.amin(dim=dim, keepdim=keepdim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Prod benchmarks
@@ -187,19 +175,16 @@ def test_prod_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = ProdFwdOp()
     bm = ManifestBenchmark(_PROD_OP, op, test)
+    def baseline_fn(x):
+        return x.float().prod(dim=-1).to(x.dtype)
+
     try:
-        result = bm.profile(op, *inputs)
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    def baseline_fn(x):
-        return x.float().prod(dim=-1).to(x.dtype)
-
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 # Std benchmarks
@@ -218,22 +203,19 @@ def test_std_bench(
     op_params.setdefault("dim", -1)
     op = StdFwdOp(correction=1, **op_params)
     bm = ManifestBenchmark(_STD_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.float().std(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Var benchmarks
@@ -252,22 +234,19 @@ def test_var_bench(
     op_params.setdefault("dim", -1)
     op = VarFwdOp(correction=1, **op_params)
     bm = ManifestBenchmark(_VAR_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return x.float().var(dim=dim, keepdim=keepdim, correction=1).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # VarMean benchmarks
@@ -286,14 +265,6 @@ def test_var_mean_bench(
     op_params.setdefault("dim", -1)
     op = VarMeanFwdOp(correction=1, **op_params)
     bm = ManifestBenchmark(_VAR_MEAN_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -302,8 +273,13 @@ def test_var_mean_bench(
         m = x.float().mean(dim=dim, keepdim=keepdim).to(x.dtype)
         return (v, m)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_rope.py
+++ b/benchmarks/ops/bench_rope.py
@@ -112,15 +112,11 @@ def _profile_rope(op, bm: ManifestBenchmark, shape: tuple[int, ...],
     x = torch.randn(shape, device="cuda", dtype=dtype)
     params = {"shape": shape, "dtype": dtype, "layout": layout}
 
-    result = bm.profile(op, x)
-    BenchmarkReport.record(op, params, result, tag="tileops")
-
     seq_len = shape[0] if layout == "1d" else shape[1]
     cos, sin = _rope_tables(seq_len, shape[-1], dtype)
     if layout != "1d":
         cos, sin = (t.view(1, seq_len, 1, shape[-1]) for t in (cos, sin))
-    result_bl = bm.profile(lambda t: _rotate(t, cos, sin), x)
-    BenchmarkReport.record(op, params, result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": lambda t: _rotate(t, cos, sin)}, x, record_as=op, params=params)
 
 
 # Per-op tests — one block per manifest entry.
@@ -215,17 +211,13 @@ def test_rope_neox_position_ids_bench(
     bm = ManifestBenchmark(_POSITION_IDS_OP, op, RopeWorkload(shape, dtype))
     params = {"shape": shape, "dtype": dtype, "max_position": max_position}
 
-    result = bm.profile(op, x, position_ids)
-    BenchmarkReport.record(op, params, result, tag="tileops")
-
     cos, sin = _rope_tables(max_position, head_dim, dtype)
 
     def baseline_fn(t: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
         idx = pos.long()
         return _rotate(t, cos[idx].unsqueeze(1), sin[idx].unsqueeze(1))
 
-    result_bl = bm.profile(baseline_fn, x, position_ids)
-    BenchmarkReport.record(op, params, result_bl, tag="torch-ref")
+    bm.compare({"tileops": op, "torch-ref": baseline_fn}, x, position_ids, record_as=op, params=params)
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_softmax.py
+++ b/benchmarks/ops/bench_softmax.py
@@ -33,19 +33,16 @@ def test_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = SoftmaxFwdOp(dim=-1, tune=True)
     bm = ManifestBenchmark(_SOFTMAX_OP, op, test)
+    def baseline_fn(x):
+        return F.softmax(x, dim=-1)
+
     try:
-        result = bm.profile(op, *inputs)
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    def baseline_fn(x):
-        return F.softmax(x, dim=-1)
-
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 # LogSoftmax benchmarks
@@ -58,19 +55,16 @@ def test_log_softmax_bench(shape: tuple, dtype: torch.dtype) -> None:
 
     op = LogSoftmaxFwdOp(dim=-1, tune=True)
     bm = ManifestBenchmark(_LOG_SOFTMAX_OP, op, test)
+    def baseline_fn(x):
+        return F.log_softmax(x, dim=-1)
+
     try:
-        result = bm.profile(op, *inputs)
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
-    def baseline_fn(x):
-        return F.log_softmax(x, dim=-1)
-
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
 
 
 # LogSumExp benchmarks
@@ -89,22 +83,19 @@ def test_logsumexp_bench(
     op_params.setdefault("dim", -1)
     op = LogSumExpFwdOp(tune=True, **op_params)
     bm = ManifestBenchmark(_LOGSUMEXP_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
     def baseline_fn(x):
         return torch.logsumexp(x, dim=dim, keepdim=keepdim)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_topk_selector.py
+++ b/benchmarks/ops/bench_topk_selector.py
@@ -41,11 +41,8 @@ def test_topk_selector_bench(batch: int, seq_len: int, seq_len_kv: int, kv_group
 
     op = TopkSelectorOp(topk=topk, tune=_TUNE)
     bm = ManifestBenchmark(_TOPK_SELECTOR_OP, op, test)
-    result = bm.profile(op, *inputs)
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
 
-    result_bl = bm.profile(test.ref_program, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    bm.compare({"tileops": op, "torch": test.ref_program}, *inputs, record_as=op, params=locals())
 
 
 if __name__ == "__main__":

--- a/benchmarks/ops/bench_unary_elementwise.py
+++ b/benchmarks/ops/bench_unary_elementwise.py
@@ -83,15 +83,12 @@ def _profile_and_record(
     instead of reflecting only this helper's locals.
     """
     try:
-        result = bm.profile(op, *inputs)
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=params)
     except ValueError as exc:
         if "No configurations to tune" in str(exc):
             pytest.skip(f"Kernel does not support this shape: {exc}")
         raise
-    BenchmarkReport.record(op, params, result, tag="tileops")
-
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, params, result_bl, tag="torch")
 
 
 # Per-op constants and tests — one block per manifest entry so the

--- a/benchmarks/ops/bench_vector_norm.py
+++ b/benchmarks/ops/bench_vector_norm.py
@@ -34,14 +34,6 @@ def test_l1_norm_bench(
     op_params.setdefault("dim", -1)
     op = L1NormFwdOp(**op_params)
     bm = ManifestBenchmark(_L1_NORM_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -50,8 +42,13 @@ def test_l1_norm_bench(
             x.float(), ord=1, dim=dim, keepdim=keepdim,
         ).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # L2 Norm benchmarks
@@ -70,14 +67,6 @@ def test_l2_norm_bench(
     op_params.setdefault("dim", -1)
     op = L2NormFwdOp(**op_params)
     bm = ManifestBenchmark(_L2_NORM_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -86,8 +75,13 @@ def test_l2_norm_bench(
             x.float(), ord=2, dim=dim, keepdim=keepdim,
         ).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 # Inf Norm benchmarks
@@ -106,14 +100,6 @@ def test_inf_norm_bench(
     op_params.setdefault("dim", -1)
     op = InfNormFwdOp(**op_params)
     bm = ManifestBenchmark(_INF_NORM_OP, op, test)
-    try:
-        result = bm.profile(op, *inputs)
-    except ValueError as exc:
-        if "No configurations to tune" in str(exc):
-            pytest.skip(f"Kernel does not support this shape: {exc}")
-        raise
-    BenchmarkReport.record(op, locals(), result, tag="tileops")
-
     dim = op_params["dim"]
     keepdim = op_params.get("keepdim", False)
 
@@ -122,8 +108,13 @@ def test_inf_norm_bench(
             x.float(), ord=float("inf"), dim=dim, keepdim=keepdim,
         ).to(x.dtype)
 
-    result_bl = bm.profile(baseline_fn, *inputs)
-    BenchmarkReport.record(op, locals(), result_bl, tag="torch")
+    try:
+        bm.compare({"tileops": op, "torch": baseline_fn}, *inputs,
+                   record_as=op, params=locals())
+    except ValueError as exc:
+        if "No configurations to tune" in str(exc):
+            pytest.skip(f"Kernel does not support this shape: {exc}")
+        raise
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -1,9 +1,3 @@
-"""Unit tests for benchmarks.benchmark_base.
-
-Verifies that the generic ``BenchmarkBase`` / ``ManifestBenchmark`` accept
-any duck-typed workload rather than requiring ``WorkloadBase`` inheritance.
-"""
-
 import pytest
 import torch
 
@@ -14,8 +8,6 @@ from benchmarks.benchmark_base import (
     bench_kernel,
     workloads_to_params,
 )
-
-# Duck-typed test workloads
 
 
 @pytest.mark.smoke
@@ -81,28 +73,10 @@ def test_attribution_excludes_prepare_and_keeps_the_operator_gap():
     assert samples_ms == pytest.approx([0.006, 0.008])
 
 
-@pytest.mark.parametrize(
-    "kernels, expected_sequence",
-    [
-        # CUPTI may publish two concurrent kernels in either start-time order.
-        ([_kernel("b", 1_000, 3_000), _kernel("a", 1_500, 2_500)], _seq("a", "b")),
-        # A repeated kernel name is matched by occurrence, not by identity.
-        (
-            [
-                _kernel("a", 1_000, 2_000),
-                _kernel("b", 1_500, 3_000),
-                _kernel("a", 2_000, 2_500),
-            ],
-            _seq("a", "a", "b"),
-        ),
-    ],
-)
-def test_attribution_accepts_overlapping_activities_in_either_order(
-    kernels, expected_sequence,
-):
-    samples_ms = _attributed_latency_samples_ms(
-        kernels, expected_sequence, n_repeat=1,
-    )
+def test_attribution_accepts_concurrent_activities_in_either_order():
+    """CUPTI may publish two overlapping kernels in either start-time order."""
+    kernels = [_kernel("b", 1_000, 3_000), _kernel("a", 1_500, 2_500)]
+    samples_ms = _attributed_latency_samples_ms(kernels, _seq("a", "b"), n_repeat=1)
     assert samples_ms == pytest.approx([0.002])
 
 


### PR DESCRIPTION
## Problem

Bench files timed the op to completion, then the baseline to completion. Drift
across a case landed entirely on whichever ran last, so every published
"vs baseline" ratio carried that bias in one fixed direction.

## Change

`BenchmarkBase.compare()` times each implementation forward, then reversed, and
records them all. The measurement budget is split across the two passes, so a
case costs what it did before.

```python
functors = {"tileops": op}
if fa3_fn is not None:
    functors["fa3"] = fa3_fn
bm.compare(functors, *inputs, record_as=op, params=locals())
```

132 functions held a profile call; 3 still do, each for a stated reason.

Two fixes fall out. `bench_bmm` and `bench_gemm` skipped the whole case when
flashinfer was missing or could not take the shape, losing the op's own numbers
with it — they now drop only the flashinfer row. `profile_autograd` is gone: no
op needed it, only baselines that build their graph inside the timed callable,
which `compare(needs_grad=...)` now marks.

## Notes for review

- Benchmark files only. No CI, image, or op changes.
- Two shapes were rewritten by an AST pass that fires only where the result is
  provably identical; the remaining 15 functions by hand.
- A checker confirms every function records the same tags for the same op.
- `bench_grouped_gemm_baselines.py` fails collection on the cu132 image for an
  unrelated Triton reason. It is untouched here.
