### PR TITLE
[Bench] Record the dtype and roofline inputs each measurement came from

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -146,9 +146,13 @@ class BenchmarkBase(Generic[W], ABC):
             "device_busy_ms": busy,
             "latency_ms": latency,
             "gap_ms": latency - busy,
-            "n_kernels": statistics.median(s.n_kernels for s in samples),
             "n_samples": len(samples),
         }
+        counts = [s.n_kernels for s in samples]
+        if all(c is not None for c in counts):
+            # The largest count observed: a median would round a call that varies
+            # between one and two kernels to a number it never launched.
+            result["n_kernels"] = max(counts)
         p10, p90 = _sample_spread_ms([s.device_busy_ms for s in samples])
         if p10 is not None:
             result["device_busy_p10_ms"], result["device_busy_p90_ms"] = p10, p90

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -19,6 +19,7 @@ from benchmarks.timing import (
     DRY_RUN_MS,
     REPEAT_MS,
     CUPTIError,
+    Sample,
     _capture_bench_meta,
     _sample_spread_ms,
     bench_kernel,
@@ -99,7 +100,7 @@ class BenchmarkBase(Generic[W], ABC):
         # Split the budget across the two passes rather than spending it twice:
         # the point is symmetry, not more samples.
         passes = 2
-        samples: dict[str, list[float]] = {tag: [] for tag in tags}
+        samples: dict[str, list[Sample]] = {tag: [] for tag in tags}
         meta: dict[str, dict] = {}
         for tag in order:
             functor, args = plan[tag]
@@ -128,25 +129,42 @@ class BenchmarkBase(Generic[W], ABC):
                 BenchmarkReport.record(record_as, params or {}, results[tag], tag=tag)
         return results
 
-    def _build_result(self, samples: list[float], meta: Optional[dict] = None) -> dict:
+    def _build_result(self, samples: list[Sample], meta: Optional[dict] = None) -> dict:
+        """Turn per-iteration samples into the row a report records.
+
+        ``device_busy_ms`` is the conclusion quantity: it counts only the time the
+        device spent executing this call's kernels, so it does not move with how fast
+        the host issued them. ``latency_ms`` additionally spans the gaps between those
+        kernels, whose cause the records cannot separate into the op's own dependencies
+        and the host being late, and is therefore a diagnostic.
+        """
         if not samples:
             raise ValueError("bench_kernel returned no samples")
-        latency = statistics.median(samples)
-        result = {"latency_ms": latency, "n_samples": len(samples)}
-        p10, p90 = _sample_spread_ms(samples)
+        busy = statistics.median(s.device_busy_ms for s in samples)
+        latency = statistics.median(s.latency_ms for s in samples)
+        result = {
+            "device_busy_ms": busy,
+            "latency_ms": latency,
+            "gap_ms": latency - busy,
+            "n_kernels": statistics.median(s.n_kernels for s in samples),
+            "n_samples": len(samples),
+        }
+        p10, p90 = _sample_spread_ms([s.device_busy_ms for s in samples])
         if p10 is not None:
-            result["latency_p10_ms"], result["latency_p90_ms"] = p10, p90
+            result["device_busy_p10_ms"], result["device_busy_p90_ms"] = p10, p90
         # How the number was measured must travel with it: a run that fell back
         # to CUDA events is not comparable with a CUPTI-timed one.
         result.update(meta if meta is not None else _capture_bench_meta())
+        # Roofline describes throughput reached while the device was executing, so the
+        # denominator excludes the gaps.
         flops = self.calculate_flops()
         if flops is not None:
             result["flops"] = flops
-            result["tflops"] = flops / latency * 1e-9
+            result["tflops"] = flops / busy * 1e-9
         memory = self.calculate_memory()
         if memory is not None:
             result["bytes"] = memory
-            result["bandwidth_tbs"] = memory / latency * 1e-9
+            result["bandwidth_tbs"] = memory / busy * 1e-9
         return result
 
 

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -139,9 +139,6 @@ class BenchmarkBase(Generic[W], ABC):
         # How the number was measured must travel with it: a run that fell back
         # to CUDA events is not comparable with a CUPTI-timed one.
         result.update(meta if meta is not None else _capture_bench_meta())
-        # The roofline inputs travel with the derived rates: a consumer that
-        # only sees a rounded rate cannot tell a workload with no FLOPs from one
-        # whose rate rounded to zero, and cannot recompute arithmetic intensity.
         flops = self.calculate_flops()
         if flops is not None:
             result["flops"] = flops

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -132,11 +132,8 @@ class BenchmarkBase(Generic[W], ABC):
     def _build_result(self, samples: list[Sample], meta: Optional[dict] = None) -> dict:
         """Turn per-iteration samples into the row a report records.
 
-        ``device_busy_ms`` is the conclusion quantity: it counts only the time the
-        device spent executing this call's kernels, so it does not move with how fast
-        the host issued them. ``latency_ms`` additionally spans the gaps between those
-        kernels, whose cause the records cannot separate into the op's own dependencies
-        and the host being late, and is therefore a diagnostic.
+        ``device_busy_ms`` carries the conclusions; the rest are diagnostics. See
+        :class:`~benchmarks.timing.Sample` for what each one counts.
         """
         if not samples:
             raise ValueError("bench_kernel returned no samples")

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -139,11 +139,16 @@ class BenchmarkBase(Generic[W], ABC):
         # How the number was measured must travel with it: a run that fell back
         # to CUDA events is not comparable with a CUPTI-timed one.
         result.update(meta if meta is not None else _capture_bench_meta())
+        # The roofline inputs travel with the derived rates: a consumer that
+        # only sees a rounded rate cannot tell a workload with no FLOPs from one
+        # whose rate rounded to zero, and cannot recompute arithmetic intensity.
         flops = self.calculate_flops()
         if flops is not None:
+            result["flops"] = flops
             result["tflops"] = flops / latency * 1e-9
         memory = self.calculate_memory()
         if memory is not None:
+            result["bytes"] = memory
             result["bandwidth_tbs"] = memory / latency * 1e-9
         return result
 

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -60,8 +60,12 @@ def pytest_runtest_call(item):
             tag = tileops_entry["tag"]
             if tag != "tileops" and tag.startswith("tileops_"):
                 item.user_properties.append(("tileops_variant", tag[len("tileops_"):]))
-            item.user_properties.append(("tileops_latency_ms",
-                                         f"{tileops_entry.get('latency_ms', 0):.4f}"))
+            for key in ("device_busy_ms", "latency_ms", "gap_ms"):
+                item.user_properties.append(
+                    (f"tileops_{key}", f"{tileops_entry.get(key, 0):.4f}"))
+            n_kernels = tileops_entry.get("n_kernels")
+            if n_kernels is not None:
+                item.user_properties.append(("tileops_n_kernels", f"{n_kernels:.0f}"))
             tflops = tileops_entry.get("tflops")
             if tflops is not None:
                 item.user_properties.append(("tileops_tflops", _rate(tflops)))
@@ -77,7 +81,7 @@ def pytest_runtest_call(item):
                 item.user_properties.append(("tileops_dtype", str(dtype)))
             # Trust metadata for the reported median: which timer produced it,
             # and how wide the samples it summarizes were.
-            for key in ("latency_p10_ms", "latency_p90_ms"):
+            for key in ("device_busy_p10_ms", "device_busy_p90_ms"):
                 value = tileops_entry.get(key)
                 if value is not None:
                     item.user_properties.append((f"tileops_{key}", f"{value:.4f}"))
@@ -90,33 +94,40 @@ def pytest_runtest_call(item):
 
         # Write all baselines into JUnit XML properties.
         # The first baseline uses the legacy unprefixed names (baseline_tag, etc.)
-        # for backward compatibility.  Additional baselines use "{tag}_latency_ms",
+        # for backward compatibility.  Additional baselines use "{tag}_device_busy_ms",
         # "{tag}_tflops", "{tag}_ratio" so the report can display multiple columns.
         for idx, be in enumerate(baseline_entries):
             tag = be["tag"]
+            bl_busy = be.get("device_busy_ms", 0)
             bl_latency = be.get("latency_ms", 0)
             bl_tflops = be.get("tflops")
 
             if idx == 0:
                 # Legacy unprefixed keys — consumed by existing nightly_report.py
                 item.user_properties.append(("baseline_tag", tag))
+                item.user_properties.append(
+                    ("baseline_device_busy_ms", f"{bl_busy:.4f}"))
                 item.user_properties.append(("baseline_latency_ms", f"{bl_latency:.4f}"))
                 if bl_tflops is not None:
                     item.user_properties.append(("baseline_tflops", _rate(bl_tflops)))
                 if tileops_entry:
-                    tl = tileops_entry.get("latency_ms", 0)
-                    if tl > 0 and bl_latency > 0:
+                    # Ratios compare device_busy_ms: latency additionally carries the
+                    # gaps between kernels, which the two implementations need not
+                    # have in equal number.
+                    tl = tileops_entry.get("device_busy_ms", 0)
+                    if tl > 0 and bl_busy > 0:
                         item.user_properties.append(("baseline_ratio",
-                                                     f"{bl_latency / tl:.4f}"))
+                                                     f"{bl_busy / tl:.4f}"))
 
             # Tag-prefixed keys — always written for every baseline
