### PR TITLE
[Refactor][Ops] Name the compile-boundary key after its op, and make RMSNormFwdOp the reference example

### DIFF
--- a/src/tileops/ops/compile_boundary.py
+++ b/src/tileops/ops/compile_boundary.py
@@ -1,19 +1,28 @@
-"""Opaque dispatch boundary for torch.compile.
+"""Lets a torch.compile dispatch boundary find the op instance behind it.
 
-Invariant: a dynamo-traced ``Op.forward`` must not construct kernels or
-enter a TileLang builder. Lazy-dispatch ops route ``forward`` through a
-``torch.library.custom_op`` whose eager body resolves the instance here
-and runs the untraced path (cache lookup, kernel construction, launch).
+An operator's schema has no type for an op object, so ``self`` cannot cross the boundary.
+The op passes its key instead, and the operator body trades the key back for the instance:
 
-``Op.dispatch_kernel`` registers every conforming op at ``__init__``
-time; weak references keep the registry from extending lifetimes. Keys
-are strings because dynamo treats string custom-op arguments as static
-constants — an ``int`` key is generalized to an unhashable ``SymInt``
-once a second instance compiles through the same frame.
+    class FooOp(Op):
+        def forward(self, x):
+            return _foo(x, self._instance_key)
 
-Being a constant is also why keys must never repeat: inductor bakes the
-fake's output shape into the artifact, so an op reaching a used key
-inherits the first one's shapes. ``id()`` is an address and gets reissued.
+    @torch.library.custom_op("top::foo", mutates_args=())
+    def _foo(x: torch.Tensor, instance_key: str) -> torch.Tensor:
+        return get_instance(instance_key)._eager_forward(x)
+
+``Op.dispatch_kernel`` assigns ``self._instance_key`` during ``__init__``, so an op gets a
+key without writing any registration code. Keys read as ``RMSNormFwdOp#3``, so a key in a
+graph dump or traceback says whose it is.
+
+The invariant this exists to keep: a dynamo-traced ``forward`` must not construct kernels or
+enter a TileLang builder. Everything past the operator body is untraced, so cache lookup,
+kernel construction and launch belong there.
+
+Two properties are load-bearing. The key is a ``str`` because dynamo treats string operator
+arguments as compile-time constants, while an ``int`` is generalized to an unhashable
+``SymInt``. A key is never reused, not even after its op is collected, because inductor bakes
+the fake's output shape into the artifact.
 """
 
 import itertools
@@ -25,7 +34,8 @@ _KEY_COUNTER = itertools.count()
 
 def register_instance(op: object) -> str:
     """Register ``op`` and return the key its dispatch custom op passes back."""
-    key = f"op{next(_KEY_COUNTER)}"
+    # ``#`` cannot appear in a class name, so no two classes can produce the same key.
+    key = f"{type(op).__name__}#{next(_KEY_COUNTER)}"
     _OP_REGISTRY[key] = op
     return key
 

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -4,15 +4,15 @@ An op that wants ``torch.compile(op, fullgraph=True)`` writes these five:
 
 1. ``forward`` — one call to the module-level operator, nothing else. This is as far as
    dynamo traces.
-2. ``_eager_forward`` — what ``forward`` used to hold. It runs inside the operator, so
-   validation, kernel construction and the launch are never traced.
+2. ``_eager_forward`` — validation, kernel construction and the launch. It runs inside the
+   operator, so none of it is traced.
 3. ``_rms_norm_fwd`` — the operator, registered once at import time.
 4. ``_rms_norm_fwd_fake`` — what the compiler is told about the output while tracing.
 5. ``compile_op_names`` — the operator's name, which lets a test assert that the traced
    graph holds nothing else.
 
-The sixth part comes from the base class: ``dispatch_kernel`` assigns the
-``_instance_key`` that piece 1 passes across the boundary.
+``_instance_key`` comes from the base class: ``dispatch_kernel`` assigns it during
+``__init__``.
 """
 
 from typing import ClassVar, Dict, Optional, Sequence, Tuple
