### PR TITLE
[CI] Name runner labels by how a job needs the card

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,5 @@
 self-hosted-runner:
   labels:
     - tile-ops
-    - venv
     - shared
     - bench

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,5 @@ self-hosted-runner:
   labels:
     - tile-ops
     - venv
-    - nightly
+    - shared
+    - bench

--- a/.github/runner/README.md
+++ b/.github/runner/README.md
@@ -70,21 +70,13 @@ command in its own header after changing a version or a requirement, and read th
 is excluded there: it is source-built in its own stage, and vLLM's exact-release dependency on it
 is overwritten by `--force-reinstall`.
 
-## Register a self-hosted runner
+## Runner registration
 
-`entrypoint.sh` registers an ephemeral runner (one job per container) and deregisters on exit.
-It strips `RUNNER_TOKEN` from the environment before the runner starts, so jobs cannot read it.
+`entrypoint.sh` registers an ephemeral runner — one job per container — and deregisters on
+exit. It strips `RUNNER_TOKEN` from the environment before the runner starts, so jobs cannot
+read it.
 
-```bash
-docker run -d --gpus all \
-  -e RUNNER_URL=https://github.com/tile-ai/TileOPs \
-  -e RUNNER_TOKEN=<registration-token> \
-  -e RUNNER_LABELS=self-hosted,tile-ops,nightly \
-  -v <host-cache-dir>:/ci-cache \
-  ghcr.io/tile-ai/tileops-runner:cu132-torch2.13-tl-<short-sha>
-```
-
-The third label decides which jobs the runner takes: `nightly` for the shared pool, `fork` for
-the pool that serves pull requests from forks. Any other label leaves it idle — no workflow
-requests one. Cache env vars (`TILELANG_CACHE_DIR`, `TRITON_CACHE_DIR`, …) point under
-`/ci-cache`, pre-created so the container also works unmounted.
+The image expects a cache directory bind-mounted at `/ci-cache`; `TILELANG_CACHE_DIR`,
+`TRITON_CACHE_DIR` and friends point under it and are pre-created, so the container also works
+unmounted. Which labels a runner registers with, and how the pools are provisioned, is a
+maintainer task outside this repository.

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -375,7 +375,7 @@ jobs:
     # Trust-level routing: untrusted (external) PRs go to the on-demand `fork` pool whose
     # runner mounts an overlay cache (read-only shared lower + throwaway upper) so their cache
     # writes never reach the shared cache. Trusted runs use the resident shared-cache pool.
-    runs-on: ${{ needs.security-policy.outputs.is_fork == 'true' && fromJSON('["self-hosted", "tile-ops", "fork"]') || fromJSON('["self-hosted", "tile-ops", "nightly"]') }}
+    runs-on: ${{ needs.security-policy.outputs.is_fork == 'true' && fromJSON('["self-hosted", "tile-ops", "fork"]') || fromJSON('["self-hosted", "tile-ops", "shared"]') }}
     # Hard backstop so a wedged kernel can never hold the single runner indefinitely; the
     # per-test --timeout below is the first line of defense, this is the ceiling.
     timeout-minutes: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 # ---------------------------------------------------------------------------
-# All nightly jobs run on a containerized self-hosted runner (label: nightly).
+# All nightly jobs run on a containerized self-hosted runner (label: shared, or bench).
 # The runner container is provisioned by the host with GPU access, persistent
 # cache mounts, and the runtime environment variables below.
 # ---------------------------------------------------------------------------
@@ -39,7 +39,7 @@ jobs:
     # 5h07m with nothing cached, and minutes once it is. Must exceed
     # --total-budget below so the runner, not GitHub, ends the sweep.
     timeout-minutes: 380
-    runs-on: [self-hosted, tile-ops, nightly]
+    runs-on: [self-hosted, tile-ops, bench]
     env:
       # Keep the long benchmark suite from fragmenting CUDA allocator segments
       # before late large MoE input tensors allocate 14-21 GiB weight blocks.
@@ -173,7 +173,7 @@ jobs:
     if: ${{ always() && github.repository == 'tile-ai/TileOPs' && (github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
     needs: [benchmark]
     timeout-minutes: 180
-    runs-on: [self-hosted, tile-ops, nightly]
+    runs-on: [self-hosted, tile-ops, shared]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -404,7 +404,7 @@ jobs:
     needs: [op_test]
     permissions:
       contents: write
-    runs-on: [self-hosted, tile-ops, nightly]
+    runs-on: [self-hosted, tile-ops, shared]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -25,9 +25,9 @@ concurrency:
 jobs:
   reclaim-disk:
     if: ${{ github.repository == 'tile-ai/TileOPs' }}
-    # `nightly` (not `fork`) keeps maintenance on the resident shared-cache runners; the
+    # `shared` (not `fork`) keeps maintenance on the resident shared-cache runners; the
     # destructive autotuner age-trim must never run against a fork pool's overlay cache.
-    runs-on: [self-hosted, tile-ops, nightly]
+    runs-on: [self-hosted, tile-ops, shared]
     timeout-minutes: 60
     steps:
       # Invoke the action directly via owner/repo/path@ref so this workflow


### PR DESCRIPTION
Runner labels now describe what a job needs from the GPU, not when it is scheduled: `shared` = one card, sharing is fine; `bench` = one card held exclusively; `fork` = isolated pool, unchanged.

The nightly benchmark job moves to `bench` because it is the only job that needs the card to itself for accurate timing. Everything else that ran on `nightly` moves to `shared`.

The runner pool already carries both the old and new labels, so this takes effect on merge with no queueing window.

Also drops the host-side runner registration guide from `.github/runner/README.md`, since the accurate version is maintained outside this public repository.