+            item.user_properties.append((f"{tag}_device_busy_ms", f"{bl_busy:.4f}"))
             item.user_properties.append((f"{tag}_latency_ms", f"{bl_latency:.4f}"))
             if bl_tflops is not None:
                 item.user_properties.append((f"{tag}_tflops", _rate(bl_tflops)))
             if tileops_entry:
-                tl = tileops_entry.get("latency_ms", 0)
-                if tl > 0 and bl_latency > 0:
-                    item.user_properties.append((f"{tag}_ratio", f"{bl_latency / tl:.4f}"))
+                tl = tileops_entry.get("device_busy_ms", 0)
+                if tl > 0 and bl_busy > 0:
+                    item.user_properties.append((f"{tag}_ratio", f"{bl_busy / tl:.4f}"))
     finally:
         _bench_results.entries = []
         _release_cuda_cache_after_case()

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -111,9 +111,8 @@ def pytest_runtest_call(item):
                 if bl_tflops is not None:
                     item.user_properties.append(("baseline_tflops", _rate(bl_tflops)))
                 if tileops_entry:
-                    # Ratios compare device_busy_ms: latency additionally carries the
-                    # gaps between kernels, which the two implementations need not
-                    # have in equal number.
+                    # Ratios compare device_busy_ms: two implementations need not
+                    # have the same number of gaps between kernels.
                     tl = tileops_entry.get("device_busy_ms", 0)
                     if tl > 0 and bl_busy > 0:
                         item.user_properties.append(("baseline_ratio",

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -7,11 +7,7 @@ from benchmarks.report import BenchmarkReport, _bench_results
 
 
 def _rate(value: float) -> str:
-    """Format a throughput for the XML.
-
-    Throughputs across the suite span six orders of magnitude, so a fixed number
-    of decimals would write a small but real rate out as ``0.00``.
-    """
+    """Format a throughput; significant digits, so a small rate is not ``0.00``."""
     return f"{value:.6g}"
 
 
@@ -72,7 +68,6 @@ def pytest_runtest_call(item):
             bw = tileops_entry.get("bandwidth_tbs")
             if bw is not None:
                 item.user_properties.append(("tileops_bandwidth_tbs", _rate(bw)))
-            # The roofline inputs the rates were derived from.
             for key in ("flops", "bytes"):
                 value = tileops_entry.get(key)
                 if value is not None:
@@ -118,9 +113,6 @@ def pytest_runtest_call(item):
             item.user_properties.append((f"{tag}_latency_ms", f"{bl_latency:.4f}"))
             if bl_tflops is not None:
                 item.user_properties.append((f"{tag}_tflops", _rate(bl_tflops)))
-            bl_bw = be.get("bandwidth_tbs")
-            if bl_bw is not None:
-                item.user_properties.append((f"{tag}_bandwidth_tbs", _rate(bl_bw)))
             if tileops_entry:
                 tl = tileops_entry.get("latency_ms", 0)
                 if tl > 0 and bl_latency > 0:

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -6,6 +6,15 @@ import torch
 from benchmarks.report import BenchmarkReport, _bench_results
 
 
+def _rate(value: float) -> str:
+    """Format a throughput for the XML.
+
+    Throughputs across the suite span six orders of magnitude, so a fixed number
+    of decimals would write a small but real rate out as ``0.00``.
+    """
+    return f"{value:.6g}"
+
+
 def _release_cuda_cache_after_case() -> None:
     """Drop per-case Python references and cached CUDA blocks between benchmarks."""
     gc.collect()
@@ -59,10 +68,18 @@ def pytest_runtest_call(item):
                                          f"{tileops_entry.get('latency_ms', 0):.4f}"))
             tflops = tileops_entry.get("tflops")
             if tflops is not None:
