### PR TITLE
[Refactor][Backend] Route canonical GQA prefill through targets

### DIFF
--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional
+from typing import Dict, Optional
 
 import torch
 import torch.nn.functional as F
@@ -33,7 +33,6 @@ from .selection import (
     PAGED_DECODE_KEYS,
     PAGED_PREFILL_KEYS,
     AttentionCall,
-    check_packed_prefill_semantics,
     fp8_dtype,
 )
 
@@ -283,10 +282,10 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         window_size_right: int = -1,
         backend: str = "auto",
         validate_uniform_cu_seqlens: bool = True,
-        *,
-        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
+        *,
+        target: Target = None,
     ) -> None:
         _validate_gqa_dims(heads, heads_kv, dim)
         _validate_positive(batch=batch, max_seqlen_q=max_seqlen_q, max_seqlen_kv=max_seqlen_kv)
@@ -340,14 +339,35 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             "gqa_prefill_fp8_tensor_core_fwd_kernel": GQAFwdFP8Fa3ContractPtxAccBN224WsTmaVKernel,
         }
 
-    def attention_call(self, *, is_fp8: bool, is_uniform: bool) -> AttentionCall:
+    def attention_call(
+        self,
+        *,
+        is_fp8: bool,
+        is_uniform: bool,
+        device: Optional[torch.device] = None,
+    ) -> AttentionCall:
         """State what one prefill call is, for selection to filter candidates against.
 
         Args:
             is_fp8: Whether the inputs carry ``torch.float8_e4m3fn`` elements.
             is_uniform: Whether both ``cu_seqlens`` describe equal-length requests.
+            device: The CUDA device whose in-tree implementations are being selected.
+                ``None`` preserves the direct-selection helper's current-device behavior.
         """
+        arch = -1
+        h200 = False
+        if device is not None:
+            if device.type != "cuda":
+                raise ValueError(
+                    f"the in-tree GQA prefill kernels require a CUDA device, got {device}"
+                )
+            from tileops.utils import get_sm_version, is_h200
+
+            arch = get_sm_version(device.index)
+            h200 = is_h200(device.index)
         return AttentionCall(
+            arch=arch,
+            h200=h200,
             dtype=self.dtype,
             batch=self.batch,
             heads=self.heads,
@@ -366,39 +386,56 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             tune=self.tune,
         )
 
-    def _build_builtin_kernel(self, *, is_fp8: bool, is_uniform: bool) -> Kernel:
+    def _build_builtin_kernel(
+        self,
+        *,
+        device: torch.device,
+        is_fp8: bool,
+        is_uniform: bool,
+    ) -> Kernel:
         """Select and construct the in-tree implementation for this call.
 
         This is deliberately inside the BUILTIN factory.  A third-party target owns its
         kernel names and selection rules, so it must never execute the in-tree
         ``PACKED_PREFILL_KEYS`` dispatch on the way to its registered builder.
         """
-        call = self.attention_call(is_fp8=is_fp8, is_uniform=is_uniform)
+        call = self.attention_call(
+            is_fp8=is_fp8,
+            is_uniform=is_uniform,
+            device=device,
+        )
         key = self.select_kernel_key(PACKED_PREFILL_KEYS, call)
         return _build_packed_prefill_kernel(self.kernel_map, key, call)
 
