### PR TITLE
[Fix][Bench] Skip the FP8 BN224 prefill cases that deadlock on the device

### DIFF
--- a/benchmarks/ops/attention/bench_gqa_fp8.py
+++ b/benchmarks/ops/attention/bench_gqa_fp8.py
@@ -118,6 +118,21 @@ def test_gqa_prefill_fp8_tensor_core_bench(case: GQAFp8TensorCoreBenchCase) -> N
         pytest.skip("torch fp8 is unavailable")
     if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
         pytest.skip("requires Hopper FP8 WGMMA")
+    # FIXME(staged-rollout): manifest workloads with more than 4 query heads per KV head
+    # are declared but not measured.
+    #
+    # Broken invariant: every manifest workload of an implemented op produces a number.
+    # Why: the BN224 warp-specialized kernel deadlocks on the device at
+    #   heads // heads_kv == 8 when built by the CUDA 13.2 toolchain, and the whole
+    #   benchmark file is killed after stalling 900s. The same shape completes under
+    #   CUDA 12.9 from byte-identical generated code, so the kernel is not fixed here.
+    # Cleanup: drop this skip once the kernel serves 8 query heads per KV head on the
+    #   toolchain the runner image ships.
+    if case.heads // case.heads_kv > 4:
+        pytest.skip(
+            f"{case.label}: BN224 FP8 kernel deadlocks at "
+            f"heads//heads_kv={case.heads // case.heads_kv} on this toolchain"
+        )
 
     op = GroupedQueryAttentionPrefillFwdOp(
         batch=case.batch,


### PR DESCRIPTION
## Problem

`benchmarks/ops/attention/bench_gqa_fp8.py` stalls the nightly and is killed after 900s
([run 31565273661](https://github.com/tile-ai/TileOPs/actions/runs/31565273661)). The BN224
warp-specialized FP8 prefill kernel never completes at `heads // heads_kv == 8` when built by the
CUDA 13.2 toolchain: the launch returns, the following `torch.cuda.synchronize()` blocks in
`cuCtxSynchronize` forever, and GPU utilisation pins at 100% with a spinning warp. Killing the file
also loses the two `s7168` cases, which never get to run.

## Change

Skip the cases with more than 4 query heads per KV head, so the file reports the four it can
measure. The manifest workloads stay declared, and the skip carries a `FIXME(staged-rollout)` marker
naming the invariant it breaks, so the gap is visible rather than silent.

This does not fix the kernel. Diagnosis and next steps are in #1900.

## Evidence

H200, `heads_kv=8`, `dim=128`, fp8 in / fp16 out, one op call then `cudaDeviceSynchronize`:

| heads | per KV head | seq | tiles | 12.9 toolchain | 13.2 toolchain |
| ---: | ---: | ---: | ---: | --- | --- |
| 32 | 4 | 1792 | 448 | ok | ok |
| 32 | 4 | 3584 | 896 | ok | ok |
| 64 | 8 | 1792 | 896 | ok | **hangs** |
| 64 | 8 | 3584 | 1792 | ok | **hangs** |

`heads=32/seq=3584` and `heads=64/seq=1792` have the same tile count (896) and the same persistent
wave count (7 over `NUM_SMS=132`), so the trigger is the query-heads-per-KV-head ratio, not the size
of the shape. The generated `device_kernel.cu` and `host_kernel.cu` are byte-identical between the
two toolchains, as are the 120 tilelang headers, so nothing in this repository changed behaviour —
only nvcc/ptxas (12.9.86 → 13.2.78).

## Verified

`benchmarks/ops/attention/bench_gqa_fp8.py` on
`ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-afcebed1-dev`, H200:
**4 passed, 4 skipped in 112s**, exit 0 — against 1004s and a kill before this change.

Op tests are unaffected: `tests/ops/attention/test_gqa_fp8.py` uses `heads=8, heads_kv=2`, i.e. 4
query heads per KV head.
