### PR TITLE
[Perf][foundry][FFT] Remove split-input copies from C2C FFT

### DIFF
--- a/src/tileops/kernels/fft.py
+++ b/src/tileops/kernels/fft.py
@@ -8,9 +8,6 @@ import torch
 
 from .kernel_base import Kernel
 
-# Sufficient precision for twiddle angles
-_PI = 3.14159265358979323846
-
 
 @functools.lru_cache(maxsize=32)
 def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Callable:
@@ -27,8 +24,9 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
       Each block reads input elements at their bit-reversed positions directly
       into shared memory, eliminating the separate bit-reversal kernel.  It
       then performs all log2(min(n, 2*threads)) butterfly stages entirely in
-      SMEM using on-the-fly trig.  Result: one global-memory read + one write
-      for the entire SMEM phase, regardless of how many stages it covers.
+      SMEM using the pre-computed twiddle LUT. Result: one global-memory read
+      + one write for the entire SMEM phase, regardless of how many stages it
+      covers.
 
     Phase 2 — LUT stages (remaining stages, one kernel each):
       For stages where butterfly strides exceed the SMEM chunk size, each
@@ -47,7 +45,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
     Returns:
         A JIT-decorated function _fft_lut_func(block_size, threads) that
         itself returns a compiled prim_func taking