-    def _get_kernel(
-        self,
-        inputs: tuple[torch.Tensor, ...],
-        *,
-        is_fp8: bool,
-        is_uniform: bool,
-    ) -> Callable[..., torch.Tensor]:
-        """Return the callable serving one manifest-shaped packed-prefill call."""
-        # ``is_uniform`` depends on cu_seqlens contents, so the in-tree implementation may
-        # select a different kernel for tensors with the same dtype and shape.  The external
-        # path ignores this key and follows the RFC contract: one callable per full input
-        # signature must serve every legal set of tensor contents with that signature.
-        builtin_key = (inputs[0].device, self.dtype, is_fp8, is_uniform)
-        return self.get_or_build_kernel(
-            "gqa_prefill",
-            inputs,
-            key=builtin_key,
-            build=lambda: self._build_builtin_kernel(
-                is_fp8=is_fp8,
-                is_uniform=is_uniform,
-            ),
-        )
+    def _validate_request(self, *, is_fp8: bool, is_uniform: bool) -> None:
+        """Validate the public packed-prefill request for every target."""
+        uses_window = self.window_size_left != -1 or self.window_size_right != -1
+        if is_fp8:
+            if self.backend not in ("auto", "fp8"):
+                raise ValueError("FP8 prefill requires backend='auto' or backend='fp8'.")
+            if self.is_causal:
+                raise ValueError("FP8 prefill currently supports non-causal prefill only.")
+            if uses_window:
+                raise ValueError("FP8 prefill does not support sliding-window dispatch.")
+            if self.max_seqlen_q != self.max_seqlen_kv:
+                raise ValueError("FP8 prefill requires max_seqlen_q == max_seqlen_kv.")
+            if not is_uniform:
+                raise ValueError("FP8 prefill requires uniform packed cu_seqlens.")
+            return
+        if self.backend == "fp8":
+            raise ValueError("backend='fp8' requires float8_e4m3fn q/k/v.")
+        if uses_window:
+            if self.backend not in ("auto", "sliding_window"):
+                raise ValueError(
+                    "sliding-window prefill requires backend='auto' or backend='sliding_window'."
+                )
+            return
+        if self.backend == "sliding_window":
+            raise ValueError(
+                "backend='sliding_window' requires window_size_left or window_size_right."
+            )
+        if self.backend == "dense" and not is_uniform:
+            raise ValueError("backend='dense' requires uniform packed cu_seqlens.")
 
     def _infer_output_shapes(
         self,
@@ -545,6 +582,9 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         v_scale: torch.Tensor,
     ) -> torch.Tensor:
         self._validate_dtypes(q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
+        self._validate_common_shapes(
+            q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale
+        )
         # Contiguity belongs to the hardware-neutral op contract.  Both BUILTIN and an
         # external target receive exactly the manifest tensors, normalized the same way.
         q = q.contiguous()
@@ -555,9 +595,6 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         q_scale = q_scale.contiguous()
         k_scale = k_scale.contiguous()
         v_scale = v_scale.contiguous()
-        self._validate_common_shapes(
-            q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale
-        )
         if self.backend == "auto" or (
             self.backend in ("dense", "fp8") and self.validate_uniform_cu_seqlens
         ):
@@ -568,22 +605,21 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             is_uniform = True
 
         is_fp8 = self._is_fp8_tensor(q)
-        check_packed_prefill_semantics(
-            is_fp8=is_fp8,
-            is_uniform=is_uniform,
-            is_causal=self.is_causal,
-            max_seqlen_q=self.max_seqlen_q,
-            max_seqlen_kv=self.max_seqlen_kv,
-            window_size_left=self.window_size_left,
-            window_size_right=self.window_size_right,
-            backend=self.backend,
-        )
+        self._validate_request(is_fp8=is_fp8, is_uniform=is_uniform)
         inputs = (q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
-        output = self._get_kernel(
+        # ``is_uniform`` depends on tensor contents. It belongs to the in-tree key only;
+        # an external callable must serve all contents sharing one input signature.
+        kernel = self.get_or_build_kernel(
+            "gqa_prefill",
             inputs,
-            is_fp8=is_fp8,
-            is_uniform=is_uniform,
-        )(*inputs)
+            key=(q.device, self.dtype, is_fp8, is_uniform),
+            build=lambda: self._build_builtin_kernel(
+                device=q.device,
+                is_fp8=is_fp8,
+                is_uniform=is_uniform,
+            ),
+        )
+        output = kernel(*inputs)
         self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
         return output
 

--- a/src/tileops/ops/attention/gqa.py
+++ b/src/tileops/ops/attention/gqa.py
@@ -1,8 +1,9 @@
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 import torch
 import torch.nn.functional as F
 
+from tileops.backend import Target
 from tileops.kernels.attention import (
     FlashAttnBwdPreprocessKernel,
     GQABwdWgmmaPipelinedKernel,
@@ -32,7 +33,7 @@ from .selection import (
     PAGED_DECODE_KEYS,
     PAGED_PREFILL_KEYS,
     AttentionCall,
-    check_packed_prefill_request,
+    check_packed_prefill_semantics,
     fp8_dtype,
 )
 
@@ -261,6 +262,9 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             float8_e4m3fn q/k/v admit either a float16 or a bfloat16 output, so
             the caller chooses here. For float16 / bfloat16 inputs it must equal
             their element type.
+        target: Which set of kernels serves this op: a registered external target,
+            ``BUILTIN`` for the in-tree implementation, or ``None`` to resolve it
+            from the first input device.
     """
 
     def __init__(
@@ -279,6 +283,8 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         window_size_right: int = -1,
         backend: str = "auto",
         validate_uniform_cu_seqlens: bool = True,
+        *,
+        target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
@@ -316,6 +322,7 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         self.window_size_right = window_size_right
         self.backend = backend
         self.validate_uniform_cu_seqlens = validate_uniform_cu_seqlens
+        self.target = target
         self.tune = tune
         self._roofline_kwargs = None
         self._uniform_cu_cache: dict[tuple[int, torch.device, torch.dtype], torch.Tensor] = {}
@@ -359,13 +366,39 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             tune=self.tune,
         )
 
-    def _kernel_for(self, key: str, call: AttentionCall) -> Kernel:
-        """The implementation *key* names, built once for this element type."""
+    def _build_builtin_kernel(self, *, is_fp8: bool, is_uniform: bool) -> Kernel:
+        """Select and construct the in-tree implementation for this call.
 
-        def build() -> Kernel:
-            return _build_packed_prefill_kernel(self.kernel_map, key, call)
+        This is deliberately inside the BUILTIN factory.  A third-party target owns its
+        kernel names and selection rules, so it must never execute the in-tree
+        ``PACKED_PREFILL_KEYS`` dispatch on the way to its registered builder.
+        """
+        call = self.attention_call(is_fp8=is_fp8, is_uniform=is_uniform)
+        key = self.select_kernel_key(PACKED_PREFILL_KEYS, call)
+        return _build_packed_prefill_kernel(self.kernel_map, key, call)
 
-        return self.get_or_build_kernel(key, key=call.dtype, build=build)
+    def _get_kernel(
+        self,
+        inputs: tuple[torch.Tensor, ...],
+        *,
+        is_fp8: bool,
+        is_uniform: bool,
+    ) -> Callable[..., torch.Tensor]:
+        """Return the callable serving one manifest-shaped packed-prefill call."""
+        # ``is_uniform`` depends on cu_seqlens contents, so the in-tree implementation may
+        # select a different kernel for tensors with the same dtype and shape.  The external
+        # path ignores this key and follows the RFC contract: one callable per full input
+        # signature must serve every legal set of tensor contents with that signature.
+        builtin_key = (inputs[0].device, self.dtype, is_fp8, is_uniform)
+        return self.get_or_build_kernel(
+            "gqa_prefill",
+            inputs,
+            key=builtin_key,
+            build=lambda: self._build_builtin_kernel(
+                is_fp8=is_fp8,
+                is_uniform=is_uniform,
+            ),
+        )
 
     def _infer_output_shapes(
         self,
@@ -429,10 +462,10 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
             (k_scale, "k_scale"),
             (v_scale, "v_scale"),
         ):
-            if tensor.device.type != "cuda":
-                raise ValueError(f"{name} must be on a cuda device, got {tensor.device}")
-            if not tensor.is_contiguous():
-                raise ValueError(f"{name} must be contiguous")
+            if tensor.device != q.device:
+                raise ValueError(
+                    f"{name} must be on the same device as q ({q.device}), got {tensor.device}"
+                )
         if q.ndim != 3 or tuple(q.shape[1:]) != (self.heads, self.dim):
             raise ValueError(
                 f"q must have shape [T, {self.heads}, {self.dim}], got {tuple(q.shape)}"
@@ -512,6 +545,16 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         v_scale: torch.Tensor,
     ) -> torch.Tensor:
         self._validate_dtypes(q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
+        # Contiguity belongs to the hardware-neutral op contract.  Both BUILTIN and an
+        # external target receive exactly the manifest tensors, normalized the same way.
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        cu_seqlens_q = cu_seqlens_q.contiguous()
+        cu_seqlens_kv = cu_seqlens_kv.contiguous()
+        q_scale = q_scale.contiguous()
+        k_scale = k_scale.contiguous()
+        v_scale = v_scale.contiguous()
         self._validate_common_shapes(
             q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale
         )
@@ -524,12 +567,23 @@ class GroupedQueryAttentionPrefillFwdOp(Op):
         else:
             is_uniform = True
 
-        call = self.attention_call(is_fp8=self._is_fp8_tensor(q), is_uniform=is_uniform)
-        check_packed_prefill_request(call)
-        key = self.select_kernel_key(PACKED_PREFILL_KEYS, call)
-        output = self._kernel_for(key, call)(
-            q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale
+        is_fp8 = self._is_fp8_tensor(q)
+        check_packed_prefill_semantics(
+            is_fp8=is_fp8,
+            is_uniform=is_uniform,
+            is_causal=self.is_causal,
+            max_seqlen_q=self.max_seqlen_q,
+            max_seqlen_kv=self.max_seqlen_kv,
+            window_size_left=self.window_size_left,
+            window_size_right=self.window_size_right,
+            backend=self.backend,
         )
+        inputs = (q, k, v, cu_seqlens_q, cu_seqlens_kv, q_scale, k_scale, v_scale)
+        output = self._get_kernel(
+            inputs,
+            is_fp8=is_fp8,
+            is_uniform=is_uniform,
+        )(*inputs)
         self._record_roofline(q, k, cu_seqlens_q, cu_seqlens_kv)
         return output
 

--- a/src/tileops/ops/attention/selection.py
+++ b/src/tileops/ops/attention/selection.py
@@ -1,8 +1,9 @@
-"""Which dispatch key an attention call takes.
+"""Which in-tree dispatch key an attention call takes.
 
-The keys implementing each attention slot, and the check that a request does not
-contradict the user-visible ``backend`` parameter. Choosing among the keys is
-``Op.select_kernel_key``; see docs/design/ops-design.md § Kernel selection.
+The keys implementing each attention slot are consumed by
+``Op.select_kernel_key``; see the Kernel selection section of
+``docs/design/ops-design.md``. External targets own their own candidate lists
+and never use these keys.
 """
 
 from tileops.kernels.attention.call_spec import AttentionCall, fp8_dtype
@@ -13,8 +14,6 @@ __all__ = [
     "PAGED_DECODE_KEYS",
     "PAGED_PREFILL_KEYS",
     "AttentionCall",
-    "check_packed_prefill_request",
-    "check_packed_prefill_semantics",
     "fp8_dtype",
 ]
 
@@ -47,69 +46,3 @@ DECODE_KEYS = ("gqa_decode_bs1_kernel", "gqa_decode_kernel")
 
 #: Implementations of paged GQA decode.
 PAGED_DECODE_KEYS = ("gqa_decode_paged_bs1_kernel", "gqa_decode_paged_kernel")
-
-
-def check_packed_prefill_request(call: AttentionCall) -> None:
-    """Reject a packed prefill request its ``backend`` knob cannot describe.
-
-    This is the user-visible contract of the parameter, not a statement about
-    any implementation: it says what the caller asked for is not what the
-    request is. Which implementation then runs is decided by capability.
-
-    Raises:
-        ValueError: When ``backend`` contradicts the request.
-    """
-    check_packed_prefill_semantics(
-        is_fp8=call.is_fp8,
-        is_uniform=call.is_uniform,
-        is_causal=call.is_causal,
-        max_seqlen_q=call.max_seqlen_q,
-        max_seqlen_kv=call.max_seqlen_kv,
-        window_size_left=call.window_size_left,
-        window_size_right=call.window_size_right,
-        backend=call.backend,
-    )
-
-
-def check_packed_prefill_semantics(
-    *,
-    is_fp8: bool,
-    is_uniform: bool,
-    is_causal: bool,
-    max_seqlen_q: int,
-    max_seqlen_kv: int,
-    window_size_left: int,
-    window_size_right: int,
-    backend: str,
-) -> None:
-    """Validate packed-prefill API semantics without inspecting a device.
-
-    This is the target-neutral half of :func:`check_packed_prefill_request`.
-    ``AttentionCall`` and its architecture facts belong only to the in-tree
-    implementation, while these user-visible parameter rules apply to every target.
-    """
-    uses_window = window_size_left != -1 or window_size_right != -1
-    if is_fp8:
-        if backend not in ("auto", "fp8"):
-            raise ValueError("FP8 prefill requires backend='auto' or backend='fp8'.")
-        if is_causal:
-            raise ValueError("FP8 prefill currently supports non-causal prefill only.")
-        if uses_window:
-            raise ValueError("FP8 prefill does not support sliding-window dispatch.")
-        if max_seqlen_q != max_seqlen_kv:
-            raise ValueError("FP8 prefill requires max_seqlen_q == max_seqlen_kv.")
-        if not is_uniform:
-            raise ValueError("FP8 prefill requires uniform packed cu_seqlens.")
-        return
-    if backend == "fp8":
-        raise ValueError("backend='fp8' requires float8_e4m3fn q/k/v.")
-    if uses_window:
-        if backend not in ("auto", "sliding_window"):
-            raise ValueError(
-                "sliding-window prefill requires backend='auto' or backend='sliding_window'."
-            )
-        return
-    if backend == "sliding_window":
-        raise ValueError("backend='sliding_window' requires window_size_left or window_size_right.")
-    if backend == "dense" and not is_uniform:
-        raise ValueError("backend='dense' requires uniform packed cu_seqlens.")

--- a/src/tileops/ops/attention/selection.py
+++ b/src/tileops/ops/attention/selection.py
@@ -5,7 +5,7 @@ contradict the user-visible ``backend`` parameter. Choosing among the keys is
 ``Op.select_kernel_key``; see docs/design/ops-design.md § Kernel selection.
 """
 
-from tileops.kernels.attention.call_spec import AttentionCall, fp8_dtype, uses_sliding_window
+from tileops.kernels.attention.call_spec import AttentionCall, fp8_dtype
 
 __all__ = [
     "DECODE_KEYS",
@@ -14,6 +14,7 @@ __all__ = [
     "PAGED_PREFILL_KEYS",
     "AttentionCall",
     "check_packed_prefill_request",
+    "check_packed_prefill_semantics",
     "fp8_dtype",
 ]
 
@@ -47,9 +48,6 @@ DECODE_KEYS = ("gqa_decode_bs1_kernel", "gqa_decode_kernel")
 #: Implementations of paged GQA decode.
 PAGED_DECODE_KEYS = ("gqa_decode_paged_bs1_kernel", "gqa_decode_paged_kernel")
 
-#: Implementations of paged MHA decode.
-MHA_PAGED_DECODE_KEYS = ("mha_decode_paged_ws_kernel", "mha_decode_paged_kernel")
-
 
 def check_packed_prefill_request(call: AttentionCall) -> None:
     """Reject a packed prefill request its ``backend`` knob cannot describe.
@@ -61,27 +59,57 @@ def check_packed_prefill_request(call: AttentionCall) -> None:
     Raises:
         ValueError: When ``backend`` contradicts the request.
     """
-    if call.is_fp8:
-        if call.backend not in ("auto", "fp8"):
+    check_packed_prefill_semantics(
+        is_fp8=call.is_fp8,
+        is_uniform=call.is_uniform,
+        is_causal=call.is_causal,
+        max_seqlen_q=call.max_seqlen_q,
+        max_seqlen_kv=call.max_seqlen_kv,
+        window_size_left=call.window_size_left,
+        window_size_right=call.window_size_right,
+        backend=call.backend,
+    )
+
+
+def check_packed_prefill_semantics(
+    *,
+    is_fp8: bool,
+    is_uniform: bool,
+    is_causal: bool,
+    max_seqlen_q: int,
+    max_seqlen_kv: int,
+    window_size_left: int,
+    window_size_right: int,
+    backend: str,
+) -> None:
+    """Validate packed-prefill API semantics without inspecting a device.
+
+    This is the target-neutral half of :func:`check_packed_prefill_request`.
+    ``AttentionCall`` and its architecture facts belong only to the in-tree
+    implementation, while these user-visible parameter rules apply to every target.
+    """
+    uses_window = window_size_left != -1 or window_size_right != -1
+    if is_fp8:
+        if backend not in ("auto", "fp8"):
             raise ValueError("FP8 prefill requires backend='auto' or backend='fp8'.")
-        if call.is_causal:
+        if is_causal:
             raise ValueError("FP8 prefill currently supports non-causal prefill only.")
-        if uses_sliding_window(call):
+        if uses_window:
             raise ValueError("FP8 prefill does not support sliding-window dispatch.")
-        if call.max_seqlen_q != call.max_seqlen_kv:
+        if max_seqlen_q != max_seqlen_kv:
             raise ValueError("FP8 prefill requires max_seqlen_q == max_seqlen_kv.")
-        if not call.is_uniform:
+        if not is_uniform:
             raise ValueError("FP8 prefill requires uniform packed cu_seqlens.")
         return
-    if call.backend == "fp8":
+    if backend == "fp8":
         raise ValueError("backend='fp8' requires float8_e4m3fn q/k/v.")
-    if uses_sliding_window(call):
-        if call.backend not in ("auto", "sliding_window"):
+    if uses_window:
+        if backend not in ("auto", "sliding_window"):
             raise ValueError(
                 "sliding-window prefill requires backend='auto' or backend='sliding_window'."
             )
         return
-    if call.backend == "sliding_window":
+    if backend == "sliding_window":
         raise ValueError("backend='sliding_window' requires window_size_left or window_size_right.")
-    if call.backend == "dense" and not call.is_uniform:
+    if backend == "dense" and not is_uniform:
         raise ValueError("backend='dense' requires uniform packed cu_seqlens.")

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -1237,7 +1237,11 @@ def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
         kernel_map=_stand_in_prefill_map(),
     )
 
-    kernel = packed._build_builtin_kernel(is_fp8=False, is_uniform=True)
+    kernel = packed._build_builtin_kernel(
+        device=torch.device("cuda"),
+        is_fp8=False,
+        is_uniform=True,
+    )
 
     assert kernel.kwargs["max_seqlen_q"] == max_seqlen_q
     assert kernel.kwargs["max_seqlen_kv"] == max_seqlen_kv

--- a/tests/ops/attention/test_gqa.py
+++ b/tests/ops/attention/test_gqa.py
@@ -676,8 +676,7 @@ def test_gqa_prefill_fwd_auto_backend_serves_uniform_input_dense() -> None:
     assert out.shape == q.shape
     # Uniform ranges put an automatic request on a dense implementation, not on
     # the ragged one — the outcome the range reading exists to produce.
-    assert list(op.built_kernels("gqa_prefill_fwd_kernel")) == [torch.float16]
-    assert not op.built_kernels("gqa_prefill_varlen_fwd_kernel")
+    assert list(op.built_kernels("gqa_prefill")) == [(q.device, torch.float16, False, True)]
 
 
 @pytest.mark.smoke
@@ -1238,8 +1237,7 @@ def test_gqa_prefill_dense_build_threads_q_and_kv_lengths_apart() -> None:
         kernel_map=_stand_in_prefill_map(),
     )
 
-    call = packed.attention_call(is_fp8=False, is_uniform=True)
-    kernel = packed._kernel_for(packed.select_kernel_key(PACKED_PREFILL_KEYS, call), call)
+    kernel = packed._build_builtin_kernel(is_fp8=False, is_uniform=True)
 
     assert kernel.kwargs["max_seqlen_q"] == max_seqlen_q
     assert kernel.kwargs["max_seqlen_kv"] == max_seqlen_kv

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -373,8 +373,8 @@ def _register_gqa(recorder):
     )
 
 
-def _gqa_op():
-    return GroupedQueryAttentionPrefillFwdOp(
+def _gqa_op(**overrides):
+    kwargs = dict(
         batch=2,
         heads=4,
         heads_kv=2,
@@ -386,6 +386,8 @@ def _gqa_op():
         backend="auto",
         target="fake",
     )
+    kwargs.update(overrides)
+    return GroupedQueryAttentionPrefillFwdOp(**kwargs)
 
 
 def _gqa_inputs(cu_values=(0, 3, 6), *, noncontiguous_q=False):
@@ -413,21 +415,8 @@ def test_gqa_target_gets_the_exact_manifest_contract(monkeypatch):
     # CallSpec, architecture probes and implementation names belong to BUILTIN.
     monkeypatch.setattr(
         op,
-        "select_kernel_key",
-        lambda *args, **kwargs: pytest.fail("external dispatch selected a builtin kernel"),
-    )
-    monkeypatch.setattr(
-        op,
-        "attention_call",
-        lambda *args, **kwargs: pytest.fail("external dispatch constructed a builtin call"),
-    )
-    monkeypatch.setattr(
-        "tileops.utils.get_sm_version",
-        lambda: pytest.fail("external dispatch inspected an NVIDIA architecture"),
-    )
-    monkeypatch.setattr(
-        "tileops.utils.is_h200",
-        lambda: pytest.fail("external dispatch inspected an NVIDIA product"),
+        "_build_builtin_kernel",
+        lambda **kwargs: pytest.fail("external dispatch entered the builtin factory"),
     )
     output = op(*inputs)
 
@@ -469,8 +458,7 @@ def test_gqa_public_semantics_are_checked_before_an_external_builder():
     """A target replaces kernels, not the op's user-visible parameter rules."""
     recorder = _GQARecorder()
     _register_gqa(recorder)
-    op = _gqa_op()
-    op.backend = "dense"
+    op = _gqa_op(backend="dense")
 
     with pytest.raises(ValueError, match="backend='dense' requires uniform"):
         op(*_gqa_inputs((0, 1, 4)))

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from tileops.backend import BUILTIN, OpNotAvailableError, TensorSpec, registry
+from tileops.ops.attention.gqa import GroupedQueryAttentionPrefillFwdOp
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 
 pytestmark = pytest.mark.smoke
@@ -340,3 +341,138 @@ def test_a_settled_instance_is_bound_to_that_target_s_devices():
 
     with pytest.raises(ValueError, match="is a CUDA kernel"):
         op(*_inputs())  # same signature, CPU tensors
+
+
+# --------------------------------------------------------------------------------------
+# A complex op: canonical packed GQA prefill
+# --------------------------------------------------------------------------------------
+
+
+class _GQARecorder:
+    """A fake GQA target that records construction separately from invocation."""
+
+    def __init__(self):
+        self.builds = []
+        self.invocations = []
+
+    def build_kernel(self, *specs, **params):
+        self.builds.append((specs, params))
+
+        def kernel(*inputs):
+            assert len(inputs) == 8
+            assert all(tensor.is_contiguous() for tensor in inputs)
+            self.invocations.append(tuple(tensor.clone() for tensor in inputs))
+            return torch.full_like(inputs[0], 7)
+
+        return kernel
+
+
+def _register_gqa(recorder):
+    registry.register_kernel_builder(
+        "GroupedQueryAttentionPrefillFwdOp", "fake", recorder.build_kernel
+    )
+
+
+def _gqa_op():
+    return GroupedQueryAttentionPrefillFwdOp(
+        batch=2,
+        heads=4,
+        heads_kv=2,
+        dim=8,
+        max_seqlen_q=3,
+        max_seqlen_kv=3,
+        dtype=torch.float16,
+        is_causal=True,
+        backend="auto",
+        target="fake",
+    )
+
+
+def _gqa_inputs(cu_values=(0, 3, 6), *, noncontiguous_q=False):
+    total = cu_values[-1]
+    if noncontiguous_q:
+        q = torch.randn(total, 4, 16, dtype=torch.float16)[:, :, ::2]
+        assert not q.is_contiguous()
+    else:
+        q = torch.randn(total, 4, 8, dtype=torch.float16)
+    k = torch.randn(total, 2, 8, dtype=torch.float16)
+    v = torch.randn_like(k)
+    cu_q = torch.tensor(cu_values, dtype=torch.int32)
+    cu_kv = torch.tensor(cu_values, dtype=torch.int32)
+    scales = tuple(torch.ones(2, 2, dtype=torch.float32) for _ in range(3))
+    return q, k, v, cu_q, cu_kv, *scales
+
+
+def test_gqa_target_gets_the_exact_manifest_contract(monkeypatch):
+    """A complex op still exposes only its manifest contract to a target."""
+    recorder = _GQARecorder()
+    _register_gqa(recorder)
+    op = _gqa_op()
+    inputs = _gqa_inputs(noncontiguous_q=True)
+
+    # CallSpec, architecture probes and implementation names belong to BUILTIN.
+    monkeypatch.setattr(
+        op,
+        "select_kernel_key",
+        lambda *args, **kwargs: pytest.fail("external dispatch selected a builtin kernel"),
+    )
+    monkeypatch.setattr(
+        op,
+        "attention_call",
+        lambda *args, **kwargs: pytest.fail("external dispatch constructed a builtin call"),
+    )
+    monkeypatch.setattr(
+        "tileops.utils.get_sm_version",
+        lambda: pytest.fail("external dispatch inspected an NVIDIA architecture"),
+    )
+    monkeypatch.setattr(
+        "tileops.utils.is_h200",
+        lambda: pytest.fail("external dispatch inspected an NVIDIA product"),
+    )
+    output = op(*inputs)
+
+    ((specs, params),) = recorder.builds
+    normalized = tuple(tensor.contiguous() for tensor in inputs)
+    assert specs == tuple(TensorSpec.of(tensor) for tensor in normalized)
+    assert params == {
+        "max_seqlen_q": 3,
+        "max_seqlen_kv": 3,
+        "is_causal": True,
+        "sm_scale": 8**-0.5,
+        "softcap": 0.0,
+        "window_size_left": -1,
+        "window_size_right": -1,
+        "backend": "auto",
+        "validate_uniform_cu_seqlens": True,
+        "dtype": torch.float16,
+    }
+    assert torch.equal(output, torch.full_like(normalized[0], 7))
+
+
+def test_gqa_same_signature_different_contents_reuses_the_callable():
+    """Runtime sequence contents do not fragment the external signature cache."""
+    recorder = _GQARecorder()
+    _register_gqa(recorder)
+    op = _gqa_op()
+
+    op(*_gqa_inputs((0, 1, 4)))
+    op(*_gqa_inputs((0, 3, 4)))
+
+    assert len(recorder.builds) == 1
+    assert len(recorder.invocations) == 2
+    assert recorder.invocations[0][3].tolist() == [0, 1, 4]
+    assert recorder.invocations[1][3].tolist() == [0, 3, 4]
+    assert len(op.built_kernels("gqa_prefill")) == 1
+
+
+def test_gqa_public_semantics_are_checked_before_an_external_builder():
+    """A target replaces kernels, not the op's user-visible parameter rules."""
+    recorder = _GQARecorder()
+    _register_gqa(recorder)
+    op = _gqa_op()
+    op.backend = "dense"
+
+    with pytest.raises(ValueError, match="backend='dense' requires uniform"):
+        op(*_gqa_inputs((0, 1, 4)))
+
+    assert recorder.builds == []


### PR DESCRIPTION
## Summary

Route `GroupedQueryAttentionPrefillFwdOp` through the multi-backend seam introduced by #1883.

- pass all eight normalized manifest tensors to `get_or_build_kernel`
- keep public validation and contiguity normalization common to every target
- keep `AttentionCall`, NVIDIA architecture inspection, and in-tree kernel selection inside the builtin factory
- memoize external callables by the manifest input signature while preserving device-aware builtin specialization
- extend the existing backend-seam tests with packed GQA's multi-input and runtime `cu_seqlens` cases

## Why GQA

RMSNorm establishes the basic seam. Canonical packed GQA exercises a more demanding contract: eight inputs, dense/varlen/FP8/sliding-window implementations, content-dependent uniformity, and architecture-specific builtin selection.

This is a draft so we can review whether the current attention `backend` / `validate_uniform_cu_seqlens` API should be simplified before this becomes the migration template for the rest of attention.

## Tests

- `ruff check` on changed files
- `pytest tests/test_op_backend_seam.py tests/ops/test_kernel_selection.py -q` — 55 passed
- `pytest tests/ops/attention/test_gqa.py -q` on H200 — 52 passed
- strict manifest validation for `GroupedQueryAttentionPrefillFwdOp`