### PR TITLE
[Fix][Norm] Put the compile boundary in the op layer and let the op own its graph node

### DIFF
--- a/src/tileops/kernels/engram/engram_bwd.py
+++ b/src/tileops/kernels/engram/engram_bwd.py
@@ -23,21 +23,17 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 __all__ = ["EngramGateConvBwdKernel"]
 
-ALIGNMENT = 256
 CONV_KERNEL_SIZE = 4
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 @functools.lru_cache(maxsize=32)
 def _engram_gate_conv_bwd_kernel(M, seq_len, d, eps, dtype):
     accum_dtype = "float"
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
     KS = CONV_KERNEL_SIZE
 
     @tilelang.jit(
@@ -379,7 +375,7 @@ def _engram_gate_conv_bwd_wrapped(
 def _(M, seq_len, d, eps, dtype_str, threads,
       dY, H, k, v, rms_w_h, rms_w_v, conv_w,
       vhat, alpha, rrms_h, rrms_k, rrms_v):
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
     device = dY.device
     dt = dY.dtype
     return [
@@ -422,7 +418,7 @@ class EngramGateConvBwdKernel(Kernel):
         self.d = d
         self.eps = eps
         self.dtype = dtype
-        self.d_padded = _align_up(d, ALIGNMENT)
+        self.d_padded = align_up(d, ALIGNMENT)
         self.kernel = _engram_gate_conv_bwd_kernel(
             M, seq_len, d, eps, self.dtype_str,
         )

--- a/src/tileops/kernels/engram/engram_decode.py
+++ b/src/tileops/kernels/engram/engram_decode.py
@@ -46,14 +46,10 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 __all__ = ["EngramDecodeKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 @functools.lru_cache(maxsize=32)
@@ -70,7 +66,7 @@ def _engram_decode_kernel(batch, d_mem, d, max_conv_len, conv_kernel_size, dilat
         dtype: data type string.
     """
     accum_dtype = "float"
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
     w = conv_kernel_size
 
     @tilelang.jit(
@@ -266,7 +262,7 @@ def _engram_decode_wrapped(
 def _(batch, d_mem, d, max_conv_len, conv_kernel_size, dilation,
       eps, dtype_str, threads,
       e_t, h_t, conv_state, W_K, W_V, rms_w_h, rms_w_v, conv_w):
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
     device = e_t.device
     dt = e_t.dtype
     return [
@@ -316,7 +312,7 @@ class EngramDecodeKernel(Kernel):
         self.dilation = dilation
         self.eps = eps
         self.dtype = dtype
-        self.d_padded = _align_up(d, ALIGNMENT)
+        self.d_padded = align_up(d, ALIGNMENT)
 
         min_cache = dilation * (conv_kernel_size - 1)
         if max_conv_len < min_cache:

--- a/src/tileops/kernels/engram/engram_fwd.py
+++ b/src/tileops/kernels/engram/engram_fwd.py
@@ -27,21 +27,17 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 __all__ = ["EngramGateConvFwdKernel"]
 
-ALIGNMENT = 256
 CONV_KERNEL_SIZE = 4
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 @functools.lru_cache(maxsize=32)
 def _engram_gate_conv_fwd_kernel(M, seq_len, d, eps, dtype):
     accum_dtype = "float"
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
 
     @tilelang.jit(
         out_idx=[6, 7, 8, 9, 10, 11],
@@ -211,7 +207,7 @@ def _engram_gate_conv_fwd_wrapped(
 
 @_engram_gate_conv_fwd_wrapped.register_fake
 def _(M, seq_len, d, eps, dtype_str, threads, H, k, v, rms_w_h, rms_w_v, conv_w):
-    d_padded = _align_up(d, ALIGNMENT)
+    d_padded = align_up(d, ALIGNMENT)
     device = H.device
     dt = H.dtype
     return [
@@ -252,7 +248,7 @@ class EngramGateConvFwdKernel(Kernel):
         self.d = d
         self.eps = eps
         self.dtype = dtype
-        self.d_padded = _align_up(d, ALIGNMENT)
+        self.d_padded = align_up(d, ALIGNMENT)
         self.kernel = _engram_gate_conv_fwd_kernel(
             M, seq_len, d, eps, self.dtype_str,
         )

--- a/src/tileops/kernels/norm/ada_layer_norm.py
+++ b/src/tileops/kernels/norm/ada_layer_norm.py
@@ -27,16 +27,12 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 from ._config import select_row_config, select_row_configs
 
 __all__ = ["AdaLayerNormKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 def _should_use_cp_async(
@@ -45,7 +41,7 @@ def _should_use_cp_async(
     has_gate: bool = False,
 ) -> bool:
     """Select async prefetch when lowering and shared-memory limits allow it."""
-    n_padded = _align_up(n, ALIGNMENT)
+    n_padded = align_up(n, ALIGNMENT)
     row_bytes = n * dtype.itemsize
     num_buffers = 4 if has_gate else 3
     shared_bytes = num_buffers * n_padded * dtype.itemsize
@@ -54,7 +50,7 @@ def _should_use_cp_async(
 
 @functools.lru_cache(maxsize=32)
 def _ada_layer_norm_kernel(M, N, eps, dtype, has_gate=False, use_cp_async=False):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
     needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
     # The async policy guarantees that each source row is a whole number of
@@ -336,7 +332,7 @@ class AdaLayerNormKernel(Kernel):
         self.eps = eps
         self.dtype = dtype
         self.has_gate = has_gate
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         # Shape policy is benchmarked independently from block/thread tuning.
         self.use_cp_async = _should_use_cp_async(N, dtype, has_gate)
         self.kernel = _ada_layer_norm_kernel(

--- a/src/tileops/kernels/norm/fused_add_norm.py
+++ b/src/tileops/kernels/norm/fused_add_norm.py
@@ -21,23 +21,19 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 from ._config import select_row_config, select_row_configs
 
 __all__ = ["FusedAddLayerNormKernel", "FusedAddRMSNormKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 # Fused Add + LayerNorm kernel
 
 @functools.lru_cache(maxsize=32)
 def _fused_add_layer_norm_kernel(M, N, eps, dtype):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
     pad_count = N_padded - N
 
     @tilelang.jit(out_idx=[4, 5])
@@ -142,7 +138,7 @@ def _fused_add_layer_norm_wrapped(
 
 @_fused_add_layer_norm_wrapped.register_fake
 def _(M, N, eps, dtype_str, block_m, threads, x, residual, weight, bias):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
     y = torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
     residual_out = torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
     return [y, residual_out]
@@ -175,7 +171,7 @@ class FusedAddLayerNormKernel(Kernel):
         self.N = N
         self.eps = eps
         self.dtype = dtype
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.kernel = _fused_add_layer_norm_kernel(self.M, self.N, self.eps, self.dtype_str)
         self.init_config(config, tune)
 
@@ -233,7 +229,7 @@ class FusedAddLayerNormKernel(Kernel):
 
 @functools.lru_cache(maxsize=32)
 def _fused_add_rms_norm_kernel(M, N, eps, dtype):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
 
     @tilelang.jit(out_idx=[3, 4])
     def _func(block_m, threads):
@@ -323,7 +319,7 @@ def _fused_add_rms_norm_wrapped(
 
 @_fused_add_rms_norm_wrapped.register_fake
 def _(M, N, eps, dtype_str, block_m, threads, x, residual, weight):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
     y = torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
     residual_out = torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
     return [y, residual_out]
@@ -356,7 +352,7 @@ class FusedAddRMSNormKernel(Kernel):
         self.N = N
         self.eps = eps
         self.dtype = dtype
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.kernel = _fused_add_rms_norm_kernel(self.M, self.N, self.eps, self.dtype_str)
         self.init_config(config, tune)
 

--- a/src/tileops/kernels/norm/group_norm.py
+++ b/src/tileops/kernels/norm/group_norm.py
@@ -32,16 +32,12 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 from ._config import select_row_config, select_row_configs
 
 __all__ = ["GroupNormKernel", "GroupNormNoAffineKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 def _channel_of(row, col, num_groups: int, channels_per_group: int, spatial_size: int):
@@ -123,7 +119,7 @@ def _group_norm_kernel(M, D, eps, dtype, num_groups, channels_per_group):
         channels_per_group: C / G. Row ``m`` covers channels
             ``(m % G) * channels_per_group`` onwards.
     """
-    D_padded = _align_up(D, ALIGNMENT)
+    D_padded = align_up(D, ALIGNMENT)
     spatial_size = D // channels_per_group
     C = num_groups * channels_per_group
 
@@ -270,7 +266,7 @@ class GroupNormKernel(Kernel):
         self.dtype = dtype
         self.num_groups = num_groups
         self.channels_per_group = channels_per_group
-        self.D_padded = _align_up(D, ALIGNMENT)
+        self.D_padded = align_up(D, ALIGNMENT)
         self.kernel = _group_norm_kernel(
             self.M, self.D, self.eps, self.dtype_str,
             self.num_groups, self.channels_per_group,
@@ -331,7 +327,7 @@ def _group_norm_no_affine_kernel(M, D, eps, dtype):
         eps: Epsilon for numerical stability.
         dtype: TileLang dtype string.
     """
-    D_padded = _align_up(D, ALIGNMENT)
+    D_padded = align_up(D, ALIGNMENT)
 
     @tilelang.jit(out_idx=[1])
     def _func(block_m, threads):
@@ -444,7 +440,7 @@ class GroupNormNoAffineKernel(Kernel):
         self.D = D
         self.eps = eps
         self.dtype = dtype
-        self.D_padded = _align_up(D, ALIGNMENT)
+        self.D_padded = align_up(D, ALIGNMENT)
         self.kernel = _group_norm_no_affine_kernel(
             self.M, self.D, self.eps, self.dtype_str,
         )

--- a/src/tileops/kernels/norm/layer_norm.py
+++ b/src/tileops/kernels/norm/layer_norm.py
@@ -18,21 +18,17 @@ import tilelang.language as T
 import torch
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 from ._config import select_row_config, select_row_configs
 
 __all__ = ["LayerNormKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 @functools.lru_cache(maxsize=32)
 def _layer_norm_kernel(M, N, eps, dtype):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
     needs_pad = N_padded != N
     pad_count = N_padded - N  # number of zero-padded elements per row
 
@@ -165,7 +161,7 @@ class LayerNormKernel(Kernel):
         self.N = N
         self.eps = eps
         self.dtype = dtype
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self.kernel = _layer_norm_kernel(self.M, self.N, self.eps, self.dtype_str)
         self.init_config(config, tune)
 

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -80,26 +80,6 @@ def _rms_norm_kernel(M, N, eps, dtype):
     return _func
 
 
-@torch.library.custom_op("top::rms_norm_fwd", mutates_args=())
-def _rms_norm_wrapped(
-    M: int,
-    N: int,
-    eps: float,
-    dtype_str: str,
-    block_m: int,
-    threads: int,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-) -> torch.Tensor:
-    return _rms_norm_kernel(M, N, eps, dtype_str)(block_m, threads)(x, weight)
-
-
-@_rms_norm_wrapped.register_fake
-def _(M, N, eps, dtype_str, block_m, threads, x, weight):
-    N_padded = _align_up(N, ALIGNMENT)
-    return torch.empty((M, N_padded), dtype=x.dtype, device=x.device)
-
-
 class RMSNormKernel(Kernel):
     """RMS Norm kernel.
 
@@ -175,16 +155,7 @@ class RMSNormKernel(Kernel):
         if pad:
             rows = F.pad(rows, (0, pad))
             weight = F.pad(weight, (0, pad))
-        y = _rms_norm_wrapped(
-            m,
-            self.N,
-            self.eps,
-            self.dtype_str,
-            self.config["block_m"],
-            self.config["threads"],
-            rows,
-            weight,
-        )
+        y = self.kernel(self.config["block_m"], self.config["threads"])(rows, weight)
         if pad:
             y = y[:, : self.N]
         return y.reshape(original_shape)

--- a/src/tileops/kernels/norm/rms_norm.py
+++ b/src/tileops/kernels/norm/rms_norm.py
@@ -16,21 +16,16 @@ import torch
 import torch.nn.functional as F
 
 from tileops.kernels.kernel_base import Kernel
+from tileops.kernels.tiling import ALIGNMENT, align_up
 
 from ._config import select_row_config, select_row_configs
 
 __all__ = ["RMSNormKernel"]
 
-ALIGNMENT = 256
-
-
-def _align_up(n: int, alignment: int) -> int:
-    return ((n + alignment - 1) // alignment) * alignment
-
 
 @functools.lru_cache(maxsize=32)
 def _rms_norm_kernel(M, N, eps, dtype):
-    N_padded = _align_up(N, ALIGNMENT)
+    N_padded = align_up(N, ALIGNMENT)
 
     @tilelang.jit(out_idx=[2])
     def _func(block_m, threads):
@@ -107,7 +102,7 @@ class RMSNormKernel(Kernel):
         self.N = N
         self.eps = eps
         self.dtype = dtype
-        self.N_padded = _align_up(N, ALIGNMENT)
+        self.N_padded = align_up(N, ALIGNMENT)
         self._tune_pending = tune  # tuning needs a program, so it waits for the first call
         self.init_config(config, tune=False)
 
@@ -122,6 +117,9 @@ class RMSNormKernel(Kernel):
     def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
         """Normalize ``x`` over its trailing ``N`` elements.
 
+        Flattening to 2-D rows and a flat weight happens here, as does the alignment
+        padding the prim_func requires.
+
         Args:
             x: Input whose trailing axes multiply to ``N``, contiguous, on a CUDA device.
             weight: Affine scale holding ``N`` elements, contiguous, on the same device.
@@ -131,9 +129,6 @@ class RMSNormKernel(Kernel):
 
         Raises:
             ValueError: Either input is not on a CUDA device.
-
-        Flattening to 2-D rows and a flat weight happens here, as does the alignment padding
-        the prim_func requires.
         """
         if not (x.is_cuda and weight.is_cuda):
             raise ValueError(

--- a/src/tileops/kernels/reduction/_primitives.py
+++ b/src/tileops/kernels/reduction/_primitives.py
@@ -13,6 +13,8 @@ import itertools
 import tilelang.language as T
 import torch
 
+from tileops.kernels.tiling import align_up
+
 __all__ = [
     "AUTOTUNE_THREADS",
     "DEFAULT_ALIGNMENT",
@@ -330,24 +332,6 @@ def device_smem_budget(device_index: int | None = None) -> int:
         if explicit:
             raise
         return SHARED_MEMORY_BUDGET_BYTES
-
-
-def align_up(n: int, alignment: int) -> int:
-    """Round *n* up to the nearest multiple of *alignment*.
-
-    Args:
-        n: Value to align.
-        alignment: Alignment boundary (must be positive).
-
-    Returns:
-        Smallest multiple of *alignment* that is >= *n*.
-
-    Raises:
-        ValueError: If *alignment* is not positive.
-    """
-    if alignment <= 0:
-        raise ValueError(f"alignment must be positive, got {alignment}")
-    return ((n + alignment - 1) // alignment) * alignment
 
 
 def compute_tile_n(

--- a/src/tileops/kernels/tiling.py
+++ b/src/tileops/kernels/tiling.py
@@ -8,18 +8,7 @@ ALIGNMENT = 256
 
 
 def align_up(n: int, alignment: int) -> int:
-    """Round *n* up to the nearest multiple of *alignment*.
-
-    Args:
-        n: Value to align.
-        alignment: Alignment boundary (must be positive).
-
-    Returns:
-        Smallest multiple of *alignment* that is >= *n*.
-
-    Raises:
-        ValueError: If *alignment* is not positive.
-    """
+    """Round *n* up to the nearest multiple of *alignment*, which must be positive."""
     if alignment <= 0:
         raise ValueError(f"alignment must be positive, got {alignment}")
     return ((n + alignment - 1) // alignment) * alignment

--- a/src/tileops/kernels/tiling.py
+++ b/src/tileops/kernels/tiling.py
@@ -1,0 +1,25 @@
+"""Padding and tile-shape arithmetic shared by TileLang kernels."""
+
+__all__ = ["ALIGNMENT", "align_up"]
+
+#: Element count a row is padded to before ``T.copy`` moves it through shared
+#: memory: 256 elements, i.e. 512 bytes for fp16/bf16 and 1024 for fp32.
+ALIGNMENT = 256
+
+
+def align_up(n: int, alignment: int) -> int:
+    """Round *n* up to the nearest multiple of *alignment*.
+
+    Args:
+        n: Value to align.
+        alignment: Alignment boundary (must be positive).
+
+    Returns:
+        Smallest multiple of *alignment* that is >= *n*.
+
+    Raises:
+        ValueError: If *alignment* is not positive.
+    """
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    return ((n + alignment - 1) // alignment) * alignment

--- a/src/tileops/manifest/normalization.yaml
+++ b/src/tileops/manifest/normalization.yaml
@@ -8,6 +8,7 @@ RMSNormFwdOp:
   ref_api: "torch.nn.functional.rms_norm"
   family: normalization
   status: implemented
+  torch_compile_fullgraph: true
 
   signature:
     inputs:

--- a/src/tileops/manifest/normalization.yaml
+++ b/src/tileops/manifest/normalization.yaml
@@ -18,7 +18,7 @@ RMSNormFwdOp:
       output: {dtype: "same_as(x)"}
     params:
       normalized_shape: {type: "list[int] | tuple[int, ...]"}
-      eps: {type: "float | None", default: null}
+      eps: {type: "float | None", default: 1.0e-6}
     shape_rules:
       - "len(normalized_shape) > 0"
       - "tuple(x.shape[-len(normalized_shape):]) == tuple(normalized_shape)"

--- a/src/tileops/ops/norm/batch_norm.py
+++ b/src/tileops/ops/norm/batch_norm.py
@@ -217,7 +217,7 @@ class BatchNormFwdOp(Op):
         self.kernel = kernel
         return kernel
 
-    def _forward_impl(
+    def _eager_forward(
         self,
         x: torch.Tensor,
         running_mean: torch.Tensor,
@@ -273,7 +273,8 @@ class BatchNormFwdOp(Op):
         Returns:
             Normalized output tensor with the same shape as ``x``.
         """
-        return self._forward_impl(x, running_mean, running_var, weight, bias)
+        return _batch_norm_fwd_wrapped(
+            x, running_mean, running_var, weight, bias, self._instance_key)
 
 
 class BatchNormBwdOp(Op):
@@ -412,7 +413,7 @@ class BatchNormBwdOp(Op):
         if tensor.ndim != 1 or tensor.shape[0] != C:
             raise ValueError(f"Expected {name} shape ({C},), got {tuple(tensor.shape)}")
 
-    def _forward_impl(
+    def _eager_forward(
         self,
         grad_out: torch.Tensor,
         x: torch.Tensor,
@@ -464,7 +465,8 @@ class BatchNormBwdOp(Op):
             has the same shape as ``x``, ``grad_weight`` has shape ``(C,)``,
             and ``grad_bias`` has shape ``(C,)``.
         """
-        return self._forward_impl(grad_out, x, weight, mean, rstd)
+        return _batch_norm_bwd_wrapped(
+            grad_out, x, weight, mean, rstd, self._instance_key)
 
 
 # torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)
@@ -499,40 +501,6 @@ def _batch_norm_fwd_fake(
     return torch.empty_like(x)
 
 
-BatchNormFwdOp._wrapped = _batch_norm_fwd_wrapped
-
-
-def _batchnorm_fwd_eager_forward(
-    self,
-    x: torch.Tensor,
-    running_mean: torch.Tensor,
-    running_var: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    """Direct kernel call (no torch.compile wrapping)."""
-    return self._forward_impl(x, running_mean, running_var, weight, bias)
-
-
-BatchNormFwdOp._eager_forward = _batchnorm_fwd_eager_forward
-
-
-
-def _patched_fwd_forward(
-    self,
-    x: torch.Tensor,
-    running_mean: torch.Tensor,
-    running_var: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor,
-) -> torch.Tensor:
-    return _batch_norm_fwd_wrapped(
-        x, running_mean, running_var, weight, bias, self._instance_key)
-
-
-BatchNormFwdOp.forward = _patched_fwd_forward
-
-
 @torch.library.custom_op("top::batch_norm_bwd", mutates_args=())
 def _batch_norm_bwd_wrapped(
     grad_out: torch.Tensor,
@@ -561,30 +529,3 @@ def _batch_norm_bwd_fake(
         torch.empty(C, device=grad_out.device, dtype=torch.float32),
         torch.empty(C, device=grad_out.device, dtype=torch.float32),
     )
-
-
-BatchNormBwdOp._wrapped = _batch_norm_bwd_wrapped
-
-
-def _batchnorm_bwd_eager_forward(
-    self,
-    grad_out: torch.Tensor,
-    x: torch.Tensor,
-    weight: torch.Tensor,
-    mean: torch.Tensor,
-    rstd: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Direct kernel call (no torch.compile wrapping)."""
-    return self._forward_impl(grad_out, x, weight, mean, rstd)
-
-
-BatchNormBwdOp._eager_forward = _batchnorm_bwd_eager_forward
-
-
-
-def _patched_bwd_forward(self, grad_out, x, weight, mean, rstd):
-    return _batch_norm_bwd_wrapped(
-        grad_out, x, weight, mean, rstd, self._instance_key)
-
-
-BatchNormBwdOp.forward = _patched_bwd_forward

--- a/src/tileops/ops/norm/norm_base.py
+++ b/src/tileops/ops/norm/norm_base.py
@@ -7,18 +7,7 @@ __all__ = ["normalized_shape_to_n"]
 
 
 def normalized_shape_to_n(normalized_shape: Sequence[int]) -> int:
-    """Return the product of ``normalized_shape``.
-
-    Args:
-        normalized_shape: Manifest-style trailing-axis shape; must be
-            non-empty.
-
-    Returns:
-        Product of every entry in ``normalized_shape``.
-
-    Raises:
-        ValueError: If ``normalized_shape`` is empty.
-    """
+    """Return the product of ``normalized_shape``, which must be non-empty."""
     shape = tuple(int(d) for d in normalized_shape)
     if len(shape) == 0:
         raise ValueError("normalized_shape must be non-empty")

--- a/src/tileops/ops/norm/norm_base.py
+++ b/src/tileops/ops/norm/norm_base.py
@@ -3,14 +3,7 @@
 import math
 from typing import Sequence
 
-__all__ = ["ALIGNMENT", "align_up", "normalized_shape_to_n"]
-
-ALIGNMENT = 256
-
-
-def align_up(n: int, alignment: int) -> int:
-    """Return ``n`` rounded up to the next multiple of ``alignment``."""
-    return ((n + alignment - 1) // alignment) * alignment
+__all__ = ["normalized_shape_to_n"]
 
 
 def normalized_shape_to_n(normalized_shape: Sequence[int]) -> int:

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Sequence, Tuple
+from typing import ClassVar, Dict, Optional, Sequence, Tuple
 
 import torch
 
@@ -26,8 +26,8 @@ class RMSNormFwdOp(Op):
     Args:
         normalized_shape: Trailing-axis shape tuple over which the
             reduction runs (manifest ``params.normalized_shape``).
-        eps: Epsilon for numerical stability (manifest ``params.eps``), default
-            ``1e-6``. ``None`` selects that same default. Normalized here, so a
+        eps: Epsilon for numerical stability (manifest ``params.eps``). ``None``
+            selects the same default the signature carries. Normalized here, so a
             backend is handed the number rather than ``None``.
         target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
             in-tree kernels, or ``None`` to decide from the input device.
@@ -41,10 +41,14 @@ class RMSNormFwdOp(Op):
         >>> y = op(x, w)  # shape: (1024, 4096)
     """
 
+    #: Manifest ``params.eps.default``. The signature default and the ``None``
+    #: normalization both read it, so the two cannot drift apart.
+    DEFAULT_EPS = 1.0e-6
+
     def __init__(
         self,
         normalized_shape: Sequence[int],
-        eps: Optional[float] = 1e-6,
+        eps: Optional[float] = DEFAULT_EPS,
         *,
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
@@ -52,9 +56,9 @@ class RMSNormFwdOp(Op):
     ) -> None:
         self.N = normalized_shape_to_n(normalized_shape)
         self.normalized_shape = tuple(int(d) for d in normalized_shape)
-        # Manifest declares ``eps: float | None``; None picks the same 1e-6 the
-        # signature defaults to, so a backend is handed a number either way.
-        self.eps = 1e-6 if eps is None else float(eps)
+        # The manifest type is ``float | None``: an explicit None means the same default,
+        # so a backend is handed a number either way.
+        self.eps = self.DEFAULT_EPS if eps is None else float(eps)
         self.target = target
         self.tune = tune
         self.dispatch_kernel(kernel_map)
@@ -64,9 +68,7 @@ class RMSNormFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"rms_norm": RMSNormKernel}
 
-    @property
-    def compile_op_names(self) -> Tuple[str, ...]:
-        return ("top::norm_rms_norm_fwd",)
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_rms_norm_fwd",)
 
     def _infer_output_shapes(
         self,

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -1,4 +1,3 @@
-import math
 from typing import Dict, Optional, Sequence, Tuple
 
 import torch
@@ -9,10 +8,9 @@ from tileops.kernels.norm import RMSNormKernel
 
 from ..compile_boundary import get_instance
 from ..op_base import Op
+from .norm_base import normalized_shape_to_n
 
 __all__ = ["RMSNormFwdOp"]
-
-_DEFAULT_EPS = 1e-6
 
 
 class RMSNormFwdOp(Op):
@@ -28,8 +26,8 @@ class RMSNormFwdOp(Op):
     Args:
         normalized_shape: Trailing-axis shape tuple over which the
             reduction runs (manifest ``params.normalized_shape``).
-        eps: Epsilon for numerical stability (manifest ``params.eps``).
-            ``None`` selects the documented default ``1e-6``. Normalized here, so a
+        eps: Epsilon for numerical stability (manifest ``params.eps``), default
+            ``1e-6``. ``None`` selects that same default. Normalized here, so a
             backend is handed the number rather than ``None``.
         target: Which set of kernels serves this op — a target name, ``BUILTIN`` for the
             in-tree kernels, or ``None`` to decide from the input device.
@@ -46,21 +44,21 @@ class RMSNormFwdOp(Op):
     def __init__(
         self,
         normalized_shape: Sequence[int],
-        eps: Optional[float] = None,
+        eps: Optional[float] = 1e-6,
         *,
         target: Target = None,
         kernel_map: Optional[Dict[str, Kernel]] = None,
         tune: bool = False,
     ) -> None:
+        self.N = normalized_shape_to_n(normalized_shape)
         self.normalized_shape = tuple(int(d) for d in normalized_shape)
-        if len(self.normalized_shape) == 0:
-            raise ValueError("normalized_shape must be non-empty")
-        self.N = math.prod(self.normalized_shape)
-        self.eps = _DEFAULT_EPS if eps is None else float(eps)
+        # Manifest declares ``eps: float | None``; None picks the same 1e-6 the
+        # signature defaults to, so a backend is handed a number either way.
+        self.eps = 1e-6 if eps is None else float(eps)
         self.target = target
         self.tune = tune
         self.dispatch_kernel(kernel_map)
-        self._last_roofline_mn: Optional[Tuple[int, int]] = None
+        self._last_m: Optional[int] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
@@ -75,12 +73,12 @@ class RMSNormFwdOp(Op):
         return {"output": tuple(x_shape)}
 
     def eval_roofline(self) -> Tuple[int, int]:
-        if self._last_roofline_mn is None or self.dtype is None:
+        if self._last_m is None or self.dtype is None:
             raise RuntimeError(
                 "RMSNormFwdOp.eval_roofline() requires a prior forward() "
                 "call to bind the leading-dims product and the dtype."
             )
-        m, n = self._last_roofline_mn
+        m, n = self._last_m, self.N
         elem_bytes = self.dtype.itemsize
         return (4 * m * n, (2 * m * n + n) * elem_bytes)
 
@@ -133,11 +131,15 @@ class RMSNormFwdOp(Op):
                 self.N, self.eps, x.dtype, tune=self.tune,
             ),
         )
-        self._last_roofline_mn = (x.numel() // self.N, self.N)
+        self._last_m = x.numel() // self.N
         return kernel(x, weight)
 
 
-# torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)
+# torch.compile dispatch boundary. Three constraints make this a pair of module-level
+# functions rather than methods: registration happens at import time and once per
+# qualified name; the schema is read off the annotations, so ``self`` cannot appear in
+# either signature; the instance is recovered from a string key. Why the key is a string
+# and why it is never reused: src/tileops/ops/compile_boundary.py.
 
 
 @torch.library.custom_op("top::norm_rms_norm_fwd", mutates_args=())

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -64,6 +64,10 @@ class RMSNormFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"rms_norm": RMSNormKernel}
 
+    @property
+    def compile_op_names(self) -> Tuple[str, ...]:
+        return ("top::norm_rms_norm_fwd",)
+
     def _infer_output_shapes(
         self,
         x_shape: Tuple[int, ...],

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -7,6 +7,7 @@ from tileops.backend import Target
 from tileops.kernels.kernel_base import Kernel
 from tileops.kernels.norm import RMSNormKernel
 
+from ..compile_boundary import get_instance
 from ..op_base import Op
 
 __all__ = ["RMSNormFwdOp"]
@@ -65,6 +66,14 @@ class RMSNormFwdOp(Op):
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"rms_norm": RMSNormKernel}
 
+    def _infer_output_shapes(
+        self,
+        x_shape: Tuple[int, ...],
+        weight_shape: Tuple[int, ...],
+    ) -> Dict[str, Tuple[int, ...]]:
+        """Manifest ``shape_rules``: ``output.shape == x.shape``."""
+        return {"output": tuple(x_shape)}
+
     def eval_roofline(self) -> Tuple[int, int]:
         if self._last_roofline_mn is None or self.dtype is None:
             raise RuntimeError(
@@ -89,6 +98,10 @@ class RMSNormFwdOp(Op):
             ValueError: Dtypes or devices disagree, or shapes are incompatible with the
                 configured ``normalized_shape``.
         """
+        return _rms_norm_fwd(x, weight, self._instance_key)
+
+    def _eager_forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        """Validate, normalize, resolve the kernel and launch — all untraced."""
         ns = self.normalized_shape
         k = len(ns)
         self._validate_dtypes(x, weight)
@@ -122,3 +135,25 @@ class RMSNormFwdOp(Op):
         )
         self._last_roofline_mn = (x.numel() // self.N, self.N)
         return kernel(x, weight)
+
+
+# torch.compile dispatch boundary (see src/tileops/ops/compile_boundary.py)
+
+
+@torch.library.custom_op("top::norm_rms_norm_fwd", mutates_args=())
+def _rms_norm_fwd(
+    x: torch.Tensor, weight: torch.Tensor, instance_key: str,
+) -> torch.Tensor:
+    return get_instance(instance_key)._eager_forward(x, weight)
+
+
+@_rms_norm_fwd.register_fake
+def _rms_norm_fwd_fake(
+    x: torch.Tensor, weight: torch.Tensor, instance_key: str,
+) -> torch.Tensor:
+    op = get_instance(instance_key)
+    shapes = op._infer_output_shapes(tuple(x.shape), tuple(weight.shape))
+    # ``new_empty``, not ``empty_like``: ``_eager_forward`` normalizes contiguity, so a
+    # non-contiguous public input's strides must not survive into the fake. Dtype is the
+    # manifest's ``same_as(x)``.
+    return x.new_empty(shapes["output"])

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -167,6 +167,28 @@ class Op(ABC):
     def default_kernel_map(self) -> dict[str, Kernel]:
         raise NotImplementedError("Op must implement default_kernel_map")
 
+    # FIXME(staged-rollout): compile_op_names returns () instead of being abstract.
+    #
+    # Broken invariant: an op that declares ``torch_compile_fullgraph`` is not forced to
+    #     say which operators are its own, so nothing checks that the node in the graph
+    #     belongs to the op rather than to a kernel.
+    # Why: most ops still register their custom op in src/tileops/kernels/, where there
+    #     is no op-level name to declare.
+    # Cleanup: make this @abstractmethod once every op that declares
+    #     ``torch_compile_fullgraph`` overrides it, and delete this marker.
+
+    @property
+    def compile_op_names(self) -> tuple[str, ...]:
+        """Operators this op registers on the torch.compile boundary.
+
+        An op that owns its boundary names what it registered, so a test can assert that
+        every node in the traced graph is one of these — that is what keeps the graph the
+        same when another target serves the op. A tuple rather than one name: a
+        conditional in-place write registers two operators. Empty means this op does not
+        own a boundary yet.
+        """
+        return ()
+
     def _infer_output_shapes(self, **shape_kwargs: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
         """Infer output tensor shapes from input shapes.
 

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -2,7 +2,17 @@ import dataclasses
 import warnings
 from abc import ABC, abstractmethod
 from types import MappingProxyType
-from typing import Callable, Hashable, Iterator, Mapping, Optional, Sequence, TypeVar, Union
+from typing import (
+    Callable,
+    ClassVar,
+    Hashable,
+    Iterator,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 import torch
 
@@ -167,27 +177,23 @@ class Op(ABC):
     def default_kernel_map(self) -> dict[str, Kernel]:
         raise NotImplementedError("Op must implement default_kernel_map")
 
-    # FIXME(staged-rollout): compile_op_names returns () instead of being abstract.
+    # FIXME(staged-rollout): compile_op_names defaults to empty instead of being required.
     #
     # Broken invariant: an op that declares ``torch_compile_fullgraph`` is not forced to
     #     say which operators are its own, so nothing checks that the node in the graph
     #     belongs to the op rather than to a kernel.
     # Why: most ops still register their custom op in src/tileops/kernels/, where there
     #     is no op-level name to declare.
-    # Cleanup: make this @abstractmethod once every op that declares
-    #     ``torch_compile_fullgraph`` overrides it, and delete this marker.
+    # Cleanup: once every op that declares ``torch_compile_fullgraph`` names its
+    #     operators, have ``register_compile_contract`` reject an empty tuple, and delete
+    #     this marker.
 
-    @property
-    def compile_op_names(self) -> tuple[str, ...]:
-        """Operators this op registers on the torch.compile boundary.
-
-        An op that owns its boundary names what it registered, so a test can assert that
-        every node in the traced graph is one of these — that is what keeps the graph the
-        same when another target serves the op. A tuple rather than one name: a
-        conditional in-place write registers two operators. Empty means this op does not
-        own a boundary yet.
-        """
-        return ()
+    #: Operators this op registers on the torch.compile boundary. Naming them is what lets
+    #: a test assert the traced graph holds nothing else, which is what keeps the graph the
+    #: same when another target serves the op. A tuple because a conditional in-place write
+    #: registers two; empty means no boundary yet. Registration happens once per class, so
+    #: this is class state.
+    compile_op_names: ClassVar[tuple[str, ...]] = ()
 
     def _infer_output_shapes(self, **shape_kwargs: tuple[int, ...]) -> dict[str, tuple[int, ...]]:
         """Infer output tensor shapes from input shapes.
@@ -378,15 +384,10 @@ class Op(ABC):
 
         settled_here = self._builder is _UNRESOLVED
         if settled_here:
-            # ``__call__`` settled this already — unless it was traced. Dynamo defers the
-            # attribute writes a traced frame makes until after the graph has run, so a
-            # ``forward`` behind the compile dispatch boundary arrives here still holding
-            # ``_UNRESOLVED`` and would take the in-tree path on the very call that chose
-            # a target. Settling again here, untraced, is what makes that first compiled
-            # call obey it.
-            #
-            # A named target and a process default need no device, so those settle here
-            # too. Detection is the one that cannot.
+            # ``__call__`` settled this already — unless it was traced. Dynamo defers a
+            # traced frame's attribute writes until after the graph has run, so a
+            # ``forward`` behind the compile boundary arrives here still ``_UNRESOLVED``
+            # and would take the in-tree path on the very call that chose a target.
             #
             # FIXME(staged-rollout): a call handing over no tensors probes no device.
             #
@@ -565,10 +566,7 @@ class Op(ABC):
             raise
 
     def _unsettle(self) -> None:
-        """Undo a settling whose call did not finish.
-
-        What that call built goes too: those kernels belong to the target just unpinned.
-        """
+        """Undo a settling whose call did not finish, dropping what it built."""
         self._builder = _UNRESOLVED
         self._settled_target = None
         self._kernel_roles = {}

--- a/src/tileops/ops/op_base.py
+++ b/src/tileops/ops/op_base.py
@@ -354,30 +354,61 @@ class Op(ABC):
             entries = {}
             roles[name] = entries
 
-        builder = self._builder
-        if builder is None or builder is _UNRESOLVED:
-            # In-tree: the op knows what its own kernel specializes on, so it says.
-            if build is None:
-                raise OpNotAvailableError(
-                    f"{type(self).__name__} has no in-tree implementation for {name!r}, so "
-                    f"it needs a target that registers one; known targets for this op: "
-                    f"{registered_targets(type(self).__name__)}")
-            if key not in entries:
-                entries[key] = build()
-            return entries[key]
+        settled_here = self._builder is _UNRESOLVED
+        if settled_here:
+            # ``__call__`` settled this already — unless it was traced. Dynamo defers the
+            # attribute writes a traced frame makes until after the graph has run, so a
+            # ``forward`` behind the compile dispatch boundary arrives here still holding
+            # ``_UNRESOLVED`` and would take the in-tree path on the very call that chose
+            # a target. Settling again here, untraced, is what makes that first compiled
+            # call obey it.
+            #
+            # A named target and a process default need no device, so those settle here
+            # too. Detection is the one that cannot.
+            #
+            # FIXME(staged-rollout): a call handing over no tensors probes no device.
+            #
+            # Broken invariant: a first compiled call takes the in-tree path when the
+            #     target would have come from device detection, where eager raises.
+            # Why: ``inputs`` is what carries a device down here, and most op classes
+            #     still call this without it.
+            # Cleanup: delete this marker once every op hands over ``inputs=``.
+            self._resolve_builder(tuple(inputs), {})
 
-        # External: this layer cannot know what the target's kernel specializes on, so it
-        # keys on every cheap fact it has: the dtype and shape of each input.
-        if not inputs:
-            raise OpNotAvailableError(
-                f"target {self._settled_target!r} serves {type(self).__name__}, but its "
-                f"{name!r} call site does not hand over the tensors a builder is described "
-                f"with; that op is not wired to external targets yet")
-        specs = tuple(TensorSpec.of(t) for t in inputs)
-        signature = tuple((spec.dtype, spec.shape) for spec in specs)
-        if signature not in entries:
-            entries[signature] = self._build_external(builder, name, specs)
-        return entries[signature]
+        try:
+            builder = self._builder
+            if builder is None or builder is _UNRESOLVED:
+                # In-tree: the op knows what its own kernel specializes on, so it says.
+                if build is None:
+                    raise OpNotAvailableError(
+                        f"{type(self).__name__} has no in-tree implementation for {name!r}, "
+                        f"so it needs a target that registers one; known targets for this "
+                        f"op: {registered_targets(type(self).__name__)}")
+                if key not in entries:
+                    entries[key] = build()
+                return entries[key]
+
+            # External: this layer cannot know what the target's kernel specializes on, so
+            # it keys on every cheap fact it has: the dtype and shape of each input.
+            if not inputs:
+                raise OpNotAvailableError(
+                    f"target {self._settled_target!r} serves {type(self).__name__}, but its "
+                    f"{name!r} call site does not hand over the tensors a builder is "
+                    f"described with; that op is not wired to external targets yet")
+            specs = tuple(TensorSpec.of(t) for t in inputs)
+            # The device is part of the key: a kernel built for one of a target's devices
+            # may hold resources allocated on it. The op layer has already checked that
+            # this call's tensors agree on a device, so the first one speaks for all.
+            signature = (specs[0].device,) + tuple((spec.dtype, spec.shape) for spec in specs)
+            if signature not in entries:
+                entries[signature] = self._build_external(builder, name, specs)
+            return entries[signature]
+        except Exception:
+            # Whoever settled it unsettles it. ``__call__``'s handler does not run when
+            # the failure comes out of a compiled graph, so this one has to.
+            if settled_here:
+                self._unsettle()
+            raise
 
     def _build_external(
         self, builder: BuildKernel, name: str, specs: tuple[TensorSpec, ...],
@@ -493,7 +524,8 @@ class Op(ABC):
 
         Settles which set of kernels serves this instance, once, then delegates to
         ``forward`` — which is the same for every target. The only fork is inside
-        :meth:`get_or_build_kernel`.
+        :meth:`get_or_build_kernel`, which settles it a second time when this settling
+        could not reach it; see there.
 
         A call that fails settles nothing. Otherwise one invalid call would aim the instance
         for good: ``op(x_cpu, weight_cuda)`` picks a target from the first tensor, then
@@ -507,11 +539,17 @@ class Op(ABC):
         try:
             return self.forward(*args, **kwargs)
         except Exception:
-            # Also drop what was built: those kernels belong to the target just unpinned.
-            self._builder = _UNRESOLVED
-            self._settled_target = None
-            self._kernel_roles = {}
+            self._unsettle()
             raise
+
+    def _unsettle(self) -> None:
+        """Undo a settling whose call did not finish.
+
+        What that call built goes too: those kernels belong to the target just unpinned.
+        """
+        self._builder = _UNRESOLVED
+        self._settled_target = None
+        self._kernel_roles = {}
 
     def _resolve_builder(self, args: tuple, kwargs: dict) -> None:
         """Decide which target serves this instance and remember its builder.

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -18,6 +18,7 @@ import importlib
 _EVIDENCE_MODULES = (
     "tests.ops.test_elementwise_compile",
     "tests.ops.test_pool",
+    "tests.ops.test_rms_norm",
     "tests.test_compile",
 )
 

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -36,29 +36,26 @@ def register_compile_contract(op_cls: type) -> None:
     _registered.add(op_cls.__name__)
 
 
+def _overload(name: str):
+    """``"top::foo"`` as the overload object a graph node carries."""
+    namespace, _, opname = name.partition("::")
+    return getattr(getattr(torch.ops, namespace), opname).default
+
+
 def assert_op_owns_graph_nodes(op, *inputs) -> None:
     """Compile *op* once and assert the graph holds nothing but its own operators.
 
-    What the graph contains is what has to stay the same when another target serves this
-    op. The op says which operators are its own through ``compile_op_names``; anything
-    else in the graph — a kernel's own registration, or a tensor op left outside the
-    boundary — means the node identity is not the op's alone.
-
-    Args:
-        op: The op instance, already constructed.
-        *inputs: Arguments to call it with.
-
-    Raises:
-        AssertionError: The op names no operators, or the graph holds a node that is not
-            one of them.
+    A kernel's own registration, or a tensor op left outside the boundary, would show up
+    here — either means the node identity is not the op's alone, so another target could
+    change the graph.
     """
-    declared = {name.replace("::", ".") + ".default" for name in op.compile_op_names}
+    declared = {_overload(name) for name in type(op).compile_op_names}
     assert declared, f"{type(op).__name__} declares no compile_op_names"
 
-    traced: list[list[str]] = []
+    traced: list[list[object]] = []
 
     def capture(gm, example_inputs):
-        traced.append([str(node.target) for node in gm.graph.nodes
+        traced.append([node.target for node in gm.graph.nodes
                        if node.op == "call_function"])
         return gm.forward
 
@@ -67,8 +64,9 @@ def assert_op_owns_graph_nodes(op, *inputs) -> None:
     (calls,) = traced
     assert calls, "the traced graph called nothing"
     assert set(calls) <= declared, (
-        f"graph holds nodes this op does not own: {sorted(set(calls) - declared)}; "
-        f"declared: {sorted(declared)}")
+        f"graph holds nodes this op does not own: "
+        f"{sorted(str(c) for c in set(calls) - declared)}; "
+        f"declared: {sorted(str(d) for d in declared)}")
 
 
 def compile_contract_ops() -> frozenset[str]:

--- a/tests/compile_contract.py
+++ b/tests/compile_contract.py
@@ -13,6 +13,8 @@ contract must not register here.
 
 import importlib
 
+import torch
+
 # Modules whose import populates the registry. Add a module here when it
 # gains contract-backing compile tests.
 _EVIDENCE_MODULES = (
@@ -32,6 +34,41 @@ def register_compile_contract(op_cls: type) -> None:
     promise. Side-effect only.
     """
     _registered.add(op_cls.__name__)
+
+
+def assert_op_owns_graph_nodes(op, *inputs) -> None:
+    """Compile *op* once and assert the graph holds nothing but its own operators.
+
+    What the graph contains is what has to stay the same when another target serves this
+    op. The op says which operators are its own through ``compile_op_names``; anything
+    else in the graph — a kernel's own registration, or a tensor op left outside the
+    boundary — means the node identity is not the op's alone.
+
+    Args:
+        op: The op instance, already constructed.
+        *inputs: Arguments to call it with.
+
+    Raises:
+        AssertionError: The op names no operators, or the graph holds a node that is not
+            one of them.
+    """
+    declared = {name.replace("::", ".") + ".default" for name in op.compile_op_names}
+    assert declared, f"{type(op).__name__} declares no compile_op_names"
+
+    traced: list[list[str]] = []
+
+    def capture(gm, example_inputs):
+        traced.append([str(node.target) for node in gm.graph.nodes
+                       if node.op == "call_function"])
+        return gm.forward
+
+    torch.compile(op, backend=capture, fullgraph=True)(*inputs)
+
+    (calls,) = traced
+    assert calls, "the traced graph called nothing"
+    assert set(calls) <= declared, (
+        f"graph holds nodes this op does not own: {sorted(set(calls) - declared)}; "
+        f"declared: {sorted(declared)}")
 
 
 def compile_contract_ops() -> frozenset[str]:

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -167,19 +167,12 @@ def test_a_warmed_up_op_can_be_captured_and_replayed() -> None:
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
 def test_a_cold_op_traces_fullgraph_and_matches_eager() -> None:
-    """The kernel is built inside the dispatch custom op, so a cold trace must hold.
-
-    Cold is the whole contract: a warm op has nothing left to build, so tracing it
-    would pass even with the boundary in the wrong place.
-    """
+    """Cold is the whole contract: a warm op has nothing left for dynamo to trace into."""
     op = RMSNormFwdOp(normalized_shape=(4096,))
     x = torch.randn(64, 4096, dtype=torch.float16, device="cuda")
     weight = torch.randn(4096, dtype=torch.float16, device="cuda")
 
-    output = torch.compile(op, fullgraph=True)(x, weight)
-
-    assert output.shape == x.shape
-    torch.testing.assert_close(output, op(x, weight))
+    torch.testing.assert_close(torch.compile(op, fullgraph=True)(x, weight), op(x, weight))
 
 
 @pytest.mark.smoke
@@ -196,11 +189,7 @@ def test_the_traced_graph_holds_only_this_ops_operator() -> None:
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
 def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> None:
-    """Contiguity is normalized inside the opaque body, after the fake has spoken.
-
-    So the fake describes the public input's shape with contiguous strides; taking
-    the input's strides instead would make the compiled graph assert.
-    """
+    """The fake speaks before the body normalizes contiguity, so it promises contiguous."""
     op = RMSNormFwdOp(normalized_shape=(256,))
     x = torch.randn(8, 512, dtype=torch.float16, device="cuda")[:, ::2]
     weight = torch.randn(256, dtype=torch.float16, device="cuda")
@@ -208,7 +197,7 @@ def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> Non
 
     output = torch.compile(op, fullgraph=True)(x, weight)
 
-    assert output.shape == x.shape and output.is_contiguous()
+    assert output.is_contiguous()
     torch.testing.assert_close(output, op(x, weight))
 
 

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -1,9 +1,12 @@
 import pytest
 import torch
 
+from tests.compile_contract import register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 from workloads.normalization import RMSNormWorkload
+
+register_compile_contract(RMSNormFwdOp)
 
 
 class RMSNormTest(RMSNormWorkload, TestBase):
@@ -159,6 +162,68 @@ def test_a_warmed_up_op_can_be_captured_and_replayed() -> None:
     torch.cuda.synchronize()
 
     assert torch.allclose(static_out, expected, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_a_cold_op_traces_fullgraph_and_matches_eager() -> None:
+    """The kernel is built inside the dispatch custom op, so a cold trace must hold.
+
+    Cold is the whole contract: a warm op has nothing left to build, so tracing it
+    would pass even with the boundary in the wrong place.
+    """
+    op = RMSNormFwdOp(normalized_shape=(4096,))
+    x = torch.randn(64, 4096, dtype=torch.float16, device="cuda")
+    weight = torch.randn(4096, dtype=torch.float16, device="cuda")
+
+    output = torch.compile(op, fullgraph=True)(x, weight)
+
+    assert output.shape == x.shape
+    torch.testing.assert_close(output, op(x, weight))
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_the_traced_graph_holds_one_opaque_node() -> None:
+    """One node, and none of the kernel's own machinery.
+
+    What the graph contains is what stays the same when another target serves this
+    op: the node is the op's, so replacing the kernel cannot change the graph.
+    """
+    op = RMSNormFwdOp(normalized_shape=(256,))
+    x = torch.randn(8, 256, dtype=torch.float16, device="cuda")
+    weight = torch.randn(256, dtype=torch.float16, device="cuda")
+
+    traced = []
+
+    def capture(gm, example_inputs):
+        traced.append([str(node.target) for node in gm.graph.nodes
+                       if node.op == "call_function"])
+        return gm.forward
+
+    torch.compile(op, backend=capture, fullgraph=True)(x, weight)
+
+    (calls,) = traced
+    assert calls == ["top.norm_rms_norm_fwd.default"], calls
+
+
+@pytest.mark.smoke
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_a_non_contiguous_input_compiles_to_the_shape_the_fake_promised() -> None:
+    """Contiguity is normalized inside the opaque body, after the fake has spoken.
+
+    So the fake describes the public input's shape with contiguous strides; taking
+    the input's strides instead would make the compiled graph assert.
+    """
+    op = RMSNormFwdOp(normalized_shape=(256,))
+    x = torch.randn(8, 512, dtype=torch.float16, device="cuda")[:, ::2]
+    weight = torch.randn(256, dtype=torch.float16, device="cuda")
+    assert not x.is_contiguous()
+
+    output = torch.compile(op, fullgraph=True)(x, weight)
+
+    assert output.shape == x.shape and output.is_contiguous()
+    torch.testing.assert_close(output, op(x, weight))
 
 
 if __name__ == "__main__":

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from tests.compile_contract import register_compile_contract
+from tests.compile_contract import assert_op_owns_graph_nodes, register_compile_contract
 from tests.test_base import FixtureBase, TestBase
 from tileops.ops.norm.rms_norm import RMSNormFwdOp
 from workloads.normalization import RMSNormWorkload
@@ -184,27 +184,13 @@ def test_a_cold_op_traces_fullgraph_and_matches_eager() -> None:
 
 @pytest.mark.smoke
 @pytest.mark.usefixtures("isolated_dynamo")
-def test_the_traced_graph_holds_one_opaque_node() -> None:
-    """One node, and none of the kernel's own machinery.
-
-    What the graph contains is what stays the same when another target serves this
-    op: the node is the op's, so replacing the kernel cannot change the graph.
-    """
+def test_the_traced_graph_holds_only_this_ops_operator() -> None:
+    """The node is the op's, so replacing the kernel cannot change the graph."""
     op = RMSNormFwdOp(normalized_shape=(256,))
     x = torch.randn(8, 256, dtype=torch.float16, device="cuda")
     weight = torch.randn(256, dtype=torch.float16, device="cuda")
 
-    traced = []
-
-    def capture(gm, example_inputs):
-        traced.append([str(node.target) for node in gm.graph.nodes
-                       if node.op == "call_function"])
-        return gm.forward
-
-    torch.compile(op, backend=capture, fullgraph=True)(x, weight)
-
-    (calls,) = traced
-    assert calls == ["top.norm_rms_norm_fwd.default"], calls
+    assert_op_owns_graph_nodes(op, x, weight)
 
 
 @pytest.mark.smoke

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -54,6 +54,17 @@ def _register(recorder, target="acme", op="RMSNormFwdOp", claims=True):
     registry.register_kernel_builder(op, target, recorder.build_kernel)
 
 
+def _stub_op(**kwargs):
+    """An op of the kind that still takes a kernel without handing over its tensors."""
+
+    class StubOp(RMSNormFwdOp):
+        def forward(self, x, weight):
+            return self.get_or_build_kernel("stub", key=x.dtype, build=lambda: None)
+
+    StubOp.__name__ = "StubOp"
+    return StubOp(normalized_shape=NORMALIZED_SHAPE, **kwargs)
+
+
 def _inputs(rows=4, shape=NORMALIZED_SHAPE, dtype=DTYPE, device="cpu"):
     x = torch.randn(rows, *shape, dtype=dtype, device=device)
     weight = torch.randn(*shape, dtype=dtype, device=device)
@@ -74,7 +85,7 @@ def test_a_target_takes_over_the_op_and_is_asked_with_the_manifest_signature():
 
     (inputs, params), = recorder.calls
     assert inputs == (TensorSpec.of(x), TensorSpec.of(weight)), "signature.inputs order"
-    # eps defaults to null in the manifest; the op settles it, so a backend gets a number.
+    # eps is optional; whether it was passed or defaulted, a backend gets the number.
     assert params == {"normalized_shape": NORMALIZED_SHAPE, "eps": 1e-6}
     assert torch.equal(out, torch.full_like(x, 7)), "the target's kernel produced the result"
 
@@ -131,6 +142,8 @@ def test_the_same_input_signature_is_built_once():
     [
         (dict(rows=8), "a different shape may need a different kernel"),
         (dict(dtype=torch.bfloat16), "a different dtype certainly does"),
+        # A second real device, not meta: meta inputs dispatch to the op's fake, which
+        # returns before a kernel is ever asked for.
         (dict(device="cuda"), "a kernel may hold resources allocated on one device"),
     ],
     ids=["shape", "dtype", "device"],
@@ -180,15 +193,8 @@ def test_an_op_that_has_not_handed_over_its_tensors_says_so():
     recorder = _Recorder()
     _register(recorder, op="StubOp")
 
-    class StubOp(RMSNormFwdOp):
-        """Stands in for the ops that still call get_or_build_kernel without inputs."""
-
-        def forward(self, x, weight):
-            return self.get_or_build_kernel("stub", key=x.dtype, build=lambda: None)
-
-    StubOp.__name__ = "StubOp"
     with pytest.raises(OpNotAvailableError, match="not wired to external targets yet"):
-        StubOp(normalized_shape=NORMALIZED_SHAPE)(*_inputs())
+        _stub_op()(*_inputs())
 
 
 def test_builtin_keeps_the_in_tree_kernels_even_when_a_target_claims_the_device():
@@ -279,13 +285,7 @@ def test_a_call_that_fails_validation_pins_nothing():
 
 @pytest.mark.usefixtures("isolated_dynamo")
 def test_the_first_compiled_call_obeys_the_target_it_picked():
-    """A traced ``__call__`` cannot be the only place the target is settled.
-
-    Dynamo defers the attribute writes a traced frame makes until after the graph has
-    run, so the dispatch custom op — which runs inside the graph — would read the
-    instance as unsettled and take the in-tree path. That is wrong numbers, silently,
-    on the first compiled call only, which is why it needs a test rather than a comment.
-    """
+    """Settling only in a traced ``__call__`` gives the in-tree kernel's numbers, once."""
     recorder = _Recorder()
     _register(recorder)
     op = RMSNormFwdOp(normalized_shape=NORMALIZED_SHAPE)
@@ -294,47 +294,35 @@ def test_the_first_compiled_call_obeys_the_target_it_picked():
     output = torch.compile(op, fullgraph=True)(x, weight)
 
     assert torch.equal(output, torch.full_like(x, 7)), "the in-tree kernel ran instead"
-    assert op._settled_target == "acme"
     assert len(recorder.calls) == 1
 
 
 @pytest.mark.usefixtures("isolated_dynamo")
 def test_a_compiled_call_whose_build_fails_pins_nothing():
-    """The settling and its undo have to sit together.
+    """``__call__``'s handler does not run when the failure comes out of a compiled graph."""
+    attempts = []
 
-    ``__call__``'s handler does not run when the failure surfaces out of a compiled
-    graph, so a first compiled call that settled a target and then failed to build for
-    it would leave the instance pinned to a target that never produced a kernel.
-    """
-    recorder = _Recorder()
-    recorder.build_kernel = lambda *inputs, **params: "not a kernel"
-    _register(recorder)
+    def build_kernel(*inputs, **params):
+        attempts.append(1)
+        return "not a kernel" if len(attempts) == 1 else (lambda x, w: torch.full_like(x, 7))
+
+    registry.register_detector("acme", lambda device: True)
+    registry.register_kernel_builder("RMSNormFwdOp", "acme", build_kernel)
     op = RMSNormFwdOp(normalized_shape=NORMALIZED_SHAPE)
 
     with pytest.raises(OpNotAvailableError, match="not callable"):
         torch.compile(op, fullgraph=True)(*_inputs())
 
-    assert op._settled_target is None and not op.built_kernels("rms_norm")
+    x, weight = _inputs()
+    assert torch.equal(op(x, weight), torch.full_like(x, 7)), "asking again tries again"
 
 
 def test_a_call_without_tensors_still_honours_an_explicit_target():
-    """An op the target does not serve raises, whether or not ``__call__`` ran first.
-
-    A named target needs no device to be resolved, so the call site handing over no
-    tensors is no reason to fall back to the in-tree kernels.
-    """
+    """A named target needs no device, so handing over no tensors is no reason to fall back."""
     _register(_Recorder(), op="StubOp")
 
-    class StubOp(RMSNormFwdOp):
-        """Stands in for the ops that still call get_or_build_kernel without inputs."""
-
-        def forward(self, x, weight):
-            return self.get_or_build_kernel("stub", key=x.dtype, build=lambda: None)
-
-    StubOp.__name__ = "StubOp"
-    op = StubOp(normalized_shape=NORMALIZED_SHAPE, target="acme")
     with pytest.raises(OpNotAvailableError, match="not wired to external targets yet"):
-        op.forward(*_inputs())
+        _stub_op(target="acme").forward(*_inputs())
 
 
 def test_a_settled_instance_is_bound_to_that_target_s_devices():

--- a/tests/test_op_backend_seam.py
+++ b/tests/test_op_backend_seam.py
@@ -54,9 +54,9 @@ def _register(recorder, target="acme", op="RMSNormFwdOp", claims=True):
     registry.register_kernel_builder(op, target, recorder.build_kernel)
 
 
-def _inputs(rows=4, shape=NORMALIZED_SHAPE, dtype=DTYPE):
-    x = torch.randn(rows, *shape, dtype=dtype)
-    weight = torch.randn(*shape, dtype=dtype)
+def _inputs(rows=4, shape=NORMALIZED_SHAPE, dtype=DTYPE, device="cpu"):
+    x = torch.randn(rows, *shape, dtype=dtype, device=device)
+    weight = torch.randn(*shape, dtype=dtype, device=device)
     return x, weight
 
 
@@ -131,8 +131,9 @@ def test_the_same_input_signature_is_built_once():
     [
         (dict(rows=8), "a different shape may need a different kernel"),
         (dict(dtype=torch.bfloat16), "a different dtype certainly does"),
+        (dict(device="cuda"), "a kernel may hold resources allocated on one device"),
     ],
-    ids=["shape", "dtype"],
+    ids=["shape", "dtype", "device"],
 )
 def test_a_different_input_signature_asks_again(second, why):
     recorder = _Recorder()
@@ -274,6 +275,66 @@ def test_a_call_that_fails_validation_pins_nothing():
     op(*_inputs())
     assert op._settled_target == "cpu_target", "the first call that worked decides"
     assert len(recorder.calls) == 1
+
+
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_the_first_compiled_call_obeys_the_target_it_picked():
+    """A traced ``__call__`` cannot be the only place the target is settled.
+
+    Dynamo defers the attribute writes a traced frame makes until after the graph has
+    run, so the dispatch custom op — which runs inside the graph — would read the
+    instance as unsettled and take the in-tree path. That is wrong numbers, silently,
+    on the first compiled call only, which is why it needs a test rather than a comment.
+    """
+    recorder = _Recorder()
+    _register(recorder)
+    op = RMSNormFwdOp(normalized_shape=NORMALIZED_SHAPE)
+    x, weight = _inputs()
+
+    output = torch.compile(op, fullgraph=True)(x, weight)
+
+    assert torch.equal(output, torch.full_like(x, 7)), "the in-tree kernel ran instead"
+    assert op._settled_target == "acme"
+    assert len(recorder.calls) == 1
+
+
+@pytest.mark.usefixtures("isolated_dynamo")
+def test_a_compiled_call_whose_build_fails_pins_nothing():
+    """The settling and its undo have to sit together.
+
+    ``__call__``'s handler does not run when the failure surfaces out of a compiled
+    graph, so a first compiled call that settled a target and then failed to build for
+    it would leave the instance pinned to a target that never produced a kernel.
+    """
+    recorder = _Recorder()
+    recorder.build_kernel = lambda *inputs, **params: "not a kernel"
+    _register(recorder)
+    op = RMSNormFwdOp(normalized_shape=NORMALIZED_SHAPE)
+
+    with pytest.raises(OpNotAvailableError, match="not callable"):
+        torch.compile(op, fullgraph=True)(*_inputs())
+
+    assert op._settled_target is None and not op.built_kernels("rms_norm")
+
+
+def test_a_call_without_tensors_still_honours_an_explicit_target():
+    """An op the target does not serve raises, whether or not ``__call__`` ran first.
+
+    A named target needs no device to be resolved, so the call site handing over no
+    tensors is no reason to fall back to the in-tree kernels.
+    """
+    _register(_Recorder(), op="StubOp")
+
+    class StubOp(RMSNormFwdOp):
+        """Stands in for the ops that still call get_or_build_kernel without inputs."""
+
+        def forward(self, x, weight):
+            return self.get_or_build_kernel("stub", key=x.dtype, build=lambda: None)
+
+    StubOp.__name__ = "StubOp"
+    op = StubOp(normalized_shape=NORMALIZED_SHAPE, target="acme")
+    with pytest.raises(OpNotAvailableError, match="not wired to external targets yet"):
+        op.forward(*_inputs())
 
 
 def test_a_settled_instance_is_bound_to_that_target_s_devices():


### PR DESCRIPTION

## Problems

- `torch.compile(op, fullgraph=True)` did not hold for `RMSNormFwdOp`: dynamo traced into `RMSNormKernel.__init__` cold, and into `@tilelang.jit` warm.
- The `custom_op` sat in the kernel file, so its schema carried `block_m`/`threads` and its fake returned the padded intermediate shape.
- The first compiled call ran the in-tree kernel under an external target.
- A failed first compiled build left the instance pinned to that target.
- The external memo key omitted the device.
- Nothing checked that the node in the traced graph belongs to the op rather than to a kernel.
- `batch_norm` reached the boundary through six post-class attribute assignments, which left each class's own `forward` unreachable.
- `eps` disagreed between the constructor default and the manifest.

## Changes

- `RMSNormFwdOp.forward` is one dispatch call; the `custom_op` and its manifest-driven fake are in the op layer; the kernel-level `custom_op` is deleted.
- `get_or_build_kernel` settles the target untraced, and undoes it there when its own build fails.
- The memo key is the device plus the per-input `(dtype, shape)`.
- `Op.compile_op_names` names the operators an op registered; `assert_op_owns_graph_nodes` asserts the traced graph holds nothing else. Class state, since registration is per class.
- `batch_norm`: the dispatch call is in `forward`, `_forward_impl` is `_eager_forward`, `_wrapped` is gone. No behaviour change, 57 lines lighter.
- `params.eps.default` is the constant it always was, held once in `RMSNormFwdOp.DEFAULT_EPS`.
- The alignment helpers the norm and engram kernels each carried are one `src/tileops/kernels/tiling.py`, and `normalized_shape_to_n` is one `norm_base.py` helper.
- `torch_compile_fullgraph: true` on `RMSNormFwdOp`. Test nodes: `tests/ops/test_rms_norm.py` 19 -> 22, `tests/test_op_backend_seam.py` 16 -> 20.

## Performance

H200, idle GPU. Kernel rows from `benchmarks/ops/bench_norm.py -k rms_norm_bench`; per-call rows
are minima of 2000 iterations x 9 repeats, three runs per side.

| | main | this branch |
| --- | --- | --- |
| kernel, 2048x4096 fp16 | 0.0119 ms | 0.0117 ms |
| kernel, 2048x8192 fp16 | 0.0213 ms | 0.0214 ms |
| kernel, 2048x16384 fp16 | 0.0418 ms | 0.0419 ms |
| eager, per call | 42.5-45.2 us | 38.2-42.0 us |
| compiled, per call | does not compile | 92-103 us |

## Left open

- A first compiled call still takes the in-tree path when the target would have come from device detection: settling needs a device, and only this op hands over `inputs=`. Marked `FIXME(staged-rollout)`, cleared when every op does.
- `compile_op_names` is declared by `RMSNormFwdOp` only; the other ops declare theirs as their boundaries move to the op layer, after which `register_compile_contract` can reject an empty one.