### PR TITLE
[Refactor][Bench] Attribute kernels by correlation id, not by time window

### DIFF
--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -9,7 +9,8 @@ which matches names literally — it will not catch a draw helper under another 
 
 ______________________________________________________________________
 
-- Every benchmark records ≥1 non-`tileops` baseline. If the external baseline is conditional, add a local torch fallback.
+- Every benchmark records ≥1 non-`tileops` baseline. Where a torch reference is a meaningful comparison, add one as a local fallback for a missing external baseline. Where it is not — an op whose point is beating a specialized library — require the library and let the import fail, rather than record a comparison nobody would read.
+- A baseline reaches its gradients through `backward_of`, never `Tensor.backward`: the autograd engine launches on its own thread, where the timer cannot attribute the kernels. Checked by `benchmarks/tests/test_benchmark_base.py`.
 - Tag names: lowercase, hyphen-separated. Tags starting with `tileops` are TileOPs entries; everything else is a baseline.
 - `calculate_flops()` / `calculate_memory()` return `None` to omit the metric.
 - Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never use arbitrary flat numbers (262K, 1M, 4M).

--- a/.claude/domain-rules/benchmark.md
+++ b/.claude/domain-rules/benchmark.md
@@ -9,8 +9,8 @@ which matches names literally — it will not catch a draw helper under another 
 
 ______________________________________________________________________
 
-- Every benchmark records ≥1 non-`tileops` baseline. Where a torch reference is a meaningful comparison, add one as a local fallback for a missing external baseline. Where it is not — an op whose point is beating a specialized library — require the library and let the import fail, rather than record a comparison nobody would read.
-- A baseline reaches its gradients through `backward_of`, never `Tensor.backward`: the autograd engine launches on its own thread, where the timer cannot attribute the kernels. Checked by `benchmarks/tests/test_benchmark_base.py`.
+- Every benchmark records ≥1 non-`tileops` baseline. Add a local torch fallback where a torch reference is a meaningful comparison; where it is not, require the external library and let the import fail.
+- A timed callable launches its own work. Gradients come from `backward_of`, never `Tensor.backward`: autograd's engine thread carries no iteration id, so the timer cannot attribute what it launches.
 - Tag names: lowercase, hyphen-separated. Tags starting with `tileops` are TileOPs entries; everything else is a baseline.
 - `calculate_flops()` / `calculate_memory()` return `None` to omit the metric.
 - Benchmark shapes reflect real DNN workloads (LLaMA-family by default). Annotate shape constants with the model/scenario; never use arbitrary flat numbers (262K, 1M, 4M).

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -35,12 +35,40 @@ __all__ = [
     "BenchmarkReport",
     "CUPTIError",
     "ManifestBenchmark",
+    "backward_of",
     "bench_kernel",
     "workload_field_params",
     "workloads_to_params",
 ]
 
 W = TypeVar("W")
+
+
+def backward_of(output: torch.Tensor) -> Any:
+    """Return a callable running *output*'s backward on the thread that calls it.
+
+    How a baseline reaches its gradients: ``Tensor.backward`` hands the graph to
+    autograd's engine thread, and a kernel launched there carries no iteration for the
+    timer to attribute it to. Applying the node runs the same backward here, and leaves
+    the engine's own overhead out of a number that a tileops backward op never pays.
+
+    Takes one gradient per output of the op that produced *output*, so an op returning
+    ``(out, lse)`` is driven with ``(grad, None)``.
+
+    Example:
+        >>> out = flash_attn_func(q, k, v)          # doctest: +SKIP
+        >>> bwd = backward_of(out)                  # doctest: +SKIP
+        >>> dq, dk, dv = bwd(grad_output)[:3]       # doctest: +SKIP
+    """
+    node = output.grad_fn
+    if node is None:
+        raise ValueError(
+            f"{type(output).__name__} has no grad_fn; build the graph under "
+            "enable_grad on inputs that require grad before timing its backward."
+        )
+    # A Python autograd.Function's node exposes apply() and is not callable; a node
+    # built in C++ is callable and has no apply(). Neither offers the other's form.
+    return getattr(node, "apply", None) or node
 
 
 def _workload_contract(op_name: str) -> tuple[str, frozenset[str]]:

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -48,17 +48,10 @@ def backward_of(output: torch.Tensor) -> Any:
     """Return a callable running *output*'s backward on the thread that calls it.
 
     How a baseline reaches its gradients: ``Tensor.backward`` hands the graph to
-    autograd's engine thread, and a kernel launched there carries no iteration for the
-    timer to attribute it to. Applying the node runs the same backward here, and leaves
-    the engine's own overhead out of a number that a tileops backward op never pays.
-
-    Takes one gradient per output of the op that produced *output*, so an op returning
-    ``(out, lse)`` is driven with ``(grad, None)``.
-
-    Example:
-        >>> out = flash_attn_func(q, k, v)          # doctest: +SKIP
-        >>> bwd = backward_of(out)                  # doctest: +SKIP
-        >>> dq, dk, dv = bwd(grad_output)[:3]       # doctest: +SKIP
+    autograd's engine thread, whose kernels carry no iteration id for the timer to
+    attribute them to, and charges the baseline for engine overhead a tileops backward
+    op never pays. Takes one gradient per output of the op that produced *output*, so
+    one returning ``(out, lse)`` is driven with ``(grad, None)``.
     """
     node = output.grad_fn
     if node is None:

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -4,7 +4,6 @@ Timing lives in :mod:`benchmarks.timing`, reporting in :mod:`benchmarks.report`.
 are re-exported here, so a bench file keeps importing what it always did.
 """
 
-import contextlib
 import statistics
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional, TypeVar
@@ -81,15 +80,15 @@ class BenchmarkBase(Generic[W], ABC):
         *inputs: Any,
         record_as: Any = None,
         params: Optional[dict] = None,
-        needs_grad: tuple[str, ...] = (),
     ) -> dict[str, dict]:
         """Time several implementations forward then reversed, and record them.
 
         Timing each one twice in opposite orders keeps drift across the case
         from landing on whichever ran last. A value is a callable timed on
-        *inputs*, or a ``(callable, args)`` pair. Tags in *needs_grad* keep
-        autograd on, which only a baseline that builds its graph inside the
-        timed callable needs.
+        *inputs*, or a ``(callable, args)`` pair. Every callable runs under
+        ``no_grad``: a graph built inside the timed region is host work, and a
+        backward reached through autograd runs where the timer cannot attribute
+        it. A backward baseline is timed by applying its node directly.
         """
         plan = {
             tag: value if isinstance(value, tuple) else (value, inputs)
@@ -104,8 +103,7 @@ class BenchmarkBase(Generic[W], ABC):
         meta: dict[str, dict] = {}
         for tag in order:
             functor, args = plan[tag]
-            grad = contextlib.nullcontext() if tag in needs_grad else torch.no_grad()
-            with grad:
+            with torch.no_grad():
                 samples[tag].extend(bench_kernel(
                     functor, args=args,
                     dry_run_ms=DRY_RUN_MS / passes,

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -91,6 +91,11 @@ def pytest_runtest_call(item):
             timing = tileops_entry.get("timing")
             if timing is not None:
                 item.user_properties.append(("tileops_timing", str(timing)))
+            # Present only when CUPTI lost records: a rising count across nights is the
+            # collector degrading, not the op.
+            retries = tileops_entry.get("attribution_retries")
+            if retries is not None:
+                item.user_properties.append(("tileops_attribution_retries", str(retries)))
 
         # Write all baselines into JUnit XML properties.
         # The first baseline uses the legacy unprefixed names (baseline_tag, etc.)

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -4,7 +4,12 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import (
+    BenchmarkBase,
+    BenchmarkReport,
+    ManifestBenchmark,
+    backward_of,
+)
 from benchmarks.ops.attention.manifest_params import (
     gqa_prefill_args,
     gqa_prefill_paged_args,
@@ -86,10 +91,10 @@ def _fa3_gqa_bwd(test: GroupedQueryAttentionBwdWorkload):
         q = q.detach().requires_grad_(True)
         k = k.detach().requires_grad_(True)
         v = v.detach().requires_grad_(True)
-        out = flash_attn_func(q, k, v, causal=test.is_causal)
-        out = out[0] if isinstance(out, tuple) else out
-        out.backward(grad_output)
-        return q.grad, k.grad, v.grad
+        raw = flash_attn_func(q, k, v, causal=test.is_causal)
+        outputs = raw if isinstance(raw, tuple) else (raw,)
+        # One gradient per output; only the attention output has one to propagate.
+        return backward_of(outputs[0])(grad_output, *(None,) * (len(outputs) - 1))
 
     return baseline_fn
 def _flashinfer_gqa_fwd(test, q, k, v):
@@ -161,8 +166,9 @@ def _torch_gqa_bwd(test):
             is_causal=test.is_causal,
             enable_gqa=True,
         )
-        out.transpose(1, 2).contiguous().backward(grad_output)
-        return q.grad, k.grad, v.grad
+        # grad_output wears the [B, S, H, D] layout of the op under test; transposing it
+        # back into SDPA's is a view, so the baseline measures SDPA's backward alone.
+        return backward_of(out)(grad_output.transpose(1, 2))
 
     return fn
 

--- a/benchmarks/ops/attention/bench_gqa.py
+++ b/benchmarks/ops/attention/bench_gqa.py
@@ -93,7 +93,6 @@ def _fa3_gqa_bwd(test: GroupedQueryAttentionBwdWorkload):
         v = v.detach().requires_grad_(True)
         raw = flash_attn_func(q, k, v, causal=test.is_causal)
         outputs = raw if isinstance(raw, tuple) else (raw,)
-        # One gradient per output; only the attention output has one to propagate.
         return backward_of(outputs[0])(grad_output, *(None,) * (len(outputs) - 1))
 
     return baseline_fn
@@ -166,8 +165,8 @@ def _torch_gqa_bwd(test):
             is_causal=test.is_causal,
             enable_gqa=True,
         )
-        # grad_output wears the [B, S, H, D] layout of the op under test; transposing it
-        # back into SDPA's is a view, so the baseline measures SDPA's backward alone.
+        # Transposing grad_output into SDPA's layout is a view, so the baseline
+        # measures SDPA's backward alone.
         return backward_of(out)(grad_output.transpose(1, 2))
 
     return fn

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch.nn import functional as F
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, backward_of
 from benchmarks.ops.attention.manifest_params import manifest_params, mha_qkv_args
 from tileops.manifest import load_workloads
 from tileops.ops import MultiHeadAttentionBwdOp, MultiHeadAttentionFwdOp
@@ -41,10 +41,10 @@ def _fa3_mha_bwd(test: MhaBwdWorkload):
         q = q.detach().requires_grad_(True)
         k = k.detach().requires_grad_(True)
         v = v.detach().requires_grad_(True)
-        out = flash_attn_func(q, k, v, causal=test.is_causal)
-        out = out[0] if isinstance(out, tuple) else out
-        out.backward(grad_output)
-        return q.grad, k.grad, v.grad
+        raw = flash_attn_func(q, k, v, causal=test.is_causal)
+        outputs = raw if isinstance(raw, tuple) else (raw,)
+        # One gradient per output; only the attention output has one to propagate.
+        return backward_of(outputs[0])(grad_output, *(None,) * (len(outputs) - 1))
 
     return baseline_fn
 
@@ -96,8 +96,9 @@ def _torch_mha_bwd(test):
         out = F.scaled_dot_product_attention(
             q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
             is_causal=test.is_causal)
-        out.transpose(1, 2).contiguous().backward(grad_output)
-        return q.grad, k.grad, v.grad
+        # grad_output wears the [B, S, H, D] layout of the op under test; transposing it
+        # back into SDPA's is a view, so the baseline measures SDPA's backward alone.
+        return backward_of(out)(grad_output.transpose(1, 2))
     return fn
 
 

--- a/benchmarks/ops/attention/bench_mha.py
+++ b/benchmarks/ops/attention/bench_mha.py
@@ -43,7 +43,6 @@ def _fa3_mha_bwd(test: MhaBwdWorkload):
         v = v.detach().requires_grad_(True)
         raw = flash_attn_func(q, k, v, causal=test.is_causal)
         outputs = raw if isinstance(raw, tuple) else (raw,)
-        # One gradient per output; only the attention output has one to propagate.
         return backward_of(outputs[0])(grad_output, *(None,) * (len(outputs) - 1))
 
     return baseline_fn
@@ -96,8 +95,8 @@ def _torch_mha_bwd(test):
         out = F.scaled_dot_product_attention(
             q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
             is_causal=test.is_causal)
-        # grad_output wears the [B, S, H, D] layout of the op under test; transposing it
-        # back into SDPA's is a view, so the baseline measures SDPA's backward alone.
+        # Transposing grad_output into SDPA's layout is a view, so the baseline
+        # measures SDPA's backward alone.
         return backward_of(out)(grad_output.transpose(1, 2))
     return fn
 

--- a/benchmarks/ops/bench_batch_norm.py
+++ b/benchmarks/ops/bench_batch_norm.py
@@ -8,7 +8,7 @@ import math
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark
+from benchmarks.benchmark_base import BenchmarkReport, ManifestBenchmark, backward_of
 from tileops.manifest import load_workloads
 from tileops.ops.norm.batch_norm import BatchNormBwdOp, BatchNormFwdOp
 from workloads.normalization import BatchNormBwdWorkload, BatchNormFwdWorkload
@@ -49,7 +49,7 @@ def _torch_bn_fwd(x, weight, bias, running_mean, running_var):
 
 
 def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
-    """PyTorch reference backward via autograd."""
+    """PyTorch reference backward, driven on this thread. Recomputes the forward."""
     with torch.enable_grad():
         x32 = x.float().requires_grad_(True)
         w32 = weight.float().requires_grad_(True)
@@ -58,8 +58,7 @@ def _torch_bn_bwd(grad_out, x, weight, mean, rstd):
         rv = torch.ones(x.shape[1], device=x.device, dtype=torch.float32)
         y = torch.nn.functional.batch_norm(
             x32, rm, rv, w32, b32, training=True, eps=1e-5)
-        y.backward(grad_out.float())
-    return x32.grad, w32.grad, b32.grad
+    return backward_of(y)(grad_out.float())
 
 
 # Manifest-driven params

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -2,11 +2,8 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, the forward benchmark still runs against a pure-torch
-reference baseline (tagged "torch"), so a missing optional dependency never blocks
-the nightly. The backward benchmark has no such fallback: a reference backward
-reached through autograd runs on the engine's thread, where the timer cannot tell
-which iteration launched a kernel.
+FLA is required, not optional: this file exists to compare against chunk_delta_rule,
+and a torch reference is not a comparison worth recording.
 
 Layout convention:
     TileOPs uses BHSD: q/k [B, H, S, DK], v [B, H, S, DV], beta [B, H, S].
@@ -15,103 +12,16 @@ Layout convention:
     compute the same function.
 """
 