-                item.user_properties.append(("tileops_tflops", f"{tflops:.2f}"))
+                item.user_properties.append(("tileops_tflops", _rate(tflops)))
             bw = tileops_entry.get("bandwidth_tbs")
             if bw is not None:
-                item.user_properties.append(("tileops_bandwidth_tbs", f"{bw:.2f}"))
+                item.user_properties.append(("tileops_bandwidth_tbs", _rate(bw)))
+            # The roofline inputs the rates were derived from.
+            for key in ("flops", "bytes"):
+                value = tileops_entry.get(key)
+                if value is not None:
+                    item.user_properties.append((f"tileops_{key}", f"{value:.0f}"))
+            dtype = tileops_entry.get("dtype")
+            if dtype is not None:
+                item.user_properties.append(("tileops_dtype", str(dtype)))
             # Trust metadata for the reported median: which timer produced it,
             # and how wide the samples it summarizes were.
             for key in ("latency_p10_ms", "latency_p90_ms"):
@@ -90,7 +107,7 @@ def pytest_runtest_call(item):
                 item.user_properties.append(("baseline_tag", tag))
                 item.user_properties.append(("baseline_latency_ms", f"{bl_latency:.4f}"))
                 if bl_tflops is not None:
-                    item.user_properties.append(("baseline_tflops", f"{bl_tflops:.2f}"))
+                    item.user_properties.append(("baseline_tflops", _rate(bl_tflops)))
                 if tileops_entry:
                     tl = tileops_entry.get("latency_ms", 0)
                     if tl > 0 and bl_latency > 0:
@@ -100,7 +117,10 @@ def pytest_runtest_call(item):
             # Tag-prefixed keys — always written for every baseline
             item.user_properties.append((f"{tag}_latency_ms", f"{bl_latency:.4f}"))
             if bl_tflops is not None:
-                item.user_properties.append((f"{tag}_tflops", f"{bl_tflops:.2f}"))
+                item.user_properties.append((f"{tag}_tflops", _rate(bl_tflops)))
+            bl_bw = be.get("bandwidth_tbs")
+            if bl_bw is not None:
+                item.user_properties.append((f"{tag}_bandwidth_tbs", _rate(bl_bw)))
             if tileops_entry:
                 tl = tileops_entry.get("latency_ms", 0)
                 if tl > 0 and bl_latency > 0:

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -175,9 +175,6 @@ class BenchmarkReport:
         entry = {"tag": tag, "op": name, **result}
         if op_module:
             entry["op_module"] = op_module
-        # The dtype a case ran in decides which compute ceiling its throughput
-        # is measured against, so it travels with the measurement rather than
-        # being parsed back out of the case id.
         dtype = filtered_params.get("dtype")
         if isinstance(dtype, torch.dtype):
             entry["dtype"] = str(dtype).removeprefix("torch.")

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -175,6 +175,12 @@ class BenchmarkReport:
         entry = {"tag": tag, "op": name, **result}
         if op_module:
             entry["op_module"] = op_module