@@ -62,8 +62,7 @@ class RMSNormFwdOp(Op):
     #: normalization both read it, so the two cannot drift apart.
     DEFAULT_EPS = 1.0e-6
 
-    #: The operator this op registers on the compile boundary. Tests assert the traced
-    #: graph holds nothing but this.
+    #: The operator this op registers; a test asserts the graph holds nothing else.
     compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_rms_norm_fwd",)
 
     def __init__(
@@ -82,8 +81,6 @@ class RMSNormFwdOp(Op):
         self.eps = self.DEFAULT_EPS if eps is None else float(eps)
         self.target = target
         self.tune = tune
-        # Installs the kernel map, and assigns the ``_instance_key`` that ``forward``
-        # passes across the boundary.
         self.dispatch_kernel(kernel_map)
         self._last_m: Optional[int] = None
 
@@ -127,10 +124,9 @@ class RMSNormFwdOp(Op):
         return _rms_norm_fwd(x, weight, self._instance_key)
 
     def _eager_forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        """Validate, normalize, resolve the kernel and launch.
+        """Validate, normalize, resolve the kernel and launch, inside the operator.
 
-        Runs inside the operator, never under dynamo: kernel construction enters a
-        TileLang builder, which is not traceable.
+        Never traced: kernel construction enters a TileLang builder, which dynamo cannot follow.
         """
         ns = self.normalized_shape
         k = len(ns)

--- a/src/tileops/ops/norm/rms_norm.py
+++ b/src/tileops/ops/norm/rms_norm.py
@@ -1,3 +1,20 @@
+"""RMS norm, and the shape an op takes once its compile boundary is in the op layer.
+
+An op that wants ``torch.compile(op, fullgraph=True)`` writes these five:
+
+1. ``forward`` — one call to the module-level operator, nothing else. This is as far as
+   dynamo traces.
+2. ``_eager_forward`` — what ``forward`` used to hold. It runs inside the operator, so
+   validation, kernel construction and the launch are never traced.
+3. ``_rms_norm_fwd`` — the operator, registered once at import time.
+4. ``_rms_norm_fwd_fake`` — what the compiler is told about the output while tracing.
+5. ``compile_op_names`` — the operator's name, which lets a test assert that the traced
+   graph holds nothing else.
+
+The sixth part comes from the base class: ``dispatch_kernel`` assigns the
+``_instance_key`` that piece 1 passes across the boundary.
+"""
+
 from typing import ClassVar, Dict, Optional, Sequence, Tuple
 
 import torch
@@ -45,6 +62,10 @@ class RMSNormFwdOp(Op):
     #: normalization both read it, so the two cannot drift apart.
     DEFAULT_EPS = 1.0e-6
 
+    #: The operator this op registers on the compile boundary. Tests assert the traced
+    #: graph holds nothing but this.
+    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_rms_norm_fwd",)
+
     def __init__(
         self,
         normalized_shape: Sequence[int],
@@ -61,14 +82,14 @@ class RMSNormFwdOp(Op):
         self.eps = self.DEFAULT_EPS if eps is None else float(eps)
         self.target = target
         self.tune = tune
+        # Installs the kernel map, and assigns the ``_instance_key`` that ``forward``
+        # passes across the boundary.
         self.dispatch_kernel(kernel_map)
         self._last_m: Optional[int] = None
 
     @property
     def default_kernel_map(self) -> Dict[str, Kernel]:
         return {"rms_norm": RMSNormKernel}
-
-    compile_op_names: ClassVar[Tuple[str, ...]] = ("top::norm_rms_norm_fwd",)
 
     def _infer_output_shapes(
         self,
@@ -100,12 +121,17 @@ class RMSNormFwdOp(Op):
 
         Raises:
             ValueError: Dtypes or devices disagree, or shapes are incompatible with the
-                configured ``normalized_shape``.
+                configured ``normalized_shape``. Raised from inside the operator, by
+                :meth:`_eager_forward`.
         """
         return _rms_norm_fwd(x, weight, self._instance_key)
 
     def _eager_forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
-        """Validate, normalize, resolve the kernel and launch — all untraced."""
+        """Validate, normalize, resolve the kernel and launch.
+
+        Runs inside the operator, never under dynamo: kernel construction enters a
+        TileLang builder, which is not traceable.
+        """
         ns = self.normalized_shape
         k = len(ns)
         self._validate_dtypes(x, weight)
@@ -132,7 +158,7 @@ class RMSNormFwdOp(Op):
         kernel = self.get_or_build_kernel(
             "rms_norm",
             (x, weight),
-            key=x.dtype,
+            key=x.dtype,                      # this instance's in-tree cache key
             build=lambda: self.kernel_map["rms_norm"](
                 self.N, self.eps, x.dtype, tune=self.tune,
             ),
@@ -141,11 +167,11 @@ class RMSNormFwdOp(Op):
         return kernel(x, weight)
 
 
-# torch.compile dispatch boundary. Three constraints make this a pair of module-level
-# functions rather than methods: registration happens at import time and once per
-# qualified name; the schema is read off the annotations, so ``self`` cannot appear in
-# either signature; the instance is recovered from a string key. Why the key is a string
-# and why it is never reused: src/tileops/ops/compile_boundary.py.
+# Both are module-level functions rather than methods, for three reasons: registration
+# happens at import time and once per qualified name; the schema is read off the
+# annotations, so ``self`` cannot appear in either signature; the instance is therefore
+# recovered from a string key. Why that key is a string and why it is never reused:
+# src/tileops/ops/compile_boundary.py.
 
 
 @torch.library.custom_op("top::norm_rms_norm_fwd", mutates_args=())

--- a/src/tileops/ops/rope.py
+++ b/src/tileops/ops/rope.py
@@ -19,8 +19,7 @@ torch.compile support:
 - All 5 concrete ops are registered via @torch.library.custom_op at module
   load time.  A factory function (_register_rope_custom_op) registers every
   op; instances are looked up at runtime through the shared registry in
-  tileops.ops.compile_boundary, keyed by
-  id(instance).
+  tileops.ops.compile_boundary, keyed by the instance's string key.
 """
 
 import math

--- a/tests/test_op_base.py
+++ b/tests/test_op_base.py
@@ -432,3 +432,11 @@ class TestInstanceKeys:
             gc.collect()
 
         assert len(keys) == 50
+
+    def test_a_key_names_the_class_it_belongs_to(self):
+        """Graph dumps and guard failures show the key, not the instance."""
+
+        class _Dummy:
+            pass
+
+        assert op_base.register_instance(_Dummy()).startswith("_Dummy")


### PR DESCRIPTION
## Problems

- The compile-boundary instance key read `op7`. That key is what appears in FX graph dumps,
  guard failures and tracebacks, where a bare number does not say which op it belongs to.
- `rope.py` documented the registry as keyed by `id(instance)`, which it has not been.
- `rms_norm.py` holds the reference shape of an op-layer compile boundary, but a reader had to
  infer from scattered code which pieces make up that boundary and in what order to write them.

## Changes

- Keys read `RMSNormFwdOp#3`. The separator is `#` because it cannot appear in a class name, so
  no two classes can collide; the global counter still supplies uniqueness and non-reuse.
- `compile_boundary.py`'s module docstring opens with the three lines an op writes, instead of
  with the reasoning behind the key.
- `rms_norm.py` gains a module docstring naming the five pieces an op writes, `compile_op_names`
  moves beside the other class constant, and three comments answer what the code leaves open.
- One test: a key names the class it belongs to.

No behaviour change beyond the key format.