-import warnings
 from typing import Optional
 
 import pytest
 import torch
+from fla.ops.delta_rule import chunk_delta_rule
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
-from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
+from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp
 from workloads.linear_attention import DeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
-
-
-def compute_w_u_torch(Aw, Au, k, v, beta, chunk_size):
-    B, H, S, DK = k.shape
-    _, _, _, DV = v.shape
-    BC = chunk_size
-    num_chunks = S // BC
-    k_beta = k.float() * beta.unsqueeze(-1)
-    v_beta = v.float() * beta.unsqueeze(-1)
-    Aw_ = Aw.reshape(B, H, num_chunks, BC, BC)
-    Au_ = Au.reshape(B, H, num_chunks, BC, BC)
-    k_beta_ = k_beta.reshape(B, H, num_chunks, BC, DK)
-    v_beta_ = v_beta.reshape(B, H, num_chunks, BC, DV)
-    w = torch.einsum("bhcij,bhcjd->bhcid", Aw_, k_beta_).reshape(B, H, S, DK)
-    u = torch.einsum("bhcij,bhcjd->bhcid", Au_, v_beta_).reshape(B, H, S, DV)
-    return w, u
-
-
-def kernel2_deltanet_torch(q, k, w, u, S_0, chunk_size):
-    """DeltaNet kernel2 reference (ungated)."""
-    B, H, S_len, DK = q.shape
-    _, _, _, DV = u.shape
-    BC = chunk_size
-    num_chunks = S_len // BC
-    q, k, w, u = q.float(), k.float(), w.float(), u.float()
-    h = S_0.float().clone()
-
-    o = torch.zeros(B, H, S_len, DV, dtype=torch.float32, device=q.device)
-    for c in range(num_chunks):
-        i0, i1 = c * BC, (c + 1) * BC
-        q_c = q[:, :, i0:i1, :]
-        k_c = k[:, :, i0:i1, :]
-        w_c = w[:, :, i0:i1, :]
-        u_c = u[:, :, i0:i1, :]
-        v_new_c = u_c - w_c @ h
-        o_part = torch.einsum("bhnk,bhkv->bhnv", q_c, h)
-        attn = torch.einsum("bhnk,bhmk->bhnm", q_c, k_c)
-        mask = torch.tril(torch.ones(BC, BC, device=q.device, dtype=torch.bool), diagonal=0)
-        attn = attn.masked_fill(~mask.unsqueeze(0).unsqueeze(0), 0.0)
-        o_c = o_part + torch.einsum("bhnm,bhmv->bhnv", attn, v_new_c)
-        o[:, :, i0:i1, :] = o_c
-        h = h + torch.einsum("bhnk,bhnv->bhkv", k_c, v_new_c)
-    return h, o
-
-
-def prepare_wy_repr_deltanet_torch(k, beta, chunk_size):
-    B, H, S, DK = k.shape
-    assert S % chunk_size == 0
-    BC = chunk_size
-    NC = S // BC
-    kc = k.float().reshape(B, H, NC, BC, DK)
-    bc = beta.float().reshape(B, H, NC, BC)
-    gram = kc @ kc.transpose(-2, -1)
-    m = bc.unsqueeze(-1) * gram
-    eye = torch.eye(BC, dtype=torch.float32, device=k.device)
-    a = eye + torch.tril(m, diagonal=-1)
-    a_inv = torch.linalg.inv(a).reshape(B, H, S, BC)
-    return a_inv, a_inv.clone()
-
-
-class DeltaNetFwdTestBaseline(DeltaNetFwdWorkload):
-    """Times the batched WY-representation idiom, not the workload reference.
-
-    ``prepare_wy_repr_deltanet_torch`` in this module inverts every chunk in one
-    batched call; the workload reference loops over (batch, head, chunk) so the
-    test can read it. Same math, different cost.
-    """
-
-    def ref_program(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        beta: torch.Tensor,
-    ) -> torch.Tensor:
-        B, H, S, DK = k.shape
-        _, _, _, DV = v.shape
-        Aw, Au = prepare_wy_repr_deltanet_torch(k, beta, self.chunk_size)
-        w, u = compute_w_u_torch(Aw, Au, k, v, beta, self.chunk_size)
-        S_0 = torch.zeros(B, H, DK, DV, dtype=torch.float32, device=q.device)
-        _S, o = kernel2_deltanet_torch(q, k, w, u, S_0, self.chunk_size)
-        return o.to(self.dtype)
-
-try:
-    from fla.ops.delta_rule import chunk_delta_rule
-except ImportError:
-    chunk_delta_rule = None
 
 
 def _to_fla_layout(q, k, v, beta):