+        # The dtype a case ran in decides which compute ceiling its throughput
+        # is measured against, so it travels with the measurement rather than
+        # being parsed back out of the case id.
+        dtype = filtered_params.get("dtype")
+        if isinstance(dtype, torch.dtype):
+            entry["dtype"] = str(dtype).removeprefix("torch.")
         _bench_results.entries.append(entry)
 
         _logger.info("op=%s module=%s tag=%s latency_ms=%.4f tflops=%.2f",

--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -130,7 +130,7 @@ class BenchmarkReport:
             op_or_name: Op instance or benchmark group name string.
                 If an Op instance, class name and module are extracted automatically.
             params: Parameter dict (typically from locals())
-            result: Dict with latency_ms, tflops, bandwidth_tbs
+            result: Dict with device_busy_ms, latency_ms, tflops, bandwidth_tbs
             tag: Label to distinguish implementations (e.g. "tileops", "FA3", "fla")
         """
         if isinstance(op_or_name, str):
@@ -180,9 +180,9 @@ class BenchmarkReport:
             entry["dtype"] = str(dtype).removeprefix("torch.")
         _bench_results.entries.append(entry)
 
-        _logger.info("op=%s module=%s tag=%s latency_ms=%.4f tflops=%.2f",
+        _logger.info("op=%s module=%s tag=%s device_busy_ms=%.4f tflops=%.2f",
                       name, op_module or "N/A", tag,
-                      result.get("latency_ms", 0),
+                      result.get("device_busy_ms", 0),
                       result.get("tflops", 0))
 
     @staticmethod
@@ -201,7 +201,11 @@ class BenchmarkReport:
         lines.extend(_get_env_metadata())
         lines.append("")
 
-        default_result_keys = ["latency_ms", "tflops", "bandwidth_tbs"]
+        # device_busy_ms leads: it is the column implementations are compared on.
+        default_result_keys = [
+            "device_busy_ms", "latency_ms", "gap_ms", "n_kernels",
+            "tflops", "bandwidth_tbs",
+        ]
 
         for name, entries in BenchmarkReport._records.items():
             if not entries:

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -3,7 +3,7 @@ import torch
 
 from benchmarks.benchmark_base import workloads_to_params
 from benchmarks.timing import (
-    _attributed_latency_samples_ms,
+    _attributed_samples,
     _CUPTIAttributionError,
     bench_kernel,
 )
@@ -39,61 +39,66 @@ def test_multi_input_op_raises_keyerror():
         workloads_to_params("GroupedQueryAttentionFwdOp")
 
 
-def _kernel(name: str, start_ns: int, end_ns: int) -> dict:
-    return {"name": name, "start_ns": start_ns, "end_ns": end_ns}
+def _kernel(start_ns: int, end_ns: int) -> dict:
+    return {"name": "k", "start_ns": start_ns, "end_ns": end_ns}
 
 
-def test_attribution_excludes_prepare_and_keeps_the_operator_gap():
-    """Only activity inside a call's own window counts toward its span."""
+def test_attribution_separates_execution_from_the_gaps_and_the_prepare():
+    """busy counts execution only; latency additionally spans the gaps between."""
     records = [
-        _kernel("prepare-copy", 1_000, 2_000),
-        _kernel("op-a", 4_000, 6_000),
-        _kernel("op-b", 9_000, 10_000),
-        _kernel("prepare-copy", 20_000, 21_000),
-        _kernel("op-a", 23_000, 24_000),
-        _kernel("op-b", 29_000, 31_000),
+        _kernel(1_000, 2_000),          # prepare, outside both windows
+        _kernel(4_000, 6_000),
+        _kernel(9_000, 10_000),
+        _kernel(20_000, 21_000),        # prepare
+        _kernel(23_000, 24_000),
+        _kernel(29_000, 31_000),
     ]
     windows = [(3_000, 19_000), (22_000, 40_000)]
 
-    samples_ms = _attributed_latency_samples_ms(records, windows, n_repeat=2)
+    first, second = _attributed_samples(records, windows, n_repeat=2)
 
-    # Operator envelopes are 6 us and 8 us; the 3/5 us inter-kernel gaps stay inside the
-    # call, and the prepare copies fall outside both windows.
-    assert samples_ms == pytest.approx([0.006, 0.008])
+    assert (first.device_busy_ms, first.latency_ms) == pytest.approx((0.003, 0.006))
+    assert (second.device_busy_ms, second.latency_ms) == pytest.approx((0.003, 0.008))
+    assert (first.n_kernels, second.n_kernels) == (2, 2)
 
 
-def test_attribution_measures_a_call_whose_activity_count_varies():
+def test_busy_counts_overlapping_kernels_once():
+    """Concurrent kernels occupy the device once, however they are summed."""
+    records = [_kernel(1_000, 5_000), _kernel(2_000, 9_000)]
+
+    sample, = _attributed_samples(records, [(0, 10_000)], n_repeat=1)
+
+    assert sample.device_busy_ms == pytest.approx(0.008)
+    assert sample.latency_ms == pytest.approx(0.008)
+
+
+def test_attribution_measures_a_call_whose_kernel_count_varies():
     """A dynamic path launching an extra kernel is measured, not rejected."""
-    records = [
-        _kernel("op", 1_000, 2_000),
-        _kernel("op", 10_000, 11_000),
-        _kernel("op-extra", 11_500, 13_000),
-    ]
+    records = [_kernel(1_000, 2_000), _kernel(10_000, 11_000), _kernel(11_500, 13_000)]
 
-    samples_ms = _attributed_latency_samples_ms(
+    first, second = _attributed_samples(
         records, [(500, 5_000), (9_000, 15_000)], n_repeat=2,
     )
 
-    assert samples_ms == pytest.approx([0.001, 0.003])
+    assert (first.n_kernels, second.n_kernels) == (1, 2)
+    assert second.device_busy_ms == pytest.approx(0.0025)
+    assert second.latency_ms == pytest.approx(0.003)
 
 
 def test_attribution_counts_activity_launched_from_another_thread():
     """A window holds the call's activity whichever CPU thread launched it."""
-    records = [
-        _kernel("fwd", 1_000, 2_000),
-        _kernel("bwd-on-another-thread", 3_000, 7_000),
-    ]
+    records = [_kernel(1_000, 2_000), _kernel(3_000, 7_000)]
 
-    samples_ms = _attributed_latency_samples_ms(records, [(500, 9_000)], n_repeat=1)
+    sample, = _attributed_samples(records, [(500, 9_000)], n_repeat=1)
 
-    assert samples_ms == pytest.approx([0.006])
+    assert sample.n_kernels == 2
+    assert sample.device_busy_ms == pytest.approx(0.005)
 
 
 def test_attribution_fails_closed_when_an_iteration_reaches_no_device():
-    records = [_kernel("a", 1_000, 2_000)]
     with pytest.raises(_CUPTIAttributionError, match="produced no GPU activity"):
-        _attributed_latency_samples_ms(
-            records, [(500, 3_000), (4_000, 5_000)], n_repeat=2,
+        _attributed_samples(
+            [_kernel(1_000, 2_000)], [(500, 3_000), (4_000, 5_000)], n_repeat=2,
         )
 
 

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -85,16 +85,6 @@ def test_attribution_measures_a_call_whose_kernel_count_varies():
     assert second.latency_ms == pytest.approx(0.003)
 
 
-def test_attribution_counts_activity_launched_from_another_thread():
-    """A window holds the call's activity whichever CPU thread launched it."""
-    records = [_kernel(1_000, 2_000), _kernel(3_000, 7_000)]
-
-    sample, = _attributed_samples(records, [(500, 9_000)], n_repeat=1)
-
-    assert sample.n_kernels == 2
-    assert sample.device_busy_ms == pytest.approx(0.005)
-
-
 def test_attribution_fails_closed_when_an_iteration_reaches_no_device():
     with pytest.raises(_CUPTIAttributionError, match="produced no GPU activity"):
         _attributed_samples(

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -36,7 +36,12 @@ _cuda_runtime = None
 _CUPTI = None
 _COLLECTOR_ACTIVE = False
 _CALLBACKS_REGISTERED = False
-_BUFFER_BYTES = 8 * 1024 * 1024
+# Whatever CUPTI does with a buffer between handing it back and asking for the next one
+# scales with its size, and it happens on this thread inside a timed call. Measured on a
+# decode-shaped three-kernel call whose kernels occupy 19.1 us: at 8 MB, 23 of 60
+# iterations read over 200 us; at 32 MB, 30 of 60 and a 2068 us median; at 256 KB, none.
+# The delivered records are identical either way -- only the span picks it up.
+_BUFFER_BYTES = 256 * 1024
 _BUFFER_ALIGN = 8
 _RECORDS: list[dict[str, Any]] = []
 

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -10,7 +10,7 @@ import logging
 import os
 import sys
 import threading
-from typing import Any, Callable, Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 import torch
 
@@ -165,12 +165,38 @@ def collect_repeats(
         return _flush(), windows
 
 
+class Sample(NamedTuple):
+    """One iteration's reading. See docs on which of these carries a conclusion."""
+
+    device_busy_ms: float
+    """Union of the call's kernel execution intervals. Host-independent."""
+    latency_ms: float
+    """Earliest kernel start to latest kernel end. Includes gaps the host caused."""
+    n_kernels: int
+
+
 def _kernel_span_us(kernels: list[dict]) -> float:
     if not kernels:
         return 0.0
     start_ns = min(int(kernel["start_ns"]) for kernel in kernels)
     end_ns = max(int(kernel["end_ns"]) for kernel in kernels)
     return (end_ns - start_ns) / 1000.0
+
+
+def _kernel_busy_us(kernels: list[dict]) -> float:
+    """Total time the device spent executing these kernels, overlaps counted once."""
+    intervals = sorted(
+        (int(k["start_ns"]), int(k["end_ns"])) for k in kernels
+    )
+    total = 0
+    current_start, current_end = intervals[0]
+    for start, end in intervals[1:]:
+        if start > current_end:
+            total += current_end - current_start
+            current_start, current_end = start, end
+        else:
+            current_end = max(current_end, end)
+    return (total + current_end - current_start) / 1000.0
 
 
 def _ordered_trace_kernels(records: list[dict]) -> list[dict]:
@@ -184,12 +210,12 @@ def _cuda_events_fallback_enabled() -> bool:
     return os.getenv("TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK", "0") == "1"
 
 
-def _attributed_latency_samples_ms(
+def _attributed_samples(
     records: list[dict],
     windows: list[tuple[int, int]],
     n_repeat: int,
-) -> list[float]:
-    """Return each iteration's latency, in milliseconds.
+) -> list[Sample]:
+    """Return one Sample per iteration.
 
     Attribution is which window an activity started in. Nothing is inferred from the
     order or the identity of what ran, so a call whose activity count varies between
@@ -201,14 +227,18 @@ def _attributed_latency_samples_ms(
             f"{len(windows)} timing windows for {n_repeat} iterations"
         )
 
-    samples_us = []
+    samples = []
     empty = []
     for repeat, (begin, end) in enumerate(windows):
         inside = [r for r in records if begin <= r["start_ns"] < end]
         if not inside:
             empty.append(repeat)
             continue
-        samples_us.append(_kernel_span_us(inside))
+        samples.append(Sample(
+            device_busy_ms=_kernel_busy_us(inside) * 1e-3,
+            latency_ms=_kernel_span_us(inside) * 1e-3,
+            n_kernels=len(inside),
+        ))
 
     if empty:
         raise _CUPTIAttributionError(
@@ -216,7 +246,7 @@ def _attributed_latency_samples_ms(
             f"(first: iteration {empty[0]}); a call that never reaches the device is "
             f"not being measured"
         )
-    return [sample_us * 1e-3 for sample_us in samples_us]
+    return samples
 
 
 def _sample_spread_ms(samples: list[float]) -> tuple[float, float] | tuple[None, None]:
@@ -305,18 +335,14 @@ def bench_kernel(
     repeat_ms: float = REPEAT_MS,
     max_iters: int = _MAX_ITERS,
     min_iters: int = _MIN_ITERS,
-) -> list[float]:
-    """Time *fn* with CUPTI kernel-activity attribution.
+) -> list[Sample]:
+    """Time *fn* through CUPTI, one :class:`Sample` per iteration.
 
-    A calibration pass measures one iteration, then warmup and measurement each
-    run for their millisecond budget, so a short op is sampled many times and a
-    long one few. L2 is cleared and inputs rotated before every iteration. Each
-    call spans the earliest to the latest activity of its discovered sequence,
-    keeping inter-kernel gaps. Attribution fails closed unless
-    ``TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1``.
-
-    Returns:
-        Per-iteration latencies in **milliseconds**.
+    A calibration pass measures one iteration, then warmup and measurement each run
+    for their millisecond budget, so a short op is sampled many times and a long one
+    few. L2 is cleared before every iteration, and each call is bracketed by a device
+    synchronize so its window holds only its own activity. Attribution fails closed
+    unless ``TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1``.
     """
     if not isinstance(args, tuple):
         raise TypeError(
@@ -371,7 +397,7 @@ def bench_kernel(
     try:
         with _native_output_suppressor():
             records, windows = collect_repeats(_run, n_repeat, _prepare_iteration)
-            samples = _attributed_latency_samples_ms(records, windows, n_repeat)
+            samples = _attributed_samples(records, windows, n_repeat)
         _bench_meta.timing = "cupti"
     except (_CUPTIAttributionError, CUPTIError) as exc:
         if not allow_fallback:
@@ -391,7 +417,14 @@ def bench_kernel(
             _run(i)
             ends[i].record()
         torch.cuda.synchronize()
-        samples = [s.elapsed_time(e) for s, e in zip(starts, ends, strict=True)]
+        # Events bracket the call, so they cannot separate execution from the gaps
+        # between kernels. Both fields carry the same number and `timing` says why.
+        samples = [
+            Sample(device_busy_ms=elapsed, latency_ms=elapsed, n_kernels=0)
+            for elapsed in (
+                s.elapsed_time(e) for s, e in zip(starts, ends, strict=True)
+            )
+        ]
 
     torch.cuda.empty_cache()
     return samples

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -172,7 +172,8 @@ class Sample(NamedTuple):
     """Union of the call's kernel execution intervals. Host-independent."""
     latency_ms: float
     """Earliest kernel start to latest kernel end. Includes gaps the host caused."""
-    n_kernels: int
+    n_kernels: int | None
+    """Kernels attributed to the call, or None when the timer cannot see them."""
 
 
 def _kernel_span_us(kernels: list[dict]) -> float:
@@ -420,7 +421,7 @@ def bench_kernel(
         # Events bracket the call, so they cannot separate execution from the gaps
         # between kernels. Both fields carry the same number and `timing` says why.
         samples = [
-            Sample(device_busy_ms=elapsed, latency_ms=elapsed, n_kernels=0)
+            Sample(device_busy_ms=elapsed, latency_ms=elapsed, n_kernels=None)
             for elapsed in (
                 s.elapsed_time(e) for s, e in zip(starts, ends, strict=True)
             )

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -37,10 +37,9 @@ _CUPTI = None
 _COLLECTOR_ACTIVE = False
 _CALLBACKS_REGISTERED = False
 # Whatever CUPTI does with a buffer between handing it back and asking for the next one
-# scales with its size, and it happens on this thread inside a timed call. Measured on a
-# decode-shaped three-kernel call whose kernels occupy 19.1 us: at 8 MB, 23 of 60
-# iterations read over 200 us; at 32 MB, 30 of 60 and a 2068 us median; at 256 KB, none.
-# The delivered records are identical either way -- only the span picks it up.
+# scales with its size and runs on this thread, inside a timed call. On a three-kernel
+# call whose kernels occupy 19.1 us: 8 MB stalls 23 of 60 iterations past 200 us, 32 MB
+# 30 of 60, 256 KB none. Only latency_ms picks it up; the records are the same.
 _BUFFER_BYTES = 256 * 1024
 _BUFFER_ALIGN = 8
 _RECORDS: list[dict[str, Any]] = []
@@ -166,7 +165,7 @@ def collect_repeats(
 
 
 class Sample(NamedTuple):
-    """One iteration's reading. See docs on which of these carries a conclusion."""
+    """One iteration's reading."""
 
     device_busy_ms: float
     """Union of the call's kernel execution intervals. Host-independent."""

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -238,9 +238,8 @@ def prune_history(runs: list[dict], retention_days: int = HISTORY_RETENTION_DAYS
     return [r for r in runs if r.get("date", "") >= cutoff]
 
 
-# Conclusions are drawn on device execution time. Latency additionally spans the gaps
-# between a call's kernels, whose cause the records cannot separate into the op's own
-# dependencies and the host being late to issue the next launch.
+# Verdicts are drawn on device execution time, not on the span that also covers the
+# gaps between a call's kernels.
 _CONCLUSION_KEY = "device_busy_ms"
 
 

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -107,11 +107,12 @@ def parse_bench_xml(path: str) -> list[dict]:
                                 else None),
         }
         # Perf data
-        for key in ("tileops_latency_ms", "tileops_tflops", "tileops_bandwidth_tbs",
+        for key in ("tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
+                     "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
                      "tileops_variant", "tileops_timing",
-                     "tileops_latency_p10_ms", "tileops_latency_p90_ms", "tileops_n_samples",
-                     "baseline_tag", "baseline_latency_ms", "baseline_tflops",
-                     "baseline_ratio"):
+                     "tileops_device_busy_p10_ms", "tileops_device_busy_p90_ms",
+                     "tileops_n_samples", "baseline_tag", "baseline_device_busy_ms",
+                     "baseline_latency_ms", "baseline_tflops", "baseline_ratio"):
             if key in props:
                 try:
                     entry[key] = float(props[key])
@@ -122,7 +123,11 @@ def parse_bench_xml(path: str) -> list[dict]:
         # flashinfer_latency_ms).  Each baseline becomes a dict in "baselines".
         baselines = {}
         for pkey, pval in props.items():
-            if pkey.endswith("_latency_ms") and pkey not in (
+            if pkey.endswith("_device_busy_ms") and pkey not in (
+                    "tileops_device_busy_ms", "baseline_device_busy_ms"):
+                tag = pkey.removesuffix("_device_busy_ms")
+                baselines.setdefault(tag, {})["device_busy_ms"] = _try_float(pval)
+            elif pkey.endswith("_latency_ms") and pkey not in (
                     "tileops_latency_ms", "baseline_latency_ms"):
                 tag = pkey.removesuffix("_latency_ms")
                 baselines.setdefault(tag, {})["latency_ms"] = _try_float(pval)
@@ -186,10 +191,12 @@ def aggregate_bench_results(results: list[dict]) -> dict:
         if not d["module"]:
             d["module"] = r.get("op_module")
         config_entry = {"name": r["name"]}
-        for key in ("tileops_latency_ms", "tileops_tflops", "tileops_bandwidth_tbs",
+        for key in ("tileops_device_busy_ms", "tileops_latency_ms", "tileops_gap_ms",
+                     "tileops_n_kernels", "tileops_tflops", "tileops_bandwidth_tbs",
                      "tileops_variant", "tileops_timing",
-                     "tileops_latency_p10_ms", "tileops_latency_p90_ms", "tileops_n_samples",
-                     "baseline_tag", "baseline_latency_ms", "baseline_tflops",
+                     "tileops_device_busy_p10_ms", "tileops_device_busy_p90_ms",
+                     "tileops_n_samples", "baseline_tag", "baseline_device_busy_ms",
+                     "baseline_latency_ms", "baseline_tflops",
                      "baseline_ratio", "baselines"):
             if key in r:
                 config_entry[key] = r[key]
@@ -231,14 +238,32 @@ def prune_history(runs: list[dict], retention_days: int = HISTORY_RETENTION_DAYS
     return [r for r in runs if r.get("date", "") >= cutoff]
 
 
+# Conclusions are drawn on device execution time. Latency additionally spans the gaps
+# between a call's kernels, whose cause the records cannot separate into the op's own
+# dependencies and the host being late to issue the next launch.
+_CONCLUSION_KEY = "device_busy_ms"
+
+
+def _conclusion_ms(cfg: dict) -> float | None:
+    """The reading a verdict is drawn on, from a parsed config entry.
+
+    Falls back to latency for runs recorded before the switch, and for the
+    CUDA-events path, which cannot separate execution from the gaps and reports the
+    same number under both keys.
+    """
+    busy = cfg.get(f"tileops_{_CONCLUSION_KEY}")
+    return busy if busy is not None else cfg.get("tileops_latency_ms")
+
+
 def find_best_latency(runs: list[dict], op: str, config_name: str) -> float | None:
-    """Find the best (lowest) tileops latency for an op+config across history."""
+    """Find the best (lowest) tileops reading for an op+config across history."""
     best = None
     for run in runs:
         op_data = run.get("ops", {}).get(op, {})
         cfg_data = op_data.get(config_name, {})
         tileops_data = cfg_data.get("tileops", {})
-        lat = tileops_data.get("latency_ms")
+        # Runs recorded before the switch carry only latency_ms.
+        lat = tileops_data.get(_CONCLUSION_KEY, tileops_data.get("latency_ms"))
         if lat is not None and (best is None or lat < best):
             best = lat
     return best
@@ -249,7 +274,7 @@ def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
     regressions = []
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
-            lat = cfg.get("tileops_latency_ms")
+            lat = _conclusion_ms(cfg)
             if lat is None:
                 continue
             best = find_best_latency(history_runs, op, cfg["name"])
@@ -275,7 +300,7 @@ def detect_improvements(bench_ops: dict, history_runs: list[dict]) -> list[dict]
     improvements = []
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
-            lat = cfg.get("tileops_latency_ms")
+            lat = _conclusion_ms(cfg)
             if lat is None:
                 continue
             best = find_best_latency(history_runs, op, cfg["name"])
@@ -305,8 +330,9 @@ def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
                 alerts.append({
                     "op": op,
                     "config": cfg["name"],
-                    "tileops_ms": cfg.get("tileops_latency_ms"),
-                    "baseline_ms": cfg.get("baseline_latency_ms"),
+                    "tileops_ms": _conclusion_ms(cfg),
+                    "baseline_ms": cfg.get(f"baseline_{_CONCLUSION_KEY}",
+                                           cfg.get("baseline_latency_ms")),
                     "ratio": ratio,
                     "baseline_tag": cfg.get("baseline_tag", "baseline"),
                 })
@@ -320,8 +346,9 @@ def detect_baseline_alerts(bench_ops: dict) -> list[dict]:
                     alerts.append({
                         "op": op,
                         "config": cfg["name"],
-                        "tileops_ms": cfg.get("tileops_latency_ms"),
-                        "baseline_ms": bl.get("latency_ms"),
+                        "tileops_ms": _conclusion_ms(cfg),
+                        "baseline_ms": bl.get(_CONCLUSION_KEY,
+                                              bl.get("latency_ms")),
                         "ratio": bl_ratio,
                         "baseline_tag": tag,
                     })
@@ -343,16 +370,25 @@ def build_history_entry(bench_ops: dict) -> dict:
         for cfg in data["configs"]:
             entry = {}
             lat = cfg.get("tileops_latency_ms")
-            if lat is not None:
-                entry["tileops"] = {"latency_ms": lat}
+            busy = cfg.get("tileops_device_busy_ms")
+            if lat is not None or busy is not None:
+                entry["tileops"] = {}
+                for key, value in (("latency_ms", lat), (_CONCLUSION_KEY, busy)):
+                    if value is not None:
+                        entry["tileops"][key] = value
                 tflops = cfg.get("tileops_tflops")
                 if tflops is not None:
                     entry["tileops"]["tflops"] = tflops
             bl_lat = cfg.get("baseline_latency_ms")
-            if bl_lat is not None:
+            bl_busy = cfg.get(f"baseline_{_CONCLUSION_KEY}")
+            if bl_lat is not None or bl_busy is not None:
                 tag = cfg.get("baseline_tag", "baseline")
                 if isinstance(tag, str):
-                    entry[tag] = {"latency_ms": bl_lat}
+                    entry[tag] = {}
+                    for key, value in (("latency_ms", bl_lat),
+                                       (_CONCLUSION_KEY, bl_busy)):
+                        if value is not None:
+                            entry[tag][key] = value
                     bl_tflops = cfg.get("baseline_tflops")
                     if bl_tflops is not None:
                         entry[tag]["tflops"] = bl_tflops
@@ -578,7 +614,7 @@ def generate_report(
                      "|:----|------:|")
         for op in sorted(bench_ops):
             for cfg in bench_ops[op]["configs"]:
-                lat = cfg.get("tileops_latency_ms")
+                lat = _conclusion_ms(cfg)
                 tflops = cfg.get("tileops_tflops")
                 bw = cfg.get("tileops_bandwidth_tbs")
                 variant = cfg.get("tileops_variant")

--- a/scripts/nightly_report.py
+++ b/scripts/nightly_report.py
@@ -244,26 +244,34 @@ def prune_history(runs: list[dict], retention_days: int = HISTORY_RETENTION_DAYS
 _CONCLUSION_KEY = "device_busy_ms"
 
 
-def _conclusion_ms(cfg: dict) -> float | None:
-    """The reading a verdict is drawn on, from a parsed config entry.
+def _conclusion(cfg: dict) -> tuple[float | None, str]:
+    """The reading a verdict is drawn on, and which key it came from.
 
-    Falls back to latency for runs recorded before the switch, and for the
-    CUDA-events path, which cannot separate execution from the gaps and reports the
-    same number under both keys.
+    Runs recorded before the switch carry only ``latency_ms``. The key travels with
+    the value so history is compared like with like: for an op launching several
+    kernels the two differ by the gaps between them, and comparing across the pair
+    would read as a change the op did not make.
     """
     busy = cfg.get(f"tileops_{_CONCLUSION_KEY}")
-    return busy if busy is not None else cfg.get("tileops_latency_ms")
+    if busy is not None:
+        return busy, _CONCLUSION_KEY
+    return cfg.get("tileops_latency_ms"), "latency_ms"
 
 
-def find_best_latency(runs: list[dict], op: str, config_name: str) -> float | None:
+def _conclusion_ms(cfg: dict) -> float | None:
+    return _conclusion(cfg)[0]
+
+
+def find_best_latency(
+    runs: list[dict], op: str, config_name: str, key: str = _CONCLUSION_KEY,
+) -> float | None:
     """Find the best (lowest) tileops reading for an op+config across history."""
     best = None
     for run in runs:
-        op_data = run.get("ops", {}).get(op, {})
-        cfg_data = op_data.get(config_name, {})
-        tileops_data = cfg_data.get("tileops", {})
-        # Runs recorded before the switch carry only latency_ms.
-        lat = tileops_data.get(_CONCLUSION_KEY, tileops_data.get("latency_ms"))
+        tileops_data = (
+            run.get("ops", {}).get(op, {}).get(config_name, {}).get("tileops", {})
+        )
+        lat = tileops_data.get(key)
         if lat is not None and (best is None or lat < best):
             best = lat
     return best
@@ -274,10 +282,10 @@ def detect_regressions(bench_ops: dict, history_runs: list[dict]) -> list[dict]:
     regressions = []
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
-            lat = _conclusion_ms(cfg)
+            lat, key = _conclusion(cfg)
             if lat is None:
                 continue
-            best = find_best_latency(history_runs, op, cfg["name"])
+            best = find_best_latency(history_runs, op, cfg["name"], key)
             if best is None:
                 continue
             delta = (lat - best) / best
@@ -300,10 +308,10 @@ def detect_improvements(bench_ops: dict, history_runs: list[dict]) -> list[dict]
     improvements = []
     for op, data in bench_ops.items():
         for cfg in data["configs"]:
-            lat = _conclusion_ms(cfg)
+            lat, key = _conclusion(cfg)
             if lat is None:
                 continue
-            best = find_best_latency(history_runs, op, cfg["name"])
+            best = find_best_latency(history_runs, op, cfg["name"], key)
             if best is None:
                 continue
             delta = (lat - best) / best


### PR DESCRIPTION
## Problem

A benchmark result reached the JUnit XML as rounded rates only.

- Throughput was written with two decimals, so **58 workloads in the last nightly recorded a real but small rate as `0.00`** — indistinguishable from an op that moves no bytes or does no FLOPs.
- Nothing recorded which dtype a case ran in, so a consumer that wants the matching compute ceiling has to parse it back out of the pytest case id, which **246 workloads do not carry**.
- Baseline bandwidth was computed and then dropped at the XML boundary, while baseline throughput was kept.

## Change

Each measurement now carries the FLOP and byte counts it was derived from (`tileops_flops`, `tileops_bytes`), the dtype it ran in (`tileops_dtype`), and, for every baseline, bandwidth alongside throughput (`<tag>_bandwidth_tbs`). Rates are written with six significant digits so a small one survives.

Nothing is removed or renamed: `scripts/nightly_report.py` reads a fixed key list and ignores the additions.

## Verification

`benchmarks/ops/bench_norm.py` re-run end to end; every new property appears with plausible values (`tileops_flops=33554432`, `tileops_bytes=33562624`, `tileops_dtype=float16`, `torch-ref_bandwidth_tbs=0.069257`). `benchmarks/tests/test_benchmark_base.py` passes; pre-commit clean.

## Consumer

The docs-site renderer prefers the recorded roofline inputs for arithmetic intensity and the recorded dtype for the compute ceiling, falling back to the derived rates for older snapshots — tile-ai/TileOPs.github.io#15. That page currently reports the dtype gap for 55 ops; this closes it from the next nightly on.