-        (x_real, x_imag, lut_real, lut_imag), split scratch outputs, and an
+        (x_pair, lut_real, lut_imag), split scratch outputs, and an
         interleaved real/imaginary output with shape (batch_size, n, 2).
     """
     if dtype == 'complex64':
@@ -66,7 +64,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
     B = batch_size  # shorter alias for tensor shapes
 
     @tilelang.jit(
-        out_idx=[4, 5, 6],
+        out_idx=[3, 4, 5],
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
         },
@@ -113,8 +111,9 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
 
         @T.macro
         def fused_bitrev_smem_stages(
-            x_real: T.Tensor((B, n), real_dtype),
-            x_imag: T.Tensor((B, n), real_dtype),
+            x_pair: T.Tensor((B, n, 2), real_dtype),
+            lut_real: T.Tensor((lut_size,), real_dtype),
+            lut_imag: T.Tensor((lut_size,), real_dtype),
             y_real: T.Tensor((B, n), real_dtype),
             y_imag: T.Tensor((B, n), real_dtype),
             y_pair: T.Tensor((B, n, 2), real_dtype),
@@ -140,8 +139,8 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
                         for _bit in T.serial(log2n):
                             rev_idx = (rev_idx << 1) | (temp & 1)
                             temp = temp >> 1
-                        smem_r[i] = x_real[bb, rev_idx]
-                        smem_i[i] = x_imag[bb, rev_idx]
+                        smem_r[i] = x_pair[bb, rev_idx, 0]
+                        smem_i[i] = x_pair[bb, rev_idx, 1]
 
                 # ---- load second half: smem[threads..smem_per_block-1] ----
                 for i in T.Parallel(threads):
@@ -155,8 +154,8 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
                         for _bit in T.serial(log2n):
                             rev_idx = (rev_idx << 1) | (temp & 1)
                             temp = temp >> 1
-                        smem_r[j] = x_real[bb, rev_idx]
-                        smem_i[j] = x_imag[bb, rev_idx]
+                        smem_r[j] = x_pair[bb, rev_idx, 0]
+                        smem_i[j] = x_pair[bb, rev_idx, 1]
 
                 T.sync_threads()
 
@@ -164,6 +163,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
                 for s in range(smem_stages):
                     m_s = 1 << (s + 1)    # compile-time constant
                     half_m_s = 1 << s     # compile-time constant
+                    lut_base_s = half_m_s - 1
 
                     for i in T.Parallel(threads):
                         if i < smem_per_block // 2:
@@ -172,13 +172,8 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
                             j_idx = group * m_s + k
                             l_idx = j_idx + half_m_s
 
-                            angle = (
-                                -2.0 * _PI
-                                * T.cast(k, "float64")
-                                / T.cast(m_s, "float64")
-                            )
-                            tw_r = T.cos(T.cast(angle, accum_dtype))
-                            tw_i = T.sin(T.cast(angle, accum_dtype))
+                            tw_r = T.cast(lut_real[lut_base_s + k], accum_dtype)
+                            tw_i = T.cast(lut_imag[lut_base_s + k], accum_dtype)
 
                             u_r = T.cast(smem_r[j_idx], accum_dtype)
                             u_i = T.cast(smem_i[j_idx], accum_dtype)
@@ -468,8 +463,7 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
 
         @T.prim_func
         def _fft_lut_main(
-            x_real: T.Tensor((B, n), real_dtype),         # type: ignore
-            x_imag: T.Tensor((B, n), real_dtype),         # type: ignore
+            x_pair: T.Tensor((B, n, 2), real_dtype),      # type: ignore
             lut_real: T.Tensor((lut_size,), real_dtype),  # type: ignore
             lut_imag: T.Tensor((lut_size,), real_dtype),  # type: ignore
             # Split outputs are global scratch for non-final LUT stages. The
@@ -480,7 +474,9 @@ def _fft_c2c_kernel(n: int, batch_size: int = 1, dtype: str = 'complex64') -> Ca
         ) -> None:
             # Fused bit-reversal + SMEM butterfly stages: single kernel launch,
             # one global-memory read of x, one write of y for all SMEM stages.
-            fused_bitrev_smem_stages(x_real, x_imag, y_real, y_imag, y_pair)
+            fused_bitrev_smem_stages(
+                x_pair, lut_real, lut_imag, y_real, y_imag, y_pair
+            )
 
             # LUT stages: use radix-8 (fused triples) where possible,
             # then radix-4 or radix-2 for the remainder.
@@ -517,13 +513,12 @@ def _fft_c2c_wrapped_kernel(
     dtype: str,
     block_size: int,
     threads: int,
-    x_real: torch.Tensor,
-    x_imag: torch.Tensor,
+    x_pair: torch.Tensor,
     lut_real: torch.Tensor,
     lut_imag: torch.Tensor,
 ) -> torch.Tensor:
     _, _, y_pair = _fft_c2c_kernel(n, batch_size, dtype)(block_size, threads)(
-        x_real, x_imag, lut_real, lut_imag
+        x_pair, lut_real, lut_imag
     )
     return y_pair
 
@@ -549,7 +544,7 @@ class FFTC2CKernel(Kernel):
 
     Combines two complementary optimizations over the baseline FFTC2CKernel:
 
-    1. SMEM stage fusion: the first log2(min(n, 2*threads))+1 butterfly stages
+    1. SMEM stage fusion: the first log2(min(n, 2*threads)) butterfly stages
        are processed entirely in shared memory within a single kernel launch,
        reducing global memory traffic from O(log N) to O(1) for small-stride
        stages.
@@ -558,7 +553,7 @@ class FFTC2CKernel(Kernel):
        twiddle factors from a GPU-resident LUT (built by FFTC2COp at
        construction time), eliminating repeated sin/cos evaluation.
 
-    Together these match cuFFT-level performance on modern NVIDIA GPUs.
+    Together these reduce global traffic and runtime trigonometric work.
 
     Args:
         x_real:    Real part of input, shape (n,), float32 or float64.
@@ -591,6 +586,11 @@ class FFTC2CKernel(Kernel):
 
     @property
     def default_config(self) -> Dict[str, Any]:
+        if self.n == 4096:
+            return {
+                "block_size": 256,
+                "threads": 256,
+            }
         return {
             "block_size": 1024,
             "threads": 512,
@@ -632,14 +632,23 @@ class FFTC2CKernel(Kernel):
         Returns:
             Interleaved FFT output with shape (batch_size, n, 2).
         """