@@ -165,7 +75,7 @@ def test_deltanet_vs_fla_fwd(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = DeltaNetFwdTestBaseline(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
+    test = DeltaNetFwdWorkload(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
     bm = DeltaNetFwdBenchmark(test)
     inputs = test.gen_inputs()  # q, k, v, beta (BHSD)
 
@@ -173,19 +83,15 @@ def test_deltanet_vs_fla_fwd(
     op = DeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     functors = {"tileops": op}
 
-    if chunk_delta_rule is not None:
-        # --- FLA (BTHK) ---
-        q, k, v, beta = inputs
-        scale = dim_k ** -0.5
-        q_fla, k_fla, v_fla, beta_fla = _to_fla_layout(q, k, v, beta)
+    # --- FLA (BTHK) ---
+    q, k, v, beta = inputs
+    scale = dim_k ** -0.5
+    q_fla, k_fla, v_fla, beta_fla = _to_fla_layout(q, k, v, beta)
 
-        def fla_fwd():
-            return chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
+    def fla_fwd():
+        return chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
 
-        functors["fla"] = (fla_fwd, ())
-    else:
-        # --- Torch reference baseline ---
-        functors["torch"] = test.ref_program
+    functors["fla"] = (fla_fwd, ())
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -230,7 +136,7 @@ def test_deltanet_vs_fla_bwd(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = DeltaNetFwdTestBaseline(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
+    test = DeltaNetFwdWorkload(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
     bm = DeltaNetBwdBenchmark(test)
 
     B, H, S, DK, DV, BC = batch, heads, seq_len, dim_k, dim_v, chunk_size
@@ -247,37 +153,25 @@ def test_deltanet_vs_fla_bwd(
     bwd_op = DeltaNetBwdOp(chunk_size=BC, tune=tune)
     functors = {"tileops": bwd_op.forward}
 
-    if chunk_delta_rule is not None:
-        # --- FLA: bwd only via autograd (BTHK layout) ---
-        scale = DK ** -0.5
-        q_fla, k_fla, v_fla, beta_fla = _to_fla_layout(q, k, v, beta)
-        do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
+    # --- FLA (BTHK layout) ---
+    scale = DK ** -0.5
+    q_fla, k_fla, v_fla, beta_fla = _to_fla_layout(q, k, v, beta)
+    do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
 
-        q_fla = q_fla.detach().requires_grad_(True)
-        k_fla = k_fla.detach().requires_grad_(True)
-        v_fla = v_fla.detach().requires_grad_(True)
-        beta_fla = beta_fla.detach().requires_grad_(True)
+    q_fla = q_fla.detach().requires_grad_(True)
+    k_fla = k_fla.detach().requires_grad_(True)
+    v_fla = v_fla.detach().requires_grad_(True)
+    beta_fla = beta_fla.detach().requires_grad_(True)
 
-        # Run fwd once to build the graph, then time the backward node directly
-        o_fla, _ = chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
-        # One grad per forward output: fla returns (o, final_state).
-        fla_backward = backward_of(o_fla)
+    # Run fwd once to build the graph, then time the backward node directly
+    o_fla, _ = chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
+    # One grad per forward output: fla returns (o, final_state).
+    fla_backward = backward_of(o_fla)
 
-        def fla_bwd():
-            return fla_backward(do_fla, None)
+    def fla_bwd():
+        return fla_backward(do_fla, None)
 
-        functors["fla"] = (fla_bwd, ())
-    else:
-        warnings.warn(
-            "fla is unavailable and the torch autograd reference cannot be timed "
-            "(its backward runs on autograd's engine thread, where the timer cannot "
-            "attribute the kernels); the baseline column will be omitted from results.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
+    functors["fla"] = (fla_bwd, ())
 
     bm.compare(functors, do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd,
                record_as=bwd_op, params=locals())
-
-
-# Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -21,7 +21,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
 from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
 from workloads.linear_attention import DeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
@@ -260,13 +260,11 @@ def test_deltanet_vs_fla_bwd(
 
         # Run fwd once to build the graph, then time the backward node directly
         o_fla, _ = chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
-        # Applying the node keeps the launches on this thread, where the timer can
-        # attribute them, and leaves the engine's overhead out of the number. One
-        # grad per forward output.
-        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
+        # One grad per forward output: fla returns (o, final_state).
+        fla_backward = backward_of(o_fla)
 
         def fla_bwd():
-            return bwd_node.apply(*node_grads)
+            return fla_backward(do_fla, None)
 
         functors["fla"] = (fla_bwd, ())
     else:

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -2,9 +2,11 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, benchmarks still run using a pure-torch reference
-implementation as baseline (tagged "torch"), so the nightly CI is never
-blocked by a missing optional dependency.
+When FLA is not installed, the forward benchmark still runs against a pure-torch
+reference baseline (tagged "torch"), so a missing optional dependency never blocks
+the nightly. The backward benchmark has no such fallback: a reference backward
+reached through autograd runs on the engine's thread, where the timer cannot tell
+which iteration launched a kernel.
 
 Layout convention:
     TileOPs uses BHSD: q/k [B, H, S, DK], v [B, H, S, DV], beta [B, H, S].
@@ -13,6 +15,7 @@ Layout convention:
     compute the same function.
 """
 
+import warnings
 from typing import Optional
 
 import pytest
@@ -22,50 +25,6 @@ from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import DeltaNetBwdOp, DeltaNetFwdOp, DeltaNetOp
 from workloads.linear_attention import DeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
-
-
-def _differentiable_fwd(q, k, v, beta, chunk_size):
-    """Fully differentiable chunked forward matching DeltaNet (ungated)."""
-    B, H, S, DK = q.shape
-    DV = v.shape[-1]
-    BC = chunk_size
-    NC = S // BC
-    h = q.new_zeros(B, H, DK, DV)
-    o_chunks = []
-    eye = torch.eye(BC, device=q.device, dtype=torch.float32)
-    mask = torch.tril(torch.ones(BC, BC, device=q.device, dtype=torch.float32))
-    for c in range(NC):
-        sl = slice(c * BC, (c + 1) * BC)
-        qc = q[:, :, sl, :].float()
-        kc = k[:, :, sl, :].float()
-        vc = v[:, :, sl, :].float()
-        bc = beta[:, :, sl].float()
-        Gram = torch.einsum("bhik,bhjk->bhij", kc, kc)
-        M = bc.unsqueeze(-1) * Gram
-        A = eye + torch.tril(M, diagonal=-1)
-        A_inv = torch.linalg.inv(A)
-        wc = A_inv @ (kc * bc.unsqueeze(-1))
-        uc = A_inv @ (vc * bc.unsqueeze(-1))
-        v_new = uc - wc @ h
-        o_part = qc @ h
-        attn = (qc @ kc.transpose(-2, -1)) * mask
-        o_c = o_part + attn @ v_new
-        o_chunks.append(o_c)
-        h = h + kc.transpose(-2, -1) @ v_new
-    return torch.cat(o_chunks, dim=2)
-
-
-def deltanet_autograd_bwd_torch(do, q, k, v, beta, chunk_size):
-    """Compute backward gradients via autograd on the differentiable forward."""
-    q_ = q.float().detach().requires_grad_(True)
-    k_ = k.float().detach().requires_grad_(True)
-    v_ = v.float().detach().requires_grad_(True)
-    beta_ = beta.float().detach().requires_grad_(True)
-
-    o = _differentiable_fwd(q_, k_, v_, beta_, chunk_size)
-    loss = (o * do.float()).sum()
-    dq, dk, dv, dbeta = torch.autograd.grad(loss, [q_, k_, v_, beta_])
-    return dq, dk, dv, dbeta
 
 
 def compute_w_u_torch(Aw, Au, k, v, beta, chunk_size):
@@ -299,25 +258,28 @@ def test_deltanet_vs_fla_bwd(
         v_fla = v_fla.detach().requires_grad_(True)
         beta_fla = beta_fla.detach().requires_grad_(True)
 
-        # Run fwd once to build computation graph, then time only backward
+        # Run fwd once to build the graph, then time the backward node directly
         o_fla, _ = chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
+        # Applying the node keeps the launches on this thread, where the timer can
+        # attribute them, and leaves the engine's overhead out of the number. One
+        # grad per forward output.
+        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
 
         def fla_bwd():
-            q_fla.grad = k_fla.grad = v_fla.grad = beta_fla.grad = None
-            o_fla.backward(do_fla, retain_graph=True)
-            return q_fla.grad, k_fla.grad, v_fla.grad
+            return bwd_node.apply(*node_grads)
 
         functors["fla"] = (fla_bwd, ())
     else:
-        # --- Torch autograd reference baseline ---
-        def torch_bwd():
-            return deltanet_autograd_bwd_torch(do, q, k, v, beta, BC)
-        functors["torch"] = (torch_bwd, ())
+        warnings.warn(
+            "fla is unavailable and the torch autograd reference cannot be timed "
+            "(its backward runs on autograd's engine thread, where the timer cannot "
+            "attribute the kernels); the baseline column will be omitted from results.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
-    # torch_bwd builds its forward graph inside the timed callable, so it needs
-    # autograd left on; compare() runs under no_grad otherwise.
     bm.compare(functors, do, q, k, v, beta, S_fwd, Aw, Au, w_fwd, u_fwd,
-               record_as=bwd_op, params=locals(), needs_grad=("torch",))
+               record_as=bwd_op, params=locals())
 
 
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_deltanet.py
+++ b/benchmarks/ops/bench_deltanet.py
@@ -163,9 +163,7 @@ def test_deltanet_vs_fla_bwd(
     v_fla = v_fla.detach().requires_grad_(True)
     beta_fla = beta_fla.detach().requires_grad_(True)
 
-    # Run fwd once to build the graph, then time the backward node directly
     o_fla, _ = chunk_delta_rule(q_fla, k_fla, v_fla, beta_fla, scale=scale)
-    # One grad per forward output: fla returns (o, final_state).
     fla_backward = backward_of(o_fla)
 
     def fla_bwd():

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -21,7 +21,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
 from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
 from workloads.linear_attention import GatedDeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
@@ -282,13 +282,11 @@ def test_gated_deltanet_vs_fla_bwd(
 
         # Run fwd once to build the graph, then time the backward node directly
         o_fla, _ = chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
-        # Applying the node keeps the launches on this thread, where the timer can
-        # attribute them, and leaves the engine's overhead out of the number. One
-        # grad per forward output.
-        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
+        # One grad per forward output: fla returns (o, final_state).
+        fla_backward = backward_of(o_fla)
 
         def fla_bwd():
-            return bwd_node.apply(*node_grads)
+            return fla_backward(do_fla, None)
 
         functors["fla"] = (fla_bwd, ())
     else:

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -2,9 +2,11 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, benchmarks still run using a pure-torch reference
-implementation as baseline (tagged "baseline"), so the nightly CI is never
-blocked by a missing optional dependency.
+When FLA is not installed, the forward benchmark still runs against a pure-torch
+reference baseline (tagged "torch"), so a missing optional dependency never blocks
+the nightly. The backward benchmark has no such fallback: a reference backward
+reached through autograd runs on the engine's thread, where the timer cannot tell
+which iteration launched a kernel.
 
 Layout convention:
     TileOPs uses BHSD: q/k [B, H, S, DK], v [B, H, S, DV], g/beta [B, H, S].
@@ -13,6 +15,7 @@ Layout convention:
     compute the same function.
 """
 
+import warnings
 from typing import Optional
 
 import pytest
@@ -22,56 +25,6 @@ from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
 from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
 from workloads.linear_attention import GatedDeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
-
-
-def _differentiable_fwd(q, k, v, g_raw, beta, chunk_size):
-    """Fully differentiable chunked forward matching paper (Eq. 10 via WY)."""
-    B, H, S, DK = q.shape
-    DV = v.shape[-1]
-    BC = chunk_size
-    NC = S // BC
-    g_cum = g_raw.float().reshape(B, H, NC, BC).cumsum(-1).reshape(B, H, S)
-    h = q.new_zeros(B, H, DK, DV)
-    o_chunks = []
-    eye = torch.eye(BC, device=q.device, dtype=torch.float32)
-    mask = torch.tril(torch.ones(BC, BC, device=q.device, dtype=torch.float32))
-    for c in range(NC):
-        sl = slice(c * BC, (c + 1) * BC)
-        qc = q[:, :, sl, :].float()
-        kc = k[:, :, sl, :].float()
-        vc = v[:, :, sl, :].float()
-        gc = g_cum[:, :, sl]
-        bc = beta[:, :, sl].float()
-        Gram = torch.einsum("bhik,bhjk->bhij", kc, kc)
-        Gamma = torch.exp(gc.unsqueeze(-1) - gc.unsqueeze(-2))
-        M = bc.unsqueeze(-1) * (Gamma * Gram)
-        A = eye + torch.tril(M, diagonal=-1)
-        A_inv = torch.linalg.inv(A)
-        wc = A_inv @ (kc * bc.unsqueeze(-1))
-        uc = A_inv @ (vc * bc.unsqueeze(-1))
-        g_last = gc[:, :, -1:]
-        v_new = uc - (wc * torch.exp(gc + g_last).unsqueeze(-1)) @ h
-        o_part = (qc @ h) * torch.exp(gc).unsqueeze(-1)
-        attn = (qc @ kc.transpose(-2, -1)) * Gamma * mask
-        o_c = o_part + attn @ v_new
-        o_chunks.append(o_c)
-        k_sc = kc * torch.exp(g_last - gc).unsqueeze(-1)
-        h = h * torch.exp(g_last).unsqueeze(-1) + k_sc.transpose(-2, -1) @ v_new
-    return torch.cat(o_chunks, dim=2)
-
-
-def gated_deltanet_autograd_bwd_torch(do, q, k, v, g, beta, chunk_size):
-    """Compute backward gradients via autograd on the differentiable forward."""
-    q_ = q.float().detach().requires_grad_(True)
-    k_ = k.float().detach().requires_grad_(True)
-    v_ = v.float().detach().requires_grad_(True)
-    g_ = g.float().detach().requires_grad_(True)
-    beta_ = beta.float().detach().requires_grad_(True)
-
-    o = _differentiable_fwd(q_, k_, v_, g_, beta_, chunk_size)
-    loss = (o * do.float()).sum()
-    dq, dk, dv, dg, dbeta = torch.autograd.grad(loss, [q_, k_, v_, g_, beta_])
-    return dq, dk, dv, dg, dbeta
 
 
 def compute_w_u_torch(Aw, Au, k, v, beta, chunk_size):
@@ -327,25 +280,28 @@ def test_gated_deltanet_vs_fla_bwd(
         g_fla = g_fla.detach().requires_grad_(True)
         beta_fla = beta_fla.detach().requires_grad_(True)
 
-        # Run fwd once to build computation graph, then time only backward
+        # Run fwd once to build the graph, then time the backward node directly
         o_fla, _ = chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
+        # Applying the node keeps the launches on this thread, where the timer can
+        # attribute them, and leaves the engine's overhead out of the number. One
+        # grad per forward output.
+        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
 
         def fla_bwd():
-            q_fla.grad = k_fla.grad = v_fla.grad = g_fla.grad = beta_fla.grad = None
-            o_fla.backward(do_fla, retain_graph=True)
-            return q_fla.grad, k_fla.grad, v_fla.grad
+            return bwd_node.apply(*node_grads)
 
         functors["fla"] = (fla_bwd, ())
     else:
-        # --- Torch autograd reference baseline ---
-        def torch_bwd():
-            return gated_deltanet_autograd_bwd_torch(do, q, k, v, g, beta, BC)
-        functors["torch"] = (torch_bwd, ())
+        warnings.warn(
+            "fla is unavailable and the torch autograd reference cannot be timed "
+            "(its backward runs on autograd's engine thread, where the timer cannot "
+            "attribute the kernels); the baseline column will be omitted from results.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
-    # torch_bwd builds its forward graph inside the timed callable, so it needs
-    # autograd left on; compare() runs under no_grad otherwise.
     bm.compare(functors, do, q, k, v, g, beta, S_fwd,
-               record_as=bwd_op, params=locals(), needs_grad=("torch",))
+               record_as=bwd_op, params=locals())
 
 
 # Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -2,11 +2,8 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, the forward benchmark still runs against a pure-torch
-reference baseline (tagged "torch"), so a missing optional dependency never blocks
-the nightly. The backward benchmark has no such fallback: a reference backward
-reached through autograd runs on the engine's thread, where the timer cannot tell
-which iteration launched a kernel.
+FLA is required, not optional: this file exists to compare against
+chunk_gated_delta_rule, and a torch reference is not a comparison worth recording.
 
 Layout convention:
     TileOPs uses BHSD: q/k [B, H, S, DK], v [B, H, S, DV], g/beta [B, H, S].
@@ -15,118 +12,16 @@ Layout convention:
     compute the same function.
 """
 
-import warnings
 from typing import Optional
 
 import pytest
 import torch
+from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
-from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp, GatedDeltaNetOp
+from tileops.ops import GatedDeltaNetBwdOp, GatedDeltaNetFwdOp
 from workloads.linear_attention import GatedDeltaNetFwdWorkload
 from workloads.workload_base import FixtureBase
-
-
-def compute_w_u_torch(Aw, Au, k, v, beta, chunk_size):
-    B, H, S, DK = k.shape
-    _, _, _, DV = v.shape
-    BC = chunk_size
-    num_chunks = S // BC
-    k_beta = k.float() * beta.unsqueeze(-1)
-    v_beta = v.float() * beta.unsqueeze(-1)
-    Aw_ = Aw.reshape(B, H, num_chunks, BC, BC)
-    Au_ = Au.reshape(B, H, num_chunks, BC, BC)
-    k_beta_ = k_beta.reshape(B, H, num_chunks, BC, DK)
-    v_beta_ = v_beta.reshape(B, H, num_chunks, BC, DV)
-    w = torch.einsum("bhcij,bhcjd->bhcid", Aw_, k_beta_).reshape(B, H, S, DK)
-    u = torch.einsum("bhcij,bhcjd->bhcid", Au_, v_beta_).reshape(B, H, S, DV)
-    return w, u
-
-
-def kernel2_gated_deltanet_torch(q, k, g, w, u, S_0, chunk_size):
-    B, H, S_len, DK = q.shape
-    _, _, _, DV = u.shape
-    BC = chunk_size
-    num_chunks = S_len // BC
-    q, k, g, w, u = q.float(), k.float(), g.float(), w.float(), u.float()
-    h = S_0.float().clone()
-
-    o = torch.zeros(B, H, S_len, DV, dtype=torch.float32, device=q.device)
-    for c in range(num_chunks):
-        i0, i1 = c * BC, (c + 1) * BC
-        q_c = q[:, :, i0:i1, :]
-        k_c = k[:, :, i0:i1, :]
-        g_c = g[:, :, i0:i1]
-        w_c = w[:, :, i0:i1, :]
-        u_c = u[:, :, i0:i1, :]
-
-        g_last_val = g_c[:, :, -1:]
-        v_new_c = u_c - (w_c * torch.exp(g_c + g_last_val).unsqueeze(-1)) @ h
-
-        o_part = torch.einsum("bhnk,bhkv->bhnv", q_c, h)
-        o_part = o_part * torch.exp(g_c).unsqueeze(-1)
-        attn = torch.einsum("bhnk,bhmk->bhnm", q_c, k_c)
-        Gamma_causal = torch.exp(g_c.unsqueeze(-1) - g_c.unsqueeze(-2))
-        mask = torch.tril(torch.ones(BC, BC, device=q.device, dtype=torch.bool), diagonal=0)
-        attn = (attn * Gamma_causal).masked_fill(~mask.unsqueeze(0).unsqueeze(0), 0.0)
-        o_c = o_part + torch.einsum("bhnm,bhmv->bhnv", attn, v_new_c)
-        o[:, :, i0:i1, :] = o_c
-
-        g_last = g_c[:, :, -1:]
-        k_scaled = k_c * torch.exp(g_last - g_c).unsqueeze(-1)
-        h = h * torch.exp(g_last).view(B, H, 1, 1)
-        h = h + torch.einsum("bhnk,bhnv->bhkv", k_scaled, v_new_c)
-    return h, o
-
-
-def prepare_wy_repr_gated_torch(k, g_cum, beta, chunk_size):
-    B, H, S, DK = k.shape
-    assert S % chunk_size == 0
-    BC = chunk_size
-    NC = S // BC
-    kc = k.float().reshape(B, H, NC, BC, DK)
-    gc = g_cum.float().reshape(B, H, NC, BC)
-    bc = beta.float().reshape(B, H, NC, BC)
-    gram = kc @ kc.transpose(-2, -1)
-    gamma = torch.exp(gc.unsqueeze(-1) - gc.unsqueeze(-2))
-    m = bc.unsqueeze(-1) * (gamma * gram)
-    eye = torch.eye(BC, dtype=torch.float32, device=k.device)
-    a_g = eye + torch.tril(m, diagonal=-1)
-    a_g_inv = torch.linalg.inv(a_g).reshape(B, H, S, BC)
-    return a_g_inv, a_g_inv.clone()
-
-
-class GatedDeltaNetFwdTestBaseline(GatedDeltaNetFwdWorkload):
-    """Times the batched WY-representation idiom, not the workload reference.
-
-    ``prepare_wy_repr_gated_torch`` in this module inverts every chunk in one
-    batched call; the workload reference loops over (batch, head, chunk) so the
-    test can read it. Same math, different cost.
-    """
-
-    def ref_program(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        g: torch.Tensor,
-        beta: torch.Tensor,
-    ) -> torch.Tensor:
-        B, H, S, DK = k.shape
-        _, _, _, DV = v.shape
-        # Chunk-local cumulative sum of g (paper requires cumulated gates)
-        BC = self.chunk_size
-        g_cum = g.float().reshape(B, H, S // BC, BC).cumsum(-1).reshape(B, H, S).to(g.dtype)
-        Aw, Au = prepare_wy_repr_gated_torch(k, g_cum, beta, self.chunk_size)
-        w, u = compute_w_u_torch(Aw, Au, k, v, beta, self.chunk_size)
-        S_0 = torch.zeros(B, H, DK, DV, dtype=torch.float32, device=q.device)
-        _S, o = kernel2_gated_deltanet_torch(q, k, g_cum, w, u, S_0, self.chunk_size)
-        return o.to(self.dtype)
-
-try:
-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
-except ImportError:
-    chunk_gated_delta_rule = None
 
 
 def _to_fla_layout(q, k, v, g, beta):
@@ -183,7 +78,7 @@ def test_gated_deltanet_vs_fla_fwd(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = GatedDeltaNetFwdTestBaseline(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
+    test = GatedDeltaNetFwdWorkload(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
     bm = GatedDeltaNetFwdBenchmark(test)
     inputs = test.gen_inputs()  # q, k, v, g, beta  (BHSD)
 
@@ -191,19 +86,15 @@ def test_gated_deltanet_vs_fla_fwd(
     op = GatedDeltaNetFwdOp(chunk_size=chunk_size, tune=tune)
     functors = {"tileops": op}
 
-    if chunk_gated_delta_rule is not None:
-        # --- FLA (BTHK) ---
-        q, k, v, g, beta = inputs
-        scale = dim_k ** -0.5
-        q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
+    # --- FLA (BTHK) ---
+    q, k, v, g, beta = inputs
+    scale = dim_k ** -0.5
+    q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
 
-        def fla_fwd():
-            return chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
+    def fla_fwd():
+        return chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
 
-        functors["fla"] = (fla_fwd, ())
-    else:
-        # --- Torch reference baseline ---
-        functors["torch"] = test.ref_program
+    functors["fla"] = (fla_fwd, ())
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -250,7 +141,7 @@ def test_gated_deltanet_vs_fla_bwd(
     dtype: torch.dtype,
     tune: bool,
 ) -> None:
-    test = GatedDeltaNetFwdTestBaseline(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
+    test = GatedDeltaNetFwdWorkload(batch, heads, seq_len, dim_k, dim_v, chunk_size, dtype)
     bm = GatedDeltaNetBwdBenchmark(test)
 
     B, H, S, DK, DV, BC = batch, heads, seq_len, dim_k, dim_v, chunk_size
@@ -268,38 +159,25 @@ def test_gated_deltanet_vs_fla_bwd(
     bwd_op = GatedDeltaNetBwdOp(chunk_size=BC, tune=tune)
     functors = {"tileops": bwd_op.forward}
 
-    if chunk_gated_delta_rule is not None:
-        # --- FLA: bwd only via autograd (BTHK layout) ---
-        scale = DK ** -0.5
-        q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
-        do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
+    # --- FLA (BTHK layout) ---
+    scale = DK ** -0.5
+    q_fla, k_fla, v_fla, g_fla, beta_fla = _to_fla_layout(q, k, v, g, beta)
+    do_fla = do.permute(0, 2, 1, 3).contiguous()  # [B,H,S,DV] -> [B,S,H,DV]
 
-        q_fla = q_fla.detach().requires_grad_(True)
-        k_fla = k_fla.detach().requires_grad_(True)
-        v_fla = v_fla.detach().requires_grad_(True)
-        g_fla = g_fla.detach().requires_grad_(True)
-        beta_fla = beta_fla.detach().requires_grad_(True)
+    q_fla = q_fla.detach().requires_grad_(True)
+    k_fla = k_fla.detach().requires_grad_(True)
+    v_fla = v_fla.detach().requires_grad_(True)
+    g_fla = g_fla.detach().requires_grad_(True)
+    beta_fla = beta_fla.detach().requires_grad_(True)
 
-        # Run fwd once to build the graph, then time the backward node directly
-        o_fla, _ = chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
-        # One grad per forward output: fla returns (o, final_state).
-        fla_backward = backward_of(o_fla)
+    # Run fwd once to build the graph, then time the backward node directly
+    o_fla, _ = chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
+    # One grad per forward output: fla returns (o, final_state).
+    fla_backward = backward_of(o_fla)
 
-        def fla_bwd():
-            return fla_backward(do_fla, None)
+    def fla_bwd():
+        return fla_backward(do_fla, None)
 
-        functors["fla"] = (fla_bwd, ())
-    else:
-        warnings.warn(
-            "fla is unavailable and the torch autograd reference cannot be timed "
-            "(its backward runs on autograd's engine thread, where the timer cannot "
-            "attribute the kernels); the baseline column will be omitted from results.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-
+    functors["fla"] = (fla_bwd, ())
     bm.compare(functors, do, q, k, v, g, beta, S_fwd,
                record_as=bwd_op, params=locals())
-
-
-# Combined fwd+bwd benchmark (fair comparison: both measure fwd+bwd total)

--- a/benchmarks/ops/bench_gated_deltanet.py
+++ b/benchmarks/ops/bench_gated_deltanet.py
@@ -170,9 +170,7 @@ def test_gated_deltanet_vs_fla_bwd(
     g_fla = g_fla.detach().requires_grad_(True)
     beta_fla = beta_fla.detach().requires_grad_(True)
 
-    # Run fwd once to build the graph, then time the backward node directly
     o_fla, _ = chunk_gated_delta_rule(q_fla, k_fla, v_fla, g_fla, beta_fla, scale=scale)
-    # One grad per forward output: fla returns (o, final_state).
     fla_backward = backward_of(o_fla)
 
     def fla_bwd():

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -154,7 +154,6 @@ def test_gla_bwd_bench(
     do_fla = do.float()
 
     o_fla, _ = chunk_gla(q_fla, k_fla, v_fla, g_fla, scale=scale)
-    # One grad per forward output: fla returns (o, final_state).
     fla_backward = backward_of(o_fla)
 
     def fla_bwd():

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -2,14 +2,17 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, benchmarks still run using a pure-torch reference
-implementation as baseline (tagged "baseline"), so the nightly CI is never
-blocked by a missing optional dependency.
+When FLA is not installed, the forward benchmark still runs against a pure-torch
+reference baseline (tagged "torch"), so a missing optional dependency never
+blocks the nightly. The backward benchmark has no such fallback: a reference
+backward reached through autograd runs on the engine's thread, where the timer
+cannot tell which iteration launched a kernel.
 
 Layout convention:
     Both TileOPs and FLA use BTHD: q/k [B, T, H, K], v [B, T, H, V], g [B, T, H, K].
 """
 
+import warnings
 from typing import Optional
 
 import pytest
@@ -67,27 +70,10 @@ def gla_fwd_chunked_torch(q, k, v, g, chunk_size, scale=None):
     return torch.cat(o_chunks, dim=1)
 
 
-def gla_autograd_bwd_torch(do, q, k, v, g, chunk_size, scale=-1.0):
-    """Compute GLA backward gradients via autograd on the differentiable forward."""
-    sc = (q.shape[-1] ** -0.5) if scale <= 0 else scale
-
-    q_ = q.float().detach().requires_grad_(True)
-    k_ = k.float().detach().requires_grad_(True)
-    v_ = v.float().detach().requires_grad_(True)
-    g_ = g.float().detach().requires_grad_(True)
-
-    o = gla_fwd_chunked_torch(q_, k_, v_, g_, chunk_size, scale=sc)
-    loss = (o * do.float()).sum()
-    dq, dk, dv, dg = torch.autograd.grad(loss, [q_, k_, v_, g_])
-    return dq, dk, dv, dg
-
 try:
     from fla.ops.gla import chunk_gla
 except ImportError:
     chunk_gla = None
-
-
-# Test helper (shared between fwd and bwd benchmarks)
 
 
 # Forward benchmark
@@ -219,7 +205,7 @@ def test_gla_bwd_bench(
     functors = {"tileops": (bwd_op.forward, (q, k, v, g, h, do, dht))}
 
     if chunk_gla is not None:
-        # --- FLA: bwd via autograd ---
+        # --- FLA: the backward node, called directly ---
         # NOTE: FLA's backward recomputes h internally (not saved from fwd),
         # so this measures bwd + h recomputation, not pure bwd.
         q_fla = q.float().detach().requires_grad_(True)
@@ -229,22 +215,25 @@ def test_gla_bwd_bench(
         do_fla = do.float()
 
         o_fla, _ = chunk_gla(q_fla, k_fla, v_fla, g_fla, scale=scale)
+        # Applying the node keeps the launches on this thread, where the timer can
+        # attribute them, and leaves the engine's overhead out of the number. One
+        # grad per forward output.
+        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
 
         def fla_bwd():
-            q_fla.grad = k_fla.grad = v_fla.grad = g_fla.grad = None
-            o_fla.backward(do_fla, retain_graph=True)
-            return q_fla.grad, k_fla.grad, v_fla.grad
+            return bwd_node.apply(*node_grads)
 
         functors["fla"] = (fla_bwd, ())
     else:
-        # --- Torch autograd reference baseline ---
-        def torch_bwd():
-            return gla_autograd_bwd_torch(do, q, k, v, g, BC, scale=scale)
+        warnings.warn(
+            "fla is unavailable and the torch autograd reference cannot be timed "
+            "(its backward runs on autograd's engine thread, where the timer cannot "
+            "attribute the kernels); the baseline column will be omitted from results.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
-        functors["torch"] = (torch_bwd, ())
-
-    # Only torch_bwd builds its graph inside the timed call.
-    bm.compare(functors, record_as=bwd_op, params=locals(), needs_grad=("torch",))
+    bm.compare(functors, record_as=bwd_op, params=locals())
 
 
 # Combined fwd+bwd benchmark

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -18,7 +18,7 @@ from typing import Optional
 import pytest
 import torch
 
-from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport
+from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
 from tileops.ops import GLABwdOp, GLAFwdOp
 from workloads.linear_attention import GLAChunkwiseWorkload
 from workloads.workload_base import FixtureBase
@@ -215,13 +215,11 @@ def test_gla_bwd_bench(
         do_fla = do.float()
 
         o_fla, _ = chunk_gla(q_fla, k_fla, v_fla, g_fla, scale=scale)
-        # Applying the node keeps the launches on this thread, where the timer can
-        # attribute them, and leaves the engine's overhead out of the number. One
-        # grad per forward output.
-        bwd_node, node_grads = o_fla.grad_fn, (do_fla, None)
+        # One grad per forward output: fla returns (o, final_state).
+        fla_backward = backward_of(o_fla)
 
         def fla_bwd():
-            return bwd_node.apply(*node_grads)
+            return fla_backward(do_fla, None)
 
         functors["fla"] = (fla_bwd, ())
     else:

--- a/benchmarks/ops/bench_gla_chunkwise.py
+++ b/benchmarks/ops/bench_gla_chunkwise.py
@@ -2,79 +2,23 @@
 
 Compares forward and backward latency across sequence lengths and dtypes.
 
-When FLA is not installed, the forward benchmark still runs against a pure-torch
-reference baseline (tagged "torch"), so a missing optional dependency never
-blocks the nightly. The backward benchmark has no such fallback: a reference
-backward reached through autograd runs on the engine's thread, where the timer
-cannot tell which iteration launched a kernel.
+FLA is required, not optional: this file exists to compare against chunk_gla, and a
+torch reference is not a comparison worth recording.
 
 Layout convention:
     Both TileOPs and FLA use BTHD: q/k [B, T, H, K], v [B, T, H, V], g [B, T, H, K].
 """
 
-import warnings
 from typing import Optional
 
 import pytest
 import torch
+from fla.ops.gla import chunk_gla
 
 from benchmarks.benchmark_base import BenchmarkBase, BenchmarkReport, backward_of
 from tileops.ops import GLABwdOp, GLAFwdOp
 from workloads.linear_attention import GLAChunkwiseWorkload
 from workloads.workload_base import FixtureBase
-
-
-def gla_fwd_chunked_torch(q, k, v, g, chunk_size, scale=None):
-    """Fully differentiable chunked GLA forward in float32."""
-    B, T, H, K = q.shape
-    V = v.shape[-1]
-    BC = chunk_size
-    NC = T // BC
-
-    if scale is None:
-        scale = K ** -0.5
-
-    q = q.float() * scale
-    k = k.float()
-    v = v.float()
-    g = g.float()
-
-    g_cum = g.reshape(B, NC, BC, H, K).cumsum(dim=2).reshape(B, T, H, K)
-
-    h = q.new_zeros(B, H, K, V)
-    mask = torch.tril(torch.ones(BC, BC, device=q.device, dtype=torch.float32))
-
-    o_chunks = []
-    for c in range(NC):
-        sl = slice(c * BC, (c + 1) * BC)
-        qc = q[:, sl, :, :]
-        kc = k[:, sl, :, :]
-        vc = v[:, sl, :, :]
-        gc = g_cum[:, sl, :, :]
-        g_last = gc[:, -1:, :, :]
-
-        q_gated = qc * torch.exp(gc)
-        o_inter = torch.einsum("bthk,bhkv->bthv", q_gated, h)
-
-        k_ungated = kc * torch.exp(-gc)
-        A = torch.einsum("bihk,bjhk->bhij", q_gated, k_ungated)
-        A = A * mask.unsqueeze(0).unsqueeze(0)
-        o_intra = torch.einsum("bhij,bjhv->bihv", A, vc)
-
-        o_chunks.append(o_inter + o_intra)
-
-        k_adj = kc * torch.exp(g_last - gc)
-        h = h * torch.exp(g_last).permute(0, 2, 3, 1).squeeze(-1).unsqueeze(-1)
-        h = h + torch.einsum("bthk,bthv->bhkv", k_adj, vc)
-
-    return torch.cat(o_chunks, dim=1)
-
-
-try:
-    from fla.ops.gla import chunk_gla
-except ImportError:
-    chunk_gla = None
-
 
 # Forward benchmark
 
@@ -124,17 +68,13 @@ def test_gla_fwd_bench(
     op = GLAFwdOp(chunk_size=chunk_size, scale=scale, tune=tune)
     functors = {"tileops": op.forward}
 
-    if chunk_gla is not None:
-        # --- FLA ---
-        q, k, v, g = inputs
+    # --- FLA ---
+    q, k, v, g = inputs
 
-        def fla_fwd():
-            return chunk_gla(q, k, v, g, scale=scale)
+    def fla_fwd():
+        return chunk_gla(q, k, v, g, scale=scale)
 
-        functors["fla"] = (fla_fwd, ())
-    else:
-        # --- Torch reference baseline ---
-        functors["torch"] = lambda q, k, v, g: gla_fwd_chunked_torch(q, k, v, g, chunk_size)
+    functors["fla"] = (fla_fwd, ())
 
     bm.compare(functors, *inputs, record_as=op, params=locals())
 
@@ -204,32 +144,23 @@ def test_gla_bwd_bench(
     bwd_op = GLABwdOp(chunk_size=BC, scale=scale, tune=tune)
     functors = {"tileops": (bwd_op.forward, (q, k, v, g, h, do, dht))}
 
-    if chunk_gla is not None:
-        # --- FLA: the backward node, called directly ---
-        # NOTE: FLA's backward recomputes h internally (not saved from fwd),
-        # so this measures bwd + h recomputation, not pure bwd.
-        q_fla = q.float().detach().requires_grad_(True)
-        k_fla = k.float().detach().requires_grad_(True)
-        v_fla = v.float().detach().requires_grad_(True)
-        g_fla = g.float().detach().requires_grad_(True)
-        do_fla = do.float()
+    # --- FLA: the backward node, called directly ---
+    # NOTE: FLA's backward recomputes h internally (not saved from fwd),
+    # so this measures bwd + h recomputation, not pure bwd.
+    q_fla = q.float().detach().requires_grad_(True)
+    k_fla = k.float().detach().requires_grad_(True)
+    v_fla = v.float().detach().requires_grad_(True)
+    g_fla = g.float().detach().requires_grad_(True)
+    do_fla = do.float()
 
-        o_fla, _ = chunk_gla(q_fla, k_fla, v_fla, g_fla, scale=scale)
-        # One grad per forward output: fla returns (o, final_state).
-        fla_backward = backward_of(o_fla)
+    o_fla, _ = chunk_gla(q_fla, k_fla, v_fla, g_fla, scale=scale)
+    # One grad per forward output: fla returns (o, final_state).
+    fla_backward = backward_of(o_fla)
 
-        def fla_bwd():
-            return fla_backward(do_fla, None)
+    def fla_bwd():
+        return fla_backward(do_fla, None)
 
-        functors["fla"] = (fla_bwd, ())
-    else:
-        warnings.warn(
-            "fla is unavailable and the torch autograd reference cannot be timed "
-            "(its backward runs on autograd's engine thread, where the timer cannot "
-            "attribute the kernels); the baseline column will be omitted from results.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
+    functors["fla"] = (fla_bwd, ())
 
     bm.compare(functors, record_as=bwd_op, params=locals())
 

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -135,12 +135,16 @@ def test_attribution_fails_closed_when_an_iteration_reaches_no_device():
         _attributed_samples([_kernel(1_000, 2_000, 1)], {1: 0}, n_repeat=2)
 
 
-def test_a_kernel_launched_off_thread_is_named_as_such():
+@pytest.mark.parametrize("iteration_of", [
+    {1: 0},                 # the second kernel carries an id nothing mapped
+    {1: 0, 99: 7},          # ... or one from outside the range this phase pushed
+])
+def test_a_kernel_no_iteration_pushed_is_named_as_such(iteration_of):
     """Autograd's engine thread never sees the pushed id, and that is not a lost record."""
     kernels = [_kernel(1_000, 2_000, 1), _kernel(3_000, 4_000, 99)]
 
     with pytest.raises(_OffThreadLaunchError, match="carry no iteration id"):
-        _attributed_samples(kernels, {1: 0}, n_repeat=1)
+        _attributed_samples(kernels, iteration_of, n_repeat=1)
 
 
 def test_a_discarded_record_is_not_reported_as_a_call_that_missed_the_device():

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 import pytest
 import torch
 
@@ -37,6 +40,29 @@ def test_workloads_to_params_include_extra_propagates_dim():
         assert isinstance(extra, dict)
     # A workload with no extras must yield an empty dict, not a missing slot.
     assert any(p.values[2] == {} for p in triples)
+
+
+def test_no_bench_reaches_its_gradients_through_the_autograd_engine():
+    """A backward baseline drives its own node; the engine launches on its own thread.
+
+    Cheap where the alternative is not: catching this by running the benchmarks costs
+    the nightly 36 minutes, and no PR-stage job executes ``benchmarks/ops`` at all.
+    """
+    ops_dir = Path(__file__).resolve().parents[1] / "ops"
+    offenders = []
+    for path in sorted(ops_dir.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            call = ast.unparse(node.func)
+            if node.func.attr == "backward" or call.endswith("autograd.grad"):
+                offenders.append(f"{path.name}:{node.lineno}: {call}()")
+
+    assert not offenders, (
+        "these launch their kernels from autograd's engine thread, where the timer "
+        "cannot tell which iteration they belong to; call the backward node instead, "
+        "via benchmarks.benchmark_base.backward_of:\n  " + "\n  ".join(offenders)
+    )
 
 
 def test_multi_input_op_raises_keyerror():

--- a/benchmarks/tests/test_benchmark_base.py
+++ b/benchmarks/tests/test_benchmark_base.py
@@ -3,8 +3,14 @@ import torch
 
 from benchmarks.benchmark_base import workloads_to_params
 from benchmarks.timing import (
+    Trace,
     _attributed_samples,
+    _bench_meta,
+    _capture_bench_meta,
+    _collect_attributed,
     _CUPTIAttributionError,
+    _CUPTIRecordsLostError,
+    _OffThreadLaunchError,
     bench_kernel,
 )
 
@@ -39,34 +45,45 @@ def test_multi_input_op_raises_keyerror():
         workloads_to_params("GroupedQueryAttentionFwdOp")
 
 
-def _kernel(start_ns: int, end_ns: int) -> dict:
-    return {"name": "k", "start_ns": start_ns, "end_ns": end_ns}
+def _kernel(start_ns: int, end_ns: int, correlation_id: int = 0) -> dict:
+    return {"name": "k", "start_ns": start_ns, "end_ns": end_ns,
+            "correlation_id": correlation_id}
 
 
-def test_attribution_separates_execution_from_the_gaps_and_the_prepare():
+def test_attribution_separates_execution_from_the_gaps_between_kernels():
     """busy counts execution only; latency additionally spans the gaps between."""
-    records = [
-        _kernel(1_000, 2_000),          # prepare, outside both windows
-        _kernel(4_000, 6_000),
-        _kernel(9_000, 10_000),
-        _kernel(20_000, 21_000),        # prepare
-        _kernel(23_000, 24_000),
-        _kernel(29_000, 31_000),
+    kernels = [
+        _kernel(4_000, 6_000, correlation_id=10),
+        _kernel(9_000, 10_000, correlation_id=10),
+        _kernel(23_000, 24_000, correlation_id=11),
+        _kernel(29_000, 31_000, correlation_id=11),
     ]
-    windows = [(3_000, 19_000), (22_000, 40_000)]
 
-    first, second = _attributed_samples(records, windows, n_repeat=2)
+    first, second = _attributed_samples(kernels, {10: 0, 11: 1}, n_repeat=2)
 
     assert (first.device_busy_ms, first.latency_ms) == pytest.approx((0.003, 0.006))
     assert (second.device_busy_ms, second.latency_ms) == pytest.approx((0.003, 0.008))
     assert (first.n_kernels, second.n_kernels) == (2, 2)
 
 
+def test_a_kernel_belongs_to_its_iteration_however_the_timestamps_fall():
+    """The whole point of identity: overlap with a neighbour changes nothing."""
+    kernels = [
+        _kernel(1_000, 9_000, correlation_id=7),
+        _kernel(2_000, 3_000, correlation_id=8),
+    ]
+
+    first, second = _attributed_samples(kernels, {7: 0, 8: 1}, n_repeat=2)
+
+    assert first.device_busy_ms == pytest.approx(0.008)
+    assert second.device_busy_ms == pytest.approx(0.001)
+
+
 def test_busy_counts_overlapping_kernels_once():
     """Concurrent kernels occupy the device once, however they are summed."""
-    records = [_kernel(1_000, 5_000), _kernel(2_000, 9_000)]
+    kernels = [_kernel(1_000, 5_000, 3), _kernel(2_000, 9_000, 3)]
 
-    sample, = _attributed_samples(records, [(0, 10_000)], n_repeat=1)
+    sample, = _attributed_samples(kernels, {3: 0}, n_repeat=1)
 
     assert sample.device_busy_ms == pytest.approx(0.008)
     assert sample.latency_ms == pytest.approx(0.008)
@@ -74,11 +91,13 @@ def test_busy_counts_overlapping_kernels_once():
 
 def test_attribution_measures_a_call_whose_kernel_count_varies():
     """A dynamic path launching an extra kernel is measured, not rejected."""
-    records = [_kernel(1_000, 2_000), _kernel(10_000, 11_000), _kernel(11_500, 13_000)]
+    kernels = [
+        _kernel(1_000, 2_000, 4),
+        _kernel(10_000, 11_000, 5),
+        _kernel(11_500, 13_000, 5),
+    ]
 
-    first, second = _attributed_samples(
-        records, [(500, 5_000), (9_000, 15_000)], n_repeat=2,
-    )
+    first, second = _attributed_samples(kernels, {4: 0, 5: 1}, n_repeat=2)
 
     assert (first.n_kernels, second.n_kernels) == (1, 2)
     assert second.device_busy_ms == pytest.approx(0.0025)
@@ -86,10 +105,69 @@ def test_attribution_measures_a_call_whose_kernel_count_varies():
 
 
 def test_attribution_fails_closed_when_an_iteration_reaches_no_device():
-    with pytest.raises(_CUPTIAttributionError, match="produced no GPU activity"):
+    with pytest.raises(_CUPTIAttributionError, match="CUPTI discarded nothing"):
+        _attributed_samples([_kernel(1_000, 2_000, 1)], {1: 0}, n_repeat=2)
+
+
+def test_a_kernel_launched_off_thread_is_named_as_such():
+    """Autograd's engine thread never sees the pushed id, and that is not a lost record."""
+    kernels = [_kernel(1_000, 2_000, 1), _kernel(3_000, 4_000, 99)]
+
+    with pytest.raises(_OffThreadLaunchError, match="carry no iteration id"):
+        _attributed_samples(kernels, {1: 0}, n_repeat=1)
+
+
+def test_a_discarded_record_is_not_reported_as_a_call_that_missed_the_device():
+    """The causes of a missing reading get separate errors, so one can be retried."""
+    with pytest.raises(_CUPTIRecordsLostError, match="discarded 7 activity records"):
         _attributed_samples(
-            [_kernel(1_000, 2_000)], [(500, 3_000), (4_000, 5_000)], n_repeat=2,
+            [_kernel(1_000, 2_000, 1)], {1: 0}, n_repeat=2, dropped=7,
         )
+
+
+def test_an_unreadable_drop_count_rules_nothing_out():
+    with pytest.raises(_CUPTIAttributionError, match="count is unproven"):
+        _attributed_samples(
+            [_kernel(1_000, 2_000, 1)], {1: 0}, n_repeat=2, dropped=None,
+        )
+
+
+def test_a_phase_that_lost_records_is_measured_again(monkeypatch):
+    """A lost reading is re-taken, and the retry asks CUPTI for a larger buffer."""
+    lossy = Trace([_kernel(1_000, 2_000, 1)], {1: 0}, 4)
+    clean = Trace(
+        [_kernel(1_000, 2_000, 1), _kernel(4_100, 4_500, 2)], {1: 0, 2: 1}, 0,
+    )
+    traces = [lossy, clean]
+    requested_bytes = []
+    monkeypatch.setattr(_bench_meta, "attribution_retries", None, raising=False)
+
+    def fake_collect(run_one, n_repeat, prepare_one, buffer_bytes=0):
+        requested_bytes.append(buffer_bytes)
+        return traces.pop(0)
+
+    monkeypatch.setattr("benchmarks.timing.collect_repeats", fake_collect)
+
+    samples = _collect_attributed(lambda i: None, 2, lambda i: None)
+
+    assert len(samples) == 2
+    assert requested_bytes[1] == requested_bytes[0] * 4
+    assert _capture_bench_meta()["attribution_retries"] == 1
+
+
+def test_a_call_that_launched_nothing_does_not_spend_the_retries(monkeypatch):
+    """Nothing discarded means re-measuring cannot help, so it fails on sight."""
+    attempts = []
+
+    def fake_collect(run_one, n_repeat, prepare_one, buffer_bytes=0):
+        attempts.append(buffer_bytes)
+        return Trace([], {}, 0)
+
+    monkeypatch.setattr("benchmarks.timing.collect_repeats", fake_collect)
+
+    with pytest.raises(_CUPTIAttributionError, match="CUPTI discarded nothing"):
+        _collect_attributed(lambda i: None, 1, lambda i: None)
+    assert len(attempts) == 1
 
 
 @pytest.mark.smoke

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -58,7 +58,7 @@ _ITERATION_OF: dict[int, int] = {}
 _ATTRIBUTION_ATTEMPTS = 3
 _DROPPED_COUNT_UNREADABLE = False
 _DROP_COUNTER_LIVE: Optional[bool] = None
-# The id worn by the L2 flush and anything else run between iterations. Labelling that
+# Pushed around the L2 flush and anything else run between iterations. Labelling that
 # work is what lets a kernel with no id at all mean one thing only: a thread the id was
 # never pushed on launched it. Out of range of any iteration index.
 _PREPARE_ID = 1 << 32
@@ -368,9 +368,7 @@ def _attributed_samples(
         if iteration == _PREPARE_ID:
             continue
         if iteration is None or not 0 <= iteration < n_repeat:
-            # An id outside the range this phase pushed is as unattributable as no id:
-            # something else pushed onto the same stack, and guessing an owner for its
-            # kernels would put another call's work in this one's reading.
+            # An id this phase never pushed is as unattributable as no id at all.
             orphans.append(kernel)
         else:
             claimed.setdefault(iteration, []).append(kernel)

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -177,22 +177,23 @@ def _buffer_completed(records) -> None:
 
 
 def _trace_launches_only(cupti) -> None:
-    """Silence every traced API except kernel launches.
+    """Silence every traced API except the ones that launch kernels.
 
-    Tracing all of them costs ~15 records per iteration instead of one, and only the
-    launch carries the correlation id a kernel needs. Must run after ``activity_enable``,
-    which resets the per-API filter -- measured, not assumed.
+    Tracing all of them costs ~15 records per iteration instead of one, and only a launch
+    carries the correlation id a kernel needs. Graph launches count: a replayed graph's
+    kernels are unattributable without ``cudaGraphLaunch`` / ``cuGraphLaunch``. Must run
+    after ``activity_enable``, which resets the per-API filter -- measured, not assumed.
     """
-    for toggle, cbids, launch_prefix in (
-        (cupti.activity_enable_runtime_api, cupti.runtime_api_trace_cbid, "cudaLaunch"),
-        (cupti.activity_enable_driver_api, cupti.driver_api_trace_cbid, "cuLaunch"),
+    for toggle, cbids in (
+        (cupti.activity_enable_runtime_api, cupti.runtime_api_trace_cbid),
+        (cupti.activity_enable_driver_api, cupti.driver_api_trace_cbid),
     ):
         for name in dir(cbids):
             cbid = getattr(cbids, name, None)
             if name.startswith("_") or not isinstance(cbid, int):
                 continue
             try:
-                toggle(int(cbid), 1 if name.startswith(launch_prefix) else 0)
+                toggle(int(cbid), 1 if "Launch" in name else 0)
             except Exception:  # noqa: BLE001, S112
                 # The enums carry sentinels (INVALID, SIZE) that CUPTI refuses.
                 continue
@@ -364,9 +365,14 @@ def _attributed_samples(
     orphans = []
     for kernel in kernels:
         iteration = iteration_of.get(kernel["correlation_id"])
-        if iteration is None:
+        if iteration == _PREPARE_ID:
+            continue
+        if iteration is None or not 0 <= iteration < n_repeat:
+            # An id outside the range this phase pushed is as unattributable as no id:
+            # something else pushed onto the same stack, and guessing an owner for its
+            # kernels would put another call's work in this one's reading.
             orphans.append(kernel)
-        elif iteration != _PREPARE_ID:
+        else:
             claimed.setdefault(iteration, []).append(kernel)
 
     unmeasured = [i for i in range(n_repeat) if i not in claimed]

--- a/benchmarks/timing.py
+++ b/benchmarks/timing.py
@@ -3,9 +3,17 @@
 The timing layer owns the measurement and nothing else -- it knows how to run a callable
 n times and return each run's device latency. What the numbers mean, and where they are
 written, belong to the layers above.
+
+A kernel belongs to the iteration whose external correlation id it carries, so nothing
+is inferred from timestamps and a kernel shorter than the host overhead around it is
+attributed as reliably as a long one. CUPTI's id stack is per-thread, which is this
+protocol's one demand on a timed callable: it must launch its own work rather than hand
+it to another thread (``Tensor.backward`` hands it to autograd's engine thread;
+``grad_fn.apply`` does not).
 """
 
 import contextlib
+import ctypes
 import logging
 import os
 import sys
@@ -42,7 +50,18 @@ _CALLBACKS_REGISTERED = False
 # 30 of 60, 256 KB none. Only latency_ms picks it up; the records are the same.
 _BUFFER_BYTES = 256 * 1024
 _BUFFER_ALIGN = 8
-_RECORDS: list[dict[str, Any]] = []
+# What the next buffer request answers with. A phase that lost records raises it for
+# the retry: a stall costs one iteration's latency_ms, a lost record costs the case.
+_buffer_bytes = _BUFFER_BYTES
+_KERNELS: list[dict[str, Any]] = []
+_ITERATION_OF: dict[int, int] = {}
+_ATTRIBUTION_ATTEMPTS = 3
+_DROPPED_COUNT_UNREADABLE = False
+_DROP_COUNTER_LIVE: Optional[bool] = None
+# The id worn by the L2 flush and anything else run between iterations. Labelling that
+# work is what lets a kernel with no id at all mean one thing only: a thread the id was
+# never pushed on launched it. Out of range of any iteration index.
+_PREPARE_ID = 1 << 32
 
 
 # L2 cache flush buffer, allocated lazily.
@@ -56,6 +75,14 @@ def _clamp_iters(raw: float, max_iters: int = _MAX_ITERS,
 
 class _CUPTIAttributionError(Exception):
     """A CUPTI trace could not be attributed to logical benchmark calls."""
+
+
+class _CUPTIRecordsLostError(_CUPTIAttributionError):
+    """A reading was taken and then discarded. Its own class because it can be retried."""
+
+
+class _OffThreadLaunchError(_CUPTIAttributionError):
+    """Kernels ran that no iteration claims, so a thread without the id launched them."""
 
 
 class CUPTIError(RuntimeError):
@@ -79,89 +106,206 @@ def _load_cupti():
 
 
 def _buffer_requested():
-    return _BUFFER_BYTES, _BUFFER_ALIGN
+    return _buffer_bytes, _BUFFER_ALIGN
+
+
+def _read_dropped() -> Optional[int]:
+    """Read CUPTI's drop counter, which resets on every read. None if the call fails."""
+    global _DROPPED_COUNT_UNREADABLE
+    cupti = _load_cupti()
+    dropped = ctypes.c_size_t(0)
+    try:
+        # Kernel records land on the global queue, which is context 0, and the binding
+        # takes the out-parameter as an address rather than returning it.
+        cupti.activity_get_num_dropped_records(0, 0, ctypes.addressof(dropped))
+    except Exception as exc:  # noqa: BLE001
+        if not _DROPPED_COUNT_UNREADABLE:
+            _DROPPED_COUNT_UNREADABLE = True
+            _logger.warning(
+                "CUPTI dropped-record count is unreadable (%s); an unmeasured iteration "
+                "can no longer be told apart from a lost record.", exc,
+            )
+        return None
+    return int(dropped.value)
+
+
+def _drop_counter_is_live() -> bool:
+    """Prove the drop counter reports a loss, by causing one, before trusting it.
+
+    A counter stuck at zero -- wrong queue, unimplemented in this binding -- would turn
+    every lost record into "the call never reached the device", the misdiagnosis this
+    path exists to prevent. Measured once per process rather than assumed.
+    """
+    global _DROP_COUNTER_LIVE
+    if _DROP_COUNTER_LIVE is not None:
+        return _DROP_COUNTER_LIVE
+    probe_kernels = 4
+    probe = torch.empty(1, device="cuda")
+    with _phase_session(buffer_bytes=8):  # too small to hold one record
+        for _ in range(probe_kernels):
+            probe.zero_()
+        torch.cuda.synchronize()
+        _load_cupti().activity_flush_all(1)
+    dropped = _read_dropped()
+    _DROP_COUNTER_LIVE = bool(dropped)
+    if not _DROP_COUNTER_LIVE:
+        _logger.warning(
+            "CUPTI reported %s dropped records after discarding %d on purpose; the "
+            "counter cannot be trusted, so an unmeasured iteration will not be blamed "
+            "on the call.", dropped, probe_kernels,
+        )
+    return _DROP_COUNTER_LIVE
 
 
 def _buffer_completed(records) -> None:
     # Copy the fields out and keep no record alive: the binding's other
     # accessors misread a newer libcupti's struct and raise, including from
     # __del__ at shutdown.
+    cupti = _load_cupti()
     for record in records:
-        _RECORDS.append({
-            "name": str(record.name),
-            "start_ns": int(record.start),
-            "end_ns": int(record.end),
-        })
+        kind = int(record.kind)
+        if kind == int(cupti.ActivityKind.CONCURRENT_KERNEL):
+            _KERNELS.append({
+                "name": str(record.name),
+                "start_ns": int(record.start),
+                "end_ns": int(record.end),
+                "correlation_id": int(record.correlation_id),
+            })
+        elif kind == int(cupti.ActivityKind.EXTERNAL_CORRELATION):
+            _ITERATION_OF[int(record.correlation_id)] = int(record.external_id)
+        # Launch-API records are collected only so CUPTI emits the correlation above.
+
+
+def _trace_launches_only(cupti) -> None:
+    """Silence every traced API except kernel launches.
+
+    Tracing all of them costs ~15 records per iteration instead of one, and only the
+    launch carries the correlation id a kernel needs. Must run after ``activity_enable``,
+    which resets the per-API filter -- measured, not assumed.
+    """
+    for toggle, cbids, launch_prefix in (
+        (cupti.activity_enable_runtime_api, cupti.runtime_api_trace_cbid, "cudaLaunch"),
+        (cupti.activity_enable_driver_api, cupti.driver_api_trace_cbid, "cuLaunch"),
+    ):
+        for name in dir(cbids):
+            cbid = getattr(cbids, name, None)
+            if name.startswith("_") or not isinstance(cbid, int):
+                continue
+            try:
+                toggle(int(cbid), 1 if name.startswith(launch_prefix) else 0)
+            except Exception:  # noqa: BLE001, S112
+                # The enums carry sentinels (INVALID, SIZE) that CUPTI refuses.
+                continue
 
 
 @contextlib.contextmanager
-def _phase_session():
+def _phase_session(buffer_bytes: int = _BUFFER_BYTES):
     """Own one session, so a failed trial leaves nothing behind for the next."""
-    global _COLLECTOR_ACTIVE, _CALLBACKS_REGISTERED
+    global _COLLECTOR_ACTIVE, _CALLBACKS_REGISTERED, _buffer_bytes
     if _COLLECTOR_ACTIVE:
         raise RuntimeError("CUPTI collector is already active")
     cupti = _load_cupti()
-    # Kernels only. A workspace memset or a staging copy is not the arithmetic being
-    # timed, and enabling the API-call kinds that would let CUPTI attribute activity by
-    # correlation id instead of by time costs 14x the records -- enough callback work
-    # between two launches of the same call to leave the device idle inside its span.
-    kinds = (cupti.ActivityKind.CONCURRENT_KERNEL,)
+    # Kernels, the launches that carry their correlation ids, and the records mapping
+    # those ids to the pushed iteration index. No other kind: a workspace memset or a
+    # staging copy is not the arithmetic being timed.
+    kinds = (
+        cupti.ActivityKind.CONCURRENT_KERNEL,
+        cupti.ActivityKind.EXTERNAL_CORRELATION,
+        cupti.ActivityKind.RUNTIME,
+        cupti.ActivityKind.DRIVER,
+    )
+    previous_bytes = _buffer_bytes
     try:
         if not _CALLBACKS_REGISTERED:
             cupti.activity_register_callbacks(_buffer_requested, _buffer_completed)
             _CALLBACKS_REGISTERED = True
-        _RECORDS.clear()
+        _buffer_bytes = buffer_bytes
+        _KERNELS.clear()
+        _ITERATION_OF.clear()
+        # Read and discard, so the count taken after the flush belongs to this phase
+        # alone. Raw, because proving the counter live opens a session of its own.
+        _read_dropped()
         for kind in kinds:
             cupti.activity_enable(kind)
+        _trace_launches_only(cupti)
     except Exception as exc:  # noqa: BLE001
+        _buffer_bytes = previous_bytes
         raise CUPTIError(f"CUPTI collector failed to start: {exc}") from exc
     _COLLECTOR_ACTIVE = True
     try:
         yield
     finally:
         _COLLECTOR_ACTIVE = False
+        _buffer_bytes = previous_bytes
         try:
-            for kind in kinds:
+            for kind in reversed(kinds):
                 cupti.activity_disable(kind)
         except Exception as exc:  # noqa: BLE001
             raise CUPTIError(f"CUPTI collector failed to stop: {exc}") from exc
 
 
-def _flush() -> list[dict[str, Any]]:
-    """Return the records completed since the previous flush."""
+def _flush() -> tuple[list[dict[str, Any]], dict[int, int]]:
+    """Return the kernels recorded since the previous flush, and their iteration map."""
     cupti = _load_cupti()
     torch.cuda.synchronize()
     try:
         cupti.activity_flush_all(1)  # CUPTI_ACTIVITY_FLAG_FLUSH_FORCED
     except Exception as exc:  # noqa: BLE001
         raise CUPTIError(f"CUPTI flush failed: {exc}") from exc
-    drained = list(_RECORDS)
-    _RECORDS.clear()
-    return drained
+    kernels, iteration_of = list(_KERNELS), dict(_ITERATION_OF)
+    _KERNELS.clear()
+    _ITERATION_OF.clear()
+    return kernels, iteration_of
+
+
+class Trace(NamedTuple):
+    """One phase of collection: what CUPTI recorded, and what it lost."""
+
+    kernels: list[dict[str, Any]]
+    iteration_of: dict[int, int]
+    """Which iteration each correlation id belongs to."""
+    dropped: Optional[int]
+    """Records discarded for want of buffer space, or None if the count is unproven."""
 
 
 def collect_repeats(
     run_one: Callable[[int], None],
     n_repeat: int,
     prepare_one: Callable[[int], None],
-) -> tuple[list[dict[str, Any]], list[tuple[int, int]]]:
-    """Run the timed repeats, bracketing each call in a window of its own.
+    buffer_bytes: int = _BUFFER_BYTES,
+) -> Trace:
+    """Run the timed repeats, each labelled with its iteration index.
 
-    ``prepare_one`` leaves the device idle, so opening the window after it and closing
-    it once the call has drained makes the window hold exactly that call's activity --
-    whichever CPU thread launched it. CUPTI stamps activity on the clock
-    ``get_timestamp`` reads, so the two are directly comparable.
+    ``prepare_one`` runs under an id of its own and leaves the device idle, and each
+    call is drained before the next begins, so an iteration's kernels neither overlap
+    nor borrow a neighbour's cache state.
     """
     cupti = _load_cupti()
-    windows = []
-    with _phase_session():
+    kind = cupti.ExternalCorrelationKind.CUSTOM0
+    # Before the session, not inside it: the proof runs a phase of its own.
+    _drop_counter_is_live()
+
+    @contextlib.contextmanager
+    def _labelled(external_id: int):
+        cupti.activity_push_external_correlation_id(kind, external_id)
+        try:
+            yield
+        finally:
+            cupti.activity_pop_external_correlation_id(kind)
+
+    with _phase_session(buffer_bytes):
         for i in range(n_repeat):
-            prepare_one(i)
-            begin = cupti.get_timestamp()
-            run_one(i)
+            with _labelled(_PREPARE_ID):
+                prepare_one(i)
+            with _labelled(i):
+                run_one(i)
             torch.cuda.synchronize()
-            windows.append((begin, cupti.get_timestamp()))
-        return _flush(), windows
+        kernels, iteration_of = _flush()
+        # Counted after the flush, once CUPTI has handed back what it did keep. Unproven
+        # counter reports None, not zero: it is the only evidence separating a lost
+        # reading from a call that launched nothing.
+        dropped = _read_dropped() if _drop_counter_is_live() else None
+        return Trace(kernels, iteration_of, dropped)
 
 
 class Sample(NamedTuple):
@@ -199,54 +343,96 @@ def _kernel_busy_us(kernels: list[dict]) -> float:
     return (total + current_end - current_start) / 1000.0
 
 
-def _ordered_trace_kernels(records: list[dict]) -> list[dict]:
-    return sorted(
-        records,
-        key=lambda kernel: (int(kernel["start_ns"]), int(kernel["end_ns"])),
-    )
-
-
 def _cuda_events_fallback_enabled() -> bool:
     return os.getenv("TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK", "0") == "1"
 
 
 def _attributed_samples(
-    records: list[dict],
-    windows: list[tuple[int, int]],
+    kernels: list[dict],
+    iteration_of: dict[int, int],
     n_repeat: int,
+    dropped: Optional[int] = 0,
 ) -> list[Sample]:
     """Return one Sample per iteration.
 
-    Attribution is which window an activity started in. Nothing is inferred from the
-    order or the identity of what ran, so a call whose activity count varies between
-    iterations is measured rather than rejected, and work the call launched from
-    another thread -- autograd runs its graph on the engine's -- still counts.
+    A kernel belongs to the iteration whose correlation id it carries, so a call whose
+    kernel count varies between iterations is measured rather than rejected. Both ways
+    of coming up short -- an unclaimed kernel, an iteration with none -- can also mean
+    the record was taken and then discarded, which is what ``dropped`` distinguishes.
     """
-    if len(windows) != n_repeat:
+    claimed: dict[int, list[dict]] = {}
+    orphans = []
+    for kernel in kernels:
+        iteration = iteration_of.get(kernel["correlation_id"])
+        if iteration is None:
+            orphans.append(kernel)
+        elif iteration != _PREPARE_ID:
+            claimed.setdefault(iteration, []).append(kernel)
+
+    unmeasured = [i for i in range(n_repeat) if i not in claimed]
+    if orphans or unmeasured:
+        short = (f"{len(unmeasured)} of {n_repeat} iterations have no kernel of their "
+                 f"own and {len(orphans)} kernels belong to no iteration")
+        if dropped:
+            raise _CUPTIRecordsLostError(
+                f"{short}; CUPTI discarded {dropped} activity records for want of "
+                f"buffer space, so those readings were lost rather than never taken"
+            )
+        if dropped is None:
+            raise _CUPTIAttributionError(
+                f"{short}; CUPTI's dropped-record count is unproven, so a lost record "
+                f"cannot be ruled out"
+            )
+        if orphans:
+            raise _OffThreadLaunchError(
+                f"{len(orphans)} of {len(kernels)} kernels carry no iteration id "
+                f"(first: {orphans[0]['name']}); the call handed its work to a thread "
+                f"the id was not pushed on"
+            )
         raise _CUPTIAttributionError(
-            f"{len(windows)} timing windows for {n_repeat} iterations"
+            f"{len(unmeasured)} of {n_repeat} iterations launched no kernel "
+            f"(first: iteration {unmeasured[0]}); CUPTI discarded nothing, so a call "
+            f"that never reaches the device is not being measured"
         )
 
-    samples = []
-    empty = []
-    for repeat, (begin, end) in enumerate(windows):
-        inside = [r for r in records if begin <= r["start_ns"] < end]
-        if not inside:
-            empty.append(repeat)
-            continue
-        samples.append(Sample(
-            device_busy_ms=_kernel_busy_us(inside) * 1e-3,
-            latency_ms=_kernel_span_us(inside) * 1e-3,
-            n_kernels=len(inside),
-        ))
-
-    if empty:
-        raise _CUPTIAttributionError(
-            f"{len(empty)} of {n_repeat} timed iterations produced no GPU activity "
-            f"(first: iteration {empty[0]}); a call that never reaches the device is "
-            f"not being measured"
+    return [
+        Sample(
+            device_busy_ms=_kernel_busy_us(claimed[i]) * 1e-3,
+            latency_ms=_kernel_span_us(claimed[i]) * 1e-3,
+            n_kernels=len(claimed[i]),
         )
-    return samples
+        for i in range(n_repeat)
+    ]
+
+
+def _collect_attributed(
+    run_one: Callable[[int], None],
+    n_repeat: int,
+    prepare_one: Callable[[int], None],
+) -> list[Sample]:
+    """Collect one fully attributed phase, re-measuring what CUPTI loses.
+
+    A discarded record is the instrument failing rather than the op: the iteration ran
+    and only its reading is gone, so the phase is run again, each attempt asking for a
+    larger buffer. Anything the drop counter does not explain fails on the first attempt.
+    """
+    buffer_bytes = _BUFFER_BYTES
+    for attempt in range(_ATTRIBUTION_ATTEMPTS):
+        trace = collect_repeats(run_one, n_repeat, prepare_one, buffer_bytes)
+        try:
+            return _attributed_samples(
+                trace.kernels, trace.iteration_of, n_repeat, trace.dropped,
+            )
+        except _CUPTIRecordsLostError as exc:
+            _bench_meta.attribution_retries = attempt + 1
+            if attempt == _ATTRIBUTION_ATTEMPTS - 1:
+                raise
+            buffer_bytes *= 4
+            _logger.warning(
+                "%s; re-measuring with a %d KB buffer (attempt %d of %d).",
+                exc, buffer_bytes // 1024, attempt + 2, _ATTRIBUTION_ATTEMPTS,
+            )
+    raise AssertionError("the loop returns or raises on its last attempt")
 
 
 def _sample_spread_ms(samples: list[float]) -> tuple[float, float] | tuple[None, None]:
@@ -323,7 +509,7 @@ def _capture_bench_meta() -> dict:
     """Snapshot how the last measurement was taken."""
     return {
         key: value
-        for key in ("timing", "fallback_reason")
+        for key in ("timing", "fallback_reason", "attribution_retries")
         if (value := getattr(_bench_meta, key, None)) is not None
     }
 
@@ -340,9 +526,11 @@ def bench_kernel(
 
     A calibration pass measures one iteration, then warmup and measurement each run
     for their millisecond budget, so a short op is sampled many times and a long one
-    few. L2 is cleared before every iteration, and each call is bracketed by a device
-    synchronize so its window holds only its own activity. Attribution fails closed
-    unless ``TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1``.
+    few. L2 is cleared before every iteration, and each call is drained before the next
+    begins. Each kernel is attributed to the iteration that launched it, so *fn* must
+    launch its own work rather than hand it to another thread. A phase whose records
+    CUPTI discarded is measured again; attribution otherwise fails closed unless
+    ``TILEOPS_ALLOW_CUDA_EVENTS_FALLBACK=1``.
     """
     if not isinstance(args, tuple):
         raise TypeError(
@@ -353,6 +541,7 @@ def bench_kernel(
     allow_fallback = _cuda_events_fallback_enabled()
     _bench_meta.timing = None
     _bench_meta.fallback_reason = None
+    _bench_meta.attribution_retries = None
     cache = _get_l2_flush_cache()
 
     def _flush_l2():
@@ -396,8 +585,7 @@ def bench_kernel(
 
     try:
         with _native_output_suppressor():
-            records, windows = collect_repeats(_run, n_repeat, _prepare_iteration)
-            samples = _attributed_samples(records, windows, n_repeat)
+            samples = _collect_attributed(_run, n_repeat, _prepare_iteration)
         _bench_meta.timing = "cupti"
     except (_CUPTIAttributionError, CUPTIError) as exc:
         if not allow_fallback:


### PR DESCRIPTION
## Problem

Last nightly failed 11 benchmark cases, all sub-30 us single-kernel ops, all with:

```
N of 100 timed iterations produced no GPU activity; a call that never reaches
the device is not being measured
```

Kernel records were matched to host-timestamped per-iteration windows. For these ops the
window is 30-70 us wide, one missing record failed the case, and the message asserted a
cause it had no evidence for. Slower cases in the same files passed.

## Change

- **Attribute by identity.** The iteration index is pushed as CUPTI's external
  correlation id, so a kernel record says which iteration launched it. No windows, no
  timestamps in the attribution path. Only launch APIs are traced: 3 records per
  iteration.
- **Prove the drop counter, then trust it.** A buffer too small for one record must make
  it non-zero. A discarded record is retried with a bigger buffer instead of being blamed
  on the call; the retry count reaches the JUnit XML.
- **Backward baselines drive their own node.** `Tensor.backward` hands the graph to
  autograd's engine thread, whose kernels carry no id — eight baselines across six files
  did that. `backward_of(output)` runs the same backward on the calling thread, with
  bit-identical gradients, and drops engine overhead the tileops side never paid.
- **fla is required in the three linear-attention benchmarks.** Their torch fallback only
  ran when fla was missing, comparing a specialized kernel against a reference
  implementation. It and its dead reference code are gone.
- **A guard**, since no PR-stage job runs `benchmarks/ops`: a test greps that tree for
  `.backward()` / `autograd.grad()`.

## Verification

On an H200 in the nightly runner image: `benchmarks/tests` 26 passed, and every
benchmark file this touches passes with its baseline column intact — including the 11
cases that failed, and `bench_mha` with fa3 hidden so the SDPA branch runs. Op numbers
are unchanged (log_softmax 13.95 → 13.95 us, maximum 26.4 → 26.5 us, same GPU and
script); backward *baselines* get faster by the engine overhead that left the timed
region.

The original failure never reproduced on an idle GPU, so its root cause stays unproven.
What changes is that guessing is no longer required: this failure class cannot recur, and
a dropped record now says so instead of blaming the op.
