### PR TITLE
[Fix][gemm] Scale the fp16 GEMV test tolerance with K

### DIFF
--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -45,6 +45,10 @@ Rules:
   - **FP16**: `rtol=1e-3`, `atol=1e-3`
   - **BF16**: `rtol=1.6e-2`, `atol=1.6e-2`
 - Use exact comparison (`torch.equal`) for non-floating outputs (bool, masks, index tensors).
+- Size `atol` by the summation order, not the reduction length. Where a kernel sums differently from
+  the reference (GEMV, cross-thread allreduce, split-K), cancellation puts outputs far below the
+  typical magnitude and only `atol` covers their error; order-matching kernels (dense GEMM, BMM
+  against cuBLAS) come out bit-exact. Measure before loosening.
 
 ### Coverage rules
 

--- a/tests/ops/test_gemm.py
+++ b/tests/ops/test_gemm.py
@@ -185,7 +185,11 @@ def test_gemm(m: int, n: int, k: int, dtype: torch.dtype, trans_a: bool, trans_b
     test = GemmTest(m, n, k, dtype, trans_a, trans_b)
     op = GemmOp(trans_a=trans_a, trans_b=trans_b, tune=tune)
     if dtype == torch.float16:
-        tolerances = {"atol": 1e-3, "rtol": 1e-3}
+        # Only GEMV sums in a different order than cuBLAS; there cancellation
+        # leaves atol alone to carry the reduction error, 3.3e-3 at K=16384.
+        gemv = not trans_a and ((m == 1 and trans_b) or (n == 1 and not trans_b))
+        atol = 1e-3 * max(1.0, k / 2048) if gemv else 1e-3
+        tolerances = {"atol": atol, "rtol": 1e-3}
     else:
         tolerances = {"atol": 1.6e-2, "rtol": 1.6e-2}
     test.check(op, *test.gen_inputs(), **tolerances)


### PR DESCRIPTION
The two K=16384 fp16 GEMV cases fail on main's full CI since the runner image moved to CUDA 13.2 ([run](https://github.com/tile-ai/TileOPs/actions/runs/31559288869/job/93998159347)).

## Why

- **Not the kernel.** Against an fp64 reference our GEMV is the more accurate side: 99.7% of its elements round bit-exactly, `torch.matmul` 94.2%.
- **GEMV sums in a different order than cuBLAS.** Cancellation drops some of its outputs two orders of magnitude below the typical one — |ref| 0.12–2.5 against a median 83.5. There `rtol` covers nothing and `atol` alone carries the reduction error, which tracks the γ_K = K·ε bound: measured at rtol=1e-3, K=1024 stays under the floor, K=7168 needs 0.93e-3, K=16384 needs 3.3e-3.
- **CUDA 13.2 tipped it over.** The new cuBLAS splits these reductions differently, moving the reference's last-bit rounding past the fixed 1e-3 floor. K=7168 was already passing by one rounding step.

## What changes

- `tests/ops/test_gemm.py` — on the GEMV path only, `atol = 1e-3 * max(1, k / 2048)`. That is 8e-3 at K=16384: still 6e-5 relative to outputs of magnitude ~130, and far under the fp16 ulp there (0.125).
- Dense GEMM keeps the flat 1e-3. It comes out bit-exact against cuBLAS at every K covered, as do BMM (K≤2048) and grouped GEMM (K=4096) — loosening those would only weaken them.
- `docs/design/testing.md` — states the rule the fix follows: size `atol` by the summation order, not the reduction length.

## Verification

`test_gemm.py` + `test_bmm.py` + `test_grouped_gemm.py` at smoke+full in `tileops-runner:cu132-torch2.13-tl-afcebed1-dev`: 74 passed.