+        x_pair = torch.stack((x_real, x_imag), dim=-1)
+        return self.forward_interleaved(x_pair, lut_real, lut_imag)
+
+    def forward_interleaved(
+        self,
+        x_pair: torch.Tensor,
+        lut_real: torch.Tensor,
+        lut_imag: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute the FFT from an interleaved real view without input copies."""
         return _fft_c2c_wrapped_kernel(
             self.n,
             self.batch_size,
             self.dtype_str,
             self.config["block_size"],
             self.config["threads"],
-            x_real,
-            x_imag,
+            x_pair,
             lut_real,
             lut_imag,
         )

--- a/src/tileops/ops/fft.py
+++ b/src/tileops/ops/fft.py
@@ -117,21 +117,37 @@ class FFTC2COp(Op):
         if n <= 0 or n & (n - 1) != 0:
             raise ValueError(f"FFT size must be a positive power of 2, got {n}")
 
-        x_real = x.real.contiguous()
-        x_imag = x.imag.contiguous()
         original_shape = x.shape
 
         # Flatten all batch dimensions into a single batch dimension
-        batch_size = x_real[..., 0].numel() if x.ndim > 1 else 1
-        x_real = x_real.reshape(batch_size, n)
-        x_imag = x_imag.reshape(batch_size, n)
+        batch_size = x.numel() // n
 
         self.n = n
         self.dtype = x.dtype
         self.twiddle_real, self.twiddle_imag = self._get_lut(n, x.dtype, x.device)
         kernel = self._get_kernel(n, batch_size, x.dtype, x.device.index)
         self.kernel = kernel
-        y_pair = kernel(x_real, x_imag, self.twiddle_real, self.twiddle_imag)
+        use_interleaved_input = (
+            "fft_c2c_kernel" not in self._overridden_keys
+            and type(kernel) is FFTC2CKernel
+            and not x.is_conj()
+        )
+        if use_interleaved_input:
+            x_pair = torch.view_as_real(x).reshape(batch_size, n, 2)
+            if not x_pair.is_contiguous():
+                x_pair = x_pair.contiguous()
+            y_pair = kernel.forward_interleaved(
+                x_pair,
+                self.twiddle_real,
+                self.twiddle_imag,
+            )
+        else:
+            # Custom kernel-map overrides retain the established split-input
+            # contract; conjugate views also use this path because
+            # view_as_real requires the conjugate bit to be resolved first.
+            x_real = x.real.contiguous().reshape(batch_size, n)
+            x_imag = x.imag.contiguous().reshape(batch_size, n)
+            y_pair = kernel(x_real, x_imag, self.twiddle_real, self.twiddle_imag)
 
         # The kernel writes the final butterfly directly in interleaved layout;
         # view_as_complex is metadata-only and launches no packing kernel.

--- a/tests/ops/test_fft.py
+++ b/tests/ops/test_fft.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from tests.test_base import FixtureBase, TestBase
+from tileops.kernels.kernel_base import Kernel
 from tileops.ops import FFTC2COp
 from workloads.fft import FFTWorkload
 
@@ -36,6 +37,70 @@ def test_fft_c2c(n: int, dtype: torch.dtype, tune: bool, batch_shape: tuple) -> 
     else:
         tolerances = {"atol": 1e-8, "rtol": 1e-8}
     test.check(op, *test.gen_inputs(), **tolerances)
+
+
+@pytest.mark.parametrize(
+    "batch_shape",
+    [
+        pytest.param((), id="manifest-c64-b1", marks=pytest.mark.smoke),
+        pytest.param((64,), id="manifest-c64-b64", marks=pytest.mark.full),
+    ],
+)
+def test_fft_manifest_c64_rows(batch_shape: tuple) -> None:
+    test = FFTTest(4096, torch.complex64, batch_shape=batch_shape)
+    test.check(FFTC2COp(), *test.gen_inputs(), atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.smoke
+def test_fft_manifest_c128_row() -> None:
+    test = FFTTest(4096, torch.complex128, batch_shape=(64,))
+    test.check(FFTC2COp(), *test.gen_inputs(), atol=1e-8, rtol=1e-8)
+
+
+@pytest.mark.parametrize(
+    ("n", "dtype", "batch_shape", "layout"),
+    [
+        pytest.param(1, torch.complex64, (), "contiguous", id="zero-stage", marks=pytest.mark.smoke),
+        pytest.param(2, torch.complex128, (), "contiguous", id="single-stage", marks=pytest.mark.smoke),
+        pytest.param(8, torch.complex64, (2, 3), "contiguous", id="leading-dims", marks=pytest.mark.full),
+        pytest.param(8, torch.complex64, (2, 3), "strided", id="strided-view", marks=pytest.mark.full),
+        pytest.param(8, torch.complex64, (), "conjugate", id="conjugate-view", marks=pytest.mark.full),
+    ],
+)
+def test_fft_boundary_and_layout_paths(
+    n: int,
+    dtype: torch.dtype,
+    batch_shape: tuple,
+    layout: str,
+) -> None:
+    test = FFTTest(n, dtype, batch_shape=batch_shape, layout=layout)
+    tolerance = 1e-4 if dtype is torch.complex64 else 1e-8
+    test.check(FFTC2COp(), *test.gen_inputs(), atol=tolerance, rtol=tolerance)
+
+
+class _SplitInputKernel(Kernel):
+    """Kernel-map probe for the established four-tensor input contract."""
+
+    def __init__(self, n, batch_size, dtype, tune=False):
+        super().__init__()
+        self.n = n
+        self.batch_size = batch_size
+        self.dtype = dtype
+
+    def forward(self, x_real, x_imag, lut_real, lut_imag):
+        assert x_real.is_contiguous()
+        assert x_imag.is_contiguous()
+        assert lut_real.shape == (self.n - 1,)
+        assert lut_imag.shape == (self.n - 1,)
+        return torch.stack((x_real, x_imag), dim=-1)
+
+
+@pytest.mark.smoke
+def test_fft_kernel_map_override_keeps_split_inputs() -> None:
+    x = torch.randn(2, 8, device="cuda", dtype=torch.complex64).conj()
+    op = FFTC2COp(kernel_map={"fft_c2c_kernel": _SplitInputKernel})
+
+    torch.testing.assert_close(op(x), x)
 
 
 if __name__ == "__main__":

--- a/workloads/fft.py
+++ b/workloads/fft.py
@@ -5,13 +5,32 @@ from workloads.workload_base import WorkloadBase
 
 class FFTWorkload(WorkloadBase):
 
-    def __init__(self, n: int, dtype: torch.dtype, batch_shape: tuple = ()):
+    def __init__(
+        self,
+        n: int,
+        dtype: torch.dtype,
+        batch_shape: tuple = (),
+        layout: str = "contiguous",
+    ):
         self.n = n
         self.dtype = dtype
         self.batch_shape = batch_shape
+        self.layout = layout
 
     def gen_inputs(self) -> tuple[torch.Tensor]:
-        x = torch.randn(*self.batch_shape, self.n, device='cuda', dtype=self.dtype)
+        if self.layout == "strided":
+            x = torch.randn(
+                *self.batch_shape,
+                self.n * 2,
+                device="cuda",
+                dtype=self.dtype,
+            )[..., ::2]
+        else:
+            x = torch.randn(*self.batch_shape, self.n, device='cuda', dtype=self.dtype)
+        if self.layout == "conjugate":
+            x = x.conj()
+        elif self.layout != "contiguous" and self.layout != "strided":
+            raise ValueError(f"unsupported FFT workload layout: {self.layout}")
         return (x,)
 
     def ref_program(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

- Consume contiguous complex inputs through a metadata-only interleaved real view, removing the two public-wrapper real and imaginary copy kernels.
- Reuse the stage-indexed twiddle lookup table in shared-memory stages and select the measured 256-thread N=4096 configuration.
- Preserve the public split-input kernel and custom-kernel contracts while comparing the candidate, exact TileOPs incumbent, and PyTorch cuFFT on every primary workload.

## TileFoundry Description

```python
@module(
    entry="dft_pair_f32",
    target=CudaTarget("nvidia.h200_sxm"),
    topologies=(Topology("cta", 132), Topology("thread", 256)),
)
class FFTPairF32:
    @func
    def complex_butterfly(
        even_r: Tensor[(BATCH, HALF), "f32"],
        even_i: Tensor[(BATCH, HALF), "f32"],
        odd_r: Tensor[(BATCH, HALF), "f32"],
        odd_i: Tensor[(BATCH, HALF), "f32"],
        tw_r: Tensor[(HALF,), "f32"],
        tw_i: Tensor[(HALF,), "f32"],
    ):
        prod_r = tf.sub(tf.mul(odd_r, tw_r), tf.mul(odd_i, tw_i))
        prod_i = tf.add(tf.mul(odd_r, tw_i), tf.mul(odd_i, tw_r))
        out_r = tf.concat(tf.add(even_r, prod_r), tf.sub(even_r, prod_r), axis=1)
        out_i = tf.concat(tf.add(even_i, prod_i), tf.sub(even_i, prod_i), axis=1)
        return out_r, out_i

    @func
    def dft_pair_f32(
        x_r: Tensor[(BATCH, N), "f32"],
        x_i: Tensor[(BATCH, N), "f32"],
        w_r: Tensor[(N, N), "f32"],
        w_i: Tensor[(N, N), "f32"],
    ):
        y_r = tf.sub(tf.matmul(x_r, w_r), tf.matmul(x_i, w_i))
        y_i = tf.add(tf.matmul(x_r, w_i), tf.matmul(x_i, w_r))
        return y_r, y_i
```

## Performance

Operator: `FFTC2COp`

| Environment | Value |
| --- | --- |
| image | ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev |
| digest | sha256:2590888968a870216e1ea076829b909e62e9053608f6a65d5ab5ecd7eb5561f7 |
| gpu | NVIDIA H200 |
| driver | 595.71.05 |
| cuda | 13.2 |
| torch | 2.13.0+cu132 |
| tilelang | 0.1.11+cu132.gitafcebed1 |
| cupti-python | 13.2.0 |
| timer | native CUPTI |

Method: Candidate, fixed-base incumbent, and warmed PyTorch cuFFT ran in one process on identical inputs with the same precision and public-call work. The current benchmark contract used native-CUPTI call-window attribution, L2 reset, forward/reverse drift balancing within each comparison, and three rotated three-way comparisons with 200 samples per implementation per trial. Compilation, tuning, lookup-table creation, and cuFFT plan creation were excluded; each value is the median of three trial medians and CUPTI failure was fail-closed.

| Workload | N | B | Dtype | TileFoundry candidate (ms) | TileOPs incumbent (ms) | PyTorch cuFFT (ms) | TileOPs incumbent / candidate | PyTorch cuFFT / candidate |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| fft-4k-c64-unbatched | 4096 | 1 | complex64 | 0.00664 | 0.11816 | 0.004608 | 17.7952x | 0.6940x |
| fft-4k-c64-b64 | 4096 | 64 | complex64 | 0.009792 | 0.107776 | 0.004896 | 11.0065x | 0.5000x |
| fft-4k-c128-b64 | 4096 | 64 | complex128 | 0.012928 | 0.120848 | 0.007392 | 9.3478x | 0.5718x |
| geometric mean |  |  |  | 0.0094375 | 0.115454 | 0.00550434 | 12.2336x | 0.5832x |

## Result And Limitations

**improvement without SOTA**

- Classification is improvement without SOTA: the candidate is 17.7952x, 11.0065x, and 9.3478x faster than the TileOPs incumbent, but 1.4410x, 2.0000x, and 1.7489x slower than cuFFT on the three rows respectively.
- The candidate, incumbent, and cuFFT trial-median spans are 1.21% / 14.99% / 0.67%, 0.33% / 3.31% / 0.65%, and 0.25% / 10.01% / 0.00% across the three rows; even the favorable endpoints do not change either conclusion.
- The candidate still uses two FFT kernels and a split temporary global-memory round trip, while cuFFT uses one specialized kernel; launch overhead dominates the unbatched gap and the extra global transfer dominates the batched gaps.
